### PR TITLE
Re-invoke DismissIntent in Autocomplete if ignored

### DIFF
--- a/packages/flutter/lib/src/widgets/autocomplete.dart
+++ b/packages/flutter/lib/src/widgets/autocomplete.dart
@@ -370,11 +370,13 @@ class _RawAutocompleteState<T extends Object> extends State<RawAutocomplete<T>> 
     _updateHighlight(_highlightedOptionIndex.value + 1);
   }
 
-  void _hideOptions(DismissIntent intent) {
+  Object? _hideOptions(DismissIntent intent) {
     if (!_userHidOptions) {
       _userHidOptions = true;
       _updateOverlay();
+      return null;
     }
+    return Actions.invoke(context, intent);
   }
 
   void _setActionsEnabled(bool enabled) {

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -883,6 +883,67 @@ void main() {
     expect(find.byKey(optionsKey), findsNothing);
   });
 
+  testWidgets('re-invokes DismissIntent if options not shown', (WidgetTester tester) async {
+    final GlobalKey fieldKey = GlobalKey();
+    final GlobalKey optionsKey = GlobalKey();
+    late FocusNode focusNode;
+    late TextEditingController textEditingController;
+    bool wrappingActionInvoked = false;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Actions(
+            actions: <Type, Action<Intent>>{
+              DismissIntent: CallbackAction<DismissIntent>(
+                onInvoke: (_) => wrappingActionInvoked = true,
+              ),
+            },
+            child: RawAutocomplete<String>(
+              optionsBuilder: (TextEditingValue textEditingValue) {
+                return kOptions.where((String option) {
+                  return option.contains(textEditingValue.text.toLowerCase());
+                });
+              },
+              fieldViewBuilder: (BuildContext context, TextEditingController fieldTextEditingController, FocusNode fieldFocusNode, VoidCallback onFieldSubmitted) {
+                focusNode = fieldFocusNode;
+                textEditingController = fieldTextEditingController;
+                return TextFormField(
+                  key: fieldKey,
+                  focusNode: focusNode,
+                  controller: textEditingController,
+                  onFieldSubmitted: (String value) {
+                    onFieldSubmitted();
+                  },
+                );
+              },
+              optionsViewBuilder: (BuildContext context, AutocompleteOnSelected<String> onSelected, Iterable<String> options) {
+                return Container(key: optionsKey);
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Enter text to show options.
+    focusNode.requestFocus();
+    await tester.enterText(find.byKey(fieldKey), 'ele');
+    await tester.pumpAndSettle();
+    expect(find.byKey(fieldKey), findsOneWidget);
+    expect(find.byKey(optionsKey), findsOneWidget);
+
+    // Hide the options.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(find.byKey(fieldKey), findsOneWidget);
+    expect(find.byKey(optionsKey), findsNothing);
+    expect(wrappingActionInvoked, false);
+
+    // Ensure the wrapping Actions can receive the DismissIntent.
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    expect(wrappingActionInvoked, true);
+  });
+
   testWidgets('optionsViewBuilders can use AutocompleteHighlightedOption to highlight selected option', (WidgetTester tester) async {
     final GlobalKey fieldKey = GlobalKey();
     final GlobalKey optionsKey = GlobalKey();

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -887,7 +887,6 @@ void main() {
     final GlobalKey fieldKey = GlobalKey();
     final GlobalKey optionsKey = GlobalKey();
     late FocusNode focusNode;
-    late TextEditingController textEditingController;
     bool wrappingActionInvoked = false;
     await tester.pumpWidget(
       MaterialApp(
@@ -906,11 +905,10 @@ void main() {
               },
               fieldViewBuilder: (BuildContext context, TextEditingController fieldTextEditingController, FocusNode fieldFocusNode, VoidCallback onFieldSubmitted) {
                 focusNode = fieldFocusNode;
-                textEditingController = fieldTextEditingController;
                 return TextFormField(
                   key: fieldKey,
                   focusNode: focusNode,
-                  controller: textEditingController,
+                  controller: fieldTextEditingController,
                   onFieldSubmitted: (String value) {
                     onFieldSubmitted();
                   },


### PR DESCRIPTION
Ensures the `DismissIntent` used to dismiss the `RawAutocomplete` menu is re-invoked if the menu isn't visible.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
