### PR TITLE
Add isActivatedBy to ShortcutActivator

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -216,9 +216,9 @@ abstract class ShortcutActivator {
   ///
   /// If the keyboard `state` isn't supplied, then it defaults to using
   /// [RawKeyboard.instance].
-  static bool isActivatedBy(ShortcutActivator activator, RawKeyEvent event, [RawKeyboard? state]) {
+  static bool isActivatedBy(ShortcutActivator activator, RawKeyEvent event) {
     return (activator.triggers?.contains(event.logicalKey) ?? true)
-        && activator.accepts(event, state ?? RawKeyboard.instance);
+        && activator.accepts(event, RawKeyboard.instance);
   }
 
   /// Returns a description of the key set that is short and readable.
@@ -1026,7 +1026,7 @@ class CallbackShortcuts extends StatelessWidget {
   // throws, by providing the activator and event as arguments that will appear
   // in the stack trace.
   bool _applyKeyBinding(ShortcutActivator activator, RawKeyEvent event) {
-    if (ShortcutActivator.isActivatedBy(activator, event, RawKeyboard.instance)) {
+    if (ShortcutActivator.isActivatedBy(activator, event)) {
       bindings[activator]!.call();
       return true;
     }

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -216,9 +216,9 @@ abstract class ShortcutActivator {
   ///
   /// If the keyboard `state` isn't supplied, then it defaults to using
   /// [RawKeyboard.instance].
-  bool isActivatedBy(RawKeyEvent event, [RawKeyboard? state]) {
-    return (triggers?.contains(event.logicalKey) ?? true)
-        && accepts(event, state ?? RawKeyboard.instance);
+  static bool isActivatedBy(ShortcutActivator activator, RawKeyEvent event, [RawKeyboard? state]) {
+    return (activator.triggers?.contains(event.logicalKey) ?? true)
+        && activator.accepts(event, state ?? RawKeyboard.instance);
   }
 
   /// Returns a description of the key set that is short and readable.
@@ -292,11 +292,6 @@ class LogicalKeySet extends KeySet<LogicalKeyboardKey> with Diagnosticable
     final bool keysEqual = collapsedRequired.difference(collapsedPressed).isEmpty
       && collapsedRequired.length == collapsedPressed.length;
     return keysEqual;
-  }
-
-  @override
-  bool isActivatedBy(RawKeyEvent event, [RawKeyboard? state]) {
-    return triggers.contains(event.logicalKey) && accepts(event, state ?? RawKeyboard.instance);
   }
 
   static final Set<LogicalKeyboardKey> _modifiers = <LogicalKeyboardKey>{
@@ -512,11 +507,6 @@ class SingleActivator with Diagnosticable implements ShortcutActivator {
   }
 
   @override
-  bool isActivatedBy(RawKeyEvent event, [RawKeyboard? state]) {
-    return event.logicalKey == trigger && accepts(event, state ?? RawKeyboard.instance);
-  }
-
-  @override
   bool accepts(RawKeyEvent event, RawKeyboard state) {
     final Set<LogicalKeyboardKey> pressed = state.keysPressed;
     return event is RawKeyDownEvent
@@ -606,11 +596,6 @@ class CharacterActivator with Diagnosticable implements ShortcutActivator {
   bool accepts(RawKeyEvent event, RawKeyboard state) {
     return event is RawKeyDownEvent
         && event.character == character;
-  }
-
-  @override
-  bool isActivatedBy(RawKeyEvent event, [RawKeyboard? state]) {
-    return accepts(event, state ?? RawKeyboard.instance);
   }
 
   @override
@@ -1041,7 +1026,7 @@ class CallbackShortcuts extends StatelessWidget {
   // throws, by providing the activator and event as arguments that will appear
   // in the stack trace.
   bool _applyKeyBinding(ShortcutActivator activator, RawKeyEvent event) {
-    if (activator.isActivatedBy(event, RawKeyboard.instance)) {
+    if (ShortcutActivator.isActivatedBy(activator, event, RawKeyboard.instance)) {
       bindings[activator]!.call();
       return true;
     }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -103,8 +103,8 @@ Widget activatorTester(
       if (hasSecond)
         TestIntent2: TestAction(onInvoke: (Intent intent) {
           onInvoke2(intent);
-	  return null;
-        }),
+        return null;
+      }),
     },
     child: Shortcuts(
       shortcuts: <ShortcutActivator, Intent>{
@@ -319,6 +319,30 @@ void main() {
         LogicalKeySet(LogicalKeyboardKey.keyA, LogicalKeyboardKey.keyB, LogicalKeyboardKey.keyC, LogicalKeyboardKey.keyD).hashCode,
         LogicalKeySet(LogicalKeyboardKey.keyD, LogicalKeyboardKey.keyC, LogicalKeyboardKey.keyB, LogicalKeyboardKey.keyA).hashCode,
       );
+    });
+
+    testWidgets('isActivatedBy works as expected', (WidgetTester tester) async {
+      // Collect some key events to use for testing.
+      final List<RawKeyEvent> events = <RawKeyEvent>[];
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          onKey: (FocusNode node, RawKeyEvent event) {
+            events.add(event);
+            return KeyEventResult.ignored;
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      final LogicalKeySet set = LogicalKeySet(LogicalKeyboardKey.keyA, LogicalKeyboardKey.control);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      expect(set.isActivatedBy(events[0], RawKeyboard.instance), isTrue);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      expect(set.isActivatedBy(events[0], RawKeyboard.instance), isFalse);
     });
 
     test('LogicalKeySet diagnostics work.', () {
@@ -541,6 +565,30 @@ void main() {
       expect(RawKeyboard.instance.keysPressed, isEmpty);
     });
 
+    testWidgets('isActivatedBy works as expected', (WidgetTester tester) async {
+      // Collect some key events to use for testing.
+      final List<RawKeyEvent> events = <RawKeyEvent>[];
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          onKey: (FocusNode node, RawKeyEvent event) {
+            events.add(event);
+            return KeyEventResult.ignored;
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      const SingleActivator singleActivator = SingleActivator(LogicalKeyboardKey.keyA, control: true);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      expect(singleActivator.isActivatedBy(events[1], RawKeyboard.instance), isTrue);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      expect(singleActivator.isActivatedBy(events[1], RawKeyboard.instance), isFalse);
+    });
+    
     group('diagnostics.', () {
       test('single key', () {
         final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
@@ -1167,6 +1215,28 @@ void main() {
       expect(invoked, 2);
       invoked = 0;
     }, variant: KeySimulatorTransitModeVariant.all());
+
+
+    testWidgets('isActivatedBy works as expected', (WidgetTester tester) async {
+      // Collect some key events to use for testing.
+      final List<RawKeyEvent> events = <RawKeyEvent>[];
+      await tester.pumpWidget(
+        Focus(
+          autofocus: true,
+          onKey: (FocusNode node, RawKeyEvent event) {
+            events.add(event);
+            return KeyEventResult.ignored;
+          },
+          child: const SizedBox(),
+        ),
+      );
+
+      const CharacterActivator characterActivator = CharacterActivator('a');
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+      expect(characterActivator.isActivatedBy(events[0], RawKeyboard.instance), isTrue);
+    });
   });
 
   group('CallbackShortcuts', () {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -339,10 +339,10 @@ void main() {
 
       await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
-      expect(ShortcutActivator.isActivatedBy(set, events[0], RawKeyboard.instance), isTrue);
+      expect(ShortcutActivator.isActivatedBy(set, events[0]), isTrue);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
-      expect(ShortcutActivator.isActivatedBy(set, events[0], RawKeyboard.instance), isFalse);
+      expect(ShortcutActivator.isActivatedBy(set, events[0]), isFalse);
     });
 
     test('LogicalKeySet diagnostics work.', () {
@@ -584,11 +584,11 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
-      expect(ShortcutActivator.isActivatedBy(singleActivator, events[1], RawKeyboard.instance), isTrue);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events[1]), isTrue);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
-      expect(ShortcutActivator.isActivatedBy(singleActivator, events[1], RawKeyboard.instance), isFalse);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events[1]), isFalse);
     });
-    
+
     group('diagnostics.', () {
       test('single key', () {
         final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
@@ -1235,7 +1235,7 @@ void main() {
 
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
-      expect(ShortcutActivator.isActivatedBy(characterActivator, events[0], RawKeyboard.instance), isTrue);
+      expect(ShortcutActivator.isActivatedBy(characterActivator, events[0]), isTrue);
     });
   });
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -339,10 +339,10 @@ void main() {
 
       await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
-      expect(set.isActivatedBy(events[0], RawKeyboard.instance), isTrue);
+      expect(ShortcutActivator.isActivatedBy(set, events[0], RawKeyboard.instance), isTrue);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
-      expect(set.isActivatedBy(events[0], RawKeyboard.instance), isFalse);
+      expect(ShortcutActivator.isActivatedBy(set, events[0], RawKeyboard.instance), isFalse);
     });
 
     test('LogicalKeySet diagnostics work.', () {
@@ -584,9 +584,9 @@ void main() {
       await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
-      expect(singleActivator.isActivatedBy(events[1], RawKeyboard.instance), isTrue);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events[1], RawKeyboard.instance), isTrue);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
-      expect(singleActivator.isActivatedBy(events[1], RawKeyboard.instance), isFalse);
+      expect(ShortcutActivator.isActivatedBy(singleActivator, events[1], RawKeyboard.instance), isFalse);
     });
     
     group('diagnostics.', () {
@@ -1235,7 +1235,7 @@ void main() {
 
       await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
       await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
-      expect(characterActivator.isActivatedBy(events[0], RawKeyboard.instance), isTrue);
+      expect(ShortcutActivator.isActivatedBy(characterActivator, events[0], RawKeyboard.instance), isTrue);
     });
   });
 


### PR DESCRIPTION
## Description

When I was working on the menu bar, I needed a simple way to tell if an event would activate a shortcut activator in the same way that `Shortcuts` does it.

## Tests
 - Added tests for all the affected classed.