### PR TITLE
Add Windows performance benchmark

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4403,6 +4403,17 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Windows home_scroll_perf__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","hostonly"]
+      task_name: windows_home_scroll_perf__timeline_summary
+      benchmark: "true"
+    scheduler: luci
+
   - name: Windows_android basic_material_app_win__compile
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4405,7 +4405,7 @@ targets:
 
   - name: Windows windows_home_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    presubmit: true
+    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4403,7 +4403,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Windows home_scroll_perf__timeline_summary
+  - name: Windows windows_home_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: true
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -74,6 +74,9 @@
 /dev/devicelab/bin/tasks/opacity_peephole_col_of_alpha_savelayer_rows_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/opacity_peephole_grid_of_alpha_savelayers_perf__e2e_summary.dart @flar @flutter/engine
 
+## Windows Devicelab tests
+/dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart @jonahwilliams @flutter/engine
+
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/channels_integration_test_win.dart @zanderso @flutter/engine

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -74,9 +74,6 @@
 /dev/devicelab/bin/tasks/opacity_peephole_col_of_alpha_savelayer_rows_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/opacity_peephole_grid_of_alpha_savelayers_perf__e2e_summary.dart @flar @flutter/engine
 
-## Windows Devicelab tests
-/dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart @jonahwilliams @flutter/engine
-
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/channels_integration_test_win.dart @zanderso @flutter/engine
@@ -202,6 +199,7 @@
 /dev/devicelab/bin/tasks/module_test_ios.dart @jmagman @flutter/tool
 /dev/devicelab/bin/tasks/plugin_lint_mac.dart @stuartmorgan @flutter/plugin
 /dev/devicelab/bin/tasks/entrypoint_dart_registrant.dart @aaclarke @flutter/plugin
+/dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart @jonahwilliams @flutter/engine
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.windows;
+  await task(createHomeScrollPerfTest());
+}

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -52,7 +52,7 @@ String? _findMatchId(List<String> idList, String idPattern) {
 DeviceDiscovery get devices => DeviceDiscovery();
 
 /// Device operating system the test is configured to test.
-enum DeviceOperatingSystem { android, androidArm, androidArm64 ,ios, fuchsia, fake }
+enum DeviceOperatingSystem { android, androidArm, androidArm64 ,ios, fuchsia, fake, windows }
 
 /// Device OS to test on.
 DeviceOperatingSystem deviceOperatingSystem = DeviceOperatingSystem.android;
@@ -71,6 +71,8 @@ abstract class DeviceDiscovery {
         return IosDeviceDiscovery();
       case DeviceOperatingSystem.fuchsia:
         return FuchsiaDeviceDiscovery();
+      case DeviceOperatingSystem.windows:
+        return WindowsDeviceDiscovery();
       case DeviceOperatingSystem.fake:
         print('Looking for fake devices! You should not see this in release builds.');
         return FakeDeviceDiscovery();
@@ -330,6 +332,41 @@ class AndroidDeviceDiscovery implements DeviceDiscovery {
     // a better method, but so far that's the best one I've found.
     await exec(adbPath, <String>['kill-server']);
   }
+}
+
+class WindowsDeviceDiscovery implements DeviceDiscovery {
+  factory WindowsDeviceDiscovery() {
+    return _instance ??= WindowsDeviceDiscovery._();
+  }
+
+  WindowsDeviceDiscovery._();
+
+  static WindowsDeviceDiscovery? _instance;
+
+  static const WindowsDevice _device = WindowsDevice();
+
+  @override
+  Future<Map<String, HealthCheckResult>> checkDevices() async {
+    return <String, HealthCheckResult>{};
+  }
+
+  @override
+  Future<void> chooseWorkingDevice() async { }
+
+  @override
+  Future<void> chooseWorkingDeviceById(String deviceId) async { }
+
+  @override
+  Future<List<String>> discoverDevices() async {
+    return <String>['windows'];
+  }
+
+  @override
+  Future<void> performPreflightTasks() async { }
+
+  @override
+  Future<Device> get workingDevice  async => _device;
+
 }
 
 class FuchsiaDeviceDiscovery implements DeviceDiscovery {
@@ -941,6 +978,55 @@ class IosDevice extends Device {
   Future<void> reboot() {
     return Process.run('idevicediagnostics', <String>['restart', '-u', deviceId]);
   }
+}
+
+class WindowsDevice extends Device {
+  const WindowsDevice();
+
+  @override
+  String get deviceId => 'windows';
+
+  @override
+  Future<Map<String, dynamic>> getMemoryStats(String packageName) async {
+    return <String, dynamic>{};
+  }
+
+  @override
+  Future<void> home() async { }
+
+  @override
+  Future<bool> isAsleep() async {
+    return false;
+  }
+
+  @override
+  Future<bool> isAwake() async {
+    return true;
+  }
+
+  @override
+  Stream<String> get logcat => const Stream<String>.empty();
+
+  @override
+  Future<void> reboot() async { }
+
+  @override
+  Future<void> sendToSleep() async { }
+
+  @override
+  Future<void> stop(String packageName) async { }
+
+  @override
+  Future<void> tap(int x, int y) async { }
+
+  @override
+  Future<void> togglePower() async { }
+
+  @override
+  Future<void> unlock() async { }
+
+  @override
+  Future<void> wakeUp() async { }
 }
 
 /// Fuchsia device.

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -615,6 +615,7 @@ class StartupTest {
           ]);
           applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
+        case DeviceOperatingSystem.windows:
         case DeviceOperatingSystem.fuchsia:
         case DeviceOperatingSystem.fake:
           break;
@@ -730,6 +731,7 @@ class DevtoolsStartupTest {
           ]);
           applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
+        case DeviceOperatingSystem.windows:
         case DeviceOperatingSystem.fuchsia:
         case DeviceOperatingSystem.fake:
           break;
@@ -1307,6 +1309,8 @@ class CompileTest {
         if (reportPackageContentSizes)
           metrics.addAll(await getSizesFromApk(apkPath));
         break;
+      case DeviceOperatingSystem.windows:
+        throw Exception('Unsupported option for Windows devices');
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
       case DeviceOperatingSystem.fake:
@@ -1343,6 +1347,8 @@ class CompileTest {
         options.insert(0, 'apk');
         options.add('--target-platform=android-arm64');
         break;
+      case DeviceOperatingSystem.windows:
+        throw Exception('Unsupported option for Windows devices');
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
       case DeviceOperatingSystem.fake:

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -214,7 +214,7 @@ class DriveCommand extends RunCommandBase {
       throwToolExit(null);
     }
     if (screenshot != null && !device.supportsScreenshot) {
-      throwToolExit('Screenshot not supported for ${device.name}.');
+      _logger.printError('Screenshot not supported for ${device.name}.');
     }
 
     final bool web = device is WebServerDevice || device is ChromiumDevice;
@@ -359,6 +359,9 @@ class DriveCommand extends RunCommandBase {
   }
 
   Future<void> _takeScreenshot(Device device) async {
+    if (!device.supportsScreenshot) {
+      return;
+    }
     try {
       final Directory outputDirectory = _fileSystem.directory(screenshot)
         ..createSync(recursive: true);


### PR DESCRIPTION
We need at least one benchmark to test if https://github.com/flutter/engine/pull/31830 improves rendering performance.

This adds a single windows host benchmark, with a small change to the tool to simplify devicelab integration