### PR TITLE
Fix AndroidView offset and resize

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -215,15 +215,6 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     });
   }
 
-  final LayerHandle<ClipRectLayer> _clipRectLayer = LayerHandle<ClipRectLayer>();
-
-  @override
-  void dispose() {
-    _isDisposed = true;
-    _clipRectLayer.layer = null;
-    super.dispose();
-  }
-
   @override
   void paint(PaintingContext context, Offset offset) {
     if (_viewController.textureId == null)
@@ -250,6 +241,15 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     }
     _clipRectLayer.layer = null;
     _paintTexture(context, offset);
+  }
+
+  final LayerHandle<ClipRectLayer> _clipRectLayer = LayerHandle<ClipRectLayer>();
+
+  @override
+  void dispose() {
+    _isDisposed = true;
+    _clipRectLayer.layer = null;
+    super.dispose();
   }
 
   void _paintTexture(PaintingContext context, Offset offset) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -237,14 +237,19 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     // To prevent unwanted scaling artifacts while resizing, clip the texture.
     // This guarantees that the size of the texture frame we're painting is always
     // _currentAndroidViewSize.
-    _clipRectLayer.layer = context.pushClipRect(
-      true,
-      offset,
-      offset & size,
-      _paintTexture,
-      clipBehavior: clipBehavior,
-      oldLayer: _clipRectLayer.layer,
-    );
+    if ((size.width < _currentAndroidViewSize!.width || size.height < _currentAndroidViewSize!.height) && clipBehavior != Clip.none) {
+      _clipRectLayer.layer = context.pushClipRect(
+        true,
+        offset,
+        offset & size,
+        _paintTexture,
+        clipBehavior: clipBehavior,
+        oldLayer: _clipRectLayer.layer,
+      );
+      return;
+    }
+    _clipRectLayer.layer = null;
+    _paintTexture(context, offset);
   }
 
   void _paintTexture(PaintingContext context, Offset offset) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -96,7 +96,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
 
   _PlatformViewState _state = _PlatformViewState.uninitialized;
 
-  Size? _currentAndroidViewSize;
+  Size? _currentAndroidTextureSize;
 
   bool _isDisposed = false;
 
@@ -192,7 +192,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     Size targetSize;
     do {
       targetSize = size;
-      _currentAndroidViewSize = await _viewController.setSize(targetSize);
+      _currentAndroidTextureSize = await _viewController.setSize(targetSize);
       // We've resized the platform view to targetSize, but it is possible that
       // while we were resizing the render object's size was changed again.
       // In that case we will resize the platform view again.
@@ -227,8 +227,8 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     // size the texture frame will be scaled.
     // To prevent unwanted scaling artifacts while resizing, clip the texture.
     // This guarantees that the size of the texture frame we're painting is always
-    // _currentAndroidViewSize.
-    if ((size.width < _currentAndroidViewSize!.width || size.height < _currentAndroidViewSize!.height) && clipBehavior != Clip.none) {
+    // _currentAndroidTextureSize.
+    if ((size.width < _currentAndroidTextureSize!.width || size.height < _currentAndroidTextureSize!.height) && clipBehavior != Clip.none) {
       _clipRectLayer.layer = context.pushClipRect(
         true,
         offset,
@@ -253,11 +253,11 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
   }
 
   void _paintTexture(PaintingContext context, Offset offset) {
-    if (_currentAndroidViewSize == null)
+    if (_currentAndroidTextureSize == null)
       return;
 
     context.addLayer(TextureLayer(
-      rect: offset & _currentAndroidViewSize!,
+      rect: offset & _currentAndroidTextureSize!,
       textureId: viewController.textureId!,
     ));
   }

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -203,8 +203,12 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
   }
 
   // Sets the offset of the underlaying platform view on the platform side.
-  // When a PlatformViewLayer is used, the offset can be inferred from the
-  // transform stack provided by the layer tree.
+  //
+  // This allows the Android native view to draw the a11y highlights in the same
+  // location on the screen as the platform view widget in the Flutter framework.
+  //
+  // It also allows platform code to obtain the correct position of the Android
+  // native view on the screen
   void _setOffset() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       if (!_isDisposed) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -208,7 +208,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
   // location on the screen as the platform view widget in the Flutter framework.
   //
   // It also allows platform code to obtain the correct position of the Android
-  // native view on the screen
+  // native view on the screen.
   void _setOffset() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       if (!_isDisposed) {

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -96,7 +96,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
 
   _PlatformViewState _state = _PlatformViewState.uninitialized;
 
-  Size? _currentAndroidTextureSize;
+  Size? _currentTextureSize;
 
   bool _isDisposed = false;
 
@@ -192,7 +192,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     Size targetSize;
     do {
       targetSize = size;
-      _currentAndroidTextureSize = await _viewController.setSize(targetSize);
+      _currentTextureSize = await _viewController.setSize(targetSize);
       // We've resized the platform view to targetSize, but it is possible that
       // while we were resizing the render object's size was changed again.
       // In that case we will resize the platform view again.
@@ -228,7 +228,9 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
     // To prevent unwanted scaling artifacts while resizing, clip the texture.
     // This guarantees that the size of the texture frame we're painting is always
     // _currentAndroidTextureSize.
-    if ((size.width < _currentAndroidTextureSize!.width || size.height < _currentAndroidTextureSize!.height) && clipBehavior != Clip.none) {
+    final bool isTextureLargerThanWidget = _currentTextureSize!.width > size.width ||
+                                           _currentTextureSize!.height > size.height;
+    if (isTextureLargerThanWidget && clipBehavior != Clip.none) {
       _clipRectLayer.layer = context.pushClipRect(
         true,
         offset,
@@ -253,11 +255,11 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
   }
 
   void _paintTexture(PaintingContext context, Offset offset) {
-    if (_currentAndroidTextureSize == null)
+    if (_currentTextureSize == null)
       return;
 
     context.addLayer(TextureLayer(
-      rect: offset & _currentAndroidTextureSize!,
+      rect: offset & _currentTextureSize!,
       textureId: viewController.textureId!,
     ));
   }

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -228,7 +228,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
   void paint(PaintingContext context, Offset offset) {
     if (_viewController.textureId == null)
       return;
-    
+
     // As resizing the Android view happens asynchronously we don't know exactly when is a
     // texture frame with the new size is ready for consumption.
     // TextureLayer is unaware of the texture frame's size and always maps it to the
@@ -250,7 +250,7 @@ class RenderAndroidView extends RenderBox with _PlatformViewGestureMixin {
   void _paintTexture(PaintingContext context, Offset offset) {
     if (_currentAndroidViewSize == null)
       return;
-    
+
     context.addLayer(TextureLayer(
       rect: offset & _currentAndroidViewSize!,
       textureId: viewController.textureId!,

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -780,18 +780,23 @@ abstract class AndroidViewController extends PlatformViewController {
 
   /// Sizes the Android View.
   ///
-  /// `size` is the view's new size in logical pixel, it must not be null and must
+  /// [size] is the view's new size in logical pixel, it must not be null and must
   /// be bigger than zero.
   ///
   /// The first time a size is set triggers the creation of the Android view.
   ///
-  /// Returns the buffer size where the platform view pixels are written to, or the size of
-  /// the platform view in logical pixels.
+  /// Returns the buffer size in logical pixel that backs the texture where the platform
+  /// view pixels are written to.
+  ///
+  /// The buffer size may or may not be the same as [size].
+  ///
+  /// As a result, consumers are expected to clip the texture using [size], while using
+  /// the return value to size the texture.
   Future<Size> setSize(Size size);
 
   /// Sets the offset of the platform view.
   ///
-  /// `off` is the view's new offset in logical pixel.
+  /// [off] is the view's new offset in logical pixel.
   ///
   /// On Android, this allows the Android native view to draw the a11y highlights in the same
   /// location on the screen as the platform view widget in the Flutter framework.

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1067,7 +1067,13 @@ class TextureAndroidViewController extends AndroidViewController {
 
   @override
   Future<void> setOffset(Offset off) async {
-    if (off == _off || _state != _AndroidViewState.created)
+    if (off == _off)
+      return;
+
+    // Don't set the offset unless the Android view has been created.
+    // The implementation of this method channel throws if the Android view for this viewId
+    // isn't addressable.
+    if (_state != _AndroidViewState.created)
       return;
 
     _off = off;

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -792,6 +792,9 @@ abstract class AndroidViewController extends PlatformViewController {
   /// Sets the offset of the platform view.
   ///
   /// `off` is the view's new offset in logical pixel.
+  ///
+  /// On Android, this allows the Android native view to draw the a11y highlights in the same
+  /// location on the screen as the platform view widget in the Flutter framework.
   Future<void> setOffset(Offset off);
 
   /// Returns the texture entry id that the Android view is rendering into.

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1003,8 +1003,7 @@ class SurfaceAndroidViewController extends AndroidViewController {
 
 /// Controls an Android view that is rendered to a texture.
 ///
-/// This is typically used by [AndroidView] to display an Android View in a
-/// [VirtualDisplay](https://developer.android.com/reference/android/hardware/display/VirtualDisplay).
+/// This is typically used by [AndroidView] to display an Android View in the Android view hierarchy.
 ///
 /// Typically created with [PlatformViewsService.initAndroidView].
 class TextureAndroidViewController extends AndroidViewController {

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -546,7 +546,7 @@ class _AndroidViewState extends State<AndroidView> {
     }
     SystemChannels.textInput.invokeMethod<void>(
       'TextInput.setPlatformViewClient',
-      <String, dynamic>{'platformViewId': _id, 'usesVirtualDisplay': true},
+      <String, dynamic>{'platformViewId': _id},
     ).catchError((dynamic e) {
       if (e is MissingPluginException) {
         // We land the framework part of Android platform views keyboard

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -264,6 +264,7 @@ class FakeAndroidPlatformViewsController {
     final int id = args['id'] as int;
     final double top = args['top'] as double;
     final double left = args['left'] as double;
+    assert(!offsets.containsKey(id), 'offset already set for view id: $id');
     offsets[id] = Offset(left, top);
     return Future<dynamic>.sync(() => null);
   }

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -264,7 +264,6 @@ class FakeAndroidPlatformViewsController {
     final int id = args['id'] as int;
     final double top = args['top'] as double;
     final double left = args['left'] as double;
-    assert(!offsets.containsKey(id), 'offset already set for view id: $id');
     offsets[id] = Offset(left, top);
     return Future<dynamic>.sync(() => null);
   }

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -252,7 +252,7 @@ class FakeAndroidPlatformViewsController {
     }
     _views[id] = _views[id]!.copyWith(size: Size(width, height));
 
-    return Future<dynamic>.sync(() => null);
+    return Future<Map<dynamic, dynamic>>.sync(() => <dynamic, dynamic>{'width': width, 'height': height});
   }
 
   Future<dynamic> _touch(MethodCall call) {

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -83,7 +83,12 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  Future<void> setSize(Size size) {
+  Future<Size> setSize(Size size) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> setOffset(Offset off) {
     throw UnimplementedError();
   }
 

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -145,6 +145,8 @@ class FakeAndroidPlatformViewsController {
 
   bool synchronizeToNativeViewHierarchy = true;
 
+  Map<int, Offset> offsets = <int, Offset>{};
+
   void registerViewType(String viewType) {
     _registeredViewTypes.add(viewType);
   }
@@ -170,6 +172,8 @@ class FakeAndroidPlatformViewsController {
         return _setDirection(call);
       case 'clearFocus':
         return _clearFocus(call);
+      case 'offset':
+        return _offset(call);
       case 'synchronizeToNativeViewHierarchy':
         return _synchronizeToNativeViewHierarchy(call);
     }
@@ -253,6 +257,15 @@ class FakeAndroidPlatformViewsController {
     _views[id] = _views[id]!.copyWith(size: Size(width, height));
 
     return Future<Map<dynamic, dynamic>>.sync(() => <dynamic, dynamic>{'width': width, 'height': height});
+  }
+
+  Future<dynamic> _offset(MethodCall call) async {
+    final Map<dynamic, dynamic> args = call.arguments as Map<dynamic, dynamic>;
+    final int id = args['id'] as int;
+    final double top = args['top'] as double;
+    final double left = args['left'] as double;
+    offsets[id] = Offset(left, top);
+    return Future<dynamic>.sync(() => null);
   }
 
   Future<dynamic> _touch(MethodCall call) {

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -219,11 +219,11 @@ void main() {
       );
     });
 
-    test("set Android view's offset", () async {
+    test("set Android view's offset if view is created", () async {
       viewsController.registerViewType('webview');
       final AndroidViewController viewController =
       PlatformViewsService.initAndroidView(id: 7, viewType: 'webview', layoutDirection: TextDirection.ltr);
-      await viewController.setSize(const Size(100.0, 100.0));
+      await viewController.setSize(const Size(100.0, 100.0)); // Creates view.
       await viewController.setOffset(const Offset(10, 20));
       expect(
         viewsController.offsets,
@@ -231,6 +231,14 @@ void main() {
           7: const Offset(10, 20),
         }),
       );
+    });
+
+    test("doesn't set Android view's offset if view isn't created", () async {
+      viewsController.registerViewType('webview');
+      final AndroidViewController viewController =
+      PlatformViewsService.initAndroidView(id: 7, viewType: 'webview', layoutDirection: TextDirection.ltr);
+      await viewController.setOffset(const Offset(10, 20));
+      expect(viewsController.offsets, equals(<int, Offset>{}));
     });
 
     test('synchronizeToNativeViewHierarchy', () async {

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -219,6 +219,20 @@ void main() {
       );
     });
 
+    test("set Android view's offset", () async {
+      viewsController.registerViewType('webview');
+      final AndroidViewController viewController =
+      PlatformViewsService.initAndroidView(id: 7, viewType: 'webview', layoutDirection: TextDirection.ltr);
+      await viewController.setSize(const Size(100.0, 100.0));
+      await viewController.setOffset(const Offset(10, 20));
+      expect(
+        viewsController.offsets,
+        equals(<int, Offset>{
+          7: const Offset(10, 20),
+        }),
+      );
+    });
+
     test('synchronizeToNativeViewHierarchy', () async {
       await PlatformViewsService.synchronizeToNativeViewHierarchy(false);
       expect(viewsController.synchronizeToNativeViewHierarchy, false);

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -1224,6 +1224,24 @@ void main() {
       clipRectLayer = tester.layers.whereType<ClipRectLayer>().first;
       expect(clipRectLayer.clipRect, const Rect.fromLTWH(0.0, 0.0, 50.0, 50.0));
     });
+
+    testWidgets('offset is sent to the platform', (WidgetTester tester) async {
+      final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      await tester.pumpWidget(
+        const Padding(
+          padding: EdgeInsets.fromLTRB(10, 20, 0, 0),
+          child: AndroidView(
+            viewType: 'webview',
+            layoutDirection: TextDirection.ltr,
+          ),
+        ),
+      );
+
+      await tester.pump();
+      expect(viewsController.offsets, equals(<int, Offset>{0: const Offset(10, 20)}));
+    });
   });
 
   group('AndroidViewSurface', () {

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -1240,7 +1240,7 @@ void main() {
       );
 
       await tester.pump();
-      expect(viewsController.offsets, equals(<int, Offset>{0: const Offset(10, 20)}));
+      expect(viewsController.offsets.values, equals(<Offset>[const Offset(10, 20)]));
     });
   });
 

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -1087,9 +1087,6 @@ void main() {
 
       expect(lastPlatformViewTextClient.containsKey('platformViewId'), true);
       expect(lastPlatformViewTextClient['platformViewId'], currentViewId + 1);
-
-      expect(lastPlatformViewTextClient.containsKey('usesVirtualDisplay'), true);
-      expect(lastPlatformViewTextClient['usesVirtualDisplay'], true);
     });
 
     testWidgets('AndroidView clears platform focus when unfocused', (WidgetTester tester) async {
@@ -2633,8 +2630,6 @@ void main() {
       expect(focusNode.hasFocus, true);
       expect(lastPlatformViewTextClient.containsKey('platformViewId'), true);
       expect(lastPlatformViewTextClient['platformViewId'], viewId);
-
-      expect(lastPlatformViewTextClient.containsKey('usesVirtualDisplay'), false);
     });
   });
 


### PR DESCRIPTION
Fixes `AndroidView` by correcting how the texture is resized and setting the right offset, so a11y highlights 
are drawn.

This PR replaces https://github.com/flutter/flutter/pull/97628

Engine PR: https://github.com/flutter/engine/pull/31198
Related Issue: https://github.com/flutter/flutter/issues/96679
