### PR TITLE
Add `HitTestBehavior` property to `MouseRegion`

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3016,9 +3016,12 @@ class RenderMouseRegion extends RenderProxyBoxWithHitTestBehavior implements Mou
     }
   }
 
+  /// How to behave during hit testing.
+  ///
+  /// This defaults to [HitTestBehavior.opaque] if null.
   HitTestBehavior? get hitTestBehavior => behavior;
   set hitTestBehavior(HitTestBehavior? value) {
-    HitTestBehavior newValue = value ?? HitTestBehavior.opaque;
+    final HitTestBehavior newValue = value ?? HitTestBehavior.opaque;
     if (behavior != newValue) {
       behavior = newValue;
       // Trigger [MouseTracker]'s device update to recalculate mouse states.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2972,7 +2972,7 @@ class RenderMouseRegion extends RenderProxyBoxWithHitTestBehavior implements Mou
     bool validForMouseTracker = true,
     bool opaque = true,
     RenderBox? child,
-    HitTestBehavior? hitTestBehavior = HitTestBehavior.opaque
+    HitTestBehavior? hitTestBehavior = HitTestBehavior.opaque,
   }) : assert(opaque != null),
        assert(cursor != null),
        _cursor = cursor,

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2958,7 +2958,7 @@ class RenderPointerListener extends RenderProxyBoxWithHitTestBehavior {
 ///
 ///  * [MouseRegion], a widget that listens to hover events using
 ///    [RenderMouseRegion].
-class RenderMouseRegion extends RenderProxyBox implements MouseTrackerAnnotation {
+class RenderMouseRegion extends RenderProxyBoxWithHitTestBehavior implements MouseTrackerAnnotation {
   /// Creates a render object that forwards pointer events to callbacks.
   ///
   /// All parameters are optional. By default this method creates an opaque
@@ -2972,16 +2972,13 @@ class RenderMouseRegion extends RenderProxyBox implements MouseTrackerAnnotation
     bool validForMouseTracker = true,
     bool opaque = true,
     RenderBox? child,
+    HitTestBehavior? hitTestBehavior = HitTestBehavior.opaque
   }) : assert(opaque != null),
        assert(cursor != null),
        _cursor = cursor,
        _validForMouseTracker = validForMouseTracker,
        _opaque = opaque,
-       super(child);
-
-  @protected
-  @override
-  bool hitTestSelf(Offset position) => true;
+       super(behavior: hitTestBehavior ?? HitTestBehavior.opaque, child: child);
 
   @override
   bool hitTest(BoxHitTestResult result, { required Offset position }) {
@@ -3014,6 +3011,16 @@ class RenderMouseRegion extends RenderProxyBox implements MouseTrackerAnnotation
   set opaque(bool value) {
     if (_opaque != value) {
       _opaque = value;
+      // Trigger [MouseTracker]'s device update to recalculate mouse states.
+      markNeedsPaint();
+    }
+  }
+
+  HitTestBehavior? get hitTestBehavior => behavior;
+  set hitTestBehavior(HitTestBehavior? value) {
+    HitTestBehavior newValue = value ?? HitTestBehavior.opaque;
+    if (behavior != newValue) {
+      behavior = newValue;
       // Trigger [MouseTracker]'s device update to recalculate mouse states.
       markNeedsPaint();
     }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6180,6 +6180,7 @@ class MouseRegion extends SingleChildRenderObjectWidget {
     this.onHover,
     this.cursor = MouseCursor.defer,
     this.opaque = true,
+    this.hitTestBehavior,
     Widget? child,
   }) : assert(cursor != null),
        assert(opaque != null),
@@ -6330,6 +6331,11 @@ class MouseRegion extends SingleChildRenderObjectWidget {
   /// This defaults to true.
   final bool opaque;
 
+  /// How to behave during hit testing.
+  ///
+  /// This defaults to [HitTestBehavior.opaque] if null.
+  final HitTestBehavior? hitTestBehavior;
+
   @override
   RenderMouseRegion createRenderObject(BuildContext context) {
     return RenderMouseRegion(
@@ -6338,6 +6344,7 @@ class MouseRegion extends SingleChildRenderObjectWidget {
       onExit: onExit,
       cursor: cursor,
       opaque: opaque,
+      hitTestBehavior: hitTestBehavior,
     );
   }
 
@@ -6348,7 +6355,8 @@ class MouseRegion extends SingleChildRenderObjectWidget {
       ..onHover = onHover
       ..onExit = onExit
       ..cursor = cursor
-      ..opaque = opaque;
+      ..opaque = opaque
+      ..hitTestBehavior = hitTestBehavior;
   }
 
   @override

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -77,23 +77,7 @@ class _HoverFeedbackState extends State<HoverFeedback> {
 
 void main() {
   // Regression test for https://github.com/flutter/flutter/issues/73330
-  testWidgets('hitTestBehavior test - default to HitTestBehavior.opaque', (WidgetTester tester) async {
-    bool onEnter = false;
-    await tester.pumpWidget(Center(
-      child: MouseRegion(
-        onEnter: (_) => onEnter = true,
-      ),
-    ));
-
-    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
-    await gesture.addPointer(location: Offset.zero);
-    addTearDown(gesture.removePointer);
-    await tester.pump();
-
-    expect(onEnter, true);
-  });
-
-  testWidgets('hitTestBehavior test - HitTestBehavior.deferToChild', (WidgetTester tester) async {
+  testWidgets('hitTestBehavior test - HitTestBehavior.deferToChild/opaque', (WidgetTester tester) async {
     bool onEnter = false;
     await tester.pumpWidget(Center(
       child: MouseRegion(
@@ -107,7 +91,17 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump();
 
+    // The child is null, so `onEnter` does not trigger.
     expect(onEnter, false);
+
+    // Update to the default value `HitTestBehavior.opaque`
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
+        onEnter: (_) => onEnter = true,
+      ),
+    ));
+
+    expect(onEnter, true);
   });
 
   testWidgets('hitTestBehavior test - HitTestBehavior.deferToChild and non-opaque', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -192,7 +192,7 @@ void main() {
     await tester.pumpWidget(Center(
       child: MouseRegion(
         child: Container(
-          color: const Color.fromARGB(0xff, 0xff, 0x11, 0x07),
+          color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
           width: 100.0,
           height: 100.0,
         ),

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -76,6 +76,116 @@ class _HoverFeedbackState extends State<HoverFeedback> {
 }
 
 void main() {
+  // Regression test for https://github.com/flutter/flutter/issues/73330
+  testWidgets('hitTestBehavior test - default to HitTestBehavior.opaque', (WidgetTester tester) async {
+    bool onEnter = false;
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
+        onEnter: (_) => onEnter = true,
+      ),
+    ));
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    expect(onEnter, true);
+  });
+
+  testWidgets('hitTestBehavior test - HitTestBehavior.deferToChild', (WidgetTester tester) async {
+    bool onEnter = false;
+    await tester.pumpWidget(Center(
+      child: MouseRegion(
+        hitTestBehavior: HitTestBehavior.deferToChild,
+        onEnter: (_) => onEnter = true,
+      ),
+    ));
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    expect(onEnter, false);
+  });
+
+  testWidgets('hitTestBehavior test - HitTestBehavior.deferToChild and non-opaque', (WidgetTester tester) async {
+    bool onEnterRegion1 = false;
+    bool onEnterRegion2 = false;
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Stack(
+        children: <Widget>[
+          SizedBox(
+            width: 50.0,
+            height: 50.0,
+            child: MouseRegion(
+              onEnter: (_) => onEnterRegion1 = true,
+            ),
+          ),
+          SizedBox(
+            width: 50.0,
+            height: 50.0,
+            child: MouseRegion(
+              opaque: false,
+              hitTestBehavior: HitTestBehavior.deferToChild,
+              onEnter: (_) => onEnterRegion2 = true,
+              child: Container(
+                color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
+                width: 50.0,
+                height: 50.0,
+              ),
+            ),
+          ),
+        ],
+      ),
+    ));
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    expect(onEnterRegion2, true);
+    expect(onEnterRegion1, true);
+  });
+
+  testWidgets('hitTestBehavior test - HitTestBehavior.translucent', (WidgetTester tester) async {
+    bool onEnterRegion1 = false;
+    bool onEnterRegion2 = false;
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Stack(
+        children: <Widget>[
+          SizedBox(
+            width: 50.0,
+            height: 50.0,
+            child: MouseRegion(
+              onEnter: (_) => onEnterRegion1 = true,
+            ),
+          ),
+          SizedBox(
+            width: 50.0,
+            height: 50.0,
+            child: MouseRegion(
+              hitTestBehavior: HitTestBehavior.translucent,
+              onEnter: (_) => onEnterRegion2 = true,
+            ),
+          ),
+        ],
+      ),
+    ));
+
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: Offset.zero);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    expect(onEnterRegion2, true);
+    expect(onEnterRegion1, true);
+  });
+
   testWidgets('onEnter and onExit can be triggered with mouse buttons pressed', (WidgetTester tester) async {
     PointerEnterEvent? enter;
     PointerExitEvent? exit;

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -1706,6 +1706,7 @@ void main() {
       'parentData: MISSING',
       'constraints: MISSING',
       'size: MISSING',
+      'behavior: opaque',
       'listeners: <none>',
     ]);
   });
@@ -1727,6 +1728,7 @@ void main() {
       'parentData: MISSING',
       'constraints: MISSING',
       'size: MISSING',
+      'behavior: opaque',
       'listeners: enter, hover, exit',
       'cursor: SystemMouseCursor(click)',
       'invalid for MouseTracker',

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -132,7 +132,7 @@ void main() {
               hitTestBehavior: HitTestBehavior.deferToChild,
               onEnter: (_) => onEnterRegion2 = true,
               child: Container(
-                color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
+                color: const Color.fromARGB(0xff, 0xff, 0x10, 0x19),
                 width: 50.0,
                 height: 50.0,
               ),
@@ -192,7 +192,7 @@ void main() {
     await tester.pumpWidget(Center(
       child: MouseRegion(
         child: Container(
-          color: const Color.fromARGB(0xff, 0xff, 0x00, 0x00),
+          color: const Color.fromARGB(0xff, 0xff, 0x11, 0x07),
           width: 100.0,
           height: 100.0,
         ),


### PR DESCRIPTION
Currently `MouseRegion` can only be hit-tested with in square size area and cannot defer to its child.

Fixes https://github.com/flutter/flutter/issues/73330