### PR TITLE
Increase the timeout for running the snippets script during sample analysis

### DIFF
--- a/dev/bots/analyze_sample_code.dart
+++ b/dev/bots/analyze_sample_code.dart
@@ -507,8 +507,9 @@ class SampleChecker {
       process.stdout.transform(utf8.decoder).forEach(stdout.write);
     }
     process.stderr.transform(utf8.decoder).forEach(stderr.write);
-    final int exitCode = await process.exitCode.timeout(const Duration(seconds: 30), onTimeout: () {
-      stderr.writeln('Snippet script timed out.');
+    const Duration timeoutDuration = Duration(minutes: 5);
+    final int exitCode = await process.exitCode.timeout(timeoutDuration, onTimeout: () {
+      stderr.writeln('Snippet script timed out after $timeoutDuration.');
       return -1;
     });
     if (exitCode != 0) {


### PR DESCRIPTION
## Description

Engine roll is blocked because the analysis script [has been timing out ](https://cirrus-ci.com/task/6663822294384640?logs=main#L78) trying to run the snippets tool, but only on Cirrus bots.  This changes the timeout to 5 minutes from 30 seconds.