### PR TITLE
Update bug number for `android_semantics_integration_test`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1399,7 +1399,7 @@ targets:
     scheduler: luci
 
   - name: Linux_android android_semantics_integration_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/74522
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/98417
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Test `android_semantics_integration_test` has been flaky and marked as `bringup: true`. The existing appended flaky bug was obsolete and causes the bot keep creating new bugs even then we have https://github.com/flutter/flutter/issues/98417 to track.

This PR update the reference to existing bug to avoid new bugs creation like: https://github.com/flutter/flutter/issues/99834#.

The future fix is to update the .ci.yaml bug reference when creating a new bug for `bringup: true` builders.