### PR TITLE
proposal: Extension getters on Set<MaterialState>

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -369,10 +369,10 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
 
   MaterialStateProperty<Color?> get _widgetFillColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+      if (states.isDisabled) {
         return null;
       }
-      if (states.contains(MaterialState.selected)) {
+      if (states.isSelected) {
         return widget.activeColor;
       }
       return null;
@@ -382,10 +382,10 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
   MaterialStateProperty<Color> get _defaultFillColor {
     final ThemeData themeData = Theme.of(context);
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+      if (states.isDisabled) {
         return themeData.disabledColor;
       }
-      if (states.contains(MaterialState.selected)) {
+      if (states.isSelected) {
         return themeData.toggleableActiveColor;
       }
       return themeData.unselectedWidgetColor;
@@ -395,7 +395,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
   BorderSide? _resolveSide(BorderSide? side) {
     if (side is MaterialStateBorderSide)
       return MaterialStateProperty.resolveAs<BorderSide?>(side, states);
-    if (!states.contains(MaterialState.selected))
+    if (!states.isSelected)
       return side;
     return null;
   }
@@ -485,8 +485,8 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
           ..focusColor = effectiveFocusOverlayColor
           ..splashRadius = widget.splashRadius ?? checkboxTheme.splashRadius ?? kRadialReactionRadius
           ..downPosition = downPosition
-          ..isFocused = states.contains(MaterialState.focused)
-          ..isHovered = states.contains(MaterialState.hovered)
+          ..isFocused = states.isFocused
+          ..isHovered = states.isHovered
           ..activeColor = effectiveActiveColor
           ..inactiveColor = effectiveInactiveColor
           ..checkColor = effectiveCheckColor

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -95,6 +95,33 @@ enum MaterialState {
   error,
 }
 
+/// Adds helper accessors to `Set`s of [MaterialState]s.
+extension SetMaterialState on Set<MaterialState> {
+  /// Whether or not this `Set` contains the value [MaterialState.hovered].
+  bool get isHovered => contains(MaterialState.hovered);
+
+  /// Whether or not this `Set` contains the value [MaterialState.focused].
+  bool get isFocused => contains(MaterialState.focused);
+
+  /// Whether or not this `Set` contains the value [MaterialState.pressed].
+  bool get isPressed => contains(MaterialState.pressed);
+
+  /// Whether or not this `Set` contains the value [MaterialState.dragged].
+  bool get isDragged => contains(MaterialState.dragged);
+
+  /// Whether or not this `Set` contains the value [MaterialState.selected].
+  bool get isSelected => contains(MaterialState.selected);
+
+  /// Whether or not this `Set` contains the value [MaterialState.scrolledUnder].
+  bool get isScrolledUnder => contains(MaterialState.scrolledUnder);
+
+  /// Whether or not this `Set` contains the value [MaterialState.disabled].
+  bool get isDisabled => contains(MaterialState.disabled);
+
+  /// Whether or not this `Set` contains the value [MaterialState.error].
+  bool get isErrored => contains(MaterialState.error);
+}
+
 /// Signature for the function that returns a value of type `T` based on a given
 /// set of states.
 typedef MaterialPropertyResolver<T> = T Function(Set<MaterialState> states);

--- a/packages/flutter/lib/src/material/material_state_mixin.dart
+++ b/packages/flutter/lib/src/material/material_state_mixin.dart
@@ -136,28 +136,28 @@ mixin MaterialStateMixin<T extends StatefulWidget> on State<T> {
   }
 
   /// Getter for whether this class considers [MaterialState.disabled] to be active.
-  bool get isDisabled => materialStates.contains(MaterialState.disabled);
+  bool get isDisabled => materialStates.isDisabled;
 
   /// Getter for whether this class considers [MaterialState.dragged] to be active.
-  bool get isDragged => materialStates.contains(MaterialState.dragged);
+  bool get isDragged => materialStates.isDragged;
 
   /// Getter for whether this class considers [MaterialState.error] to be active.
-  bool get isErrored => materialStates.contains(MaterialState.error);
+  bool get isErrored => materialStates.isErrored;
 
   /// Getter for whether this class considers [MaterialState.focused] to be active.
-  bool get isFocused => materialStates.contains(MaterialState.focused);
+  bool get isFocused => materialStates.isFocused;
 
   /// Getter for whether this class considers [MaterialState.hovered] to be active.
-  bool get isHovered => materialStates.contains(MaterialState.hovered);
+  bool get isHovered => materialStates.isHovered;
 
   /// Getter for whether this class considers [MaterialState.pressed] to be active.
-  bool get isPressed => materialStates.contains(MaterialState.pressed);
+  bool get isPressed => materialStates.isPressed;
 
   /// Getter for whether this class considers [MaterialState.scrolledUnder] to be active.
-  bool get isScrolledUnder => materialStates.contains(MaterialState.scrolledUnder);
+  bool get isScrolledUnder => materialStates.isScrolledUnder;
 
   /// Getter for whether this class considers [MaterialState.selected] to be active.
-  bool get isSelected => materialStates.contains(MaterialState.selected);
+  bool get isSelected => materialStates.isSelected;
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {


### PR DESCRIPTION
Adds extension getters to `Set<MaterialState>`, allowing developers (in and out of the framework itself) to condense calls like `states.contains(MaterialState.hovered)` down to just `states.isHovered`.

Admittedly, a small qualify of life win, but one I expect developers will enjoy as MaterialStateProperty usage becomes more widespread.

As a demonstration, I have applied to changes to just one file (`checkbox.dart`). If this proposal is accepted, I will propagate the change everywhere in the framework and add tests (if we think this requires any) before merging this PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.