### PR TITLE
Check string size before Win32 MultiByte <-> WideChar conversions

### DIFF
--- a/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
@@ -48,10 +48,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr);
-  if (target_length == 0) {
-    return std::string();
-  }
   std::string utf8_string;
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
+    return utf8_string;
+  }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,

--- a/dev/manual_tests/windows/runner/utils.cpp
+++ b/dev/manual_tests/windows/runner/utils.cpp
@@ -48,10 +48,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr);
-  if (target_length == 0) {
-    return std::string();
-  }
   std::string utf8_string;
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
+    return utf8_string;
+  }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,

--- a/examples/api/windows/runner/utils.cpp
+++ b/examples/api/windows/runner/utils.cpp
@@ -48,10 +48,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr);
-  if (target_length == 0) {
-    return std::string();
-  }
   std::string utf8_string;
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
+    return utf8_string;
+  }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
@@ -48,10 +48,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr);
-  if (target_length == 0) {
-    return std::string();
-  }
   std::string utf8_string;
+  if (target_length == 0 || target_length > utf8_string.max_size()) {
+    return utf8_string;
+  }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,


### PR DESCRIPTION
This PR adds an additional check to ensure the target length of a string is within the supported maximum string length prior to calling WideCharToMultiByte/MultiByteToWideChar in the Windows runner template.

This is to prevent resize() from failing if called with a count > std::string::max_size().

According to Win32 API docs ([WideCharToMultiByte](https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte), [MultiByteToWideChar](https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar)) it's the caller responsibility to make sure the buffers are correctly allocated.

This patch was originally proposed by @tgucio in #94608.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
