### PR TITLE
Reintroduce the ability to override the coverage formatter

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -123,18 +123,23 @@ class CoverageCollector extends TestWatcher {
   /// This will not start any collection tasks. It us up to the caller of to
   /// call [collectCoverage] for each process first.
   String finalizeCoverage({
+    String Function(Map<String, coverage.HitMap> hitmap) formatter,
     coverage.Resolver resolver,
     Directory coverageDirectory,
   }) {
     if (_globalHitmap == null) {
       return null;
     }
-    resolver ??= coverage.Resolver(packagesPath: packagesPath);
-    final String packagePath = globals.fs.currentDirectory.path;
-    final List<String> reportOn = coverageDirectory == null
-      ? <String>[globals.fs.path.join(packagePath, 'lib')]
-      : <String>[coverageDirectory.path];
-    final String result = _globalHitmap.formatLcov(resolver, reportOn: reportOn, basePath: packagePath);
+    if (formatter == null) {
+      resolver ??= coverage.Resolver(packagesPath: packagesPath);
+      final String packagePath = globals.fs.currentDirectory.path;
+      final List<String> reportOn = coverageDirectory == null
+          ? <String>[globals.fs.path.join(packagePath, 'lib')]
+          : <String>[coverageDirectory.path];
+      formatter = (Map<String, coverage.HitMap> hitmap) => hitmap
+          .formatLcov(resolver, reportOn: reportOn, basePath: packagePath);
+    }
+    final String result = formatter(_globalHitmap);
     _globalHitmap = null;
     return result;
   }


### PR DESCRIPTION
This fixes an internal issue (b/223355185) where a coverage user was relying on the ability to override the coverage formatter. The bug was introduced [here](https://github.com/flutter/flutter/pull/98513/files#diff-ae90e83968d51b03349779e6260c9e0d19ad8645ec3d3958301de5457ae1e732L133-L141).
