### PR TITLE
`CupertinoSegmentedControl`/`CupertinoSlidingSegmentedControl`: Add clickable cursor for web

### DIFF
--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -5,6 +5,7 @@
 import 'dart:collection';
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
@@ -351,24 +352,27 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
         child: widget.children[currentKey],
       );
 
-      child = GestureDetector(
-        behavior: HitTestBehavior.opaque,
-        onTapDown: (TapDownDetails event) {
-          _onTapDown(currentKey);
-        },
-        onTapCancel: _onTapCancel,
-        onTap: () {
-          _onTap(currentKey);
-        },
-        child: IconTheme(
-          data: iconTheme,
-          child: DefaultTextStyle(
-            style: textStyle,
-            child: Semantics(
-              button: true,
-              inMutuallyExclusiveGroup: true,
-              selected: widget.groupValue == currentKey,
-              child: child,
+      child = MouseRegion(
+        cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+        child: GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTapDown: (TapDownDetails event) {
+            _onTapDown(currentKey);
+          },
+          onTapCancel: _onTapCancel,
+          onTap: () {
+            _onTap(currentKey);
+          },
+          child: IconTheme(
+            data: iconTheme,
+            child: DefaultTextStyle(
+              style: textStyle,
+              child: Semantics(
+                button: true,
+                inMutuallyExclusiveGroup: true,
+                selected: widget.groupValue == currentKey,
+                child: child,
+              ),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/physics.dart';
 import 'package:flutter/rendering.dart';
@@ -656,12 +657,15 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
           onTap: () { widget.onValueChanged(entry.key); },
           inMutuallyExclusiveGroup: true,
           selected: widget.groupValue == entry.key,
-          child: _Segment<T>(
-            key: ValueKey<T>(entry.key),
-            highlighted: isHighlighted,
-            pressed: pressed == entry.key,
-            isDragging: isThumbDragging,
-            child: entry.value,
+          child: MouseRegion(
+            cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+            child: _Segment<T>(
+              key: ValueKey<T>(entry.key),
+              highlighted: isHighlighted,
+              pressed: pressed == entry.key,
+              isDragging: isThumbDragging,
+              child: entry.value,
+            ),
           ),
         ),
       );


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/86174

Complete details https://github.com/flutter/flutter/issues/86174#issuecomment-1016596648

### Integration test for web results:
### CupertinoSegmentedControl
```console
Launching integration_test/cupertino/cupertino_segement_control.dart on Chrome in debug mode...
integration_test/cupertino/cupertino_segement_control.dart:1
DartUri: Unresolved uri: dart:web_sql
DartUri: Unresolved uri: dart:ui

This app is linked to the debug service: ws://127.0.0.1:58595/lCFVeemg1dM=/ws
Debug service listening on ws://127.0.0.1:58595/lCFVeemg1dM=/ws
💪 Running with sound null safety 💪
Connecting to VM Service at ws://127.0.0.1:58595/lCFVeemg1dM=/ws
00:00 +0: Hovering over Cupertino segmented control updates cursor to clickable on Web
00:00 +1: (tearDownAll)
00:00 +2: All tests passed!
```

### CupertinoSlidingSegmentedControl
```console
Launching integration_test/cupertino/cupertino_segement_control.dart on Chrome in debug mode...
integration_test/cupertino/cupertino_segement_control.dart:1
DartUri: Unresolved uri: dart:web_sql
DartUri: Unresolved uri: dart:ui

This app is linked to the debug service: ws://127.0.0.1:59205/yBqwxPo4z7M=/ws
Debug service listening on ws://127.0.0.1:59205/yBqwxPo4z7M=/ws
💪 Running with sound null safety 💪
Connecting to VM Service at ws://127.0.0.1:59205/yBqwxPo4z7M=/ws
00:00 +0: Hovering over Cupertino sliding segmented control updates cursor to clickable on Web
00:00 +1: (tearDownAll)
00:00 +2: All tests passed!
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
