### PR TITLE
iOS Strip debug symbols in release

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -467,7 +467,7 @@ Future<void> _checkBitcode(String frameworkPath, String mode) async {
   }
 }
 
-Future<String> _dylibSymbols(String pathToDylib, global) {
+Future<String> _dylibSymbols(String pathToDylib, bool global) {
   return eval('nm', <String>[
     if (global)
       '-g',

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -123,6 +123,7 @@ abstract class AotAssemblyBase extends Target {
     if (result.exitCode != 0) {
       throw Exception('lipo exited with code ${result.exitCode}.\n${result.stderr}');
     }
+    _stripDebugSymbols(environment, resultPath, buildMode);
   }
 }
 
@@ -622,6 +623,20 @@ Future<void> _createStubAppFramework(File outputFile, Environment environment,
   }
 
   _signFramework(environment, outputFile.path, BuildMode.debug);
+}
+
+void _stripDebugSymbols(Environment environment, String binaryPath, BuildMode buildMode) {
+  if (buildMode == BuildMode.release) {
+    final ProcessResult result = environment.processManager.runSync(<String>[
+      'xcrun',
+      'strip',
+      '-rSTx',
+      binaryPath,
+    ]);
+    if (result.exitCode != 0) {
+      throw Exception('Failed to strip debug symbols in binary $binaryPath.\n${result.stderr}');
+    }
+  }
 }
 
 void _signFramework(Environment environment, String binaryPath, BuildMode buildMode) {


### PR DESCRIPTION
Hello! This is my first pr in this repo, I have plenty experience with iOS compilation but not too much with Flutter tbh
We are looking to reduce the app size impact of Flutter in our app and I noticed that there is no strip debug symbols step in the App.framework generation for release mode.

With this change our app size slightly gets reduced (Data gathered from App Store Connect)

<img width="622" alt="image" src="https://user-images.githubusercontent.com/6267487/157165690-2094c965-ba9e-4763-88ec-4510860c7676.png">



## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
