### PR TITLE
adds `isAttached` getter to DraggableScrollableController

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -77,7 +77,7 @@ class DraggableScrollableController extends ChangeNotifier {
   /// If this is false, then members that interact with the [ScrollPosition],
   /// such as [sizeToPixels], [size], [animateTo], and [jumpTo], must not be
   /// called.
-  bool get isAttached => _attachedController != null;
+  bool get isAttached => _attachedController != null && _attachedController!.hasClients;
 
   /// Convert a sheet's pixel height to size (fractional value of parent container height).
   double pixelsToSize(double pixels) {

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -71,6 +71,14 @@ class DraggableScrollableController extends ChangeNotifier {
     return _attachedController!.extent.sizeToPixels(size);
   }
 
+  /// Returns Whether any [DraggableScrollableController] objects have attached themselves to the
+  /// [DraggableScrollableSheet].
+  ///
+  /// If this is false, then members that interact with the [ScrollPosition],
+  /// such as [sizeToPixels], [size], [animateTo], and [jumpTo], must not be
+  /// called.
+  bool get isAttached => _attachedController != null;
+
   /// Convert a sheet's pixel height to size (fractional value of parent container height).
   double pixelsToSize(double pixels) {
     _assertAttached();

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -165,7 +165,7 @@ class DraggableScrollableController extends ChangeNotifier {
 
   void _assertAttached() {
     assert(
-      _attachedController != null,
+      isAttached,
       'DraggableScrollableController is not attached to a sheet. A DraggableScrollableController '
         'must be used in a DraggableScrollableSheet before any of its methods are called.',
     );

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1195,4 +1195,18 @@ void main() {
     // Can't use animateTo with a zero duration.
     expect(() => controller.animateTo(.5, duration: Duration.zero, curve: Curves.linear), throwsAssertionError);
   });
+
+  testWidgets('DraggableScrollableController must be attached before using any of its paramters', (WidgetTester tester) async {
+    final DraggableScrollableController controller = DraggableScrollableController();
+    expect(controller.isAttached, false);
+    expect(()=>controller.size, throwsAssertionError);
+    final Widget boilerplate = _boilerplate(
+        null,
+        minChildSize: 0.4,
+        controller: controller,
+      );
+    await tester.pumpWidget(boilerplate);
+    expect(controller.isAttached, true);
+    expect(controller.size, isNotNull);
+    });
 }


### PR DESCRIPTION
This PR adds `isAttached` getter to DraggableScrollableController similar to `ScrollController.hasClients`

Fixes https://github.com/flutter/flutter/issues/99994

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
