### PR TITLE
fix type error in service_worker_test.dart

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -57,7 +57,7 @@ Future<void> _rebuildApp({ required int version }) async {
 /// test zone.
 void expect(Object? actual, Object? expected) {
   final Matcher matcher = wrapMatcher(expected);
-  final Map<Object, Object> matchState = <Object, Object>{};
+  final Map<Object?, Object?> matchState = <Object?, Object?>{};
   if (matcher.matches(actual, matchState)) {
     return;
   }

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -57,6 +57,7 @@ Future<void> _rebuildApp({ required int version }) async {
 /// test zone.
 void expect(Object? actual, Object? expected) {
   final Matcher matcher = wrapMatcher(expected);
+  // matchState needs to be of type <Object?, Object?>, see https://github.com/flutter/flutter/issues/99522
   final Map<Object?, Object?> matchState = <Object?, Object?>{};
   if (matcher.matches(actual, matchState)) {
     return;


### PR DESCRIPTION
make map literal match an internal Map<dynamic, dynamic> in package:match

Fixes https://github.com/flutter/flutter/issues/99522

Note, this map literal needs to match the type of https://github.com/dart-lang/matcher/blob/0.12.11/lib/src/equals_matcher.dart#L261