### PR TITLE
Remove tool crash git.io link shortener

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -181,7 +181,6 @@ Future<T> runInContext<T>(
         fileSystem: globals.fs,
         logger: globals.logger,
         flutterProjectFactory: globals.projectFactory,
-        client: globals.httpClientFactory?.call() ?? HttpClient(),
       ),
       DevFSConfig: () => DevFSConfig(),
       DeviceManager: () => FlutterDeviceManager(

--- a/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
+++ b/packages/flutter_tools/lib/src/reporting/crash_reporting.dart
@@ -59,16 +59,13 @@ class CrashReporter {
     required FileSystem fileSystem,
     required Logger logger,
     required FlutterProjectFactory flutterProjectFactory,
-    required HttpClient client,
   }) : _fileSystem = fileSystem,
        _logger = logger,
-       _flutterProjectFactory = flutterProjectFactory,
-       _client = client;
+       _flutterProjectFactory = flutterProjectFactory;
 
   final FileSystem _fileSystem;
   final Logger _logger;
   final FlutterProjectFactory _flutterProjectFactory;
-  final HttpClient _client;
 
   /// Prints instructions for filing a bug about the crash.
   Future<void> informUser(CrashDetails details, File crashFile) async {
@@ -86,7 +83,6 @@ class CrashReporter {
       fileSystem: _fileSystem,
       logger: _logger,
       flutterProjectFactory: _flutterProjectFactory,
-      client: _client,
     );
 
     final String gitHubTemplateURL = await gitHubTemplateCreator.toolCrashIssueTemplateGitHubURL(

--- a/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
+++ b/packages/flutter_tools/test/general.shard/crash_reporting_test.dart
@@ -19,7 +19,6 @@ import 'package:http/testing.dart';
 import 'package:test/fake.dart';
 
 import '../src/common.dart';
-import '../src/fake_http_client.dart';
 import '../src/fake_process_manager.dart';
 
 void main() {
@@ -83,7 +82,6 @@ void main() {
       fileSystem: fs,
       logger: logger,
       flutterProjectFactory: FlutterProjectFactory(fileSystem: fs, logger: logger),
-      client: FakeHttpClient.any(),
     );
 
     final File file = fs.file('flutter_00.log');

--- a/packages/flutter_tools/test/general.shard/github_template_test.dart
+++ b/packages/flutter_tools/test/general.shard/github_template_test.dart
@@ -14,9 +14,6 @@ import 'package:flutter_tools/src/reporting/github_template.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
-import '../src/fake_http_client.dart';
-
-const String _kShortURL = 'https://www.example.com/short';
 
 void main() {
   BufferLogger logger;
@@ -157,41 +154,10 @@ void main() {
         error = ArgumentError('argument error message');
       });
 
-      testUsingContext('shortened', () async {
+      testUsingContext('shows GitHub issue URL', () async {
         final GitHubTemplateCreator creator = GitHubTemplateCreator(
           fileSystem: fs,
           logger: logger,
-          client: FakeHttpClient.list(<FakeRequest>[
-            FakeRequest(Uri.parse('https://git.io'), method: HttpMethod.post, response: const FakeResponse(
-              statusCode: 201,
-              headers: <String, List<String>>{
-                HttpHeaders.locationHeader: <String>[_kShortURL],
-              }
-            ))
-          ]),
-          flutterProjectFactory: FlutterProjectFactory(
-            fileSystem: fs,
-            logger: logger,
-          ),
-        );
-        expect(
-            await creator.toolCrashIssueTemplateGitHubURL(command, error, stackTrace, doctorText),
-            _kShortURL
-        );
-      }, overrides: <Type, Generator>{
-        FileSystem: () => MemoryFileSystem.test(),
-        ProcessManager: () => FakeProcessManager.any(),
-      });
-
-      testUsingContext('with network failure', () async {
-        final GitHubTemplateCreator creator = GitHubTemplateCreator(
-          fileSystem: fs,
-          logger: logger,
-          client: FakeHttpClient.list(<FakeRequest>[
-            FakeRequest(Uri.parse('https://git.io'), method: HttpMethod.post, response: const FakeResponse(
-              statusCode: 500,
-            ))
-          ]),
           flutterProjectFactory: FlutterProjectFactory(
             fileSystem: fs,
             logger: logger,
@@ -207,7 +173,6 @@ void main() {
             'eport%0A%60%60%60%0A%0A%23%23+Flutter+Application+Metadata%0ANo+pubspec+in+working+d'
             'irectory.%0A&labels=tool%2Csevere%3A+crash'
         );
-        expect(logger.traceText, contains('Failed to shorten GitHub template URL'));
       }, overrides: <Type, Generator>{
         FileSystem: () => MemoryFileSystem.test(),
         ProcessManager: () => FakeProcessManager.any(),
@@ -217,7 +182,6 @@ void main() {
         final GitHubTemplateCreator creator = GitHubTemplateCreator(
           fileSystem: fs,
           logger: logger,
-          client: FakeHttpClient.any(),
           flutterProjectFactory: FlutterProjectFactory(
             fileSystem: fs,
             logger: logger,

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -56,26 +56,6 @@ String _toMethodString(HttpMethod method) {
   }
 }
 
-/// Override the creation of all [HttpClient] objects with a zone injection.
-///
-/// This should only be used when the http client cannot be set directly, such as
-/// when testing `package:http` code.
-Future<void> overrideHttpClients(Future<void> Function() callback,  FakeHttpClient httpClient) async {
-  final HttpOverrides overrides = _FakeHttpClientOverrides(httpClient);
-  await HttpOverrides.runWithHttpOverrides(callback, overrides);
-}
-
-class _FakeHttpClientOverrides extends HttpOverrides {
-  _FakeHttpClientOverrides(this.httpClient);
-
-  final FakeHttpClient httpClient;
-
-  @override
-  HttpClient createHttpClient(SecurityContext? context) {
-    return httpClient;
-  }
-}
-
 /// Create a fake request that configures the [FakeHttpClient] to respond
 /// with the provided [response].
 ///


### PR DESCRIPTION
git.io link shortener is dead, service responding 422. [GitHub has removed the service as of January 2022.](https://github.blog/changelog/2022-01-11-git-io-no-longer-accepts-new-urls/)

Remove the code that posts a request to have the link shortened.

Fixes https://github.com/flutter/flutter/issues/53140
See also https://github.com/flutter/flutter/issues/99572

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
