### PR TITLE
Fix initial off-centered alignment of selectable text

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -189,7 +189,7 @@ class SelectableText extends StatefulWidget {
     ToolbarOptions? toolbarOptions,
     this.minLines,
     this.maxLines,
-    this.cursorWidth = 2.0,
+    this.cursorWidth = 0,
     this.cursorHeight,
     this.cursorRadius,
     this.cursorColor,
@@ -247,7 +247,7 @@ class SelectableText extends StatefulWidget {
     ToolbarOptions? toolbarOptions,
     this.minLines,
     this.maxLines,
-    this.cursorWidth = 2.0,
+    this.cursorWidth = 0,
     this.cursorHeight,
     this.cursorRadius,
     this.cursorColor,
@@ -442,7 +442,7 @@ class SelectableText extends StatefulWidget {
     properties.add(EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(DoubleProperty('textScaleFactor', textScaleFactor, defaultValue: null));
-    properties.add(DoubleProperty('cursorWidth', cursorWidth, defaultValue: 2.0));
+    properties.add(DoubleProperty('cursorWidth', cursorWidth, defaultValue: 0));
     properties.add(DoubleProperty('cursorHeight', cursorHeight, defaultValue: null));
     properties.add(DiagnosticsProperty<Radius>('cursorRadius', cursorRadius, defaultValue: null));
     properties.add(DiagnosticsProperty<Color>('cursorColor', cursorColor, defaultValue: null));

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -316,7 +316,7 @@ void main() {
     );
 
     final RenderBox longtextBox = findSelectableTextBox();
-    expect(longtextBox.size, const Size(199.0, 14.0));
+    expect(longtextBox.size, const Size(197.0, 14.0));
   });
 
   testWidgets('can scale with textScaleFactor', (WidgetTester tester) async {
@@ -1078,7 +1078,7 @@ void main() {
     final Offset middleStringPos = textOffsetToPosition(tester, testValue.indexOf('irst'));
 
     expect(firstPos.dx, 25.5);
-    expect(secondPos.dx, 24.5);
+    expect(secondPos.dx, 25.5);
     expect(thirdPos.dx, 24.5);
     expect(middleStringPos.dx, 58.5);
     expect(firstPos.dx, secondPos.dx);
@@ -3830,7 +3830,7 @@ void main() {
         tester.getSize(find.byType(SelectableText)),
         // This is the height of the decoration (24) plus the metrics from the default
         // TextStyle of the theme (16).
-        const Size(129.0, 14.0),
+        const Size(127.0, 14.0),
       );
     },
   );
@@ -3877,7 +3877,7 @@ void main() {
       expect(
         tester.getSize(find.byType(SelectableText)),
         // The height here should match the previous version with strut enabled.
-        const Size(183.0, 20.0),
+        const Size(181.0, 20.0),
       );
     },
   );
@@ -4050,7 +4050,7 @@ void main() {
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 3)).topLeft,
     );
-    expect(topLeft.dx, equals(413));
+    expect(topLeft.dx, equals(414));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
@@ -4086,7 +4086,7 @@ void main() {
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 8)).topLeft,
     );
-    expect(topLeft.dx, equals(483));
+    expect(topLeft.dx, equals(484));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 4)).topLeft,

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -307,7 +307,7 @@ void main() {
     RenderBox findSelectableTextBox() => tester.renderObject(find.byType(SelectableText));
 
     final RenderBox textBox = findSelectableTextBox();
-    expect(textBox.size, const Size(17.0, 14.0));
+    expect(textBox.size, const Size(15.0, 14.0));
 
     await tester.pumpWidget(
         boilerplate(
@@ -365,7 +365,7 @@ void main() {
       ),
     );
     textBox = findTextBox();
-    expect(textBox.size, const Size(633.0, 28.0));
+    expect(textBox.size, const Size(631.0, 28.0));
   });
 
   testWidgets('can switch between textHeightBehavior', (WidgetTester tester) async {
@@ -1077,7 +1077,7 @@ void main() {
     final Offset thirdPos = textOffsetToPosition(tester, testValue.indexOf('Third'));
     final Offset middleStringPos = textOffsetToPosition(tester, testValue.indexOf('irst'));
 
-    expect(firstPos.dx, 24.5);
+    expect(firstPos.dx, 25.5);
     expect(secondPos.dx, 24.5);
     expect(thirdPos.dx, 24.5);
     expect(middleStringPos.dx, 58.5);
@@ -1285,7 +1285,7 @@ void main() {
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
 
-    expect(topLeft.dx, equals(399.0));
+    expect(topLeft.dx, equals(400.0));
   });
 
   testWidgets('Can align to center within center', (WidgetTester tester) async {
@@ -1309,7 +1309,7 @@ void main() {
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
 
-    expect(topLeft.dx, equals(399.0));
+    expect(topLeft.dx, equals(400.0));
   });
 
   testWidgets('Selectable text is skipped during focus traversal', (WidgetTester tester) async {
@@ -3856,7 +3856,7 @@ void main() {
         tester.getSize(find.byType(SelectableText)),
         // Strut should inherit the TextStyle.fontSize by default and produce the
         // same height as if it were disabled.
-        const Size(183.0, 20.0),
+        const Size(181.0, 20.0),
       );
 
       await tester.pumpWidget(
@@ -3901,7 +3901,7 @@ void main() {
 
       expect(
         tester.getSize(find.byType(SelectableText)),
-        const Size(129.0, 84.0),
+        const Size(127.0, 84.0),
       );
     },
   );
@@ -3933,7 +3933,7 @@ void main() {
         // When the strut's height is smaller than TextStyle's and forceStrutHeight
         // is disabled, then the TextStyle takes precedence. Should be the same height
         // as 'strut basic multi line'.
-        const Size(129.0, 84.0),
+        const Size(127.0, 84.0),
       );
     },
   );
@@ -3962,7 +3962,7 @@ void main() {
         tester.getSize(find.byType(SelectableText)),
         // When the strut's height is larger than TextStyle's and forceStrutHeight
         // is disabled, then the StrutStyle takes precedence.
-        const Size(129.0, 150.0),
+        const Size(127.0, 150.0),
       );
     },
   );
@@ -3991,7 +3991,7 @@ void main() {
       expect(
         tester.getSize(find.byType(SelectableText)),
         // The smaller font size of strut make the field shorter than normal.
-        const Size(129.0, 24.0),
+        const Size(127.0, 24.0),
       );
     },
   );
@@ -4022,7 +4022,7 @@ void main() {
         tester.getSize(find.byType(SelectableText)),
         // When the strut fontSize is larger than a provided TextStyle, the
         // strut's height takes precedence.
-        const Size(93.0, 54.0),
+        const Size(91.0, 54.0),
       );
     },
   );
@@ -4045,7 +4045,7 @@ void main() {
     Offset topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 4)).topLeft,
     );
-    expect(topLeft.dx, equals(427));
+    expect(topLeft.dx, equals(428));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 3)).topLeft,
@@ -4081,7 +4081,7 @@ void main() {
     Offset topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 7)).topLeft,
     );
-    expect(topLeft.dx, equals(469));
+    expect(topLeft.dx, equals(470));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 8)).topLeft,

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -1079,8 +1079,8 @@ void main() {
 
     expect(firstPos.dx, 25.5);
     expect(secondPos.dx, 25.5);
-    expect(thirdPos.dx, 24.5);
-    expect(middleStringPos.dx, 58.5);
+    expect(thirdPos.dx, 25.5);
+    expect(middleStringPos.dx, 59.5);
     expect(firstPos.dx, secondPos.dx);
     expect(firstPos.dx, thirdPos.dx);
     expect(firstPos.dy, lessThan(secondPos.dy));
@@ -4055,12 +4055,12 @@ void main() {
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
-    expect(topLeft.dx, equals(399));
+    expect(topLeft.dx, equals(400));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 1)).topLeft,
     );
-    expect(topLeft.dx, equals(385));
+    expect(topLeft.dx, equals(386));
   });
 
   testWidgets('Caret indexes into trailing whitespace center align', (WidgetTester tester) async {
@@ -4091,22 +4091,22 @@ void main() {
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 4)).topLeft,
     );
-    expect(topLeft.dx, equals(427));
+    expect(topLeft.dx, equals(428));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 3)).topLeft,
     );
-    expect(topLeft.dx, equals(413));
+    expect(topLeft.dx, equals(414));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 2)).topLeft,
     );
-    expect(topLeft.dx, equals(399));
+    expect(topLeft.dx, equals(400));
 
     topLeft = editable.localToGlobal(
       editable.getLocalRectForCaret(const TextPosition(offset: 1)).topLeft,
     );
-    expect(topLeft.dx, equals(385));
+    expect(topLeft.dx, equals(386));
   });
 
   testWidgets('selection handles are rendered and not faded away', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -195,7 +195,7 @@ void main() {
     expect(selectableText.showCursor, false);
     expect(selectableText.autofocus, false);
     expect(selectableText.dragStartBehavior, DragStartBehavior.start);
-    expect(selectableText.cursorWidth, 2.0);
+    expect(selectableText.cursorWidth, 0);
     expect(selectableText.cursorHeight, isNull);
     expect(selectableText.enableInteractiveSelection, true);
   });
@@ -240,7 +240,7 @@ void main() {
     expect(selectableText.showCursor, false);
     expect(selectableText.autofocus, false);
     expect(selectableText.dragStartBehavior, DragStartBehavior.start);
-    expect(selectableText.cursorWidth, 2.0);
+    expect(selectableText.cursorWidth, 0);
     expect(selectableText.cursorHeight, isNull);
     expect(selectableText.enableInteractiveSelection, true);
   });


### PR DESCRIPTION
#83784
Please see the linked issue for the full description of the problem.

The purpose of this PR is to fix a default value that caused text to initially appear off centered in a selectable text widget. My reasoning behind this PR is that regardless of whether or not this "different alignment" is intended behavior, it should not be an issue by default. In my PR, I default cursorWidth to 0 and by doing so any users who use the widget will not experience any alignment issues by default.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
