### PR TITLE
Remove unnecessary ignore: override_on_non_overriding_member

### DIFF
--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -115,7 +115,6 @@ class _MockHttpClient implements HttpClient {
   void addProxyCredentials(String host, int port, String realm, HttpClientCredentials credentials) { }
 
   @override
-  // ignore: override_on_non_overriding_member
   Future<ConnectionTask<Socket>> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
 
   @override
@@ -128,7 +127,6 @@ class _MockHttpClient implements HttpClient {
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
-  // ignore: override_on_non_overriding_member
   Function(String line)? keyLog;
 
   @override

--- a/packages/flutter_tools/test/src/fake_http_client.dart
+++ b/packages/flutter_tools/test/src/fake_http_client.dart
@@ -141,7 +141,6 @@ class FakeHttpClient implements HttpClient {
   }
 
   @override
-  // ignore: override_on_non_overriding_member
   Future<ConnectionTask<Socket>> Function(Uri url, String? proxyHost, int? proxyPort)? connectionFactory;
 
   @override
@@ -154,7 +153,6 @@ class FakeHttpClient implements HttpClient {
   bool Function(X509Certificate cert, String host, int port)? badCertificateCallback;
 
   @override
-  // ignore: override_on_non_overriding_member
   Function(String line)? keyLog;
 
   @override


### PR DESCRIPTION
Remove `// ignore: override_on_non_overriding_member`  annotations that were added in 76855aa893654c1b5781db616491673114697027 and are no longer necessary now that the corresponding Dart changes have landed:
-  https://github.com/dart-lang/sdk/issues/48093
-  https://github.com/dart-lang/sdk/issues/47887

