### PR TITLE
Enable TestDefaultBinaryMessenger to intercept all platform channels.

### DIFF
--- a/packages/flutter_test/test/test_default_binary_messenger_test.dart
+++ b/packages/flutter_test/test/test_default_binary_messenger_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter/services.dart';
@@ -26,6 +27,19 @@ class TestDelegate extends BinaryMessenger {
   void setMessageHandler(String channel, MessageHandler? handler) => throw UnimplementedError();
 }
 
+class WorkingTestDelegate extends BinaryMessenger {
+  @override
+  Future<ByteData?>? send(String channel, ByteData? message) async {
+    return ByteData.sublistView(Uint8List.fromList(<int>[1, 2, 3]));
+  }
+
+  // Rest of the API isn't needed for this test.
+  @override
+  Future<void> handlePlatformMessage(String channel, ByteData? data, ui.PlatformMessageResponseCallback? callback) => throw UnimplementedError();
+  @override
+  void setMessageHandler(String channel, MessageHandler? handler) => throw UnimplementedError();
+}
+
 void main() {
   testWidgets('Caught exceptions are caught by the test framework', (WidgetTester tester) async {
     final BinaryMessenger delegate = TestDelegate();
@@ -38,5 +52,30 @@ void main() {
     } catch (error) {
       expect(error, const RecognizableTestException());
     }
+  });
+
+  testWidgets('Mock MessageHandler is set correctly',
+      (WidgetTester tester) async {
+    final TestDefaultBinaryMessenger binaryMessenger =
+        TestDefaultBinaryMessenger(WorkingTestDelegate());
+    binaryMessenger.setMockMessageHandler(
+        '',
+        (ByteData? message) async =>
+            ByteData.sublistView(Uint8List.fromList(<int>[2, 3, 4])));
+
+    final ByteData? result = await binaryMessenger.send('', null);
+    expect(result?.buffer.asUint8List(), Uint8List.fromList(<int>[2, 3, 4]));
+  });
+
+  testWidgets('Mock AllMessagesHandler is set correctly',
+      (WidgetTester tester) async {
+    final TestDefaultBinaryMessenger binaryMessenger =
+        TestDefaultBinaryMessenger(WorkingTestDelegate());
+    binaryMessenger.allMessagesHandler =
+        (String channel, MessageHandler? handler, ByteData? message) async =>
+            ByteData.sublistView(Uint8List.fromList(<int>[2, 3, 4]));
+
+    final ByteData? result = await binaryMessenger.send('', null);
+    expect(result?.buffer.asUint8List(), Uint8List.fromList(<int>[2, 3, 4]));
   });
 }


### PR DESCRIPTION
This PR defines `AllMessageHandler`, and adds a method `setMockAllMessagesHandler` to `TestDefaultBinaryMessenger`. This method allows a test to intercept all platform channel calls made during the duration of the test.

Solves #94853.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

I could not find where to add documentation (outside code comments), if I should. 

I also couldn't find a test testing `setMockMethodCallHandler`, and `setMockAllMessagesHandler` is sort of an extension of that, so I wasn't sure how to test this. Any suggestions are welcome!

Thanks!