### PR TITLE
Cache iOS 15 simulator runtime on mac_ios test configs

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -98,8 +98,7 @@ platform_properties:
             {"name":"openjdk","path":"java"},
             {"name":"pub_cache","path":".pub-cache"},
             {"name":"xcode_binary","path":"xcode_binary"},
-            {"name":"osx_sdk","path":"osx_sdk"},
-            {"name":"xcode_runtime_ios-15-0","path":"xcode_runtime_ios-15-0"}
+            {"name":"osx_sdk","path":"osx_sdk"}
           ]
       dependencies: >-
         [
@@ -110,6 +109,7 @@ platform_properties:
       os: Mac-12
       device_os: iOS-15.1
       xcode: 13a233
+      runtime_versions: ["ios-15-0"]
   windows:
     properties:
       caches: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -98,7 +98,8 @@ platform_properties:
             {"name":"openjdk","path":"java"},
             {"name":"pub_cache","path":".pub-cache"},
             {"name":"xcode_binary","path":"xcode_binary"},
-            {"name":"osx_sdk","path":"osx_sdk"}
+            {"name":"osx_sdk","path":"osx_sdk"},
+            {"name":"xcode_runtime_ios-15-0","path":"xcode_runtime_ios-15-0"}
           ]
       dependencies: >-
         [


### PR DESCRIPTION
Explicitly cache the iOS 15 simulator runtime during on `mac_ios` tests.  This is the default cipd runtime that should be   automatically cached by mac_toolchain, but seems to not be in some cases.
https://github.com/flutter/flutter/issues/99039

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
