### PR TITLE
Handle Flutter.Error events and disable structure errors for noDebug mode

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -223,9 +223,27 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
           case 'Flutter.ServiceExtensionStateChanged':
             _sendServiceExtensionStateChanged(event.extensionData);
             break;
+            case 'Flutter.Error':
+            _handleFlutterErrorEvent(event.extensionData);
+            break;
         }
         break;
     }
+  }
+
+  /// Sends OutputEvents to the client for a Flutter.Error event.
+  void _handleFlutterErrorEvent(vm.ExtensionData? data) {
+    final Map<String, dynamic>? errorData = data?.data;
+    if (errorData == null) {
+      return;
+    }
+
+    final String errorText = (errorData['renderedErrorText'] as String?)
+        ?? (errorData['description'] as String?)
+        // We should never not error text, but if we do at least send something
+        // so it's not just completely silent.
+        ?? 'Unknown error in Flutter.Error event';
+    sendOutput('stderr', '$errorText\n');
   }
 
   /// Called by [launchRequest] to request that we actually start the app to be run/debugged.
@@ -240,6 +258,12 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
       'run',
       '--machine',
       if (enableDebugger) '--start-paused',
+      // Structured errors are enabled by default, but since we don't connect
+      // the VM Service for noDebug, we need to disable them so that error text
+      // is sent to stderr. Otherwise the user will not see any exception text
+      // (because nobody is listening for Flutter.Error events).
+      if (!enableDebugger)
+        '--dart-define=flutter.inspector.structuredErrors=false',
     ];
 
     await _startProcess(

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -223,7 +223,7 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
           case 'Flutter.ServiceExtensionStateChanged':
             _sendServiceExtensionStateChanged(event.extensionData);
             break;
-            case 'Flutter.Error':
+          case 'Flutter.Error':
             _handleFlutterErrorEvent(event.extensionData);
             break;
         }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -115,7 +115,7 @@ void main() {
       expect(output, contains('Exited (1)'));
     });
 
-      /// Helper that tests exception output in either debug or noDebug mode.
+    /// Helper that tests exception output in either debug or noDebug mode.
     Future<void> testExceptionOutput({required bool noDebug}) async {
         final BasicProjectThatThrows project = BasicProjectThatThrows();
         await project.setUpIn(tempDir);

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -140,7 +140,7 @@ void main() {
             'The following _Exception was thrown building App(dirty):',
             'Exception: c',
             'The relevant error-causing widget was:',
-            '  App:${Uri.file(project.dir.path)}/lib/main.dart:24:12',
+            'App:${Uri.file(project.dir.path)}/lib/main.dart:24:12',
         ]));
     }
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -134,16 +134,14 @@ void main() {
           );
         });
 
-        final String output = _uniqueOutputLines(outputEvents);
-        expect(output, contains('''
-══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════
-The following _Exception was thrown building App(dirty):
-Exception: c
-
-The relevant error-causing widget was:
-  App
-  App:${Uri.file(project.dir.path)}/lib/main.dart:24:12
-'''));
+        final List<String> outputLines = _uniqueOutputLines(outputEvents).split('\n');
+        expect( outputLines, containsAllInOrder(<String>[
+            '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════',
+            'The following _Exception was thrown building App(dirty):',
+            'Exception: c',
+            'The relevant error-causing widget was:',
+            '  App:${Uri.file(project.dir.path)}/lib/main.dart:24:12',
+        ]));
     }
 
     testWithoutContext('correctly outputs exceptions in debug mode', () => testExceptionOutput(noDebug: false));

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -134,14 +134,15 @@ void main() {
           );
         });
 
-        final List<String> outputLines = _uniqueOutputLines(outputEvents).split('\n');
+        final String output = _uniqueOutputLines(outputEvents);
+        final List<String> outputLines = output.split('\n');
         expect( outputLines, containsAllInOrder(<String>[
             '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════',
             'The following _Exception was thrown building App(dirty):',
             'Exception: c',
             'The relevant error-causing widget was:',
-            'App:${Uri.file(project.dir.path)}/lib/main.dart:24:12',
         ]));
+        expect(output, contains('App:${Uri.file(project.dir.path)}/lib/main.dart:24:12'));
     }
 
     testWithoutContext('correctly outputs exceptions in debug mode', () => testExceptionOutput(noDebug: false));

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -33,6 +33,9 @@ final bool useInProcessDap = Platform.environment['DAP_TEST_INTERNAL'] == 'true'
 /// Service traffic (wrapped in a custom 'dart.log' event).
 final bool verboseLogging = Platform.environment['DAP_TEST_VERBOSE'] == 'true';
 
+const startOfErrorOutputMarker = '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════';
+const endOfErrorOutputMarker = '════════════════════════════════════════════════════════════════════════════════════════════════════';
+
 /// Expects the lines in [actual] to match the relevant matcher in [expected],
 /// ignoring differences in line endings and trailing whitespace.
 void expectLines(

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -33,8 +33,8 @@ final bool useInProcessDap = Platform.environment['DAP_TEST_INTERNAL'] == 'true'
 /// Service traffic (wrapped in a custom 'dart.log' event).
 final bool verboseLogging = Platform.environment['DAP_TEST_VERBOSE'] == 'true';
 
-const startOfErrorOutputMarker = '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════';
-const endOfErrorOutputMarker = '════════════════════════════════════════════════════════════════════════════════════════════════════';
+const String startOfErrorOutputMarker = '══╡ EXCEPTION CAUGHT BY WIDGETS LIBRARY ╞═══════════════════════════════════════════════════════════';
+const String endOfErrorOutputMarker = '════════════════════════════════════════════════════════════════════════════════════════════════════';
 
 /// Expects the lines in [actual] to match the relevant matcher in [expected],
 /// ignoring differences in line endings and trailing whitespace.


### PR DESCRIPTION
This PR does two things:

1. Disabled structure errors when running in noDebug mode. This is because in `noDebug` mode we don't connect to the VM Service so won't see `Flutter.Error` events, and structured errors suppress error output to stderr and the user would not see any output.
2. When running in debug mode, handle `Flutter.Error` events and forward them to the user via `OutputEvent`s.

@christopherfujino right now, this handling is quite basic (it just forwards the main error string), though I intend to improve it in future. For example in Dart-Code's existing DAP, we walk the tree ourselves and build the output string so we can colour stack frames differently (eg. make frames from the users code bolder than framework frames). I'd like to reuse some code from Flutter or DevTools for that though, and that's not currently available here. In the meantime, I want to at least get error output showing because not having it is a blocker to starting to move and VS Code users over to this DAP.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
