### PR TITLE
95533 min sdk error msgs enhancements

### DIFF
--- a/packages/flutter_tools/README.md
+++ b/packages/flutter_tools/README.md
@@ -97,7 +97,7 @@ variable to be set. The full invocation to run everything might
 therefore look something like:
 
 ```shell
-$ FLUTTER_ROOT=~/path/to/flutter-sdk
+$ export FLUTTER_ROOT=~/path/to/flutter-sdk
 $ flutter test --concurrency 1
 ```
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -414,21 +414,9 @@ class FlutterPlugin implements Plugin<Project> {
 
         // Wait until the Android plugin loaded.
         pluginProject.afterEvaluate {
-            Boolean showBuildConfigurationMessage = false
-
             // Checks if there is a mismatch between the plugin compileSdkVersion and the project compileSdkVersion.
             if (pluginProject.android.compileSdkVersion > project.android.compileSdkVersion) {
                 project.logger.quiet("Warning: The plugin ${pluginName} requires Android SDK version ${pluginProject.android.compileSdkVersion.substring(8)}.")
-                showBuildConfigurationMessage = true
-            }
-
-            // Checks if there is a mismatch between the plugin minSdkVersion and the project minSdkVersion.
-            if(pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel > project.android.defaultConfig?.minSdkVersion?.apiLevel) {
-                project.logger.quiet("Warning: The plugin ${pluginName} requires minSdkVersion ${pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel}.")
-                showBuildConfigurationMessage = true
-            }
-
-            if (showBuildConfigurationMessage) {
                 project.logger.quiet("For more information about build configuration, see $kWebsiteDeploymentAndroidBuildConfig.")
             }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -139,6 +139,11 @@ class FlutterPlugin implements Plugin<Project> {
     private Properties localProperties
     private String engineVersion
 
+    /**
+     * Flutter Docs Website URLs for help messages.
+     */
+    private final String kWebsiteDeploymentAndroidBuildConfig = 'https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration'
+
     @Override
     void apply(Project project) {
         this.project = project
@@ -409,9 +414,24 @@ class FlutterPlugin implements Plugin<Project> {
 
         // Wait until the Android plugin loaded.
         pluginProject.afterEvaluate {
+            Boolean showBuildConfigurationMessage = false
+
+            // Checks if there is a mismatch between the plugin compileSdkVersion and the project compileSdkVersion.
             if (pluginProject.android.compileSdkVersion > project.android.compileSdkVersion) {
                 project.logger.quiet("Warning: The plugin ${pluginName} requires Android SDK version ${pluginProject.android.compileSdkVersion.substring(8)}.")
+                showBuildConfigurationMessage = true
             }
+
+            // Checks if there is a mismatch between the plugin minSdkVersion and the project minSdkVersion.
+            if(pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel > project.android.defaultConfig?.minSdkVersion?.apiLevel) {
+                project.logger.quiet("Warning: The plugin ${pluginName} requires minSdkVersion ${pluginProject.android.defaultConfig?.minSdkVersion?.apiLevel}.")
+                showBuildConfigurationMessage = true
+            }
+
+            if (showBuildConfigurationMessage) {
+                project.logger.quiet("For more information about build configuration, see $kWebsiteDeploymentAndroidBuildConfig.")
+            }
+
             project.android.buildTypes.all addEmbeddingDependencyToPlugin
         }
     }

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -410,7 +410,8 @@ final GradleHandledError minSdkVersion = GradleHandledError(
       'The plugin ${minSdkVersionMatch?.group(3)} requires a higher Android SDK version.\n'
       '$textInBold\n'
       "Note that your app won't be available to users running Android SDKs below ${minSdkVersionMatch?.group(2)}.\n"
-      'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.',
+      'Alternatively, try to find a version of this plugin that supports these lower versions of the Android SDK.\n'
+      'For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;
@@ -518,8 +519,8 @@ final GradleHandledError minCompileSdkVersionHandler = GradleHandledError(
     required bool usesAndroidX,
     required bool multidexEnabled,
   }) async {
-    final Match? minSdkVersionMatch = _minCompileSdkVersionPattern.firstMatch(line);
-    assert(minSdkVersionMatch?.groupCount == 1);
+    final Match? minCompileSdkVersionMatch = _minCompileSdkVersionPattern.firstMatch(line);
+    assert(minCompileSdkVersionMatch?.groupCount == 1);
 
     final File gradleFile = project.directory
         .childDirectory('android')
@@ -529,7 +530,7 @@ final GradleHandledError minCompileSdkVersionHandler = GradleHandledError(
       '${globals.logger.terminal.warningMark} Your project requires a higher compileSdkVersion.\n'
       'Fix this issue by bumping the compileSdkVersion in ${gradleFile.path}:\n'
       'android {\n'
-      '  compileSdkVersion ${minSdkVersionMatch?.group(1)}\n'
+      '  compileSdkVersion ${minCompileSdkVersionMatch?.group(1)}\n'
       '}',
       title: _boxTitle,
     );

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -37,6 +37,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
+        // You can update the following values to match your application needs. (https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration)
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-java.tmpl/app/build.gradle.tmpl
@@ -37,7 +37,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
-        // You can update the following values to match your application needs. (https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration)
+        // You can update the following values to match your application needs. 
+        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -45,6 +45,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
+        // You can update the following values to match your application needs. (https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration)
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
+++ b/packages/flutter_tools/templates/app_shared/android-kotlin.tmpl/app/build.gradle.tmpl
@@ -45,7 +45,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "{{androidIdentifier}}"
-        // You can update the following values to match your application needs. (https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration)
+        // You can update the following values to match your application needs.
+        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -780,6 +780,8 @@ assembleProfile
           "│ Note that your app won't be available to users running Android SDKs below 19.                 │\n"
           '│ Alternatively, try to find a version of this plugin that supports these lower versions of the │\n'
           '│ Android SDK.                                                                                  │\n'
+          '│ For more information, see:                                                                    │\n'
+          '│ https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration                 │\n'
           '└───────────────────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );


### PR DESCRIPTION
This PR changes `flutter.gradle` to detect and warn the developer with a `logger.quiet` message about mismatches with plugins API level. 

It also changes the `gradle_errors.dart` to update the box message about how to fix the API level error by adding a reference to the docs. The test was updated and checked.

It changes the `build.gradle` templates from android and kotlin to add a comment about the SDK values, also pointing to the flutter website docs.

It fixes a shell command at the README required to export the `FLUTTER_ROOT` variable in order to run tests.

It closes #95533
Partially solves #95485 (Android part)

This PR was previously https://github.com/flutter/flutter/pull/98450, then reverted at https://github.com/flutter/flutter/pull/99191 and now modified to keep complying with AGP conventions (https://github.com/flutter/flutter/issues/95533#issuecomment-1051489232) while enhancing the feedback to the developer.

cc @blasten 