### PR TITLE
Revert "[framework] don't hit test for system nav bar or system chrome on desktop"

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -265,49 +265,30 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     //    |                        |
     //    ++++++++++++++++++++++++++ <- bounds.bottom
     final Rect bounds = paintBounds;
-
-    // Only Android / iOS / Fuchsia have a customizable status bar.
-    SystemUiOverlayStyle? upperOverlayStyle;
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-      case TargetPlatform.iOS:
-      case TargetPlatform.fuchsia:
-        // Center of the status bar
-        final Offset top = Offset(
-          // Horizontal center of the screen
-          bounds.center.dx,
-          // The vertical center of the system status bar. The system status bar
-          // height is kept as top window padding.
-          _window.padding.top / 2.0,
-        );
-        upperOverlayStyle = layer!.find<SystemUiOverlayStyle>(top);
-        break;
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        break;
-    }
-
-    // Only Android has a customizable system navigation bar.
+    // Center of the status bar
+    final Offset top = Offset(
+      // Horizontal center of the screen
+      bounds.center.dx,
+      // The vertical center of the system status bar. The system status bar
+      // height is kept as top window padding.
+      _window.padding.top / 2.0,
+    );
+    // Center of the navigation bar
+    final Offset bottom = Offset(
+      // Horizontal center of the screen
+      bounds.center.dx,
+      // Vertical center of the system navigation bar. The system navigation bar
+      // height is kept as bottom window padding. The "1" needs to be subtracted
+      // from the bottom because available pixels are in (0..bottom) range.
+      // I.e. for a device with 1920 height, bound.bottom is 1920, but the most
+      // bottom drawn pixel is at 1919 position.
+      bounds.bottom - 1.0 - _window.padding.bottom / 2.0,
+    );
+    final SystemUiOverlayStyle? upperOverlayStyle = layer!.find<SystemUiOverlayStyle>(top);
+    // Only android has a customizable system navigation bar.
     SystemUiOverlayStyle? lowerOverlayStyle;
     switch (defaultTargetPlatform) {
       case TargetPlatform.android:
-        // If there is no bottom view padding, then there is no navigation bar
-        // and the hit test can be skipped.
-        if (_window.viewPadding.bottom == 0.0) {
-          break;
-        }
-        // Center of the navigation bar
-        final Offset bottom = Offset(
-          // Horizontal center of the screen
-          bounds.center.dx,
-          // Vertical center of the system navigation bar. The system navigation bar
-          // height is kept as bottom window padding. The "1" needs to be subtracted
-          // from the bottom because available pixels are in (0..bottom) range.
-          // I.e. for a device with 1920 height, bound.bottom is 1920, but the most
-          // bottom drawn pixel is at 1919 position.
-          bounds.bottom - 1.0 - _window.padding.bottom / 2.0,
-        );
         lowerOverlayStyle = layer!.find<SystemUiOverlayStyle>(bottom);
         break;
       case TargetPlatform.fuchsia:

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -974,11 +974,8 @@ void main() {
         },
       ),
     );
-    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
-      statusBarIconBrightness: Brightness.light,
-      statusBarBrightness: Brightness.dark,
-    ));
-  }, variant: TargetPlatformVariant.mobile());
+    expect(SystemChrome.latestStyle, SystemUiOverlayStyle.light);
+  });
 
   testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -997,11 +994,8 @@ void main() {
         },
       ),
     );
-    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
-      statusBarIconBrightness: Brightness.dark,
-      statusBarBrightness: Brightness.light,
-    ));
-  }, variant: TargetPlatformVariant.mobile());
+    expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
+  });
 
   testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoNavigationBarBackButton());

--- a/packages/flutter/test/rendering/view_chrome_style_test.dart
+++ b/packages/flutter/test/rendering/view_chrome_style_test.dart
@@ -16,11 +16,11 @@ void main() {
     const double deviceWidth = 480.0;
     const double devicePixelRatio = 2.0;
 
-    void setupTestDevice({ double bottomPadding = navigationBarHeight * devicePixelRatio }) {
+    void setupTestDevice() {
       final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
-      final FakeWindowPadding padding = FakeWindowPadding(
+      const FakeWindowPadding padding = FakeWindowPadding(
         top: statusBarHeight * devicePixelRatio,
-        bottom: bottomPadding,
+        bottom: navigationBarHeight * devicePixelRatio,
       );
 
       binding.window
@@ -94,35 +94,8 @@ void main() {
         variant: TargetPlatformVariant.mobile(),
       );
 
-      testWidgets("statusBarColor isn't set on desktop platforms",
-        (WidgetTester tester) async {
-          setupTestDevice();
-          const double moreThanHalfOfTheStatusBarHeight =
-              statusBarHeight / 2.0 + 1;
-          await tester.pumpWidget(const Align(
-            alignment: Alignment.topCenter,
-            child: AnnotatedRegion<SystemUiOverlayStyle>(
-              value: SystemUiOverlayStyle(
-                statusBarColor: Colors.blue,
-              ),
-              child: SizedBox(
-                width: 100,
-                height: moreThanHalfOfTheStatusBarHeight,
-              ),
-            ),
-          ));
-          await tester.pumpAndSettle();
-
-          expect(
-            SystemChrome.latestStyle?.statusBarColor,
-            isNull,
-          );
-        },
-        variant: TargetPlatformVariant.desktop(),
-      );
-
       testWidgets(
-        'statusBarColor is set when view covers more than half of the system status bar',
+        'statusBarColor is set when view covers more than half of tye system status bar',
         (WidgetTester tester) async {
           setupTestDevice();
           const double moreThanHalfOfTheStatusBarHeight =
@@ -255,28 +228,6 @@ void main() {
         variant: TargetPlatformVariant.only(TargetPlatform.android),
       );
     });
-
-    testWidgets('systemNavigationBarColor is not set when there is no window padding', (WidgetTester tester) async {
-      setupTestDevice(bottomPadding: 0);
-      await tester.pumpWidget(const Align(
-        alignment: Alignment.bottomCenter,
-        child: AnnotatedRegion<SystemUiOverlayStyle>(
-          value: SystemUiOverlayStyle(
-            systemNavigationBarColor: Colors.blue,
-          ),
-          child: SizedBox(
-            width: 100,
-            height: 100
-          ),
-        ),
-      ));
-      await tester.pumpAndSettle();
-
-      expect(
-        SystemChrome.latestStyle?.systemNavigationBarColor,
-        null,
-      );
-    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
 }
 


### PR DESCRIPTION
Reverts flutter/flutter#97883

We're missing integration tests for this functionality