### PR TITLE
Revert "reads min/target sdk versions from localproperties"

### DIFF
--- a/examples/api/android/app/build.gradle
+++ b/examples/api/android/app/build.gradle
@@ -29,16 +29,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -58,8 +48,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "dev.flutter.flutter_api_samples"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/flutter_view/android/app/build.gradle
+++ b/examples/flutter_view/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -48,8 +38,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.flutter_view"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/hello_world/android/app/build.gradle
+++ b/examples/hello_world/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -48,8 +38,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.hello_world"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/image_list/android/app/build.gradle
+++ b/examples/image_list/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -49,8 +39,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.image_list"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/layers/android/app/build.gradle
+++ b/examples/layers/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -48,8 +38,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.layers"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/examples/platform_channel/android/app/build.gradle
+++ b/examples/platform_channel/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -48,8 +38,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.platform_channel"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/examples/platform_view/android/app/build.gradle
+++ b/examples/platform_view/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -48,8 +38,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.examples.platform_view"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/README.md
+++ b/packages/flutter_tools/README.md
@@ -97,7 +97,7 @@ variable to be set. The full invocation to run everything might
 therefore look something like:
 
 ```shell
-$ export FLUTTER_ROOT=~/path/to/flutter-sdk
+$ FLUTTER_ROOT=~/path/to/flutter-sdk
 $ flutter test --concurrency 1
 ```
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -139,11 +139,6 @@ class FlutterPlugin implements Plugin<Project> {
     private Properties localProperties
     private String engineVersion
 
-    /**
-     * Flutter Docs Website references URLs for help messages.
-     */
-    private final String kWebsiteDeploymentAndroidBuildConfig = 'https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration'
-
     @Override
     void apply(Project project) {
         this.project = project
@@ -305,7 +300,7 @@ class FlutterPlugin implements Plugin<Project> {
             localEngine = engineOut.name
             localEngineSrcPath = engineOut.parentFile.parent
         }
-        project.android.buildTypes.all this.&addFlutterDependencies        
+        project.android.buildTypes.all this.&addFlutterDependencies
     }
 
     private static Boolean shouldShrinkResources(Project project) {
@@ -414,33 +409,9 @@ class FlutterPlugin implements Plugin<Project> {
 
         // Wait until the Android plugin loaded.
         pluginProject.afterEvaluate {
-            Boolean showBuildConfigurationMessage = false
-            
-            // Checks if there is a mismatch between the plugin compileSdkVersion and the project compileSdkVersion.
             if (pluginProject.android.compileSdkVersion > project.android.compileSdkVersion) {
                 project.logger.quiet("Warning: The plugin ${pluginName} requires Android SDK version ${pluginProject.android.compileSdkVersion.substring(8)}.")
-                showBuildConfigurationMessage = true
             }
-
-            // Checks if there is a mismatch between the plugin minSdkVersion and the project minSdkVersion.
-            if(pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel > project.android.defaultConfig?.minSdkVersion?.apiLevel) {
-                project.logger.quiet("Warning: The plugin ${pluginName} requires minSdkVersion ${pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel}.")
-                showBuildConfigurationMessage = true
-                
-                if (!resolveProperty("flutter.minSdkVersion", null)) {
-                    project.logger.quiet("flutter.minSdkVersion not found on ${project.projectDir.parentFile}${File.separator}local.properties, consider adding it. Using ${project.android.defaultConfig.minSdkVersion.apiLevel} as default.")
-                }
-
-                // Additionally checks if the targetSdkVersion was set.
-                if (!resolveProperty("flutter.targetSdkVersion", null)) {
-                    project.logger.quiet("flutter.targetSdkVersion not found on ${project.projectDir.parentFile}${File.separator}local.properties, consider adding it. Using ${project.android.defaultConfig.targetSdkVersion.apiLevel} as default.")
-                }
-            }
-            
-            if (showBuildConfigurationMessage) {
-                project.logger.quiet("For more information about build configuration, see $kWebsiteDeploymentAndroidBuildConfig.")
-            }
-
             project.android.buildTypes.all addEmbeddingDependencyToPlugin
         }
     }

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -390,24 +390,27 @@ final GradleHandledError minSdkVersion = GradleHandledError(
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
-    final File localPropertiesFile = project.directory
+    final File gradleFile = project.directory
         .childDirectory('android')
-        .childFile('local.properties');
+        .childDirectory('app')
+        .childFile('build.gradle');
 
     final Match? minSdkVersionMatch = _minSdkVersionPattern.firstMatch(line);
     assert(minSdkVersionMatch?.groupCount == 3);
 
     final String textInBold = globals.logger.terminal.bolden(
-      'Fix this issue by adding the following to the file ${localPropertiesFile.path}:\n'
-      '\n'
-      'flutter.minSdkVersion=${minSdkVersionMatch?.group(2)}\n'
+      'Fix this issue by adding the following to the file ${gradleFile.path}:\n'
+      'android {\n'
+      '  defaultConfig {\n'
+      '    minSdkVersion ${minSdkVersionMatch?.group(2)}\n'
+      '  }\n'
+      '}\n'
     );
     globals.printBox(
       'The plugin ${minSdkVersionMatch?.group(3)} requires a higher Android SDK version.\n'
       '$textInBold\n'
       "Note that your app won't be available to users running Android SDKs below ${minSdkVersionMatch?.group(2)}.\n"
-      'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.\n'
-      'For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration',
+      'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;
@@ -515,8 +518,8 @@ final GradleHandledError minCompileSdkVersionHandler = GradleHandledError(
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
-    final Match? minCompileSdkVersionMatch = _minCompileSdkVersionPattern.firstMatch(line);
-    assert(minCompileSdkVersionMatch?.groupCount == 1);
+    final Match? minSdkVersionMatch = _minCompileSdkVersionPattern.firstMatch(line);
+    assert(minSdkVersionMatch?.groupCount == 1);
 
     final File gradleFile = project.directory
         .childDirectory('android')
@@ -526,7 +529,7 @@ final GradleHandledError minCompileSdkVersionHandler = GradleHandledError(
       '${globals.logger.terminal.warningMark} Your project requires a higher compileSdkVersion.\n'
       'Fix this issue by bumping the compileSdkVersion in ${gradleFile.path}:\n'
       'android {\n'
-      '  compileSdkVersion ${minCompileSdkVersionMatch?.group(1)}\n'
+      '  compileSdkVersion ${minSdkVersionMatch?.group(1)}\n'
       '}',
       title: _boxTitle,
     );

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -25,16 +25,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
@@ -47,8 +37,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -25,16 +25,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
     ndkVersion flutter.ndkVersion
@@ -55,8 +45,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/module/android/library_new_embedding/Flutter.tmpl/build.gradle.tmpl
@@ -26,16 +26,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.library'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 group '{{androidIdentifier}}'
 version '1.0'
 
@@ -49,8 +39,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2479,7 +2479,7 @@ void main() {
     expect(env['flutter'].allows(Version(2, 4, 9)), false);
   });
 
-  testUsingContext('default app uses local properties or flutter default versions', () async {
+  testUsingContext('default app uses flutter default versions', () async {
     Cache.flutterRoot = '../..';
 
     final CreateCommand command = CreateCommand();
@@ -2493,8 +2493,7 @@ void main() {
 
     expect(buildContent.contains('compileSdkVersion flutter.compileSdkVersion'), true);
     expect(buildContent.contains('ndkVersion flutter.ndkVersion'), true);
-    expect(buildContent.contains('minSdkVersion flutterMinSdkVersion'), true);
-    expect(buildContent.contains('targetSdkVersion flutterTargetSdkVersion'), true);
+    expect(buildContent.contains('targetSdkVersion flutter.targetSdkVersion'), true);
   });
 
   testUsingContext('Linux plugins handle partially camel-case project names correctly', () async {

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -770,15 +770,16 @@ assembleProfile
           '\n'
           '┌─ Flutter Fix ─────────────────────────────────────────────────────────────────────────────────┐\n'
           '│ The plugin webview_flutter requires a higher Android SDK version.                             │\n'
-          '│ Fix this issue by adding the following to the file /android/local.properties:                 │\n'
-          '│                                                                                               │\n'
-          '│ flutter.minSdkVersion=19                                                                      │\n'
+          '│ Fix this issue by adding the following to the file /android/app/build.gradle:                 │\n'
+          '│ android {                                                                                     │\n'
+          '│   defaultConfig {                                                                             │\n'
+          '│     minSdkVersion 19                                                                          │\n'
+          '│   }                                                                                           │\n'
+          '│ }                                                                                             │\n'
           '│                                                                                               │\n'
           "│ Note that your app won't be available to users running Android SDKs below 19.                 │\n"
           '│ Alternatively, try to find a version of this plugin that supports these lower versions of the │\n'
           '│ Android SDK.                                                                                  │\n'
-          '│ For more information, see:                                                                    │\n'
-          '│ https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration                 │\n'
           '└───────────────────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );

--- a/packages/integration_test/example/android/app/build.gradle
+++ b/packages/integration_test/example/android/app/build.gradle
@@ -28,16 +28,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-def flutterMinSdkVersion = localProperties.getProperty('flutter.minSdkVersion')
-if (flutterMinSdkVersion == null) {
-    flutterMinSdkVersion = flutter.minSdkVersion
-}
-
-def flutterTargetSdkVersion = localProperties.getProperty('flutter.targetSdkVersion')
-if (flutterTargetSdkVersion == null) {
-    flutterTargetSdkVersion = flutter.targetSdkVersion
-}
-
 android {
     compileSdkVersion flutter.compileSdkVersion
 
@@ -49,8 +39,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.integration_test_example"
-        minSdkVersion flutterMinSdkVersion
-        targetSdkVersion flutterTargetSdkVersion
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Reverts flutter/flutter#98450

Broke the Flutter roll into the plugins repo https://github.com/flutter/plugins/pull/4925

I'd suggest we add comments to `android/app/build.gradle`, so folks know that can replace the `flutter.*` 
constants.

This keeps Flutter apps a bit more consistent with other use cases. 
e.g. Flutter plugins, add-to-app, and the rest of Android.

cc @brunotacca