### PR TITLE
Use `PlatformDispatcher.instance` over `window` where possible

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -262,7 +262,7 @@ abstract class SceneBuilderRecorder extends Recorder {
     final Completer<Profile> profileCompleter = Completer<Profile>();
     _profile = Profile(name: name);
 
-    window.onBeginFrame = (_) {
+    PlatformDispatcher.instance.onBeginFrame = (_) {
       try {
         startMeasureFrame(profile!);
         onBeginFrame();
@@ -271,7 +271,7 @@ abstract class SceneBuilderRecorder extends Recorder {
         rethrow;
       }
     };
-    window.onDrawFrame = () {
+    PlatformDispatcher.instance.onDrawFrame = () {
       try {
         _profile!.record('drawFrameDuration', () {
           final SceneBuilder sceneBuilder = SceneBuilder();
@@ -286,7 +286,7 @@ abstract class SceneBuilderRecorder extends Recorder {
         endMeasureFrame();
 
         if (shouldContinue()) {
-          window.scheduleFrame();
+          PlatformDispatcher.instance.scheduleFrame();
         } else {
           profileCompleter.complete(_profile);
         }
@@ -295,7 +295,7 @@ abstract class SceneBuilderRecorder extends Recorder {
         rethrow;
       }
     };
-    window.scheduleFrame();
+    PlatformDispatcher.instance.scheduleFrame();
     return profileCompleter.future;
   }
 }
@@ -403,7 +403,7 @@ abstract class WidgetRecorder extends Recorder implements FrameRecorder {
     profile!.addDataPoint('drawFrameDuration', _drawFrameStopwatch.elapsed, reported: true);
 
     if (shouldContinue()) {
-      window.scheduleFrame();
+      PlatformDispatcher.instance.scheduleFrame();
     } else {
       for (final VoidCallback fn in _didStopCallbacks)
         fn();

--- a/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show window;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stocks/main.dart' as stocks;
@@ -61,8 +59,8 @@ void main() {
     expect(find.text('Account Balance'), findsNothing);
 
     // drag the drawer out
-    final Offset left = Offset(0.0, (ui.window.physicalSize / ui.window.devicePixelRatio).height / 2.0);
-    final Offset right = Offset((ui.window.physicalSize / ui.window.devicePixelRatio).width, left.dy);
+    final Offset left = Offset(0.0, (WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio).height / 2.0);
+    final Offset right = Offset((WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio).width, left.dy);
     final TestGesture gesture = await tester.startGesture(left);
     await tester.pump();
     await gesture.moveTo(right);

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/lib/main.dart
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/lib/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -14,8 +12,8 @@ VoidCallback? originalSemanticsListener;
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
   // Disconnects semantics listener for testing purposes.
-  originalSemanticsListener = ui.window.onSemanticsEnabledChanged;
-  ui.window.onSemanticsEnabledChanged = null;
+  originalSemanticsListener = WidgetsBinding.instance.platformDispatcher.onSemanticsEnabledChanged;
+  RendererBinding.instance.platformDispatcher.onSemanticsEnabledChanged = null;
   RendererBinding.instance.setSemanticsEnabled(false);
   // If the test passes, LifeCycleSpy will rewire the semantics listener back.
   runApp(const LifeCycleSpy());
@@ -71,7 +69,7 @@ class _LifeCycleSpyState extends State<LifeCycleSpy> with WidgetsBindingObserver
     if (const ListEquality<AppLifecycleState?>().equals(_actualLifeCycleSequence, _expectedLifeCycleSequence)) {
       // Rewires the semantics harness if test passes.
       RendererBinding.instance.setSemanticsEnabled(true);
-      ui.window.onSemanticsEnabledChanged = originalSemanticsListener;
+      RendererBinding.instance.platformDispatcher.onSemanticsEnabledChanged = originalSemanticsListener;
     }
     return const MaterialApp(
       title: 'Flutter View',

--- a/dev/integration_tests/ui/lib/route.dart
+++ b/dev/integration_tests/ui/lib/route.dart
@@ -10,6 +10,6 @@ import 'package:flutter_driver/driver_extension.dart';
 
 void main() {
   enableFlutterDriverExtension(handler: (String? message) async {
-    return ui.window.defaultRouteName;
+    return ui.PlatformDispatcher.instance.defaultRouteName;
   });
 }

--- a/examples/layers/raw/canvas.dart
+++ b/examples/layers/raw/canvas.dart
@@ -122,6 +122,7 @@ void beginFrame(Duration timeStamp) {
 }
 
 void main() {
-  ui.window.onBeginFrame = beginFrame;
-  ui.window.scheduleFrame();
+  ui.PlatformDispatcher.instance
+    ..onBeginFrame = beginFrame
+    ..scheduleFrame();
 }

--- a/examples/layers/raw/hello_world.dart
+++ b/examples/layers/raw/hello_world.dart
@@ -42,9 +42,9 @@ void beginFrame(Duration timeStamp) {
 // calls main() as soon as it has loaded your code.
 void main() {
   // The engine calls onBeginFrame whenever it wants us to produce a frame.
-  ui.window.onBeginFrame = beginFrame;
+  ui.PlatformDispatcher.instance.onBeginFrame = beginFrame;
   // Here we kick off the whole process by asking the engine to schedule a new
   // frame. The engine will eventually call onBeginFrame when it is time for us
   // to actually produce the frame.
-  ui.window.scheduleFrame();
+  ui.PlatformDispatcher.instance.scheduleFrame();
 }

--- a/examples/layers/raw/spinning_square.dart
+++ b/examples/layers/raw/spinning_square.dart
@@ -52,10 +52,11 @@ void beginFrame(Duration timeStamp) {
   // After rendering the current frame of the animation, we ask the engine to
   // schedule another frame. The engine will call beginFrame again when its time
   // to produce the next frame.
-  ui.window.scheduleFrame();
+  ui.PlatformDispatcher.instance.scheduleFrame();
 }
 
 void main() {
-  ui.window.onBeginFrame = beginFrame;
-  ui.window.scheduleFrame();
+  ui.PlatformDispatcher.instance
+    ..onBeginFrame = beginFrame
+    ..scheduleFrame();
 }

--- a/examples/layers/raw/text.dart
+++ b/examples/layers/raw/text.dart
@@ -89,6 +89,7 @@ void main() {
     ..layout(const ui.ParagraphConstraints(width: 180.0));
 
   // Finally, we register our beginFrame callback and kick off the first frame.
-  ui.window.onBeginFrame = beginFrame;
-  ui.window.scheduleFrame();
+  ui.PlatformDispatcher.instance
+      ..onBeginFrame = beginFrame
+      ..scheduleFrame();
 }

--- a/examples/layers/raw/touch_input.dart
+++ b/examples/layers/raw/touch_input.dart
@@ -94,7 +94,7 @@ void handlePointerDataPacket(ui.PointerDataPacket packet) {
       // point where the engine calls onBeginFrame, which signals the boundary
       // between one frame and another.
       color = const ui.Color(0xFF00FF00);
-      ui.window.scheduleFrame();
+      ui.PlatformDispatcher.instance.scheduleFrame();
     }
   }
 }
@@ -104,12 +104,12 @@ void handlePointerDataPacket(ui.PointerDataPacket packet) {
 void main() {
   color = const ui.Color(0xFF00FF00);
   // The engine calls onBeginFrame whenever it wants us to produce a frame.
-  ui.window.onBeginFrame = beginFrame;
+  ui.PlatformDispatcher.instance.onBeginFrame = beginFrame;
   // The engine calls onPointerDataPacket whenever it had updated information
   // about the pointers directed at our app.
-  ui.window.onPointerDataPacket = handlePointerDataPacket;
+  ui.PlatformDispatcher.instance.onPointerDataPacket = handlePointerDataPacket;
   // Here we kick off the whole process by asking the engine to schedule a new
   // frame. The engine will eventually call onBeginFrame when it is time for us
   // to actually produce the frame.
-  ui.window.scheduleFrame();
+  ui.PlatformDispatcher.instance.scheduleFrame();
 }

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
-import 'dart:ui' show window;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -1360,7 +1359,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     if (result == null) {
       // If there's no MediaQuery, then use the window aspect to determine
       // orientation.
-      final Size size = window.physicalSize;
+      final Size size = WidgetsBinding.instance.window.physicalSize;
       result = size.width > size.height ? Orientation.landscape : Orientation.portrait;
     }
     return result;

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui' as ui;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -1746,7 +1745,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
     //
     // TODO(rami-a): Once https://github.com/flutter/flutter/issues/67571 is
     // resolved, remove the window check for semantics being enabled on web.
-    final String? hintText = MediaQuery.of(context).accessibleNavigation || ui.window.semanticsEnabled
+    final String? hintText = MediaQuery.of(context).accessibleNavigation || WidgetsBinding.instance.window.semanticsEnabled
         ? widget.semanticHintText
         : (focusNode.hasFocus ? null : _formattedValue);
     inputDecoration = inputDecoration.copyWith(

--- a/packages/flutter/test/animation/animation_controller_test.dart
+++ b/packages/flutter/test/animation/animation_controller_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/scheduler.dart';
@@ -16,9 +14,10 @@ import '../scheduler/scheduler_tester.dart';
 void main() {
   setUp(() {
     WidgetsFlutterBinding.ensureInitialized();
-    WidgetsBinding.instance.resetEpoch();
-    ui.window.onBeginFrame = null;
-    ui.window.onDrawFrame = null;
+    WidgetsBinding.instance
+        ..resetEpoch()
+        ..platformDispatcher.onBeginFrame = null
+        ..platformDispatcher.onDrawFrame = null;
   });
 
   test('Can set value during status callback', () {

--- a/packages/flutter/test/animation/animations_test.dart
+++ b/packages/flutter/test/animation/animations_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -17,9 +15,10 @@ class BogusCurve extends Curve {
 void main() {
   setUp(() {
     WidgetsFlutterBinding.ensureInitialized();
-    WidgetsBinding.instance.resetEpoch();
-    ui.window.onBeginFrame = null;
-    ui.window.onDrawFrame = null;
+    WidgetsBinding.instance
+      ..resetEpoch()
+      ..platformDispatcher.onBeginFrame = null
+      ..platformDispatcher.onDrawFrame = null;
   });
 
   test('toString control test', () {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -80,10 +80,10 @@ class TestServiceExtensionsBinding extends BindingBase
   }
   Future<void> doFrame() async {
     frameScheduled = false;
-    ui.window.onBeginFrame?.call(Duration.zero);
+    binding.platformDispatcher.onBeginFrame?.call(Duration.zero);
     await flushMicrotasks();
-    ui.window.onDrawFrame?.call();
-    ui.window.onReportTimings?.call(<ui.FrameTiming>[]);
+    binding.platformDispatcher.onDrawFrame?.call();
+    binding.platformDispatcher.onReportTimings?.call(<ui.FrameTiming>[]);
   }
 
   @override

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_on_widget_test.dart
@@ -93,7 +93,7 @@ void main() {
     GestureBinding.instance.resamplingEnabled = true;
     const Duration kSamplingOffset = Duration(milliseconds: -5);
     GestureBinding.instance.samplingOffset = kSamplingOffset;
-    ui.window.onPointerDataPacket!(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket!(packet);
     expect(events.length, 0);
 
     requestFrame();
@@ -101,7 +101,7 @@ void main() {
     expect(events.length, 1);
     expect(events[0], isA<PointerDownEvent>());
     expect(events[0].timeStamp, currentTestFrameTime() + kSamplingOffset);
-    expect(events[0].position, Offset(7.5 / ui.window.devicePixelRatio, 0.0));
+    expect(events[0].position, Offset(7.5 / GestureBinding.instance.window.devicePixelRatio, 0.0));
 
     // Now the system time is epoch + 20ms
     requestFrame();
@@ -109,8 +109,8 @@ void main() {
     expect(events.length, 2);
     expect(events[1].timeStamp, currentTestFrameTime() + kSamplingOffset);
     expect(events[1], isA<PointerMoveEvent>());
-    expect(events[1].position, Offset(22.5 / ui.window.devicePixelRatio, 0.0));
-    expect(events[1].delta, Offset(15.0 / ui.window.devicePixelRatio, 0.0));
+    expect(events[1].position, Offset(22.5 / GestureBinding.instance.window.devicePixelRatio, 0.0));
+    expect(events[1].delta, Offset(15.0 / GestureBinding.instance.window.devicePixelRatio, 0.0));
 
     // Now the system time is epoch + 30ms
     requestFrame();
@@ -118,8 +118,8 @@ void main() {
     expect(events.length, 4);
     expect(events[2].timeStamp, currentTestFrameTime() + kSamplingOffset);
     expect(events[2], isA<PointerMoveEvent>());
-    expect(events[2].position, Offset(37.5 / ui.window.devicePixelRatio, 0.0));
-    expect(events[2].delta, Offset(15.0 / ui.window.devicePixelRatio, 0.0));
+    expect(events[2].position, Offset(37.5 / GestureBinding.instance.window.devicePixelRatio, 0.0));
+    expect(events[2].delta, Offset(15.0 / GestureBinding.instance.window.devicePixelRatio, 0.0));
     expect(events[3].timeStamp, currentTestFrameTime() + kSamplingOffset);
     expect(events[3], isA<PointerUpEvent>());
   });
@@ -134,7 +134,7 @@ void main() {
       ],
     );
     GestureBinding.instance.resamplingEnabled = true;
-    ui.window.onPointerDataPacket!(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket!(packet);
 
     // Expected to stop resampling, but the timer keeps active if _timer?.cancel() not be called.
     GestureBinding.instance.resamplingEnabled = false;

--- a/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_resample_event_test.dart
@@ -122,7 +122,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     binding.callback = events.add;
 
-    ui.window.onPointerDataPacket?.call(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
 
     // No pointer events should have been dispatched yet.
     expect(events.length, 0);
@@ -139,7 +139,7 @@ void main() {
     expect(events.length, 1);
     expect(events[0], isA<PointerDownEvent>());
     expect(events[0].timeStamp, binding.frameTime! + samplingOffset);
-    expect(events[0].position, Offset(0.0 / ui.window.devicePixelRatio, 0.0));
+    expect(events[0].position, Offset(0.0 / GestureBinding.instance.window.devicePixelRatio, 0.0));
 
     // Second frame callback should have been requested.
     callback = binding.postFrameCallback;
@@ -154,8 +154,8 @@ void main() {
     expect(events.length, 2);
     expect(events[1], isA<PointerMoveEvent>());
     expect(events[1].timeStamp, binding.frameTime! + samplingOffset);
-    expect(events[1].position, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
-    expect(events[1].delta, Offset(10.0 / ui.window.devicePixelRatio, 0.0));
+    expect(events[1].position, Offset(10.0 / GestureBinding.instance.window.devicePixelRatio, 0.0));
+    expect(events[1].delta, Offset(10.0 / GestureBinding.instance.window.devicePixelRatio, 0.0));
 
     // Verify that resampling continues without a frame callback.
     async.elapse(frameInterval * 1.5);

--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -59,7 +59,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     binding.callback = events.add;
 
-    ui.window.onPointerDataPacket?.call(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 2);
     expect(events[0], isA<PointerDownEvent>());
     expect(events[1], isA<PointerUpEvent>());
@@ -77,7 +77,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     binding.callback = events.add;
 
-    ui.window.onPointerDataPacket?.call(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 3);
     expect(events[0], isA<PointerDownEvent>());
     expect(events[1], isA<PointerMoveEvent>());
@@ -102,7 +102,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     binding.callback = events.add;
 
-    ui.window.onPointerDataPacket?.call(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 3);
     expect(events[0], isA<PointerHoverEvent>());
     expect(events[1], isA<PointerHoverEvent>());
@@ -127,7 +127,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     binding.callback = events.add;
 
-    ui.window.onPointerDataPacket?.call(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 2);
     expect(events[0], isA<PointerDownEvent>());
     expect(events[1], isA<PointerCancelEvent>());
@@ -148,7 +148,7 @@ void main() {
         binding.cancelPointer(event.pointer);
     };
 
-    ui.window.onPointerDataPacket?.call(packet);
+    GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 2);
     expect(events[0], isA<PointerDownEvent>());
     expect(events[1], isA<PointerCancelEvent>());
@@ -165,7 +165,7 @@ void main() {
       ],
     );
 
-    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
     expect(events.length, 5);
     expect(events[0], isA<PointerAddedEvent>());
@@ -183,7 +183,7 @@ void main() {
         ],
     );
 
-    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
     expect(events.length, 2);
     expect(events[0], isA<PointerAddedEvent>());
@@ -191,7 +191,7 @@ void main() {
   });
 
   test('Should synthesize kPrimaryButton for touch when no button is set', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    final Offset location = const Offset(10.0, 10.0) * GestureBinding.instance.window.devicePixelRatio;
     final ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
         ui.PointerData(change: ui.PointerChange.add, physicalX: location.dx, physicalY: location.dy),
@@ -202,7 +202,7 @@ void main() {
       ],
     );
 
-    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
     expect(events.length, 5);
     expect(events[0], isA<PointerAddedEvent>());
@@ -218,7 +218,7 @@ void main() {
   });
 
   test('Should not synthesize kPrimaryButton for touch when a button is set', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    final Offset location = const Offset(10.0, 10.0) * GestureBinding.instance.window.devicePixelRatio;
     final ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
         ui.PointerData(change: ui.PointerChange.add, physicalX: location.dx, physicalY: location.dy),
@@ -229,7 +229,7 @@ void main() {
       ],
     );
 
-    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
     expect(events.length, 5);
     expect(events[0], isA<PointerAddedEvent>());
@@ -245,7 +245,7 @@ void main() {
   });
 
   test('Should synthesize kPrimaryButton for stylus when no button is set', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    final Offset location = const Offset(10.0, 10.0) * GestureBinding.instance.window.devicePixelRatio;
     for (final PointerDeviceKind kind in <PointerDeviceKind>[
       PointerDeviceKind.stylus,
       PointerDeviceKind.invertedStylus,
@@ -261,7 +261,7 @@ void main() {
         ],
       );
 
-      final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+      final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
       expect(events.length, 5);
       expect(events[0], isA<PointerAddedEvent>());
@@ -278,7 +278,7 @@ void main() {
   });
 
   test('Should synthesize kPrimaryButton for unknown devices when no button is set', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    final Offset location = const Offset(10.0, 10.0) * GestureBinding.instance.window.devicePixelRatio;
     const PointerDeviceKind kind = PointerDeviceKind.unknown;
     final ui.PointerDataPacket packet = ui.PointerDataPacket(
       data: <ui.PointerData>[
@@ -290,7 +290,7 @@ void main() {
       ],
     );
 
-    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+    final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
     expect(events.length, 5);
     expect(events[0], isA<PointerAddedEvent>());
@@ -306,7 +306,7 @@ void main() {
   });
 
   test('Should not synthesize kPrimaryButton for mouse', () {
-    final Offset location = const Offset(10.0, 10.0) * ui.window.devicePixelRatio;
+    final Offset location = const Offset(10.0, 10.0) * GestureBinding.instance.window.devicePixelRatio;
     for (final PointerDeviceKind kind in <PointerDeviceKind>[
       PointerDeviceKind.mouse,
     ]) {
@@ -320,7 +320,7 @@ void main() {
         ],
       );
 
-      final List<PointerEvent> events = PointerEventConverter.expand(packet.data, ui.window.devicePixelRatio).toList();
+      final List<PointerEvent> events = PointerEventConverter.expand(packet.data, GestureBinding.instance.window.devicePixelRatio).toList();
 
       expect(events.length, 5);
       expect(events[0], isA<PointerAddedEvent>());

--- a/packages/flutter/test/gestures/locking_test.dart
+++ b/packages/flutter/test/gestures/locking_test.dart
@@ -30,7 +30,7 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding {
   Future<void> test(VoidCallback callback) {
     assert(callback != null);
     return _binding.lockEvents(() async {
-      ui.window.onPointerDataPacket?.call(packet);
+      GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
       callback();
     });
   }

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show window;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -84,7 +82,7 @@ Widget _wrapForChip({
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(window).copyWith(textScaleFactor: textScaleFactor),
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScaleFactor),
         child: Material(child: child),
       ),
     ),

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:math' as math;
-import 'dart:ui' show window;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -91,7 +90,7 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(window).copyWith(size: widget.mediaSize),
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -13,7 +13,6 @@
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
 
 import 'dart:math' as math;
-import 'dart:ui' show window;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
@@ -218,7 +217,7 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(window).copyWith(size: widget.mediaSize),
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show window, SemanticsFlag;
+import 'dart:ui' show SemanticsFlag;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -2595,7 +2595,7 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(window),
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1548,7 +1548,7 @@ void main() {
           child: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
               return MediaQuery(
-                data: MediaQueryData.fromWindow(window).copyWith(textScaleFactor: 2.0),
+                data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: 2.0),
                 child: Material(
                   child: Center(
                     child: Theme(

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show window;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -378,7 +376,7 @@ void main() {
         home: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
-            data: MediaQueryData.fromWindow(window).copyWith(textScaleFactor: textScale),
+            data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScale),
             child: Material(
               child: Row(
                 children: <Widget>[
@@ -555,7 +553,7 @@ void main() {
         home: Directionality(
           textDirection: TextDirection.ltr,
           child: MediaQuery(
-            data: MediaQueryData.fromWindow(window).copyWith(textScaleFactor: textScale),
+            data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScale),
             child: Material(
               child: Row(
                 children: <Widget>[

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -13,7 +13,7 @@
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
 
 import 'dart:math' as math;
-import 'dart:ui' as ui show window, BoxHeightStyle, BoxWidthStyle, WindowPadding;
+import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, WindowPadding;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -6454,7 +6454,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: MediaQuery(
-              data: MediaQueryData.fromWindow(ui.window).copyWith(textScaleFactor: 4.0),
+              data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: 4.0),
               child: Center(
                 child: TextField(
                   decoration: const InputDecoration(labelText: 'Label', border: UnderlineInputBorder()),

--- a/packages/flutter/test/rendering/independent_layout_test.dart
+++ b/packages/flutter/test/rendering/independent_layout_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show window;
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -46,7 +44,7 @@ void main() {
     expect(offscreen.child.hasSize, isFalse);
     expect(offscreen.painted, isFalse);
     // Attach the offscreen to a custom render view and owner
-    final RenderView renderView = RenderView(configuration: testConfiguration, window: ui.window);
+    final RenderView renderView = RenderView(configuration: testConfiguration, window: RendererBinding.instance.window);
     final PipelineOwner pipelineOwner = PipelineOwner();
     renderView.attach(pipelineOwner);
     renderView.child = offscreen.root;
@@ -76,7 +74,7 @@ void main() {
     expect(offscreen.child.hasSize, isFalse);
     expect(offscreen.painted, isFalse);
     // Attach the offscreen to a custom render view and owner
-    final RenderView renderView = RenderView(configuration: testConfiguration, window: ui.window);
+    final RenderView renderView = RenderView(configuration: testConfiguration, window: RendererBinding.instance.window);
     final PipelineOwner pipelineOwner = PipelineOwner();
     renderView.attach(pipelineOwner);
     renderView.child = offscreen.root;

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -169,7 +169,7 @@ void main() {
   test('switching layer link of an attached leader layer should not crash', () {
     final LayerLink link = LayerLink();
     final LeaderLayer leaderLayer = LeaderLayer(link: link);
-    final RenderView view = RenderView(configuration: const ViewConfiguration(), window: window);
+    final RenderView view = RenderView(configuration: const ViewConfiguration(), window: RendererBinding.instance.window);
     leaderLayer.attach(view);
     final LayerLink link2 = LayerLink();
     leaderLayer.link = link2;
@@ -182,7 +182,7 @@ void main() {
     final LayerLink link = LayerLink();
     final LeaderLayer leaderLayer1 = LeaderLayer(link: link);
     final LeaderLayer leaderLayer2 = LeaderLayer(link: link);
-    final RenderView view = RenderView(configuration: const ViewConfiguration(), window: window);
+    final RenderView view = RenderView(configuration: const ViewConfiguration(), window: RendererBinding.instance.window);
     leaderLayer1.attach(view);
     leaderLayer2.attach(view);
     leaderLayer2.detach();

--- a/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
@@ -49,7 +49,7 @@ void main() {
   }
 
   void dispatchRemoveDevice([int device = 0]) {
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero, device: device),
     ]));
   }
@@ -78,7 +78,7 @@ void main() {
       },
     );
 
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
     addTearDown(dispatchRemoveDevice);
@@ -95,7 +95,7 @@ void main() {
     );
 
     // Pointer is added outside of the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
 
@@ -106,7 +106,7 @@ void main() {
 
     // Pointer moves into the annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
     ]));
 
@@ -117,7 +117,7 @@ void main() {
 
     // Pointer moves within the annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(10.0, 0.0)),
     ]));
 
@@ -126,7 +126,7 @@ void main() {
 
     // Pointer moves out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, Offset.zero),
     ]));
 
@@ -136,7 +136,7 @@ void main() {
     logCursors.clear();
 
     // Pointer is removed outside of the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero),
     ]));
 
@@ -153,7 +153,7 @@ void main() {
 
     // Pointer is added in the annotation.
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
 
@@ -164,7 +164,7 @@ void main() {
 
     // Pointer moves out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
     ]));
 
@@ -175,7 +175,7 @@ void main() {
 
     // Pointer moves around out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(10.0, 0.0)),
     ]));
 
@@ -184,7 +184,7 @@ void main() {
 
     // Pointer moves back into the annotation
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, Offset.zero),
     ]));
 
@@ -194,7 +194,7 @@ void main() {
     logCursors.clear();
 
     // Pointer is removed within the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero),
     ]));
 
@@ -210,7 +210,7 @@ void main() {
     );
 
     // Pointer is added outside of the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
 
@@ -237,7 +237,7 @@ void main() {
     logCursors.clear();
 
     // Pointer is removed outside of the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero),
     ]));
 
@@ -257,7 +257,7 @@ void main() {
       const TestAnnotationTarget(cursor: SystemMouseCursors.click),
       const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing),
     ];
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
 
@@ -267,7 +267,7 @@ void main() {
     logCursors.clear();
 
     // Remove
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(5.0, 0.0)),
     ]));
   });
@@ -285,7 +285,7 @@ void main() {
       const TestAnnotationTarget(),
       const TestAnnotationTarget(cursor: SystemMouseCursors.grabbing),
     ];
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
 
@@ -295,7 +295,7 @@ void main() {
     logCursors.clear();
 
     // Remove
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(5.0, 0.0)),
     ]));
   });
@@ -309,7 +309,7 @@ void main() {
     );
 
     // Pointer is added outside of the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
 
@@ -320,7 +320,7 @@ void main() {
 
     // Pointer moved to an annotation specified with the default cursor
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.basic);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
     ]));
 
@@ -329,7 +329,7 @@ void main() {
 
     // Pointer moved to no annotations
     annotation = null;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, Offset.zero),
     ]));
 
@@ -337,7 +337,7 @@ void main() {
     logCursors.clear();
 
     // Remove
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero),
     ]));
   });
@@ -352,7 +352,7 @@ void main() {
 
     // Pointer is added to the annotation, then removed
     annotation = const TestAnnotationTarget(cursor: SystemMouseCursors.click);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
       _pointerData(PointerChange.hover, const Offset(5.0, 0.0)),
       _pointerData(PointerChange.remove, const Offset(5.0, 0.0)),
@@ -362,7 +362,7 @@ void main() {
 
     // Pointer is added out of the annotation
     annotation = null;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
     addTearDown(dispatchRemoveDevice);
@@ -387,7 +387,7 @@ void main() {
     );
 
     // Pointers are added outside of the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero, device: 1),
       _pointerData(PointerChange.add, Offset.zero, device: 2),
     ]));
@@ -401,7 +401,7 @@ void main() {
     logCursors.clear();
 
     // Pointer 1 moved to cursor "click"
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(101.0, 0.0), device: 1),
     ]));
 
@@ -411,7 +411,7 @@ void main() {
     logCursors.clear();
 
     // Pointer 2 moved to cursor "click"
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(102.0, 0.0), device: 2),
     ]));
 
@@ -421,7 +421,7 @@ void main() {
     logCursors.clear();
 
     // Pointer 2 moved to cursor "forbidden"
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(202.0, 0.0), device: 2),
     ]));
 
@@ -440,8 +440,8 @@ ui.PointerData _pointerData(
 }) {
   return ui.PointerData(
     change: change,
-    physicalX: logicalPosition.dx * ui.window.devicePixelRatio,
-    physicalY: logicalPosition.dy * ui.window.devicePixelRatio,
+    physicalX: logicalPosition.dx * RendererBinding.instance.window.devicePixelRatio,
+    physicalY: logicalPosition.dy * RendererBinding.instance.window.devicePixelRatio,
     kind: kind,
     device: device,
   );

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -64,7 +64,7 @@ void main() {
   }
 
   void dispatchRemoveDevice([int device = 0]) {
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero, device: device),
     ]));
   }
@@ -87,7 +87,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
     // Pointer enters the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -100,7 +100,7 @@ void main() {
     listenerLogs.clear();
 
     // Pointer hovers the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -111,7 +111,7 @@ void main() {
     events.clear();
 
     // Pointer is removed while on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(1.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -122,7 +122,7 @@ void main() {
     listenerLogs.clear();
 
     // Pointer is added on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 301.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -140,7 +140,7 @@ void main() {
     expect(_mouseTracker.mouseIsConnected, isFalse);
 
     // The first mouse is added on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, Offset.zero),
       _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
@@ -152,7 +152,7 @@ void main() {
     events.clear();
 
     // The second mouse is added on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 401.0), device: 1),
       _pointerData(PointerChange.hover, const Offset(1.0, 401.0), device: 1),
     ]));
@@ -164,7 +164,7 @@ void main() {
     events.clear();
 
     // The first mouse moves on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -174,7 +174,7 @@ void main() {
     events.clear();
 
     // The second mouse moves on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 501.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -184,7 +184,7 @@ void main() {
     events.clear();
 
     // The first mouse is removed while on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 101.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -194,7 +194,7 @@ void main() {
     events.clear();
 
     // The second mouse still moves on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(1.0, 601.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -204,7 +204,7 @@ void main() {
     events.clear();
 
     // The second mouse is removed while on the annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(1.0, 601.0), device: 1),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[
@@ -218,7 +218,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     _setUpWithOneAnnotation(logEvents: events);
 
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
       _pointerData(PointerChange.down, const Offset(0.0, 101.0)),
     ]));
@@ -230,13 +230,13 @@ void main() {
     ]));
     events.clear();
 
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.move, const Offset(0.0, 201.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[]));
     events.clear();
 
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.up, const Offset(0.0, 301.0)),
     ]));
     expect(events, _equalToEventsOnCriticalFields(<BaseEventMatcher>[]));
@@ -260,7 +260,7 @@ void main() {
     isInHitRegion = false;
 
     // Connect a mouse when there is no annotation.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -308,7 +308,7 @@ void main() {
     isInHitRegion = false;
 
     // Connect a mouse.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -359,7 +359,7 @@ void main() {
 
     // Connect a mouse in the region. Should trigger Enter.
     isInHitRegion = true;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0)),
     ]));
 
@@ -370,7 +370,7 @@ void main() {
     events.clear();
 
     // Disconnect the mouse from the region. Should trigger Exit.
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, const Offset(0.0, 100.0)),
     ]));
     expect(binding.postFrameCallbacks, hasLength(0));
@@ -394,7 +394,7 @@ void main() {
     });
 
     isInHitRegion = false;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(200.0, 100.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -404,7 +404,7 @@ void main() {
 
     // Moves the mouse into the region. Should trigger Enter.
     isInHitRegion = true;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 100.0)),
     ]));
     expect(binding.postFrameCallbacks, hasLength(0));
@@ -416,7 +416,7 @@ void main() {
 
     // Moves the mouse out of the region. Should trigger Exit.
     isInHitRegion = false;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(200.0, 100.0)),
     ]));
     expect(binding.postFrameCallbacks, hasLength(0));
@@ -430,7 +430,7 @@ void main() {
     });
 
     // Connect a touch device, which should not be recognized by MouseTracker
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 100.0), kind: PointerDeviceKind.touch),
     ]));
     expect(_mouseTracker.mouseIsConnected, isFalse);
@@ -456,7 +456,7 @@ void main() {
 
     isInHitRegionOne = false;
     isInHitRegionTwo = true;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 101.0)),
       _pointerData(PointerChange.hover, const Offset(1.0, 101.0)),
     ]));
@@ -497,7 +497,7 @@ void main() {
 
     // Starts out of A.
     isInB = false;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 1.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -505,7 +505,7 @@ void main() {
 
     // Moves into B within one frame.
     isInB = true;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 10.0)),
     ]));
     expect(logs, <String>['enterA', 'enterB', 'hoverB', 'hoverA']);
@@ -513,7 +513,7 @@ void main() {
 
     // Moves out of A within one frame.
     isInB = false;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 20.0)),
     ]));
     expect(logs, <String>['exitB', 'exitA']);
@@ -552,7 +552,7 @@ void main() {
     // Starts within A.
     isInA = true;
     isInB = false;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.add, const Offset(0.0, 1.0)),
     ]));
     addTearDown(() => dispatchRemoveDevice());
@@ -562,7 +562,7 @@ void main() {
     // Moves into B within one frame.
     isInA = false;
     isInB = true;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 10.0)),
     ]));
     expect(logs, <String>['exitA', 'enterB', 'hoverB']);
@@ -571,7 +571,7 @@ void main() {
     // Moves into A within one frame.
     isInA = true;
     isInB = false;
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.hover, const Offset(0.0, 1.0)),
     ]));
     expect(logs, <String>['exitB', 'enterA', 'hoverA']);
@@ -586,8 +586,8 @@ ui.PointerData _pointerData(
 }) {
   return ui.PointerData(
     change: change,
-    physicalX: logicalPosition.dx * ui.window.devicePixelRatio,
-    physicalY: logicalPosition.dy * ui.window.devicePixelRatio,
+    physicalX: logicalPosition.dx * RendererBinding.instance.window.devicePixelRatio,
+    physicalY: logicalPosition.dy * RendererBinding.instance.window.devicePixelRatio,
     kind: kind,
     device: device,
   );

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -78,7 +78,7 @@ void main() {
       layout(platformViewRenderBox);
       pumpFrame(phase: EnginePhase.flushSemantics);
 
-      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, Offset.zero),
         _pointerData(ui.PointerChange.hover, const Offset(10, 10)),
         _pointerData(ui.PointerChange.remove, const Offset(10, 10)),
@@ -91,7 +91,7 @@ void main() {
       layout(platformViewRenderBox);
       pumpFrame(phase: EnginePhase.flushSemantics);
 
-      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, Offset.zero),
         _pointerData(ui.PointerChange.hover, const Offset(10, 10)),
         _pointerData(ui.PointerChange.remove, const Offset(10, 10)),
@@ -124,7 +124,7 @@ void main() {
 
     FakeAsync().run((FakeAsync async) {
       // Put one pointer down.
-      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, Offset.zero, pointer: 1, kind: PointerDeviceKind.touch),
         _pointerData(ui.PointerChange.down, const Offset(10, 10), pointer: 1, kind: PointerDeviceKind.touch),
         _pointerData(ui.PointerChange.remove, const Offset(10, 10), pointer: 1, kind: PointerDeviceKind.touch),
@@ -132,7 +132,7 @@ void main() {
       async.flushMicrotasks();
 
       // Put another pointer down and then cancel it.
-      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, Offset.zero, pointer: 2, kind: PointerDeviceKind.touch),
         _pointerData(ui.PointerChange.down, const Offset(20, 10), pointer: 2, kind: PointerDeviceKind.touch),
         _pointerData(ui.PointerChange.cancel, const Offset(20, 10), pointer: 2, kind: PointerDeviceKind.touch),
@@ -140,7 +140,7 @@ void main() {
       async.flushMicrotasks();
 
       // The first pointer can still moving without crashing.
-      ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      RendererBinding.instance.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
         _pointerData(ui.PointerChange.add, Offset.zero, pointer: 1, kind: PointerDeviceKind.touch),
         _pointerData(ui.PointerChange.move, const Offset(10, 10), pointer: 1, kind: PointerDeviceKind.touch),
         _pointerData(ui.PointerChange.remove, const Offset(10, 10), pointer: 1, kind: PointerDeviceKind.touch),
@@ -202,8 +202,8 @@ ui.PointerData _pointerData(
     pointerIdentifier: pointer,
     embedderId: pointer,
     change: change,
-    physicalX: logicalPosition.dx * ui.window.devicePixelRatio,
-    physicalY: logicalPosition.dy * ui.window.devicePixelRatio,
+    physicalX: logicalPosition.dx * RendererBinding.instance.window.devicePixelRatio,
+    physicalY: logicalPosition.dy * RendererBinding.instance.window.devicePixelRatio,
     kind: kind,
     device: device,
   );

--- a/packages/flutter/test/rendering/view_test.dart
+++ b/packages/flutter/test/rendering/view_test.dart
@@ -32,7 +32,7 @@ void main() {
     });
 
     test('does not replace the root layer unnecessarily', () {
-      final ui.FlutterView window = TestWindow(window: ui.window);
+      final ui.FlutterView window = TestWindow(window: RendererBinding.instance.window);
       final RenderView view = RenderView(
         configuration: createViewConfiguration(),
         window: window,

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:ui' show window;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/scheduler.dart';
@@ -141,7 +140,7 @@ void main() {
   });
 
   test('Flutter.Frame event fired', () async {
-    window.onReportTimings!(<FrameTiming>[FrameTiming(
+    SchedulerBinding.instance.platformDispatcher.onReportTimings!(<FrameTiming>[FrameTiming(
       vsyncStart: 5000,
       buildStart: 10000,
       buildFinish: 15000,
@@ -171,7 +170,7 @@ void main() {
     SchedulerBinding.instance.addTimingsCallback((List<FrameTiming> timings) {
       throw Exception('Test');
     });
-    window.onReportTimings!(<FrameTiming>[]);
+    SchedulerBinding.instance.platformDispatcher.onReportTimings!(<FrameTiming>[]);
     expect(errorCaught!.exceptionAsString(), equals('Exception: Test'));
   });
 
@@ -233,9 +232,9 @@ void main() {
     // Simulate an animation frame firing between warm-up begin frame and warm-up draw frame.
     // Expect a timer that reschedules the frame.
     expect(scheduler.hasScheduledFrame, isFalse);
-    window.onBeginFrame!(Duration.zero);
+    SchedulerBinding.instance.platformDispatcher.onBeginFrame!(Duration.zero);
     expect(scheduler.hasScheduledFrame, isFalse);
-    window.onDrawFrame!();
+    SchedulerBinding.instance.platformDispatcher.onDrawFrame!();
     expect(scheduler.hasScheduledFrame, isFalse);
 
     // The draw frame part of the warm-up frame will run the post-frame

--- a/packages/flutter/test/widgets/annotated_region_test.dart
+++ b/packages/flutter/test/widgets/annotated_region_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show window;
-
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -31,13 +29,13 @@ void main() {
       ),
     );
     int? result = RendererBinding.instance.renderView.debugLayer!.find<int>(Offset(
-      10.0 * window.devicePixelRatio,
-      10.0 * window.devicePixelRatio,
+      10.0 * RendererBinding.instance.window.devicePixelRatio,
+      10.0 * RendererBinding.instance.window.devicePixelRatio,
     ));
     expect(result, null);
     result = RendererBinding.instance.renderView.debugLayer!.find<int>(Offset(
-      50.0 * window.devicePixelRatio,
-      50.0 * window.devicePixelRatio,
+      50.0 * RendererBinding.instance.window.devicePixelRatio,
+      50.0 * RendererBinding.instance.window.devicePixelRatio,
     ));
     expect(result, 1);
   });

--- a/packages/flutter/test/widgets/binding_frame_scheduling_test.dart
+++ b/packages/flutter/test/widgets/binding_frame_scheduling_test.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show window;
+import 'dart:ui';
 
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -14,26 +14,26 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/39494.
 
     // Preconditions.
-    expect(window.onBeginFrame, isNull);
-    expect(window.onDrawFrame, isNull);
+    expect(PlatformDispatcher.instance.onBeginFrame, isNull);
+    expect(PlatformDispatcher.instance.onDrawFrame, isNull);
 
     // Instantiation does nothing with regards to frame scheduling.
     expect(WidgetsFlutterBinding.ensureInitialized(), isA<WidgetsFlutterBinding>());
     expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
-    expect(window.onBeginFrame, isNull);
-    expect(window.onDrawFrame, isNull);
+    expect(PlatformDispatcher.instance.onBeginFrame, isNull);
+    expect(PlatformDispatcher.instance.onDrawFrame, isNull);
 
     // Framework starts with detached statue. Sends resumed signal to enable frame.
     final ByteData message = const StringCodec().encodeMessage('AppLifecycleState.resumed')!;
     await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage('flutter/lifecycle', message, (_) { });
-    expect(window.onBeginFrame, isNull);
-    expect(window.onDrawFrame, isNull);
+    expect(PlatformDispatcher.instance.onBeginFrame, isNull);
+    expect(PlatformDispatcher.instance.onDrawFrame, isNull);
     expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
 
     // Frame callbacks are registered lazily (and a frame scheduled) when the root widget is attached.
     WidgetsBinding.instance.attachRootWidget(const Placeholder());
-    expect(window.onBeginFrame, isNotNull);
-    expect(window.onDrawFrame, isNotNull);
+    expect(PlatformDispatcher.instance.onBeginFrame, isNotNull);
+    expect(PlatformDispatcher.instance.onDrawFrame, isNotNull);
     expect(SchedulerBinding.instance.hasScheduledFrame, isTrue);
   });
 }

--- a/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show window;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -98,7 +96,7 @@ void main() {
     Widget deepChild = Container();
 
     await tester.pumpWidget(MediaQuery(
-      data: MediaQueryData.fromWindow(ui.window),
+      data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
       child: Column(
         children: <Widget>[
           StatefulBuilder(builder: (BuildContext context, StateSetter setState) {

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' show window;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -301,7 +299,7 @@ void main() {
           child: Directionality(
             textDirection: TextDirection.ltr,
             child: MediaQuery(
-              data: MediaQueryData.fromWindow(window),
+              data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
               child: Material(
                 child: Center(
                   child: Slider(

--- a/packages/flutter_localizations/test/widgets_test.dart
+++ b/packages/flutter_localizations/test/widgets_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -689,8 +687,8 @@ void main() {
           const OnlyRTLDefaultWidgetsLocalizationsDelegate(),
         ],
         buildContent: (BuildContext context) {
-          final Locale locale1 = ui.window.locales.first;
-          final Locale locale2 = ui.window.locales[1];
+          final Locale locale1 = WidgetsBinding.instance.platformDispatcher.locales.first;
+          final Locale locale2 = WidgetsBinding.instance.platformDispatcher.locales[1];
           return Text('$locale1 $locale2');
         },
       )

--- a/packages/integration_test/lib/_callback_io.dart
+++ b/packages/integration_test/lib/_callback_io.dart
@@ -109,7 +109,7 @@ class IOCallbackManager implements CallbackManager {
   Future<dynamic> _onMethodChannelCall(MethodCall call) async {
     switch (call.method) {
       case 'scheduleFrame':
-        window.scheduleFrame();
+        PlatformDispatcher.instance.scheduleFrame();
         break;
     }
     return null;


### PR DESCRIPTION
Similar to https://github.com/flutter/flutter/pull/99443, but focused on direct usage of dart:ui's `window` global and moves those usages to `PlatformDispatcher.instance`.

Where appropriate, the PR also moves away from using the globals exposed by `dart:ui` directly and instead accesses the window/platformDispatcher via the Binding as recommended in the docs [1] and [2].

Part of https://github.com/flutter/flutter/issues/60131 to work towards https://github.com/flutter/flutter/issues/30701.

[1] https://master-api.flutter.dev/flutter/dart-ui/window.html
[2] https://master-api.flutter.dev/flutter/dart-ui/PlatformDispatcher/instance.html