### PR TITLE
Use runUnsynchronized for android_views test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2272,6 +2272,7 @@ targets:
     scheduler: luci
 
   - name: Linux android views
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/99001
     recipe: flutter/android_views
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2272,7 +2272,6 @@ targets:
     scheduler: luci
 
   - name: Linux android views
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/99001
     recipe: flutter/android_views
     properties:
       dependencies: >-

--- a/dev/integration_tests/android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/android_views/test_driver/main_test.dart
@@ -22,7 +22,9 @@ Future<void> main() async {
     final SerializableFinder motionEventsListTile =
     find.byValueKey('MotionEventsListTile');
     await driver.tap(motionEventsListTile);
-    await driver.waitFor(find.byValueKey('PlatformView'));
+    await driver.runUnsynchronized(() async {
+      driver.waitFor(find.byValueKey('PlatformView'));
+    });
     final String errorMessage = await driver.requestData('run test');
     expect(errorMessage, '');
     final SerializableFinder backButton = find.byValueKey('back');


### PR DESCRIPTION
Synchronized driver wait may be the culprit behind flakes. Try unsynchronized to see if the flakiness improved.