### PR TITLE
docs: Add more potential use case for Bottom Navigation Bar

### DIFF
--- a/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
+++ b/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
@@ -1,0 +1,106 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for BottomNavigationBar
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: _title,
+      home: MyStatefulWidget(),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({super.key});
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  int _selectedIndex = 1;
+  FontWeight _fontWeight = FontWeight.normal;
+  final ScrollController _homeController = ScrollController();
+
+  Widget _listViewBody() {
+    return ListView.separated(
+        controller: _homeController,
+        itemBuilder: (BuildContext context, int index) {
+          return Center(
+            child: Text(
+              'Item $index',
+              style: TextStyle(
+                fontWeight: _fontWeight,
+              ),
+            ),
+          );
+        },
+        separatorBuilder: (BuildContext context, int index) => const Divider(
+              thickness: 1,
+            ),
+        itemCount: 50);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('BottomNavigationBar Sample'),
+      ),
+      body: _listViewBody(),
+      bottomNavigationBar: BottomNavigationBar(
+          items: const <BottomNavigationBarItem>[
+            BottomNavigationBarItem(
+              icon: Icon(Icons.arrow_circle_up),
+              label: 'Back top',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.format_bold),
+              label: 'Bold Fonts',
+            ),
+            BottomNavigationBarItem(
+              icon: Icon(Icons.format_clear),
+              label: 'Normalize Fonts',
+            ),
+          ],
+          currentIndex: _selectedIndex,
+          selectedItemColor: Colors.amber[800],
+          onTap: (int index) {
+            switch (index) {
+              case 0:
+                _homeController.animateTo(
+                  0.0,
+                  duration: const Duration(milliseconds: 500),
+                  curve: Curves.easeOut,
+                );
+                break;
+              case 1:
+                setState(() {
+                  _fontWeight = FontWeight.bold;
+                });
+                break;
+              case 2:
+                setState(() {
+                  _fontWeight = FontWeight.normal;
+                });
+                break;
+            }
+            setState(() {
+              _selectedIndex = index;
+            });
+          }),
+    );
+  }
+}

--- a/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
+++ b/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
@@ -30,8 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
-  int _selectedIndex = 1;
-  FontWeight _fontWeight = FontWeight.normal;
+  int _selectedIndex = 0;
   final ScrollController _homeController = ScrollController();
 
   Widget _listViewBody() {
@@ -41,9 +40,6 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
           return Center(
             child: Text(
               'Item $index',
-              style: TextStyle(
-                fontWeight: _fontWeight,
-              ),
             ),
           );
         },
@@ -61,46 +57,58 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
       ),
       body: _listViewBody(),
       bottomNavigationBar: BottomNavigationBar(
-          items: const <BottomNavigationBarItem>[
-            BottomNavigationBarItem(
-              icon: Icon(Icons.arrow_circle_up),
-              label: 'Back top',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.format_bold),
-              label: 'Bold Fonts',
-            ),
-            BottomNavigationBarItem(
-              icon: Icon(Icons.format_clear),
-              label: 'Normalize Fonts',
-            ),
-          ],
-          currentIndex: _selectedIndex,
-          selectedItemColor: Colors.amber[800],
-          onTap: (int index) {
-            switch (index) {
-              case 0:
+        items: const <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.open_in_new_rounded),
+            label: 'Open Dialog',
+          ),
+        ],
+        currentIndex: _selectedIndex,
+        selectedItemColor: Colors.amber[800],
+        onTap: (int index) {
+          switch (index) {
+            case 0:
+              // only scroll to top when current index is selected.
+              if (_selectedIndex == index) {
                 _homeController.animateTo(
                   0.0,
                   duration: const Duration(milliseconds: 500),
                   curve: Curves.easeOut,
                 );
-                break;
-              case 1:
-                setState(() {
-                  _fontWeight = FontWeight.bold;
-                });
-                break;
-              case 2:
-                setState(() {
-                  _fontWeight = FontWeight.normal;
-                });
-                break;
-            }
-            setState(() {
+              }
+              break;
+            case 1:
+              showModal(context);
+              break;
+          }
+          setState(
+            () {
               _selectedIndex = index;
-            });
-          }),
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  void showModal(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        content: const Text('Example Dialog'),
+        actions: <TextButton>[
+          TextButton(
+            onPressed: () {
+              Navigator.pop(context);
+            },
+            child: const Text('Close'),
+          )
+        ],
+      ),
     );
   }
 }

--- a/examples/api/test/material/bottom_navigation_bar/bottom_navigation_bar.2.test.dart
+++ b/examples/api/test/material/bottom_navigation_bar/bottom_navigation_bar.2.test.dart
@@ -1,0 +1,45 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/bottom_navigation_bar/bottom_navigation_bar.2.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BottomNavigationBar Updates Screen Content',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    expect(find.widgetWithText(AppBar, 'BottomNavigationBar Sample'),
+        findsOneWidget);
+    expect(find.byType(BottomNavigationBar), findsOneWidget);
+    expect(find.widgetWithText(Center, 'Item 0'), findsOneWidget);
+
+    await tester.scrollUntilVisible(
+        find.widgetWithText(Center, 'Item 49'), 100);
+    await tester.pumpAndSettle();
+    expect(find.widgetWithText(Center, 'Item 49'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.arrow_circle_up));
+    await tester.pumpAndSettle();
+    final Scrollable bodyScrollView = tester.widget(find.byType(Scrollable));
+    expect(bodyScrollView.controller?.offset, 0.0);
+
+    final Finder textFinder = find.text('Item 0');
+    expect(
+        tester.widget<Text>(textFinder).style?.fontWeight, FontWeight.normal);
+
+    await tester.tap(find.byIcon(Icons.format_bold));
+    await tester.pumpAndSettle();
+    expect(tester.widget<Text>(textFinder).style?.fontWeight, FontWeight.bold);
+
+    await tester.tap(find.byIcon(Icons.format_clear));
+    await tester.pumpAndSettle();
+    expect(
+        tester.widget<Text>(textFinder).style?.fontWeight, FontWeight.normal);
+  });
+}

--- a/examples/api/test/material/bottom_navigation_bar/bottom_navigation_bar.2.test.dart
+++ b/examples/api/test/material/bottom_navigation_bar/bottom_navigation_bar.2.test.dart
@@ -24,22 +24,15 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.widgetWithText(Center, 'Item 49'), findsOneWidget);
 
-    await tester.tap(find.byIcon(Icons.arrow_circle_up));
+    await tester.tap(find.byIcon(Icons.home));
+    await tester.tap(find.byIcon(Icons.home));
     await tester.pumpAndSettle();
+
     final Scrollable bodyScrollView = tester.widget(find.byType(Scrollable));
     expect(bodyScrollView.controller?.offset, 0.0);
 
-    final Finder textFinder = find.text('Item 0');
-    expect(
-        tester.widget<Text>(textFinder).style?.fontWeight, FontWeight.normal);
-
-    await tester.tap(find.byIcon(Icons.format_bold));
+    await tester.tap(find.byIcon(Icons.open_in_new_rounded));
     await tester.pumpAndSettle();
-    expect(tester.widget<Text>(textFinder).style?.fontWeight, FontWeight.bold);
-
-    await tester.tap(find.byIcon(Icons.format_clear));
-    await tester.pumpAndSettle();
-    expect(
-        tester.widget<Text>(textFinder).style?.fontWeight, FontWeight.normal);
+    expect(find.byType(AlertDialog), findsOneWidget);
   });
 }

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -119,86 +119,14 @@ enum BottomNavigationBarLandscapeLayout {
 /// ** See code in examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.1.dart **
 /// {@end-tool}
 ///
-/// {@tool dartpad --template=stateful_widget_material}
+/// {@tool dartpad}
 /// This example shows [BottomNavigationBar] used in a [Scaffold] Widget with
 /// different interaction patterns. Tapping on the first [BottomNavigationBarItem]
 /// uses the [ScrollController] to animate the [ListView] to the top. The second
 /// and third [BottomNavigationBarItem] change the fontWeight to bold and normal
 /// respectively.
-/// ```dart
-/// int _selectedIndex = 1;
-/// FontWeight _fontWeight = FontWeight.normal;
-/// final ScrollController _homeController = ScrollController();
-/// Widget _listViewBody() {
-///   return ListView.separated(
-///       controller: _homeController,
-///       itemBuilder: (BuildContext context, int index) {
-///         return Center(
-///           child: Text(
-///             'Item $index',
-///             style: TextStyle(
-///               fontWeight: _fontWeight,
-///             ),
-///           ),
-///         );
-///       },
-///       separatorBuilder: (BuildContext context, int index) => const Divider(
-///             thickness: 1,
-///           ),
-///       itemCount: 50);
-/// }
 ///
-/// @override
-/// Widget build(BuildContext context) {
-///   return Scaffold(
-///     appBar: AppBar(
-///       title: const Text('BottomNavigationBar Sample'),
-///     ),
-///     body: _listViewBody(),
-///     bottomNavigationBar: BottomNavigationBar(
-///         items: const <BottomNavigationBarItem>[
-///           BottomNavigationBarItem(
-///             icon: Icon(Icons.arrow_circle_up),
-///             label: 'Back top',
-///           ),
-///           BottomNavigationBarItem(
-///             icon: Icon(Icons.format_bold),
-///             label: 'Bold Fonts',
-///           ),
-///           BottomNavigationBarItem(
-///             icon: Icon(Icons.format_clear),
-///             label: 'Normalize Fonts',
-///           ),
-///         ],
-///         currentIndex: _selectedIndex,
-///         selectedItemColor: Colors.amber[800],
-///         onTap: (int index) {
-///           switch (index) {
-///             case 0:
-///               _homeController.animateTo(
-///                 0.0,
-///                 duration: const Duration(milliseconds: 500),
-///                 curve: Curves.easeOut,
-///               );
-///               break;
-///             case 1:
-///               setState(() {
-///                 _fontWeight = FontWeight.bold;
-///               });
-///               break;
-///             case 2:
-///               setState(() {
-///                 _fontWeight = FontWeight.normal;
-///               });
-///               break;
-///           }
-///           setState(() {
-///             _selectedIndex = index;
-///           });
-///         }),
-///   );
-/// }
-/// ```
+/// ** See code in examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart **
 /// {@end-tool}
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -127,79 +127,78 @@ enum BottomNavigationBarLandscapeLayout {
 /// respectively.
 /// ```dart
 /// int _selectedIndex = 1;
-///   FontWeight _fontWeight = FontWeight.normal;
-///   final ScrollController _homeController = ScrollController();
+/// FontWeight _fontWeight = FontWeight.normal;
+/// final ScrollController _homeController = ScrollController();
+/// / Widget _listViewBody() {
+///   return ListView.separated(
+///       controller: _homeController,
+///       itemBuilder: (BuildContext context, int index) {
+///         return Center(
+///           child: Text(
+///             'Item $index',
+///             style: TextStyle(
+///               fontWeight: _fontWeight,
+///             ),
+///           ),
+///         );
+///       },
+///       separatorBuilder: (BuildContext context, int index) => const Divider(
+///             thickness: 1,
+///           ),
+///       itemCount: 50);
+/// }
 ///
-///   Widget _listViewBody() {
-///     return ListView.separated(
-///         controller: _homeController,
-///         itemBuilder: (BuildContext context, int index) {
-///           return Center(
-///             child: Text(
-///               'Item $index',
-///               style: TextStyle(
-///                 fontWeight: _fontWeight,
-///               ),
-///             ),
-///           );
-///         },
-///         separatorBuilder: (BuildContext context, int index) => const Divider(
-///               thickness: 1,
-///             ),
-///         itemCount: 50);
-///   }
-///
-///   @override
-///   Widget build(BuildContext context) {
-///     return Scaffold(
-///       appBar: AppBar(
-///         title: const Text('BottomNavigationBar Sample'),
-///       ),
-///       body: _listViewBody(),
-///       bottomNavigationBar: BottomNavigationBar(
-///           items: const <BottomNavigationBarItem>[
-///             BottomNavigationBarItem(
-///               icon: Icon(Icons.arrow_circle_up),
-///               label: 'Back top',
-///             ),
-///             BottomNavigationBarItem(
-///               icon: Icon(Icons.format_bold),
-///               label: 'Bold Fonts',
-///             ),
-///             BottomNavigationBarItem(
-///               icon: Icon(Icons.format_clear),
-///               label: 'Normalize Fonts',
-///             ),
-///           ],
-///           currentIndex: _selectedIndex,
-///           selectedItemColor: Colors.amber[800],
-///           onTap: (int index) {
-///             switch (index) {
-///               case 0:
-///                 _homeController.animateTo(
-///                   0.0,
-///                   duration: const Duration(milliseconds: 500),
-///                   curve: Curves.easeOut,
-///                 );
-///                 break;
-///               case 1:
-///                 setState(() {
-///                   _fontWeight = FontWeight.bold;
-///                 });
-///                 break;
-///               case 2:
-///                 setState(() {
-///                   _fontWeight = FontWeight.normal;
-///                 });
-///                 break;
-///             }
-///             setState(() {
-///               _selectedIndex = index;
-///             });
-///           }),
-///     );
-///   }
-///```
+/// @override
+/// Widget build(BuildContext context) {
+///   return Scaffold(
+///     appBar: AppBar(
+///       title: const Text('BottomNavigationBar Sample'),
+///     ),
+///     body: _listViewBody(),
+///     bottomNavigationBar: BottomNavigationBar(
+///         items: const <BottomNavigationBarItem>[
+///           BottomNavigationBarItem(
+///             icon: Icon(Icons.arrow_circle_up),
+///             label: 'Back top',
+///           ),
+///           BottomNavigationBarItem(
+///             icon: Icon(Icons.format_bold),
+///             label: 'Bold Fonts',
+///           ),
+///           BottomNavigationBarItem(
+///             icon: Icon(Icons.format_clear),
+///             label: 'Normalize Fonts',
+///           ),
+///         ],
+///         currentIndex: _selectedIndex,
+///         selectedItemColor: Colors.amber[800],
+///         onTap: (int index) {
+///           switch (index) {
+///             case 0:
+///               _homeController.animateTo(
+///                 0.0,
+///                 duration: const Duration(milliseconds: 500),
+///                 curve: Curves.easeOut,
+///               );
+///               break;
+///             case 1:
+///               setState(() {
+///                 _fontWeight = FontWeight.bold;
+///               });
+///               break;
+///             case 2:
+///               setState(() {
+///                 _fontWeight = FontWeight.normal;
+///               });
+///               break;
+///           }
+///           setState(() {
+///             _selectedIndex = index;
+///           });
+///         }),
+///   );
+/// }
+/// ```
 /// {@end-tool}
 /// See also:
 ///

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -129,7 +129,7 @@ enum BottomNavigationBarLandscapeLayout {
 /// int _selectedIndex = 1;
 /// FontWeight _fontWeight = FontWeight.normal;
 /// final ScrollController _homeController = ScrollController();
-/// / Widget _listViewBody() {
+/// Widget _listViewBody() {
 ///   return ListView.separated(
 ///       controller: _homeController,
 ///       itemBuilder: (BuildContext context, int index) {

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -121,10 +121,9 @@ enum BottomNavigationBarLandscapeLayout {
 ///
 /// {@tool dartpad}
 /// This example shows [BottomNavigationBar] used in a [Scaffold] Widget with
-/// different interaction patterns. Tapping on the first [BottomNavigationBarItem]
+/// different interaction patterns. Tapping twice on the first [BottomNavigationBarItem]
 /// uses the [ScrollController] to animate the [ListView] to the top. The second
-/// and third [BottomNavigationBarItem] change the fontWeight to bold and normal
-/// respectively.
+/// [BottomNavigationBarItem] shows a Modal Dialog.
 ///
 /// ** See code in examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -118,6 +118,89 @@ enum BottomNavigationBarLandscapeLayout {
 ///
 /// ** See code in examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.1.dart **
 /// {@end-tool}
+///
+/// {@tool dartpad --template=stateful_widget_material}
+/// This example shows [BottomNavigationBar] used in a [Scaffold] Widget with
+/// different interaction patterns. Tapping on the first [BottomNavigationBarItem]
+/// uses the [ScrollController] to animate the [ListView] to the top. The second
+/// and third [BottomNavigationBarItem] change the fontWeight to bold and normal
+/// respectively.
+/// ```dart
+/// int _selectedIndex = 1;
+///   FontWeight _fontWeight = FontWeight.normal;
+///   final ScrollController _homeController = ScrollController();
+///
+///   Widget _listViewBody() {
+///     return ListView.separated(
+///         controller: _homeController,
+///         itemBuilder: (BuildContext context, int index) {
+///           return Center(
+///             child: Text(
+///               'Item $index',
+///               style: TextStyle(
+///                 fontWeight: _fontWeight,
+///               ),
+///             ),
+///           );
+///         },
+///         separatorBuilder: (BuildContext context, int index) => const Divider(
+///               thickness: 1,
+///             ),
+///         itemCount: 50);
+///   }
+///
+///   @override
+///   Widget build(BuildContext context) {
+///     return Scaffold(
+///       appBar: AppBar(
+///         title: const Text('BottomNavigationBar Sample'),
+///       ),
+///       body: _listViewBody(),
+///       bottomNavigationBar: BottomNavigationBar(
+///           items: const <BottomNavigationBarItem>[
+///             BottomNavigationBarItem(
+///               icon: Icon(Icons.arrow_circle_up),
+///               label: 'Back top',
+///             ),
+///             BottomNavigationBarItem(
+///               icon: Icon(Icons.format_bold),
+///               label: 'Bold Fonts',
+///             ),
+///             BottomNavigationBarItem(
+///               icon: Icon(Icons.format_clear),
+///               label: 'Normalize Fonts',
+///             ),
+///           ],
+///           currentIndex: _selectedIndex,
+///           selectedItemColor: Colors.amber[800],
+///           onTap: (int index) {
+///             switch (index) {
+///               case 0:
+///                 _homeController.animateTo(
+///                   0.0,
+///                   duration: const Duration(milliseconds: 500),
+///                   curve: Curves.easeOut,
+///                 );
+///                 break;
+///               case 1:
+///                 setState(() {
+///                   _fontWeight = FontWeight.bold;
+///                 });
+///                 break;
+///               case 2:
+///                 setState(() {
+///                   _fontWeight = FontWeight.normal;
+///                 });
+///                 break;
+///             }
+///             setState(() {
+///               _selectedIndex = index;
+///             });
+///           }),
+///     );
+///   }
+///```
+/// {@end-tool}
 /// See also:
 ///
 ///  * [BottomNavigationBarItem]


### PR DESCRIPTION
Adds the dartpad example for the use case mentioned in the issue

Fixes #33810

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
