### PR TITLE
Marks Mac dart_plugin_registry_test to be flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2594,6 +2594,7 @@ targets:
 
   - name: Mac dart_plugin_registry_test
     recipe: devicelab/devicelab_drone
+    bringup: # Flaky https://github.com/flutter/flutter/issues/99940
     timeout: 60
     properties:
       caches: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2594,7 +2594,7 @@ targets:
 
   - name: Mac dart_plugin_registry_test
     recipe: devicelab/devicelab_drone
-    bringup: # Flaky https://github.com/flutter/flutter/issues/99940
+    bringup: true # Flaky https://github.com/flutter/flutter/issues/99940
     timeout: 60
     properties:
       caches: >-


### PR DESCRIPTION
Issue link: https://github.com/flutter/flutter/issues/99940