### PR TITLE
Wait for ios-deploy stdout before closing logLine stream

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -395,11 +395,11 @@ class IOSDeployDebugger {
         _monitorIOSDeployFailure(line, _logger);
         _logger.printTrace(line);
       });
-      unawaited(_iosDeployProcess!.exitCode.then((int status) {
+      unawaited(_iosDeployProcess!.exitCode.then((int status) async {
         _logger.printTrace('ios-deploy exited with code $exitCode');
         _debuggerState = _IOSDeployDebuggerState.detached;
-        unawaited(stdoutSubscription.cancel());
-        unawaited(stderrSubscription.cancel());
+        await stdoutSubscription.cancel();
+        await stderrSubscription.cancel();
       }).whenComplete(() async {
         if (_debuggerOutput.hasListener) {
           // Tell listeners the process died.

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -75,8 +75,9 @@ void main () {
         interfaceType: IOSDeviceConnectionInterface.network,
       );
 
+      expect(iosDeployDebugger.logLines, emits('Did finish launching.'));
       expect(await iosDeployDebugger.launchAndAttach(), isTrue);
-      expect(await iosDeployDebugger.logLines.toList(), <String>['Did finish launching.']);
+      await iosDeployDebugger.logLines.drain();
       expect(processManager, hasNoRemainingExpectations);
       expect(appDeltaDirectory, exists);
     });
@@ -92,7 +93,6 @@ void main () {
 
       testWithoutContext('debugger attached and stopped', () async {
         final StreamController<List<int>> stdin = StreamController<List<int>>();
-        final Stream<String> stdinStream = stdin.stream.transform<String>(const Utf8Decoder());
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           FakeCommand(
             command: const <String>['ios-deploy'],
@@ -108,24 +108,25 @@ void main () {
         final Stream<String> logLines = iosDeployDebugger.logLines
           ..listen(receivedLogLines.add);
 
-        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
-        await logLines.toList();
-        expect(receivedLogLines, <String>[
+        expect(iosDeployDebugger.logLines, emitsInOrder(<String>[
           'success', // ignore first "success" from lldb, but log subsequent ones from real logging.
           'Log on attach1',
           'Log on attach2',
           '',
           '',
           'Log after process stop'
-        ]);
-        expect(logger.traceText, contains('PROCESS_STOPPED'));
-        expect(logger.traceText, contains('thread backtrace all'));
-        expect(logger.traceText, contains('* thread #1'));
-        expect(await stdinStream.take(3).toList(), <String>[
+        ]));
+        expect(stdin.stream.transform<String>(const Utf8Decoder()), emitsInOrder(<String>[
           'thread backtrace all',
           '\n',
           'process detach',
-        ]);
+        ]));
+        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
+        await logLines.drain();
+
+        expect(logger.traceText, contains('PROCESS_STOPPED'));
+        expect(logger.traceText, contains('thread backtrace all'));
+        expect(logger.traceText, contains('* thread #1'));
       });
 
       testWithoutContext('handle processing logging after process exit', () async {
@@ -144,13 +145,10 @@ void main () {
           processManager: processManager,
           logger: logger,
         );
-        final List<String> receivedLogLines = <String>[];
-        final Stream<String> logLines = iosDeployDebugger.logLines
-          ..listen(receivedLogLines.add);
 
+        expect(iosDeployDebugger.logLines, emitsDone);
         expect(await iosDeployDebugger.launchAndAttach(), isFalse);
-        await logLines.toList();
-        expect(receivedLogLines, isEmpty);
+        await iosDeployDebugger.logLines.drain();
       });
 
       testWithoutContext('app exit', () async {
@@ -164,21 +162,17 @@ void main () {
           processManager: processManager,
           logger: logger,
         );
-        final List<String> receivedLogLines = <String>[];
-        final Stream<String> logLines = iosDeployDebugger.logLines
-          ..listen(receivedLogLines.add);
-
-        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
-        await logLines.toList();
-        expect(receivedLogLines, <String>[
+        expect(iosDeployDebugger.logLines, emitsInOrder(<String>[
           'Log on attach',
           'Log after process exit',
-        ]);
+        ]));
+
+        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
+        await iosDeployDebugger.logLines.drain();
       });
 
       testWithoutContext('app crash', () async {
         final StreamController<List<int>> stdin = StreamController<List<int>>();
-        final Stream<String> stdinStream = stdin.stream.transform<String>(const Utf8Decoder());
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           FakeCommand(
             command: const <String>['ios-deploy'],
@@ -191,24 +185,24 @@ void main () {
           processManager: processManager,
           logger: logger,
         );
-        final List<String> receivedLogLines = <String>[];
-        final Stream<String> logLines = iosDeployDebugger.logLines
-          ..listen(receivedLogLines.add);
 
-        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
-        await logLines.toList();
-        expect(receivedLogLines, <String>[
+        expect(iosDeployDebugger.logLines, emitsInOrder(<String>[
           'Log on attach',
           '* thread #1, stop reason = Assertion failed:',
-        ]);
-        expect(logger.traceText, contains('Process 6156 stopped'));
-        expect(logger.traceText, contains('thread backtrace all'));
-        expect(logger.traceText, contains('* thread #1'));
-        expect(await stdinStream.take(3).toList(), <String>[
+        ]));
+
+        expect(stdin.stream.transform<String>(const Utf8Decoder()), emitsInOrder(<String>[
           'thread backtrace all',
           '\n',
           'process detach',
-        ]);
+        ]));
+
+        expect(await iosDeployDebugger.launchAndAttach(), isTrue);
+        await iosDeployDebugger.logLines.drain();
+
+        expect(logger.traceText, contains('Process 6156 stopped'));
+        expect(logger.traceText, contains('thread backtrace all'));
+        expect(logger.traceText, contains('* thread #1'));
       });
 
       testWithoutContext('attach failed', () async {
@@ -223,15 +217,12 @@ void main () {
           processManager: processManager,
           logger: logger,
         );
-        final List<String> receivedLogLines = <String>[];
-        final Stream<String> logLines = iosDeployDebugger.logLines
-          ..listen(receivedLogLines.add);
-
-        expect(await iosDeployDebugger.launchAndAttach(), isFalse);
-        await logLines.toList();
         // Debugger lines are double spaced, separated by an extra \r\n. Skip the extra lines.
         // Still include empty lines other than the extra added newlines.
-        expect(receivedLogLines, isEmpty);
+        expect(iosDeployDebugger.logLines, emitsDone);
+
+        expect(await iosDeployDebugger.launchAndAttach(), isFalse);
+        await iosDeployDebugger.logLines.drain();
       });
 
       testWithoutContext('no provisioning profile 1, stdout', () async {
@@ -298,7 +289,6 @@ void main () {
 
     testWithoutContext('detach', () async {
       final StreamController<List<int>> stdin = StreamController<List<int>>();
-      final Stream<String> stdinStream = stdin.stream.transform<String>(const Utf8Decoder());
       final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
           command: const <String>[
@@ -311,9 +301,9 @@ void main () {
       final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
         processManager: processManager,
       );
+      expect(stdin.stream.transform<String>(const Utf8Decoder()), emits('process detach'));
       await iosDeployDebugger.launchAndAttach();
       iosDeployDebugger.detach();
-      expect(await stdinStream.first, 'process detach');
     });
 
     testWithoutContext('stop with backtrace', () async {


### PR DESCRIPTION
Also migrate the `ios_deploy_test` file to use the `emits` matcher instead of checking the values from `Stream.toList()`

Fixes https://github.com/flutter/flutter/issues/99021

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
