### PR TITLE
Migrate `TimePicker` to Material 3

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -55,9 +55,6 @@ const double _kTimePickerHeightLandscape = 316.0;
 const double _kTimePickerHeightPortraitCollapsed = 484.0;
 const double _kTimePickerHeightLandscapeCollapsed = 304.0;
 
-const BorderRadius _kDefaultBorderRadius = BorderRadius.all(Radius.circular(4.0));
-const ShapeBorder _kDefaultShape = RoundedRectangleBorder(borderRadius: _kDefaultBorderRadius);
-
 /// Interactive input mode of the time picker dialog.
 ///
 /// In [TimePickerEntryMode.dial] mode, a clock dial is displayed and
@@ -132,7 +129,8 @@ class _TimePickerHeader extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
-    final ThemeData themeData = Theme.of(context);
+    final ThemeData theme = Theme.of(context);
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
     final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat(
       alwaysUse24HourFormat: MediaQuery.of(context).alwaysUse24HourFormat,
     );
@@ -241,7 +239,7 @@ class _TimePickerHeader extends StatelessWidget {
           const SizedBox(height: 16.0),
           Text(
             helpText ?? MaterialLocalizations.of(context).timePickerDialHelpText,
-            style: TimePickerTheme.of(context).helpTextStyle ?? themeData.textTheme.overline,
+            style: TimePickerTheme.of(context).helpTextStyle ?? defaults.helpTextStyle!,
           ),
           controls,
         ],
@@ -267,25 +265,21 @@ class _HourMinuteControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ThemeData themeData = Theme.of(context);
+    final ThemeData theme = Theme.of(context);
     final TimePickerThemeData timePickerTheme = TimePickerTheme.of(context);
-    final bool isDark = themeData.colorScheme.brightness == Brightness.dark;
-    final Color textColor = timePickerTheme.hourMinuteTextColor
-        ?? MaterialStateColor.resolveWith((Set<MaterialState> states) {
-          return states.contains(MaterialState.selected)
-              ? themeData.colorScheme.primary
-              : themeData.colorScheme.onSurface;
-        });
-    final Color backgroundColor = timePickerTheme.hourMinuteColor
-        ?? MaterialStateColor.resolveWith((Set<MaterialState> states) {
-          return states.contains(MaterialState.selected)
-              ? themeData.colorScheme.primary.withOpacity(isDark ? 0.24 : 0.12)
-              : themeData.colorScheme.onSurface.withOpacity(0.12);
-        });
-    final TextStyle style = timePickerTheme.hourMinuteTextStyle ?? themeData.textTheme.headline2!;
-    final ShapeBorder shape = timePickerTheme.hourMinuteShape ?? _kDefaultShape;
-
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
+    final Color textColor = timePickerTheme.hourMinuteTextColor ?? defaults.hourMinuteTextColor!;
+    final Color backgroundColor = timePickerTheme.hourMinuteColor ?? defaults.hourMinuteColor!;
+    final TextStyle style = timePickerTheme.hourMinuteTextStyle ?? defaults.hourMinuteTextStyle!;
+    OutlinedBorder shape = timePickerTheme.hourMinuteShape as OutlinedBorder? ?? defaults.hourMinuteShape! as OutlinedBorder;
+    final BorderSide borderSide = timePickerTheme.hourMinuteBorderSide ?? defaults.hourMinuteBorderSide!;
     final Set<MaterialState> states = isSelected ? <MaterialState>{MaterialState.selected} : <MaterialState>{};
+    if (theme.useMaterial3) {
+      shape = shape.copyWith(
+        side: MaterialStateProperty.resolveAs(borderSide, states),
+      );
+    }
+
     return SizedBox(
       height: _kTimePickerHeaderControlHeight,
       child: Material(
@@ -401,8 +395,9 @@ class _StringFragment extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final TimePickerThemeData timePickerTheme = TimePickerTheme.of(context);
-    final TextStyle hourMinuteStyle = timePickerTheme.hourMinuteTextStyle ?? theme.textTheme.headline2!;
-    final Color textColor = timePickerTheme.hourMinuteTextColor ?? theme.colorScheme.onSurface;
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
+    final TextStyle hourMinuteStyle = timePickerTheme.hourMinuteTextStyle ?? defaults.hourMinuteTextStyle!;
+    final Color textColor = timePickerTheme.hourMinuteTextColor ?? defaults.hourMinuteTextColor!;
 
     return ExcludeSemantics(
       child: Padding(
@@ -522,41 +517,24 @@ class _DayPeriodControl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final MaterialLocalizations materialLocalizations = MaterialLocalizations.of(context);
-    final ColorScheme colorScheme = Theme.of(context).colorScheme;
+    final ThemeData theme = Theme.of(context);
     final TimePickerThemeData timePickerTheme = TimePickerTheme.of(context);
-    final bool isDark = colorScheme.brightness == Brightness.dark;
-    final Color textColor = timePickerTheme.dayPeriodTextColor
-        ?? MaterialStateColor.resolveWith((Set<MaterialState> states) {
-          return states.contains(MaterialState.selected)
-              ? colorScheme.primary
-              : colorScheme.onSurface.withOpacity(0.60);
-        });
-    final Color backgroundColor = timePickerTheme.dayPeriodColor
-        ?? MaterialStateColor.resolveWith((Set<MaterialState> states) {
-          // The unselected day period should match the overall picker dialog
-          // color. Making it transparent enables that without being redundant
-          // and allows the optional elevation overlay for dark mode to be
-          // visible.
-          return states.contains(MaterialState.selected)
-              ? colorScheme.primary.withOpacity(isDark ? 0.24 : 0.12)
-              : Colors.transparent;
-        });
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
+    final Color textColor = timePickerTheme.dayPeriodTextColor ?? defaults.dayPeriodTextColor!;
+    final Color backgroundColor = timePickerTheme.dayPeriodColor ?? defaults.dayPeriodColor!;
     final bool amSelected = selectedTime.period == DayPeriod.am;
     final Set<MaterialState> amStates = amSelected ? <MaterialState>{MaterialState.selected} : <MaterialState>{};
     final bool pmSelected = !amSelected;
     final Set<MaterialState> pmStates = pmSelected ? <MaterialState>{MaterialState.selected} : <MaterialState>{};
-    final TextStyle textStyle = timePickerTheme.dayPeriodTextStyle ?? Theme.of(context).textTheme.subtitle1!;
+    final TextStyle textStyle = timePickerTheme.dayPeriodTextStyle ?? defaults.dayPeriodTextStyle!;
     final TextStyle amStyle = textStyle.copyWith(
       color: MaterialStateProperty.resolveAs(textColor, amStates),
     );
     final TextStyle pmStyle = textStyle.copyWith(
       color: MaterialStateProperty.resolveAs(textColor, pmStates),
     );
-    OutlinedBorder shape = timePickerTheme.dayPeriodShape ??
-        const RoundedRectangleBorder(borderRadius: _kDefaultBorderRadius);
-    final BorderSide borderSide = timePickerTheme.dayPeriodBorderSide ?? BorderSide(
-      color: Color.alphaBlend(colorScheme.onBackground.withOpacity(0.38), colorScheme.surface),
-    );
+    OutlinedBorder shape = timePickerTheme.dayPeriodShape ?? defaults.dayPeriodShape!;
+    final BorderSide borderSide = timePickerTheme.dayPeriodBorderSide ?? defaults.dayPeriodBorderSide!;
     // Apply the custom borderSide.
     shape = shape.copyWith(
       side: borderSide,
@@ -1162,7 +1140,9 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
   ];
 
   _TappableLabel _buildTappableLabel(TextTheme textTheme, Color color, int value, String label, VoidCallback onTap) {
-    final TextStyle style = textTheme.bodyText1!.copyWith(color: color);
+    final TextStyle style = Theme.of(context).useMaterial3
+      ? textTheme.bodyLarge!.copyWith(color: color)
+      : textTheme.bodyText1!.copyWith(color: color);
     final double labelScaleFactor = math.min(MediaQuery.of(context).textScaleFactor, 2.0);
     return _TappableLabel(
       value: value,
@@ -1235,10 +1215,13 @@ class _DialState extends State<_Dial> with SingleTickerProviderStateMixin {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final TimePickerThemeData pickerTheme = TimePickerTheme.of(context);
-    final Color backgroundColor = pickerTheme.dialBackgroundColor ?? themeData.colorScheme.onBackground.withOpacity(0.12);
-    final Color accentColor = pickerTheme.dialHandColor ?? themeData.colorScheme.primary;
-    final Color primaryLabelColor = MaterialStateProperty.resolveAs(pickerTheme.dialTextColor, <MaterialState>{}) ?? themeData.colorScheme.onSurface;
-    final Color secondaryLabelColor = MaterialStateProperty.resolveAs(pickerTheme.dialTextColor, <MaterialState>{MaterialState.selected}) ?? themeData.colorScheme.onPrimary;
+    final TimePickerThemeData defaults = themeData.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
+    final Color backgroundColor = pickerTheme.dialBackgroundColor ?? defaults.dialBackgroundColor!;
+    final Color accentColor = pickerTheme.dialHandColor ?? defaults.dialHandColor!;
+    final Color primaryLabelColor = MaterialStateProperty.resolveAs(pickerTheme.dialTextColor, <MaterialState>{})
+      ??  MaterialStateProperty.resolveAs(defaults.dialTextColor!, <MaterialState>{});
+    final Color secondaryLabelColor = MaterialStateProperty.resolveAs(pickerTheme.dialTextColor, <MaterialState>{MaterialState.selected})
+      ?? MaterialStateProperty.resolveAs(defaults.dialTextColor!, <MaterialState>{MaterialState.selected});
     List<_TappableLabel> primaryLabels;
     List<_TappableLabel> secondaryLabels;
     final int selectedDialValue;
@@ -1449,7 +1432,18 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
     final TimeOfDayFormat timeOfDayFormat = MaterialLocalizations.of(context).timeOfDayFormat(alwaysUse24HourFormat: media.alwaysUse24HourFormat);
     final bool use24HourDials = hourFormat(of: timeOfDayFormat) != HourFormat.h;
     final ThemeData theme = Theme.of(context);
-    final TextStyle hourMinuteStyle = TimePickerTheme.of(context).hourMinuteTextStyle ?? theme.textTheme.headline2!;
+    final TextTheme textTheme = theme.textTheme;
+    final TimePickerThemeData timePickerTheme = TimePickerTheme.of(context);
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
+    final TextStyle hourMinuteStyle = TimePickerTheme.of(context).hourMinuteTextStyle ?? defaults.hourMinuteTextStyle!;
+    final OutlinedBorder shape = theme.useMaterial3
+      ? (timePickerTheme.hourMinuteShape as OutlinedBorder?
+        ?? defaults.hourMinuteShape! as OutlinedBorder)
+      : const RoundedRectangleBorder();
+    final TextStyle? minuteLabelTextStyle = theme.useMaterial3 ? textTheme.bodySmall : textTheme.caption;
+    final TextStyle errorInvalidTextStyle = theme.useMaterial3
+      ? textTheme.bodyMedium!.copyWith(color: theme.colorScheme.error)
+      : textTheme.bodyText2!.copyWith(color: theme.colorScheme.error);
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0),
@@ -1458,7 +1452,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
         children: <Widget>[
           Text(
             widget.helpText ?? MaterialLocalizations.of(context).timePickerInputHelpText,
-            style: TimePickerTheme.of(context).helpTextStyle ?? theme.textTheme.overline,
+            style: TimePickerTheme.of(context).helpTextStyle ?? defaults.helpTextStyle!,
           ),
           const SizedBox(height: 16.0),
           Row(
@@ -1483,22 +1477,25 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
                           const SizedBox(height: 8.0),
-                          _HourTextField(
-                            restorationId: 'hour_text_field',
-                            selectedTime: _selectedTime.value,
-                            style: hourMinuteStyle,
-                            autofocus: widget.autofocusHour,
-                            validator: _validateHour,
-                            onSavedSubmitted: _handleHourSavedSubmitted,
-                            onChanged: _handleHourChanged,
-                            hourLabelText: widget.hourLabelText,
+                          DecoratedBox(
+                            decoration: ShapeDecoration(shape: shape),
+                            child: _HourTextField(
+                              restorationId: 'hour_text_field',
+                              selectedTime: _selectedTime.value,
+                              style: hourMinuteStyle,
+                              autofocus: widget.autofocusHour,
+                              validator: _validateHour,
+                              onSavedSubmitted: _handleHourSavedSubmitted,
+                              onChanged: _handleHourChanged,
+                              hourLabelText: widget.hourLabelText,
+                            ),
                           ),
                           const SizedBox(height: 8.0),
                           if (!hourHasError.value && !minuteHasError.value)
                             ExcludeSemantics(
                               child: Text(
                                 widget.hourLabelText ?? MaterialLocalizations.of(context).timePickerHourLabel,
-                                style: theme.textTheme.caption,
+                                style: minuteLabelTextStyle,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                               ),
@@ -1530,7 +1527,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
                             ExcludeSemantics(
                               child: Text(
                                 widget.minuteLabelText ?? MaterialLocalizations.of(context).timePickerMinuteLabel,
-                                style: theme.textTheme.caption,
+                                style: minuteLabelTextStyle,
                                 maxLines: 1,
                                 overflow: TextOverflow.ellipsis,
                               ),
@@ -1554,7 +1551,7 @@ class _TimePickerInputState extends State<_TimePickerInput> with RestorationMixi
           if (hourHasError.value || minuteHasError.value)
             Text(
               widget.errorInvalidText ?? MaterialLocalizations.of(context).invalidTimeLabel,
-              style: theme.textTheme.bodyText2!.copyWith(color: theme.colorScheme.error),
+              style: errorInvalidTextStyle,
             )
           else
             const SizedBox(height: 2.0),
@@ -1711,6 +1708,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final TimePickerThemeData timePickerTheme = TimePickerTheme.of(context);
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
     final ColorScheme colorScheme = theme.colorScheme;
 
     final InputDecorationTheme? inputDecorationTheme = timePickerTheme.inputDecorationTheme;
@@ -1738,7 +1736,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
         errorStyle: const TextStyle(fontSize: 0.0, height: 0.0), // Prevent the error text from appearing.
       );
     }
-    final Color unfocusedFillColor = timePickerTheme.hourMinuteColor ?? colorScheme.onSurface.withOpacity(0.12);
+    final Color unfocusedFillColor = timePickerTheme.hourMinuteColor ?? defaults.hourMinuteColor!;
     // If screen reader is in use, make the hint text say hours/minutes.
     // Otherwise, remove the hint text when focused because the centered cursor
     // appears odd above the hint text.
@@ -1770,7 +1768,7 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
             focusNode: focusNode,
             textAlign: TextAlign.center,
             keyboardType: TextInputType.number,
-            style: widget.style.copyWith(color: timePickerTheme.hourMinuteTextColor ?? colorScheme.onSurface),
+            style: widget.style.copyWith(color: timePickerTheme.hourMinuteTextColor ?? defaults.hourMinuteTextColor!),
             controller: controller.value,
             decoration: inputDecoration,
             validator: widget.validator,
@@ -2171,16 +2169,15 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
     final TimeOfDayFormat timeOfDayFormat = localizations.timeOfDayFormat(alwaysUse24HourFormat: media.alwaysUse24HourFormat);
     final bool use24HourDials = hourFormat(of: timeOfDayFormat) != HourFormat.h;
     final ThemeData theme = Theme.of(context);
-    final ShapeBorder shape = TimePickerTheme.of(context).shape ?? _kDefaultShape;
+    final TimePickerThemeData defaults = theme.useMaterial3 ? _DefaultsM3(context) : _DefaultsM2(context);
+    final ShapeBorder shape = TimePickerTheme.of(context).shape ?? defaults.shape!;
     final Orientation orientation = media.orientation;
 
     final Widget actions = Row(
       children: <Widget>[
         const SizedBox(width: 10.0),
         IconButton(
-          color: TimePickerTheme.of(context).entryModeIconColor ?? theme.colorScheme.onSurface.withOpacity(
-            theme.colorScheme.brightness == Brightness.dark ? 1.0 : 0.6,
-          ),
+          color: TimePickerTheme.of(context).entryModeIconColor ?? defaults.entryModeIconColor!,
           onPressed: _handleEntryModeToggle,
           icon: Icon(_entryMode.value == TimePickerEntryMode.dial ? Icons.keyboard : Icons.access_time),
           tooltip: _entryMode.value == TimePickerEntryMode.dial
@@ -2310,7 +2307,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
     final Size dialogSize = _dialogSize(context);
     return Dialog(
       shape: shape,
-      backgroundColor: TimePickerTheme.of(context).backgroundColor ?? theme.colorScheme.surface,
+      backgroundColor: TimePickerTheme.of(context).backgroundColor ?? defaults.backgroundColor!,
       insetPadding: EdgeInsets.symmetric(
         horizontal: 16.0,
         vertical: _entryMode.value == TimePickerEntryMode.input ? 0.0 : 24.0,
@@ -2459,4 +2456,209 @@ Future<TimeOfDay?> showTimePicker({
 
 void _announceToAccessibility(BuildContext context, String message) {
   SemanticsService.announce(message, Directionality.of(context));
+}
+
+// Generate a TimePickerTheme that represents the M2 default values.
+// This was generated by hand from the previous hand coded defaults
+// for M2. It uses get method overrides instead of properties to
+// avoid computing values that we may not need upfront.
+class _DefaultsM2 extends TimePickerThemeData {
+  _DefaultsM2(this.context)
+    : _textTheme = Theme.of(context).textTheme,
+      _colorScheme = Theme.of(context).colorScheme;
+
+  final BuildContext context;
+  final TextTheme _textTheme;
+  final ColorScheme _colorScheme;
+
+  @override
+  Color? get backgroundColor => _colorScheme.surface;
+
+  @override
+  Color? get hourMinuteTextColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.primary
+        : _colorScheme.onSurface;
+    });
+  }
+
+  @override
+  Color? get hourMinuteColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.primary.withOpacity(isDark ? 0.24 : 0.12)
+        : _colorScheme.onSurface.withOpacity(0.12);
+    });
+  }
+
+  @override
+  Color? get dayPeriodTextColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.primary
+        : _colorScheme.onSurface.withOpacity(0.60);
+    });
+  }
+
+  @override
+  Color? get dialHandColor => _colorScheme.primary;
+
+  @override
+  Color? get dialBackgroundColor => _colorScheme.onBackground.withOpacity(0.12);
+
+  @override
+  Color? get dialTextColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.onPrimary
+        : _colorScheme.onSurface;
+    });
+  }
+
+  @override
+  Color? get entryModeIconColor => _colorScheme.onSurface.withOpacity(isDark ? 1.0 : 0.6);
+
+  @override
+  Color? get dayPeriodColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      // The unselected day period should match the overall picker dialog
+      // color. Making it transparent enables that without being redundant
+      // and allows the optional elevation overlay for dark mode to be
+      // visible.
+      return states.contains(MaterialState.selected)
+          ? _colorScheme.primary.withOpacity(isDark ? 0.24 : 0.12)
+          : Colors.transparent;
+    });
+  }
+
+  @override
+  TextStyle? get hourMinuteTextStyle => _textTheme.headline2;
+
+  @override
+  TextStyle? get dayPeriodTextStyle => _textTheme.subtitle1;
+
+  @override
+  TextStyle? get helpTextStyle => _textTheme.overline;
+
+  @override
+  ShapeBorder? get shape => const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0)));
+
+  @override
+  ShapeBorder? get hourMinuteShape => const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0)));
+
+  @override
+  OutlinedBorder? get dayPeriodShape => const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0)));
+
+  @override
+  BorderSide? get dayPeriodBorderSide => BorderSide(
+    color: Color.alphaBlend(_colorScheme.onBackground.withOpacity(0.38), _colorScheme.surface),
+  );
+
+  @override
+  BorderSide? get hourMinuteBorderSide => BorderSide.none;
+
+  bool get isDark => _colorScheme.brightness == Brightness.dark;
+}
+
+class _DefaultsM3 extends TimePickerThemeData {
+  _DefaultsM3(this.context)
+    : _textTheme = Theme.of(context).textTheme,
+      _colorScheme = Theme.of(context).colorScheme;
+
+  final BuildContext context;
+  final TextTheme _textTheme;
+  final ColorScheme _colorScheme;
+
+  @override
+  Color? get backgroundColor => _colorScheme.surface;
+
+  @override
+  Color? get hourMinuteTextColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.onPrimaryContainer
+        : _colorScheme.onSurface;
+    });
+  }
+
+  @override
+  Color? get hourMinuteColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.primaryContainer
+        : _colorScheme.surfaceVariant;
+    });
+  }
+
+  @override
+  Color? get dayPeriodTextColor => _colorScheme.onSurface;
+
+  @override
+  Color? get dayPeriodColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      // The unselected day period should match the overall picker dialog
+      // color. Making it transparent enables that without being redundant
+      // and allows the optional elevation overlay for dark mode to be
+      // visible.
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.tertiaryContainer
+        : Colors.transparent;
+    });
+  }
+
+  @override
+  Color? get dialHandColor => _colorScheme.primary;
+
+  @override
+  Color? get dialBackgroundColor => _colorScheme.surfaceVariant;
+
+  @override
+  Color? get dialTextColor {
+    return MaterialStateColor.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? _colorScheme.surface
+        : _colorScheme.onBackground;
+    });
+  }
+
+  @override
+  Color? get entryModeIconColor => _colorScheme.onSurfaceVariant.withOpacity(isDark ? 1.0 : 0.6);
+
+  @override
+  TextStyle? get hourMinuteTextStyle => _textTheme.displayMedium;
+
+  @override
+  TextStyle? get dayPeriodTextStyle => _textTheme.titleMedium;
+
+  @override
+  TextStyle? get helpTextStyle => _textTheme.labelSmall;
+
+  @override
+  ShapeBorder? get shape => const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0)));
+
+  @override
+  ShapeBorder? get hourMinuteShape {
+    return const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0)));
+  }
+
+  @override
+  OutlinedBorder? get dayPeriodShape => const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0)));
+
+  @override
+  BorderSide? get dayPeriodBorderSide =>  BorderSide(color: _colorScheme.outline);
+
+  @override
+  BorderSide? get hourMinuteBorderSide {
+    return MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
+      return states.contains(MaterialState.selected)
+        ? BorderSide(
+            width: 2,
+            color: _colorScheme.primary,
+          )
+        : BorderSide.none;
+    });
+  }
+
+  bool get isDark => _colorScheme.brightness == Brightness.dark;
 }

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -49,6 +49,7 @@ class TimePickerThemeData with Diagnosticable {
     this.dayPeriodShape,
     this.dayPeriodBorderSide,
     this.inputDecorationTheme,
+    this.hourMinuteBorderSide,
   });
 
   /// The background color of a time picker.
@@ -191,6 +192,22 @@ class TimePickerThemeData with Diagnosticable {
   /// ```
   final BorderSide? dayPeriodBorderSide;
 
+  /// When using Material 3, this property is used for color and weight of the hour
+  /// and minute's outline.
+  ///
+  /// If this is null, the time picker defaults to:
+  /// ```
+  /// return MaterialStateBorderSide.resolveWith((Set<MaterialState> states) {
+  ///   return states.contains(MaterialState.selected)
+  ///     ? BorderSide(
+  ///         width: 2,
+  ///         color: _colorScheme.primary,
+  ///       )
+  ///     : BorderSide.none;
+  /// });
+  /// ```
+  final BorderSide? hourMinuteBorderSide;
+
   /// The input decoration theme for the [TextField]s in the time picker.
   ///
   /// If this is null, the time picker provides its own defaults.
@@ -215,6 +232,7 @@ class TimePickerThemeData with Diagnosticable {
     ShapeBorder? hourMinuteShape,
     OutlinedBorder? dayPeriodShape,
     BorderSide? dayPeriodBorderSide,
+    BorderSide? hourMinuteBorderSide,
     InputDecorationTheme? inputDecorationTheme,
   }) {
     return TimePickerThemeData(
@@ -234,6 +252,7 @@ class TimePickerThemeData with Diagnosticable {
       hourMinuteShape: hourMinuteShape ?? this.hourMinuteShape,
       dayPeriodShape: dayPeriodShape ?? this.dayPeriodShape,
       dayPeriodBorderSide: dayPeriodBorderSide ?? this.dayPeriodBorderSide,
+      hourMinuteBorderSide: hourMinuteBorderSide ?? this.hourMinuteBorderSide,
       inputDecorationTheme: inputDecorationTheme ?? this.inputDecorationTheme,
     );
   }
@@ -247,15 +266,25 @@ class TimePickerThemeData with Diagnosticable {
     assert(t != null);
 
     // Workaround since BorderSide's lerp does not allow for null arguments.
-    BorderSide? lerpedBorderSide;
+    BorderSide? lerpedDayBorderSide;
     if (a?.dayPeriodBorderSide == null && b?.dayPeriodBorderSide == null) {
-      lerpedBorderSide = null;
+      lerpedDayBorderSide = null;
     } else if (a?.dayPeriodBorderSide == null) {
-      lerpedBorderSide = b?.dayPeriodBorderSide;
+      lerpedDayBorderSide = b?.dayPeriodBorderSide;
     } else if (b?.dayPeriodBorderSide == null) {
-      lerpedBorderSide = a?.dayPeriodBorderSide;
+      lerpedDayBorderSide = a?.dayPeriodBorderSide;
     } else {
-      lerpedBorderSide = BorderSide.lerp(a!.dayPeriodBorderSide!, b!.dayPeriodBorderSide!, t);
+      lerpedDayBorderSide = BorderSide.lerp(a!.dayPeriodBorderSide!, b!.dayPeriodBorderSide!, t);
+    }
+    BorderSide? lerpedHourMinuteBorderSide;
+    if (a?.hourMinuteBorderSide == null && b?.hourMinuteBorderSide == null) {
+      lerpedHourMinuteBorderSide = null;
+    } else if (a?.dayPeriodBorderSide == null) {
+      lerpedHourMinuteBorderSide = b?.hourMinuteBorderSide;
+    } else if (b?.dayPeriodBorderSide == null) {
+      lerpedHourMinuteBorderSide = a?.dayPeriodBorderSide;
+    } else {
+      lerpedHourMinuteBorderSide = BorderSide.lerp(a!.hourMinuteBorderSide!, b!.hourMinuteBorderSide!, t);
     }
     return TimePickerThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
@@ -273,7 +302,8 @@ class TimePickerThemeData with Diagnosticable {
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
       hourMinuteShape: ShapeBorder.lerp(a?.hourMinuteShape, b?.hourMinuteShape, t),
       dayPeriodShape: ShapeBorder.lerp(a?.dayPeriodShape, b?.dayPeriodShape, t) as OutlinedBorder?,
-      dayPeriodBorderSide: lerpedBorderSide,
+      dayPeriodBorderSide: lerpedDayBorderSide,
+      hourMinuteBorderSide: lerpedHourMinuteBorderSide,
       inputDecorationTheme: t < 0.5 ? a?.inputDecorationTheme : b?.inputDecorationTheme,
     );
   }
@@ -296,6 +326,7 @@ class TimePickerThemeData with Diagnosticable {
     hourMinuteShape,
     dayPeriodShape,
     dayPeriodBorderSide,
+    hourMinuteBorderSide,
     inputDecorationTheme,
   );
 
@@ -322,6 +353,7 @@ class TimePickerThemeData with Diagnosticable {
         && other.hourMinuteShape == hourMinuteShape
         && other.dayPeriodShape == dayPeriodShape
         && other.dayPeriodBorderSide == dayPeriodBorderSide
+        && other.hourMinuteBorderSide == hourMinuteBorderSide
         && other.inputDecorationTheme == inputDecorationTheme;
   }
 
@@ -344,6 +376,7 @@ class TimePickerThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<ShapeBorder>('hourMinuteShape', hourMinuteShape, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('dayPeriodShape', dayPeriodShape, defaultValue: null));
     properties.add(DiagnosticsProperty<BorderSide>('dayPeriodBorderSide', dayPeriodBorderSide, defaultValue: null));
+    properties.add(DiagnosticsProperty<BorderSide>('hourMinuteBorderSide', hourMinuteBorderSide, defaultValue: null));
     properties.add(DiagnosticsProperty<InputDecorationTheme>('inputDecorationTheme', inputDecorationTheme, defaultValue: null));
   }
 }

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -32,6 +32,7 @@ void main() {
     expect(timePickerTheme.hourMinuteShape, null);
     expect(timePickerTheme.dayPeriodShape, null);
     expect(timePickerTheme.dayPeriodBorderSide, null);
+    expect(timePickerTheme.hourMinuteBorderSide, null);
     expect(timePickerTheme.inputDecorationTheme, null);
   });
 
@@ -66,6 +67,7 @@ void main() {
       hourMinuteShape: RoundedRectangleBorder(),
       dayPeriodShape: RoundedRectangleBorder(),
       dayPeriodBorderSide: BorderSide(),
+      hourMinuteBorderSide: BorderSide(),
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -90,6 +92,7 @@ void main() {
       'hourMinuteShape: RoundedRectangleBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none), BorderRadius.zero)',
       'dayPeriodShape: RoundedRectangleBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none), BorderRadius.zero)',
       'dayPeriodBorderSide: BorderSide(Color(0xff000000), 1.0, BorderStyle.solid)',
+      'hourMinuteBorderSide: BorderSide(Color(0xff000000), 1.0, BorderStyle.solid)',
     ]);
   });
 
@@ -220,7 +223,7 @@ void main() {
 
     final InputDecoration hourDecoration = _textField(tester, '7').decoration!;
     expect(hourDecoration.filled, true);
-    expect(hourDecoration.fillColor, defaultTheme.colorScheme.onSurface.withOpacity(0.12));
+    expect(MaterialStateProperty.resolveAs(hourDecoration.fillColor, enabled), defaultTheme.colorScheme.onSurface.withOpacity(0.12));
     expect(hourDecoration.enabledBorder, const OutlineInputBorder(borderSide: BorderSide(color: Colors.transparent)));
     expect(hourDecoration.errorBorder, OutlineInputBorder(borderSide: BorderSide(color: defaultTheme.colorScheme.error, width: 2)));
     expect(hourDecoration.focusedBorder, OutlineInputBorder(borderSide: BorderSide(color: defaultTheme.colorScheme.primary, width: 2)));
@@ -234,7 +237,7 @@ void main() {
 
   testWidgets('Time picker uses values from TimePickerThemeData', (WidgetTester tester) async {
     final TimePickerThemeData timePickerTheme = _timePickerTheme();
-    final ThemeData theme = ThemeData(timePickerTheme: timePickerTheme);
+    final ThemeData theme = ThemeData(useMaterial3: true, timePickerTheme: timePickerTheme);
     await tester.pumpWidget(_TimePickerLauncher(themeData: theme));
     await tester.tap(find.text('X'));
     await tester.pumpAndSettle(const Duration(seconds: 1));
@@ -254,8 +257,8 @@ void main() {
     final RenderParagraph hourText = _textRenderParagraph(tester, '7');
     expect(
       hourText.text.style,
-      Typography.material2014().englishLike.bodyText2!
-          .merge(Typography.material2014().black.bodyText2)
+      Typography.material2021().englishLike.bodyMedium!
+          .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.hourMinuteTextStyle)
           .copyWith(color: _selectedColor),
     );
@@ -263,8 +266,8 @@ void main() {
     final RenderParagraph minuteText = _textRenderParagraph(tester, '15');
     expect(
       minuteText.text.style,
-      Typography.material2014().englishLike.bodyText2!
-          .merge(Typography.material2014().black.bodyText2)
+      Typography.material2021().englishLike.bodyMedium!
+          .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.hourMinuteTextStyle)
           .copyWith(color: _unselectedColor),
     );
@@ -272,8 +275,8 @@ void main() {
     final RenderParagraph amText = _textRenderParagraph(tester, 'AM');
     expect(
       amText.text.style,
-      Typography.material2014().englishLike.subtitle1!
-          .merge(Typography.material2014().black.subtitle1)
+      Typography.material2021().englishLike.bodyMedium!
+          .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.dayPeriodTextStyle)
           .copyWith(color: _selectedColor),
     );
@@ -281,8 +284,8 @@ void main() {
     final RenderParagraph pmText = _textRenderParagraph(tester, 'PM');
     expect(
       pmText.text.style,
-      Typography.material2014().englishLike.subtitle1!
-          .merge(Typography.material2014().black.subtitle1)
+      Typography.material2021().englishLike.bodyMedium!
+          .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.dayPeriodTextStyle)
           .copyWith(color: _unselectedColor),
     );
@@ -290,8 +293,8 @@ void main() {
     final RenderParagraph helperText = _textRenderParagraph(tester, 'SELECT TIME');
     expect(
       helperText.text.style,
-      Typography.material2014().englishLike.bodyText2!
-          .merge(Typography.material2014().black.bodyText2)
+      Typography.material2021().englishLike.bodyMedium!
+          .merge(Typography.material2021().black.bodyMedium)
           .merge(timePickerTheme.helpTextStyle),
     );
 
@@ -302,8 +305,8 @@ void main() {
     expect(
       // ignore: avoid_dynamic_calls
       primaryLabels.first.painter.text.style,
-      Typography.material2014().englishLike.bodyText1!
-          .merge(Typography.material2014().black.bodyText1)
+      Typography.material2021().englishLike.bodyLarge!
+          .merge(Typography.material2021().black.bodyLarge)
           .copyWith(color: _unselectedColor),
     );
     // ignore: avoid_dynamic_calls
@@ -311,18 +314,26 @@ void main() {
     expect(
       // ignore: avoid_dynamic_calls
       secondaryLabels.first.painter.text.style,
-      Typography.material2014().englishLike.bodyText1!
-          .merge(Typography.material2014().white.bodyText1)
+      Typography.material2021().englishLike.bodyLarge!
+          .merge(Typography.material2021().white.bodyLarge)
           .copyWith(color: _selectedColor),
     );
 
     final Material hourMaterial = _textMaterial(tester, '7');
+    OutlinedBorder? hourShape = hourMaterial.shape as OutlinedBorder?;
+    hourShape = hourShape?.copyWith(
+      side: BorderSide.none,
+    );
     expect(hourMaterial.color, _selectedColor);
-    expect(hourMaterial.shape, timePickerTheme.hourMinuteShape);
+    expect(hourShape, timePickerTheme.hourMinuteShape);
 
-    final Material minuteMaterial = _textMaterial(tester, '15');
+    final Material minuteMaterial = _textMaterial(tester,  '15');
+    OutlinedBorder? minuteShape = hourMaterial.shape as OutlinedBorder?;
+    minuteShape = minuteShape?.copyWith(
+      side: BorderSide.none,
+    );
     expect(minuteMaterial.color, _unselectedColor);
-    expect(minuteMaterial.shape, timePickerTheme.hourMinuteShape);
+    expect(minuteShape, timePickerTheme.hourMinuteShape);
 
     final Material amMaterial = _textMaterial(tester, 'AM');
     expect(amMaterial.color, _selectedColor);
@@ -376,6 +387,126 @@ void main() {
     final InputDecoration hourDecoration = _textField(tester, '7').decoration!;
     expect(hourDecoration.fillColor, timePickerTheme.hourMinuteColor);
   });
+
+  group('Material 2', () {
+    // Original Material 2 tests. Remove this group after `useMaterial3` has been deprecated.
+    testWidgets('Time picker uses values from TimePickerThemeData', (WidgetTester tester) async {
+      final TimePickerThemeData timePickerTheme = _timePickerTheme();
+      final ThemeData theme = ThemeData(timePickerTheme: timePickerTheme);
+      await tester.pumpWidget(_TimePickerLauncher(themeData: theme));
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      final Material dialogMaterial = _dialogMaterial(tester);
+      expect(dialogMaterial.color, timePickerTheme.backgroundColor);
+      expect(dialogMaterial.shape, timePickerTheme.shape);
+
+      final RenderBox dial = tester.firstRenderObject<RenderBox>(find.byType(CustomPaint));
+      expect(
+        dial,
+        paints
+          ..circle(color: Color(timePickerTheme.dialBackgroundColor!.value)) // Dial background color.
+          ..circle(color: Color(timePickerTheme.dialHandColor!.value)), // Dial hand color.
+      );
+
+      final RenderParagraph hourText = _textRenderParagraph(tester, '7');
+      expect(
+        hourText.text.style,
+        Typography.material2014().englishLike.bodyText2!
+            .merge(Typography.material2014().black.bodyText2)
+            .merge(timePickerTheme.hourMinuteTextStyle)
+            .copyWith(color: _selectedColor),
+      );
+
+      final RenderParagraph minuteText = _textRenderParagraph(tester, '15');
+      expect(
+        minuteText.text.style,
+        Typography.material2014().englishLike.bodyText2!
+            .merge(Typography.material2014().black.bodyText2)
+            .merge(timePickerTheme.hourMinuteTextStyle)
+            .copyWith(color: _unselectedColor),
+      );
+
+      final RenderParagraph amText = _textRenderParagraph(tester, 'AM');
+      expect(
+        amText.text.style,
+        Typography.material2014().englishLike.subtitle1!
+            .merge(Typography.material2014().black.subtitle1)
+            .merge(timePickerTheme.dayPeriodTextStyle)
+            .copyWith(color: _selectedColor),
+      );
+
+      final RenderParagraph pmText = _textRenderParagraph(tester, 'PM');
+      expect(
+        pmText.text.style,
+        Typography.material2014().englishLike.subtitle1!
+            .merge(Typography.material2014().black.subtitle1)
+            .merge(timePickerTheme.dayPeriodTextStyle)
+            .copyWith(color: _unselectedColor),
+      );
+
+      final RenderParagraph helperText = _textRenderParagraph(tester, 'SELECT TIME');
+      expect(
+        helperText.text.style,
+        Typography.material2014().englishLike.bodyText2!
+            .merge(Typography.material2014().black.bodyText2)
+            .merge(timePickerTheme.helpTextStyle),
+      );
+
+      final CustomPaint dialPaint = tester.widget(findDialPaint);
+      final dynamic dialPainter = dialPaint.painter;
+      // ignore: avoid_dynamic_calls
+      final List<dynamic> primaryLabels = dialPainter.primaryLabels as List<dynamic>;
+      expect(
+        // ignore: avoid_dynamic_calls
+        primaryLabels.first.painter.text.style,
+        Typography.material2014().englishLike.bodyText1!
+            .merge(Typography.material2014().black.bodyText1)
+            .copyWith(color: _unselectedColor),
+      );
+      // ignore: avoid_dynamic_calls
+      final List<dynamic> secondaryLabels = dialPainter.secondaryLabels as List<dynamic>;
+      expect(
+        // ignore: avoid_dynamic_calls
+        secondaryLabels.first.painter.text.style,
+        Typography.material2014().englishLike.bodyText1!
+            .merge(Typography.material2014().white.bodyText1)
+            .copyWith(color: _selectedColor),
+      );
+
+      final Material hourMaterial = _textMaterial(tester, '7');
+      expect(hourMaterial.color, _selectedColor);
+      expect(hourMaterial.shape, timePickerTheme.hourMinuteShape);
+
+      final Material minuteMaterial = _textMaterial(tester, '15');
+      expect(minuteMaterial.color, _unselectedColor);
+      expect(minuteMaterial.shape, timePickerTheme.hourMinuteShape);
+
+      final Material amMaterial = _textMaterial(tester, 'AM');
+      expect(amMaterial.color, _selectedColor);
+
+      final Material pmMaterial = _textMaterial(tester, 'PM');
+      expect(pmMaterial.color, _unselectedColor);
+
+      final Material dayPeriodMaterial = _dayPeriodMaterial(tester);
+      expect(
+        dayPeriodMaterial.shape,
+        timePickerTheme.dayPeriodShape!.copyWith(side: timePickerTheme.dayPeriodBorderSide),
+      );
+
+      final Container dayPeriodDivider = _dayPeriodDivider(tester);
+      expect(
+        dayPeriodDivider.decoration,
+        BoxDecoration(border: Border(left: timePickerTheme.dayPeriodBorderSide!)),
+      );
+
+      final IconButton entryModeIconButton = _entryModeIconButton(tester);
+      expect(
+        entryModeIconButton.color,
+        timePickerTheme.entryModeIconColor,
+      );
+    });
+  }); // End Material 2 group
 }
 
 final Color _selectedColor = Colors.green[100]!;
@@ -403,6 +534,7 @@ TimePickerThemeData _timePickerTheme({bool includeInputDecoration = false}) {
     hourMinuteShape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0))),
     dayPeriodShape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(16.0))),
     dayPeriodBorderSide: const BorderSide(color: Colors.blueAccent),
+    hourMinuteBorderSide: const BorderSide(color: Colors.blueAccent),
     inputDecorationTheme: includeInputDecoration ? const InputDecorationTheme(
       filled: true,
       fillColor: Colors.purple,
@@ -483,3 +615,5 @@ final Finder findDialPaint = find.descendant(
   of: find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_Dial'),
   matching: find.byWidgetPredicate((Widget w) => w is CustomPaint),
 );
+
+Set<MaterialState> enabled = <MaterialState>{};


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/91605
fixes https://github.com/flutter/flutter/issues/101480

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key, this.dark = false, this.useMaterial3 = true})
      : super(key: key);

  final bool dark;
  final bool useMaterial3;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      title: 'Material App',
      themeMode: dark ? ThemeMode.dark : ThemeMode.light,
      theme: ThemeData.light().copyWith(
        useMaterial3: useMaterial3,
        colorScheme:
            useMaterial3 ? lightColorScheme : const ColorScheme.light(),
      ),
      darkTheme: ThemeData.dark().copyWith(
        useMaterial3: useMaterial3,
        colorScheme: useMaterial3 ? darkColorScheme : const ColorScheme.dark(),
      ),
      home: const TimePickerSample(),
    );
  }
}

class TimePickerSample extends StatelessWidget {
  const TimePickerSample({Key? key}) : super(key: key);

  Future<TimeOfDay?> _showTimePicker(BuildContext context) {
    return showTimePicker(
      initialTime: TimeOfDay.now(),
      initialEntryMode: TimePickerEntryMode.input,
      context: context,
      confirmText: 'Accept',
      cancelText: 'Reject',
      hourLabelText: 'Happy Hour',
      minuteLabelText: 'Happy Minute',
      helpText: 'Spend your time wisely',
      onEntryModeChanged: (TimePickerEntryMode mode) {
        print('Current Mode: $mode');
      },
    );
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('TimePicker Sample'),
      ),
      body: Center(
        child: OutlinedButton(
          onPressed: () => _showTimePicker(context),
          child: const Text('Show TimePicker'),
        ),
      ),
    );
  }
}

const seed = Color(0xFF6750A4);

const lightColorScheme = ColorScheme(
  brightness: Brightness.light,
  primary: Color(0xFF6750A4),
  onPrimary: Color(0xFFFFFFFF),
  primaryContainer: Color(0xFFEADDFF),
  onPrimaryContainer: Color(0xFF21005D),
  secondary: Color(0xFF625B71),
  onSecondary: Color(0xFFFFFFFF),
  secondaryContainer: Color(0xFFE8DEF8),
  onSecondaryContainer: Color(0xFF1D192B),
  tertiary: Color(0xFF7D5260),
  onTertiary: Color(0xFFFFFFFF),
  tertiaryContainer: Color(0xFFFFD8E4),
  onTertiaryContainer: Color(0xFF31111D),
  error: Color(0xFFB3261E),
  errorContainer: Color(0xFFF9DEDC),
  onError: Color(0xFFFFFFFF),
  onErrorContainer: Color(0xFF410E0B),
  background: Color(0xFFFFFBFE),
  onBackground: Color(0xFF1C1B1F),
  surface: Color(0xFFFFFBFE),
  onSurface: Color(0xFF1C1B1F),
  surfaceVariant: Color(0xFFE7E0EC),
  onSurfaceVariant: Color(0xFF49454F),
  outline: Color(0xFF79747E),
  onInverseSurface: Color(0xFFF4EFF4),
  inverseSurface: Color(0xFF313033),
  inversePrimary: Color(0xFFD0BCFF),
  shadow: Color(0xFF000000),
);

const darkColorScheme = ColorScheme(
  brightness: Brightness.dark,
  primary: Color(0xFFD0BCFF),
  onPrimary: Color(0xFF381E72),
  primaryContainer: Color(0xFF4F378B),
  onPrimaryContainer: Color(0xFFEADDFF),
  secondary: Color(0xFFCCC2DC),
  onSecondary: Color(0xFF332D41),
  secondaryContainer: Color(0xFF4A4458),
  onSecondaryContainer: Color(0xFFE8DEF8),
  tertiary: Color(0xFFEFB8C8),
  onTertiary: Color(0xFF492532),
  tertiaryContainer: Color(0xFF633B48),
  onTertiaryContainer: Color(0xFFFFD8E4),
  error: Color(0xFFF2B8B5),
  errorContainer: Color(0xFF8C1D18),
  onError: Color(0xFF601410),
  onErrorContainer: Color(0xFFF9DEDC),
  background: Color(0xFF1C1B1F),
  onBackground: Color(0xFFE6E1E5),
  surface: Color(0xFF1C1B1F),
  onSurface: Color(0xFFE6E1E5),
  surfaceVariant: Color(0xFF49454F),
  onSurfaceVariant: Color(0xFFCAC4D0),
  outline: Color(0xFF938F99),
  onInverseSurface: Color(0xFF1C1B1F),
  inverseSurface: Color(0xFFE6E1E5),
  inversePrimary: Color(0xFF6750A4),
  shadow: Color(0xFF000000),
);

``` 
	
</details>

| M2 | M3 |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/157756289-52c2d0d5-60f8-485b-a94a-5db2950e4323.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/157756229-4bbebf5e-2b1a-4d40-8095-01685e9be024.png" height="450" /> |

| M2 | M3 |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/157756368-b5a67377-c48a-4131-80ce-808d6b65e1bd.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/157756379-c09b2ea6-6266-4eef-99a5-59261ce9a6b4.png" height="450" /> |



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
