### PR TITLE
Remove redundant hide handles API from TextSelectionDelegate

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -990,13 +990,6 @@ mixin TextSelectionDelegate {
   ///   updating the text editing state.
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause);
 
-  /// Hides the text selection toolbar.
-  ///
-  /// By default, hideHandles is true, and the toolbar is hidden along with its
-  /// handles. If hideHandles is set to false, then the toolbar will be hidden
-  /// but the handles will remain.
-  void hideToolbar([bool hideHandles = true]);
-
   /// Brings the provided [TextPosition] into the visible area of the text
   /// input.
   void bringIntoView(TextPosition position);

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2908,7 +2908,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     return true;
   }
 
-  @override
+  /// Hides the text selection toolbar.
+  ///
+  /// By default, hideHandles is true, and the toolbar is hidden along with its
+  /// handles. If hideHandles is set to false, then the toolbar will be hidden
+  /// but the handles will remain.
   void hideToolbar([bool hideHandles = true]) {
     if (hideHandles) {
       // Hide the handles and the toolbar.

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -28,9 +28,6 @@ class _FakeEditableTextState with TextSelectionDelegate {
   TextEditingValue textEditingValue = TextEditingValue.empty;
 
   @override
-  void hideToolbar([bool hideHandles = true]) { }
-
-  @override
   void userUpdateTextEditingValue(TextEditingValue value, SelectionChangedCause cause) { }
 
   @override


### PR DESCRIPTION
This method only used internally in editableText or directly called on EditableText without going through TextSelectionDelegate interface.

Removing this makes it easier to reuse SelectionOverlay

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
