### PR TITLE
Removed no-shuffle tag and fixed order dependency in daemon_test.dart

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -4,12 +4,6 @@
 
 // @dart = 2.8
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-
 import 'dart:async';
 import 'dart:io' as io;
 import 'dart:typed_data';
@@ -79,12 +73,12 @@ class FakeDaemonStreams implements DaemonStreams {
 void main() {
   Daemon daemon;
   NotifyingLogger notifyingLogger;
-  BufferLogger bufferLogger;
 
   group('daemon', () {
     FakeDaemonStreams daemonStreams;
     DaemonConnection daemonConnection;
     setUp(() {
+      BufferLogger bufferLogger;
       bufferLogger = BufferLogger.test();
       notifyingLogger = NotifyingLogger(verbose: false, parent: bufferLogger);
       daemonStreams = FakeDaemonStreams();
@@ -677,37 +671,46 @@ void main() {
     });
   });
 
-  testUsingContext('notifyingLogger outputs trace messages in verbose mode', () async {
-    final NotifyingLogger logger = NotifyingLogger(verbose: true, parent: bufferLogger);
+  group('notifyingLogger', () {
+    BufferLogger bufferLogger;
+    setUp(() {
+      bufferLogger = BufferLogger.test();
+    });
 
-    logger.printTrace('test');
+    tearDown(() {
+      bufferLogger.clear();
+    });
 
-    expect(bufferLogger.errorText, contains('test'));
-  });
+    testUsingContext('outputs trace messages in verbose mode', () async {    
+      final NotifyingLogger logger = NotifyingLogger(verbose: true, parent: bufferLogger);
+      logger.printTrace('test');
+      expect(bufferLogger.errorText, contains('test'));
+    });
 
-  testUsingContext('notifyingLogger ignores trace messages in non-verbose mode', () async {
-    final NotifyingLogger logger = NotifyingLogger(verbose: false, parent: bufferLogger);
+    testUsingContext('ignores trace messages in non-verbose mode', () async {
+      final NotifyingLogger logger = NotifyingLogger(verbose: false, parent: bufferLogger);
 
-    final Future<LogMessage> messageResult = logger.onMessage.first;
-    logger.printTrace('test');
-    logger.printStatus('hello');
+      final Future<LogMessage> messageResult = logger.onMessage.first;
+      logger.printTrace('test');
+      logger.printStatus('hello');
 
-    final LogMessage message = await messageResult;
+      final LogMessage message = await messageResult;
 
-    expect(message.level, 'status');
-    expect(message.message, 'hello');
-    expect(bufferLogger.errorText, contains('test'));
-  });
+      expect(message.level, 'status');
+      expect(message.message, 'hello');
+      expect(bufferLogger.errorText, isEmpty);
+    });
 
-  testUsingContext('notifyingLogger buffers messages sent before a subscription', () async {
-    final NotifyingLogger logger = NotifyingLogger(verbose: false, parent: bufferLogger);
+    testUsingContext('buffers messages sent before a subscription', () async {
+      final NotifyingLogger logger = NotifyingLogger(verbose: false, parent: bufferLogger);
 
-    logger.printStatus('hello');
+      logger.printStatus('hello');
 
-    final LogMessage message = await logger.onMessage.first;
+      final LogMessage message = await logger.onMessage.first;
 
-    expect(message.level, 'status');
-    expect(message.message, 'hello');
+      expect(message.level, 'status');
+      expect(message.message, 'hello');
+    });
   });
 
   group('daemon queue', () {

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -681,7 +681,7 @@ void main() {
       bufferLogger.clear();
     });
 
-    testUsingContext('outputs trace messages in verbose mode', () async {    
+    testUsingContext('outputs trace messages in verbose mode', () async {
       final NotifyingLogger logger = NotifyingLogger(verbose: true, parent: bufferLogger);
       logger.printTrace('test');
       expect(bufferLogger.errorText, contains('test'));


### PR DESCRIPTION
This PR fixed the problem that has prevented daemon_test.dart being shuffled. Part of #85160.

## The issues
Two issues were found related to three tests. No test failed for me using the reported seed 1000. But it failed on seed 123.

Test A: 'notifyingLogger outputs trace messages in verbose mode'
Test B: 'notifyingLogger ignores trace messages in non-verbose mode'
Test C: 'notifyingLogger buffers messages sent before a subscription'

### First Issue - Order Dependency
All three tests use the bufferLogger variable that is initialized inside group 'daemon'. As these 
three tests are placed outside that group, they were failing if run before the group 'daemon'.

### Second Issue - Broken Test and Order Dependency
As far as I can see, the test B has never been working as intended.
The line 'logger.printTrace('test');' should not be logged in bufferLogger in non-verbose mode. The test expected it to be logged.

It was working though because test A was logging the same string to bufferLogger and leaving the log behind for later tests. But if test B was run before test A, it would fail.

## The fix

### First issue
Create a new test group called 'notifyingLogger' to initialize bufferLogger and then clear it, after each of these tests. The bufferLogger variable was isolated in each group to avoid future mistakes.

### Second Issue
Test B was changed to expect the bufferLogger to be empty.

## Note
I could not reproduce any test failings on randomize ordering seed 1000. I found these issues using seed 123.
Any reviewer should consider testing seed 1000 to make sure there is no race condition that I cannot reproduce.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].