### PR TITLE
[macOS] Enable universal binary builds by default

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -70,7 +70,7 @@ BuildApp() {
     "assemble"
     "--no-version-check"
     "-dTargetPlatform=darwin"
-    "-dDarwinArchs=x86_64"
+    "-dDarwinArchs=x86_64 arm64"
     "-dTargetFile=${target_path}"
     "-dBuildMode=${build_mode}"
     "-dTreeShakeIcons=${TREE_SHAKE_ICONS}"

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -116,9 +116,6 @@ def flutter_additional_macos_build_settings(target)
     configuration_engine_dir = build_configuration.type == :debug ? debug_framework_dir : release_framework_dir
     build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS'] = "\"#{configuration_engine_dir}\" $(inherited)"
 
-    # ARM not yet supported https://github.com/flutter/flutter/issues/69221
-    build_configuration.build_settings['EXCLUDED_ARCHS'] = 'arm64'
-
     # When deleted, the deployment version will inherit from the higher version derived from the 'Runner' target.
     # If the pod only supports a higher version, do not delete to correctly produce an error.
     build_configuration.build_settings.delete 'MACOSX_DEPLOYMENT_TARGET' if inherit_deployment_target

--- a/packages/flutter_tools/lib/src/build_system/targets/macos.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/macos.dart
@@ -80,7 +80,7 @@ abstract class UnpackMacOS extends Target {
   }
 
   void _thinFramework(Environment environment, String frameworkBinaryPath) {
-    final String archs = environment.defines[kDarwinArchs] ?? 'x86_64';
+    final String archs = environment.defines[kDarwinArchs] ?? 'x86_64 arm64';
     final List<String> archList = archs.split(' ').toList();
     final ProcessResult infoResult = environment.processManager.runSync(<String>[
       'lipo',
@@ -186,7 +186,7 @@ class DebugMacOSFramework extends Target {
     final Iterable<DarwinArch> darwinArchs = environment.defines[kDarwinArchs]
       ?.split(' ')
       .map(getDarwinArchForName)
-      ?? <DarwinArch>[DarwinArch.x86_64];
+      ?? <DarwinArch>[DarwinArch.x86_64, DarwinArch.arm64];
 
     final Iterable<String> darwinArchArguments =
         darwinArchs.expand((DarwinArch arch) => <String>['-arch', getNameForDarwinArch(arch)]);
@@ -256,7 +256,7 @@ class CompileMacOSFramework extends Target {
       ?.split(' ')
       .map(getDarwinArchForName)
       .toList()
-      ?? <DarwinArch>[DarwinArch.x86_64];
+      ?? <DarwinArch>[DarwinArch.x86_64, DarwinArch.arm64];
     if (targetPlatform != TargetPlatform.darwin) {
       throw Exception('compile_macos_framework is only supported for darwin TargetPlatform.');
     }

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -200,15 +200,12 @@ Future<List<String>> _xcodeBuildSettingsLines({
       xcodeBuildSettings.add('ARCHS=$arch');
     }
   }
-  if (useMacOSConfig) {
-    // ARM not yet supported https://github.com/flutter/flutter/issues/69221
-    xcodeBuildSettings.add('EXCLUDED_ARCHS=arm64');
-  } else {
-    String excludedSimulatorArchs = 'i386';
 
+  if (!useMacOSConfig) {
     // If any plugins or their dependencies do not support arm64 simulators
     // (to run natively without Rosetta translation on an ARM Mac),
     // the app will fail to build unless it also excludes arm64 simulators.
+    String excludedSimulatorArchs = 'i386';
     if (!(await project.ios.pluginsSupportArmSimulator())) {
       excludedSimulatorArchs += ' arm64';
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -291,7 +291,6 @@ void main() {
       'FLUTTER_BUILD_DIR=build',
       'FLUTTER_BUILD_NAME=1.0.0',
       'FLUTTER_BUILD_NUMBER=1',
-      'EXCLUDED_ARCHS=arm64',
       'DART_DEFINES=Zm9vLmJhcj0y,Zml6ei5mYXI9Mw==',
       'DART_OBFUSCATION=true',
       'EXTRA_FRONT_END_OPTIONS=--enable-experiment=non-nullable',
@@ -303,6 +302,7 @@ void main() {
       'PACKAGE_CONFIG=/.dart_tool/package_config.json',
       'COCOAPODS_PARALLEL_CODE_SIGN=true',
     ]));
+    expect(contents, isNot(contains('EXCLUDED_ARCHS')));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[


### PR DESCRIPTION
This changes the default build architectures for Flutter macOS apps to
x86_64 and arm64. Previously, we manually excluded arm64 builds via the
EXCLUDE_ARCHS Xcode setting in Flutter's generated xcconfig file. This
eliminates setting EXCLUDE_ARCHS during the build and updates the
default architectures in the tool and in the macos_assemble.sh wrapper.

Issue: https://github.com/flutter/flutter/issues/97681
Umbrella issue: https://github.com/flutter/flutter/issues/60113

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
