### PR TITLE
`CupertinoContextMenu`/`ContextMenuAction`: Add clickable cursor for web

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 import 'dart:ui' as ui;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show kMinFlingVelocity, kLongPressTimeout;
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -367,17 +368,20 @@ class _CupertinoContextMenuState extends State<CupertinoContextMenu> with Ticker
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTapCancel: _onTapCancel,
-      onTapDown: _onTapDown,
-      onTapUp: _onTapUp,
-      onTap: _onTap,
-      child: TickerMode(
-        enabled: !_childHidden,
-        child: Opacity(
-          key: _childGlobalKey,
-          opacity: _childHidden ? 0.0 : 1.0,
-          child: widget.child,
+    return MouseRegion(
+      cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      child: GestureDetector(
+        onTapCancel: _onTapCancel,
+        onTapDown: _onTapDown,
+        onTapUp: _onTapUp,
+        onTap: _onTap,
+        child: TickerMode(
+          enabled: !_childHidden,
+          child: Opacity(
+            key: _childGlobalKey,
+            opacity: _childHidden ? 0.0 : 1.0,
+            child: widget.child,
+          ),
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -108,7 +108,7 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
   @override
   Widget build(BuildContext context) {
     return MouseRegion(
-      cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      cursor: widget.onPressed != null && kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
       child: GestureDetector(
         key: _globalKey,
         onTapDown: onTapDown,

--- a/packages/flutter/lib/src/cupertino/context_menu_action.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu_action.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'colors.dart';
 
@@ -106,43 +107,46 @@ class _CupertinoContextMenuActionState extends State<CupertinoContextMenuAction>
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      key: _globalKey,
-      onTapDown: onTapDown,
-      onTapUp: onTapUp,
-      onTapCancel: onTapCancel,
-      onTap: widget.onPressed,
-      behavior: HitTestBehavior.opaque,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(
-          minHeight: _kButtonHeight,
-        ),
-        child: Semantics(
-          button: true,
-          child: Container(
-            decoration: BoxDecoration(
-              color: _isPressed
-                ? CupertinoDynamicColor.resolve(_kBackgroundColorPressed, context)
-                : CupertinoDynamicColor.resolve(_kBackgroundColor, context),
-            ),
-            padding: const EdgeInsets.symmetric(
-              vertical: 16.0,
-              horizontal: 10.0,
-            ),
-            child: DefaultTextStyle(
-              style: _textStyle,
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: <Widget>[
-                  Flexible(
-                    child: widget.child,
-                  ),
-                  if (widget.trailingIcon != null)
-                    Icon(
-                      widget.trailingIcon,
-                      color: _textStyle.color,
+    return MouseRegion(
+      cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      child: GestureDetector(
+        key: _globalKey,
+        onTapDown: onTapDown,
+        onTapUp: onTapUp,
+        onTapCancel: onTapCancel,
+        onTap: widget.onPressed,
+        behavior: HitTestBehavior.opaque,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            minHeight: _kButtonHeight,
+          ),
+          child: Semantics(
+            button: true,
+            child: Container(
+              decoration: BoxDecoration(
+                color: _isPressed
+                  ? CupertinoDynamicColor.resolve(_kBackgroundColorPressed, context)
+                  : CupertinoDynamicColor.resolve(_kBackgroundColor, context),
+              ),
+              padding: const EdgeInsets.symmetric(
+                vertical: 16.0,
+                horizontal: 10.0,
+              ),
+              child: DefaultTextStyle(
+                style: _textStyle,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Flexible(
+                      child: widget.child,
                     ),
-                ],
+                    if (widget.trailingIcon != null)
+                      Icon(
+                        widget.trailingIcon,
+                        color: _textStyle.color,
+                      ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -134,13 +134,13 @@ void main() {
       await tester.pump();
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
 
-      /// Cupertino conext menu action without "onPressed" callback.
+      /// Cupertino context menu action without "onPressed" callback.
       await tester.pumpWidget(_getApp());
       final Offset contextMenuAction = tester.getCenter(find.byType(CupertinoContextMenuAction));
       await gesture.moveTo(contextMenuAction);
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
 
-      /// Cupertino conext menu action with "onPressed" callback.
+      /// Cupertino context menu action with "onPressed" callback.
       await tester.pumpWidget(_getApp(onPressed: (){}));
       await gesture.moveTo(contextMenuAction);
       addTearDown(gesture.removePointer);

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -128,14 +128,21 @@ void main() {
   testWidgets(
     'Hovering over Cupertino context menu action updates cursor to clickable on Web',
     (WidgetTester tester) async {
-      await tester.pumpWidget(_getApp());
-      final Offset actionCenter = tester.getCenter(find.byType(CupertinoContextMenuAction));
-      await tester.startGesture(actionCenter);
-      await tester.pump();
-
-      final Offset contextMenuAction = tester.getCenter(find.byType(CupertinoContextMenuAction));
+      await tester.pumpWidget(_getApp(onPressed: (){}));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
-      await gesture.addPointer(location: contextMenuAction);
+      await gesture.addPointer(location: const Offset(10, 10));
+      await tester.pump();
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+
+      /// Cupertino conext menu action without "onPressed" callback.
+      await tester.pumpWidget(_getApp());
+      final Offset contextMenuAction = tester.getCenter(find.byType(CupertinoContextMenuAction));
+      await gesture.moveTo(contextMenuAction);
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+
+      /// Cupertino conext menu action with "onPressed" callback.
+      await tester.pumpWidget(_getApp(onPressed: (){}));
+      await gesture.moveTo(contextMenuAction);
       addTearDown(gesture.removePointer);
       await tester.pump();
       expect(

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
@@ -122,4 +125,22 @@ void main() {
     expect(_getTextStyle(tester).fontWeight, kDefaultActionWeight);
   });
 
+  testWidgets(
+    'Hovering over Cupertino context menu action updates cursor to clickable on Web',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_getApp());
+      final Offset actionCenter = tester.getCenter(find.byType(CupertinoContextMenuAction));
+      await tester.startGesture(actionCenter);
+      await tester.pump();
+
+      final Offset contextMenuAction = tester.getCenter(find.byType(CupertinoContextMenuAction));
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+      await gesture.addPointer(location: contextMenuAction);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      expect(
+        RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+        kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
+      );
+  });
 }

--- a/packages/flutter/test/cupertino/context_menu_action_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_action_test.dart
@@ -128,23 +128,23 @@ void main() {
   testWidgets(
     'Hovering over Cupertino context menu action updates cursor to clickable on Web',
     (WidgetTester tester) async {
-      await tester.pumpWidget(_getApp(onPressed: (){}));
-      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
-      await gesture.addPointer(location: const Offset(10, 10));
-      await tester.pump();
-      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
-
       /// Cupertino context menu action without "onPressed" callback.
       await tester.pumpWidget(_getApp());
-      final Offset contextMenuAction = tester.getCenter(find.byType(CupertinoContextMenuAction));
-      await gesture.moveTo(contextMenuAction);
+      final Offset contextMenuAction = tester.getCenter(find.text('I am a CupertinoContextMenuAction'));
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+      await gesture.addPointer(location: contextMenuAction);
+      await tester.pumpAndSettle();
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
 
-      /// Cupertino context menu action with "onPressed" callback.
+      // / Cupertino context menu action with "onPressed" callback.
       await tester.pumpWidget(_getApp(onPressed: (){}));
+      await gesture.moveTo(const Offset(10, 10));
+      await tester.pumpAndSettle();
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+
       await gesture.moveTo(contextMenuAction);
       addTearDown(gesture.removePointer);
-      await tester.pump();
+      await tester.pumpAndSettle();
       expect(
         RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
         kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -216,13 +216,13 @@ void main() {
 
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
       await gesture.addPointer(location: const Offset(10, 10));
-      await tester.pump();
+      await tester.pumpAndSettle();
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
 
       final Offset contextMenu = tester.getCenter(find.byWidget(child));
       await gesture.moveTo(contextMenu);
       addTearDown(gesture.removePointer);
-      await tester.pump();
+      await tester.pumpAndSettle();
       expect(
         RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
         kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -214,9 +214,13 @@ void main() {
         ),
       ));
 
-      final Offset contextMenu = tester.getCenter(find.byWidget(child));
       final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
-      await gesture.addPointer(location: contextMenu);
+      await gesture.addPointer(location: const Offset(10, 10));
+      await tester.pump();
+      expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+
+      final Offset contextMenu = tester.getCenter(find.byWidget(child));
+      await gesture.moveTo(contextMenu);
       addTearDown(gesture.removePointer);
       await tester.pump();
       expect(

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -192,6 +195,34 @@ void main() {
       await gesture.up();
       await tester.pumpAndSettle();
       expect(_findStatic(), findsOneWidget);
+    });
+
+    testWidgets('Hovering over Cupertino context menu updates cursor to clickable on Web', (WidgetTester tester) async {
+      final Widget child  = _getChild();
+      await tester.pumpWidget(CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: CupertinoContextMenu(
+              actions: const <CupertinoContextMenuAction>[
+                CupertinoContextMenuAction(
+                  child: Text('CupertinoContextMenuAction One'),
+                ),
+              ],
+              child: child,
+            ),
+          ),
+        ),
+      ));
+
+      final Offset contextMenu = tester.getCenter(find.byWidget(child));
+      final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+      await gesture.addPointer(location: contextMenu);
+      addTearDown(gesture.removePointer);
+      await tester.pump();
+      expect(
+        RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+        kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
+      );
     });
   });
 


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/86174

Complete details https://github.com/flutter/flutter/issues/86174#issuecomment-1016596648

### Integration test for web results:
### CupertinoContextMenu
```console
Launching integration_test/cupertino/cupertino_context_menu.dart on Chrome in debug mode...
integration_test/cupertino/cupertino_context_menu.dart:1
DartUri: Unresolved uri: dart:web_sql
DartUri: Unresolved uri: dart:ui

This app is linked to the debug service: ws://127.0.0.1:56350/DTH7jaimvhA=/ws
Debug service listening on ws://127.0.0.1:56350/DTH7jaimvhA=/ws
💪 Running with sound null safety 💪
Connecting to VM Service at ws://127.0.0.1:56350/DTH7jaimvhA=/ws
00:00 +0: Hovering over Cupertino context menu updates cursor to clickable on Web
00:00 +1: (tearDownAll)
00:00 +2: All tests passed!
```

### CupertinoContextMenuAction
```console
Launching integration_test/cupertino/cupertino_context_menu.dart on Chrome in debug mode...
integration_test/cupertino/cupertino_context_menu.dart:1
DartUri: Unresolved uri: dart:web_sql
DartUri: Unresolved uri: dart:ui

This app is linked to the debug service: ws://127.0.0.1:57326/SQxGCQ7HeeY=/ws
Debug service listening on ws://127.0.0.1:57326/SQxGCQ7HeeY=/ws
💪 Running with sound null safety 💪
Connecting to VM Service at ws://127.0.0.1:57326/SQxGCQ7HeeY=/ws
00:00 +0: Hovering over Cupertino context menu action updates cursor to clickable on Web
00:00 +1: (tearDownAll)
00:00 +2: All tests passed!
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
