### PR TITLE
[flutter_tools] exec rather than spawn subprocess from bin/internal/shared.sh

### DIFF
--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -222,10 +222,10 @@ function shared::execute() {
     flutter*)
       # FLUTTER_TOOL_ARGS aren't quoted below, because it is meant to be
       # considered as separate space-separated args.
-      "$DART" --disable-dart-dev --packages="$FLUTTER_TOOLS_DIR/.packages" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
+      exec "$DART" --disable-dart-dev --packages="$FLUTTER_TOOLS_DIR/.packages" $FLUTTER_TOOL_ARGS "$SNAPSHOT_PATH" "$@"
       ;;
     dart*)
-      "$DART" "$@"
+      exec "$DART" "$@"
       ;;
     *)
       >&2 echo "Error! Executable name $BIN_NAME not recognized!"

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -1,0 +1,68 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io' as io;
+
+import 'package:file/file.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+final String flutterRootPath = getFlutterRoot();
+final Directory flutterRoot = fileSystem.directory(flutterRootPath);
+
+Future<void> main() async {
+  test('verify terminating flutter/bin/dart terminates the underlying dart process', () async {
+    final Completer<void> childReadyCompleter = Completer<void>();
+    String stdout = '';
+    final io.Process process = await io.Process.start(
+      dartBash.path,
+      <String>[listenForSigtermScript.path],
+    );
+    final Future<Object?> stdoutFuture = process.stdout
+        .transform<String>(utf8.decoder)
+        .forEach((String str) {
+          stdout += str;
+          if (stdout.contains('Ready to receive signals') && !childReadyCompleter.isCompleted) {
+            childReadyCompleter.complete();
+          }
+        });
+    // Ensure that the child app has registered its signal handler
+    await childReadyCompleter.future;
+    final bool killSuccess = process.kill();
+    expect(killSuccess, true);
+    // Wait for stdout to complete
+    await stdoutFuture;
+    // Ensure child exited successfully
+    expect(
+      await process.exitCode,
+      0,
+      reason: 'child process exited with code ${await process.exitCode}, and '
+        'stdout:\n$stdout',
+    );
+    expect(stdout, contains('Successfully received SIGTERM!'));
+  });
+}
+
+// A test Dart app that will run until it receives SIGTERM
+File get listenForSigtermScript {
+  return flutterRoot
+      .childDirectory('packages')
+      .childDirectory('flutter_tools')
+      .childDirectory('test')
+      .childDirectory('integration.shard')
+      .childDirectory('test_data')
+      .childFile('listen_for_sigterm.dart')
+      .absolute;
+}
+
+// The executable bash entrypoint for the Dart binary.
+File get dartBash {
+  return flutterRoot
+      .childDirectory('bin')
+      .childFile('dart')
+      .absolute;
+}

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -19,10 +19,10 @@ Future<void> main() async {
     final Completer<void> childReadyCompleter = Completer<void>();
     String stdout = '';
     final Process process = await processManager.start(
-      <String>[
-        dartBash.path,
-        listenForSigtermScript.path,
-      ],
+        <String>[
+          dartBash.path,
+          listenForSigtermScript.path,
+        ],
     );
     final Future<Object?> stdoutFuture = process.stdout
         .transform<String>(utf8.decoder)
@@ -40,14 +40,14 @@ Future<void> main() async {
     await stdoutFuture;
     // Ensure child exited successfully
     expect(
-      await process.exitCode,
-      0,
-      reason: 'child process exited with code ${await process.exitCode}, and '
+        await process.exitCode,
+        0,
+        reason: 'child process exited with code ${await process.exitCode}, and '
         'stdout:\n$stdout',
     );
     expect(stdout, contains('Successfully received SIGTERM!'));
-    // Windows does not use the bash entrypoint
-  }, skip: platform.isWindows);
+  },
+  skip: platform.isWindows); // [intended] Windows does not use the bash entrypoint
 }
 
 // A test Dart app that will run until it receives SIGTERM

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -46,7 +46,8 @@ Future<void> main() async {
         'stdout:\n$stdout',
     );
     expect(stdout, contains('Successfully received SIGTERM!'));
-  });
+    // Windows does not use the bash entrypoint
+  }, skip: platform.isWindows);
 }
 
 // A test Dart app that will run until it receives SIGTERM

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -4,9 +4,9 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io' as io;
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
 
 import '../src/common.dart';
 import 'test_utils.dart';
@@ -18,9 +18,11 @@ Future<void> main() async {
   test('verify terminating flutter/bin/dart terminates the underlying dart process', () async {
     final Completer<void> childReadyCompleter = Completer<void>();
     String stdout = '';
-    final io.Process process = await io.Process.start(
-      dartBash.path,
-      <String>[listenForSigtermScript.path],
+    final Process process = await processManager.start(
+      <String>[
+        dartBash.path,
+        listenForSigtermScript.path,
+      ],
     );
     final Future<Object?> stdoutFuture = process.stdout
         .transform<String>(utf8.decoder)

--- a/packages/flutter_tools/test/integration.shard/test_data/listen_for_sigterm.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/listen_for_sigterm.dart
@@ -3,11 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
+import 'package:flutter_tools/src/base/io.dart';
 
 // This application will log to STDOUT and exit with 0 when it receives the
 // SIGTERM signal.
 Future<void> main() async {
+  final Stdout stdout = Stdio().stdout;
+  final IOSink stderr = Stdio().stderr;
   final Stream<ProcessSignal> interruptStream = ProcessSignal.sigterm.watch();
   interruptStream.listen((_) {
     // The test should assert that this was logged

--- a/packages/flutter_tools/test/integration.shard/test_data/listen_for_sigterm.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/listen_for_sigterm.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+
+// This application will log to STDOUT and exit with 0 when it receives the
+// SIGTERM signal.
+Future<void> main() async {
+  final Stream<ProcessSignal> interruptStream = ProcessSignal.sigterm.watch();
+  interruptStream.listen((_) {
+    // The test should assert that this was logged
+    stdout.writeln('Successfully received SIGTERM!');
+    exit(0);
+  });
+  // The test should wait for this message before sending SIGTERM, or else the
+  // listener may not have been registered.
+  stdout.writeln('Ready to receive signals');
+
+  await Future<void>.delayed(const Duration(seconds: 10));
+  stderr.writeln('Did not receive SIGTERM!');
+  exit(1);
+}

--- a/packages/flutter_tools/test/integration.shard/test_data/listen_for_sigterm.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/listen_for_sigterm.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/base/io.dart';
 // SIGTERM signal.
 Future<void> main() async {
   final Stdout stdout = Stdio().stdout;
-  final IOSink stderr = Stdio().stderr;
   final Stream<ProcessSignal> interruptStream = ProcessSignal.sigterm.watch();
   interruptStream.listen((_) {
     // The test should assert that this was logged
@@ -21,6 +20,6 @@ Future<void> main() async {
   stdout.writeln('Ready to receive signals');
 
   await Future<void>.delayed(const Duration(seconds: 10));
-  stderr.writeln('Did not receive SIGTERM!');
+  stdout.writeln('Did not receive SIGTERM!');
   exit(1);
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/98435

Using `exec` from bash causes the new process to replace the current one (the bash script), so that any signals sent from the host be sent to the new process (the dart process). Before this change, the test I added will leak the dart process.

It does not seem like there is an `exec` equivalent on Windows https://stackoverflow.com/questions/20892102/kill-batch-file-in-such-a-way-that-its-children-are-killed-too-in-windows

## Context

The following quotes are from the [bash manpages](https://www.man7.org/linux/man-pages/man1/bash.1.html):

exec [-cl] [-a name] [command [arguments]]

If command is specified, it replaces the shell. No new process is created. The arguments become the arguments to command. If the -l option is supplied, the shell places a dash at the beginning of the zeroth argument passed to command. This is what [login](https://www.man7.org/linux/man-pages/man1/login.1.html)(1) does. The -c option causes command to be executed with an empty environment. If -a is supplied, the shell passes name as the zeroth argument to the executed command. If command cannot be executed for some reason, a non-interactive shell exits, unless the shell option execfail is enabled, in which case it returns failure. An interactive shell returns failure if the file cannot be executed. If command is not specified, any redirections take effect in the current shell, and the return status is 0. If there is a redirection error, the return status is 1.