### PR TITLE
Use int for PlaceholderSpan.placeholderCodeUnit

### DIFF
--- a/packages/flutter/lib/src/painting/placeholder_span.dart
+++ b/packages/flutter/lib/src/painting/placeholder_span.dart
@@ -42,7 +42,7 @@ abstract class PlaceholderSpan extends InlineSpan {
   }) : super(style: style);
 
   /// The unicode character to represent a placeholder.
-  static const String placeholderCodeUnit = '\uFFFC';
+  static const int placeholderCodeUnit = 0xFFFC;
 
   /// How the placeholder aligns vertically with the text.
   ///
@@ -60,7 +60,7 @@ abstract class PlaceholderSpan extends InlineSpan {
   @override
   void computeToPlainText(StringBuffer buffer, {bool includeSemanticsLabels = true, bool includePlaceholders = true}) {
     if (includePlaceholders) {
-      buffer.write(placeholderCodeUnit);
+      buffer.writeCharCode(placeholderCodeUnit);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/widget_span.dart
+++ b/packages/flutter/lib/src/widgets/widget_span.dart
@@ -140,7 +140,7 @@ class WidgetSpan extends PlaceholderSpan {
   @override
   int? codeUnitAtVisitor(int index, Accumulator offset) {
     offset.increment(1);
-    return PlaceholderSpan.placeholderCodeUnit.codeUnitAt(0);
+    return PlaceholderSpan.placeholderCodeUnit;
   }
 
   @override


### PR DESCRIPTION
This PR changes the type of PlaceholderSpan.placeholderCodeUnit introduced in #98542 to int so as to avoid conversions.

Text exempt - optimisation only.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
