### PR TITLE
Make popup menus avoid display features

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show DisplayFeature;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -636,6 +638,7 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
     this.selectedItemIndex,
     this.textDirection,
     this.padding,
+    this.avoidBounds,
   );
 
   // Rectangle of underlying button, relative to the overlay's dimensions.
@@ -654,6 +657,9 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
 
   // The padding of unsafe area.
   EdgeInsets padding;
+
+  // List of rectangles that we should avoid overlapping. Unusable screen area.
+  final Set<Rect> avoidBounds;
 
   // We put the child wherever position specifies, so long as it will fit within
   // the specified parent size padded (inset) by 8. If necessary, we adjust the
@@ -705,19 +711,38 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
           break;
       }
     }
+    final Offset wantedPosition = Offset(x,y);
+    final Offset originCenter = position.toRect(Offset.zero & size).center;
+    final Iterable<Rect> subScreens = DisplayFeatureSubScreen.subScreensInBounds(Offset.zero & size, avoidBounds);
+    final Rect subScreen = _closestScreen(subScreens, originCenter);
+    return _fitInsideScreen(subScreen, childSize, wantedPosition);
+  }
 
+  Rect _closestScreen(Iterable<Rect> screens, Offset point) {
+    Rect closest = screens.first;
+    for (final Rect screen in screens) {
+      if ((screen.center - point).distance < (closest.center - point).distance) {
+        closest = screen;
+      }
+    }
+    return closest;
+  }
+
+  Offset _fitInsideScreen(Rect screen, Size childSize, Offset wantedPosition){
+    double x = wantedPosition.dx;
+    double y = wantedPosition.dy;
     // Avoid going outside an area defined as the rectangle 8.0 pixels from the
     // edge of the screen in every direction.
-    if (x < _kMenuScreenPadding + padding.left)
-      x = _kMenuScreenPadding + padding.left;
-    else if (x + childSize.width > size.width - _kMenuScreenPadding - padding.right)
-      x = size.width - childSize.width - _kMenuScreenPadding - padding.right  ;
-    if (y < _kMenuScreenPadding + padding.top)
+    if (x < screen.left + _kMenuScreenPadding + padding.left)
+      x = screen.left + _kMenuScreenPadding + padding.left;
+    else if (x + childSize.width > screen.right - _kMenuScreenPadding - padding.right)
+      x = screen.right - childSize.width - _kMenuScreenPadding - padding.right;
+    if (y < screen.top + _kMenuScreenPadding + padding.top)
       y = _kMenuScreenPadding + padding.top;
-    else if (y + childSize.height > size.height - _kMenuScreenPadding - padding.bottom)
-      y = size.height - padding.bottom - _kMenuScreenPadding - childSize.height ;
+    else if (y + childSize.height > screen.bottom - _kMenuScreenPadding - padding.bottom)
+      y = screen.bottom - childSize.height - _kMenuScreenPadding - padding.bottom;
 
-    return Offset(x, y);
+    return Offset(x,y);
   }
 
   @override
@@ -731,7 +756,8 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
       || selectedItemIndex != oldDelegate.selectedItemIndex
       || textDirection != oldDelegate.textDirection
       || !listEquals(itemSizes, oldDelegate.itemSizes)
-      || padding != oldDelegate.padding;
+      || padding != oldDelegate.padding
+      || !setEquals(avoidBounds, oldDelegate.avoidBounds);
   }
 }
 
@@ -813,12 +839,20 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
               selectedItemIndex,
               Directionality.of(context),
               mediaQuery.padding,
+              _avoidBounds(mediaQuery),
             ),
             child: capturedThemes.wrap(menu),
           );
         },
       ),
     );
+  }
+
+  Set<Rect> _avoidBounds(MediaQueryData mediaQuery) {
+    return mediaQuery.displayFeatures
+        .map<Rect>((final DisplayFeature displayFeature) => displayFeature.bounds)
+        .where((Rect element) => element.shortestSide > 0)
+        .toSet();
   }
 }
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -849,10 +849,7 @@ class _PopupMenuRoute<T> extends PopupRoute<T> {
   }
 
   Set<Rect> _avoidBounds(MediaQueryData mediaQuery) {
-    return mediaQuery.displayFeatures
-        .map<Rect>((final DisplayFeature displayFeature) => displayFeature.bounds)
-        .where((Rect element) => element.shortestSide > 0)
-        .toSet();
+    return DisplayFeatureSubScreen.avoidBounds(mediaQuery).toSet();
   }
 }
 

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show DisplayFeature;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -709,7 +709,7 @@ class _PopupMenuRouteLayout extends SingleChildLayoutDelegate {
           break;
       }
     }
-    final Offset wantedPosition = Offset(x,y);
+    final Offset wantedPosition = Offset(x, y);
     final Offset originCenter = position.toRect(Offset.zero & size).center;
     final Iterable<Rect> subScreens = DisplayFeatureSubScreen.subScreensInBounds(Offset.zero & size, avoidBounds);
     final Rect subScreen = _closestScreen(subScreens, originCenter);

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
-import 'dart:ui' show DisplayFeature;
+import 'dart:ui' show DisplayFeature, DisplayFeatureState;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
@@ -19,9 +19,8 @@ import 'media_query.dart';
 /// A [DisplayFeature] splits the screen into sub-screens when both these
 /// conditions are met:
 ///
-///   * it obstructs the screen, meaning the area it occupies is not 0. Display
-///     features of type [DisplayFeatureType.fold] can have height 0 or width 0
-///     and not be obstructing the screen.
+///   * it obstructs the screen, meaning the area it occupies is not 0 or the
+///     `state` is [DisplayFeatureState.postureHalfOpened].
 ///   * it is at least as tall as the screen, producing a left and right
 ///     sub-screen or it is at least as wide as the screen, producing a top and
 ///     bottom sub-screen
@@ -100,7 +99,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     final Size parentSize = mediaQuery.size;
     final Rect wantedBounds = Offset.zero & parentSize;
     final Offset resolvedAnchorPoint = _capOffset(anchorPoint ?? _fallbackAnchorPoint(context), parentSize);
-    final Iterable<Rect> subScreens = subScreensInBounds(wantedBounds, _avoidBounds(mediaQuery));
+    final Iterable<Rect> subScreens = subScreensInBounds(wantedBounds, avoidBounds(mediaQuery));
     final Rect closestSubScreen = _closestToAnchorPoint(subScreens, resolvedAnchorPoint);
 
     return Padding(
@@ -127,9 +126,15 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     }
   }
 
-  static Iterable<Rect> _avoidBounds(MediaQueryData mediaQuery) {
-    return mediaQuery.displayFeatures.map((DisplayFeature d) => d.bounds)
-        .where((Rect r) => r.shortestSide > 0);
+  /// Returns the areas of the screen that are obstructed by display features.
+  ///
+  /// A [DisplayFeature] obstructs the screen when the the area it occupies is
+  /// not 0 or the `state` is [DisplayFeatureState.postureHalfOpened].
+  static Iterable<Rect> avoidBounds(MediaQueryData mediaQuery) {
+    return mediaQuery.displayFeatures
+        .where((DisplayFeature d) => d.bounds.shortestSide > 0 ||
+            d.state == DisplayFeatureState.postureHalfOpened)
+        .map((DisplayFeature d) => d.bounds);
   }
 
   /// Returns the closest sub-screen to the [anchorPoint].
@@ -188,7 +193,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
   }
 
   /// Returns sub-screens resulted by dividing [wantedBounds] along items of
-  /// [avoidBounds] that are at least as high or as wide.
+  /// [avoidBounds] that are at least as tall or as wide.
   static Iterable<Rect> subScreensInBounds(Rect wantedBounds, Iterable<Rect> avoidBounds) {
     Iterable<Rect> subScreens = <Rect>[wantedBounds];
     for (final Rect bounds in avoidBounds) {

--- a/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
+++ b/packages/flutter/lib/src/widgets/display_feature_sub_screen.dart
@@ -100,7 +100,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
     final Size parentSize = mediaQuery.size;
     final Rect wantedBounds = Offset.zero & parentSize;
     final Offset resolvedAnchorPoint = _capOffset(anchorPoint ?? _fallbackAnchorPoint(context), parentSize);
-    final Iterable<Rect> subScreens = _subScreensInBounds(wantedBounds, _avoidBounds(mediaQuery));
+    final Iterable<Rect> subScreens = subScreensInBounds(wantedBounds, _avoidBounds(mediaQuery));
     final Rect closestSubScreen = _closestToAnchorPoint(subScreens, resolvedAnchorPoint);
 
     return Padding(
@@ -189,7 +189,7 @@ class DisplayFeatureSubScreen extends StatelessWidget {
 
   /// Returns sub-screens resulted by dividing [wantedBounds] along items of
   /// [avoidBounds] that are at least as high or as wide.
-  static Iterable<Rect> _subScreensInBounds(Rect wantedBounds, Iterable<Rect> avoidBounds) {
+  static Iterable<Rect> subScreensInBounds(Rect wantedBounds, Iterable<Rect> avoidBounds) {
     Iterable<Rect> subScreens = <Rect>[wantedBounds];
     for (final Rect bounds in avoidBounds) {
       final List<Rect> newSubScreens = <Rect>[];

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -192,6 +192,11 @@ void main() {
               type: DisplayFeatureType.cutout,
               state: DisplayFeatureState.unknown,
             ),
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(0, 300, 800, 300),
+              type: DisplayFeatureType.fold,
+              state: DisplayFeatureState.postureFlat,
+            ),
           ]
       );
 
@@ -216,6 +221,38 @@ void main() {
       expect(renderBox.size.width, equals(800.0));
       expect(renderBox.size.height, equals(600.0));
       expect(renderBox.localToGlobal(Offset.zero), equals(Offset.zero));
+    });
+
+    testWidgets('with size 0 display feature in half-opened posture and anchorPoint', (WidgetTester tester) async {
+      const Key childKey = Key('childKey');
+      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+          displayFeatures: <DisplayFeature>[
+            const DisplayFeature(
+              bounds: Rect.fromLTRB(0, 300, 800, 300),
+              type: DisplayFeatureType.fold,
+              state: DisplayFeatureState.postureHalfOpened,
+            ),
+          ]
+      );
+
+      await tester.pumpWidget(
+        MediaQuery(
+          data: mediaQuery,
+          child: const DisplayFeatureSubScreen(
+            anchorPoint: Offset(1000, 1000),
+            child: SizedBox(
+              key: childKey,
+              width: double.infinity,
+              height: double.infinity,
+            ),
+          ),
+        ),
+      );
+
+      final RenderBox renderBox = tester.renderObject(find.byKey(childKey));
+      expect(renderBox.size.width, equals(800.0));
+      expect(renderBox.size.height, equals(300.0));
+      expect(renderBox.localToGlobal(Offset.zero), equals(const Offset(0,300)));
     });
   });
 }


### PR DESCRIPTION
This PR makes popup menus avoid overlapping display features. 

Here is an example of showing a popup menu on one of the screens, instead of the middle of the screen (where the example device has a display feature):

![Screenshot_1645622794](https://user-images.githubusercontent.com/1402046/155328377-7c8f5453-5a13-4891-a6cf-491954cd18c6.png)

This is split from a larger PR for foldable support in order to make it easier to review (https://github.com/flutter/flutter/pull/77156). 

Issues that will be fixed by this PR:
- https://github.com/flutter/flutter/issues/49411

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
