### PR TITLE
Limit overscroll stretching

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -707,7 +707,15 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
         } else {
           assert(notification.overscroll != 0.0);
           if (notification.dragDetails != null) {
-            _stretchController.pull(notification.overscroll.abs() / notification.metrics.viewportDimension);
+            // We clamp the overscroll amount relative to the length of the viewport,
+            // which is the furthest distance a single pointer could pull on the
+            // screen. This is because more than one pointer will multiply the
+            // amount of overscroll - https://github.com/flutter/flutter/issues/11884
+            final double viewportDimension = notification.metrics.viewportDimension;
+            final double distanceForPull =
+              (notification.overscroll.abs() / viewportDimension) + _stretchController.pullDistance;
+            final double clampedOverscroll = distanceForPull.clamp(0, 1.0);
+            _stretchController.pull(clampedOverscroll);
           }
         }
       }
@@ -818,6 +826,8 @@ class _StretchController extends ChangeNotifier {
   late final Animation<double> _stretchSize;
   final Tween<double> _stretchSizeTween = Tween<double>(begin: 0.0, end: 0.0);
   _StretchState _state = _StretchState.idle;
+
+  double get pullDistance => _pullDistance;
   double _pullDistance = 0.0;
 
   // Constants from Android.
@@ -848,7 +858,7 @@ class _StretchController extends ChangeNotifier {
   /// in the main axis.
   void pull(double normalizedOverscroll) {
     assert(normalizedOverscroll >= 0.0);
-    _pullDistance = normalizedOverscroll + _pullDistance;
+    _pullDistance = normalizedOverscroll;
     _stretchSizeTween.begin = _stretchSize.value;
     final double linearIntensity =_stretchIntensity * _pullDistance;
     final double exponentialIntensity = _stretchIntensity * (1 - math.exp(-_pullDistance * _exponentialScalar));

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -451,4 +451,125 @@ void main() {
     await gesture.up();
     await tester.pumpAndSettle();
   });
+
+  testWidgets('Stretch limit', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/99264
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ScrollConfiguration(
+            behavior: const ScrollBehavior().copyWith(overscroll: false),
+            child: StretchingOverscrollIndicator(
+              axisDirection: AxisDirection.down,
+              child: SizedBox(
+                height: 300,
+                child: ListView.builder(
+                  itemCount: 20,
+                  itemBuilder: (BuildContext context, int index){
+                    return Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: Text('Index $index'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        )
+      )
+    );
+    const double maxStretchLocation = 52.63178407049861;
+
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, 51.0);
+
+    TestGesture pointer = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll beyond the limit (the viewport is 600.0).
+    await pointer.moveBy(const Offset(0.0, 610.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, maxStretchLocation);
+
+    pointer = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll way way beyond the limit
+    await pointer.moveBy(const Offset(0.0, 1000.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, maxStretchLocation);
+
+    await pointer.up();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('Multiple pointers wll not exceed stretch limit', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/99264
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ScrollConfiguration(
+            behavior: const ScrollBehavior().copyWith(overscroll: false),
+            child: StretchingOverscrollIndicator(
+              axisDirection: AxisDirection.down,
+              child: SizedBox(
+                height: 300,
+                child: ListView.builder(
+                  itemCount: 20,
+                  itemBuilder: (BuildContext context, int index){
+                    return Padding(
+                      padding: const EdgeInsets.all(10.0),
+                      child: Text('Index $index'),
+                    );
+                  },
+                ),
+              ),
+            ),
+          ),
+        )
+      )
+    );
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, 51.0);
+
+    final TestGesture pointer1 = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll the start.
+    await pointer1.moveBy(const Offset(0.0, 210.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    double lastStretchedLocation = tester.getCenter(find.text('Index 1')).dy;
+    expect(lastStretchedLocation, greaterThan(51.0));
+
+    final TestGesture pointer2 = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Add overscroll from an additional pointer
+    await pointer2.moveBy(const Offset(0.0, 210.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(lastStretchedLocation));
+    lastStretchedLocation = tester.getCenter(find.text('Index 1')).dy;
+
+    final TestGesture pointer3 = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Add overscroll from an additional pointer, exceeding the max stretch (600)
+    await pointer3.moveBy(const Offset(0.0, 210.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(lastStretchedLocation));
+    lastStretchedLocation = tester.getCenter(find.text('Index 1')).dy;
+
+    final TestGesture pointer4 = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Since we have maxed out the overscroll, it should not have stretched
+    // further, regardless of the number of pointers.
+    await pointer4.moveBy(const Offset(0.0, 210.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, lastStretchedLocation);
+
+    await pointer1.up();
+    await pointer2.up();
+    await pointer3.up();
+    await pointer4.up();
+    await tester.pumpAndSettle();
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/99264

This limits the amount of stretch that the indicator can reach, regardless of how many pointers you apply.
(I see you #11884 😝 )

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
