### PR TITLE
Always use texture layer when displaying an Android view

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -196,7 +196,8 @@ class RenderAndroidView extends PlatformViewRenderBox {
   void _setOffset() {
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       if (!_isDisposed) {
-        await _viewController.setOffset(localToGlobal(Offset.zero));
+        if (attached)
+          await _viewController.setOffset(localToGlobal(Offset.zero));
         // Schedule a new post frame callback.
         _setOffset();
       }

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -52,7 +52,7 @@ Set<Type> _factoriesTypeSet<T>(Set<Factory<T>> factories) {
 
 /// A render object for an Android view.
 ///
-/// Requires Android API level 20 or greater.
+/// Requires Android API level 23 or greater.
 ///
 /// [RenderAndroidView] is responsible for sizing, displaying and passing touch events to an
 /// Android [View](https://developer.android.com/reference/android/view/View).

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -85,8 +85,8 @@ class RenderAndroidView extends PlatformViewRenderBox {
        assert(hitTestBehavior != null),
        assert(gestureRecognizers != null),
        assert(clipBehavior != null),
-       _clipBehavior = clipBehavior,
        _viewController = viewController,
+       _clipBehavior = clipBehavior,
        super(controller: viewController, hitTestBehavior: hitTestBehavior, gestureRecognizers: gestureRecognizers) {
     _viewController.pointTransformer = (Offset offset) => globalToLocal(offset);
     updateGestureRecognizers(gestureRecognizers);

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -325,7 +325,7 @@ class RenderUiKitView extends RenderBox {
   // any newly arriving events there's nothing we need to invalidate.
   PlatformViewHitTestBehavior hitTestBehavior;
 
-  /// {@macro flutter.rendering.RenderAndroidView.updateGestureRecognizers}
+  /// {@macro flutter.rendering.PlatformViewRenderBox.updateGestureRecognizers}
   void updateGestureRecognizers(Set<Factory<OneSequenceGestureRecognizer>> gestureRecognizers) {
     assert(gestureRecognizers != null);
     assert(
@@ -654,6 +654,7 @@ class PlatformViewRenderBox extends RenderBox with _PlatformViewGestureMixin {
     }
   }
 
+  /// {@template flutter.rendering.PlatformViewRenderBox.updateGestureRecognizers}
   /// Updates which gestures should be forwarded to the platform view.
   ///
   /// Gesture recognizers created by factories in this set participate in the gesture arena for each
@@ -665,6 +666,7 @@ class PlatformViewRenderBox extends RenderBox with _PlatformViewGestureMixin {
   ///
   /// Setting a new set of gesture recognizer factories with the same [Factory.type]s as the current
   /// set has no effect, because the factories' constructors would have already been called with the previous set.
+  /// {@endtemplate}
   ///
   /// Any active gesture arena the `PlatformView` participates in is rejected when the
   /// set of gesture recognizers is changed.

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -76,10 +76,8 @@ class PlatformViewsService {
   /// The callbacks are invoked when the platform view asks to be focused.
   final Map<int, VoidCallback> _focusCallbacks = <int, VoidCallback>{};
 
-
-  /// Creates an [AndroidViewController] for a new Android view.
-  ///
-  /// The view is created after calling [TextureAndroidViewController.setSize].
+  /// {@template flutter.services.PlatformViewsService.initAndroidView}
+  /// Creates a controller for a new Android view.
   ///
   /// `id` is an unused unique identifier generated with [platformViewsRegistry].
   ///
@@ -103,6 +101,7 @@ class PlatformViewsService {
   ///
   /// The `id, `viewType, and `layoutDirection` parameters must not be null.
   /// If `creationParams` is non null then `creationParamsCodec` must not be null.
+  /// {@endtemplate}
   static AndroidViewController initAndroidView({
     required int id,
     required String viewType,
@@ -128,8 +127,9 @@ class PlatformViewsService {
     return controller;
   }
 
-  /// Alias for [initAndroidView].
-  /// When possible, use [initAndroidView] directly.
+  /// {@macro flutter.services.PlatformViewsService.initAndroidView}
+  ///
+  /// Alias for [initAndroidView]. When possible, use [initAndroidView] directly.
   static SurfaceAndroidViewController initSurfaceAndroidView({
     required int id,
     required String viewType,

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -77,7 +77,7 @@ class PlatformViewsService {
   final Map<int, VoidCallback> _focusCallbacks = <int, VoidCallback>{};
 
 
-  /// Creates a [TextureAndroidViewController] for a new Android view.
+  /// Creates an [AndroidViewController] for a new Android view.
   ///
   /// The view is created after calling [TextureAndroidViewController.setSize].
   ///
@@ -103,7 +103,7 @@ class PlatformViewsService {
   ///
   /// The `id, `viewType, and `layoutDirection` parameters must not be null.
   /// If `creationParams` is non null then `creationParamsCodec` must not be null.
-  static TextureAndroidViewController initAndroidView({
+  static AndroidViewController initAndroidView({
     required int id,
     required String viewType,
     required TextDirection layoutDirection,
@@ -128,33 +128,8 @@ class PlatformViewsService {
     return controller;
   }
 
-  /// Creates a [SurfaceAndroidViewController] for a new Android view.
-  ///
-  /// The view is created after calling [AndroidViewController.create].
-  ///
-  /// `id` is an unused unique identifier generated with [platformViewsRegistry].
-  ///
-  /// `viewType` is the identifier of the Android view type to be created, a
-  /// factory for this view type must have been registered on the platform side.
-  /// Platform view factories are typically registered by plugin code.
-  /// Plugins can register a platform view factory with
-  /// [PlatformViewRegistry#registerViewFactory](/javadoc/io/flutter/plugin/platform/PlatformViewRegistry.html#registerViewFactory-java.lang.String-io.flutter.plugin.platform.PlatformViewFactory-).
-  ///
-  /// `creationParams` will be passed as the args argument of [PlatformViewFactory#create](/javadoc/io/flutter/plugin/platform/PlatformViewFactory.html#create-android.content.Context-int-java.lang.Object-)
-  ///
-  /// `creationParamsCodec` is the codec used to encode `creationParams` before sending it to the
-  /// platform side. It should match the codec passed to the constructor of [PlatformViewFactory](/javadoc/io/flutter/plugin/platform/PlatformViewFactory.html#PlatformViewFactory-io.flutter.plugin.common.MessageCodec-).
-  /// This is typically one of: [StandardMessageCodec], [JSONMessageCodec], [StringCodec], or [BinaryCodec].
-  ///
-  /// `onFocus` is a callback that will be invoked when the Android View asks to get the
-  /// input focus.
-  ///
-  /// The Android view will only be created after [AndroidViewController.setSize] is called for the
-  /// first time.
-  ///
-  /// The `id, `viewType, and `layoutDirection` parameters must not be null.
-  /// If `creationParams` is non null then `creationParamsCodec` must not be null.
-  static SurfaceAndroidViewController initSurfaceAndroidView({
+  /// Alias for [initAndroidView].
+  static AndroidViewController initSurfaceAndroidView({
     required int id,
     required String viewType,
     required TextDirection layoutDirection,
@@ -162,21 +137,14 @@ class PlatformViewsService {
     MessageCodec<dynamic>? creationParamsCodec,
     VoidCallback? onFocus,
   }) {
-    assert(id != null);
-    assert(viewType != null);
-    assert(layoutDirection != null);
-    assert(creationParams == null || creationParamsCodec != null);
-
-    final SurfaceAndroidViewController controller = SurfaceAndroidViewController._(
-      viewId: id,
+    return initAndroidView(
+      id: id,
       viewType: viewType,
       layoutDirection: layoutDirection,
       creationParams: creationParams,
       creationParamsCodec: creationParamsCodec,
+      onFocus: onFocus,
     );
-
-    _instance._focusCallbacks[id] = onFocus ?? () {};
-    return controller;
   }
 
   /// Whether the render surface of the Android `FlutterView` should be converted to a `FlutterImageView`.
@@ -189,13 +157,11 @@ class PlatformViewsService {
   /// This flag allows disabling this conversion.
   ///
   /// Defaults to true.
-  static Future<void> synchronizeToNativeViewHierarchy(bool yes) {
-    assert(defaultTargetPlatform == TargetPlatform.android);
-    return SystemChannels.platform_views.invokeMethod<void>(
-      'synchronizeToNativeViewHierarchy',
-      yes,
-    );
-  }
+  @Deprecated(
+    'This API is no longer relevant. '
+    'This feature was deprecated after 2.12.0-0.1.pre.',
+  )
+  static Future<void> synchronizeToNativeViewHierarchy(bool yes) async {}
 
   // TODO(amirh): reference the iOS plugin API for registering a UIView factory once it lands.
   /// This is work in progress, not yet ready to be used, and requires a custom engine build. Creates a controller for a new iOS UIView.

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -160,7 +160,7 @@ class PlatformViewsService {
   /// Defaults to true.
   @Deprecated(
     'No longer necessary to improve performance. '
-    'This feature was deprecated after 2.11.0-0.1.pre.',
+    'This feature was deprecated after v2.11.0-0.1.pre.',
   )
   static Future<void> synchronizeToNativeViewHierarchy(bool yes) async {}
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -158,8 +158,8 @@ class PlatformViewsService {
   ///
   /// Defaults to true.
   @Deprecated(
-    'This API is no longer relevant. '
-    'This feature was deprecated after 2.12.0-0.1.pre.',
+    'No longer necessary to improve performance. '
+    'This feature was deprecated after 2.11.0-0.1.pre.',
   )
   static Future<void> synchronizeToNativeViewHierarchy(bool yes) async {}
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -818,9 +818,15 @@ abstract class AndroidViewController extends PlatformViewController {
 
   /// Removes a callback added with [addOnPlatformViewCreatedListener].
   void removeOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) {
+    assert(listener != null);
     assert(_state != _AndroidViewState.disposed);
     _platformViewCreatedCallbacks.remove(listener);
   }
+
+  /// The created callbacks that are invoked after the platform view has been
+  /// created.
+  @visibleForTesting
+  List<PlatformViewCreatedCallback> get createdCallbacks => _platformViewCreatedCallbacks;
 
   /// Sets the layout direction for the Android view.
   Future<void> setLayoutDirection(TextDirection layoutDirection) async {

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -842,15 +842,11 @@ class PlatformViewLink extends StatefulWidget {
 class _PlatformViewLinkState extends State<PlatformViewLink> {
   int? _id;
   PlatformViewController? _controller;
-  bool _platformViewCreated = false;
   Widget? _surface;
   FocusNode? _focusNode;
 
   @override
   Widget build(BuildContext context) {
-    if (!_platformViewCreated) {
-      return const SizedBox.expand();
-    }
     _surface ??= widget._surfaceFactory(context, _controller!);
     return Focus(
       focusNode: _focusNode,
@@ -875,9 +871,6 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
       // The _surface has to be recreated as its controller is disposed.
       // Setting _surface to null will trigger its creation in build().
       _surface = null;
-
-      // We are about to create a new platform view.
-      _platformViewCreated = false;
       _initialize();
     }
   }
@@ -888,14 +881,10 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
       PlatformViewCreationParams._(
         id: _id!,
         viewType: widget.viewType,
-        onPlatformViewCreated: _onPlatformViewCreated,
+        onPlatformViewCreated: (_) {},
         onFocusChanged: _handlePlatformFocusChanged,
       ),
     );
-  }
-
-  void _onPlatformViewCreated(int id) {
-    setState(() { _platformViewCreated = true; });
   }
 
   void _handleFrameworkFocusChanged(bool isFocused) {
@@ -1020,18 +1009,18 @@ class PlatformViewSurface extends LeafRenderObjectWidget {
 
 /// Integrates an Android view with Flutter's compositor, touch, and semantics subsystems.
 ///
-/// The compositor integration is done by adding a [PlatformViewLayer] to the layer tree. [PlatformViewLayer]
-/// isn't supported on all platforms. Custom Flutter embedders can support
-/// [PlatformViewLayer]s by implementing a SystemCompositor.
+/// The compositor integration is done by adding a [TextureLayer] to the layer tree.
 ///
-/// The widget fills all available space, the parent of this object must provide bounded layout
-/// constraints.
+/// The parent of this object must provide bounded layout constraints.
 ///
 /// If the associated platform view is not created, the [AndroidViewSurface] does not paint any contents.
 ///
+/// When possible, you may want to use [AndroidView] directly, since it requires less boilerplate code
+/// than [AndroidViewSurface], and there's no difference in performance, or other trade-off(s).
+///
 /// See also:
 ///
-///  * [AndroidView] which embeds an Android platform view in the widget hierarchy using a [TextureLayer].
+///  * [AndroidView] which embeds an Android platform view in the widget hierarchy.
 ///  * [UiKitView] which embeds an iOS platform view in the widget hierarchy.
 class AndroidViewSurface extends PlatformViewSurface {
   /// Construct an `AndroidPlatformViewSurface`.
@@ -1052,12 +1041,22 @@ class AndroidViewSurface extends PlatformViewSurface {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    final PlatformViewRenderBox renderBox =
-        super.createRenderObject(context) as PlatformViewRenderBox;
+    final AndroidViewController androidController = controller as AndroidViewController;
+    final RenderAndroidView renderObject = RenderAndroidView(
+      viewController: androidController,
+      gestureRecognizers: gestureRecognizers,
+      hitTestBehavior: hitTestBehavior,
+    );
+    androidController.pointTransformer =
+        (Offset position) => renderObject.globalToLocal(position);
+    return renderObject;
+  }
 
-    (controller as AndroidViewController).pointTransformer =
-        (Offset position) => renderBox.globalToLocal(position);
-
-    return renderBox;
+  @override
+  void updateRenderObject(BuildContext context, RenderAndroidView renderObject) {
+    renderObject
+      ..viewController = controller as AndroidViewController
+      ..hitTestBehavior = hitTestBehavior
+      ..updateGestureRecognizers(gestureRecognizers);
   }
 }

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -681,7 +681,7 @@ class _AndroidPlatformView extends LeafRenderObjectWidget {
 
   @override
   void updateRenderObject(BuildContext context, RenderAndroidView renderObject) {
-    renderObject.viewController = controller;
+    renderObject.controller = controller;
     renderObject.hitTestBehavior = hitTestBehavior;
     renderObject.updateGestureRecognizers(gestureRecognizers);
     renderObject.clipBehavior = clipBehavior;
@@ -1055,7 +1055,7 @@ class AndroidViewSurface extends PlatformViewSurface {
   @override
   void updateRenderObject(BuildContext context, RenderAndroidView renderObject) {
     renderObject
-      ..viewController = controller as AndroidViewController
+      ..controller = controller as AndroidViewController
       ..hitTestBehavior = hitTestBehavior
       ..updateGestureRecognizers(gestureRecognizers);
   }

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -1041,13 +1041,13 @@ class AndroidViewSurface extends PlatformViewSurface {
 
   @override
   RenderObject createRenderObject(BuildContext context) {
-    final AndroidViewController androidController = controller as AndroidViewController;
+    final AndroidViewController viewController = controller as AndroidViewController;
     final RenderAndroidView renderObject = RenderAndroidView(
-      viewController: androidController,
+      viewController: viewController,
       gestureRecognizers: gestureRecognizers,
       hitTestBehavior: hitTestBehavior,
     );
-    androidController.pointTransformer =
+    viewController.pointTransformer =
         (Offset position) => renderObject.globalToLocal(position);
     return renderObject;
   }

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -15,7 +15,7 @@ import 'framework.dart';
 
 /// Embeds an Android view in the Widget hierarchy.
 ///
-/// Requires Android API level 20 or greater.
+/// Requires Android API level 23 or greater.
 ///
 /// Embedding Android views is an expensive operation and should be avoided when a Flutter
 /// equivalent is possible.

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -151,6 +151,38 @@ void main() {
     // Passes if no crashes.
   });
 
+  test('created callback is reset when controller is changed', () {
+    final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
+    viewsController.registerViewType('webview');
+    final AndroidViewController firstController = PlatformViewsService.initAndroidView(
+      id: 0,
+      viewType: 'webview',
+      layoutDirection: TextDirection.rtl,
+    );
+    final RenderAndroidView renderBox = RenderAndroidView(
+      viewController: firstController,
+      hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+    );
+    layout(renderBox);
+    pumpFrame(phase: EnginePhase.flushSemantics);
+
+    expect(firstController.createdCallbacks, isNotEmpty);
+    expect(firstController.createdCallbacks.length, 1);
+
+    final AndroidViewController secondController = PlatformViewsService.initAndroidView(
+      id: 0,
+      viewType: 'webview',
+      layoutDirection: TextDirection.rtl,
+    );
+    // Reset controller.
+    renderBox.controller = secondController;
+
+    expect(firstController.createdCallbacks, isEmpty);
+    expect(secondController.createdCallbacks, isNotEmpty);
+    expect(secondController.createdCallbacks.length, 1);
+  });
+
   test('render object changed its visual appearance after texture is created', () {
     FakeAsync().run((FakeAsync async) {
       final AndroidViewController viewController =

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -143,8 +143,6 @@ class FakeAndroidPlatformViewsController {
 
   int? lastClearedFocusViewId;
 
-  bool synchronizeToNativeViewHierarchy = true;
-
   Map<int, Offset> offsets = <int, Offset>{};
 
   void registerViewType(String viewType) {
@@ -174,8 +172,6 @@ class FakeAndroidPlatformViewsController {
         return _clearFocus(call);
       case 'offset':
         return _offset(call);
-      case 'synchronizeToNativeViewHierarchy':
-        return _synchronizeToNativeViewHierarchy(call);
     }
     return Future<dynamic>.sync(() => null);
   }
@@ -316,11 +312,6 @@ class FakeAndroidPlatformViewsController {
       );
 
     lastClearedFocusViewId = id;
-    return Future<dynamic>.sync(() => null);
-  }
-
-  Future<dynamic> _synchronizeToNativeViewHierarchy(MethodCall call) {
-    synchronizeToNativeViewHierarchy = call.arguments as bool;
     return Future<dynamic>.sync(() => null);
   }
 }

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -118,6 +118,9 @@ class FakeAndroidViewController implements AndroidViewController {
 
   @override
   Future<void> create() async {}
+
+  @override
+  List<PlatformViewCreatedCallback> get createdCallbacks => <PlatformViewCreatedCallback>[];
 }
 
 class FakeAndroidPlatformViewsController {

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -84,23 +84,22 @@ class FakeAndroidViewController implements AndroidViewController {
 
   @override
   Future<Size> setSize(Size size) {
-    throw UnimplementedError();
+    return Future<Size>.value(size);
   }
 
   @override
-  Future<void> setOffset(Offset off) {
-    throw UnimplementedError();
+  Future<void> setOffset(Offset off) async {}
+
+  @override
+  int get textureId => 0;
+
+  @override
+  bool get isCreated => created;
+
+  @override
+  void addOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) {
+    created = true;
   }
-
-  @override
-  int get textureId => throw UnimplementedError();
-
-  @override
-  bool get isCreated => throw UnimplementedError();
-
-  @override
-  void addOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) =>
-      throw UnimplementedError();
 
   @override
   void removeOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) {
@@ -118,9 +117,7 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  Future<void> create() async {
-    created = true;
-  }
+  Future<void> create() async {}
 }
 
 class FakeAndroidPlatformViewsController {

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -36,7 +36,17 @@ void main() {
           layoutDirection: TextDirection.ltr,
         ).create();
       } catch (e) {
-        expect(false, isTrue, reason: 'did not expected any exception, but got $e');
+        expect(false, isTrue, reason: 'did not expected any exception, but instead got `$e`');
+      }
+
+      try {
+        await PlatformViewsService.initAndroidView(
+          id: 0,
+          viewType: 'web',
+          layoutDirection: TextDirection.ltr,
+        ).create();
+      } catch (e) {
+        expect(false, isTrue, reason: 'did not expected any exception, but instead got `$e`');
       }
     });
 

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -240,11 +240,6 @@ void main() {
       await viewController.setOffset(const Offset(10, 20));
       expect(viewsController.offsets, equals(<int, Offset>{}));
     });
-
-    test('synchronizeToNativeViewHierarchy', () async {
-      await PlatformViewsService.synchronizeToNativeViewHierarchy(false);
-      expect(viewsController.synchronizeToNativeViewHierarchy, false);
-    });
   });
 
   group('iOS', () {

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('create Android view of unregistered type', () async {
-      expect(
+      expectLater(
         () {
           return PlatformViewsService.initAndroidView(
             id: 0,
@@ -29,16 +29,15 @@ void main() {
         throwsA(isA<PlatformException>()),
       );
 
-      expect(
-        () {
-          return PlatformViewsService.initSurfaceAndroidView(
-            id: 0,
-            viewType: 'web',
-            layoutDirection: TextDirection.ltr,
-          ).create();
-        },
-        throwsA(isA<PlatformException>()),
-      );
+      try {
+        await PlatformViewsService.initSurfaceAndroidView(
+          id: 0,
+          viewType: 'web',
+          layoutDirection: TextDirection.ltr,
+        ).create();
+      } catch (e) {
+        expect(false, isTrue, reason: 'did not expected any exception, but got $e');
+      }
     });
 
     test('create Android views', () async {
@@ -47,13 +46,13 @@ void main() {
           .setSize(const Size(100.0, 100.0));
       await PlatformViewsService.initAndroidView( id: 1, viewType: 'webview', layoutDirection: TextDirection.rtl)
           .setSize(const Size(200.0, 300.0));
+      // This platform view isn't created until the size is set.
       await PlatformViewsService.initSurfaceAndroidView(id: 2, viewType: 'webview', layoutDirection: TextDirection.rtl).create();
       expect(
         viewsController.views,
         unorderedEquals(<FakeAndroidPlatformView>[
           const FakeAndroidPlatformView(0, 'webview', Size(100.0, 100.0), AndroidViewController.kAndroidLayoutDirectionLtr, null),
           const FakeAndroidPlatformView(1, 'webview', Size(200.0, 300.0), AndroidViewController.kAndroidLayoutDirectionRtl, null),
-          const FakeAndroidPlatformView(2, 'webview', null, AndroidViewController.kAndroidLayoutDirectionRtl, true),
         ]),
       );
     });
@@ -65,26 +64,12 @@ void main() {
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
       ).setSize(const Size(100.0, 100.0));
-      expect(
+      expectLater(
         () => PlatformViewsService.initAndroidView(
           id: 0,
           viewType: 'web',
           layoutDirection: TextDirection.ltr,
         ).setSize(const Size(100.0, 100.0)),
-        throwsA(isA<PlatformException>()),
-      );
-
-      await PlatformViewsService.initSurfaceAndroidView(
-        id: 1,
-        viewType: 'webview',
-        layoutDirection: TextDirection.ltr,
-      ).create();
-      expect(
-        () => PlatformViewsService.initSurfaceAndroidView(
-          id: 1,
-          viewType: 'web',
-          layoutDirection: TextDirection.ltr,
-        ).create(),
         throwsA(isA<PlatformException>()),
       );
     });

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2312,43 +2312,6 @@ void main() {
       expect(factoryInvocationCount, 1);
     });
 
-    testWidgets(
-      'PlatformViewLink Widget init, should create a SizedBox widget before onPlatformViewCreated and a PlatformViewSurface after',
-      (WidgetTester tester) async {
-        final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-        late int createdPlatformViewId;
-
-        late PlatformViewCreatedCallback onPlatformViewCreatedCallBack;
-
-        final PlatformViewLink platformViewLink = PlatformViewLink(
-          viewType: 'webview',
-          onCreatePlatformView: (PlatformViewCreationParams params) {
-            onPlatformViewCreatedCallBack = params.onPlatformViewCreated;
-            createdPlatformViewId = params.id;
-            return FakePlatformViewController(params.id);
-          },
-          surfaceFactory: (BuildContext context, PlatformViewController controller) {
-            return PlatformViewSurface(
-              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
-              controller: controller,
-              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-            );
-          },
-        );
-
-        await tester.pumpWidget(platformViewLink);
-        expect(() => tester.allWidgets.whereType<SizedBox>().first, returnsNormally);
-
-        onPlatformViewCreatedCallBack(createdPlatformViewId);
-
-        await tester.pump();
-
-        expect(() => tester.allWidgets.whereType<PlatformViewSurface>().first, returnsNormally);
-
-        expect(createdPlatformViewId, currentViewId + 1);
-      },
-    );
-
     testWidgets('PlatformViewLink Widget dispose', (WidgetTester tester) async {
       late FakePlatformViewController disposedController;
       final PlatformViewLink platformViewLink = PlatformViewLink(


### PR DESCRIPTION
Ensures that Android views are always rendered using a texture layer.

Related issue: https://github.com/flutter/flutter/issues/96679
