### PR TITLE
Add logging when first frame is not rendering

### DIFF
--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -82,6 +82,8 @@ class Tracing {
                 _logger.printTrace('No isolate ID associated with the view.');
                 continue;
               }
+              final vm_service.Stack stack = await vmService.service.getStack(isolateId);
+              _logger.printTrace(stack.toString());
               final vm_service.Isolate? isolate = await vmService.getIsolateOrNull(isolateId);
               if (isolate == null) {
                 _logger.printTrace('Isolate $isolateId not found.');
@@ -92,9 +94,6 @@ class Tracing {
               // "libraries" has very long output and is likely unrelated to any first-frame issues.
               isolateState.remove('libraries');
               _logger.printTrace(jsonEncode(isolateState));
-
-              final vm_service.Stack stack = await vmService.service.getStack(isolateId);
-              _logger.printTrace(stack.toString());
             }
             _logger.printTrace('Received VM events:');
             _logger.printTrace(bufferedEvents.toString());

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -92,6 +92,9 @@ class Tracing {
               // "libraries" has very long output and is likely unrelated to any first-frame issues.
               isolateState.remove('libraries');
               _logger.printTrace(jsonEncode(isolateState));
+
+              final vm_service.Stack stack = await vmService.service.getStack(isolateId);
+              _logger.printTrace(stack.toString());
             }
             _logger.printTrace('Received VM events:');
             _logger.printTrace(bufferedEvents.toString());

--- a/packages/flutter_tools/lib/src/tracing.dart
+++ b/packages/flutter_tools/lib/src/tracing.dart
@@ -82,8 +82,6 @@ class Tracing {
                 _logger.printTrace('No isolate ID associated with the view.');
                 continue;
               }
-              final vm_service.Stack stack = await vmService.service.getStack(isolateId);
-              _logger.printTrace(stack.toString());
               final vm_service.Isolate? isolate = await vmService.getIsolateOrNull(isolateId);
               if (isolate == null) {
                 _logger.printTrace('Isolate $isolateId not found.');

--- a/packages/flutter_tools/test/general.shard/tracing_test.dart
+++ b/packages/flutter_tools/test/general.shard/tracing_test.dart
@@ -232,7 +232,8 @@ void main() {
       return completer.future;
     });
     expect(logger.statusText, contains('First frame is taking longer than expected'));
-    expect(logger.traceText, contains('id: 1 isolate: null'));
+    expect(logger.traceText, contains('View ID: 1'));
+    expect(logger.traceText, contains('No isolate ID associated with the view'));
     expect(logger.traceText, contains('Flutter.Error: [ExtensionData {test: data, renderedErrorText: error text}]'));
   });
 


### PR DESCRIPTION
Help debug https://github.com/flutter/flutter/issues/98419

```
[+181880 ms] First frame is taking longer than expected...
[+2804 ms] View ID: _flutterView/0x121815820
[  +27 ms] Isolate isolates/2451146379095359 state:
[   +6 ms] {"type":"Isolate","id":"isolates/2451146379095359","number":"2451146379095359","name":"main","isSystemIsolate":false,"isolateFlags":[{"name":"copy_parent_code","valueAsString":"false"},{"name":"is_system_isolate","valueAsString":"false"}],"startTime":1646423553553,"runnable":true,"livePorts":0,"pauseOnExit":false,"pauseEvent":{"type":"Event","kind":"Resume","timestamp":1646423553614,"isolate":{"type":"@Isolate","id":"isolates/2451146379095359","number":"2451146379095359","name":"main","isSystemIsolate":false}},"breakpoints":[],"exceptionPauseMode":"None","rootLib":{"type":"@Library","id":"libraries/@564330433","fixedId":true,"name":"","uri":"package:flutter_view/main.dart"},"extensionRPCs":["ext.dart.io.getHttpEnableTimelineLogging","ext.dart.io.setHttpEnableTimelineLogging","ext.dart.io.httpEnableTimelineLogging","ext.dart.io.getSocketProfile","ext.dart.io.startSocketProfiling","ext.dart.io.pauseSocketProfiling","ext.dart.io.socketProfilingEnabled","ext.dart.io.clearSocketProfile","ext.dart.io.getVersion","ext.dart.io.getHttpProfile","ext.dart.io.getHttpProfileRequest","ext.dart.io.clearHttpProfile","ext.flutter.exit","ext.flutter.connectedVmServiceUri","ext.flutter.activeDevToolsServerAddress","ext.flutter.timeDilation","ext.flutter.debugDumpRenderTree","ext.flutter.debugDumpSemanticsTreeInTraversalOrder","ext.flutter.debugDumpSemanticsTreeInInverseHitTestOrder","ext.flutter.profileRenderObjectPaints","ext.flutter.profileRenderObjectLayouts","ext.flutter.debugDumpApp","ext.flutter.showPerformanceOverlay","ext.flutter.didSendFirstFrameEvent","ext.flutter.didSendFirstFrameRasterizedEvent","ext.flutter.fastReassemble","ext.flutter.profileWidgetBuilds"]}
[        ] Received VM events:
[        ] Flutter.ServiceExtensionStateChanged: [ExtensionData {extension: ext.flutter.activeDevToolsServerAddress, value: http://127.0.0.1:9100}]
           Flutter.ServiceExtensionStateChanged: [ExtensionData {extension: ext.flutter.connectedVmServiceUri, value: http://127.0.0.1:61703/bCbbp06lomA=/}]
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
