### PR TITLE
Enable Samsung S10 tests in post-submit CI

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -48,6 +48,26 @@ platform_properties:
         ]
       os: Linux
       device_os: "N"
+  linux_samsung:
+    properties:
+      caches: >-
+        [
+          {"name":"builder_linux_devicelab","path":"builder"},
+          {"name":"android_sdk","path":"android"},
+          {"name":"chrome_and_driver","path":"chrome"},
+          {"name":"flutter_sdk","path":"flutter sdk"},
+          {"name":"gradle","path":"gradle"},
+          {"name":"openjdk","path":"java"},
+          {"name":"pub_cache","path":".pub-cache"}
+        ]
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:31v8"},
+          {"dependency": "curl"},
+          {"dependency": "open_jdk"}
+        ]
+      os: Linux
+      device_os: "R"
   mac:
     properties:
       caches: >-
@@ -1455,6 +1475,18 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_samsung backdrop_filter_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux","samsung"]
+      task_name: backdrop_filter_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android basic_material_app_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1593,6 +1625,26 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_samsung complex_layout_scroll_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
+      task_name: complex_layout_scroll_perf__timeline_summary
+      dependencies: >-
+        [
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      caches: >-
+        [
+          {"name": "openjdk", "path": "java11"}
+        ]
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android complex_layout_semantics_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1676,6 +1728,18 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_samsung cubic_bezier_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
+      task_name: cubic_bezier_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android cull_opacity_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1694,6 +1758,18 @@ targets:
     properties:
       tags: >
         ["devicelab","android","linux"]
+      task_name: cull_opacity_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
+  - name: Linux_samsung cull_opacity_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
       task_name: cull_opacity_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -2010,6 +2086,18 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_samsung imagefiltered_transform_animation_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
+      task_name: imagefiltered_transform_animation_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android image_list_reported_duration
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2116,6 +2204,18 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_samsung new_gallery__transition_perf
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
+      task_name: new_gallery__transition_perf
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android picture_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2134,6 +2234,18 @@ targets:
     properties:
       tags: >
         ["devicelab","android","linux"]
+      task_name: picture_cache_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
+  - name: Linux_samsung picture_cache_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
       task_name: picture_cache_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -2190,6 +2302,18 @@ targets:
       benchmark: "true"
     scheduler: luci
 
+  - name: Linux_samsung platform_views_scroll_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
+      task_name: platform_views_scroll_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
   - name: Linux_android platform_view__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2238,6 +2362,18 @@ targets:
     properties:
       tags: >
         ["devicelab","android","linux"]
+      task_name: textfield_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
+  - name: Linux_samsung textfield_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/92612
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux", "samsung"]
       task_name: textfield_perf__timeline_summary
       benchmark: "true"
     scheduler: luci

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1482,7 +1482,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: backdrop_filter_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -1632,7 +1632,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: complex_layout_scroll_perf__timeline_summary
       dependencies: >-
         [
@@ -1735,7 +1735,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: cubic_bezier_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -1769,7 +1769,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: cull_opacity_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -2093,7 +2093,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: imagefiltered_transform_animation_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -2211,7 +2211,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: new_gallery__transition_perf
       benchmark: "true"
     scheduler: luci
@@ -2245,7 +2245,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: picture_cache_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -2309,7 +2309,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: platform_views_scroll_perf__timeline_summary
       benchmark: "true"
     scheduler: luci
@@ -2373,7 +2373,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux", "samsung"]
+        ["devicelab","android","linux","samsung","s10"]
       task_name: textfield_perf__timeline_summary
       benchmark: "true"
     scheduler: luci

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -48,7 +48,7 @@ platform_properties:
         ]
       os: Linux
       device_os: "N"
-  linux_samsung:
+  linux_samsung_s10:
     properties:
       caches: >-
         [
@@ -1475,7 +1475,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung backdrop_filter_perf__timeline_summary
+  - name: Linux_samsung_s10 backdrop_filter_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -1625,7 +1625,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung complex_layout_scroll_perf__timeline_summary
+  - name: Linux_samsung_s10 complex_layout_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -1728,7 +1728,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung cubic_bezier_perf__timeline_summary
+  - name: Linux_samsung_s10 cubic_bezier_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -1762,7 +1762,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung cull_opacity_perf__timeline_summary
+  - name: Linux_samsung_s10 cull_opacity_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -2086,7 +2086,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung imagefiltered_transform_animation_perf__timeline_summary
+  - name: Linux_samsung_s10 imagefiltered_transform_animation_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -2204,7 +2204,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung new_gallery__transition_perf
+  - name: Linux_samsung_s10 new_gallery__transition_perf
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -2238,7 +2238,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung picture_cache_perf__timeline_summary
+  - name: Linux_samsung_s10 picture_cache_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -2302,7 +2302,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung platform_views_scroll_perf__timeline_summary
+  - name: Linux_samsung_s10 platform_views_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
@@ -2366,7 +2366,7 @@ targets:
       benchmark: "true"
     scheduler: luci
 
-  - name: Linux_samsung textfield_perf__timeline_summary
+  - name: Linux_samsung_s10 textfield_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/92612.

With [two Linux/SamsungS10 test beds](https://chromium-swarm.appspot.com/botlist?c=id&c=task&c=device&c=device_os&c=device_os_type&c=device_type&c=mac_model&c=machine_type&c=os&c=status&d=asc&f=pool%3Aluci.flutter.prod&f=device_type%3ASM-G973U1&k=device_type&s=id) in prod pool, we are ready to start testing in post-submit as `bringup: true`.