### PR TITLE
[flutter_conductor] deprecate increment

### DIFF
--- a/dev/conductor/README.md
+++ b/dev/conductor/README.md
@@ -44,8 +44,12 @@ conductor start \
   --engine-cherrypicks=72114dafe28c8700f1d5d629c6ae9d34172ba395 \
   --framework-cherrypicks=a3e66b396746f6581b2b7efd1b0d0f0074215128,d8d853436206e86f416236b930e97779b143a100 \
   --dart-revision=4511eb2a779a612d9d6b2012123575013e0aef12 \
-  --increment=m
 ```
+
+The conductor will, based on the release channel and the presence/lack of
+previous tags, determine which part of the release version should be
+incremented. In the cases where this is not correct, the version can be
+overridden with `--version-override=3.0.0`.
 
 For more details on these command line arguments, see `conductor help start`.
 This command will write to disk a state file that will persist until the release

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -16,8 +16,6 @@ const List<String> kBaseReleaseChannels = <String>['stable', 'beta'];
 
 const List<String> kReleaseChannels = <String>[...kBaseReleaseChannels, FrameworkRepository.defaultBranch];
 
-const List<String> kReleaseIncrements = <String>['y', 'z', 'm', 'n'];
-
 const String kReleaseDocumentationUrl = 'https://github.com/flutter/flutter/wiki/Flutter-Cherrypick-Process';
 
 const String kLuciPackagingConsoleLink = 'https://ci.chromium.org/p/flutter/g/packaging/console';

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -197,10 +197,3 @@ String getNewPrLink({
       '&title=${Uri.encodeQueryComponent(title)}'
       '&body=${Uri.encodeQueryComponent(body.toString())}';
 }
-
-enum ReleaseType {
-  StableInitial, // z = 0
-  StableHotfix, // z += 1
-  BetaInitial, // parse x, y, and m from branch, n == 0
-  BetaHotfix, // n += 1
-}

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -197,3 +197,10 @@ String getNewPrLink({
       '&title=${Uri.encodeQueryComponent(title)}'
       '&body=${Uri.encodeQueryComponent(body.toString())}';
 }
+
+enum ReleaseType {
+  StableInitial, // z = 0
+  StableHotfix, // z += 1
+  BetaInitial, // parse x, y, and m from branch, n == 0
+  BetaHotfix, // n += 1
+}

--- a/dev/conductor/core/lib/src/proto/compile_proto.sh
+++ b/dev/conductor/core/lib/src/proto/compile_proto.sh
@@ -5,7 +5,6 @@
 
 # //flutter/dev/tools/lib/proto
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-DARTFMT="$DIR/../../../../bin/cache/dart-sdk/bin/dartfmt"
 
 # Ensure dart-sdk is cached
 "$DIR/../../../../bin/dart" --version
@@ -29,7 +28,7 @@ protoc --dart_out="$DIR" --proto_path="$DIR" "$DIR/conductor_state.proto"
 
 for SOURCE_FILE in $(ls "$DIR"/*.pb*.dart); do
   # Format in place file
-  "$DARTFMT" --overwrite --line-length 120 "$SOURCE_FILE"
+  dart format --output=write --line-length 120 "$SOURCE_FILE"
 
   # Create temp copy with the license header prepended
   cp "$DIR/license_header.txt" "${SOURCE_FILE}.tmp"

--- a/dev/conductor/core/lib/src/proto/conductor_state.pb.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pb.dart
@@ -19,11 +19,14 @@ import 'conductor_state.pbenum.dart';
 export 'conductor_state.pbenum.dart';
 
 class Remote extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Remote', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Remote',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
+      createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
-    ..hasRequiredFields = false
-  ;
+    ..hasRequiredFields = false;
 
   Remote._() : super();
   factory Remote({
@@ -39,18 +42,19 @@ class Remote extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Remote.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Remote.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Remote.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Remote.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Remote clone() => Remote()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Remote copyWith(void Function(Remote) updates) => super.copyWith((message) => updates(message as Remote)) as Remote; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Remote copyWith(void Function(Remote) updates) =>
+      super.copyWith((message) => updates(message as Remote)) as Remote; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Remote create() => Remote._();
@@ -63,7 +67,10 @@ class Remote extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -72,7 +79,10 @@ class Remote extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get url => $_getSZ(1);
   @$pb.TagNumber(2)
-  set url($core.String v) { $_setString(1, v); }
+  set url($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -80,12 +90,19 @@ class Remote extends $pb.GeneratedMessage {
 }
 
 class Cherrypick extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Cherrypick', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'trunkRevision', protoName: 'trunkRevision')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appliedRevision', protoName: 'appliedRevision')
-    ..e<CherrypickState>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'state', $pb.PbFieldType.OE, defaultOrMaker: CherrypickState.PENDING, valueOf: CherrypickState.valueOf, enumValues: CherrypickState.values)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Cherrypick',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'trunkRevision',
+        protoName: 'trunkRevision')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appliedRevision',
+        protoName: 'appliedRevision')
+    ..e<CherrypickState>(
+        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'state', $pb.PbFieldType.OE,
+        defaultOrMaker: CherrypickState.PENDING, valueOf: CherrypickState.valueOf, enumValues: CherrypickState.values)
+    ..hasRequiredFields = false;
 
   Cherrypick._() : super();
   factory Cherrypick({
@@ -105,18 +122,19 @@ class Cherrypick extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Cherrypick.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Cherrypick.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Cherrypick.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Cherrypick.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Cherrypick clone() => Cherrypick()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Cherrypick copyWith(void Function(Cherrypick) updates) => super.copyWith((message) => updates(message as Cherrypick)) as Cherrypick; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Cherrypick copyWith(void Function(Cherrypick) updates) =>
+      super.copyWith((message) => updates(message as Cherrypick)) as Cherrypick; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Cherrypick create() => Cherrypick._();
@@ -129,7 +147,10 @@ class Cherrypick extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get trunkRevision => $_getSZ(0);
   @$pb.TagNumber(1)
-  set trunkRevision($core.String v) { $_setString(0, v); }
+  set trunkRevision($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasTrunkRevision() => $_has(0);
   @$pb.TagNumber(1)
@@ -138,7 +159,10 @@ class Cherrypick extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get appliedRevision => $_getSZ(1);
   @$pb.TagNumber(2)
-  set appliedRevision($core.String v) { $_setString(1, v); }
+  set appliedRevision($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasAppliedRevision() => $_has(1);
   @$pb.TagNumber(2)
@@ -147,7 +171,10 @@ class Cherrypick extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   CherrypickState get state => $_getN(2);
   @$pb.TagNumber(3)
-  set state(CherrypickState v) { setField(3, v); }
+  set state(CherrypickState v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasState() => $_has(2);
   @$pb.TagNumber(3)
@@ -155,18 +182,31 @@ class Cherrypick extends $pb.GeneratedMessage {
 }
 
 class Repository extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Repository', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'candidateBranch', protoName: 'candidateBranch')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'startingGitHead', protoName: 'startingGitHead')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentGitHead', protoName: 'currentGitHead')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'checkoutPath', protoName: 'checkoutPath')
-    ..aOM<Remote>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'upstream', subBuilder: Remote.create)
-    ..aOM<Remote>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mirror', subBuilder: Remote.create)
-    ..pc<Cherrypick>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cherrypicks', $pb.PbFieldType.PM, subBuilder: Cherrypick.create)
-    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dartRevision', protoName: 'dartRevision')
-    ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'workingBranch', protoName: 'workingBranch')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Repository',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'candidateBranch',
+        protoName: 'candidateBranch')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'startingGitHead',
+        protoName: 'startingGitHead')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentGitHead',
+        protoName: 'currentGitHead')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'checkoutPath',
+        protoName: 'checkoutPath')
+    ..aOM<Remote>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'upstream',
+        subBuilder: Remote.create)
+    ..aOM<Remote>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mirror',
+        subBuilder: Remote.create)
+    ..pc<Cherrypick>(
+        7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cherrypicks', $pb.PbFieldType.PM,
+        subBuilder: Cherrypick.create)
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dartRevision',
+        protoName: 'dartRevision')
+    ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'workingBranch',
+        protoName: 'workingBranch')
+    ..hasRequiredFields = false;
 
   Repository._() : super();
   factory Repository({
@@ -210,18 +250,19 @@ class Repository extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Repository.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory Repository.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory Repository.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Repository.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   Repository clone() => Repository()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  Repository copyWith(void Function(Repository) updates) => super.copyWith((message) => updates(message as Repository)) as Repository; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Repository copyWith(void Function(Repository) updates) =>
+      super.copyWith((message) => updates(message as Repository)) as Repository; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Repository create() => Repository._();
@@ -234,7 +275,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get candidateBranch => $_getSZ(0);
   @$pb.TagNumber(1)
-  set candidateBranch($core.String v) { $_setString(0, v); }
+  set candidateBranch($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasCandidateBranch() => $_has(0);
   @$pb.TagNumber(1)
@@ -243,7 +287,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get startingGitHead => $_getSZ(1);
   @$pb.TagNumber(2)
-  set startingGitHead($core.String v) { $_setString(1, v); }
+  set startingGitHead($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasStartingGitHead() => $_has(1);
   @$pb.TagNumber(2)
@@ -252,7 +299,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get currentGitHead => $_getSZ(2);
   @$pb.TagNumber(3)
-  set currentGitHead($core.String v) { $_setString(2, v); }
+  set currentGitHead($core.String v) {
+    $_setString(2, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasCurrentGitHead() => $_has(2);
   @$pb.TagNumber(3)
@@ -261,7 +311,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get checkoutPath => $_getSZ(3);
   @$pb.TagNumber(4)
-  set checkoutPath($core.String v) { $_setString(3, v); }
+  set checkoutPath($core.String v) {
+    $_setString(3, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasCheckoutPath() => $_has(3);
   @$pb.TagNumber(4)
@@ -270,7 +323,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   Remote get upstream => $_getN(4);
   @$pb.TagNumber(5)
-  set upstream(Remote v) { setField(5, v); }
+  set upstream(Remote v) {
+    setField(5, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasUpstream() => $_has(4);
   @$pb.TagNumber(5)
@@ -281,7 +337,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   Remote get mirror => $_getN(5);
   @$pb.TagNumber(6)
-  set mirror(Remote v) { setField(6, v); }
+  set mirror(Remote v) {
+    setField(6, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasMirror() => $_has(5);
   @$pb.TagNumber(6)
@@ -295,7 +354,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get dartRevision => $_getSZ(7);
   @$pb.TagNumber(8)
-  set dartRevision($core.String v) { $_setString(7, v); }
+  set dartRevision($core.String v) {
+    $_setString(7, v);
+  }
+
   @$pb.TagNumber(8)
   $core.bool hasDartRevision() => $_has(7);
   @$pb.TagNumber(8)
@@ -304,7 +366,10 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get workingBranch => $_getSZ(8);
   @$pb.TagNumber(9)
-  set workingBranch($core.String v) { $_setString(8, v); }
+  set workingBranch($core.String v) {
+    $_setString(8, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasWorkingBranch() => $_has(8);
   @$pb.TagNumber(9)
@@ -312,19 +377,39 @@ class Repository extends $pb.GeneratedMessage {
 }
 
 class ConductorState extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConductorState', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseChannel', protoName: 'releaseChannel')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseVersion', protoName: 'releaseVersion')
-    ..aOM<Repository>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'engine', subBuilder: Repository.create)
-    ..aOM<Repository>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'framework', subBuilder: Repository.create)
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'createdDate', protoName: 'createdDate')
-    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lastUpdatedDate', protoName: 'lastUpdatedDate')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConductorState',
+      package: const $pb.PackageName(
+          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
+      createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseChannel',
+        protoName: 'releaseChannel')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseVersion',
+        protoName: 'releaseVersion')
+    ..aOM<Repository>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'engine',
+        subBuilder: Repository.create)
+    ..aOM<Repository>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'framework',
+        subBuilder: Repository.create)
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'createdDate',
+        protoName: 'createdDate')
+    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lastUpdatedDate',
+        protoName: 'lastUpdatedDate')
     ..pPS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'logs')
-    ..e<ReleasePhase>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentPhase', $pb.PbFieldType.OE, protoName: 'currentPhase', defaultOrMaker: ReleasePhase.APPLY_ENGINE_CHERRYPICKS, valueOf: ReleasePhase.valueOf, enumValues: ReleasePhase.values)
-    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'conductorVersion', protoName: 'conductorVersion')
-    ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'incrementLevel', protoName: 'incrementLevel')
-    ..hasRequiredFields = false
-  ;
+    ..e<ReleasePhase>(
+        9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentPhase', $pb.PbFieldType.OE,
+        protoName: 'currentPhase',
+        defaultOrMaker: ReleasePhase.APPLY_ENGINE_CHERRYPICKS,
+        valueOf: ReleasePhase.valueOf,
+        enumValues: ReleasePhase.values)
+    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'conductorVersion',
+        protoName: 'conductorVersion')
+    ..e<ReleaseType>(
+        11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseType', $pb.PbFieldType.OE,
+        protoName: 'releaseType',
+        defaultOrMaker: ReleaseType.STABLE_INITIAL,
+        valueOf: ReleaseType.valueOf,
+        enumValues: ReleaseType.values)
+    ..hasRequiredFields = false;
 
   ConductorState._() : super();
   factory ConductorState({
@@ -337,7 +422,7 @@ class ConductorState extends $pb.GeneratedMessage {
     $core.Iterable<$core.String>? logs,
     ReleasePhase? currentPhase,
     $core.String? conductorVersion,
-    $core.String? incrementLevel,
+    ReleaseType? releaseType,
   }) {
     final _result = create();
     if (releaseChannel != null) {
@@ -367,23 +452,25 @@ class ConductorState extends $pb.GeneratedMessage {
     if (conductorVersion != null) {
       _result.conductorVersion = conductorVersion;
     }
-    if (incrementLevel != null) {
-      _result.incrementLevel = incrementLevel;
+    if (releaseType != null) {
+      _result.releaseType = releaseType;
     }
     return _result;
   }
-  factory ConductorState.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory ConductorState.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory ConductorState.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory ConductorState.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   ConductorState clone() => ConductorState()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  ConductorState copyWith(void Function(ConductorState) updates) => super.copyWith((message) => updates(message as ConductorState)) as ConductorState; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  ConductorState copyWith(void Function(ConductorState) updates) =>
+      super.copyWith((message) => updates(message as ConductorState))
+          as ConductorState; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ConductorState create() => ConductorState._();
@@ -396,7 +483,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get releaseChannel => $_getSZ(0);
   @$pb.TagNumber(1)
-  set releaseChannel($core.String v) { $_setString(0, v); }
+  set releaseChannel($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasReleaseChannel() => $_has(0);
   @$pb.TagNumber(1)
@@ -405,7 +495,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get releaseVersion => $_getSZ(1);
   @$pb.TagNumber(2)
-  set releaseVersion($core.String v) { $_setString(1, v); }
+  set releaseVersion($core.String v) {
+    $_setString(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasReleaseVersion() => $_has(1);
   @$pb.TagNumber(2)
@@ -414,7 +507,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   Repository get engine => $_getN(2);
   @$pb.TagNumber(4)
-  set engine(Repository v) { setField(4, v); }
+  set engine(Repository v) {
+    setField(4, v);
+  }
+
   @$pb.TagNumber(4)
   $core.bool hasEngine() => $_has(2);
   @$pb.TagNumber(4)
@@ -425,7 +521,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   Repository get framework => $_getN(3);
   @$pb.TagNumber(5)
-  set framework(Repository v) { setField(5, v); }
+  set framework(Repository v) {
+    setField(5, v);
+  }
+
   @$pb.TagNumber(5)
   $core.bool hasFramework() => $_has(3);
   @$pb.TagNumber(5)
@@ -436,7 +535,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get createdDate => $_getI64(4);
   @$pb.TagNumber(6)
-  set createdDate($fixnum.Int64 v) { $_setInt64(4, v); }
+  set createdDate($fixnum.Int64 v) {
+    $_setInt64(4, v);
+  }
+
   @$pb.TagNumber(6)
   $core.bool hasCreatedDate() => $_has(4);
   @$pb.TagNumber(6)
@@ -445,7 +547,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get lastUpdatedDate => $_getI64(5);
   @$pb.TagNumber(7)
-  set lastUpdatedDate($fixnum.Int64 v) { $_setInt64(5, v); }
+  set lastUpdatedDate($fixnum.Int64 v) {
+    $_setInt64(5, v);
+  }
+
   @$pb.TagNumber(7)
   $core.bool hasLastUpdatedDate() => $_has(5);
   @$pb.TagNumber(7)
@@ -457,7 +562,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   ReleasePhase get currentPhase => $_getN(7);
   @$pb.TagNumber(9)
-  set currentPhase(ReleasePhase v) { setField(9, v); }
+  set currentPhase(ReleasePhase v) {
+    setField(9, v);
+  }
+
   @$pb.TagNumber(9)
   $core.bool hasCurrentPhase() => $_has(7);
   @$pb.TagNumber(9)
@@ -466,19 +574,24 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get conductorVersion => $_getSZ(8);
   @$pb.TagNumber(10)
-  set conductorVersion($core.String v) { $_setString(8, v); }
+  set conductorVersion($core.String v) {
+    $_setString(8, v);
+  }
+
   @$pb.TagNumber(10)
   $core.bool hasConductorVersion() => $_has(8);
   @$pb.TagNumber(10)
   void clearConductorVersion() => clearField(10);
 
   @$pb.TagNumber(11)
-  $core.String get incrementLevel => $_getSZ(9);
+  ReleaseType get releaseType => $_getN(9);
   @$pb.TagNumber(11)
-  set incrementLevel($core.String v) { $_setString(9, v); }
-  @$pb.TagNumber(11)
-  $core.bool hasIncrementLevel() => $_has(9);
-  @$pb.TagNumber(11)
-  void clearIncrementLevel() => clearField(11);
-}
+  set releaseType(ReleaseType v) {
+    setField(11, v);
+  }
 
+  @$pb.TagNumber(11)
+  $core.bool hasReleaseType() => $_has(9);
+  @$pb.TagNumber(11)
+  void clearReleaseType() => clearField(11);
+}

--- a/dev/conductor/core/lib/src/proto/conductor_state.pb.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pb.dart
@@ -19,14 +19,11 @@ import 'conductor_state.pbenum.dart';
 export 'conductor_state.pbenum.dart';
 
 class Remote extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Remote',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
-      createEmptyInstance: create)
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Remote', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
     ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
     ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'url')
-    ..hasRequiredFields = false;
+    ..hasRequiredFields = false
+  ;
 
   Remote._() : super();
   factory Remote({
@@ -42,19 +39,18 @@ class Remote extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Remote.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Remote.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory Remote.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Remote.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Remote clone() => Remote()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Remote copyWith(void Function(Remote) updates) =>
-      super.copyWith((message) => updates(message as Remote)) as Remote; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Remote copyWith(void Function(Remote) updates) => super.copyWith((message) => updates(message as Remote)) as Remote; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Remote create() => Remote._();
@@ -67,10 +63,7 @@ class Remote extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) {
-    $_setString(0, v);
-  }
-
+  set name($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -79,10 +72,7 @@ class Remote extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get url => $_getSZ(1);
   @$pb.TagNumber(2)
-  set url($core.String v) {
-    $_setString(1, v);
-  }
-
+  set url($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasUrl() => $_has(1);
   @$pb.TagNumber(2)
@@ -90,19 +80,12 @@ class Remote extends $pb.GeneratedMessage {
 }
 
 class Cherrypick extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Cherrypick',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
-      createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'trunkRevision',
-        protoName: 'trunkRevision')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appliedRevision',
-        protoName: 'appliedRevision')
-    ..e<CherrypickState>(
-        3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'state', $pb.PbFieldType.OE,
-        defaultOrMaker: CherrypickState.PENDING, valueOf: CherrypickState.valueOf, enumValues: CherrypickState.values)
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Cherrypick', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'trunkRevision', protoName: 'trunkRevision')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'appliedRevision', protoName: 'appliedRevision')
+    ..e<CherrypickState>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'state', $pb.PbFieldType.OE, defaultOrMaker: CherrypickState.PENDING, valueOf: CherrypickState.valueOf, enumValues: CherrypickState.values)
+    ..hasRequiredFields = false
+  ;
 
   Cherrypick._() : super();
   factory Cherrypick({
@@ -122,19 +105,18 @@ class Cherrypick extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Cherrypick.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Cherrypick.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory Cherrypick.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Cherrypick.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Cherrypick clone() => Cherrypick()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Cherrypick copyWith(void Function(Cherrypick) updates) =>
-      super.copyWith((message) => updates(message as Cherrypick)) as Cherrypick; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Cherrypick copyWith(void Function(Cherrypick) updates) => super.copyWith((message) => updates(message as Cherrypick)) as Cherrypick; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Cherrypick create() => Cherrypick._();
@@ -147,10 +129,7 @@ class Cherrypick extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get trunkRevision => $_getSZ(0);
   @$pb.TagNumber(1)
-  set trunkRevision($core.String v) {
-    $_setString(0, v);
-  }
-
+  set trunkRevision($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasTrunkRevision() => $_has(0);
   @$pb.TagNumber(1)
@@ -159,10 +138,7 @@ class Cherrypick extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get appliedRevision => $_getSZ(1);
   @$pb.TagNumber(2)
-  set appliedRevision($core.String v) {
-    $_setString(1, v);
-  }
-
+  set appliedRevision($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasAppliedRevision() => $_has(1);
   @$pb.TagNumber(2)
@@ -171,10 +147,7 @@ class Cherrypick extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   CherrypickState get state => $_getN(2);
   @$pb.TagNumber(3)
-  set state(CherrypickState v) {
-    setField(3, v);
-  }
-
+  set state(CherrypickState v) { setField(3, v); }
   @$pb.TagNumber(3)
   $core.bool hasState() => $_has(2);
   @$pb.TagNumber(3)
@@ -182,31 +155,18 @@ class Cherrypick extends $pb.GeneratedMessage {
 }
 
 class Repository extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Repository',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
-      createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'candidateBranch',
-        protoName: 'candidateBranch')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'startingGitHead',
-        protoName: 'startingGitHead')
-    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentGitHead',
-        protoName: 'currentGitHead')
-    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'checkoutPath',
-        protoName: 'checkoutPath')
-    ..aOM<Remote>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'upstream',
-        subBuilder: Remote.create)
-    ..aOM<Remote>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mirror',
-        subBuilder: Remote.create)
-    ..pc<Cherrypick>(
-        7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cherrypicks', $pb.PbFieldType.PM,
-        subBuilder: Cherrypick.create)
-    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dartRevision',
-        protoName: 'dartRevision')
-    ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'workingBranch',
-        protoName: 'workingBranch')
-    ..hasRequiredFields = false;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'Repository', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'candidateBranch', protoName: 'candidateBranch')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'startingGitHead', protoName: 'startingGitHead')
+    ..aOS(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentGitHead', protoName: 'currentGitHead')
+    ..aOS(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'checkoutPath', protoName: 'checkoutPath')
+    ..aOM<Remote>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'upstream', subBuilder: Remote.create)
+    ..aOM<Remote>(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'mirror', subBuilder: Remote.create)
+    ..pc<Cherrypick>(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'cherrypicks', $pb.PbFieldType.PM, subBuilder: Cherrypick.create)
+    ..aOS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'dartRevision', protoName: 'dartRevision')
+    ..aOS(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'workingBranch', protoName: 'workingBranch')
+    ..hasRequiredFields = false
+  ;
 
   Repository._() : super();
   factory Repository({
@@ -250,19 +210,18 @@ class Repository extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory Repository.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory Repository.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory Repository.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory Repository.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   Repository clone() => Repository()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  Repository copyWith(void Function(Repository) updates) =>
-      super.copyWith((message) => updates(message as Repository)) as Repository; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  Repository copyWith(void Function(Repository) updates) => super.copyWith((message) => updates(message as Repository)) as Repository; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static Repository create() => Repository._();
@@ -275,10 +234,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get candidateBranch => $_getSZ(0);
   @$pb.TagNumber(1)
-  set candidateBranch($core.String v) {
-    $_setString(0, v);
-  }
-
+  set candidateBranch($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasCandidateBranch() => $_has(0);
   @$pb.TagNumber(1)
@@ -287,10 +243,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get startingGitHead => $_getSZ(1);
   @$pb.TagNumber(2)
-  set startingGitHead($core.String v) {
-    $_setString(1, v);
-  }
-
+  set startingGitHead($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasStartingGitHead() => $_has(1);
   @$pb.TagNumber(2)
@@ -299,10 +252,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $core.String get currentGitHead => $_getSZ(2);
   @$pb.TagNumber(3)
-  set currentGitHead($core.String v) {
-    $_setString(2, v);
-  }
-
+  set currentGitHead($core.String v) { $_setString(2, v); }
   @$pb.TagNumber(3)
   $core.bool hasCurrentGitHead() => $_has(2);
   @$pb.TagNumber(3)
@@ -311,10 +261,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   $core.String get checkoutPath => $_getSZ(3);
   @$pb.TagNumber(4)
-  set checkoutPath($core.String v) {
-    $_setString(3, v);
-  }
-
+  set checkoutPath($core.String v) { $_setString(3, v); }
   @$pb.TagNumber(4)
   $core.bool hasCheckoutPath() => $_has(3);
   @$pb.TagNumber(4)
@@ -323,10 +270,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   Remote get upstream => $_getN(4);
   @$pb.TagNumber(5)
-  set upstream(Remote v) {
-    setField(5, v);
-  }
-
+  set upstream(Remote v) { setField(5, v); }
   @$pb.TagNumber(5)
   $core.bool hasUpstream() => $_has(4);
   @$pb.TagNumber(5)
@@ -337,10 +281,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   Remote get mirror => $_getN(5);
   @$pb.TagNumber(6)
-  set mirror(Remote v) {
-    setField(6, v);
-  }
-
+  set mirror(Remote v) { setField(6, v); }
   @$pb.TagNumber(6)
   $core.bool hasMirror() => $_has(5);
   @$pb.TagNumber(6)
@@ -354,10 +295,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(8)
   $core.String get dartRevision => $_getSZ(7);
   @$pb.TagNumber(8)
-  set dartRevision($core.String v) {
-    $_setString(7, v);
-  }
-
+  set dartRevision($core.String v) { $_setString(7, v); }
   @$pb.TagNumber(8)
   $core.bool hasDartRevision() => $_has(7);
   @$pb.TagNumber(8)
@@ -366,10 +304,7 @@ class Repository extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   $core.String get workingBranch => $_getSZ(8);
   @$pb.TagNumber(9)
-  set workingBranch($core.String v) {
-    $_setString(8, v);
-  }
-
+  set workingBranch($core.String v) { $_setString(8, v); }
   @$pb.TagNumber(9)
   $core.bool hasWorkingBranch() => $_has(8);
   @$pb.TagNumber(9)
@@ -377,35 +312,19 @@ class Repository extends $pb.GeneratedMessage {
 }
 
 class ConductorState extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
-      const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConductorState',
-      package: const $pb.PackageName(
-          const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'),
-      createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseChannel',
-        protoName: 'releaseChannel')
-    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseVersion',
-        protoName: 'releaseVersion')
-    ..aOM<Repository>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'engine',
-        subBuilder: Repository.create)
-    ..aOM<Repository>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'framework',
-        subBuilder: Repository.create)
-    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'createdDate',
-        protoName: 'createdDate')
-    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lastUpdatedDate',
-        protoName: 'lastUpdatedDate')
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'ConductorState', package: const $pb.PackageName(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'conductor_state'), createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseChannel', protoName: 'releaseChannel')
+    ..aOS(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'releaseVersion', protoName: 'releaseVersion')
+    ..aOM<Repository>(4, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'engine', subBuilder: Repository.create)
+    ..aOM<Repository>(5, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'framework', subBuilder: Repository.create)
+    ..aInt64(6, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'createdDate', protoName: 'createdDate')
+    ..aInt64(7, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'lastUpdatedDate', protoName: 'lastUpdatedDate')
     ..pPS(8, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'logs')
-    ..e<ReleasePhase>(
-        9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentPhase', $pb.PbFieldType.OE,
-        protoName: 'currentPhase',
-        defaultOrMaker: ReleasePhase.APPLY_ENGINE_CHERRYPICKS,
-        valueOf: ReleasePhase.valueOf,
-        enumValues: ReleasePhase.values)
-    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'conductorVersion',
-        protoName: 'conductorVersion')
-    ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'incrementLevel',
-        protoName: 'incrementLevel')
-    ..hasRequiredFields = false;
+    ..e<ReleasePhase>(9, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'currentPhase', $pb.PbFieldType.OE, protoName: 'currentPhase', defaultOrMaker: ReleasePhase.APPLY_ENGINE_CHERRYPICKS, valueOf: ReleasePhase.valueOf, enumValues: ReleasePhase.values)
+    ..aOS(10, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'conductorVersion', protoName: 'conductorVersion')
+    ..aOS(11, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'incrementLevel', protoName: 'incrementLevel')
+    ..hasRequiredFields = false
+  ;
 
   ConductorState._() : super();
   factory ConductorState({
@@ -453,20 +372,18 @@ class ConductorState extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory ConductorState.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromBuffer(i, r);
-  factory ConductorState.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
-      create()..mergeFromJson(i, r);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-      'Will be removed in next major version')
+  factory ConductorState.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory ConductorState.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
   ConductorState clone() => ConductorState()..mergeFromMessage(this);
-  @$core.Deprecated('Using this can add significant overhead to your binary. '
-      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-      'Will be removed in next major version')
-  ConductorState copyWith(void Function(ConductorState) updates) =>
-      super.copyWith((message) => updates(message as ConductorState))
-          as ConductorState; // ignore: deprecated_member_use
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  ConductorState copyWith(void Function(ConductorState) updates) => super.copyWith((message) => updates(message as ConductorState)) as ConductorState; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static ConductorState create() => ConductorState._();
@@ -479,10 +396,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(1)
   $core.String get releaseChannel => $_getSZ(0);
   @$pb.TagNumber(1)
-  set releaseChannel($core.String v) {
-    $_setString(0, v);
-  }
-
+  set releaseChannel($core.String v) { $_setString(0, v); }
   @$pb.TagNumber(1)
   $core.bool hasReleaseChannel() => $_has(0);
   @$pb.TagNumber(1)
@@ -491,10 +405,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.String get releaseVersion => $_getSZ(1);
   @$pb.TagNumber(2)
-  set releaseVersion($core.String v) {
-    $_setString(1, v);
-  }
-
+  set releaseVersion($core.String v) { $_setString(1, v); }
   @$pb.TagNumber(2)
   $core.bool hasReleaseVersion() => $_has(1);
   @$pb.TagNumber(2)
@@ -503,10 +414,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(4)
   Repository get engine => $_getN(2);
   @$pb.TagNumber(4)
-  set engine(Repository v) {
-    setField(4, v);
-  }
-
+  set engine(Repository v) { setField(4, v); }
   @$pb.TagNumber(4)
   $core.bool hasEngine() => $_has(2);
   @$pb.TagNumber(4)
@@ -517,10 +425,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(5)
   Repository get framework => $_getN(3);
   @$pb.TagNumber(5)
-  set framework(Repository v) {
-    setField(5, v);
-  }
-
+  set framework(Repository v) { setField(5, v); }
   @$pb.TagNumber(5)
   $core.bool hasFramework() => $_has(3);
   @$pb.TagNumber(5)
@@ -531,10 +436,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(6)
   $fixnum.Int64 get createdDate => $_getI64(4);
   @$pb.TagNumber(6)
-  set createdDate($fixnum.Int64 v) {
-    $_setInt64(4, v);
-  }
-
+  set createdDate($fixnum.Int64 v) { $_setInt64(4, v); }
   @$pb.TagNumber(6)
   $core.bool hasCreatedDate() => $_has(4);
   @$pb.TagNumber(6)
@@ -543,10 +445,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(7)
   $fixnum.Int64 get lastUpdatedDate => $_getI64(5);
   @$pb.TagNumber(7)
-  set lastUpdatedDate($fixnum.Int64 v) {
-    $_setInt64(5, v);
-  }
-
+  set lastUpdatedDate($fixnum.Int64 v) { $_setInt64(5, v); }
   @$pb.TagNumber(7)
   $core.bool hasLastUpdatedDate() => $_has(5);
   @$pb.TagNumber(7)
@@ -558,10 +457,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(9)
   ReleasePhase get currentPhase => $_getN(7);
   @$pb.TagNumber(9)
-  set currentPhase(ReleasePhase v) {
-    setField(9, v);
-  }
-
+  set currentPhase(ReleasePhase v) { setField(9, v); }
   @$pb.TagNumber(9)
   $core.bool hasCurrentPhase() => $_has(7);
   @$pb.TagNumber(9)
@@ -570,10 +466,7 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(10)
   $core.String get conductorVersion => $_getSZ(8);
   @$pb.TagNumber(10)
-  set conductorVersion($core.String v) {
-    $_setString(8, v);
-  }
-
+  set conductorVersion($core.String v) { $_setString(8, v); }
   @$pb.TagNumber(10)
   $core.bool hasConductorVersion() => $_has(8);
   @$pb.TagNumber(10)
@@ -582,12 +475,10 @@ class ConductorState extends $pb.GeneratedMessage {
   @$pb.TagNumber(11)
   $core.String get incrementLevel => $_getSZ(9);
   @$pb.TagNumber(11)
-  set incrementLevel($core.String v) {
-    $_setString(9, v);
-  }
-
+  set incrementLevel($core.String v) { $_setString(9, v); }
   @$pb.TagNumber(11)
   $core.bool hasIncrementLevel() => $_has(9);
   @$pb.TagNumber(11)
   void clearIncrementLevel() => clearField(11);
 }
+

--- a/dev/conductor/core/lib/src/proto/conductor_state.pbenum.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pbenum.dart
@@ -14,15 +14,22 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class ReleasePhase extends $pb.ProtobufEnum {
-  static const ReleasePhase APPLY_ENGINE_CHERRYPICKS = ReleasePhase._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_ENGINE_CHERRYPICKS');
-  static const ReleasePhase CODESIGN_ENGINE_BINARIES = ReleasePhase._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CODESIGN_ENGINE_BINARIES');
-  static const ReleasePhase APPLY_FRAMEWORK_CHERRYPICKS = ReleasePhase._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_FRAMEWORK_CHERRYPICKS');
-  static const ReleasePhase PUBLISH_VERSION = ReleasePhase._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_VERSION');
-  static const ReleasePhase PUBLISH_CHANNEL = ReleasePhase._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_CHANNEL');
-  static const ReleasePhase VERIFY_RELEASE = ReleasePhase._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'VERIFY_RELEASE');
-  static const ReleasePhase RELEASE_COMPLETED = ReleasePhase._(6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'RELEASE_COMPLETED');
+  static const ReleasePhase APPLY_ENGINE_CHERRYPICKS =
+      ReleasePhase._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_ENGINE_CHERRYPICKS');
+  static const ReleasePhase CODESIGN_ENGINE_BINARIES =
+      ReleasePhase._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CODESIGN_ENGINE_BINARIES');
+  static const ReleasePhase APPLY_FRAMEWORK_CHERRYPICKS = ReleasePhase._(
+      2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_FRAMEWORK_CHERRYPICKS');
+  static const ReleasePhase PUBLISH_VERSION =
+      ReleasePhase._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_VERSION');
+  static const ReleasePhase PUBLISH_CHANNEL =
+      ReleasePhase._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_CHANNEL');
+  static const ReleasePhase VERIFY_RELEASE =
+      ReleasePhase._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'VERIFY_RELEASE');
+  static const ReleasePhase RELEASE_COMPLETED =
+      ReleasePhase._(6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'RELEASE_COMPLETED');
 
-  static const $core.List<ReleasePhase> values = <ReleasePhase> [
+  static const $core.List<ReleasePhase> values = <ReleasePhase>[
     APPLY_ENGINE_CHERRYPICKS,
     CODESIGN_ENGINE_BINARIES,
     APPLY_FRAMEWORK_CHERRYPICKS,
@@ -39,12 +46,16 @@ class ReleasePhase extends $pb.ProtobufEnum {
 }
 
 class CherrypickState extends $pb.ProtobufEnum {
-  static const CherrypickState PENDING = CherrypickState._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING');
-  static const CherrypickState PENDING_WITH_CONFLICT = CherrypickState._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING_WITH_CONFLICT');
-  static const CherrypickState COMPLETED = CherrypickState._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'COMPLETED');
-  static const CherrypickState ABANDONED = CherrypickState._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'ABANDONED');
+  static const CherrypickState PENDING =
+      CherrypickState._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING');
+  static const CherrypickState PENDING_WITH_CONFLICT =
+      CherrypickState._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING_WITH_CONFLICT');
+  static const CherrypickState COMPLETED =
+      CherrypickState._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'COMPLETED');
+  static const CherrypickState ABANDONED =
+      CherrypickState._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'ABANDONED');
 
-  static const $core.List<CherrypickState> values = <CherrypickState> [
+  static const $core.List<CherrypickState> values = <CherrypickState>[
     PENDING,
     PENDING_WITH_CONFLICT,
     COMPLETED,
@@ -58,12 +69,16 @@ class CherrypickState extends $pb.ProtobufEnum {
 }
 
 class ReleaseType extends $pb.ProtobufEnum {
-  static const ReleaseType STABLE_INITIAL = ReleaseType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STABLE_INITIAL');
-  static const ReleaseType STABLE_HOTFIX = ReleaseType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STABLE_HOTFIX');
-  static const ReleaseType BETA_INITIAL = ReleaseType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BETA_INITIAL');
-  static const ReleaseType BETA_HOTFIX = ReleaseType._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BETA_HOTFIX');
+  static const ReleaseType STABLE_INITIAL =
+      ReleaseType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STABLE_INITIAL');
+  static const ReleaseType STABLE_HOTFIX =
+      ReleaseType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STABLE_HOTFIX');
+  static const ReleaseType BETA_INITIAL =
+      ReleaseType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BETA_INITIAL');
+  static const ReleaseType BETA_HOTFIX =
+      ReleaseType._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BETA_HOTFIX');
 
-  static const $core.List<ReleaseType> values = <ReleaseType> [
+  static const $core.List<ReleaseType> values = <ReleaseType>[
     STABLE_INITIAL,
     STABLE_HOTFIX,
     BETA_INITIAL,
@@ -75,4 +90,3 @@ class ReleaseType extends $pb.ProtobufEnum {
 
   const ReleaseType._($core.int v, $core.String n) : super(v, n);
 }
-

--- a/dev/conductor/core/lib/src/proto/conductor_state.pbenum.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pbenum.dart
@@ -14,22 +14,15 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class ReleasePhase extends $pb.ProtobufEnum {
-  static const ReleasePhase APPLY_ENGINE_CHERRYPICKS =
-      ReleasePhase._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_ENGINE_CHERRYPICKS');
-  static const ReleasePhase CODESIGN_ENGINE_BINARIES =
-      ReleasePhase._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CODESIGN_ENGINE_BINARIES');
-  static const ReleasePhase APPLY_FRAMEWORK_CHERRYPICKS = ReleasePhase._(
-      2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_FRAMEWORK_CHERRYPICKS');
-  static const ReleasePhase PUBLISH_VERSION =
-      ReleasePhase._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_VERSION');
-  static const ReleasePhase PUBLISH_CHANNEL =
-      ReleasePhase._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_CHANNEL');
-  static const ReleasePhase VERIFY_RELEASE =
-      ReleasePhase._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'VERIFY_RELEASE');
-  static const ReleasePhase RELEASE_COMPLETED =
-      ReleasePhase._(6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'RELEASE_COMPLETED');
+  static const ReleasePhase APPLY_ENGINE_CHERRYPICKS = ReleasePhase._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_ENGINE_CHERRYPICKS');
+  static const ReleasePhase CODESIGN_ENGINE_BINARIES = ReleasePhase._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'CODESIGN_ENGINE_BINARIES');
+  static const ReleasePhase APPLY_FRAMEWORK_CHERRYPICKS = ReleasePhase._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'APPLY_FRAMEWORK_CHERRYPICKS');
+  static const ReleasePhase PUBLISH_VERSION = ReleasePhase._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_VERSION');
+  static const ReleasePhase PUBLISH_CHANNEL = ReleasePhase._(4, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PUBLISH_CHANNEL');
+  static const ReleasePhase VERIFY_RELEASE = ReleasePhase._(5, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'VERIFY_RELEASE');
+  static const ReleasePhase RELEASE_COMPLETED = ReleasePhase._(6, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'RELEASE_COMPLETED');
 
-  static const $core.List<ReleasePhase> values = <ReleasePhase>[
+  static const $core.List<ReleasePhase> values = <ReleasePhase> [
     APPLY_ENGINE_CHERRYPICKS,
     CODESIGN_ENGINE_BINARIES,
     APPLY_FRAMEWORK_CHERRYPICKS,
@@ -46,16 +39,12 @@ class ReleasePhase extends $pb.ProtobufEnum {
 }
 
 class CherrypickState extends $pb.ProtobufEnum {
-  static const CherrypickState PENDING =
-      CherrypickState._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING');
-  static const CherrypickState PENDING_WITH_CONFLICT =
-      CherrypickState._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING_WITH_CONFLICT');
-  static const CherrypickState COMPLETED =
-      CherrypickState._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'COMPLETED');
-  static const CherrypickState ABANDONED =
-      CherrypickState._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'ABANDONED');
+  static const CherrypickState PENDING = CherrypickState._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING');
+  static const CherrypickState PENDING_WITH_CONFLICT = CherrypickState._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'PENDING_WITH_CONFLICT');
+  static const CherrypickState COMPLETED = CherrypickState._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'COMPLETED');
+  static const CherrypickState ABANDONED = CherrypickState._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'ABANDONED');
 
-  static const $core.List<CherrypickState> values = <CherrypickState>[
+  static const $core.List<CherrypickState> values = <CherrypickState> [
     PENDING,
     PENDING_WITH_CONFLICT,
     COMPLETED,
@@ -67,3 +56,23 @@ class CherrypickState extends $pb.ProtobufEnum {
 
   const CherrypickState._($core.int v, $core.String n) : super(v, n);
 }
+
+class ReleaseType extends $pb.ProtobufEnum {
+  static const ReleaseType STABLE_INITIAL = ReleaseType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STABLE_INITIAL');
+  static const ReleaseType STABLE_HOTFIX = ReleaseType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'STABLE_HOTFIX');
+  static const ReleaseType BETA_INITIAL = ReleaseType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BETA_INITIAL');
+  static const ReleaseType BETA_HOTFIX = ReleaseType._(3, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'BETA_HOTFIX');
+
+  static const $core.List<ReleaseType> values = <ReleaseType> [
+    STABLE_INITIAL,
+    STABLE_HOTFIX,
+    BETA_INITIAL,
+    BETA_HOTFIX,
+  ];
+
+  static final $core.Map<$core.int, ReleaseType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static ReleaseType? valueOf($core.int value) => _byValue[value];
+
+  const ReleaseType._($core.int v, $core.String n) : super(v, n);
+}
+

--- a/dev/conductor/core/lib/src/proto/conductor_state.pbjson.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pbjson.dart
@@ -12,6 +12,7 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use releasePhaseDescriptor instead')
 const ReleasePhase$json = const {
   '1': 'ReleasePhase',
@@ -27,7 +28,8 @@ const ReleasePhase$json = const {
 };
 
 /// Descriptor for `ReleasePhase`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List releasePhaseDescriptor = $convert.base64Decode('CgxSZWxlYXNlUGhhc2USHAoYQVBQTFlfRU5HSU5FX0NIRVJSWVBJQ0tTEAASHAoYQ09ERVNJR05fRU5HSU5FX0JJTkFSSUVTEAESHwobQVBQTFlfRlJBTUVXT1JLX0NIRVJSWVBJQ0tTEAISEwoPUFVCTElTSF9WRVJTSU9OEAMSEwoPUFVCTElTSF9DSEFOTkVMEAQSEgoOVkVSSUZZX1JFTEVBU0UQBRIVChFSRUxFQVNFX0NPTVBMRVRFRBAG');
+final $typed_data.Uint8List releasePhaseDescriptor = $convert.base64Decode(
+    'CgxSZWxlYXNlUGhhc2USHAoYQVBQTFlfRU5HSU5FX0NIRVJSWVBJQ0tTEAASHAoYQ09ERVNJR05fRU5HSU5FX0JJTkFSSUVTEAESHwobQVBQTFlfRlJBTUVXT1JLX0NIRVJSWVBJQ0tTEAISEwoPUFVCTElTSF9WRVJTSU9OEAMSEwoPUFVCTElTSF9DSEFOTkVMEAQSEgoOVkVSSUZZX1JFTEVBU0UQBRIVChFSRUxFQVNFX0NPTVBMRVRFRBAG');
 @$core.Deprecated('Use cherrypickStateDescriptor instead')
 const CherrypickState$json = const {
   '1': 'CherrypickState',
@@ -40,7 +42,8 @@ const CherrypickState$json = const {
 };
 
 /// Descriptor for `CherrypickState`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List cherrypickStateDescriptor = $convert.base64Decode('Cg9DaGVycnlwaWNrU3RhdGUSCwoHUEVORElORxAAEhkKFVBFTkRJTkdfV0lUSF9DT05GTElDVBABEg0KCUNPTVBMRVRFRBACEg0KCUFCQU5ET05FRBAD');
+final $typed_data.Uint8List cherrypickStateDescriptor = $convert.base64Decode(
+    'Cg9DaGVycnlwaWNrU3RhdGUSCwoHUEVORElORxAAEhkKFVBFTkRJTkdfV0lUSF9DT05GTElDVBABEg0KCUNPTVBMRVRFRBACEg0KCUFCQU5ET05FRBAD');
 @$core.Deprecated('Use releaseTypeDescriptor instead')
 const ReleaseType$json = const {
   '1': 'ReleaseType',
@@ -53,7 +56,8 @@ const ReleaseType$json = const {
 };
 
 /// Descriptor for `ReleaseType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List releaseTypeDescriptor = $convert.base64Decode('CgtSZWxlYXNlVHlwZRISCg5TVEFCTEVfSU5JVElBTBAAEhEKDVNUQUJMRV9IT1RGSVgQARIQCgxCRVRBX0lOSVRJQUwQAhIPCgtCRVRBX0hPVEZJWBAD');
+final $typed_data.Uint8List releaseTypeDescriptor = $convert.base64Decode(
+    'CgtSZWxlYXNlVHlwZRISCg5TVEFCTEVfSU5JVElBTBAAEhEKDVNUQUJMRV9IT1RGSVgQARIQCgxCRVRBX0lOSVRJQUwQAhIPCgtCRVRBX0hPVEZJWBAD');
 @$core.Deprecated('Use remoteDescriptor instead')
 const Remote$json = const {
   '1': 'Remote',
@@ -64,7 +68,8 @@ const Remote$json = const {
 };
 
 /// Descriptor for `Remote`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List remoteDescriptor = $convert.base64Decode('CgZSZW1vdGUSEgoEbmFtZRgBIAEoCVIEbmFtZRIQCgN1cmwYAiABKAlSA3VybA==');
+final $typed_data.Uint8List remoteDescriptor =
+    $convert.base64Decode('CgZSZW1vdGUSEgoEbmFtZRgBIAEoCVIEbmFtZRIQCgN1cmwYAiABKAlSA3VybA==');
 @$core.Deprecated('Use cherrypickDescriptor instead')
 const Cherrypick$json = const {
   '1': 'Cherrypick',
@@ -76,7 +81,8 @@ const Cherrypick$json = const {
 };
 
 /// Descriptor for `Cherrypick`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List cherrypickDescriptor = $convert.base64Decode('CgpDaGVycnlwaWNrEiQKDXRydW5rUmV2aXNpb24YASABKAlSDXRydW5rUmV2aXNpb24SKAoPYXBwbGllZFJldmlzaW9uGAIgASgJUg9hcHBsaWVkUmV2aXNpb24SNgoFc3RhdGUYAyABKA4yIC5jb25kdWN0b3Jfc3RhdGUuQ2hlcnJ5cGlja1N0YXRlUgVzdGF0ZQ==');
+final $typed_data.Uint8List cherrypickDescriptor = $convert.base64Decode(
+    'CgpDaGVycnlwaWNrEiQKDXRydW5rUmV2aXNpb24YASABKAlSDXRydW5rUmV2aXNpb24SKAoPYXBwbGllZFJldmlzaW9uGAIgASgJUg9hcHBsaWVkUmV2aXNpb24SNgoFc3RhdGUYAyABKA4yIC5jb25kdWN0b3Jfc3RhdGUuQ2hlcnJ5cGlja1N0YXRlUgVzdGF0ZQ==');
 @$core.Deprecated('Use repositoryDescriptor instead')
 const Repository$json = const {
   '1': 'Repository',
@@ -94,7 +100,8 @@ const Repository$json = const {
 };
 
 /// Descriptor for `Repository`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List repositoryDescriptor = $convert.base64Decode('CgpSZXBvc2l0b3J5EigKD2NhbmRpZGF0ZUJyYW5jaBgBIAEoCVIPY2FuZGlkYXRlQnJhbmNoEigKD3N0YXJ0aW5nR2l0SGVhZBgCIAEoCVIPc3RhcnRpbmdHaXRIZWFkEiYKDmN1cnJlbnRHaXRIZWFkGAMgASgJUg5jdXJyZW50R2l0SGVhZBIiCgxjaGVja291dFBhdGgYBCABKAlSDGNoZWNrb3V0UGF0aBIzCgh1cHN0cmVhbRgFIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSCHVwc3RyZWFtEi8KBm1pcnJvchgGIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSBm1pcnJvchI9CgtjaGVycnlwaWNrcxgHIAMoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5DaGVycnlwaWNrUgtjaGVycnlwaWNrcxIiCgxkYXJ0UmV2aXNpb24YCCABKAlSDGRhcnRSZXZpc2lvbhIkCg13b3JraW5nQnJhbmNoGAkgASgJUg13b3JraW5nQnJhbmNo');
+final $typed_data.Uint8List repositoryDescriptor = $convert.base64Decode(
+    'CgpSZXBvc2l0b3J5EigKD2NhbmRpZGF0ZUJyYW5jaBgBIAEoCVIPY2FuZGlkYXRlQnJhbmNoEigKD3N0YXJ0aW5nR2l0SGVhZBgCIAEoCVIPc3RhcnRpbmdHaXRIZWFkEiYKDmN1cnJlbnRHaXRIZWFkGAMgASgJUg5jdXJyZW50R2l0SGVhZBIiCgxjaGVja291dFBhdGgYBCABKAlSDGNoZWNrb3V0UGF0aBIzCgh1cHN0cmVhbRgFIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSCHVwc3RyZWFtEi8KBm1pcnJvchgGIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSBm1pcnJvchI9CgtjaGVycnlwaWNrcxgHIAMoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5DaGVycnlwaWNrUgtjaGVycnlwaWNrcxIiCgxkYXJ0UmV2aXNpb24YCCABKAlSDGRhcnRSZXZpc2lvbhIkCg13b3JraW5nQnJhbmNoGAkgASgJUg13b3JraW5nQnJhbmNo');
 @$core.Deprecated('Use conductorStateDescriptor instead')
 const ConductorState$json = const {
   '1': 'ConductorState',
@@ -108,9 +115,10 @@ const ConductorState$json = const {
     const {'1': 'logs', '3': 8, '4': 3, '5': 9, '10': 'logs'},
     const {'1': 'currentPhase', '3': 9, '4': 1, '5': 14, '6': '.conductor_state.ReleasePhase', '10': 'currentPhase'},
     const {'1': 'conductorVersion', '3': 10, '4': 1, '5': 9, '10': 'conductorVersion'},
-    const {'1': 'incrementLevel', '3': 11, '4': 1, '5': 9, '10': 'incrementLevel'},
+    const {'1': 'releaseType', '3': 11, '4': 1, '5': 14, '6': '.conductor_state.ReleaseType', '10': 'releaseType'},
   ],
 };
 
 /// Descriptor for `ConductorState`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List conductorStateDescriptor = $convert.base64Decode('Cg5Db25kdWN0b3JTdGF0ZRImCg5yZWxlYXNlQ2hhbm5lbBgBIAEoCVIOcmVsZWFzZUNoYW5uZWwSJgoOcmVsZWFzZVZlcnNpb24YAiABKAlSDnJlbGVhc2VWZXJzaW9uEjMKBmVuZ2luZRgEIAEoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5SZXBvc2l0b3J5UgZlbmdpbmUSOQoJZnJhbWV3b3JrGAUgASgLMhsuY29uZHVjdG9yX3N0YXRlLlJlcG9zaXRvcnlSCWZyYW1ld29yaxIgCgtjcmVhdGVkRGF0ZRgGIAEoA1ILY3JlYXRlZERhdGUSKAoPbGFzdFVwZGF0ZWREYXRlGAcgASgDUg9sYXN0VXBkYXRlZERhdGUSEgoEbG9ncxgIIAMoCVIEbG9ncxJBCgxjdXJyZW50UGhhc2UYCSABKA4yHS5jb25kdWN0b3Jfc3RhdGUuUmVsZWFzZVBoYXNlUgxjdXJyZW50UGhhc2USKgoQY29uZHVjdG9yVmVyc2lvbhgKIAEoCVIQY29uZHVjdG9yVmVyc2lvbhImCg5pbmNyZW1lbnRMZXZlbBgLIAEoCVIOaW5jcmVtZW50TGV2ZWw=');
+final $typed_data.Uint8List conductorStateDescriptor = $convert.base64Decode(
+    'Cg5Db25kdWN0b3JTdGF0ZRImCg5yZWxlYXNlQ2hhbm5lbBgBIAEoCVIOcmVsZWFzZUNoYW5uZWwSJgoOcmVsZWFzZVZlcnNpb24YAiABKAlSDnJlbGVhc2VWZXJzaW9uEjMKBmVuZ2luZRgEIAEoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5SZXBvc2l0b3J5UgZlbmdpbmUSOQoJZnJhbWV3b3JrGAUgASgLMhsuY29uZHVjdG9yX3N0YXRlLlJlcG9zaXRvcnlSCWZyYW1ld29yaxIgCgtjcmVhdGVkRGF0ZRgGIAEoA1ILY3JlYXRlZERhdGUSKAoPbGFzdFVwZGF0ZWREYXRlGAcgASgDUg9sYXN0VXBkYXRlZERhdGUSEgoEbG9ncxgIIAMoCVIEbG9ncxJBCgxjdXJyZW50UGhhc2UYCSABKA4yHS5jb25kdWN0b3Jfc3RhdGUuUmVsZWFzZVBoYXNlUgxjdXJyZW50UGhhc2USKgoQY29uZHVjdG9yVmVyc2lvbhgKIAEoCVIQY29uZHVjdG9yVmVyc2lvbhI+CgtyZWxlYXNlVHlwZRgLIAEoDjIcLmNvbmR1Y3Rvcl9zdGF0ZS5SZWxlYXNlVHlwZVILcmVsZWFzZVR5cGU=');

--- a/dev/conductor/core/lib/src/proto/conductor_state.pbjson.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pbjson.dart
@@ -12,7 +12,6 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
-
 @$core.Deprecated('Use releasePhaseDescriptor instead')
 const ReleasePhase$json = const {
   '1': 'ReleasePhase',
@@ -28,8 +27,7 @@ const ReleasePhase$json = const {
 };
 
 /// Descriptor for `ReleasePhase`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List releasePhaseDescriptor = $convert.base64Decode(
-    'CgxSZWxlYXNlUGhhc2USHAoYQVBQTFlfRU5HSU5FX0NIRVJSWVBJQ0tTEAASHAoYQ09ERVNJR05fRU5HSU5FX0JJTkFSSUVTEAESHwobQVBQTFlfRlJBTUVXT1JLX0NIRVJSWVBJQ0tTEAISEwoPUFVCTElTSF9WRVJTSU9OEAMSEwoPUFVCTElTSF9DSEFOTkVMEAQSEgoOVkVSSUZZX1JFTEVBU0UQBRIVChFSRUxFQVNFX0NPTVBMRVRFRBAG');
+final $typed_data.Uint8List releasePhaseDescriptor = $convert.base64Decode('CgxSZWxlYXNlUGhhc2USHAoYQVBQTFlfRU5HSU5FX0NIRVJSWVBJQ0tTEAASHAoYQ09ERVNJR05fRU5HSU5FX0JJTkFSSUVTEAESHwobQVBQTFlfRlJBTUVXT1JLX0NIRVJSWVBJQ0tTEAISEwoPUFVCTElTSF9WRVJTSU9OEAMSEwoPUFVCTElTSF9DSEFOTkVMEAQSEgoOVkVSSUZZX1JFTEVBU0UQBRIVChFSRUxFQVNFX0NPTVBMRVRFRBAG');
 @$core.Deprecated('Use cherrypickStateDescriptor instead')
 const CherrypickState$json = const {
   '1': 'CherrypickState',
@@ -42,8 +40,20 @@ const CherrypickState$json = const {
 };
 
 /// Descriptor for `CherrypickState`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List cherrypickStateDescriptor = $convert.base64Decode(
-    'Cg9DaGVycnlwaWNrU3RhdGUSCwoHUEVORElORxAAEhkKFVBFTkRJTkdfV0lUSF9DT05GTElDVBABEg0KCUNPTVBMRVRFRBACEg0KCUFCQU5ET05FRBAD');
+final $typed_data.Uint8List cherrypickStateDescriptor = $convert.base64Decode('Cg9DaGVycnlwaWNrU3RhdGUSCwoHUEVORElORxAAEhkKFVBFTkRJTkdfV0lUSF9DT05GTElDVBABEg0KCUNPTVBMRVRFRBACEg0KCUFCQU5ET05FRBAD');
+@$core.Deprecated('Use releaseTypeDescriptor instead')
+const ReleaseType$json = const {
+  '1': 'ReleaseType',
+  '2': const [
+    const {'1': 'STABLE_INITIAL', '2': 0},
+    const {'1': 'STABLE_HOTFIX', '2': 1},
+    const {'1': 'BETA_INITIAL', '2': 2},
+    const {'1': 'BETA_HOTFIX', '2': 3},
+  ],
+};
+
+/// Descriptor for `ReleaseType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List releaseTypeDescriptor = $convert.base64Decode('CgtSZWxlYXNlVHlwZRISCg5TVEFCTEVfSU5JVElBTBAAEhEKDVNUQUJMRV9IT1RGSVgQARIQCgxCRVRBX0lOSVRJQUwQAhIPCgtCRVRBX0hPVEZJWBAD');
 @$core.Deprecated('Use remoteDescriptor instead')
 const Remote$json = const {
   '1': 'Remote',
@@ -54,8 +64,7 @@ const Remote$json = const {
 };
 
 /// Descriptor for `Remote`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List remoteDescriptor =
-    $convert.base64Decode('CgZSZW1vdGUSEgoEbmFtZRgBIAEoCVIEbmFtZRIQCgN1cmwYAiABKAlSA3VybA==');
+final $typed_data.Uint8List remoteDescriptor = $convert.base64Decode('CgZSZW1vdGUSEgoEbmFtZRgBIAEoCVIEbmFtZRIQCgN1cmwYAiABKAlSA3VybA==');
 @$core.Deprecated('Use cherrypickDescriptor instead')
 const Cherrypick$json = const {
   '1': 'Cherrypick',
@@ -67,8 +76,7 @@ const Cherrypick$json = const {
 };
 
 /// Descriptor for `Cherrypick`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List cherrypickDescriptor = $convert.base64Decode(
-    'CgpDaGVycnlwaWNrEiQKDXRydW5rUmV2aXNpb24YASABKAlSDXRydW5rUmV2aXNpb24SKAoPYXBwbGllZFJldmlzaW9uGAIgASgJUg9hcHBsaWVkUmV2aXNpb24SNgoFc3RhdGUYAyABKA4yIC5jb25kdWN0b3Jfc3RhdGUuQ2hlcnJ5cGlja1N0YXRlUgVzdGF0ZQ==');
+final $typed_data.Uint8List cherrypickDescriptor = $convert.base64Decode('CgpDaGVycnlwaWNrEiQKDXRydW5rUmV2aXNpb24YASABKAlSDXRydW5rUmV2aXNpb24SKAoPYXBwbGllZFJldmlzaW9uGAIgASgJUg9hcHBsaWVkUmV2aXNpb24SNgoFc3RhdGUYAyABKA4yIC5jb25kdWN0b3Jfc3RhdGUuQ2hlcnJ5cGlja1N0YXRlUgVzdGF0ZQ==');
 @$core.Deprecated('Use repositoryDescriptor instead')
 const Repository$json = const {
   '1': 'Repository',
@@ -86,8 +94,7 @@ const Repository$json = const {
 };
 
 /// Descriptor for `Repository`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List repositoryDescriptor = $convert.base64Decode(
-    'CgpSZXBvc2l0b3J5EigKD2NhbmRpZGF0ZUJyYW5jaBgBIAEoCVIPY2FuZGlkYXRlQnJhbmNoEigKD3N0YXJ0aW5nR2l0SGVhZBgCIAEoCVIPc3RhcnRpbmdHaXRIZWFkEiYKDmN1cnJlbnRHaXRIZWFkGAMgASgJUg5jdXJyZW50R2l0SGVhZBIiCgxjaGVja291dFBhdGgYBCABKAlSDGNoZWNrb3V0UGF0aBIzCgh1cHN0cmVhbRgFIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSCHVwc3RyZWFtEi8KBm1pcnJvchgGIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSBm1pcnJvchI9CgtjaGVycnlwaWNrcxgHIAMoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5DaGVycnlwaWNrUgtjaGVycnlwaWNrcxIiCgxkYXJ0UmV2aXNpb24YCCABKAlSDGRhcnRSZXZpc2lvbhIkCg13b3JraW5nQnJhbmNoGAkgASgJUg13b3JraW5nQnJhbmNo');
+final $typed_data.Uint8List repositoryDescriptor = $convert.base64Decode('CgpSZXBvc2l0b3J5EigKD2NhbmRpZGF0ZUJyYW5jaBgBIAEoCVIPY2FuZGlkYXRlQnJhbmNoEigKD3N0YXJ0aW5nR2l0SGVhZBgCIAEoCVIPc3RhcnRpbmdHaXRIZWFkEiYKDmN1cnJlbnRHaXRIZWFkGAMgASgJUg5jdXJyZW50R2l0SGVhZBIiCgxjaGVja291dFBhdGgYBCABKAlSDGNoZWNrb3V0UGF0aBIzCgh1cHN0cmVhbRgFIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSCHVwc3RyZWFtEi8KBm1pcnJvchgGIAEoCzIXLmNvbmR1Y3Rvcl9zdGF0ZS5SZW1vdGVSBm1pcnJvchI9CgtjaGVycnlwaWNrcxgHIAMoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5DaGVycnlwaWNrUgtjaGVycnlwaWNrcxIiCgxkYXJ0UmV2aXNpb24YCCABKAlSDGRhcnRSZXZpc2lvbhIkCg13b3JraW5nQnJhbmNoGAkgASgJUg13b3JraW5nQnJhbmNo');
 @$core.Deprecated('Use conductorStateDescriptor instead')
 const ConductorState$json = const {
   '1': 'ConductorState',
@@ -106,5 +113,4 @@ const ConductorState$json = const {
 };
 
 /// Descriptor for `ConductorState`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List conductorStateDescriptor = $convert.base64Decode(
-    'Cg5Db25kdWN0b3JTdGF0ZRImCg5yZWxlYXNlQ2hhbm5lbBgBIAEoCVIOcmVsZWFzZUNoYW5uZWwSJgoOcmVsZWFzZVZlcnNpb24YAiABKAlSDnJlbGVhc2VWZXJzaW9uEjMKBmVuZ2luZRgEIAEoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5SZXBvc2l0b3J5UgZlbmdpbmUSOQoJZnJhbWV3b3JrGAUgASgLMhsuY29uZHVjdG9yX3N0YXRlLlJlcG9zaXRvcnlSCWZyYW1ld29yaxIgCgtjcmVhdGVkRGF0ZRgGIAEoA1ILY3JlYXRlZERhdGUSKAoPbGFzdFVwZGF0ZWREYXRlGAcgASgDUg9sYXN0VXBkYXRlZERhdGUSEgoEbG9ncxgIIAMoCVIEbG9ncxJBCgxjdXJyZW50UGhhc2UYCSABKA4yHS5jb25kdWN0b3Jfc3RhdGUuUmVsZWFzZVBoYXNlUgxjdXJyZW50UGhhc2USKgoQY29uZHVjdG9yVmVyc2lvbhgKIAEoCVIQY29uZHVjdG9yVmVyc2lvbhImCg5pbmNyZW1lbnRMZXZlbBgLIAEoCVIOaW5jcmVtZW50TGV2ZWw=');
+final $typed_data.Uint8List conductorStateDescriptor = $convert.base64Decode('Cg5Db25kdWN0b3JTdGF0ZRImCg5yZWxlYXNlQ2hhbm5lbBgBIAEoCVIOcmVsZWFzZUNoYW5uZWwSJgoOcmVsZWFzZVZlcnNpb24YAiABKAlSDnJlbGVhc2VWZXJzaW9uEjMKBmVuZ2luZRgEIAEoCzIbLmNvbmR1Y3Rvcl9zdGF0ZS5SZXBvc2l0b3J5UgZlbmdpbmUSOQoJZnJhbWV3b3JrGAUgASgLMhsuY29uZHVjdG9yX3N0YXRlLlJlcG9zaXRvcnlSCWZyYW1ld29yaxIgCgtjcmVhdGVkRGF0ZRgGIAEoA1ILY3JlYXRlZERhdGUSKAoPbGFzdFVwZGF0ZWREYXRlGAcgASgDUg9sYXN0VXBkYXRlZERhdGUSEgoEbG9ncxgIIAMoCVIEbG9ncxJBCgxjdXJyZW50UGhhc2UYCSABKA4yHS5jb25kdWN0b3Jfc3RhdGUuUmVsZWFzZVBoYXNlUgxjdXJyZW50UGhhc2USKgoQY29uZHVjdG9yVmVyc2lvbhgKIAEoCVIQY29uZHVjdG9yVmVyc2lvbhImCg5pbmNyZW1lbnRMZXZlbBgLIAEoCVIOaW5jcmVtZW50TGV2ZWw=');

--- a/dev/conductor/core/lib/src/proto/conductor_state.pbserver.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pbserver.dart
@@ -10,4 +10,3 @@
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 export 'conductor_state.pb.dart';
-

--- a/dev/conductor/core/lib/src/proto/conductor_state.pbserver.dart
+++ b/dev/conductor/core/lib/src/proto/conductor_state.pbserver.dart
@@ -10,3 +10,4 @@
 // ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
 
 export 'conductor_state.pb.dart';
+

--- a/dev/conductor/core/lib/src/proto/conductor_state.proto
+++ b/dev/conductor/core/lib/src/proto/conductor_state.proto
@@ -45,10 +45,21 @@ enum CherrypickState {
   ABANDONED = 3;
 }
 
+// The type of release that is being created.
+//
+// This determines how the version will be calculated.
 enum ReleaseType {
+  // All pre-release metadata from previous beta releases will be discarded. The
+  // z must be 0.
   STABLE_INITIAL = 0;
+
+  // Increment z.
   STABLE_HOTFIX = 1;
+
+  // Compute x, y, and m from the candidate branch name. z and n should be 0.
   BETA_INITIAL = 2;
+
+  // Increment n.
   BETA_HOTFIX = 3;
 }
 
@@ -120,6 +131,5 @@ message ConductorState {
   // that created the [ConductorState] object.
   string conductorVersion = 10;
 
-  // One of x, y, z, m, or n.
-  string incrementLevel = 11;
+  ReleaseType releaseType = 11;
 }

--- a/dev/conductor/core/lib/src/proto/conductor_state.proto
+++ b/dev/conductor/core/lib/src/proto/conductor_state.proto
@@ -45,6 +45,13 @@ enum CherrypickState {
   ABANDONED = 3;
 }
 
+enum ReleaseType {
+  STABLE_INITIAL = 0;
+  STABLE_HOTFIX = 1;
+  BETA_INITIAL = 2;
+  BETA_HOTFIX = 3;
+}
+
 message Cherrypick {
   // The revision on trunk to cherrypick.
   string trunkRevision = 1;

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -187,7 +187,6 @@ class StartCommand extends Command<void> {
     );
     Version? versionOverride;
     if (versionOverrideString != null) {
-      // TODO test bogus override string
       versionOverride = Version.fromString(versionOverrideString);
     }
 

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -411,14 +411,11 @@ class StartContext extends Context {
       stdio.printError(e.message);
     }
 
-    Version nextVersion = calculateNextVersion(lastVersion, releaseType);
-    if (!force) {
-      nextVersion = await ensureBranchPointTagged(
-        branchPoint: branchPoint,
-        requestedVersion: nextVersion,
-        framework: framework,
-      );
-    }
+    final Version nextVersion = await ensureBranchPointTagged(
+      branchPoint: branchPoint,
+      requestedVersion: calculateNextVersion(lastVersion, releaseType),
+      framework: framework,
+    );
 
     state.releaseVersion = nextVersion.toString();
 

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -410,11 +410,17 @@ class StartContext extends Context {
       stdio.printError(e.message);
     }
 
-    final Version nextVersion = await ensureBranchPointTagged(
-      branchPoint: branchPoint,
-      requestedVersion: calculateNextVersion(lastVersion, releaseType),
-      framework: framework,
-    );
+    Version nextVersion;
+    if (versionOverride != null) {
+      nextVersion = versionOverride!;
+    } else {
+      nextVersion = calculateNextVersion(lastVersion, releaseType);
+      nextVersion = await ensureBranchPointTagged(
+        branchPoint: branchPoint,
+        requestedVersion: nextVersion,
+        framework: framework,
+      );
+    }
 
     state.releaseVersion = nextVersion.toString();
 

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -442,22 +442,27 @@ class StartContext extends Context {
 
   /// Determine this release's version number from the [lastVersion] and the [incrementLetter].
   Version calculateNextVersion(Version lastVersion, ReleaseType releaseType) {
+    late final Version nextVersion;
     switch (releaseType) {
       case ReleaseType.STABLE_INITIAL:
-        return Version(
+        nextVersion = Version(
             x: lastVersion.x,
             y: lastVersion.y,
             z: 0,
             type: VersionType.stable,
         );
+        break;
       case ReleaseType.STABLE_HOTFIX:
-        return Version.increment(lastVersion, 'z');
+        nextVersion = Version.increment(lastVersion, 'z');
+        break;
       case ReleaseType.BETA_INITIAL:
-        return Version.fromCandidateBranch(candidateBranch);
+        nextVersion = Version.fromCandidateBranch(candidateBranch);
+        break;
       case ReleaseType.BETA_HOTFIX:
-        return Version.increment(lastVersion, 'n');
+        nextVersion = Version.increment(lastVersion, 'n');
+        break;
     }
-    throw 'unreachable';
+    return nextVersion;
   }
 
   /// Ensures the branch point [candidateBranch] and `master` has a version tag.

--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -297,7 +297,7 @@ class Version {
       if (m != int.tryParse(branchM)) {
         throw ConductorException(
           'Parsed version ${toString()} has a different m value than candidate '
-          'branch $candidateBranch',
+          'branch $candidateBranch with type $type',
         );
       }
     }

--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import './globals.dart' show ConductorException, kReleaseIncrements, releaseCandidateBranchRegex;
+import 'globals.dart' show ConductorException, releaseCandidateBranchRegex;
+
+import 'proto/conductor_state.pbenum.dart';
 
 /// Possible string formats that `flutter --version` can return.
 enum VersionType {
@@ -262,10 +264,7 @@ class Version {
   ///
   /// Will throw a [ConductorException] if the version is not possible given the
   /// [candidateBranch] and [incrementLetter].
-  void ensureValid(String candidateBranch, String incrementLetter) {
-    if (!kReleaseIncrements.contains(incrementLetter)) {
-      throw ConductorException('Invalid incrementLetter: $incrementLetter');
-    }
+  void ensureValid(String candidateBranch, ReleaseType releaseType) {
     final RegExpMatch? branchMatch = releaseCandidateBranchRegex.firstMatch(candidateBranch);
     if (branchMatch == null) {
       throw ConductorException(
@@ -292,7 +291,7 @@ class Version {
     }
 
     // stable type versions don't have an m field set
-    if (type != VersionType.stable && incrementLetter != 'm') {
+    if (type != VersionType.stable && releaseType != ReleaseType.STABLE_HOTFIX && releaseType != ReleaseType.STABLE_INITIAL) {
       final String branchM = branchMatch.group(3)!;
       if (m != int.tryParse(branchM)) {
         throw ConductorException(

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -121,6 +121,34 @@ void main() {
       );
     });
 
+    test('throws if provided an invalid --$kVersionOverrideOption', () async {
+      final CommandRunner<void> runner = createRunner();
+
+      final String stateFilePath = fileSystem.path.join(
+        platform.environment['HOME']!,
+        kStateFileName,
+      );
+
+      await expectLater(
+        () async => runner.run(<String>[
+          'start',
+          '--$kFrameworkMirrorOption',
+          frameworkMirror,
+          '--$kEngineMirrorOption',
+          engineMirror,
+          '--$kCandidateOption',
+          candidateBranch,
+          '--$kReleaseOption',
+          releaseChannel,
+          '--$kStateOption',
+          stateFilePath,
+          '--$kVersionOverrideOption',
+          'an invalid version string',
+        ]),
+        throwsExceptionWith('an invalid version string cannot be parsed'),
+      );
+    });
+
     test('creates state file if provided correct inputs', () async {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -247,6 +247,14 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
+          command: <String>['git', 'merge-base', candidateBranch, 'master'],
+          stdout: branchPointRevision,
+        ),
+        // check if commit is tagged, zero exit means it is tagged
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+        ),
+        const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
           stdout: revision3,
         ),

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -247,14 +247,6 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', candidateBranch, 'master'],
-          stdout: branchPointRevision,
-        ),
-        // check if commit is tagged, zero exit means it is tagged
-        const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
-        ),
-        const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
           stdout: revision3,
         ),

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -426,6 +426,10 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision3,
+        ),
+        const FakeCommand(
           command: <String>['git', 'merge-base', candidateBranch, 'master'],
           stdout: branchPointRevision,
         ),
@@ -440,10 +444,6 @@ void main() {
         ),
         const FakeCommand(
           command: <String>['git', 'push', FrameworkRepository.defaultUpstream, branchPointTag],
-        ),
-        const FakeCommand(
-          command: <String>['git', 'rev-parse', 'HEAD'],
-          stdout: revision3,
         ),
       ];
 

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -644,16 +644,16 @@ void main() {
           stdout: '$previousVersion-42-gabc123',
         ),
         const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision3,
+        ),
+        const FakeCommand(
           command: <String>['git', 'merge-base', candidateBranch, 'master'],
           stdout: branchPointRevision,
         ),
         // check if commit is tagged, 0 exit code thus it is tagged
         const FakeCommand(
           command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
-        ),
-        const FakeCommand(
-          command: <String>['git', 'rev-parse', 'HEAD'],
-          stdout: revision3,
         ),
       ];
 

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -345,8 +345,6 @@ void main() {
       const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
       const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-1.0.pre';
-      // This is what this release will be
-      const String nextVersion = '1.2.0-1.1.pre';
       const String candidateBranch = 'flutter-1.2-candidate.1';
       const String versionOverride = '42.0.0-42.0.pre';
 
@@ -469,10 +467,6 @@ void main() {
         const FakeCommand(
           command: <String>['git', 'merge-base', candidateBranch, 'master'],
           stdout: branchPointRevision,
-        ),
-        // check if commit is tagged, zero exit code means it is tagged
-        const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
         ),
       ];
 

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -338,6 +338,185 @@ void main() {
       expect(state.conductorVersion, conductorVersion);
     });
 
+    test('uses --$kVersionOverrideOption', () async {
+      stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
+      const String revision2 = 'def789';
+      const String revision3 = '123abc';
+      const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
+      const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
+      const String previousVersion = '1.2.0-1.0.pre';
+      // This is what this release will be
+      const String nextVersion = '1.2.0-1.1.pre';
+      const String candidateBranch = 'flutter-1.2-candidate.1';
+      const String versionOverride = '42.0.0-42.0.pre';
+
+      final Directory engine = fileSystem
+          .directory(checkoutsParentDirectory)
+          .childDirectory('flutter_conductor_checkouts')
+          .childDirectory('engine');
+
+      final File depsFile = engine.childFile('DEPS');
+
+      final List<FakeCommand> engineCommands = <FakeCommand>[
+        FakeCommand(
+            command: <String>[
+              'git',
+              'clone',
+              '--origin',
+              'upstream',
+              '--',
+              EngineRepository.defaultUpstream,
+              engine.path,
+            ],
+            onRun: () {
+              // Create the DEPS file which the tool will update
+              engine.createSync(recursive: true);
+              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+            }),
+        const FakeCommand(
+          command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'fetch', 'mirror'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'checkout', 'upstream/$candidateBranch'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision2,
+        ),
+        const FakeCommand(
+          command: <String>[
+            'git',
+            'checkout',
+            '-b',
+            'cherrypicks-$candidateBranch',
+          ],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'status', '--porcelain'],
+          stdout: 'MM path/to/DEPS',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'add', '--all'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'commit', "--message='Update Dart SDK to $nextDartRevision'"],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision2,
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision2,
+        ),
+      ];
+
+      final List<FakeCommand> frameworkCommands = <FakeCommand>[
+        FakeCommand(
+          command: <String>[
+            'git',
+            'clone',
+            '--origin',
+            'upstream',
+            '--',
+            FrameworkRepository.defaultUpstream,
+            fileSystem.path.join(
+              checkoutsParentDirectory,
+              'flutter_conductor_checkouts',
+              'framework',
+            ),
+          ],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'remote', 'add', 'mirror', frameworkMirror],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'fetch', 'mirror'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'checkout', 'upstream/$candidateBranch'],
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision3,
+        ),
+        const FakeCommand(
+          command: <String>[
+            'git',
+            'checkout',
+            '-b',
+            'cherrypicks-$candidateBranch',
+          ],
+        ),
+        const FakeCommand(
+          command: <String>[
+            'git',
+            'describe',
+            '--match',
+            '*.*.*',
+            '--tags',
+            'refs/remotes/upstream/$candidateBranch',
+          ],
+          stdout: '$previousVersion-42-gabc123',
+        ),
+        const FakeCommand(
+          command: <String>['git', 'rev-parse', 'HEAD'],
+          stdout: revision3,
+        ),
+        const FakeCommand(
+          command: <String>['git', 'merge-base', candidateBranch, 'master'],
+          stdout: branchPointRevision,
+        ),
+        // check if commit is tagged, zero exit code means it is tagged
+        const FakeCommand(
+          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+        ),
+      ];
+
+      final CommandRunner<void> runner = createRunner(
+        commands: <FakeCommand>[
+          ...engineCommands,
+          ...frameworkCommands,
+        ],
+      );
+
+      final String stateFilePath = fileSystem.path.join(
+        platform.environment['HOME']!,
+        kStateFileName,
+      );
+
+      await runner.run(<String>[
+        'start',
+        '--$kFrameworkMirrorOption',
+        frameworkMirror,
+        '--$kEngineMirrorOption',
+        engineMirror,
+        '--$kCandidateOption',
+        candidateBranch,
+        '--$kReleaseOption',
+        releaseChannel,
+        '--$kStateOption',
+        stateFilePath,
+        '--$kDartRevisionOption',
+        nextDartRevision,
+        '--$kVersionOverrideOption',
+        versionOverride,
+      ]);
+
+      final File stateFile = fileSystem.file(stateFilePath);
+
+      final pb.ConductorState state = pb.ConductorState();
+      state.mergeFromProto3Json(
+        jsonDecode(stateFile.readAsStringSync()),
+      );
+
+      expect(processManager, hasNoRemainingExpectations);
+      expect(state.releaseVersion, versionOverride);
+    });
+
     test('logs to STDERR but does not fail on an unexpected candidate branch', () async {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -7,7 +7,7 @@ import 'dart:convert' show jsonDecode;
 import 'package:args/command_runner.dart';
 import 'package:conductor_core/src/globals.dart';
 import 'package:conductor_core/src/proto/conductor_state.pb.dart' as pb;
-import 'package:conductor_core/src/proto/conductor_state.pbenum.dart' show ReleasePhase;
+import 'package:conductor_core/src/proto/conductor_state.pbenum.dart';
 import 'package:conductor_core/src/repository.dart';
 import 'package:conductor_core/src/start.dart';
 import 'package:conductor_core/src/state.dart';
@@ -298,7 +298,7 @@ void main() {
       expect(state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
-      expect(state.incrementLevel, 'n');
+      expect(state.releaseType, ReleaseType.STABLE_HOTFIX);
     });
 
     test('creates state file if provided correct inputs', () async {
@@ -312,7 +312,6 @@ void main() {
       const String branchPointTag = '1.2.0-3.0.pre';
       // This is what this release will be
       const String nextVersion = '1.2.0-3.1.pre';
-      const String incrementLevel = 'm';
 
       final Directory engine = fileSystem
           .directory(checkoutsParentDirectory)
@@ -496,7 +495,7 @@ void main() {
       expect(state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
-      expect(state.incrementLevel, incrementLevel);
+      expect(state.releaseType, ReleaseType.STABLE_HOTFIX);
       expect(stdio.stdout, contains('Applying the tag $branchPointTag at the branch point $branchPointRevision'));
       expect(stdio.stdout, contains('The actual release will be version $nextVersion'));
       expect(branchPointTag != nextVersion, true);
@@ -887,7 +886,7 @@ void main() {
       expect(state.framework.startingGitHead, revision3);
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
-      expect(state.incrementLevel, 'z');
+      expect(state.releaseType, ReleaseType.STABLE_INITIAL);
     });
 
     test('StartContext gets engine and framework checkout directories after run', () async {
@@ -1088,6 +1087,7 @@ void main() {
 
       expect((await startContext.engine.checkoutDirectory).path, equals(engine.path));
       expect((await startContext.framework.checkoutDirectory).path, equals(framework.path));
+      expect(processManager, hasNoRemainingExpectations);
     });
   }, onPlatform: <String, dynamic>{
     'windows': const Skip('Flutter Conductor only supported on macos/linux'),

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -25,7 +25,7 @@ void main() {
     const String frameworkMirror = 'https://github.com/user/flutter.git';
     const String engineMirror = 'https://github.com/user/engine.git';
     const String candidateBranch = 'flutter-1.2-candidate.3';
-    const String releaseChannel = 'stable';
+    const String releaseChannel = 'beta';
     const String revision = 'abcd1234';
     const String conductorVersion = 'deadbeef';
     late Checkouts checkouts;
@@ -97,8 +97,6 @@ void main() {
           'beta',
           '--$kStateOption',
           '/path/to/statefile.json',
-          '--$kIncrementOption',
-          'y',
         ]),
         throwsExceptionWith(
           'Error! This tool is only supported on macOS and Linux',
@@ -132,7 +130,6 @@ void main() {
       const String previousVersion = '1.2.0-1.0.pre';
       // This is what this release will be
       const String nextVersion = '1.2.0-1.1.pre';
-      const String incrementLevel = 'n';
 
       final Directory engine = fileSystem
           .directory(checkoutsParentDirectory)
@@ -278,8 +275,6 @@ void main() {
         stateFilePath,
         '--$kDartRevisionOption',
         nextDartRevision,
-        '--$kIncrementOption',
-        incrementLevel,
         '--$kForceFlag',
       ]);
 
@@ -303,7 +298,7 @@ void main() {
       expect(state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
-      expect(state.incrementLevel, incrementLevel);
+      expect(state.incrementLevel, 'n');
     });
 
     test('creates state file if provided correct inputs', () async {
@@ -479,8 +474,6 @@ void main() {
         stateFilePath,
         '--$kDartRevisionOption',
         nextDartRevision,
-        '--$kIncrementOption',
-        incrementLevel,
       ]);
 
       final File stateFile = fileSystem.file(stateFilePath);
@@ -721,7 +714,6 @@ void main() {
       const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-3.0.pre';
       const String nextVersion = '1.2.0';
-      const String incrementLevel = 'z';
 
       final Directory engine = fileSystem
           .directory(checkoutsParentDirectory)
@@ -870,13 +862,11 @@ void main() {
         '--$kCandidateOption',
         candidateBranch,
         '--$kReleaseOption',
-        releaseChannel,
+        'stable',
         '--$kStateOption',
         stateFilePath,
         '--$kDartRevisionOption',
         nextDartRevision,
-        '--$kIncrementOption',
-        incrementLevel,
       ]);
 
       final File stateFile = fileSystem.file(stateFilePath);
@@ -888,7 +878,7 @@ void main() {
 
       expect(processManager.hasRemainingExpectations, false);
       expect(state.isInitialized(), true);
-      expect(state.releaseChannel, releaseChannel);
+      expect(state.releaseChannel, 'stable');
       expect(state.releaseVersion, nextVersion);
       expect(state.engine.candidateBranch, candidateBranch);
       expect(state.engine.startingGitHead, revision2);
@@ -897,7 +887,7 @@ void main() {
       expect(state.framework.startingGitHead, revision3);
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
-      expect(state.incrementLevel, incrementLevel);
+      expect(state.incrementLevel, 'z');
     });
 
     test('StartContext gets engine and framework checkout directories after run', () async {
@@ -910,8 +900,6 @@ void main() {
       const String previousVersion = '1.2.0-1.0.pre';
       // This is a git tag applied to the branch point, not an actual release
       const String branchPointTag = '1.2.0-3.0.pre';
-      // This is what this release will be
-      const String incrementLevel = 'm';
 
       final Directory engine = fileSystem
           .directory(checkoutsParentDirectory)
@@ -1081,20 +1069,20 @@ void main() {
       );
 
       final StartContext startContext = StartContext(
-          candidateBranch: candidateBranch,
-          checkouts: checkouts,
-          dartRevision: nextDartRevision,
-          engineCherrypickRevisions: <String>[],
-          engineMirror: engineMirror,
-          engineUpstream: EngineRepository.defaultUpstream,
-          frameworkCherrypickRevisions: <String>[],
-          frameworkMirror: frameworkMirror,
-          frameworkUpstream: FrameworkRepository.defaultUpstream,
-          releaseChannel: releaseChannel,
-          incrementLetter: incrementLevel,
-          processManager: processManager,
-          conductorVersion: conductorVersion,
-          stateFile: stateFile);
+        candidateBranch: candidateBranch,
+        checkouts: checkouts,
+        dartRevision: nextDartRevision,
+        engineCherrypickRevisions: <String>[],
+        engineMirror: engineMirror,
+        engineUpstream: EngineRepository.defaultUpstream,
+        frameworkCherrypickRevisions: <String>[],
+        frameworkMirror: frameworkMirror,
+        frameworkUpstream: FrameworkRepository.defaultUpstream,
+        releaseChannel: releaseChannel,
+        processManager: processManager,
+        conductorVersion: conductorVersion,
+        stateFile: stateFile,
+      );
 
       await startContext.run();
 

--- a/dev/conductor/core/test/state_test.dart
+++ b/dev/conductor/core/test/state_test.dart
@@ -18,7 +18,6 @@ void main() {
     final pb.ConductorState state = pb.ConductorState(
       releaseChannel: 'stable',
       releaseVersion: '2.3.4',
-      incrementLevel: 'z',
       engine: pb.Repository(
         candidateBranch: candidateBranch,
         upstream: pb.Remote(
@@ -60,8 +59,7 @@ void main() {
   },
   "logs": [
     "[status] hello world"
-  ],
-  "incrementLevel": "z"
+  ]
 }''';
     expect(serializedState, expectedString);
   });

--- a/dev/conductor/core/test/version_test.dart
+++ b/dev/conductor/core/test/version_test.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:conductor_core/src/proto/conductor_state.pbenum.dart';
 import 'package:conductor_core/src/version.dart';
 
-import './common.dart';
+import 'common.dart';
 
 void main() {
   group('Version.fromString()', () {
@@ -106,7 +107,7 @@ void main() {
       const String candidateBranch = 'flutter-3.2-candidate.4';
       final Version version = Version.fromString(versionString);
       expect(
-        () => version.ensureValid(candidateBranch, 'n'),
+        () => version.ensureValid(candidateBranch, ReleaseType.BETA_HOTFIX),
         throwsExceptionWith(
           'Parsed version $versionString has a different x value than '
           'candidate branch $candidateBranch',
@@ -119,7 +120,7 @@ void main() {
       const String candidateBranch = 'flutter-1.15-candidate.4';
       final Version version = Version.fromString(versionString);
       expect(
-        () => version.ensureValid(candidateBranch, 'm'),
+        () => version.ensureValid(candidateBranch, ReleaseType.BETA_INITIAL),
         throwsExceptionWith(
           'Parsed version $versionString has a different y value than '
           'candidate branch $candidateBranch',
@@ -132,7 +133,7 @@ void main() {
       const String candidateBranch = 'flutter-1.2-candidate.0';
       final Version version = Version.fromString(versionString);
       expect(
-        () => version.ensureValid(candidateBranch, 'n'),
+        () => version.ensureValid(candidateBranch, ReleaseType.BETA_HOTFIX),
         throwsExceptionWith(
           'Parsed version $versionString has a different m value than '
           'candidate branch $candidateBranch',
@@ -145,7 +146,7 @@ void main() {
       const String candidateBranch = 'flutter-1.2-candidate.98';
       final Version version = Version.fromString(versionString);
       expect(
-        () => version.ensureValid(candidateBranch, 'n'),
+        () => version.ensureValid(candidateBranch, ReleaseType.STABLE_HOTFIX),
         isNot(throwsException),
       );
     });
@@ -155,20 +156,10 @@ void main() {
       const String candidateBranch = 'stable';
       final Version version = Version.fromString(versionString);
       expect(
-        () => version.ensureValid(candidateBranch, 'z'),
+        () => version.ensureValid(candidateBranch, ReleaseType.STABLE_HOTFIX),
         throwsExceptionWith(
           'Candidate branch $candidateBranch does not match the pattern',
         ),
-      );
-    });
-
-    test('does not validate m if incrementLetter is m', () {
-      const String versionString = '1.2.0-0.0.pre';
-      const String candidateBranch = 'flutter-1.2-candidate.42';
-      final Version version = Version.fromString(versionString);
-      expect(
-        () => version.ensureValid(candidateBranch, 'm'),
-        isNot(throwsException),
       );
     });
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98608

Rather than requiring the user to know the correct increment level for the next release version, instead have the tool auto-determine the next version with the algorithm:

1. if the tip of the candidate branch is also on master, that means this is the first release on the branch; compute the version from the candidate branch (this would fail if the candidate branch was named wrong) and tag the branch point, then increment the n for the actual release
2. else if the channel is stable, the increment should be z (the tool already has logic to "increment" to 0 if this is the first stable release)
2. else (i.e. channel is beta), increment the n

Also, provide an optional `--version-override` command-line option, for situations where we need to tell the tool exactly which version to use.