### PR TITLE
fix a bug when android uses CupertinoPageTransitionsBuilder.

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -77,6 +77,8 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 ///  * [PageTransitionsTheme], which defines the default page transitions used
 ///    by the [MaterialRouteTransitionMixin.buildTransitions].
 mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
+  PageTransitionsBuilder? _prevPageTranstionsBuilder;
+
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -123,7 +125,16 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
-    return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child);
+
+    // The builder should be kept unchanged during an iOS-style back swipe pop gesture.
+    final PageTransitionsBuilder builder;
+    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(this) && _prevPageTranstionsBuilder != null) {
+      builder = _prevPageTranstionsBuilder!;
+    } else {
+      builder = _prevPageTranstionsBuilder = theme.getMatchingBuilder(context);
+    }
+
+    return builder.buildTransitions<T>(this, context, animation, secondaryAnimation, child);
   }
 }
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -126,9 +126,9 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
 
-    // The builder should be kept unchanged during an iOS-style back swipe pop gesture.
+    // The builder should be kept unchanged during an user gesture.
     final PageTransitionsBuilder builder;
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(this) && _prevPageTranstionsBuilder != null) {
+    if ((navigator?.userGestureInProgress ?? false) && _prevPageTranstionsBuilder != null) {
       builder = _prevPageTranstionsBuilder!;
     } else {
       builder = _prevPageTranstionsBuilder = theme.getMatchingBuilder(context);

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -592,9 +592,6 @@ class PageTransitionsTheme with Diagnosticable {
   ) {
     TargetPlatform platform = Theme.of(context).platform;
 
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route))
-      platform = TargetPlatform.iOS;
-
     final PageTransitionsBuilder matchingBuilder =
       builders[platform] ?? const FadeUpwardsPageTransitionsBuilder();
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -543,8 +543,7 @@ class CupertinoPageTransitionsBuilder extends PageTransitionsBuilder {
 /// for different [TargetPlatform]s.
 ///
 /// The [MaterialPageRoute.buildTransitions] method looks up the current
-/// current [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`
-/// and delegates to [buildTransitions].
+/// [PageTransitionsTheme] with `Theme.of(context).pageTransitionsTheme`.
 ///
 /// If a builder with a matching platform is not found, then the
 /// [FadeUpwardsPageTransitionsBuilder] is used.
@@ -579,22 +578,11 @@ class PageTransitionsTheme with Diagnosticable {
   Map<TargetPlatform, PageTransitionsBuilder> get builders => _builders;
   final Map<TargetPlatform, PageTransitionsBuilder> _builders;
 
-  /// Delegates to the builder for the current [ThemeData.platform]
-  /// or [FadeUpwardsPageTransitionsBuilder].
-  ///
-  /// [MaterialPageRoute.buildTransitions] delegates to this method.
-  Widget buildTransitions<T>(
-    PageRoute<T> route,
-    BuildContext context,
-    Animation<double> animation,
-    Animation<double> secondaryAnimation,
-    Widget child,
-  ) {
+  /// Returns the builder that matches the current [ThemeData.platform] or
+  /// [FadeUpwardsPageTransitionsBuilder].
+  PageTransitionsBuilder getMatchingBuilder(BuildContext context){
     final TargetPlatform platform = Theme.of(context).platform;
-
-    final PageTransitionsBuilder matchingBuilder =
-      builders[platform] ?? const FadeUpwardsPageTransitionsBuilder();
-    return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);
+    return builders[platform] ?? const FadeUpwardsPageTransitionsBuilder();
   }
 
   // Just used to the builders Map to a list with one PageTransitionsBuilder per platform

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -590,7 +590,7 @@ class PageTransitionsTheme with Diagnosticable {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    TargetPlatform platform = Theme.of(context).platform;
+    final TargetPlatform platform = Theme.of(context).platform;
 
     final PageTransitionsBuilder matchingBuilder =
       builders[platform] ?? const FadeUpwardsPageTransitionsBuilder();


### PR DESCRIPTION
When android uses iOS style `PageTransitionsBuilder` and iOS uses android style `PageTransitionsBuilder`, on android, swipe from the left edge of the screen doesn't work. This PR solves that problem.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
