### PR TITLE
[flutter_conductor] clone from remote upstream, and not local filesystem

### DIFF
--- a/dev/conductor/core/lib/src/codesign.dart
+++ b/dev/conductor/core/lib/src/codesign.dart
@@ -73,9 +73,8 @@ class CodesignCommand extends Command<void> {
 
   FrameworkRepository? _framework;
   FrameworkRepository get framework {
-    return _framework ??= FrameworkRepository.localRepoAsUpstream(
+    return _framework ??= FrameworkRepository(
       checkouts,
-      upstreamPath: flutterRoot.path,
     );
   }
 
@@ -113,7 +112,7 @@ class CodesignCommand extends Command<void> {
     } else {
       revision = ((await processManager.run(
         <String>['git', 'rev-parse', 'HEAD'],
-        workingDirectory: (await framework.checkoutDirectory).path,
+        workingDirectory: flutterRoot.path,
       )).stdout as String).trim();
       assert(revision.isNotEmpty);
     }

--- a/dev/conductor/core/test/codesign_test.dart
+++ b/dev/conductor/core/test/codesign_test.dart
@@ -105,11 +105,16 @@ void main() {
       createRunner(commands: <FakeCommand>[
         const FakeCommand(command: <String>[
           'git',
+          'rev-parse',
+          'HEAD',
+        ], stdout: revision),
+        const FakeCommand(command: <String>[
+          'git',
           'clone',
           '--origin',
           'upstream',
           '--',
-          'file://$flutterRoot/',
+          FrameworkRepository.defaultUpstream,
           '${checkoutsParentDirectory}flutter_conductor_checkouts/framework',
         ]),
         const FakeCommand(command: <String>[
@@ -117,11 +122,6 @@ void main() {
           'checkout',
           FrameworkRepository.defaultBranch,
         ]),
-        const FakeCommand(command: <String>[
-          'git',
-          'rev-parse',
-          'HEAD',
-        ], stdout: revision),
         const FakeCommand(command: <String>[
           'git',
           'rev-parse',
@@ -198,7 +198,7 @@ void main() {
           '--origin',
           'upstream',
           '--',
-          'file://$flutterRoot/',
+          FrameworkRepository.defaultUpstream,
           '${checkoutsParentDirectory}flutter_conductor_checkouts/framework',
         ]),
         const FakeCommand(command: <String>[
@@ -291,7 +291,7 @@ void main() {
           '--origin',
           'upstream',
           '--',
-          'file://$flutterRoot/',
+          FrameworkRepository.defaultUpstream,
           '${checkoutsParentDirectory}flutter_conductor_checkouts/framework',
         ]),
         const FakeCommand(command: <String>[
@@ -383,7 +383,7 @@ void main() {
           '--origin',
           'upstream',
           '--',
-          'file://$flutterRoot/',
+          FrameworkRepository.defaultUpstream,
           '${checkoutsParentDirectory}flutter_conductor_checkouts/framework',
         ]),
         const FakeCommand(command: <String>[
@@ -447,7 +447,7 @@ void main() {
           '--origin',
           'upstream',
           '--',
-          'file://$flutterRoot/',
+          FrameworkRepository.defaultUpstream,
           '${checkoutsParentDirectory}flutter_conductor_checkouts/framework',
         ]),
         const FakeCommand(command: <String>[


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100306

This is a speculative fix, when I tried to reproduce the failure with a led build without any changes, it actually worked (?!): https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/fujino_google.com/fffd2fdfc4950e8a455f466a5c08ea32fcac1666506fe2a74f1d8b2aa5ddeca6/+/build.proto

Note that it actually ran the test, and did not fail trying to check out the commit.

In any case, this works around the host framework repo needing to have a specific commit by letting the framework created by the conductor fetch directly from upstream. I initially had the conductor managed framework repo clone from the LUCI managed framework repo on disk so that it would be faster, and not need to fetch the commits from the network, but this has continually caused problems because of the complicated way we set up the LUCI managed repo.