### PR TITLE
Fix `ColorScheme.shadow` to default to black even for dark themes.

### DIFF
--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -708,7 +708,7 @@ class ColorScheme with Diagnosticable {
 
   final Color? _shadow;
   /// A color use to paint the drop shadows of elevated components.
-  Color get shadow => _shadow ?? onBackground;
+  Color get shadow => _shadow ?? const Color(0xff000000);
 
   final Color? _inverseSurface;
   /// A surface color used for displaying the reverse of what’s seen in the

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -36,7 +36,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.outline, scheme.onBackground);
-    expect(scheme.shadow, scheme.onBackground);
+    expect(scheme.shadow, const Color(0xff000000));
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
@@ -75,7 +75,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.outline, scheme.onBackground);
-    expect(scheme.shadow, scheme.onBackground);
+    expect(scheme.shadow, const Color(0xff000000));
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
@@ -114,7 +114,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.outline, scheme.onBackground);
-    expect(scheme.shadow, scheme.onBackground);
+    expect(scheme.shadow, const Color(0xff000000));
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);
@@ -153,7 +153,7 @@ void main() {
     expect(scheme.surfaceVariant, scheme.surface);
     expect(scheme.onSurfaceVariant, scheme.onSurface);
     expect(scheme.outline, scheme.onBackground);
-    expect(scheme.shadow, scheme.onBackground);
+    expect(scheme.shadow, const Color(0xff000000));
     expect(scheme.inverseSurface, scheme.onSurface);
     expect(scheme.onInverseSurface, scheme.surface);
     expect(scheme.inversePrimary, scheme.onPrimary);


### PR DESCRIPTION
Fixes: #98455

As @rydmike rightly pointed out the current default for `ColorScheme.shadow` shouldn't be `onBackground` as it leads to white shadows in the default dark themes.

This PR changes the default value for `shadow` to black (`const Color(0xff000000)`) as intended.

