### PR TITLE
Deflake Mac module_test_ios

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2774,7 +2774,6 @@ targets:
 
   - name: Mac module_test_ios
     recipe: devicelab/devicelab_drone
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/89175
     timeout: 60
     properties:
       caches: >-


### PR DESCRIPTION
Deflake module_test_ios as no flake in recent 100 commits.

https://github.com/flutter/flutter/issues/89175