### PR TITLE
Flush and close stdin in dart_plugin_registry_test

### DIFF
--- a/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
+++ b/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
@@ -193,13 +193,16 @@ class ApluginPlatformInterfaceMacOS {
 
       // Hot restart.
       run.stdin.write('R');
-      registryExecutedCompleter = Completer<void>();
+      await run.stdin.flush();
+      await run.stdin.close();
 
+      registryExecutedCompleter = Completer<void>();
       section('Wait for registry execution after hot restart');
       await waitOrExit(registryExecutedCompleter.future);
 
       run.kill();
 
+      section('Wait for stdout/stderr streams');
       await waitForStreams();
 
       unawaited(stdoutSub.cancel());


### PR DESCRIPTION
Related issue: https://github.com/flutter/flutter/issues/99940

This may be causing the issue seen in the recent flakes.