### PR TITLE
Fix AppBar to can have automatic Backbutton and endDrawer together

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -808,6 +808,8 @@ class _AppBarState extends State<AppBar> {
 
     final bool hasDrawer = scaffold?.hasDrawer ?? false;
     final bool hasEndDrawer = scaffold?.hasEndDrawer ?? false;
+    final bool isEndDrawerOpen = scaffold?.isEndDrawerOpen ?? false;
+    final bool isFirstRoute = parentRoute?.isFirst ?? false;
     final bool canPop = parentRoute?.canPop ?? false;
     final bool useCloseButton = parentRoute is PageRoute<dynamic> && parentRoute.fullscreenDialog;
 
@@ -881,8 +883,10 @@ class _AppBarState extends State<AppBar> {
           tooltip: MaterialLocalizations.of(context).openAppDrawerTooltip,
         );
       } else {
-        if (!hasEndDrawer && canPop)
+        final bool canHaveLeadingWithEndDrawer = !(isFirstRoute && isEndDrawerOpen);
+        if (canPop && canHaveLeadingWithEndDrawer) {
           leading = useCloseButton ? const CloseButton() : const BackButton();
+        }
       }
     }
     if (leading != null) {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2447,7 +2447,44 @@ void main() {
     expect(tester.getRect(find.byKey(key)), const Rect.fromLTRB(0, 0, 100, 56));
   });
 
-  testWidgets("AppBar with EndDrawer doesn't have leading", (WidgetTester tester) async {
+  testWidgets('AppBar can show leading and endDrawer together', (WidgetTester tester) async {
+    const Page<void> page1 = MaterialPage<void>(child: Scaffold());
+    final Page<void> page2 = MaterialPage<void>(
+      child: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            appBar: AppBar(),
+            endDrawer: const Drawer(),
+            onEndDrawerChanged: (bool isOpened) {
+              setState.call(() {});
+            },
+          );
+        },
+      ),
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Navigator(
+          pages: <Page<void>>[ page1, page2 ],
+          onPopPage: (Route<dynamic> route, dynamic result) => false,
+        ),
+      ),
+    );
+
+    Finder findBackButton() => find.byType(BackButton);
+    Finder findEndDrawer() => find.byTooltip('Open navigation menu');
+
+    expect(findBackButton(), findsOneWidget);
+    expect(findEndDrawer(), findsOneWidget);
+
+    await tester.tap(findEndDrawer());
+    await tester.pump();
+
+    expect(findBackButton(), findsOneWidget);
+    expect(findEndDrawer(), findsOneWidget);
+  });
+
+  testWidgets("AppBar with endDrawer doesn't have leading if there's no route below scaffold and drawer is open", (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
         appBar: AppBar(),


### PR DESCRIPTION
This is a recreation of #98815.

This PR fixes #97608.

cc @chunhtai

<details>
<summary>sample code</summary>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MaterialApp(home: MyApp()));
}

class MyApp extends StatefulWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(),
      endDrawer: const Drawer(),
      onEndDrawerChanged: (_) {
        setState(() {});
      },
      floatingActionButton: FloatingActionButton(
        child: const Icon(Icons.add),
        onPressed: () {
          Navigator.push(
            context,
            MaterialPageRoute(
              builder: (_) => StatefulBuilder(builder: (context, setState) {
                return Scaffold(
                  appBar: AppBar(),
                  endDrawer: const Drawer(),
                  onEndDrawerChanged: (_) {
                    setState.call(() {});
                  },
                );
              }),
            ),
          );
        },
      ),
    );
  }
}
```

</details>

### Before

https://user-images.githubusercontent.com/57604817/154826705-73117abf-f0fa-4a7b-99a0-2e3bef9ee15a.mov

### After

https://user-images.githubusercontent.com/57604817/154826688-8a0601c3-0e8a-4274-8314-f73ae7fb358d.mov


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
