### PR TITLE
`CupertinoActionSheet`/`CupertinoAlertDialog`: Add clickable cursor for web

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -703,25 +703,28 @@ class CupertinoActionSheetAction extends StatelessWidget {
       style = style.copyWith(fontWeight: FontWeight.w600);
     }
 
-    return GestureDetector(
-      onTap: onPressed,
-      behavior: HitTestBehavior.opaque,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(
-          minHeight: _kActionSheetButtonHeight,
-        ),
-        child: Semantics(
-          button: true,
-          child: Container(
-            alignment: Alignment.center,
-            padding: const EdgeInsets.symmetric(
-              vertical: 16.0,
-              horizontal: 10.0,
-            ),
-            child: DefaultTextStyle(
-              style: style,
-              textAlign: TextAlign.center,
-              child: child,
+    return MouseRegion(
+      cursor: onPressed != null && kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      child: GestureDetector(
+        onTap: onPressed,
+        behavior: HitTestBehavior.opaque,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            minHeight: _kActionSheetButtonHeight,
+          ),
+          child: Semantics(
+            button: true,
+            child: Container(
+              alignment: Alignment.center,
+              padding: const EdgeInsets.symmetric(
+                vertical: 16.0,
+                horizontal: 10.0,
+              ),
+              child: DefaultTextStyle(
+                style: style,
+                textAlign: TextAlign.center,
+                child: child,
+              ),
             ),
           ),
         ),
@@ -1751,18 +1754,21 @@ class CupertinoDialogAction extends StatelessWidget {
             content: child,
           );
 
-    return GestureDetector(
-      excludeFromSemantics: true,
-      onTap: onPressed,
-      behavior: HitTestBehavior.opaque,
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(
-          minHeight: _kDialogMinButtonHeight,
-        ),
-        child: Container(
-          alignment: Alignment.center,
-          padding: EdgeInsets.all(_calculatePadding(context)),
-          child: sizedContent,
+    return MouseRegion(
+      cursor: onPressed != null && kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      child: GestureDetector(
+        excludeFromSemantics: true,
+        onTap: onPressed,
+        behavior: HitTestBehavior.opaque,
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(
+            minHeight: _kDialogMinButtonHeight,
+          ),
+          child: Container(
+            alignment: Alignment.center,
+            padding: EdgeInsets.all(_calculatePadding(context)),
+            child: sizedContent,
+          ),
         ),
       ),
     );

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -12,6 +12,7 @@ import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -1442,6 +1442,51 @@ void main() {
       expect(tester.getBottomRight(find.byType(Placeholder)), const Offset(390.0, 600.0));
     });
   });
+
+  testWidgets('Hovering over Cupertino alert dialog action updates cursor to clickable on Web', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      createAppWithButtonThatLaunchesDialog(
+        dialogBuilder: (BuildContext context) {
+          return MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaleFactor: 3.0),
+            child: RepaintBoundary(
+              child: CupertinoAlertDialog(
+                title: const Text('Title'),
+                content: const Text('text'),
+                actions: <Widget>[
+                  CupertinoDialogAction(
+                    onPressed: () {},
+                    child: const Text('NO'),
+                  ),
+                  CupertinoDialogAction(
+                    onPressed: () {},
+                    child: const Text('OK'),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    await tester.tap(find.text('Go'));
+    await tester.pumpAndSettle();
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse, pointer: 1);
+    await gesture.addPointer(location: const Offset(10, 10));
+    await tester.pumpAndSettle();
+    expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
+
+    final Offset dialogAction = tester.getCenter(find.text('OK'));
+    await gesture.moveTo(dialogAction);
+    addTearDown(gesture.removePointer);
+    await tester.pumpAndSettle();
+    expect(
+      RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1),
+      kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
+    );
+  });
 }
 
 RenderBox findActionButtonRenderBoxByTitle(WidgetTester tester, String title) {


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/86174

Complete details https://github.com/flutter/flutter/issues/86174#issuecomment-1016596648

### Integration test for web results:
### CupertinoAlertDialog
```console
Launching integration_test/cupertino/cupertino_alert_dialog.dart on Chrome in debug mode...
integration_test/cupertino/cupertino_alert_dialog.dart:1
DartUri: Unresolved uri: dart:web_sql
DartUri: Unresolved uri: dart:ui
This app is linked to the debug service: ws://127.0.0.1:51491/JQ62nlDzu78=/ws
Debug service listening on ws://127.0.0.1:51491/JQ62nlDzu78=/ws
💪 Running with sound null safety 💪
Connecting to VM Service at ws://127.0.0.1:51491/JQ62nlDzu78=/ws
00:00 +0: Hovering over Cupertino dialog action updates cursor to clickable on Web
00:00 +1: (tearDownAll)
00:00 +2: All tests passed!
```

### CupertinoActionSheet
```console
Launching integration_test/cupertino/cupertino_action_sheet.dart on Chrome in debug mode...
integration_test/cupertino/cupertino_action_sheet.dart:1
DartUri: Unresolved uri: dart:web_sql
DartUri: Unresolved uri: dart:ui

This app is linked to the debug service: ws://127.0.0.1:51702/ZOm9ms5kjP8=/ws
Debug service listening on ws://127.0.0.1:51702/ZOm9ms5kjP8=/ws
💪 Running with sound null safety 💪
Connecting to VM Service at ws://127.0.0.1:51702/ZOm9ms5kjP8=/ws
00:00 +0: Hovering over Cupertino action sheet action updates cursor to clickable on Web
00:00 +1: (tearDownAll)
00:00 +2: All tests passed!
```


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
