### PR TITLE
FocusTrap behavior by platform

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2179,8 +2179,7 @@ class _RenderFocusTrap extends RenderProxyBoxWithHitTestBehavior {
     return hitTarget;
   }
 
-  /// The focus dropping behavior is only present on desktop platforms
-  /// and mobile browsers.
+  /// The focus dropping behavior is only present on web (mobile and desktop).
   bool get _shouldIgnoreEvents {
     return !kIsWeb;
   }

--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -2182,16 +2182,7 @@ class _RenderFocusTrap extends RenderProxyBoxWithHitTestBehavior {
   /// The focus dropping behavior is only present on desktop platforms
   /// and mobile browsers.
   bool get _shouldIgnoreEvents {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      case TargetPlatform.iOS:
-        return !kIsWeb;
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-      case TargetPlatform.fuchsia:
-        return false;
-    }
+    return !kIsWeb;
   }
 
   @override
@@ -2199,7 +2190,6 @@ class _RenderFocusTrap extends RenderProxyBoxWithHitTestBehavior {
     assert(debugHandleEvent(event, entry));
     if (event is! PointerDownEvent
       || event.buttons != kPrimaryButton
-      || event.kind != PointerDeviceKind.mouse
       || _shouldIgnoreEvents
       || _focusScopeNode.focusedChild == null) {
       return;

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -395,7 +396,7 @@ void main() {
     expect(tester.testTextInput.isVisible, isFalse);
   });
 
-  testWidgets('A Focused text-field will lose focus when clicking outside of its hitbox with a mouse on desktop', (WidgetTester tester) async {
+  testWidgets('A Focused text-field will lose focus when clicking outside of its hitbox on web', (WidgetTester tester) async {
     final FocusNode focusNodeA = FocusNode();
     final FocusNode focusNodeB = FocusNode();
     final Key key = UniqueKey();
@@ -450,7 +451,7 @@ void main() {
 
     expect(focusNodeA.hasFocus, false);
     expect(focusNodeB.hasFocus, true);
-  }, variant: TargetPlatformVariant.desktop());
+  }, skip: !kIsWeb);
 
   testWidgets('A Focused text-field will not lose focus when clicking on its decoration', (WidgetTester tester) async {
     final FocusNode focusNodeA = FocusNode();
@@ -491,7 +492,7 @@ void main() {
     expect(focusNodeA.hasFocus, true);
   }, variant: TargetPlatformVariant.desktop());
 
-  testWidgets('A Focused text-field will lose focus when clicking outside of its hitbox with a mouse on desktop after tab navigation', (WidgetTester tester) async {
+  testWidgets('A Focused text-field will lose focus when clicking outside of its hitbox on web after tab navigation', (WidgetTester tester) async {
     final FocusNode focusNodeA = FocusNode();
     final FocusNode focusNodeB = FocusNode();
     final Key key = UniqueKey();
@@ -547,7 +548,7 @@ void main() {
 
     expect(focusNodeA.hasFocus, false);
     expect(focusNodeB.hasFocus, true);
-  }, variant: TargetPlatformVariant.desktop());
+  }, skip: !kIsWeb);
 }
 
 class _APage extends Page<void> {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11004,4 +11004,40 @@ void main() {
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 14);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux,  TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
+
+  testWidgets('tapping an empty area loses focus only on web (desktop and mobile)', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(
+              focusNode: focusNode,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(focusNode.hasFocus, isFalse);
+
+    final Offset fieldOffset = tester.getCenter(find.byType(EditableText));
+    final Offset emptyOffset = Offset(
+      fieldOffset.dx,
+      tester.getTopLeft(find.byType(EditableText)).dy - 50.0,
+    );
+
+    await tester.tapAt(fieldOffset);
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+
+    await tester.tapAt(emptyOffset);
+    await tester.pumpAndSettle();
+
+    if (kIsWeb) {
+      expect(focusNode.hasFocus, isFalse);
+    } else {
+      expect(focusNode.hasFocus, isTrue);
+    }
+  }, variant: TargetPlatformVariant.all());
 }


### PR DESCRIPTION
Based on my testing of native platforms, only web (mobile and desktop) remove focus when tapping on an empty area.  All other platforms do not.  This PR makes Flutter match that behavior.

Related to https://github.com/flutter/flutter/issues/92541 and https://github.com/flutter/flutter/issues/92079
A full solution for FocusTrap behavior would be https://github.com/flutter/flutter/issues/86972.