### PR TITLE
Move text selection theme to widget libraries

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -110,11 +110,11 @@ const Map<String, List<String>> kWebTestFileKnownFailures = <String, List<String
     // These tests are broken and need to be fixed.
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/71604
     'test/painting/decoration_test.dart',
-    'test/material/text_selection_theme_test.dart',
     'test/material/date_picker_test.dart',
     'test/rendering/layers_test.dart',
     'test/painting/text_style_test.dart',
     'test/widgets/image_test.dart',
+    'test/widgets/text_selection_theme_test.dart',
     'test/cupertino/colors_test.dart',
     'test/cupertino/slider_test.dart',
     'test/material/text_field_test.dart',

--- a/packages/flutter/lib/material.dart
+++ b/packages/flutter/lib/material.dart
@@ -144,7 +144,6 @@ export 'src/material/text_button_theme.dart';
 export 'src/material/text_field.dart';
 export 'src/material/text_form_field.dart';
 export 'src/material/text_selection.dart';
-export 'src/material/text_selection_theme.dart';
 export 'src/material/text_selection_toolbar.dart';
 export 'src/material/text_selection_toolbar_text_button.dart';
 export 'src/material/text_theme.dart';

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -579,18 +579,24 @@ class _CupertinoAppState extends State<CupertinoApp> {
   @override
   Widget build(BuildContext context) {
     final CupertinoThemeData effectiveThemeData = widget.theme ?? const CupertinoThemeData();
-
     return ScrollConfiguration(
       behavior: widget.scrollBehavior ?? const CupertinoScrollBehavior(),
       child: CupertinoUserInterfaceLevel(
         data: CupertinoUserInterfaceLevelData.base,
         child: CupertinoTheme(
           data: effectiveThemeData,
-          child: HeroControllerScope(
-            controller: _heroController,
-            child: Builder(
-              builder: _buildWidgetApp,
+          child: TextSelectionTheme(
+            data: TextSelectionThemeData(
+              cursorColor: effectiveThemeData.primaryColor,
+              selectionColor: effectiveThemeData.primaryColor.withOpacity(0.40),
+              selectionHandleColor: effectiveThemeData.primaryColor,
             ),
+            child: HeroControllerScope(
+              controller: _heroController,
+              child: Builder(
+                builder: _buildWidgetApp,
+              ),
+            )
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -862,29 +862,36 @@ class _MaterialAppState extends State<MaterialApp> {
       theme = widget.highContrastTheme;
     }
     theme ??= widget.theme ?? ThemeData.light();
-
+    final TextSelectionThemeData effectiveTextSelectionTheme = TextSelectionThemeData(
+      selectionColor: theme.colorScheme.primary.withOpacity(0.40),
+      selectionHandleColor: theme.colorScheme.primary,
+      cursorColor: theme.colorScheme.primary,
+    ).merge(theme.textSelectionTheme);
     return ScaffoldMessenger(
       key: widget.scaffoldMessengerKey,
-      child: AnimatedTheme(
-        data: theme,
-        child: widget.builder != null
-          ? Builder(
-              builder: (BuildContext context) {
-                // Why are we surrounding a builder with a builder?
-                //
-                // The widget.builder may contain code that invokes
-                // Theme.of(), which should return the theme we selected
-                // above in AnimatedTheme. However, if we invoke
-                // widget.builder() directly as the child of AnimatedTheme
-                // then there is no Context separating them, and the
-                // widget.builder() will not find the theme. Therefore, we
-                // surround widget.builder with yet another builder so that
-                // a context separates them and Theme.of() correctly
-                // resolves to the theme we passed to AnimatedTheme.
-                return widget.builder!(context, child);
-              },
-            )
-          : child ?? const SizedBox.shrink(),
+      child: TextSelectionTheme(
+        data: effectiveTextSelectionTheme,
+        child: AnimatedTheme(
+          data: theme,
+          child: widget.builder != null
+              ? Builder(
+                  builder: (BuildContext context) {
+                    // Why are we surrounding a builder with a builder?
+                    //
+                    // The widget.builder may contain code that invokes
+                    // Theme.of(), which should return the theme we selected
+                    // above in AnimatedTheme. However, if we invoke
+                    // widget.builder() directly as the child of AnimatedTheme
+                    // then there is no Context separating them, and the
+                    // widget.builder() will not find the theme. Therefore, we
+                    // surround widget.builder with yet another builder so that
+                    // a context separates them and Theme.of() correctly
+                    // resolves to the theme we passed to AnimatedTheme.
+                    return widget.builder!(context, child);
+                  },
+                )
+              : child ?? const SizedBox.shrink(),
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -12,7 +12,6 @@ import 'package:flutter/rendering.dart';
 import 'desktop_text_selection.dart';
 import 'feedback.dart';
 import 'text_selection.dart';
-import 'text_selection_theme.dart';
 import 'theme.dart';
 
 /// An eyeballed value that moves the cursor slightly left of where it is

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -19,7 +19,6 @@ import 'material_localizations.dart';
 import 'material_state.dart';
 import 'selectable_text.dart' show iOSHorizontalOffset;
 import 'text_selection.dart';
-import 'text_selection_theme.dart';
 import 'theme.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;

--- a/packages/flutter/lib/src/material/text_selection.dart
+++ b/packages/flutter/lib/src/material/text_selection.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
 import 'material_localizations.dart';
-import 'text_selection_theme.dart';
 import 'text_selection_toolbar.dart';
 import 'text_selection_toolbar_text_button.dart';
 import 'theme.dart';

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -43,7 +43,6 @@ import 'snack_bar_theme.dart';
 import 'switch_theme.dart';
 import 'tab_bar_theme.dart';
 import 'text_button_theme.dart';
-import 'text_selection_theme.dart';
 import 'text_theme.dart';
 import 'time_picker_theme.dart';
 import 'toggle_buttons_theme.dart';

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -34,6 +34,7 @@ import 'shortcuts.dart';
 import 'text.dart';
 import 'text_editing_intents.dart';
 import 'text_selection.dart';
+import 'text_selection_theme.dart';
 import 'ticker_provider.dart';
 import 'widget_span.dart';
 
@@ -3296,7 +3297,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                         minLines: widget.minLines,
                         expands: widget.expands,
                         strutStyle: widget.strutStyle,
-                        selectionColor: widget.selectionColor,
+                        selectionColor: widget.selectionColor ?? TextSelectionTheme.of(context).selectionColor,
                         textScaleFactor: widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context),
                         textAlign: widget.textAlign,
                         textDirection: _textDirection,

--- a/packages/flutter/lib/src/widgets/text_selection_theme.dart
+++ b/packages/flutter/lib/src/widgets/text_selection_theme.dart
@@ -2,13 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/painting.dart';
 
-import 'theme.dart';
+import 'framework.dart';
+import 'inherited_theme.dart';
 
-/// Defines the visual properties needed for text selection in [TextField] and
-/// [SelectableText] widgets.
+/// Defines the visual properties needed for text selection in [EditableText]
+/// and its subclasses, [TextField] and [SelectableText].
 ///
 /// Used by [TextSelectionTheme] to control the visual properties of text
 /// selection in a widget subtree.
@@ -64,6 +67,23 @@ class TextSelectionThemeData with Diagnosticable {
     );
   }
 
+  /// Creates a copy of this object with the given fields replaced with the
+  /// specified values.
+  ///
+  /// Returns a new text selection theme that matches this text selection theme
+  /// but with some values replaced by the non-null parameters of the given text
+  /// selection theme. If the given text selection theme is null, simply returns
+  /// this text selection theme.
+  TextSelectionThemeData merge(TextSelectionThemeData? other) {
+    if (other == null)
+      return this;
+    return copyWith(
+      cursorColor: other.cursorColor,
+      selectionColor: other.selectionColor,
+      selectionHandleColor: other.selectionHandleColor,
+    );
+  }
+
   /// Linearly interpolate between two text field themes.
   ///
   /// If both arguments are null, then null is returned.
@@ -111,8 +131,9 @@ class TextSelectionThemeData with Diagnosticable {
 /// An inherited widget that defines the appearance of text selection in
 /// this widget's subtree.
 ///
-/// Values specified here are used for [TextField] and [SelectableText]
-/// properties that are not given an explicit non-null value.
+/// Values specified here are used for [EditableText] and its subclasses,
+/// [TextField] and [SelectableText], properties that are not given an explicit
+/// non-null value.
 ///
 /// {@tool snippet}
 ///
@@ -154,7 +175,7 @@ class TextSelectionTheme extends InheritedTheme {
   /// ```
   static TextSelectionThemeData of(BuildContext context) {
     final TextSelectionTheme? selectionTheme = context.dependOnInheritedWidgetOfExactType<TextSelectionTheme>();
-    return selectionTheme?.data ?? Theme.of(context).textSelectionTheme;
+    return selectionTheme?.data ?? const TextSelectionThemeData();
   }
 
   @override

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -124,6 +124,7 @@ export 'src/widgets/table.dart';
 export 'src/widgets/text.dart';
 export 'src/widgets/text_editing_intents.dart';
 export 'src/widgets/text_selection.dart';
+export 'src/widgets/text_selection_theme.dart';
 export 'src/widgets/text_selection_toolbar_layout_delegate.dart';
 export 'src/widgets/texture.dart';
 export 'src/widgets/ticker_provider.dart';

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -170,6 +170,7 @@ void main() {
       '     _InheritedTheme\n'
       '     Theme\n'
       '     AnimatedTheme\n'
+      '     TextSelectionTheme\n'
       '     _ScaffoldMessengerScope\n'
       '     ScaffoldMessenger\n'
       '     Builder\n'

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -552,11 +552,9 @@ void main() {
   group('material handles', () {
     testWidgets('draws transparent handle correctly', (WidgetTester tester) async {
       await tester.pumpWidget(RepaintBoundary(
-        child: Theme(
-          data: ThemeData(
-            textSelectionTheme: const TextSelectionThemeData(
-              selectionHandleColor: Color(0x550000AA),
-            ),
+        child: TextSelectionTheme(
+          data: const TextSelectionThemeData(
+            selectionHandleColor: Color(0x550000AA),
           ),
           child: Builder(
             builder: (BuildContext context) {

--- a/packages/flutter/test/widgets/text_selection_theme_test.dart
+++ b/packages/flutter/test/widgets/text_selection_theme_test.dart
@@ -14,6 +14,21 @@ void main() {
     expect(const TextSelectionThemeData().hashCode, const TextSelectionThemeData().copyWith().hashCode);
   });
 
+  test('TextSelectionThemeData merge', () {
+    const TextSelectionThemeData theme1 = TextSelectionThemeData(
+      cursorColor: Colors.yellow,
+      selectionColor: Colors.red,
+      selectionHandleColor: Colors.blue,
+    );
+    const TextSelectionThemeData theme2 = TextSelectionThemeData(
+      selectionColor: Colors.black,
+    );
+    final TextSelectionThemeData merged = theme1.merge(theme2);
+    expect(merged.cursorColor, theme1.cursorColor);
+    expect(merged.selectionColor, theme2.selectionColor);
+    expect(merged.selectionHandleColor, theme1.selectionHandleColor);
+  });
+
   test('TextSelectionThemeData null fields by default', () {
     const TextSelectionThemeData theme = TextSelectionThemeData();
     expect(theme.cursorColor, null);
@@ -150,6 +165,41 @@ void main() {
     await tester.pumpAndSettle();
     final RenderBox handle = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
     expect(handle, paints..path(color: textSelectionTheme.selectionHandleColor));
+  });
+
+  testWidgets('ThemeData.textSelectionTheme will be used in EditableText if provided', (WidgetTester tester) async {
+    const TextSelectionThemeData textSelectionTheme = TextSelectionThemeData(
+      selectionColor: Color(0x88888888),
+    );
+    final ThemeData theme = ThemeData.fallback().copyWith(
+      textSelectionTheme: textSelectionTheme,
+    );
+
+    final FocusNode focusNode = FocusNode();
+    final TextEditingController controller = TextEditingController();
+    // Test TextField's cursor & selection color.
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: theme,
+        home: Material(
+          child: EditableText(
+            backgroundCursorColor: Colors.grey,
+            controller: controller,
+            focusNode: focusNode,
+            style: const TextStyle(),
+            cursorColor: Colors.yellow,
+            cursorWidth: 10.0,
+            cursorHeight: 10.0,
+            cursorRadius: const Radius.circular(2.0),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+    final RenderEditable renderEditable = editableTextState.renderEditable;
+    expect(renderEditable.selectionColor, textSelectionTheme.selectionColor);
   });
 
   testWidgets('TextSelectionTheme widget will override ThemeData.textSelectionTheme', (WidgetTester tester) async {


### PR DESCRIPTION
Moves the text selection theme to widget layer to be reused by Global selection

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
