### PR TITLE
Persistent InkWell splashes

### DIFF
--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -271,10 +271,20 @@ class _InkState extends State<Ink> {
   }
 
   @override
-  void deactivate() {
+  void activate() {
+    final MaterialInkController? validInkController = _ink?.controller;
+    if (validInkController != null && !identical(validInkController, Material.of(context))) {
+      _ink?.dispose();
+      assert(_ink == null);
+    }
+    super.activate();
+  }
+
+  @override
+  void dispose() {
     _ink?.dispose();
     assert(_ink == null);
-    super.deactivate();
+    super.dispose();
   }
 
   Widget _build(BuildContext context) {

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -592,7 +592,6 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
           }
 
           child = AnimatedContainer(
-            key: _MergeableMaterialSliceKey(_children[i].key),
             decoration: BoxDecoration(border: border),
             duration: kThemeAnimationDuration,
             curve: Curves.fastOutSlowIn,
@@ -607,6 +606,7 @@ class _MergeableMaterialState extends State<MergeableMaterial> with TickerProvid
               borderRadius: _borderRadius(i, i == 0, i == _children.length - 1),
             ),
             child: Material(
+              key: _MergeableMaterialSliceKey(_children[i].key),
               type: MaterialType.transparency,
               child: child,
             ),

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -964,6 +964,12 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   /// It is an error to call [setState] unless [mounted] is true.
   bool get mounted => _element != null;
 
+  /// This field is used tracks [activate] and [deactivate], to assert that
+  /// they are called alternatively.
+  ///
+  /// This field is not set in release mode.
+  bool _debugActive = true;
+
   /// Called when this object is inserted into the tree.
   ///
   /// The framework will call this method exactly once for each [State] object
@@ -1144,7 +1150,8 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
     _element!.markNeedsBuild();
   }
 
-  /// Called when this object is removed from the tree.
+  /// Whenever the framework removes this [State] object from the tree, the
+  /// framework will call this method.
   ///
   /// The framework calls this method whenever it removes this [State] object
   /// from the tree. In some cases, the framework will reinsert the [State]
@@ -1172,7 +1179,12 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   ///    from the tree permanently.
   @protected
   @mustCallSuper
-  void deactivate() { }
+  void deactivate() {
+    assert(() {
+      _debugActive = !_debugActive;
+      return !_debugActive;
+    }());
+  }
 
   /// Called when this object is reinserted into the tree after having been
   /// removed via [deactivate].
@@ -1206,7 +1218,12 @@ abstract class State<T extends StatefulWidget> with Diagnosticable {
   ///    transitions from the "inactive" to the "active" lifecycle state.
   @protected
   @mustCallSuper
-  void activate() { }
+  void activate() {
+    assert(() {
+      _debugActive = !_debugActive;
+      return _debugActive;
+    }());
+  }
 
   /// Called when this object is removed from the tree permanently.
   ///

--- a/packages/flutter/test/material/ink_well_test.dart
+++ b/packages/flutter/test/material/ink_well_test.dart
@@ -1122,118 +1122,6 @@ void main() {
     await gesture3.up();
   });
 
-  testWidgets('When ink wells are reparented, the old parent can display splash while the new parent can not', (WidgetTester tester) async {
-    final GlobalKey innerKey = GlobalKey();
-    final GlobalKey leftKey = GlobalKey();
-    final GlobalKey rightKey = GlobalKey();
-
-    Widget doubleInkWellRow({
-      required double leftWidth,
-      required double rightWidth,
-      Widget? leftChild,
-      Widget? rightChild,
-    }) {
-      return Material(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Align(
-            alignment: Alignment.topLeft,
-            child: SizedBox(
-              width: leftWidth+rightWidth,
-              height: 100,
-              child: Row(
-                children: <Widget>[
-                  SizedBox(
-                    width: leftWidth,
-                    height: 100,
-                    child: InkWell(
-                      key: leftKey,
-                      onTap: () {},
-                      child: Center(
-                        child: SizedBox(
-                          width: leftWidth,
-                          height: 50,
-                          child: leftChild,
-                        ),
-                      ),
-                    ),
-                  ),
-                  SizedBox(
-                    width: rightWidth,
-                    height: 100,
-                    child: InkWell(
-                      key: rightKey,
-                      onTap: () {},
-                      child: Center(
-                        child: SizedBox(
-                          width: leftWidth,
-                          height: 50,
-                          child: rightChild,
-                        ),
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    await tester.pumpWidget(
-      doubleInkWellRow(
-        leftWidth: 110,
-        rightWidth: 90,
-        leftChild: InkWell(
-          key: innerKey,
-          onTap: () {},
-        ),
-      ),
-    );
-    final MaterialInkController material = Material.of(tester.element(find.byKey(innerKey)))!;
-
-    // Press inner
-    final TestGesture gesture = await tester.startGesture(const Offset(100, 50), pointer: 1);
-    await tester.pump(const Duration(milliseconds: 200));
-    expect(material, paintsExactlyCountTimes(#drawCircle, 1));
-
-    // Switch side
-    await tester.pumpWidget(
-      doubleInkWellRow(
-        leftWidth: 90,
-        rightWidth: 110,
-        rightChild: InkWell(
-          key: innerKey,
-          onTap: () {},
-        ),
-      ),
-    );
-    expect(material, paintsExactlyCountTimes(#drawCircle, 0));
-
-    // A second pointer presses inner
-    final TestGesture gesture2 = await tester.startGesture(const Offset(100, 50), pointer: 2);
-    await tester.pump(const Duration(milliseconds: 200));
-    expect(material, paintsExactlyCountTimes(#drawCircle, 1));
-
-    await gesture.up();
-    await gesture2.up();
-    await tester.pumpAndSettle();
-
-    // Press inner
-    await gesture.down(const Offset(100, 50));
-    await tester.pump(const Duration(milliseconds: 200));
-    expect(material, paintsExactlyCountTimes(#drawCircle, 1));
-
-    // Press left
-    await gesture2.down(const Offset(50, 50));
-    await tester.pump(const Duration(milliseconds: 200));
-    expect(material, paintsExactlyCountTimes(#drawCircle, 2));
-
-    await gesture.up();
-    await gesture2.up();
-  });
-
   testWidgets("Ink wells's splash starts before tap is confirmed and disappear after tap is canceled", (WidgetTester tester) async {
     final GlobalKey innerKey = GlobalKey();
     await tester.pumpWidget(
@@ -1514,6 +1402,184 @@ void main() {
     expect(inkFeatures, paintsExactlyCountTimes(#drawCircle, 0));
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/6751
+  testWidgets('When InkWell has a GlobalKey and changes position, splash should not stop', (WidgetTester tester) async {
+    final GlobalKey<_TestAppState> testAppKey = GlobalKey();
+    int frames;
+
+    await tester.pumpWidget(_TestApp(key: testAppKey));
+
+    void expectPaintedCircle(bool painted) {
+      final PaintPattern paintPattern = paints..circle();
+      expect(
+        Material.of(tester.element(find.byType(InkWell)))! as RenderBox,
+        painted ? paintPattern : isNot(paintPattern),
+      );
+    }
+    Future<void> expectSplashContinueAfterMove(bool value) async {
+      await tester.pump();
+      expectPaintedCircle(true);
+      await tester.pump(const Duration(milliseconds: 10));
+      expectPaintedCircle(true);
+      await tester.pump(const Duration(milliseconds: 40));
+      expectPaintedCircle(value);
+    }
+
+    // InkWell does not have any key, so splash will stop.
+    testAppKey.currentState!.switchTapChangeWrap();
+    await tester.pump();
+    await tester.tap(find.byType(InkWell));
+    await expectSplashContinueAfterMove(false);
+    frames = await tester.pumpAndSettle();
+    expect(frames, 1);
+    expectPaintedCircle(false);
+
+    // InkWell has a ValueKey, so splash will also stop.
+    testAppKey.currentState!.setInkWellKey(const Key('foo'));
+    await tester.pump();
+    await tester.tap(find.byType(InkWell));
+    await expectSplashContinueAfterMove(false);
+    frames = await tester.pumpAndSettle();
+    expect(frames, 1);
+    expectPaintedCircle(false);
+
+    // InkWell has a GlobalKey, so splash will continue.
+    testAppKey.currentState!.setInkWellKey(GlobalKey());
+    await tester.pump();
+    await tester.tap(find.byType(InkWell));
+    await expectSplashContinueAfterMove(true);
+    frames = await tester.pumpAndSettle();
+    expect(frames > 1, isTrue);
+    expectPaintedCircle(false);
+
+    testAppKey.currentState!.switchTapDownChangeWrap();
+    await tester.pump();
+    final TestGesture testGesture = await tester.startGesture(tester.getRect(find.byType(InkWell)).center);
+    await expectSplashContinueAfterMove(true);
+    await testGesture.up();
+    frames = await tester.pumpAndSettle();
+    expect(frames > 1, isTrue);
+    expectPaintedCircle(false);
+  });
+
+  testWidgets('When InkWell/Ancestor has a GlobalKey and ancestor Material is replaced, splash should stop.', (WidgetTester tester) async {
+    final Key key = GlobalKey();
+    bool replaced = false;
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: StatefulBuilder(builder: (BuildContext context, void Function(void Function()) setState) {
+        Future<void> changeReplace() async {
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          setState(() {
+            replaced = !replaced;
+          });
+        }
+        return Material(
+          key: ValueKey<bool>(replaced),
+          child: InkWell(
+            key: key,
+            onTap: () {
+              changeReplace();
+            },
+          ),
+        );
+      }),
+    ));
+
+    await tester.tap(find.byType(InkWell));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 60));
+
+    final PaintPattern paintPattern = paints..circle();
+    expect(
+      Material.of(tester.element(find.byType(InkWell)))! as RenderBox,
+      isNot(paintPattern),
+    );
+  });
+
+  testWidgets('When InkWell/Ancestor has a GlobalKey and ancestor Material is replaced, highlight should always be maintained.', (WidgetTester tester) async {
+    const Color hoverColor = Color(0xff00ff00);
+    final Key key = GlobalKey();
+    int onHoverCount = 0;
+    int callChangeReplaceCount = 0;
+    bool replaced = false;
+    int frames;
+
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: StatefulBuilder(builder: (BuildContext context, void Function(void Function()) setState) {
+        Future<void> changeReplace() async {
+          callChangeReplaceCount += 1;
+          await Future<void>.delayed(const Duration(milliseconds: 50));
+          setState(() {
+            replaced = !replaced;
+          });
+        }
+        return Container(
+          margin: replaced ? const EdgeInsets.only(top: 1) : EdgeInsets.zero,
+          child: Material(
+            key: ValueKey<bool>(replaced),
+            child: InkWell(
+              key: key,
+              hoverColor: hoverColor,
+              onTap: () {},
+              onHover: (bool hovered) {
+                onHoverCount += 1;
+                if (hovered)
+                  changeReplace();
+              },
+            ),
+          ),
+        );
+      }),
+    ));
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    addTearDown(gesture.removePointer);
+    // When replaced is true, InkWell point at the top left is 1.
+    await gesture.moveTo(Offset.zero);
+    frames = await tester.pumpAndSettle();
+    expect(frames > 1, isTrue);
+    RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, isNot(paints..rect(color: hoverColor)));
+    expect(onHoverCount, 2);
+    expect(callChangeReplaceCount, 1);
+    expect(replaced, true);
+
+    await gesture.moveTo(tester.getCenter(find.byType(InkWell)));
+    frames = await tester.pumpAndSettle();
+    expect(frames > 1, isTrue);
+    inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+    expect(inkFeatures, paints..rect(color: hoverColor));
+    expect(onHoverCount, 3);
+    expect(callChangeReplaceCount, 2);
+    expect(replaced, false);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/pull/79300
+  testWidgets('When widget dispose, trigger tap cancel', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(
+      // Colors.
+      splashFactory: InkRipple.splashFactory,
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+      home: Scaffold(
+        body: InputChip(
+          label: const Text('Chip'),
+          onPressed: () {},
+        ),
+      ),
+    ));
+
+    await tester.press(find.byType(RawChip));
+    // widget dispose and tap cancel.
+    await tester.pump();
+  });
+
   testWidgets('InkWell dispose statesController', (WidgetTester tester) async {
     int tapCount = 0;
     Widget buildFrame(MaterialStatesController? statesController) {
@@ -1556,4 +1622,76 @@ void main() {
     expect(tapCount, 3);
     expect(pressedCount, 2);
   });
+}
+
+class _TestApp extends StatefulWidget {
+  const _TestApp({super.key});
+
+  @override
+  _TestAppState createState() => _TestAppState();
+}
+
+class _TestAppState extends State<_TestApp> {
+  bool wrap = false;
+  bool tapDownChangeWrap = false;
+  bool tapChangeWrap = false;
+  Key? inkWellKey;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = InkWell(
+      key: inkWellKey,
+      onTap: () async {
+        if (tapChangeWrap) {
+          await changeWrap();
+        }
+      },
+      onTapDown: (_) async {
+        if (tapDownChangeWrap) {
+          await changeWrap();
+        }
+      },
+    );
+
+    if (wrap) {
+      child = Container(
+        child: child,
+      );
+    }
+
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Material(
+        child: child,
+      ),
+    );
+  }
+
+  Future<void> changeWrap() async {
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+    setState(() {
+      wrap = !wrap;
+    });
+  }
+
+  void setInkWellKey(Key key) {
+    setState(() {
+      inkWellKey = key;
+    });
+  }
+
+  void switchTapDownChangeWrap() {
+    setState(() {
+      tapDownChangeWrap = true;
+      tapChangeWrap = false;
+    });
+  }
+
+  void switchTapChangeWrap() {
+    setState(() {
+      tapChangeWrap = true;
+      tapDownChangeWrap = false;
+    });
+  }
+
 }

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -1769,6 +1769,26 @@ void main() {
     expect(item1Height, 30.0);
     expect(item2Height, 30.0);
   });
+
+  // Test the case where an item contains an InkWell.
+  //
+  // This is a regression test to an issue where lifting such an item might lead
+  // to a crash, due to the InkFeature's controller no longer being the
+  // InkWell's ancestor.
+  testWidgets('Items might contain InkWells', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: _SwitchListView(),
+        ),
+      ),
+    );
+
+    await tester.startGesture(tester.getCenter(find.byKey(const Key('1'))));
+    await tester.pumpAndSettle(const Duration(seconds: 2));
+
+    // If it passes it works.
+  });
 }
 
 Future<void> longPressDrag(WidgetTester tester, Offset start, Offset end) async {
@@ -1802,6 +1822,44 @@ class _StatefulState extends State<_Stateful> {
           onChanged: (bool? newValue) => checked = newValue,
         ),
       ),
+    );
+  }
+}
+
+class _SwitchListView extends StatefulWidget {
+  const _SwitchListView();
+
+  @override
+  State<_SwitchListView> createState() => _SwitchListViewState();
+}
+
+class _SwitchListViewState extends State<_SwitchListView> {
+  final List<int> _items = List<int>.generate(50, (int index) => index);
+
+  @override
+  Widget build(BuildContext context) {
+    return ReorderableListView(
+      padding: const EdgeInsets.symmetric(horizontal: 40),
+      children: <Widget>[
+        for (int index = 0; index < _items.length; index++)
+          Container(
+            key: Key('$index'),
+            child: SwitchListTile.adaptive(
+              title: Text('Item ${_items[index]}'),
+              value: true,
+              onChanged: (bool _) {},
+            ),
+          ),
+      ],
+      onReorder: (int oldIndex, int newIndex) {
+        setState(() {
+          if (oldIndex < newIndex) {
+            newIndex -= 1;
+          }
+          final int item = _items.removeAt(oldIndex);
+          _items.insert(newIndex, item);
+        });
+      },
     );
   }
 }


### PR DESCRIPTION
This is a reland of https://github.com/flutter/flutter/pull/81445, https://github.com/flutter/flutter/pull/70607 and https://github.com/flutter/flutter/pull/80466, co-authored by @YeungKC, fixing a 5-year old issue https://github.com/flutter/flutter/issues/6751.

With this PR, if an `InkWell` is marked with a `GlobalKey`, reparenting it will keep its splashes, instead of resetting them. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
