### PR TITLE
Add vs_build dep to windows performance test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4404,7 +4404,6 @@ targets:
 
   - name: Windows windows_home_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
-    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4405,6 +4405,7 @@ targets:
   - name: Windows windows_home_scroll_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     timeout: 60
+    bringup: true
     properties:
       tags: >
         ["devicelab","hostonly"]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4409,6 +4409,10 @@ targets:
     properties:
       tags: >
         ["devicelab","hostonly"]
+      dependencies: >-
+        [
+          {"dependency": "vs_build", "version": "version:vs2019"}
+        ]
       task_name: windows_home_scroll_perf__timeline_summary
       benchmark: "true"
     scheduler: luci


### PR DESCRIPTION
This test is failing on ToT because there is no visual studio installed. Maybe an explicit property is required?