### PR TITLE
Implements a PlatformMenuBar widget and associated data structures

### DIFF
--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -10,6 +10,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 void main() => runApp(const SampleApp());
 
@@ -76,7 +77,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
       children: <MenuItem>[
         PlatformMenu(
           label: 'Flutter API Sample',
-          children: <MenuItem>[
+          menus: <MenuItem>[
             PlatformMenuItemGroup(
               members: <MenuItem>[
                 PlatformMenuItem(
@@ -93,13 +94,15 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                   onSelected: () {
                     _handleMenuSelection(MenuSelection.showMessage);
                   },
+                  shortcut: CharacterActivator('m'),
                   label: _showMessage ? 'Hide Message' : 'Show Message',
                 ),
                 PlatformMenu(
                   label: 'Messages',
-                  children: <MenuItem>[
+                  menus: <MenuItem>[
                     PlatformMenuItem(
                       label: 'I am not throwing away my shot.',
+                      shortcut: SingleActivator(LogicalKeyboardKey.digit1, meta: true),
                       onSelected: () {
                         setState(() {
                           _message = 'I am not throwing away my shot.';
@@ -108,6 +111,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                     ),
                     PlatformMenuItem(
                       label: "There's a million things I haven't done, but just you wait.",
+                      shortcut: SingleActivator(LogicalKeyboardKey.digit2, meta: true),
                       onSelected: () {
                         setState(() {
                           _message = "There's a million things I haven't done, but just you wait.";

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // Flutter code sample for PlatformMenuBar
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const SampleApp());
@@ -15,12 +17,10 @@ enum MenuSelection {
 class SampleApp extends StatelessWidget {
   const SampleApp({Key? key}) : super(key: key);
 
-  static const String _title = 'MenuBar Sample';
-
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      title: _title,
+      title: 'MenuBar Sample',
       home: Scaffold(body: MyMenuBarApp()),
     );
   }
@@ -34,42 +34,45 @@ class MyMenuBarApp extends StatefulWidget {
 }
 
 class _MyMenuBarAppState extends State<MyMenuBarApp> {
-  bool get showMessage => _showMessage;
-  bool _showMessage = false;
   String _message = 'Hello';
-  set showMessage(bool value) {
-    if (_showMessage != value) {
-      setState(() {
-        _showMessage = value;
-      });
-    }
-  }
+  bool _showMessage = false;
 
   void _handleMenuSelection(MenuSelection value) {
     switch (value) {
       case MenuSelection.about:
         showAboutDialog(
           context: context,
-          applicationName: 'MenuBar Test',
+          applicationName: 'MenuBar Sample',
           applicationVersion: '1.0.0',
         );
         break;
       case MenuSelection.showMessage:
-        showMessage = !showMessage;
+        setState(() {
+          _showMessage = !_showMessage;
+        });
         break;
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    assert(defaultTargetPlatform == TargetPlatform.macOS, 'This sample only works on macOS');
+    // This builds a menu hierarchy that looks like this:
+    // Sample App
+    //  ├ About
+    //  ├ ────────  (group divider)
+    //  ├ Hide/Show Message
+    //  └ Messages
+    //     ├ I am not throwing away my shot.
+    //     └ There's a million things I haven't done, but just you wait.
     return PlatformMenuBar(
       children: <MenuItem>[
-        PlatformSubMenu(
-          label: 'Test App',
+        PlatformMenu(
+          label: 'Sample App',
           children: <MenuItem>[
             PlatformMenuItemGroup(
               members: <MenuItem>[
-                PlatformMenuBarItem(
+                PlatformMenuItem(
                   label: 'About',
                   onSelected: () => _handleMenuSelection(MenuSelection.about),
                 )
@@ -77,14 +80,14 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
             ),
             PlatformMenuItemGroup(
               members: <MenuItem>[
-                PlatformMenuBarItem(
+                PlatformMenuItem(
                   onSelected: () => _handleMenuSelection(MenuSelection.showMessage),
-                  label: showMessage ? 'Hide Message' : 'Show Message',
+                  label: _showMessage ? 'Hide Message' : 'Show Message',
                 ),
-                PlatformSubMenu(
+                PlatformMenu(
                   label: 'Messages',
                   children: <MenuItem>[
-                    PlatformMenuBarItem(
+                    PlatformMenuItem(
                       label: 'I am not throwing away my shot.',
                       onSelected: () {
                         setState(() {
@@ -92,7 +95,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                         });
                       },
                     ),
-                    PlatformMenuBarItem(
+                    PlatformMenuItem(
                       label: "There's a million things I haven't done, but just you wait.",
                       onSelected: () {
                         setState(() {
@@ -109,7 +112,10 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
         ),
       ],
       body: Center(
-        child: Text(_showMessage ? _message : 'Application Body'),
+        child: Text(_showMessage
+            ? _message
+            : 'This space intentionally left blank.\n'
+              'Show a message here using the menu.'),
       ),
     );
   }

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -122,7 +122,8 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                 )
               ],
             ),
-            const PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.quit),
+            if (PlatformProvidedMenuItem.hasMenu(PlatformProvidedMenuItemType.quit))
+              const PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.quit),
           ],
         ),
       ],

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -20,7 +20,6 @@ class SampleApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return const MaterialApp(
-      title: 'MenuBar Sample',
       home: Scaffold(body: MyMenuBarApp()),
     );
   }
@@ -74,14 +73,18 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
               members: <MenuItem>[
                 PlatformMenuItem(
                   label: 'About',
-                  onSelected: () => _handleMenuSelection(MenuSelection.about),
+                  onSelected: () {
+                    _handleMenuSelection(MenuSelection.about);
+                  },
                 )
               ],
             ),
             PlatformMenuItemGroup(
               members: <MenuItem>[
                 PlatformMenuItem(
-                  onSelected: () => _handleMenuSelection(MenuSelection.showMessage),
+                  onSelected: () {
+                    _handleMenuSelection(MenuSelection.showMessage);
+                  },
                   label: _showMessage ? 'Hide Message' : 'Show Message',
                 ),
                 PlatformMenu(

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -1,0 +1,116 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for PlatformMenuBar
+import 'package:flutter/material.dart';
+
+void main() => runApp(const SampleApp());
+
+enum MenuSelection {
+  about,
+  showMessage,
+}
+
+class SampleApp extends StatelessWidget {
+  const SampleApp({Key? key}) : super(key: key);
+
+  static const String _title = 'MenuBar Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: _title,
+      home: Scaffold(body: MyMenuBarApp()),
+    );
+  }
+}
+
+class MyMenuBarApp extends StatefulWidget {
+  const MyMenuBarApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyMenuBarApp> createState() => _MyMenuBarAppState();
+}
+
+class _MyMenuBarAppState extends State<MyMenuBarApp> {
+  bool get showMessage => _showMessage;
+  bool _showMessage = false;
+  String _message = 'Hello';
+  set showMessage(bool value) {
+    if (_showMessage != value) {
+      setState(() {
+        _showMessage = value;
+      });
+    }
+  }
+
+  void _handleMenuSelection(MenuSelection value) {
+    switch (value) {
+      case MenuSelection.about:
+        showAboutDialog(
+          context: context,
+          applicationName: 'MenuBar Test',
+          applicationVersion: '1.0.0',
+        );
+        break;
+      case MenuSelection.showMessage:
+        showMessage = !showMessage;
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlatformMenuBar(
+      children: <MenuItem>[
+        PlatformSubMenu(
+          label: 'Test App',
+          children: <MenuItem>[
+            PlatformMenuItemGroup(
+              members: <MenuItem>[
+                PlatformMenuBarItem(
+                  label: 'About',
+                  onSelected: () => _handleMenuSelection(MenuSelection.about),
+                )
+              ],
+            ),
+            PlatformMenuItemGroup(
+              members: <MenuItem>[
+                PlatformMenuBarItem(
+                  onSelected: () => _handleMenuSelection(MenuSelection.showMessage),
+                  label: showMessage ? 'Hide Message' : 'Show Message',
+                ),
+                PlatformSubMenu(
+                  label: 'Messages',
+                  children: <MenuItem>[
+                    PlatformMenuBarItem(
+                      label: 'I am not throwing away my shot.',
+                      onSelected: () {
+                        setState(() {
+                          _message = 'I am not throwing away my shot.';
+                        });
+                      },
+                    ),
+                    PlatformMenuBarItem(
+                      label: "There's a million things I haven't done, but just you wait.",
+                      onSelected: () {
+                        setState(() {
+                          _message = "There's a million things I haven't done, but just you wait.";
+                        });
+                      },
+                    ),
+                  ],
+                )
+              ],
+            ),
+            const PlatformProvidedMenuItem(type: PlatformProvidedMenuItemType.quit),
+          ],
+        ),
+      ],
+      body: Center(
+        child: Text(_showMessage ? _message : 'Application Body'),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -74,7 +74,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
     //  │  └ There's a million things I haven't done, but just you wait.
     //  └ Quit
     return PlatformMenuBar(
-      children: <MenuItem>[
+      menus: <MenuItem>[
         PlatformMenu(
           label: 'Flutter API Sample',
           menus: <MenuItem>[
@@ -94,7 +94,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                   onSelected: () {
                     _handleMenuSelection(MenuSelection.showMessage);
                   },
-                  shortcut: CharacterActivator('m'),
+                  shortcut: const CharacterActivator('m'),
                   label: _showMessage ? 'Hide Message' : 'Show Message',
                 ),
                 PlatformMenu(
@@ -102,7 +102,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                   menus: <MenuItem>[
                     PlatformMenuItem(
                       label: 'I am not throwing away my shot.',
-                      shortcut: SingleActivator(LogicalKeyboardKey.digit1, meta: true),
+                      shortcut: const SingleActivator(LogicalKeyboardKey.digit1, meta: true),
                       onSelected: () {
                         setState(() {
                           _message = 'I am not throwing away my shot.';
@@ -111,7 +111,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                     ),
                     PlatformMenuItem(
                       label: "There's a million things I haven't done, but just you wait.",
-                      shortcut: SingleActivator(LogicalKeyboardKey.digit2, meta: true),
+                      shortcut: const SingleActivator(LogicalKeyboardKey.digit2, meta: true),
                       onSelected: () {
                         setState(() {
                           _message = "There's a million things I haven't done, but just you wait.";

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -4,6 +4,10 @@
 
 // Flutter code sample for PlatformMenuBar
 
+////////////////////////////////////
+// THIS SAMPLE ONLY WORKS ON MACOS.
+////////////////////////////////////
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -55,19 +59,23 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
 
   @override
   Widget build(BuildContext context) {
-    assert(defaultTargetPlatform == TargetPlatform.macOS, 'This sample only works on macOS');
+    ////////////////////////////////////
+    // THIS SAMPLE ONLY WORKS ON MACOS.
+    ////////////////////////////////////
+
     // This builds a menu hierarchy that looks like this:
-    // Sample App
+    // Flutter API Sample
     //  ├ About
     //  ├ ────────  (group divider)
     //  ├ Hide/Show Message
-    //  └ Messages
-    //     ├ I am not throwing away my shot.
-    //     └ There's a million things I haven't done, but just you wait.
+    //  ├ Messages
+    //  │  ├ I am not throwing away my shot.
+    //  │  └ There's a million things I haven't done, but just you wait.
+    //  └ Quit
     return PlatformMenuBar(
       children: <MenuItem>[
         PlatformMenu(
-          label: 'Sample App',
+          label: 'Flutter API Sample',
           children: <MenuItem>[
             PlatformMenuItemGroup(
               members: <MenuItem>[

--- a/packages/flutter/lib/src/rendering/layout_helper.dart
+++ b/packages/flutter/lib/src/rendering/layout_helper.dart
@@ -28,7 +28,7 @@ class ChildLayoutHelper {
   /// This method calls [RenderBox.getDryLayout] on the given [RenderBox].
   ///
   /// This method should only be called by the parent of the provided
-  /// [RenderBox] child as it bounds parent and child together (if the child
+  /// [RenderBox] child as it binds parent and child together (if the child
   /// is marked as dirty, the child will also be marked as dirty).
   ///
   /// See also:
@@ -46,7 +46,7 @@ class ChildLayoutHelper {
   /// `parentUsesSize` set to true to receive its [Size].
   ///
   /// This method should only be called by the parent of the provided
-  /// [RenderBox] child as it bounds parent and child together (if the child
+  /// [RenderBox] child as it binds parent and child together (if the child
   /// is marked as dirty, the child will also be marked as dirty).
   ///
   /// See also:

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -400,27 +400,29 @@ class SystemChannels {
   ///
   ///  * `Menu.setMenu`: sends the configuration of the platform menu, including
   ///    labels, enable/disable information, and unique integer identifiers for
-  ///    each menu item. The configuration is sent as a `List<Map<String,
-  ///    Object?>>` encoding the list of top level menu items, which each have a
-  ///    hierarchy of `Map<String, Object?>` containing the required data, sent
-  ///    via a [StandardMessageCodec]. It is typically generated from a list of
-  ///    [MenuItem]s like this example:
+  ///    each menu item. The configuration is sent as a `Map<String, Object?>`
+  ///    encoding the list of top level menu items in window "0", which each
+  ///    have a hierarchy of `Map<String, Object?>` containing the required
+  ///    data, sent via a [StandardMessageCodec]. It is typically generated from
+  ///    a list of [MenuItem]s, and ends up looking like this example:
   ///
   /// ```dart
-  /// List<Map<String, Object?>> menu = <Map<String, Object?>>[
-  ///   <String, Object?>{
-  ///     'id': 1,
-  ///     'label': 'First Menu Label',
-  ///     'enabled': true,
-  ///     'children': <Map<String, Object?>>[
-  ///       <String, Object?>{
-  ///         'id': 2,
-  ///         'label': 'Sub Menu Label',
-  ///         'enabled': true,
-  ///       },
-  ///     ]
-  ///   },
-  /// ];
+  /// List<Map<String, Object?>> menu = <String, Object?>{
+  ///   '0': <Map<String, Object?>>[
+  ///     <String, Object?>{
+  ///       'id': 1,
+  ///       'label': 'First Menu Label',
+  ///       'enabled': true,
+  ///       'children': <Map<String, Object?>>[
+  ///         <String, Object?>{
+  ///           'id': 2,
+  ///           'label': 'Sub Menu Label',
+  ///           'enabled': true,
+  ///         },
+  ///       ],
+  ///     },
+  ///   ],
+  /// };
   /// ```
   ///
   /// The following incoming methods are defined for this channel (registered

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -398,24 +398,41 @@ class SystemChannels {
   /// The following outgoing method is defined for this channel (invoked using
   /// [OptionalMethodChannel.invokeMethod]):
   ///
-  ///  * `Menu.SetMenu`: sends the configuration of the platform menu, including
+  ///  * `Menu.setMenu`: sends the configuration of the platform menu, including
   ///    labels, enable/disable information, and unique integer identifiers for
   ///    each menu item. The configuration is sent as a `List<Map<String,
-  ///    dynamic>>` encoding the list of top level menu items, which each have a
-  ///    hierarchy of `Map<String, dynamic>` containing the required data, sent
-  ///    via a StandardMessageCodec. It is typically generated from a list of
-  ///    [MenuItem]s.
+  ///    Object?>>` encoding the list of top level menu items, which each have a
+  ///    hierarchy of `Map<String, Object?>` containing the required data, sent
+  ///    via a [StandardMessageCodec]. It is typically generated from a list of
+  ///    [MenuItem]s like this example:
+  ///
+  /// ```dart
+  /// List<Map<String, Object?>> menu = <Map<String, Object?>>[
+  ///   <String, Object?>{
+  ///     'id': 1,
+  ///     'label': 'First Menu Label',
+  ///     'enabled': true,
+  ///     'children': <Map<String, Object?>>[
+  ///       <String, Object?>{
+  ///         'id': 2,
+  ///         'label': 'Sub Menu Label',
+  ///         'enabled': true,
+  ///       },
+  ///     ]
+  ///   },
+  /// ];
+  /// ```
   ///
   /// The following incoming methods are defined for this channel (registered
   /// using [MethodChannel.setMethodCallHandler]).
   ///
-  ///  * `Menu.SelectedCallback`: Called when a menu item is selected, along
+  ///  * `Menu.selectedCallback`: Called when a menu item is selected, along
   ///    with the unique ID of the menu item selected.
   ///
-  ///  * `Menu.Opened`: Called when a submenu is opened, along with the unique
+  ///  * `Menu.opened`: Called when a submenu is opened, along with the unique
   ///    ID of the submenu.
   ///
-  ///  * `Menu.Closed`: Called when a submenu is closed, along with the unique
+  ///  * `Menu.closed`: Called when a submenu is closed, along with the unique
   ///    ID of the submenu.
   ///
   /// See also:

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -392,4 +392,34 @@ class SystemChannels {
     'flutter/localization',
     JSONMethodCodec(),
   );
+
+  /// A [MethodChannel] for platform menu specification and control.
+  ///
+  /// The following outgoing method is defined for this channel (invoked using
+  /// [OptionalMethodChannel.invokeMethod]):
+  ///
+  ///  * `Menu.SetMenu`: sends the configuration of the platform menu, including
+  ///    labels, enable/disable information, and unique integer identifiers for
+  ///    each menu item. The configuration is sent as a `List<Map<String,
+  ///    dynamic>>` encoding the list of top level menu items, which each have a
+  ///    hierarchy of `Map<String, dynamic>` containing the required data, sent
+  ///    via a StandardMessageCodec. It is typically generated from a list of
+  ///    [MenuItem]s.
+  ///
+  /// The following incoming methods are defined for this channel (registered
+  /// using [MethodChannel.setMethodCallHandler]).
+  ///
+  ///  * `Menu.SelectedCallback`: Called when a menu item is selected, along
+  ///    with the unique ID of the menu item selected.
+  ///
+  ///  * `Menu.Opened`: Called when a submenu is opened, along with the unique
+  ///    ID of the submenu.
+  ///
+  ///  * `Menu.Closed`: Called when a submenu is closed, along with the unique
+  ///    ID of the submenu.
+  ///
+  /// See also:
+  ///
+  ///  * [DefaultPlatformMenuDelegate], which uses this channel.
+  static const MethodChannel menu = OptionalMethodChannel('flutter/menu');
 }

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -16,6 +16,7 @@ import 'app.dart';
 import 'debug.dart';
 import 'focus_manager.dart';
 import 'framework.dart';
+import 'platform_menu_bar.dart';
 import 'router.dart';
 import 'widget_inspector.dart';
 
@@ -294,6 +295,7 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
       FlutterErrorDetails.propertiesTransformers.add(debugTransformDebugCreator);
       return true;
     }());
+    platformMenuDelegate = DefaultPlatformMenuDelegate();
   }
 
   /// The current [WidgetsBinding], if one has been created.
@@ -522,6 +524,13 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
   ///
   /// See [FocusManager] for more details.
   FocusManager get focusManager => _buildOwner!.focusManager;
+
+  /// A delegate that communicates with a platform plugin for serializing and
+  /// managing platform-rendered menu bars created by [PlatformMenuBar].
+  ///
+  /// This is set by default to a [DefaultPlatformMenuDelegate] instance in
+  /// [initInstances].
+  late PlatformMenuDelegate platformMenuDelegate;
 
   final List<WidgetsBindingObserver> _observers = <WidgetsBindingObserver>[];
 

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -299,7 +299,7 @@ class DefaultPlatformMenuDelegate extends PlatformMenuDelegate {
 /// the box, but support for other platforms may be provided via plugins that
 /// set [WidgetsBinding.platformMenuDelegate] in their initialization.
 ///
-/// The [children] member contains [MenuItem]s. They will not be part of the
+/// The [menus] member contains [MenuItem]s. They will not be part of the
 /// widget tree, since they are not required to be widgets (even if they happen
 /// to be widgets that implement [MenuItem], they still won't be part of the
 /// widget tree). They are provided to configure the properties of the menus on
@@ -328,11 +328,11 @@ class DefaultPlatformMenuDelegate extends PlatformMenuDelegate {
 class PlatformMenuBar extends StatefulWidget with DiagnosticableTreeMixin {
   /// Creates a const [PlatformMenuBar].
   ///
-  /// The [body] and [children] attributes are required.
+  /// The [body] and [menus] attributes are required.
   const PlatformMenuBar({
     Key? key,
     required this.body,
-    required this.children,
+    required this.menus,
   }) : super(key: key);
 
   /// The widget to be rendered in the Flutter window that these platform menus
@@ -344,23 +344,23 @@ class PlatformMenuBar extends StatefulWidget with DiagnosticableTreeMixin {
   /// The list of menu items that are the top level children of the
   /// [PlatformMenuBar].
   ///
-  /// The `children` member contains [MenuItem]s. They will not be part
+  /// The `menus` member contains [MenuItem]s. They will not be part
   /// of the widget tree, since they are not widgets. They are provided to
   /// configure the properties of the menus on the platform menu bar.
   ///
   /// Also, a Widget in Flutter is immutable, so directly modifying the
-  /// `children` with `List` APIs such as
-  /// `somePlatformMenuBarWidget.children.add(...)` will result in incorrect
-  /// behaviors. Whenever the children list is modified, a new list object
+  /// `menus` with `List` APIs such as
+  /// `somePlatformMenuBarWidget.menus.add(...)` will result in incorrect
+  /// behaviors. Whenever the menus list is modified, a new list object
   /// should be provided.
-  final List<MenuItem> children;
+  final List<MenuItem> menus;
 
   @override
   State<PlatformMenuBar> createState() => _PlatformMenuBarState();
 
   @override
   List<DiagnosticsNode> debugDescribeChildren() {
-    return children.map<DiagnosticsNode>((MenuItem child) => child.toDiagnosticsNode()).toList();
+    return menus.map<DiagnosticsNode>((MenuItem child) => child.toDiagnosticsNode()).toList();
   }
 }
 
@@ -390,7 +390,7 @@ class _PlatformMenuBarState extends State<PlatformMenuBar> {
   void didUpdateWidget(PlatformMenuBar oldWidget) {
     super.didUpdateWidget(oldWidget);
     final List<MenuItem> newDescendants = <MenuItem>[
-      for (final MenuItem item in widget.children) ...<MenuItem>[
+      for (final MenuItem item in widget.menus) ...<MenuItem>[
         item,
         ...item.descendants,
       ],
@@ -404,7 +404,7 @@ class _PlatformMenuBarState extends State<PlatformMenuBar> {
   // Updates the data structures for the menu and send them to the platform
   // plugin.
   void _updateMenu() {
-    WidgetsBinding.instance.platformMenuDelegate.setMenus(widget.children);
+    WidgetsBinding.instance.platformMenuDelegate.setMenus(widget.menus);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -727,7 +727,7 @@ class PlatformProvidedMenuItem extends PlatformMenuItem with DefaultPlatformMenu
           PlatformProvidedMenuItemType.toggleFullScreen,
           PlatformProvidedMenuItemType.minimizeWindow,
           PlatformProvidedMenuItemType.zoomWindow,
-          PlatformProvidedMenuItemType.arrangeWindowInFront,
+          PlatformProvidedMenuItemType.arrangeWindowsInFront,
         }.contains(menu);
     }
   }
@@ -882,5 +882,5 @@ enum PlatformProvidedMenuItemType {
   /// On macOS, this is the `arrangeInFront` default menu.
   ///
   /// This default menu is currently only supported on macOS.
-  arrangeWindowInFront,
+  arrangeWindowsInFront,
 }

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -236,6 +236,8 @@ class DefaultPlatformMenuDelegate extends PlatformMenuDelegate {
   @override
   bool debugLockDelegate(BuildContext context) {
     assert(() {
+      // It's OK to lock if the lock isn't set, but not OK if a different
+      // context is locking it.
       if (_lockedContext != null && _lockedContext != context) {
         return false;
       }
@@ -248,7 +250,9 @@ class DefaultPlatformMenuDelegate extends PlatformMenuDelegate {
   @override
   bool debugUnlockDelegate(BuildContext context) {
     assert(() {
-      if (_lockedContext == context) {
+      // It's OK to unlock if the lock isn't set, but not OK if a different
+      // context is unlocking it.
+      if (_lockedContext != null && _lockedContext != context) {
         return false;
       }
       _lockedContext = null;

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -112,7 +112,7 @@ abstract class MenuItem with Diagnosticable {
   /// generates a unique ID for each menu item, which is to be returned in the
   /// "id" field of the menu item data.
   Iterable<Map<String, Object?>> toChannelRepresentation(
-    DefaultPlatformMenuDelegate delegate, {
+    PlatformMenuDelegate delegate, {
     required int index,
     required int count,
     required MenuItemSerializableIdGenerator getId,
@@ -236,7 +236,7 @@ abstract class PlatformMenuDelegate {
 }
 
 /// The signature for a function that generates unique menu item IDs for
-/// serialization of a [DefaultPlatformMenuDelegateSerializable].
+/// serialization of a [MenuItem].
 typedef MenuItemSerializableIdGenerator = int Function(MenuItem item);
 
 /// The platform menu delegate that handles the built-in macOS platform menu
@@ -538,7 +538,7 @@ class PlatformMenu extends MenuItem with DiagnosticableTreeMixin {
 
   @override
   Iterable<Map<String, Object?>> toChannelRepresentation(
-    DefaultPlatformMenuDelegate delegate, {
+    PlatformMenuDelegate delegate, {
     required int index,
     required int count,
     required MenuItemSerializableIdGenerator getId,
@@ -553,7 +553,7 @@ class PlatformMenu extends MenuItem with DiagnosticableTreeMixin {
   /// this implementation.
   static Map<String, Object?> serialize(
     PlatformMenu item,
-    DefaultPlatformMenuDelegate delegate,
+    PlatformMenuDelegate delegate,
     MenuItemSerializableIdGenerator getId,
   ) {
     final List<Map<String, Object?>> result = <Map<String, Object?>>[];
@@ -606,7 +606,7 @@ class PlatformMenuItemGroup extends MenuItem {
 
   @override
   Iterable<Map<String, Object?>> toChannelRepresentation(
-    DefaultPlatformMenuDelegate delegate, {
+    PlatformMenuDelegate delegate, {
     required int index,
     required int count,
     required MenuItemSerializableIdGenerator getId,
@@ -680,7 +680,7 @@ class PlatformMenuItem extends MenuItem {
 
   @override
   Iterable<Map<String, Object?>> toChannelRepresentation(
-    DefaultPlatformMenuDelegate delegate, {
+    PlatformMenuDelegate delegate, {
     required int index,
     required int count,
     required MenuItemSerializableIdGenerator getId,
@@ -695,7 +695,7 @@ class PlatformMenuItem extends MenuItem {
   /// this implementation.
   static Map<String, Object?> serialize(
     PlatformMenuItem item,
-    DefaultPlatformMenuDelegate delegate,
+    PlatformMenuDelegate delegate,
     MenuItemSerializableIdGenerator getId,
   ) {
     final MenuSerializableShortcut? shortcut = item.shortcut;
@@ -792,7 +792,7 @@ class PlatformProvidedMenuItem extends PlatformMenuItem {
 
   @override
   Iterable<Map<String, Object?>> toChannelRepresentation(
-    DefaultPlatformMenuDelegate delegate, {
+    PlatformMenuDelegate delegate, {
     required int index,
     required int count,
     required MenuItemSerializableIdGenerator getId,

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -1,0 +1,829 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+
+import 'binding.dart';
+import 'framework.dart';
+import 'shortcuts.dart';
+
+// "flutter/menu" Method channel methods.
+const String _kMenuSetMethod = 'Menu.SetMenu';
+const String _kMenuSelectedCallbackMethod = 'Menu.SelectedCallback';
+const String _kMenuItemOpenedMethod = 'Menu.Opened';
+const String _kMenuItemClosedMethod = 'Menu.Closed';
+
+// Keys for channel communication map.
+const String _kIdKey = 'id';
+const String _kLabelKey = 'label';
+const String _kEnabledKey = 'enabled';
+const String _kChildrenKey = 'children';
+const String _kIsDividerKey = 'isDivider';
+const String _kPlatformDefaultMenuKey = 'platformProvidedMenu';
+const String _kShortcutTriggerKey = 'shortcutTrigger';
+const String _kShortcutModifiersKey = 'shortcutModifiers';
+
+// Bit masks for modifier keys sent in channel communication.
+const int _kFlutterShortcutModifierMeta = 1 << 0;
+const int _kFlutterShortcutModifierShift = 1 << 1;
+const int _kFlutterShortcutModifierAlt = 1 << 2;
+const int _kFlutterShortcutModifierControl = 1 << 3;
+
+/// An abstract class for describing cascading menu hierarchies that are part of
+/// a [PlatformMenuBar].
+///
+/// This type is used by the [PlatformMenuDelegate.setMenus] to accept the menu
+/// hierarchy to be sent to the platform, and by [PlatformMenuBar] to define the
+/// menu hierarchy.
+///
+/// See also:
+///
+///  * [PlatformMenuBar], a widget that renders menu items using
+///    platform APIs instead of Flutter.
+abstract class MenuItem with Diagnosticable {
+  /// Allows subclasses to have const constructors.
+  const MenuItem();
+}
+
+/// An abstract delegate class that can be used to set
+/// [WidgetsBinding.platformMenuDelegate] to provide for managing platform
+/// menus.
+///
+/// This can be subclassed to provide a different menu plugin than the default
+/// system-provided plugin for managing [PlatformMenuBar] menus.
+///
+/// The [setMenus] method allows for setting of the menu hierarchy when the
+/// [PlatformMenuBar] menu hierarchy changes.
+///
+/// This delegate doesn't handle the results of clicking on a menu item, which
+/// is left to the implementor of subclasses of `PlatformMenuDelegate` to
+/// handle for their implementation.
+///
+/// This delegate typically knows how to serialize a [PlatformSubMenu]
+/// hierarchy, send it over a channel, and register for calls from the channel
+/// when a menu is invoked or a submenu is opened or closed.
+///
+/// See [DefaultPlatformMenuDelegate] for an example of implementing one of
+/// these.
+///
+/// See also:
+///
+///  * [PlatformMenuBar], the widget that adds a platform menu bar to an
+///    application.
+///  * [PlatformSubMenu], the class that describes a menu item with children
+///    that appear in a cascading menu.
+///  * [PlatformMenuBarItem], the class that describes the leaves of a menu
+///    hierarchy.
+abstract class PlatformMenuDelegate {
+  /// A const constructor so that subclasses can have const constructors.
+  const PlatformMenuDelegate();
+
+  /// Sets the entire menu hierarchy for a platform-rendered menu bar.
+  ///
+  /// `topLevelMenus` is the list of menus that appear in the menu bar, which
+  /// themselves can have children.
+  ///
+  /// See also:
+  ///
+  ///  * [PlatformMenuBar], the widget that adds a platform menu bar to an
+  ///    application.
+  ///  * [PlatformSubMenu], the class that describes a menu item with children
+  ///    that appear in a cascading menu.
+  ///  * [PlatformMenuBarItem], the class that describes the leaves of a menu
+  ///    hierarchy.
+  void setMenus(List<MenuItem> topLevelMenus);
+
+  /// Clears any existing platform-rendered menus.
+  void clearMenus();
+
+  /// This is called by [PlatformMenuBar] when it is initialized, to be sure that
+  /// only one is active at a time.
+  ///
+  /// If your implementation of a [PlatformMenuDelegate] can have only limited
+  /// active instances, enforce it when you override this.
+  ///
+  /// See also:
+  ///
+  ///  * [unlock], where the delegate is unlocked.
+  void lock(BuildContext context);
+
+  /// This is called by [PlatformMenuBar] when it is disposed, so that another
+  /// one can take over.
+  ///
+  /// See also:
+  ///
+  ///  * [lock], where the delegate is locked.
+  void unlock(BuildContext context);
+}
+
+/// A mixin for doing serialization of [MenuItem] objects.
+///
+/// This is used by the [DefaultPlatformMenuDelegate] to serialize menu
+/// hierarchies for sending to the platform for rendering.
+mixin DefaultPlatformMenuDelegateSerializer {
+  /// Converts the representation of this item into a map suitable for sending
+  /// over the default "flutter/menu" channel used by
+  /// [DefaultPlatformMenuDelegate].
+  Map<String, Object?> toChannelRepresentation(DefaultPlatformMenuDelegate delegate);
+}
+
+/// The platform menu delegate that handles the built-in macOS platform menu
+/// generation using the 'flutter/menu' channel.
+///
+/// An instance of this class is set on [WidgetsBinding.platformMenuDelegate] by
+/// default when the [WidgetsBinding] is initialized.
+///
+/// See also:
+///
+///  * [PlatformMenuBar], the widget that adds a platform menu bar to an
+///    application.
+///  * [PlatformSubMenu], the class that describes a menu item with children
+///    that appear in a cascading menu.
+///  * [PlatformMenuBarItem], the class that describes the leaves of a menu
+///    hierarchy.
+class DefaultPlatformMenuDelegate extends PlatformMenuDelegate {
+  /// Creates a const [DefaultPlatformMenuDelegate].
+  DefaultPlatformMenuDelegate({MethodChannel? channel})
+      : channel = channel ?? SystemChannels.menu,
+        _idMap = <int, MenuItem>{} {
+    this.channel.setMethodCallHandler(_methodCallHandler);
+  }
+
+  // Map of distributed IDs to menu items.
+  final Map<int, MenuItem> _idMap;
+  // An ever increasing value used to dole out IDs.
+  int _serial = 0;
+
+  @override
+  void clearMenus() => setMenus(<MenuItem>[]);
+
+  @override
+  void setMenus(List<MenuItem> topLevelMenus) {
+    _idMap.clear();
+    List<Map<String, Object?>> representation;
+    if (topLevelMenus.isNotEmpty) {
+      representation = _expandGroups(topLevelMenus);
+    } else {
+      representation = const <Map<String, Object?>>[];
+    }
+    channel.invokeMethod<void>(_kMenuSetMethod, representation);
+  }
+
+  /// Sets the channel that the [DefaultPlatformMenuDelegate] uses to
+  /// communicate with the platform.
+  ///
+  /// Clears any menus in the old channel before setting the new channel, and in
+  /// the new channel.
+  ///
+  /// If the channel is the same as the one already set, nothing is cleared.
+  final MethodChannel channel;
+
+  /// Get the next serialization ID.
+  ///
+  /// This is called by each [DefaultPlatformMenuDelegateSerializer] when
+  /// serializing a new object so that it has a unique ID.
+  int getId(MenuItem item) {
+    _serial += 1;
+    _idMap[_serial] = item;
+    return _serial;
+  }
+
+  /// Expands groups in a menu to include any necessary dividers, flattening all
+  /// of the PlatformMenuItemGroups in the process.
+  ///
+  /// Called by each [DefaultPlatformMenuDelegateSerializer] when
+  List<Map<String, Object?>> _expandGroups(List<MenuItem> children) {
+    final List<Map<String, Object?>> expanded = <Map<String, Object?>>[];
+    bool lastWasGroup = false;
+    for (final MenuItem item in children) {
+      if (lastWasGroup) {
+        expanded.add(<String, Object?>{
+          _kIdKey: getId(item),
+          _kIsDividerKey: true,
+        });
+      }
+      if (item is PlatformMenuItemGroup) {
+        expanded.addAll(
+          item.members.map<Map<String, Object?>>(
+            (MenuItem item) {
+              if (item is DefaultPlatformMenuDelegateSerializer) {
+                return (item as DefaultPlatformMenuDelegateSerializer).toChannelRepresentation(this);
+              } else {
+                throw UnimplementedError(
+                    'Tried to serialize a menu item that was not a DefaultPlatformMenuDelegateSerializer');
+              }
+            },
+          ),
+        );
+        lastWasGroup = true;
+      } else {
+        if (item is DefaultPlatformMenuDelegateSerializer) {
+          expanded.add((item as DefaultPlatformMenuDelegateSerializer).toChannelRepresentation(this));
+        } else {
+          throw UnimplementedError(
+              'Tried to serialize a menu item that was not a DefaultPlatformMenuDelegateSerializer');
+        }
+        lastWasGroup = false;
+      }
+    }
+    return expanded;
+  }
+
+  /// This is called by [PlatformMenuBar] when it is initialized, to be sure that
+  /// only one is active at a time.
+  ///
+  /// Takes the [BuildContext] of the [PlatformMenuBar] that is locking this
+  /// delegate.
+  ///
+  /// Only one instance of [PlatformMenuBar] can be using the
+  /// [DefaultPlatformMenuDelegate] at a time, so this function will assert if
+  /// more than one attempts to lock at the same time.
+  ///
+  /// See also:
+  ///
+  ///  * [unlock], where the delegate is unlocked.
+  @override
+  void lock(BuildContext context) {
+    assert(
+        _lockedContext == null || _lockedContext == context,
+        'More than one active $PlatformMenuBar detected. Only one active '
+        'platform-rendered menu bar is allowed at a time.');
+    _lockedContext = context;
+  }
+
+  /// This is called by [PlatformMenuBar] when it is disposed, so that another
+  /// menu bar can take over.
+  ///
+  /// Takes the [BuildContext] of the [PlatformMenuBar] that is unlocking this
+  /// delegate.
+  ///
+  /// See also:
+  ///
+  ///  * [lock], where the delegate is locked.
+  @override
+  void unlock(BuildContext context) {
+    assert(_lockedContext == context, 'tried to unlock the $DefaultPlatformMenuDelegate more than once.');
+    _lockedContext = null;
+    // Clear all the platform menus on an unlock.
+    clearMenus();
+  }
+
+  BuildContext? _lockedContext;
+
+  // Handles the method calls from the plugin to forward to selection and
+  // open/close callbacks.
+  Future<Object?> _methodCallHandler(MethodCall call) {
+    final int id = call.arguments as int;
+    assert(_idMap.containsKey(id),
+        'Received a menu ${call.method} for a menu item with an ID that was not recognized: $id');
+    if (!_idMap.containsKey(id)) {
+      return Future<void>.value();
+    }
+    final MenuItem item = _idMap[id]!;
+    if (item is PlatformMenuBarItem && call.method == _kMenuSelectedCallbackMethod) {
+      item.onSelected?.call();
+    } else if (item is PlatformSubMenu && call.method == _kMenuItemOpenedMethod) {
+      item.onOpen?.call();
+    } else if (item is PlatformSubMenu && call.method == _kMenuItemClosedMethod) {
+      item.onClose?.call();
+    }
+    return Future<void>.value();
+  }
+}
+
+/// A menu bar that uses the platform's native APIs to construct and render a
+/// menu described by a [PlatformSubMenu]/[PlatformMenuBarItem] hierarchy.
+///
+/// This widget is especially useful on macOS, where a system menu is a required
+/// part of every application. Flutter only includes support for macOS out of
+/// the box, but support for other platforms may be provided via plugins that
+/// set [WidgetsBinding.platformMenuDelegate] in their initialization.
+///
+/// The [children] member contains [MenuItem]s. They will not be part of the
+/// widget tree, since they are not required to be widgets (even if they happen
+/// to be widgets that implement [MenuItem], they still won't be part of the
+/// widget tree). They are provided to configure the properties of the menus on
+/// the platform menu bar.
+///
+/// As far as Flutter is concerned, this widget has no visual representation,
+/// and intercepts no events: it just returns the [body] from its build
+/// function. This is because all of the rendering, shortcuts, and event
+/// handling for the menu is handled by the plugin on the host platform.
+///
+/// There can only be one [PlatformMenuBar] at a time using the same
+/// [PlatformMenuDelegate]. It will assert if more than one is detected.
+///
+/// {@tool sample}
+/// This example shows a [PlatformMenuBar] that contains a single top level
+/// menu, containing three items for "About", a toggleable menu item for showing
+/// a message, a cascading submenu with message choices, and "Quit".
+///
+/// **This example will only work on macOS.**
+///
+/// ** See code in examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart **
+/// {@end-tool}
+class PlatformMenuBar extends StatefulWidget with DiagnosticableTreeMixin {
+  /// Creates a const [PlatformMenuBar].
+  ///
+  /// The [body] and [children] attributes are required.
+  const PlatformMenuBar({
+    Key? key,
+    required this.body,
+    required this.children,
+  }) : super(key: key);
+
+  /// The widget to be rendered in the Flutter window that these platform menus
+  /// are associated with.
+  ///
+  /// This is typically the body of the application's UI.
+  final Widget body;
+
+  /// The list of menu items that are the top level children of the
+  /// [PlatformMenuBar].
+  ///
+  /// The `children` member contains [MenuItem]s. They will not be part
+  /// of the widget tree, since they are not widgets. They are provided to
+  /// configure the properties of the menus on the platform menu bar.
+  final List<MenuItem> children;
+
+  @override
+  State<PlatformMenuBar> createState() => _PlatformMenuBarState();
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return children.map<DiagnosticsNode>((MenuItem child) => child.toDiagnosticsNode()).toList();
+  }
+}
+
+class _PlatformMenuBarState extends State<PlatformMenuBar> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.platformMenuDelegate.lock(context);
+    _updateMenu();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.platformMenuDelegate.unlock(context);
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(PlatformMenuBar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final List<MenuItem> newDescendants = <MenuItem>[
+      for (final MenuItem item in widget.children) ...<MenuItem>[
+        item,
+        if (item is PlatformSubMenu) ...item.descendants,
+      ],
+    ];
+    final List<MenuItem> oldDescendants = <MenuItem>[
+      for (final MenuItem item in oldWidget.children) ...<MenuItem>[
+        item,
+        if (item is PlatformSubMenu) ...item.descendants,
+      ],
+    ];
+    if (!listEquals(newDescendants, oldDescendants)) {
+      _updateMenu();
+    }
+  }
+
+  // Updates the data structures for the menu and send them to the platform
+  // plugin.
+  void _updateMenu() {
+    WidgetsBinding.instance.platformMenuDelegate.setMenus(widget.children);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // PlatformMenuBar is really about managing the platform menu bar, and
+    // doesn't do any rendering or event handling in Flutter.
+    return widget.body;
+  }
+}
+
+/// An class for representing menu items that have child submenus.
+///
+/// See also:
+///
+///  * [PlatformMenuBarItem], a class representing a leaf menu item in a
+///    [PlatformMenuBar].
+class PlatformSubMenu extends MenuItem with DiagnosticableTreeMixin, DefaultPlatformMenuDelegateSerializer {
+  /// Creates a const [PlatformSubMenu].
+  ///
+  /// The [label] and [children] fields are required.
+  const PlatformSubMenu({
+    required this.label,
+    this.enabled = true,
+    this.onOpen,
+    this.onClose,
+    required this.children,
+  });
+
+  /// The label used by default for rendering the menu item, and for
+  /// accessibility labeling.
+  final String label;
+
+  /// Whether or not this submenu is enabled.
+  ///
+  /// If the submenu is disabled, then it can't be opened.
+  final bool enabled;
+
+  /// The callback that is called when this submenu is opened.
+  final VoidCallback? onOpen;
+
+  /// The callback that is called when this submenu is closed.
+  final VoidCallback? onClose;
+
+  /// The child menus of this menu item.
+  ///
+  /// If empty, this menu item will be show as if [enabled] were false.
+  final List<MenuItem> children;
+
+  /// Returns all descendant [MenuItem]s of this item.
+  List<MenuItem> get descendants => getDescendants(this);
+
+  /// Returns all descendants of the given item.
+  ///
+  /// This API is supplied so that implementers of [PlatformSubMenu] can share
+  /// this implementation.
+  static List<MenuItem> getDescendants(PlatformSubMenu item) {
+    return <MenuItem>[
+      for (final MenuItem child in item.children) ...<MenuItem>[
+        child,
+        if (child is PlatformSubMenu) ...child.descendants,
+      ],
+    ];
+  }
+
+  @override
+  Map<String, Object?> toChannelRepresentation(DefaultPlatformMenuDelegate delegate) {
+    return serialize(this, delegate);
+  }
+
+  /// Converts the supplied object to the correct channel representation for the
+  /// 'flutter/menu' channel.
+  ///
+  /// This API is supplied so that implementers of [PlatformSubMenu] can share
+  /// this implementation.
+  static Map<String, Object?> serialize(
+    PlatformSubMenu item,
+    DefaultPlatformMenuDelegate delegate,
+  ) {
+    return <String, Object?>{
+      _kIdKey: delegate.getId(item),
+      _kLabelKey: item.label,
+      _kEnabledKey: item.enabled,
+      _kChildrenKey: delegate._expandGroups(item.children),
+    };
+  }
+
+  @override
+  List<DiagnosticsNode> debugDescribeChildren() {
+    return children.map<DiagnosticsNode>((MenuItem child) => child.toDiagnosticsNode()).toList();
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('label', label));
+    properties.add(FlagProperty('enabled', value: enabled, ifFalse: 'DISABLED'));
+  }
+}
+
+/// An interface for [MenuItem]s that group other menu items into sections
+/// delineated by dividers.
+///
+/// Visual dividers will be added before and after this group if other menu
+/// items appear in the submenu.
+class PlatformMenuItemGroup extends MenuItem with DefaultPlatformMenuDelegateSerializer {
+  /// Creates a const [PlatformMenuItemGroup].
+  ///
+  /// The [members] field is required.
+  const PlatformMenuItemGroup({required this.members});
+
+  /// The [MenuItem]s that are members of this menu item group.
+  ///
+  /// If empty, this menu item will be disabled.
+  final List<MenuItem> members;
+
+  @override
+  Map<String, Object?> toChannelRepresentation(DefaultPlatformMenuDelegate delegate) {
+    // This method shouldn't get called, since delegate.expandGroups should skip it.
+    throw UnimplementedError('Unexpected call of toChannelRepresentation for PlatformMenuItemGroup');
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(IterableProperty<MenuItem>('members', members));
+  }
+}
+
+/// An interface for [MenuItem]s that do not have submenus, but can be
+/// activated.
+///
+/// These [MenuItem]s are the leaves of the menu item tree, and can be activated
+/// by clicking on them, or via an optional keyboard [shortcut].
+class PlatformMenuBarItem extends MenuItem with DefaultPlatformMenuDelegateSerializer {
+  /// Creates a const [PlatformMenuBarItem].
+  ///
+  /// The [label] attribute is required.
+  const PlatformMenuBarItem({
+    required this.label,
+    this.shortcut,
+    this.onSelected,
+  });
+
+  /// The required label used by default for rendering the menu item, and for
+  /// accessibility labeling.
+  final String label;
+
+  /// The optional shortcut that activates this [PlatformMenuBarItem].
+  final ShortcutActivator? shortcut;
+
+  /// An optional callback that is called when this [PlatformMenuBarItem] is
+  /// activated.
+  ///
+  /// If unset, this menu item will be disabled.
+  final VoidCallback? onSelected;
+
+  @override
+  Map<String, Object?> toChannelRepresentation(DefaultPlatformMenuDelegate delegate) {
+    return PlatformMenuBarItem.serialize(this, delegate);
+  }
+
+  /// Converts the given [PlatformMenuBarItem] into a data structure accepted by
+  /// the 'flutter/menu' method channel method 'Menu.SetMenu'.
+  ///
+  /// This API is supplied so that implementers of [PlatformMenuBarItem] can share
+  /// this implementation.
+  static Map<String, Object?> serialize(PlatformMenuBarItem item, DefaultPlatformMenuDelegate delegate) {
+    int modifiers = 0;
+    int? logicalKeyId;
+    final ShortcutActivator? shortcut = item.shortcut;
+    if (item.shortcut != null && shortcut is SingleActivator) {
+      if (shortcut.shift) {
+        modifiers |= _kFlutterShortcutModifierShift;
+      }
+      if (shortcut.alt) {
+        modifiers |= _kFlutterShortcutModifierAlt;
+      }
+      if (shortcut.meta) {
+        modifiers |= _kFlutterShortcutModifierMeta;
+      }
+      if (shortcut.control) {
+        modifiers |= _kFlutterShortcutModifierControl;
+      }
+      logicalKeyId = shortcut.trigger.keyId;
+    }
+    return <String, Object?>{
+      _kIdKey: delegate.getId(item),
+      _kLabelKey: item.label,
+      _kEnabledKey: item.onSelected != null,
+      if (shortcut != null) _kShortcutTriggerKey: logicalKeyId,
+      if (shortcut != null) _kShortcutModifiersKey: modifiers,
+    };
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(StringProperty('label', label));
+    properties.add(DiagnosticsProperty<ShortcutActivator?>('shortcut', shortcut, defaultValue: null));
+    properties.add(FlagProperty('enabled', value: onSelected != null, ifFalse: 'DISABLED'));
+  }
+}
+
+/// A widget that represents a menu item that is preconfigured for the given
+/// platform.
+///
+/// This is used to add things like the "About" and "Quit" menu items to a
+/// platform menu.
+///
+/// The [type] enum determines which type of platform defined menu will be
+/// added.
+///
+/// This is most useful on a macOS platform where there are many different types
+/// of platform provided menu items in the standard menu setup.
+///
+/// In order to know if a [PlatformProvidedMenuItem] is available on a
+/// particular platform, call [PlatformProvidedMenuItem.hasMenu].
+///
+/// If the platform does not support the given [type], then the menu item will
+/// throw an [ArgumentError].
+///
+/// See also:
+///
+///  * [PlatformMenuBar] which takes these items for inclusion in a
+///    platform-rendered menu bar.
+class PlatformProvidedMenuItem extends PlatformMenuBarItem with DefaultPlatformMenuDelegateSerializer {
+  /// Creates a const [PlatformProvidedMenuItem] of the appropriate type. Throws if the
+  /// platform doesn't support the given default menu type.
+  ///
+  /// The [type] argument is required.
+  const PlatformProvidedMenuItem({
+    required this.type,
+    this.enabled = true,
+  }) : super(
+          label: '', // The label is ignored for standard menus.
+        );
+
+  /// The type of default menu this is.
+  ///
+  /// See [PlatformProvidedMenuItemType] for the different types available.  Not
+  /// all of the types will be available on every platform. Use [hasMenu] to
+  /// determine if the current platform has a given default menu item.
+  ///
+  /// If the platform does not support the given [type], then the menu item will
+  /// throw an [ArgumentError].
+  final PlatformProvidedMenuItemType type;
+
+  /// True if this [PlatformProvidedMenuItem] should be enabled or not.
+  final bool enabled;
+
+  /// Checks to see if the given default menu type is supported on this
+  /// platform.
+  static bool hasMenu(PlatformProvidedMenuItemType menu) {
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+      case TargetPlatform.fuchsia:
+        return false;
+      case TargetPlatform.linux:
+        return const <PlatformProvidedMenuItemType>{
+          PlatformProvidedMenuItemType.about,
+          PlatformProvidedMenuItemType.quit,
+        }.contains(menu);
+      case TargetPlatform.macOS:
+        return const <PlatformProvidedMenuItemType>{
+          PlatformProvidedMenuItemType.about,
+          PlatformProvidedMenuItemType.quit,
+          PlatformProvidedMenuItemType.servicesSubmenu,
+          PlatformProvidedMenuItemType.hide,
+          PlatformProvidedMenuItemType.hideOtherApplications,
+          PlatformProvidedMenuItemType.showAllApplications,
+          PlatformProvidedMenuItemType.startSpeaking,
+          PlatformProvidedMenuItemType.stopSpeaking,
+          PlatformProvidedMenuItemType.toggleFullScreen,
+          PlatformProvidedMenuItemType.minimizeWindow,
+          PlatformProvidedMenuItemType.zoomWindow,
+          PlatformProvidedMenuItemType.arrangeWindowInFront,
+        }.contains(menu);
+      case TargetPlatform.windows:
+        return const <PlatformProvidedMenuItemType>{
+          PlatformProvidedMenuItemType.about,
+          PlatformProvidedMenuItemType.quit,
+        }.contains(menu);
+    }
+  }
+
+  @override
+  Map<String, Object?> toChannelRepresentation(DefaultPlatformMenuDelegate delegate) {
+    if (!hasMenu(type)) {
+      throw ArgumentError(
+        'Platform ${defaultTargetPlatform.name} has no standard menu for '
+        '$type. Call StandardMenuItem.hasMenu to determine this before '
+        'instantiating one.',
+      );
+    }
+
+    return <String, Object?>{
+      _kIdKey: delegate.getId(this),
+      _kEnabledKey: enabled,
+      _kPlatformDefaultMenuKey: type.index,
+    };
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(FlagProperty('enabled', value: enabled, ifFalse: 'DISABLED'));
+  }
+}
+
+/// The list of possible standard, prebuilt menus for use in a [PlatformMenuBar].
+///
+/// These are menus that the platform typically provides that cannot be
+/// reproduced in Flutter without calling platform functions, but are standard
+/// on the platform.
+///
+/// Examples include things like the "Quit" or "Services" menu items on macOS.
+/// Not all platforms support all menu item types. Use
+/// [PlatformProvidedMenuItem.hasMenu] to know if a particular type is supported
+/// on a the current platform.
+///
+/// Add these to your [PlatformMenuBar] using the [PlatformProvidedMenuItem]
+/// class.
+///
+/// You can tell if the platform supports the given standard menu using the
+/// [PlatformProvidedMenuItem.hasMenu] method.
+// Must be kept in sync with the plugin code's enum of the same name.
+enum PlatformProvidedMenuItemType {
+  /// The system provided "About" menu item.
+  ///
+  /// On macOS, this is the `orderFrontStandardAboutPanel` default menu.
+  about,
+
+  /// The system provided "Quit" menu item.
+  ///
+  /// On macOS, this is the `terminate` default menu.
+  ///
+  /// This menu item will simply exit the application when activated.
+  quit,
+
+  /// The system provided "Services" submenu.
+  ///
+  /// This submenu provides a list of system provided application services.
+  ///
+  /// This default menu is only supported on macOS.
+  servicesSubmenu,
+
+  /// The system provided "Hide" menu item.
+  ///
+  /// This menu item hides the application window.
+  ///
+  /// On macOS, this is the `hide` default menu.
+  ///
+  /// This default menu is only supported on macOS.
+  hide,
+
+  /// The system provided "Hide Others" menu item.
+  ///
+  /// This menu item hides other application windows.
+  ///
+  /// On macOS, this is the `hideOtherApplications` default menu.
+  ///
+  /// This default menu is only supported on macOS.
+  hideOtherApplications,
+
+  /// The system provided "Show All" menu item.
+  ///
+  /// This menu item shows all hidden application windows.
+  ///
+  /// On macOS, this is the `unhideAllApplications` default menu.
+  ///
+  /// This default menu is only supported on macOS.
+  showAllApplications,
+
+  /// The system provided "Start Dictation..." menu item.
+  ///
+  /// This menu item tells the system to start the screen reader.
+  ///
+  /// On macOS, this is the `startSpeaking` default menu.
+  ///
+  /// This default menu is currently only supported on macOS.
+  startSpeaking,
+
+  /// The system provided "Stop Dictation..." menu item.
+  ///
+  /// This menu item tells the system to stop the screen reader.
+  ///
+  /// On macOS, this is the `stopSpeaking` default menu.
+  ///
+  /// This default menu is currently only supported on macOS.
+  stopSpeaking,
+
+  /// The system provided "Enter Full Screen" menu item.
+  ///
+  /// This menu item tells the system to toggle full screen mode for the window.
+  ///
+  /// On macOS, this is the `toggleFullScreen` default menu.
+  ///
+  /// This default menu is currently only supported on macOS.
+  toggleFullScreen,
+
+  /// The system provided "Minimize" menu item.
+  ///
+  /// This menu item tells the system to minimize the window.
+  ///
+  /// On macOS, this is the `performMiniaturize` default menu.
+  ///
+  /// This default menu is currently only supported on macOS.
+  minimizeWindow,
+
+  /// The system provided "Zoom" menu item.
+  ///
+  /// This menu item tells the system to expand the window size.
+  ///
+  /// On macOS, this is the `performZoom` default menu.
+  ///
+  /// This default menu is currently only supported on macOS.
+  zoomWindow,
+
+  /// The system provided "Bring To Front" menu item.
+  ///
+  /// This menu item tells the system to stack the window above other windows.
+  ///
+  /// On macOS, this is the `arrangeInFront` default menu.
+  ///
+  /// This default menu is currently only supported on macOS.
+  arrangeWindowInFront,
+}

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -694,7 +694,7 @@ class PlatformProvidedMenuItem extends PlatformMenuItem with DefaultPlatformMenu
   /// determine if the current platform has a given default menu item.
   ///
   /// If the platform does not support the given [type], then the menu item will
-  /// throw an [ArgumentError].
+  /// throw an [ArgumentError] in debug mode.
   final PlatformProvidedMenuItemType type;
 
   /// True if this [PlatformProvidedMenuItem] should be enabled or not.
@@ -707,12 +707,9 @@ class PlatformProvidedMenuItem extends PlatformMenuItem with DefaultPlatformMenu
       case TargetPlatform.android:
       case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
-        return false;
       case TargetPlatform.linux:
-        return const <PlatformProvidedMenuItemType>{
-          PlatformProvidedMenuItemType.about,
-          PlatformProvidedMenuItemType.quit,
-        }.contains(menu);
+      case TargetPlatform.windows:
+        return false;
       case TargetPlatform.macOS:
         return const <PlatformProvidedMenuItemType>{
           PlatformProvidedMenuItemType.about,
@@ -728,11 +725,6 @@ class PlatformProvidedMenuItem extends PlatformMenuItem with DefaultPlatformMenu
           PlatformProvidedMenuItemType.zoomWindow,
           PlatformProvidedMenuItemType.arrangeWindowInFront,
         }.contains(menu);
-      case TargetPlatform.windows:
-        return const <PlatformProvidedMenuItemType>{
-          PlatformProvidedMenuItemType.about,
-          PlatformProvidedMenuItemType.quit,
-        }.contains(menu);
     }
   }
 
@@ -743,13 +735,16 @@ class PlatformProvidedMenuItem extends PlatformMenuItem with DefaultPlatformMenu
     required int count,
     required DefaultPlatformMenuDelegateSerializableIdGenerator getId,
   }) {
-    if (!hasMenu(type)) {
-      throw ArgumentError(
-        'Platform ${defaultTargetPlatform.name} has no standard menu for '
-        '$type. Call StandardMenuItem.hasMenu to determine this before '
-        'instantiating one.',
-      );
-    }
+    assert(() {
+      if (!hasMenu(type)) {
+        throw ArgumentError(
+          'Platform ${defaultTargetPlatform.name} has no standard menu for '
+          '$type. Call PlatformProvidedMenuItem.hasMenu to determine this before '
+          'instantiating one.',
+        );
+      }
+      return true;
+    }());
 
     return <Map<String, Object?>>[
       <String, Object?>{

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:ui';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -713,12 +712,24 @@ class PlatformMenuItem extends MenuItem {
     final MenuSerializableShortcut? shortcut = item.shortcut;
     final Map<String, Object?> shortcutSerialized = shortcut?.serializeForMenu() ?? <String, Object?>{};
     assert(() {
-      return shortcutSerialized.containsKey(MenuSerializableShortcut.shortcutCharacter) ||
-          (shortcutSerialized.containsKey(MenuSerializableShortcut.shortcutModifiers) &&
-              shortcutSerialized.containsKey(MenuSerializableShortcut.shortcutTrigger));
-    }(), 'Shortcut serialization must contain either a MenuSerializableShortcut.shortcutCharacter '
-         'key, or both a MenuSerializableShortcut.shortcutModifiers and a '
-         'MenuSerializableShortcut.shortcutTrigger key.');
+      if (shortcut == null) {
+        return true;
+      }
+      final bool hasCharacter = shortcutSerialized.containsKey(MenuSerializableShortcut.shortcutCharacter);
+      final bool hasModifiers = shortcutSerialized.containsKey(MenuSerializableShortcut.shortcutModifiers);
+      final bool hasTrigger = shortcutSerialized.containsKey(MenuSerializableShortcut.shortcutTrigger);
+      if ((hasCharacter && !hasModifiers && !hasTrigger) || (hasModifiers && hasTrigger && !hasCharacter)) {
+        if (hasCharacter) {
+          return shortcutSerialized[MenuSerializableShortcut.shortcutCharacter] is String;
+        } else {
+          return shortcutSerialized[MenuSerializableShortcut.shortcutModifiers] is int &&
+              shortcutSerialized[MenuSerializableShortcut.shortcutTrigger] is int;
+        }
+      }
+      return false;
+    }(), 'Shortcut serialization must contain either a String MenuSerializableShortcut.shortcutCharacter '
+         'field, or both an integer MenuSerializableShortcut.shortcutModifiers and an integer '
+         'MenuSerializableShortcut.shortcutTrigger field.');
     return <String, Object?>{
       _kIdKey: getId(item),
       _kLabelKey: item.label,

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -635,7 +635,6 @@ class CharacterActivator with Diagnosticable, MenuSerializableShortcut implement
   Map<String, Object?> serializeForMenu() {
     return <String, Object?>{
       MenuSerializableShortcut.shortcutCharacter: character,
-      MenuSerializableShortcut.shortcutModifiers: 0,
     };
   }
 

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -12,6 +12,7 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
 import 'inherited_notifier.dart';
+import 'platform_menu_bar.dart';
 
 /// A set of [KeyboardKey]s that can be used as the keys in a [Map].
 ///
@@ -397,7 +398,7 @@ class ShortcutMapProperty extends DiagnosticsProperty<Map<ShortcutActivator, Int
 ///
 ///  * [CharacterActivator], an activator that represents key combinations
 ///    that result in the specified character, such as question mark.
-class SingleActivator with Diagnosticable implements ShortcutActivator {
+class SingleActivator with Diagnosticable, MenuSerializableShortcut implements ShortcutActivator {
   /// Triggered when the [trigger] key is pressed while the modifiers are held.
   ///
   /// The `trigger` should be the non-modifier key that is pressed after all the
@@ -517,6 +518,28 @@ class SingleActivator with Diagnosticable implements ShortcutActivator {
       && (meta == (pressed.contains(LogicalKeyboardKey.metaLeft) || pressed.contains(LogicalKeyboardKey.metaRight)));
   }
 
+  @override
+  Map<String, Object?> serializeForMenu() {
+    int modifiers = 0;
+    if (shift) {
+      modifiers |= MenuSerializableShortcut.shortcutModifierShift;
+    }
+    if (alt) {
+      modifiers |= MenuSerializableShortcut.shortcutModifierAlt;
+    }
+    if (meta) {
+      modifiers |= MenuSerializableShortcut.shortcutModifierMeta;
+    }
+    if (control) {
+      modifiers |= MenuSerializableShortcut.shortcutModifierControl;
+    }
+
+    return <String, Object?>{
+      MenuSerializableShortcut.shortcutTrigger: trigger.keyId,
+      MenuSerializableShortcut.shortcutModifiers: modifiers,
+    };
+  }
+
   /// Returns a short and readable description of the key combination.
   ///
   /// Intended to be used in debug mode for logging purposes. In release mode,
@@ -572,7 +595,7 @@ class SingleActivator with Diagnosticable implements ShortcutActivator {
 ///
 ///  * [SingleActivator], an activator that represents a single key combined
 ///    with modifiers, such as `Ctrl+C`.
-class CharacterActivator with Diagnosticable implements ShortcutActivator {
+class CharacterActivator with Diagnosticable, MenuSerializableShortcut implements ShortcutActivator {
   /// Create a [CharacterActivator] from the triggering character.
   const CharacterActivator(this.character);
 
@@ -606,6 +629,14 @@ class CharacterActivator with Diagnosticable implements ShortcutActivator {
       return true;
     }());
     return result;
+  }
+
+  @override
+  Map<String, Object?> serializeForMenu() {
+    return <String, Object?>{
+      MenuSerializableShortcut.shortcutEquivalent: character,
+      MenuSerializableShortcut.shortcutModifiers: 0,
+    };
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -519,25 +519,14 @@ class SingleActivator with Diagnosticable, MenuSerializableShortcut implements S
   }
 
   @override
-  Map<String, Object?> serializeForMenu() {
-    int modifiers = 0;
-    if (shift) {
-      modifiers |= MenuSerializableShortcut.shortcutModifierShift;
-    }
-    if (alt) {
-      modifiers |= MenuSerializableShortcut.shortcutModifierAlt;
-    }
-    if (meta) {
-      modifiers |= MenuSerializableShortcut.shortcutModifierMeta;
-    }
-    if (control) {
-      modifiers |= MenuSerializableShortcut.shortcutModifierControl;
-    }
-
-    return <String, Object?>{
-      MenuSerializableShortcut.shortcutTrigger: trigger.keyId,
-      MenuSerializableShortcut.shortcutModifiers: modifiers,
-    };
+  ShortcutSerialization serializeForMenu() {
+    return ShortcutSerialization.modifier(
+      trigger,
+      shift: shift,
+      alt: alt,
+      meta: meta,
+      control: control,
+    );
   }
 
   /// Returns a short and readable description of the key combination.
@@ -632,10 +621,8 @@ class CharacterActivator with Diagnosticable, MenuSerializableShortcut implement
   }
 
   @override
-  Map<String, Object?> serializeForMenu() {
-    return <String, Object?>{
-      MenuSerializableShortcut.shortcutCharacter: character,
-    };
+  ShortcutSerialization serializeForMenu() {
+    return ShortcutSerialization.character(character);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -634,7 +634,7 @@ class CharacterActivator with Diagnosticable, MenuSerializableShortcut implement
   @override
   Map<String, Object?> serializeForMenu() {
     return <String, Object?>{
-      MenuSerializableShortcut.shortcutEquivalent: character,
+      MenuSerializableShortcut.shortcutCharacter: character,
       MenuSerializableShortcut.shortcutModifiers: 0,
     };
   }

--- a/packages/flutter/lib/widgets.dart
+++ b/packages/flutter/lib/widgets.dart
@@ -83,6 +83,7 @@ export 'src/widgets/page_view.dart';
 export 'src/widgets/pages.dart';
 export 'src/widgets/performance_overlay.dart';
 export 'src/widgets/placeholder.dart';
+export 'src/widgets/platform_menu_bar.dart';
 export 'src/widgets/platform_view.dart';
 export 'src/widgets/preferred_size.dart';
 export 'src/widgets/primary_scroll_controller.dart';

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -53,7 +53,7 @@ void main() {
           home: Material(
             child: PlatformMenuBar(
               body: const Center(child: Text('Body')),
-              children: createTestMenus(
+              menus: createTestMenus(
                 onActivate: onActivate,
                 onOpen: onOpen,
                 onClose: onClose,
@@ -177,9 +177,9 @@ void main() {
             child: PlatformMenuBar(
               body: PlatformMenuBar(
                 body: SizedBox(),
-                children: <MenuItem>[],
+                menus: <MenuItem>[],
               ),
-              children: <MenuItem>[],
+              menus: <MenuItem>[],
             ),
           ),
         ),
@@ -193,7 +193,7 @@ void main() {
       );
       const PlatformMenuBar menuBar = PlatformMenuBar(
         body: SizedBox(),
-        children: <MenuItem>[item],
+        menus: <MenuItem>[item],
       );
 
       await tester.pumpWidget(

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -57,7 +57,7 @@ void main() {
                 onActivate: onActivate,
                 onOpen: onOpen,
                 onClose: onClose,
-                shortcuts: <String, ShortcutActivator>{
+                shortcuts: <String, MenuSerializableShortcut>{
                   subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
                   subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.keyB, shift: true),
                   subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.keyC, alt: true),
@@ -274,7 +274,7 @@ List<MenuItem> createTestMenus({
   void Function(String)? onActivate,
   void Function(String)? onOpen,
   void Function(String)? onClose,
-  Map<String, ShortcutActivator> shortcuts = const <String, ShortcutActivator>{},
+  Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
   bool includeStandard = false,
 }) {
   final List<MenuItem> result = <MenuItem>[

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -69,84 +69,90 @@ void main() {
         ),
       );
 
-      expect(fakeMenuChannel.outgoingCalls.last.method, equals('Menu.SetMenu'));
+      expect(fakeMenuChannel.outgoingCalls.last.method, equals('Menu.setMenu'));
       expect(
         fakeMenuChannel.outgoingCalls.last.arguments,
         equals(
           <Map<String, Object?>>[
             <String, Object?>{
-              'id': 1,
+              'id': 2,
               'label': 'Menu 0',
               'enabled': true,
               'children': <Map<String, Object?>>[
                 <String, Object?>{
-                  'id': 2,
+                  'id': 1,
                   'label': 'Sub Menu 00',
                   'enabled': true,
-                },
+                }
               ]
             },
             <String, Object?>{
-              'id': 3,
+              'id': 12,
               'label': 'Menu 1',
               'enabled': true,
               'children': <Map<String, Object?>>[
                 <String, Object?>{
-                  'id': 4,
+                  'id': 3,
                   'label': 'Sub Menu 10',
                   'enabled': true,
                 },
-                <String, Object?>{'id': 5, 'isDivider': true},
                 <String, Object?>{
-                  'id': 6,
+                  'id': 4,
+                  'isDivider': true,
+                },
+                <String, Object?>{
+                  'id': 10,
                   'label': 'Sub Menu 11',
                   'enabled': true,
                   'children': <Map<String, Object?>>[
                     <String, Object?>{
-                      'id': 7,
+                      'id': 5,
                       'label': 'Sub Sub Menu 100',
                       'enabled': true,
                       'shortcutTrigger': 97,
-                      'shortcutModifiers': 8,
+                      'shortcutModifiers': 8
                     },
-                    <String, Object?>{'id': 8, 'isDivider': true},
                     <String, Object?>{
-                      'id': 9,
+                      'id': 6,
+                      'isDivider': true,
+                    },
+                    <String, Object?>{
+                      'id': 7,
                       'label': 'Sub Sub Menu 101',
                       'enabled': true,
                       'shortcutTrigger': 98,
-                      'shortcutModifiers': 2,
+                      'shortcutModifiers': 2
                     },
                     <String, Object?>{
-                      'id': 10,
+                      'id': 8,
                       'label': 'Sub Sub Menu 102',
                       'enabled': true,
                       'shortcutTrigger': 99,
-                      'shortcutModifiers': 4,
+                      'shortcutModifiers': 4
                     },
                     <String, Object?>{
-                      'id': 11,
+                      'id': 9,
                       'label': 'Sub Sub Menu 103',
                       'enabled': true,
                       'shortcutTrigger': 100,
-                      'shortcutModifiers': 1,
+                      'shortcutModifiers': 1
                     }
                   ]
                 },
                 <String, Object?>{
-                  'id': 12,
+                  'id': 11,
                   'label': 'Sub Menu 12',
                   'enabled': true,
                 }
               ]
             },
             <String, Object?>{
-              'id': 13,
+              'id': 14,
               'label': 'Menu 2',
               'enabled': true,
               'children': <Map<String, Object?>>[
                 <String, Object?>{
-                  'id': 14,
+                  'id': 13,
                   'label': 'Sub Menu 20',
                   'enabled': false,
                 }
@@ -195,7 +201,7 @@ void main() {
         menuBar.toStringDeep(),
         equalsIgnoringHashCodes(
           'PlatformMenuBar#00000\n'
-          ' └─PlatformMenuBarItem#00000\n'
+          ' └─PlatformMenuItem#00000\n'
           '     label: "label2"\n'
           '     shortcut: SingleActivator#00000(keys: Key A)\n'
           '     DISABLED\n',

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -1,0 +1,378 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter/src/foundation/diagnostics.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late FakeMenuChannel fakeMenuChannel;
+  late PlatformMenuDelegate originalDelegate;
+  late DefaultPlatformMenuDelegate delegate;
+  final List<String> activated = <String>[];
+  final List<String> opened = <String>[];
+  final List<String> closed = <String>[];
+
+  void onActivate(String item) {
+    activated.add(item);
+  }
+
+  void onOpen(String item) {
+    opened.add(item);
+  }
+
+  void onClose(String item) {
+    closed.add(item);
+  }
+
+  setUp(() {
+    fakeMenuChannel = FakeMenuChannel((MethodCall call) async {});
+    delegate = DefaultPlatformMenuDelegate(channel: fakeMenuChannel);
+    originalDelegate = WidgetsBinding.instance.platformMenuDelegate;
+    WidgetsBinding.instance.platformMenuDelegate = delegate;
+    activated.clear();
+    opened.clear();
+    closed.clear();
+  });
+
+  tearDown(() {
+    WidgetsBinding.instance.platformMenuDelegate = originalDelegate;
+  });
+
+  group('PlatformMenuBar', () {
+    testWidgets('basic menu structure is transmitted to platform', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Material(
+            child: PlatformMenuBar(
+              body: const Center(child: Text('Body')),
+              children: createTestMenus(
+                onActivate: onActivate,
+                onOpen: onOpen,
+                onClose: onClose,
+                shortcuts: <String, ShortcutActivator>{
+                  subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
+                  subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.keyB, shift: true),
+                  subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.keyC, alt: true),
+                  subSubMenu10[3]: const SingleActivator(LogicalKeyboardKey.keyD, meta: true),
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(fakeMenuChannel.outgoingCalls.last.method, equals('Menu.SetMenu'));
+      expect(
+        fakeMenuChannel.outgoingCalls.last.arguments,
+        equals(
+          <Map<String, Object?>>[
+            <String, Object?>{
+              'id': 1,
+              'label': 'Menu 0',
+              'enabled': true,
+              'children': <Map<String, Object?>>[
+                <String, Object?>{
+                  'id': 2,
+                  'label': 'Sub Menu 00',
+                  'enabled': true,
+                },
+              ]
+            },
+            <String, Object?>{
+              'id': 3,
+              'label': 'Menu 1',
+              'enabled': true,
+              'children': <Map<String, Object?>>[
+                <String, Object?>{
+                  'id': 4,
+                  'label': 'Sub Menu 10',
+                  'enabled': true,
+                },
+                <String, Object?>{'id': 5, 'isDivider': true},
+                <String, Object?>{
+                  'id': 6,
+                  'label': 'Sub Menu 11',
+                  'enabled': true,
+                  'children': <Map<String, Object?>>[
+                    <String, Object?>{
+                      'id': 7,
+                      'label': 'Sub Sub Menu 100',
+                      'enabled': true,
+                      'shortcutTrigger': 97,
+                      'shortcutModifiers': 8,
+                    },
+                    <String, Object?>{'id': 8, 'isDivider': true},
+                    <String, Object?>{
+                      'id': 9,
+                      'label': 'Sub Sub Menu 101',
+                      'enabled': true,
+                      'shortcutTrigger': 98,
+                      'shortcutModifiers': 2,
+                    },
+                    <String, Object?>{
+                      'id': 10,
+                      'label': 'Sub Sub Menu 102',
+                      'enabled': true,
+                      'shortcutTrigger': 99,
+                      'shortcutModifiers': 4,
+                    },
+                    <String, Object?>{
+                      'id': 11,
+                      'label': 'Sub Sub Menu 103',
+                      'enabled': true,
+                      'shortcutTrigger': 100,
+                      'shortcutModifiers': 1,
+                    }
+                  ]
+                },
+                <String, Object?>{
+                  'id': 12,
+                  'label': 'Sub Menu 12',
+                  'enabled': true,
+                }
+              ]
+            },
+            <String, Object?>{
+              'id': 13,
+              'label': 'Menu 2',
+              'enabled': true,
+              'children': <Map<String, Object?>>[
+                <String, Object?>{
+                  'id': 14,
+                  'label': 'Sub Menu 20',
+                  'enabled': false,
+                }
+              ]
+            }
+          ],
+        ),
+      );
+    });
+    testWidgets('asserts when more than one has locked the delegate', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: PlatformMenuBar(
+              body: PlatformMenuBar(
+                body: SizedBox(),
+                children: <MenuItem>[],
+              ),
+              children: <MenuItem>[],
+            ),
+          ),
+        ),
+      );
+      expect(tester.takeException(), isA<AssertionError>());
+    });
+    testWidgets('diagnostics', (WidgetTester tester) async {
+      const PlatformMenuBarItem item = PlatformMenuBarItem(
+        label: 'label2',
+        shortcut: SingleActivator(LogicalKeyboardKey.keyA),
+      );
+      const PlatformMenuBar menuBar = PlatformMenuBar(
+        body: SizedBox(),
+        children: <MenuItem>[item],
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: menuBar,
+          ),
+        ),
+      );
+      await tester.pump();
+
+      expect(
+        menuBar.toStringDeep(),
+        equalsIgnoringHashCodes(
+          'PlatformMenuBar#00000\n'
+          ' └─PlatformMenuBarItem#00000\n'
+          '     label: "label2"\n'
+          '     shortcut: SingleActivator#00000(keys: Key A)\n'
+          '     DISABLED\n',
+        ),
+      );
+    });
+  });
+  group('PlatformMenuBarItem', () {
+    testWidgets('diagnostics', (WidgetTester tester) async {
+      const PlatformMenuBarItem childItem = PlatformMenuBarItem(
+        label: 'label',
+      );
+      const PlatformSubMenu item = PlatformSubMenu(
+        label: 'label',
+        children: <MenuItem>[childItem],
+      );
+
+      final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
+      item.debugFillProperties(builder);
+
+      final List<String> description = builder.properties
+          .where((DiagnosticsNode node) => !node.isFiltered(DiagnosticLevel.info))
+          .map((DiagnosticsNode node) => node.toString())
+          .toList();
+
+      expect(description, <String>[
+        'label: "label"',
+      ]);
+    });
+  });
+}
+
+const List<String> mainMenu = <String>[
+  'Menu 0',
+  'Menu 1',
+  'Menu 2',
+];
+
+const List<String> subMenu0 = <String>[
+  'Sub Menu 00',
+];
+
+const List<String> subMenu1 = <String>[
+  'Sub Menu 10',
+  'Sub Menu 11',
+  'Sub Menu 12',
+];
+
+const List<String> subSubMenu10 = <String>[
+  'Sub Sub Menu 100',
+  'Sub Sub Menu 101',
+  'Sub Sub Menu 102',
+  'Sub Sub Menu 103',
+];
+
+const List<String> subMenu2 = <String>[
+  'Sub Menu 20',
+];
+
+List<MenuItem> createTestMenus({
+  void Function(String)? onActivate,
+  void Function(String)? onOpen,
+  void Function(String)? onClose,
+  Map<String, ShortcutActivator> shortcuts = const <String, ShortcutActivator>{},
+  bool includeStandard = false,
+}) {
+  final List<MenuItem> result = <MenuItem>[
+    PlatformSubMenu(
+      label: mainMenu[0],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[0]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[0]) : null,
+      children: <MenuItem>[
+        PlatformMenuBarItem(
+          label: subMenu0[0],
+          onSelected: onActivate != null ? () => onActivate(subMenu0[0]) : null,
+          shortcut: shortcuts[subMenu0[0]],
+        ),
+      ],
+    ),
+    PlatformSubMenu(
+      label: mainMenu[1],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[1]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[1]) : null,
+      children: <MenuItem>[
+        PlatformMenuItemGroup(
+          members: <MenuItem>[
+            PlatformMenuBarItem(
+              label: subMenu1[0],
+              onSelected: onActivate != null ? () => onActivate(subMenu1[0]) : null,
+              shortcut: shortcuts[subMenu1[0]],
+            ),
+          ],
+        ),
+        PlatformSubMenu(
+          label: subMenu1[1],
+          onOpen: onOpen != null ? () => onOpen(subMenu1[1]) : null,
+          onClose: onClose != null ? () => onClose(subMenu1[1]) : null,
+          children: <MenuItem>[
+            PlatformMenuItemGroup(
+              members: <MenuItem>[
+                PlatformMenuBarItem(
+                  label: subSubMenu10[0],
+                  onSelected: onActivate != null ? () => onActivate(subSubMenu10[0]) : null,
+                  shortcut: shortcuts[subSubMenu10[0]],
+                ),
+              ],
+            ),
+            PlatformMenuBarItem(
+              label: subSubMenu10[1],
+              onSelected: onActivate != null ? () => onActivate(subSubMenu10[1]) : null,
+              shortcut: shortcuts[subSubMenu10[1]],
+            ),
+            PlatformMenuBarItem(
+              label: subSubMenu10[2],
+              onSelected: onActivate != null ? () => onActivate(subSubMenu10[2]) : null,
+              shortcut: shortcuts[subSubMenu10[2]],
+            ),
+            PlatformMenuBarItem(
+              label: subSubMenu10[3],
+              onSelected: onActivate != null ? () => onActivate(subSubMenu10[3]) : null,
+              shortcut: shortcuts[subSubMenu10[3]],
+            ),
+          ],
+        ),
+        PlatformMenuBarItem(
+          label: subMenu1[2],
+          onSelected: onActivate != null ? () => onActivate(subMenu1[2]) : null,
+          shortcut: shortcuts[subMenu1[2]],
+        ),
+      ],
+    ),
+    PlatformSubMenu(
+      label: mainMenu[2],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
+      children: <MenuItem>[
+        PlatformMenuBarItem(
+          // Always disabled.
+          label: subMenu2[0],
+          shortcut: shortcuts[subMenu2[0]],
+        ),
+      ],
+    ),
+  ];
+  return result;
+}
+
+class FakeMenuChannel implements MethodChannel {
+  FakeMenuChannel(this.outgoing) : assert(outgoing != null);
+
+  Future<dynamic> Function(MethodCall) outgoing;
+  Future<void> Function(MethodCall)? incoming;
+
+  List<MethodCall> outgoingCalls = <MethodCall>[];
+
+  @override
+  BinaryMessenger get binaryMessenger => throw UnimplementedError();
+
+  @override
+  MethodCodec get codec => const StandardMethodCodec();
+
+  @override
+  Future<List<T>> invokeListMethod<T>(String method, [dynamic arguments]) => throw UnimplementedError();
+
+  @override
+  Future<Map<K, V>> invokeMapMethod<K, V>(String method, [dynamic arguments]) => throw UnimplementedError();
+
+  @override
+  Future<T> invokeMethod<T>(String method, [dynamic arguments]) async {
+    final MethodCall call = MethodCall(method, arguments);
+    outgoingCalls.add(call);
+    return await outgoing(call) as T;
+  }
+
+  @override
+  String get name => 'flutter/menu';
+
+  @override
+  void setMethodCallHandler(Future<void> Function(MethodCall call)? handler) => incoming = handler;
+}

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -73,92 +73,100 @@ void main() {
       expect(
         fakeMenuChannel.outgoingCalls.last.arguments,
         equals(
-          <Map<String, Object?>>[
-            <String, Object?>{
-              'id': 2,
-              'label': 'Menu 0',
-              'enabled': true,
-              'children': <Map<String, Object?>>[
-                <String, Object?>{
-                  'id': 1,
-                  'label': 'Sub Menu 00',
-                  'enabled': true,
-                }
-              ]
-            },
-            <String, Object?>{
-              'id': 12,
-              'label': 'Menu 1',
-              'enabled': true,
-              'children': <Map<String, Object?>>[
-                <String, Object?>{
-                  'id': 3,
-                  'label': 'Sub Menu 10',
-                  'enabled': true,
-                },
-                <String, Object?>{
-                  'id': 4,
-                  'isDivider': true,
-                },
-                <String, Object?>{
-                  'id': 10,
-                  'label': 'Sub Menu 11',
-                  'enabled': true,
-                  'children': <Map<String, Object?>>[
-                    <String, Object?>{
-                      'id': 5,
-                      'label': 'Sub Sub Menu 100',
-                      'enabled': true,
-                      'shortcutTrigger': 97,
-                      'shortcutModifiers': 8
-                    },
-                    <String, Object?>{
-                      'id': 6,
-                      'isDivider': true,
-                    },
-                    <String, Object?>{
-                      'id': 7,
-                      'label': 'Sub Sub Menu 101',
-                      'enabled': true,
-                      'shortcutTrigger': 98,
-                      'shortcutModifiers': 2
-                    },
-                    <String, Object?>{
-                      'id': 8,
-                      'label': 'Sub Sub Menu 102',
-                      'enabled': true,
-                      'shortcutTrigger': 99,
-                      'shortcutModifiers': 4
-                    },
-                    <String, Object?>{
-                      'id': 9,
-                      'label': 'Sub Sub Menu 103',
-                      'enabled': true,
-                      'shortcutTrigger': 100,
-                      'shortcutModifiers': 1
-                    }
-                  ]
-                },
-                <String, Object?>{
-                  'id': 11,
-                  'label': 'Sub Menu 12',
-                  'enabled': true,
-                }
-              ]
-            },
-            <String, Object?>{
-              'id': 14,
-              'label': 'Menu 2',
-              'enabled': true,
-              'children': <Map<String, Object?>>[
-                <String, Object?>{
-                  'id': 13,
-                  'label': 'Sub Menu 20',
-                  'enabled': false,
-                }
-              ]
-            }
-          ],
+          <String, Object?>{
+            '0': <Map<String, Object?>>[
+              <String, Object?>{
+                'id': 2,
+                'label': 'Menu 0',
+                'enabled': true,
+                'children': <Map<String, Object?>>[
+                  <String, Object?>{
+                    'id': 1,
+                    'label': 'Sub Menu 00',
+                    'enabled': true,
+                  }
+                ]
+              },
+              <String, Object?>{
+                'id': 12,
+                'label': 'Menu 1',
+                'enabled': true,
+                'children': <Map<String, Object?>>[
+                  <String, Object?>{
+                    'id': 3,
+                    'label': 'Sub Menu 10',
+                    'enabled': true,
+                  },
+                  <String, Object?>{
+                    'id': 4,
+                    'isDivider': true,
+                  },
+                  <String, Object?>{
+                    'id': 10,
+                    'label': 'Sub Menu 11',
+                    'enabled': true,
+                    'children': <Map<String, Object?>>[
+                      <String, Object?>{
+                        'id': 5,
+                        'label': 'Sub Sub Menu 100',
+                        'enabled': true,
+                        'shortcutTrigger': 97,
+                        'shortcutModifiers': 8
+                      },
+                      <String, Object?>{
+                        'id': 6,
+                        'isDivider': true,
+                      },
+                      <String, Object?>{
+                        'id': 7,
+                        'label': 'Sub Sub Menu 101',
+                        'enabled': true,
+                        'shortcutTrigger': 98,
+                        'shortcutModifiers': 2
+                      },
+                      <String, Object?>{
+                        'id': 8,
+                        'label': 'Sub Sub Menu 102',
+                        'enabled': true,
+                        'shortcutTrigger': 99,
+                        'shortcutModifiers': 4
+                      },
+                      <String, Object?>{
+                        'id': 9,
+                        'label': 'Sub Sub Menu 103',
+                        'enabled': true,
+                        'shortcutTrigger': 100,
+                        'shortcutModifiers': 1
+                      }
+                    ]
+                  },
+                  <String, Object?>{
+                    'id': 11,
+                    'label': 'Sub Menu 12',
+                    'enabled': true,
+                  }
+                ]
+              },
+              <String, Object?>{
+                'id': 14,
+                'label': 'Menu 2',
+                'enabled': true,
+                'children': <Map<String, Object?>>[
+                  <String, Object?>{
+                    'id': 13,
+                    'label': 'Sub Menu 20',
+                    'enabled': false,
+                  }
+                ]
+              },
+              <String, Object?>{
+                'id': 15,
+                'label': 'Menu 3',
+                'enabled': false,
+                'children': <Map<String, Object?>>[],
+              },
+            ],
+          },
         ),
       );
     });
@@ -216,7 +224,7 @@ void main() {
       );
       const PlatformMenu item = PlatformMenu(
         label: 'label',
-        children: <MenuItem>[childItem],
+        menus: <MenuItem>[childItem],
       );
 
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
@@ -238,6 +246,7 @@ const List<String> mainMenu = <String>[
   'Menu 0',
   'Menu 1',
   'Menu 2',
+  'Menu 3',
 ];
 
 const List<String> subMenu0 = <String>[
@@ -273,7 +282,7 @@ List<MenuItem> createTestMenus({
       label: mainMenu[0],
       onOpen: onOpen != null ? () => onOpen(mainMenu[0]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[0]) : null,
-      children: <MenuItem>[
+      menus: <MenuItem>[
         PlatformMenuItem(
           label: subMenu0[0],
           onSelected: onActivate != null ? () => onActivate(subMenu0[0]) : null,
@@ -285,7 +294,7 @@ List<MenuItem> createTestMenus({
       label: mainMenu[1],
       onOpen: onOpen != null ? () => onOpen(mainMenu[1]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[1]) : null,
-      children: <MenuItem>[
+      menus: <MenuItem>[
         PlatformMenuItemGroup(
           members: <MenuItem>[
             PlatformMenuItem(
@@ -299,7 +308,7 @@ List<MenuItem> createTestMenus({
           label: subMenu1[1],
           onOpen: onOpen != null ? () => onOpen(subMenu1[1]) : null,
           onClose: onClose != null ? () => onClose(subMenu1[1]) : null,
-          children: <MenuItem>[
+          menus: <MenuItem>[
             PlatformMenuItemGroup(
               members: <MenuItem>[
                 PlatformMenuItem(
@@ -337,13 +346,20 @@ List<MenuItem> createTestMenus({
       label: mainMenu[2],
       onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
-      children: <MenuItem>[
+      menus: <MenuItem>[
         PlatformMenuItem(
           // Always disabled.
           label: subMenu2[0],
           shortcut: shortcuts[subMenu2[0]],
         ),
       ],
+    ),
+    // Disabled menu
+    PlatformMenu(
+      label: mainMenu[3],
+      onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
+      onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
+      menus: <MenuItem>[],
     ),
   ];
   return result;

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -173,7 +173,7 @@ void main() {
       expect(tester.takeException(), isA<AssertionError>());
     });
     testWidgets('diagnostics', (WidgetTester tester) async {
-      const PlatformMenuBarItem item = PlatformMenuBarItem(
+      const PlatformMenuItem item = PlatformMenuItem(
         label: 'label2',
         shortcut: SingleActivator(LogicalKeyboardKey.keyA),
       );
@@ -205,10 +205,10 @@ void main() {
   });
   group('PlatformMenuBarItem', () {
     testWidgets('diagnostics', (WidgetTester tester) async {
-      const PlatformMenuBarItem childItem = PlatformMenuBarItem(
+      const PlatformMenuItem childItem = PlatformMenuItem(
         label: 'label',
       );
-      const PlatformSubMenu item = PlatformSubMenu(
+      const PlatformMenu item = PlatformMenu(
         label: 'label',
         children: <MenuItem>[childItem],
       );
@@ -263,76 +263,76 @@ List<MenuItem> createTestMenus({
   bool includeStandard = false,
 }) {
   final List<MenuItem> result = <MenuItem>[
-    PlatformSubMenu(
+    PlatformMenu(
       label: mainMenu[0],
       onOpen: onOpen != null ? () => onOpen(mainMenu[0]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[0]) : null,
       children: <MenuItem>[
-        PlatformMenuBarItem(
+        PlatformMenuItem(
           label: subMenu0[0],
           onSelected: onActivate != null ? () => onActivate(subMenu0[0]) : null,
           shortcut: shortcuts[subMenu0[0]],
         ),
       ],
     ),
-    PlatformSubMenu(
+    PlatformMenu(
       label: mainMenu[1],
       onOpen: onOpen != null ? () => onOpen(mainMenu[1]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[1]) : null,
       children: <MenuItem>[
         PlatformMenuItemGroup(
           members: <MenuItem>[
-            PlatformMenuBarItem(
+            PlatformMenuItem(
               label: subMenu1[0],
               onSelected: onActivate != null ? () => onActivate(subMenu1[0]) : null,
               shortcut: shortcuts[subMenu1[0]],
             ),
           ],
         ),
-        PlatformSubMenu(
+        PlatformMenu(
           label: subMenu1[1],
           onOpen: onOpen != null ? () => onOpen(subMenu1[1]) : null,
           onClose: onClose != null ? () => onClose(subMenu1[1]) : null,
           children: <MenuItem>[
             PlatformMenuItemGroup(
               members: <MenuItem>[
-                PlatformMenuBarItem(
+                PlatformMenuItem(
                   label: subSubMenu10[0],
                   onSelected: onActivate != null ? () => onActivate(subSubMenu10[0]) : null,
                   shortcut: shortcuts[subSubMenu10[0]],
                 ),
               ],
             ),
-            PlatformMenuBarItem(
+            PlatformMenuItem(
               label: subSubMenu10[1],
               onSelected: onActivate != null ? () => onActivate(subSubMenu10[1]) : null,
               shortcut: shortcuts[subSubMenu10[1]],
             ),
-            PlatformMenuBarItem(
+            PlatformMenuItem(
               label: subSubMenu10[2],
               onSelected: onActivate != null ? () => onActivate(subSubMenu10[2]) : null,
               shortcut: shortcuts[subSubMenu10[2]],
             ),
-            PlatformMenuBarItem(
+            PlatformMenuItem(
               label: subSubMenu10[3],
               onSelected: onActivate != null ? () => onActivate(subSubMenu10[3]) : null,
               shortcut: shortcuts[subSubMenu10[3]],
             ),
           ],
         ),
-        PlatformMenuBarItem(
+        PlatformMenuItem(
           label: subMenu1[2],
           onSelected: onActivate != null ? () => onActivate(subMenu1[2]) : null,
           shortcut: shortcuts[subMenu1[2]],
         ),
       ],
     ),
-    PlatformSubMenu(
+    PlatformMenu(
       label: mainMenu[2],
       onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
       children: <MenuItem>[
-        PlatformMenuBarItem(
+        PlatformMenuItem(
           // Always disabled.
           label: subMenu2[0],
           shortcut: shortcuts[subMenu2[0]],


### PR DESCRIPTION
## Description

Implements a `PlatformMenuBar` widget and associated data structures for defining menu bars that use native APIs for rendering.

This PR includes:
- A `PlatformMenuBar` class, which is a widget that menu bar data can be attached to for sending to the platform.
- A `PlatformMenuDelegate` base, which is the type taken by a new `WidgetsBinding.platformMenuDelegate`.
-  An implementation of the above in `DefaultPlatformMenuDelegate` that talks to the built-in "flutter/menu" channel to talk to the built-in platform implementation. The delegate is so that a plugin could override with its own delegate and provide other platforms with native menu support using the same widgets to define the menus.

This is the framework part of the implementation.  The engine part will be in https://github.com/flutter/engine/pull/32080 (and https://github.com/flutter/engine/pull/32358)

The design doc for this feature is [here](https://flutter.dev/go/cascading-menus).

## Related Issues
 - https://github.com/flutter/flutter/issues/23600

## Tests
 - Added tests for `PlatformMenuBar` and the items, and test the `PlatformMenuDelegate` through the `PlatformMenuBar` test.