### PR TITLE
mark canvaskit benchmarks as bringup: true

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -870,6 +870,7 @@ targets:
 
   - name: Linux web_benchmarks_canvaskit
     recipe: devicelab/devicelab_drone
+    bringup: true # rolling to Chrome 96: https://github.com/flutter/flutter/issues/98723
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
Temporarily mark canvaskit benchmarks as `bringup: true`. Since canvaskit benchmarks don't run on pre-submit it's difficult to fix them in a PR. So I'm going with the following:

- Mark as bring up
- Fix
- Unmark as bring up