### PR TITLE
Deflake post-submit Linux/Samsung S10 tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1477,7 +1477,6 @@ targets:
 
   - name: Linux_samsung_s10 backdrop_filter_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -1627,7 +1626,6 @@ targets:
 
   - name: Linux_samsung_s10 complex_layout_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -1730,7 +1728,6 @@ targets:
 
   - name: Linux_samsung_s10 cubic_bezier_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -1764,7 +1761,6 @@ targets:
 
   - name: Linux_samsung_s10 cull_opacity_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -2088,7 +2084,6 @@ targets:
 
   - name: Linux_samsung_s10 imagefiltered_transform_animation_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -2206,7 +2201,6 @@ targets:
 
   - name: Linux_samsung_s10 new_gallery__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -2240,7 +2234,6 @@ targets:
 
   - name: Linux_samsung_s10 picture_cache_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -2304,7 +2297,6 @@ targets:
 
   - name: Linux_samsung_s10 platform_views_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:
@@ -2368,7 +2360,6 @@ targets:
 
   - name: Linux_samsung_s10 textfield_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true # https://github.com/flutter/flutter/issues/92612
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
These tests have been validated in the staging pool for more than 50 runs (e.g. [backdrop_file_perf__timeline_summary](https://ci.chromium.org/p/flutter/builders/staging/Linux_android_staging%20backdrop_filter_perf__timeline_summary?limit=50)), and were newly enabled in prod as `bringup: true` (https://github.com/flutter/flutter/pull/99353).

Now tests are running successfully, this PR is removing `bringup: true` flag.