### PR TITLE
Use flutter pub instead of dart pub

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -1578,7 +1578,7 @@ Future<void> _checkConsumerDependencies() async {
   // Parse the output of pub deps --json to determine all of the
   // current packages used by the core set of flutter packages.
   for (final String package in kCorePackages) {
-    final ProcessResult result = await Process.run(dart, <String>[
+    final ProcessResult result = await Process.run(flutter, <String>[
       'pub',
       'deps',
       '--json',

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -27,7 +27,7 @@ class PackagesCommand extends FlutterCommand {
     addSubcommand(PackagesTestCommand());
     addSubcommand(PackagesForwardCommand('publish', 'Publish the current package to pub.dartlang.org', requiresPubspec: true));
     addSubcommand(PackagesForwardCommand('downgrade', 'Downgrade packages in a Flutter project', requiresPubspec: true));
-    addSubcommand(PackagesForwardCommand('deps', 'Print package dependencies', requiresPubspec: true));
+    addSubcommand(PackagesForwardCommand('deps', 'Print package dependencies')); // path to package can be specified with --directory argument
     addSubcommand(PackagesForwardCommand('run', 'Run an executable from a package', requiresPubspec: true));
     addSubcommand(PackagesForwardCommand('cache', 'Work with the Pub system cache'));
     addSubcommand(PackagesForwardCommand('version', 'Print Pub version'));


### PR DESCRIPTION
The dart HHH bots pub resolves to a pub not in the Flutter SDK, which causes "the flutter SDK is not available" when trying to run `dart pub deps` on a flutter package. Explicitly use pub from the Flutter SDK instead.