### PR TITLE
Print events and views when first frame is taking awhile during tracing

### DIFF
--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -54,7 +54,7 @@ class Tracing {
         final StringBuffer bufferedEvents = StringBuffer();
         void Function(String) handleBufferedEvent = bufferedEvents.writeln;
         vmService.service.onExtensionEvent.listen((vm_service.Event event) {
-          handleBufferedEvent(processVmServiceMessage(event));
+          handleBufferedEvent('${event.extensionKind}: ${event.extensionData}');
           if (event.extensionKind == 'Flutter.FirstFrame') {
             whenFirstFrameRendered.complete();
           }

--- a/packages/flutter_tools/test/general.shard/tracing_test.dart
+++ b/packages/flutter_tools/test/general.shard/tracing_test.dart
@@ -189,6 +189,10 @@ void main() {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final Completer<void> completer = Completer<void>();
     await FakeAsync().run((FakeAsync time) {
+      final Map<String, String> extensionData = <String, String>{
+        'test': 'data',
+        'renderedErrorText': 'error text',
+      };
       final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[
         const FakeVmServiceRequest(
           method: 'streamListen',
@@ -213,7 +217,7 @@ void main() {
           event: vm_service.Event(
             timestamp: 0,
             extensionKind: 'Flutter.Error',
-            bytes: base64.encode(utf8.encode('error text')),
+            extensionData: vm_service.ExtensionData.parse(extensionData),
             kind: vm_service.EventStreams.kExtension,
           ),
         ),
@@ -229,7 +233,7 @@ void main() {
     });
     expect(logger.statusText, contains('First frame is taking longer than expected'));
     expect(logger.traceText, contains('id: 1 isolate: null'));
-    expect(logger.traceText, contains('error text'));
+    expect(logger.traceText, contains('Flutter.Error: [ExtensionData {test: data, renderedErrorText: error text}]'));
   });
 
   testWithoutContext('throws tool exit if first frame events are missing', () async {


### PR DESCRIPTION
Help debug https://github.com/flutter/flutter/issues/98419.  Added a 10 second timer to start logging events if the first frame is not detected.

A very similar 10 second timeout was removed in https://github.com/flutter/flutter/pull/26736, but this just logs the events we're received, and the isolate ID of the views.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
