### PR TITLE
Fix `PopupMenuButton`'s `IconButton` not inheriting `IconTheme` size

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -37,6 +37,7 @@ const double _kMenuMinWidth = 2.0 * _kMenuWidthStep;
 const double _kMenuVerticalPadding = 8.0;
 const double _kMenuWidthStep = 56.0;
 const double _kMenuScreenPadding = 8.0;
+const double _kDefaultIconSize = 24.0;
 
 /// Used to configure how the [PopupMenuButton] positions its popup menu.
 enum PopupMenuPosition {
@@ -1215,7 +1216,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
       icon: widget.icon ?? Icon(Icons.adaptive.more),
       padding: widget.padding,
       splashRadius: widget.splashRadius,
-      iconSize: widget.iconSize ?? iconTheme.size ?? 24.0,
+      iconSize: widget.iconSize ?? iconTheme.size ?? _kDefaultIconSize,
       tooltip: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
       onPressed: widget.enabled ? showButtonMenu : null,
       enableFeedback: enableFeedback,

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -1088,7 +1088,9 @@ class PopupMenuButton<T> extends StatefulWidget {
 
   /// If provided, the size of the [Icon].
   ///
-  /// If this property is null, the default size is 24.0 pixels.
+  /// If this property is null, then [IconThemeData.size] is used.
+  /// If [IconThemeData.size] is also null, then
+  /// default size is 24.0 pixels.
   final double? iconSize;
 
   /// Optional size constraints for the menu.
@@ -1190,6 +1192,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
 
   @override
   Widget build(BuildContext context) {
+    final IconThemeData iconTheme = IconTheme.of(context);
     final bool enableFeedback = widget.enableFeedback
       ?? PopupMenuTheme.of(context).enableFeedback
       ?? true;
@@ -1212,7 +1215,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
       icon: widget.icon ?? Icon(Icons.adaptive.more),
       padding: widget.padding,
       splashRadius: widget.splashRadius,
-      iconSize: widget.iconSize ?? 24.0,
+      iconSize: widget.iconSize ?? iconTheme.size ?? 24.0,
       tooltip: widget.tooltip ?? MaterialLocalizations.of(context).showMenuTooltip,
       onPressed: widget.enabled ? showButtonMenu : null,
       enableFeedback: enableFeedback,

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -2700,16 +2700,17 @@ void main() {
   });
 
   testWidgets("PopupMenuButton icon inherits IconTheme's size", (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
+    Widget _buildPopupMenu({double? themeIconSize, double? iconSize}) {
+      return MaterialApp(
         theme: ThemeData(
-          iconTheme: const IconThemeData(
-            size: 50.0,
+          iconTheme: IconThemeData(
+            size: themeIconSize,
           ),
         ),
         home: Scaffold(
           body: Center(
             child: PopupMenuButton<String>(
+              iconSize: iconSize,
               itemBuilder: (_) => <PopupMenuEntry<String>>[
                 const PopupMenuItem<String>(
                   value: 'value',
@@ -2719,10 +2720,27 @@ void main() {
             ),
           ),
         ),
-      ),
-    );
+      );
+    }
 
-    final IconButton iconButton = tester.widget(find.widgetWithIcon(IconButton, Icons.more_vert));
+    // Popup menu with default icon size.
+    await tester.pumpWidget(_buildPopupMenu());
+    IconButton iconButton = tester.widget(find.widgetWithIcon(IconButton, Icons.more_vert));
+    // Default PopupMenuButton icon size is 24.0.
+    expect(iconButton.iconSize, 24.0);
+
+    // Popup menu with custom theme icon size.
+    await tester.pumpWidget(_buildPopupMenu(themeIconSize: 30.0));
+    await tester.pumpAndSettle();
+    iconButton = tester.widget(find.widgetWithIcon(IconButton, Icons.more_vert));
+    // PopupMenuButton icon inherits IconTheme's size.
+    expect(iconButton.iconSize, 30.0);
+
+    // Popup menu with custom icon size.
+    await tester.pumpWidget(_buildPopupMenu(themeIconSize: 30.0, iconSize: 50.0));
+    await tester.pumpAndSettle();
+    iconButton = tester.widget(find.widgetWithIcon(IconButton, Icons.more_vert));
+    // PopupMenuButton icon size overrides IconTheme's size.
     expect(iconButton.iconSize, 50.0);
   });
 }

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -2698,6 +2698,33 @@ void main() {
 
     expect(tester.getTopLeft(find.byWidgetPredicate((Widget w) => '${w.runtimeType}' == '_PopupMenu<int?>')), const Offset(8.0, 90.0));
   });
+
+  testWidgets("PopupMenuButton icon inherits IconTheme's size", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          iconTheme: const IconThemeData(
+            size: 50.0,
+          ),
+        ),
+        home: Scaffold(
+          body: Center(
+            child: PopupMenuButton<String>(
+              itemBuilder: (_) => <PopupMenuEntry<String>>[
+                const PopupMenuItem<String>(
+                  value: 'value',
+                  child: Text('Item 0'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final IconButton iconButton = tester.widget(find.widgetWithIcon(IconButton, Icons.more_vert));
+    expect(iconButton.iconSize, 50.0);
+  });
 }
 
 class TestApp extends StatefulWidget {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/100105


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
