### PR TITLE
Fix `CupertinoFormRow` dark mode text color

### DIFF
--- a/packages/flutter/lib/src/cupertino/form_row.dart
+++ b/packages/flutter/lib/src/cupertino/form_row.dart
@@ -148,7 +148,10 @@ class CupertinoFormRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final TextStyle textStyle = CupertinoTheme.of(context).textTheme.textStyle;
+    final CupertinoThemeData theme = CupertinoTheme.of(context);
+    final TextStyle textStyle = theme.textTheme.textStyle.copyWith(
+      color: CupertinoDynamicColor.maybeResolve(theme.textTheme.textStyle.color, context)
+    );
 
     return Padding(
       padding: padding ?? _kDefaultPadding,

--- a/packages/flutter/test/cupertino/form_row_test.dart
+++ b/packages/flutter/test/cupertino/form_row_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -162,5 +164,45 @@ void main() {
         tester.widget(find.byType(DefaultTextStyle).last);
 
     expect(errorTextStyle.style.color, CupertinoColors.destructiveRed);
+  });
+
+  testWidgets('CupertinoFormRow adapts to MaterialApp dark mode', (WidgetTester tester) async {
+    const Widget prefix = Text('Prefix');
+    const Widget helper = Text('Helper');
+
+    Widget _buildFormRow(Brightness brightness) {
+      return MaterialApp(
+        theme: ThemeData(brightness: brightness),
+        home: const Center(
+          child: CupertinoFormRow(
+            prefix: prefix,
+            helper: helper,
+            child: CupertinoTextField(),
+          ),
+        ),
+      );
+    }
+
+    // CupertinoFormRow with light theme.
+    await tester.pumpWidget(_buildFormRow(Brightness.light));
+    RenderParagraph helperParagraph = tester.renderObject(find.text('Helper'));
+    expect(helperParagraph.text.style!.color, CupertinoColors.label);
+    // Text style should not return unresolved color.
+    expect(helperParagraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
+    RenderParagraph prefixParagraph = tester.renderObject(find.text('Prefix'));
+    expect(prefixParagraph.text.style!.color, CupertinoColors.label);
+    // Text style should not return unresolved color.
+    expect(prefixParagraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
+
+    // CupertinoFormRow with light theme.
+    await tester.pumpWidget(_buildFormRow(Brightness.dark));
+    helperParagraph = tester.renderObject(find.text('Helper'));
+    expect(helperParagraph.text.style!.color, CupertinoColors.label);
+    // Text style should not return unresolved color.
+    expect(helperParagraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
+    prefixParagraph = tester.renderObject(find.text('Prefix'));
+    expect(prefixParagraph.text.style!.color, CupertinoColors.label);
+    // Text style should not return unresolved color.
+    expect(prefixParagraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
   });
 }


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/100180

### Code Sample

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';
import 'package:flutter/cupertino.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {

    return MaterialApp(
      title: 'CupertinoFormRow (MaterialApp)',
      theme: ThemeData(brightness: Brightness.dark),
      home: const Scaffold(
        body: Center(
          child: SizedBox(
            height: 250,
            child: CupertinoFormRow(
              prefix: Text('Prefix'),
              helper: Text('Helper'),
              error: Text('Error'),
              child: Text('CupertinoFormRow Child'),
            ),
          ),
        ),
      ),
    );
  }
}
``` 
	
</details>

| Issue | Fix |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/158854924-64674624-d849-444b-ab5f-663afd99607d.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/158854935-12d5aa33-1ed1-4936-a3db-2405152e10eb.png" height="450" /> |

Similar to:

https://github.com/flutter/flutter/blob/b4040c867b26097903aaf8814c6ee149400557c7/packages/flutter/lib/src/cupertino/dialog.dart#L284

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
