### PR TITLE
Revert "Add the refresh rate fields to perf_test"

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -969,12 +969,6 @@ const List<String> _kCommonScoreKeys = <String>[
   'worst_picture_cache_memory',
   'new_gen_gc_count',
   'old_gen_gc_count',
-  '30hz_frame_percentage',
-  '60hz_frame_percentage',
-  '80hz_frame_percentage',
-  '90hz_frame_percentage',
-  '120hz_frame_percentage',
-  'illegal_refresh_rate_frame_count',
 ];
 
 class PerfTestWithSkSL extends PerfTest {

--- a/packages/flutter_driver/lib/src/driver/refresh_rate_summarizer.dart
+++ b/packages/flutter_driver/lib/src/driver/refresh_rate_summarizer.dart
@@ -28,10 +28,6 @@ class RefreshRateSummary {
         _numberOf60HzFrames++;
         continue;
       }
-      if ((refreshRate - 80).abs() < _kErrorMargin) {
-        _numberOf80HzFrames++;
-        continue;
-      }
       if ((refreshRate - 90).abs() < _kErrorMargin) {
         _numberOf90HzFrames++;
         continue;
@@ -45,16 +41,24 @@ class RefreshRateSummary {
     assert(_numberOfTotalFrames ==
         _numberOf30HzFrames +
             _numberOf60HzFrames +
-            _numberOf80HzFrames +
             _numberOf90HzFrames +
             _numberOf120HzFrames +
             _framesWithIllegalRefreshRate.length);
   }
 
-  // The error margin to determine the frame refresh rate.
-  // For example, when we calculated a frame that has a refresh rate of 65, we consider the frame to be a 60Hz frame.
-  // Can be adjusted if necessary.
   static const double _kErrorMargin = 6.0;
+
+  /// Number of frames with 30hz refresh rate
+  int get numberOf30HzFrames => _numberOf30HzFrames;
+
+  /// Number of frames with 60hz refresh rate
+  int get numberOf60HzFrames => _numberOf60HzFrames;
+
+  /// Number of frames with 90hz refresh rate
+  int get numberOf90HzFrames => _numberOf90HzFrames;
+
+  /// Number of frames with 120hz refresh rate
+  int get numberOf120HzFrames => _numberOf120HzFrames;
 
   /// The percentage of 30hz frames.
   ///
@@ -72,14 +76,6 @@ class RefreshRateSummary {
       ? _numberOf60HzFrames / _numberOfTotalFrames * 100
       : 0;
 
-  /// The percentage of 80hz frames.
-  ///
-  /// For example, if this value is 20, it means there are 20 percent of total
-  /// frames are 80hz. 0 means no frames are 80hz, 100 means all frames are 80hz.
-  double get percentageOf80HzFrames => _numberOfTotalFrames > 0
-      ? _numberOf80HzFrames / _numberOfTotalFrames * 100
-      : 0;
-
   /// The percentage of 90hz frames.
   ///
   /// For example, if this value is 20, it means there are 20 percent of total
@@ -88,7 +84,7 @@ class RefreshRateSummary {
       ? _numberOf90HzFrames / _numberOfTotalFrames * 100
       : 0;
 
-  /// The percentage of 120hz frames.
+  /// The percentage of 90hz frames.
   ///
   /// For example, if this value is 20, it means there are 20 percent of total
   /// frames are 120hz. 0 means no frames are 120hz, 100 means all frames are 120hz.
@@ -98,14 +94,13 @@ class RefreshRateSummary {
 
   /// A list of all the frames with Illegal refresh rate.
   ///
-  /// A refresh rate is consider illegal if it does not belong to anyone of the refresh rate this class is
-  /// explicitly tracking.
+  /// A refresh rate is consider illegal if it does not belong to anyone below:
+  /// 30hz, 60hz, 90hz or 120hz.
   List<double> get framesWithIllegalRefreshRate =>
       _framesWithIllegalRefreshRate;
 
   int _numberOf30HzFrames = 0;
   int _numberOf60HzFrames = 0;
-  int _numberOf80HzFrames = 0;
   int _numberOf90HzFrames = 0;
   int _numberOf120HzFrames = 0;
   int _numberOfTotalFrames = 0;

--- a/packages/flutter_driver/lib/src/driver/timeline_summary.dart
+++ b/packages/flutter_driver/lib/src/driver/timeline_summary.dart
@@ -275,7 +275,6 @@ class TimelineSummary {
       'total_ui_gc_time': gcSummarizer.totalGCTimeMillis,
       '30hz_frame_percentage': refreshRateSummary.percentageOf30HzFrames,
       '60hz_frame_percentage': refreshRateSummary.percentageOf60HzFrames,
-      '80hz_frame_percentage': refreshRateSummary.percentageOf80HzFrames,
       '90hz_frame_percentage': refreshRateSummary.percentageOf90HzFrames,
       '120hz_frame_percentage': refreshRateSummary.percentageOf120HzFrames,
       'illegal_refresh_rate_frame_count': refreshRateSummary.framesWithIllegalRefreshRate.length,

--- a/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/timeline_summary_test.dart
@@ -475,7 +475,6 @@ void main() {
             'total_ui_gc_time': 0.4,
             '30hz_frame_percentage': 0,
             '60hz_frame_percentage': 0,
-            '80hz_frame_percentage': 0,
             '90hz_frame_percentage': 0,
             '120hz_frame_percentage': 0,
             'illegal_refresh_rate_frame_count': 0,
@@ -596,7 +595,6 @@ void main() {
           'total_ui_gc_time': 0.4,
           '30hz_frame_percentage': 0,
           '60hz_frame_percentage': 100,
-          '80hz_frame_percentage': 0,
           '90hz_frame_percentage': 0,
           '120hz_frame_percentage': 0,
           'illegal_refresh_rate_frame_count': 0,
@@ -871,11 +869,9 @@ void main() {
         final List<Map<String, dynamic>> events = <Map<String, dynamic>>[];
         const int num30Hz = 10;
         const int num60Hz = 20;
-        const int num80Hz = 20;
         const int num90Hz = 20;
         const int num120Hz = 40;
         const int numIllegal = 10;
-        const int totalFrames = num30Hz + num60Hz + num80Hz + num90Hz + num120Hz + numIllegal;
 
         // Add 30hz frames
         events.addAll(_populateEvents(numberOfEvents: num30Hz,
@@ -891,12 +887,6 @@ void main() {
                                       margin: 0,
                                       ));
 
-        // Add 80hz frames
-        events.addAll(_populateEvents(numberOfEvents: num80Hz,
-                                      startTime: 0,
-                                      interval: 12000000,
-                                      margin: 0,
-                                      ));
 
         // Add 90hz frames
         events.addAll(_populateEvents(numberOfEvents: num90Hz,
@@ -920,12 +910,10 @@ void main() {
                                       ));
 
         final RefreshRateSummary summary  = _summarize(events);
-
-        expect(summary.percentageOf30HzFrames, closeTo(num30Hz/totalFrames*100, kCompareDelta));
-        expect(summary.percentageOf60HzFrames, closeTo(num60Hz/totalFrames*100, kCompareDelta));
-        expect(summary.percentageOf80HzFrames, closeTo(num80Hz/totalFrames*100, kCompareDelta));
-        expect(summary.percentageOf90HzFrames, closeTo(num90Hz/totalFrames*100, kCompareDelta));
-        expect(summary.percentageOf120HzFrames, closeTo(num120Hz/totalFrames*100, kCompareDelta));
+        expect(summary.percentageOf30HzFrames, closeTo(num30Hz, kCompareDelta));
+        expect(summary.percentageOf60HzFrames, closeTo(num60Hz, kCompareDelta));
+        expect(summary.percentageOf90HzFrames, closeTo(num90Hz, kCompareDelta));
+        expect(summary.percentageOf120HzFrames, closeTo(num120Hz, kCompareDelta));
         expect(summary.framesWithIllegalRefreshRate, isNotEmpty);
         expect(summary.framesWithIllegalRefreshRate.length, 10);
       });


### PR DESCRIPTION
Reverts flutter/flutter#99710

Failures like https://ci.chromium.org/ui/p/flutter/builders/prod/Linux_android%20animated_placeholder_perf__e2e_summary/2036/overview