### PR TITLE
Don't terminate Dart process pids from VM Service, record flutter_tools VM pid

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -192,15 +192,11 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
 
   @override
   Future<void> debuggerConnected(vm.VM vmInfo) async {
-    // Capture the PID from the VM Service so that we can terminate it when
-    // cleaning up. Terminating the process might not be enough as it could be
-    // just a shell script (e.g. flutter.bat on Windows) and may not pass the
-    // signal on correctly.
-    // See: https://github.com/Dart-Code/Dart-Code/issues/907
-    final int? pid = vmInfo.pid;
-    if (pid != null) {
-      pidsToTerminate.add(pid);
-    }
+    // Usually we'd capture the pid from the VM here and record it for
+    // terminating, however for Flutter apps it may be running on a remove
+    // device so it's not valid to terminate a process with that pid locally.
+    // For attach, pids should never be collected as terminateRequest() should
+    // not terminate the debugee.
   }
 
   /// Called by [disconnectRequest] to request that we forcefully shut down the app being run (or in the case of an attach, disconnect).

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -193,7 +193,7 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   @override
   Future<void> debuggerConnected(vm.VM vmInfo) async {
     // Usually we'd capture the pid from the VM here and record it for
-    // terminating, however for Flutter apps it may be running on a remove
+    // terminating, however for Flutter apps it may be running on a remote
     // device so it's not valid to terminate a process with that pid locally.
     // For attach, pids should never be collected as terminateRequest() should
     // not terminate the debugee.

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -238,6 +238,8 @@ void main() {
 }
 
 class _FakeVm extends Fake implements VM {
-  final int pid;
   _FakeVm({this.pid = 1});
+
+  @override
+  final int pid;
 }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -354,36 +354,6 @@ void main() {
 
       await dap.client.terminate();
     });
-
-   testWithoutContext('can attach to an already-running Flutter app and detach', () async {
-      final Uri vmServiceUri = await testProcess.vmServiceUri;
-      bool debugeeTerminated = false;
-      unawaited(testProcess.process.exitCode.then((_) => debugeeTerminated = true));
-
-      // Launch the app and wait for it to print "topLevelFunction".
-      await Future.wait(<Future<void>>[
-        dap.client.stdoutOutput.firstWhere(
-            (String output) => output.startsWith('topLevelFunction')),
-        dap.client.start(
-          launch: () => dap.client.attach(
-            cwd: project.dir.path,
-            toolArgs: <String>['-d', 'flutter-tester'],
-            vmServiceUri: vmServiceUri.toString(),
-          ),
-        ),
-      ], eagerError: true);
-
-      // Send a terminate request which should terminate the debugger, but not
-      // terminate the debugee
-      await Future.wait(<Future<void>>[
-        dap.client.event('terminated'),
-        dap.client.terminate(),
-      ]);
-
-      // Wait a short amount before checking to ensure it really didn't quit.
-      await Future<void>.delayed(const Duration(milliseconds: 500));
-      expect(debugeeTerminated, isFalse);
-    });
   });
 }
 


### PR DESCRIPTION
The deleted code here was from the original Dart DAP adapter and captures the processes `pid` from the VM Service to help ensure processes are cleaned up on shutdown.

For Flutter, this doesn't make sense because the `pid` from the VM Service may correspond to another device and if it overlaps with something on the local machine, we may just terminate a "random" process. For `attachRequest`, it was never really valid to terminate the debugee anyway, as we should only detach (terminate the `flutter attach` process, not the running apps VM).

Additionally, we now _do_ record the `pid` from the `daemon.connected` event, as on Windows the `pid` of the process we spawn is a shell and not the actual flutter_tools VM process, so termination didn't always clean up properly (the shell doesn't seem to always pass the signals on to the process).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
