### PR TITLE
Refactor l10n generator to handle multiple plurals/selects

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_templates.dart
@@ -109,26 +109,39 @@ abstract class @(class) {
 ''';
 
 const String numberFormatPositionalTemplate = '''
-    final intl.NumberFormat @(placeholder)NumberFormat = intl.NumberFormat.@(format)(localeName);
-    final String @(placeholder)String = @(placeholder)NumberFormat.format(@(placeholder));
+    final String @(varname) = intl.NumberFormat.@(format)(localeName).format(@(placeholder));
 ''';
 
 const String numberFormatNamedTemplate = '''
-    final intl.NumberFormat @(placeholder)NumberFormat = intl.NumberFormat.@(format)(
+    final String @(varname) = intl.NumberFormat.@(format)(
       locale: localeName,
       @(parameters)
-    );
-    final String @(placeholder)String = @(placeholder)NumberFormat.format(@(placeholder));
+    ).format(@(placeholder));
 ''';
 
-const String dateFormatTemplate = '''
-    final intl.DateFormat @(placeholder)DateFormat = intl.DateFormat.@(format)(localeName);
-    final String @(placeholder)String = @(placeholder)DateFormat.format(@(placeholder));
+const String dateFormatBuiltinTemplate = '''
+    final String @(varname) = intl.DateFormat.@(format)(localeName).format(@(placeholder));
 ''';
 
 const String dateFormatCustomTemplate = '''
-    final intl.DateFormat @(placeholder)DateFormat = intl.DateFormat(@(format), localeName);
-    final String @(placeholder)String = @(placeholder)DateFormat.format(@(placeholder));
+    final String @(varname) = intl.DateFormat(@(format), localeName).format(@(placeholder));
+''';
+
+const String selectFormatTemplate = '''
+    final String @(varname) = intl.Intl.select(
+      @(placeholder),
+      {
+        @(cases)
+      }
+    );
+''';
+
+const String pluralFormatTemplate = '''
+    final String @(varname) = intl.Intl.pluralLogic(
+      @(placeholder),
+      locale: localeName,
+      @(pluralLogicArgs),
+    );
 ''';
 
 const String getterTemplate = '''
@@ -138,67 +151,8 @@ const String getterTemplate = '''
 const String methodTemplate = '''
   @override
   String @(name)(@(parameters)) {
+    @(variables)
     return @(message);
-  }''';
-
-const String formatMethodTemplate = '''
-  @override
-  String @(name)(@(parameters)) {
-@(dateFormatting)
-@(numberFormatting)
-    return @(message);
-  }''';
-
-const String pluralMethodTemplate = '''
-  @override
-  String @(name)(@(parameters)) {
-@(dateFormatting)
-@(numberFormatting)
-    return intl.Intl.pluralLogic(
-      @(count),
-      locale: localeName,
-@(pluralLogicArgs),
-    );
-  }''';
-
-const String pluralMethodTemplateInString = '''
-  @override
-  String @(name)(@(parameters)) {
-@(dateFormatting)
-@(numberFormatting)
-    final String @(variable) = intl.Intl.pluralLogic(
-      @(count),
-      locale: localeName,
-@(pluralLogicArgs),
-    );
-
-    return @(string);
-  }''';
-
-const String selectMethodTemplate = '''
-  @override
-  String @(name)(@(parameters)) {
-    return intl.Intl.select(
-      @(choice),
-      {
-        @(cases)
-      },
-      desc: '@(description)'
-    );
-  }''';
-
-const String selectMethodTemplateInString = '''
-  @override
-  String @(name)(@(parameters)) {
-    final String @(variable) = intl.Intl.select(
-      @(choice),
-      {
-        @(cases)
-      },
-      desc: '@(description)'
-    );
-
-    return @(string);
   }''';
 
 const String classFileTemplate = '''

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -431,6 +431,35 @@ class Message {
   }
 }
 
+// Represents part of a parsed ICU message.
+class MessageToken {
+  const MessageToken(this.literalText, this.argumentText);
+  final String literalText;
+  final String? argumentText;
+}
+
+// Represents possible argument types of an ICU placeholder.
+enum ArgumentType {
+  simple,
+  select,
+  plural,
+}
+
+// Represents a placeholder element extracted from ICU message.
+class FormattingArgument {
+  const FormattingArgument(this.type, this.name, this.params);
+  final ArgumentType type;
+  final String name;
+  final String params;
+}
+
+// Represents a generated variable to format placeholder in the final message.
+class FormattingVariable {
+  const FormattingVariable(this.name, this.argument);
+  final String name;
+  final FormattingArgument argument;
+}
+
 // Represents the contents of one ARB file.
 class AppResourceBundle {
   factory AppResourceBundle(File file) {

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -251,8 +251,8 @@ String describeLocale(String tag) {
 /// ```
 /// foo => 'foo'
 /// foo "bar" => 'foo "bar"'
-/// foo 'bar' => "foo 'bar'"
-/// foo 'bar' "baz" => '''foo 'bar' "baz"'''
+/// foo 'bar' => 'foo \'bar\''
+/// foo 'bar' "baz" => 'foo \'bar\' \"baz\"'
 /// ```
 ///
 /// This function is used by tools that take in a JSON-formatted file to

--- a/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
+++ b/packages/flutter_tools/test/integration.shard/gen_l10n_test.dart
@@ -125,45 +125,79 @@ void main() {
       '#l10n 70 (Indeed, they like Flutter!)\n'
       '#l10n 71 (Indeed, he likes ice cream!)\n'
       '#l10n 72 (Indeed, she likes chocolate!)\n'
-      '#l10n 73 (--- es ---)\n'
-      '#l10n 74 (ES - Hello world)\n'
-      '#l10n 75 (ES - Hello _NEWLINE_ World)\n'
-      '#l10n 76 (ES - Hola \$ Mundo)\n'
-      '#l10n 77 (ES - Hello Mundo)\n'
-      '#l10n 78 (ES - Hola Mundo)\n'
-      '#l10n 79 (ES - Hello World on viernes, 1 de enero de 1960)\n'
-      '#l10n 80 (ES - Hello world argument on 1/1/1960 at 0:00)\n'
-      '#l10n 81 (ES - Hello World from 1960 to 2020)\n'
-      '#l10n 82 (ES - Hello for 123)\n'
-      '#l10n 83 (ES - Hello)\n'
-      '#l10n 84 (ES - Hello World)\n'
-      '#l10n 85 (ES - Hello two worlds)\n'
-      '#l10n 86 (ES - Hello)\n'
-      '#l10n 87 (ES - Hello nuevo World)\n'
-      '#l10n 88 (ES - Hello two nuevo worlds)\n'
-      '#l10n 89 (ES - Hello on viernes, 1 de enero de 1960)\n'
-      '#l10n 90 (ES - Hello World, on viernes, 1 de enero de 1960)\n'
-      '#l10n 91 (ES - Hello two worlds, on viernes, 1 de enero de 1960)\n'
-      '#l10n 92 (ES - Hello other 0 worlds, with a total of 100 citizens)\n'
-      '#l10n 93 (ES - Hello World of 101 citizens)\n'
-      '#l10n 94 (ES - Hello two worlds with 102 total citizens)\n'
-      '#l10n 95 (ES - [Hola] -Mundo- #123#)\n'
-      '#l10n 96 (ES - \$!)\n'
-      '#l10n 97 (ES - One \$)\n'
-      "#l10n 98 (ES - Flutter's amazing!)\n"
-      "#l10n 99 (ES - Flutter's amazing, times 2!)\n"
-      '#l10n 100 (ES - Flutter is "amazing"!)\n'
-      '#l10n 101 (ES - Flutter is "amazing", times 2!)\n'
-      '#l10n 102 (ES - 16 wheel truck)\n'
-      "#l10n 103 (ES - Sedan's elegance)\n"
-      '#l10n 104 (ES - Cabriolet has "acceleration")\n'
-      '#l10n 105 (ES - Oh, she found ES - 1 itemES - !)\n'
-      '#l10n 106 (ES - Indeed, ES - they like ES - Flutter!)\n'
-      '#l10n 107 (--- es_419 ---)\n'
-      '#l10n 108 (ES 419 - Hello World)\n'
-      '#l10n 109 (ES 419 - Hello)\n'
-      '#l10n 110 (ES 419 - Hello World)\n'
-      '#l10n 111 (ES 419 - Hello two worlds)\n'
+      '#l10n 73 (Indeed, she likes Dart a lot!)\n'
+      '#l10n 74 (Indeed, they like Flutter a lot!)\n'
+      '#l10n 75 (There is 1 world.)\n'
+      '#l10n 76 (There are 10 worlds.)\n'
+      '#l10n 77 (I can see one apple.)\n'
+      '#l10n 78 (I can see 3 bananas.)\n'
+      "#l10n 79 (Some 'message' with ''quotes'')\n"
+      "#l10n 80 (This {isn't} obvious, }is it?{)\n"
+      "#l10n 81 (Hello quoted 'World')\n"
+      "#l10n 82 (The quoted 'apples'.)\n"
+      '#l10n 83 (The braced {bananas}.)\n'
+      "#l10n 84 (The double-quoted ''peaches''.)\n"
+      "#l10n 85 ('Testing 'A'')\n"
+      "#l10n 86 ('Testing } B {')\n"
+      "#l10n 87 ('Testing ' } C { '')\n"
+      "#l10n 88 ('Testing '{D}'')\n"
+      '#l10n 89 (The value of pi is approximately 3.14)\n'
+      '#l10n 90 (--- es ---)\n'
+      '#l10n 91 (ES - Hello world)\n'
+      '#l10n 92 (ES - Hello _NEWLINE_ World)\n'
+      '#l10n 93 (ES - Hola \$ Mundo)\n'
+      '#l10n 94 (ES - Hello Mundo)\n'
+      '#l10n 95 (ES - Hola Mundo)\n'
+      '#l10n 96 (ES - Hello World on viernes, 1 de enero de 1960)\n'
+      '#l10n 97 (ES - Hello world argument on 1/1/1960 at 0:00)\n'
+      '#l10n 98 (ES - Hello World from 1960 to 2020)\n'
+      '#l10n 99 (ES - Hello for 123)\n'
+      '#l10n 100 (ES - Hello)\n'
+      '#l10n 101 (ES - Hello World)\n'
+      '#l10n 102 (ES - Hello two worlds)\n'
+      '#l10n 103 (ES - Hello)\n'
+      '#l10n 104 (ES - Hello nuevo World)\n'
+      '#l10n 105 (ES - Hello two nuevo worlds)\n'
+      '#l10n 106 (ES - Hello on viernes, 1 de enero de 1960)\n'
+      '#l10n 107 (ES - Hello World, on viernes, 1 de enero de 1960)\n'
+      '#l10n 108 (ES - Hello two worlds, on viernes, 1 de enero de 1960)\n'
+      '#l10n 109 (ES - Hello other 0 worlds, with a total of 100 citizens)\n'
+      '#l10n 110 (ES - Hello World of 101 citizens)\n'
+      '#l10n 111 (ES - Hello two worlds with 102 total citizens)\n'
+      '#l10n 112 (ES - [Hola] -Mundo- #123#)\n'
+      '#l10n 113 (ES - \$!)\n'
+      '#l10n 114 (ES - One \$)\n'
+      "#l10n 115 (ES - Flutter's amazing!)\n"
+      "#l10n 116 (ES - Flutter's amazing, times 2!)\n"
+      '#l10n 117 (ES - Flutter is "amazing"!)\n'
+      '#l10n 118 (ES - Flutter is "amazing", times 2!)\n'
+      '#l10n 119 (ES - 16 wheel truck)\n'
+      "#l10n 120 (ES - Sedan's elegance)\n"
+      '#l10n 121 (ES - Cabriolet has "acceleration")\n'
+      '#l10n 122 (ES - Oh, she found ES - 1 itemES - !)\n'
+      '#l10n 123 (ES - Indeed, ES - they like ES - Flutter!)\n'
+      '#l10n 124 (ES - Indeed, ES - she likes ES - Dart a lot!)\n'
+      '#l10n 125 (ES - Indeed, ES - they like ES - Flutter a lot!)\n'
+      '#l10n 126 (ES - There ES - is 1 world - ES.)\n'
+      '#l10n 127 (ES - There ES - are 10 worlds - ES.)\n'
+      '#l10n 128 (ES - I can see ES - one apple.)\n'
+      '#l10n 129 (ES - I can see ES - 3 bananas.)\n'
+      "#l10n 130 (ES - Some 'message' with ''quotes'')\n"
+      "#l10n 131 (ES - This {isn't} obvious, }is it?{)\n"
+      "#l10n 132 (ES - Hello quoted 'World')\n"
+      "#l10n 133 (ES - The quoted 'apples'.)\n"
+      '#l10n 134 (ES - The braced {bananas}.)\n'
+      "#l10n 135 (ES - The double-quoted ''peaches''.)\n"
+      "#l10n 136 (ES - 'Testing 'A'')\n"
+      "#l10n 137 (ES - 'Testing } B {')\n"
+      "#l10n 138 (ES - 'Testing ' } C { '')\n"
+      "#l10n 139 (ES - 'Testing '{D}'')\n"
+      '#l10n 140 (ES - The value of pi is approximately 3,14)\n'
+      '#l10n 141 (--- es_419 ---)\n'
+      '#l10n 142 (ES 419 - Hello World)\n'
+      '#l10n 143 (ES 419 - Hello)\n'
+      '#l10n 144 (ES 419 - Hello World)\n'
+      '#l10n 145 (ES 419 - Hello two worlds)\n'
       '#l10n END\n'
     );
   }

--- a/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/gen_l10n_project.dart
@@ -229,6 +229,23 @@ class Home extends StatelessWidget {
               "${localizations.selectInString('he')}",
               "${localizations.selectWithPlaceholder('male', 'ice cream')}",
               "${localizations.selectWithPlaceholder('female', 'chocolate')}",
+              "${localizations.pluralThenString(1, 'Dart')}",
+              "${localizations.pluralThenString(2, 'Flutter')}",
+              "${localizations.multiplePlurals(1)}",
+              "${localizations.multiplePlurals(10)}",
+              "${localizations.pluralInSelect(1, 'apple')}",
+              "${localizations.pluralInSelect(3, 'banana')}",
+              "${localizations.doubleQuotes}",
+              "${localizations.escapedMessage}",
+              "${localizations.nonEscapingDoubleQuotes('World')}",
+              "${localizations.quotingInsideSelect('apple')}",
+              "${localizations.quotingInsideSelect('banana')}",
+              "${localizations.quotingInsideSelect('peach')}",
+              "${localizations.escapingInsideSelect('a')}",
+              "${localizations.escapingInsideSelect('b')}",
+              "${localizations.escapingInsideSelect('c')}",
+              "${localizations.escapingInsideSelect('d')}",
+              '${localizations.noNameCollision("pi", 3.14)}',
             ]);
           },
         ),
@@ -275,6 +292,23 @@ class Home extends StatelessWidget {
               "${localizations.doubleQuoteSelect('cabriolet')}",
               "${localizations.pluralInString(1)}",
               "${localizations.selectInString('he')}",
+              "${localizations.pluralThenString(1, 'Dart')}",
+              "${localizations.pluralThenString(2, 'Flutter')}",
+              "${localizations.multiplePlurals(1)}",
+              "${localizations.multiplePlurals(10)}",
+              "${localizations.pluralInSelect(1, 'apple')}",
+              "${localizations.pluralInSelect(3, 'banana')}",
+              "${localizations.doubleQuotes}",
+              "${localizations.escapedMessage}",
+              "${localizations.nonEscapingDoubleQuotes('World')}",
+              "${localizations.quotingInsideSelect('apple')}",
+              "${localizations.quotingInsideSelect('banana')}",
+              "${localizations.quotingInsideSelect('peach')}",
+              "${localizations.escapingInsideSelect('a')}",
+              "${localizations.escapingInsideSelect('b')}",
+              "${localizations.escapingInsideSelect('c')}",
+              "${localizations.escapingInsideSelect('d')}",
+              '${localizations.noNameCollision("pi", 3.14)}',
             ]);
           },
         ),
@@ -324,7 +358,7 @@ void main() {
 }
 ''';
 
-  final String appEn = r'''
+  final String appEn = r"""
 {
   "@@locale": "en",
 
@@ -666,9 +700,79 @@ void main() {
       "gender": {},
       "preference": {}
     }
+  },
+
+  "pluralThenString": "Indeed, {count, plural, =1 {she likes} other {they like}} {project} a lot!",
+  "@pluralThenString": {
+    "placeholders": {
+      "count": {},
+      "project": {
+        "type": "String"
+      }
+    }
+  },
+
+  "multiplePlurals": "There {count, plural, =1{is} other{are}} {count} world{count, plural, =1{} other{s}}.",
+  "@multiplePlurals": {
+    "placeholders": {
+      "count": {}
+    }
+  },
+
+  "pluralInSelect": "I can see {fruit, select, apple{{count, plural, =0{no apple} =1{one apple} other{some apples}}} banana{{count, plural, =0{no banana} =1{one banana} other{{count} bananas}}}}.",
+  "@pluralInSelect": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "fruit": {}
+    }
+  },
+
+  "doubleQuotes": "Some ''message'' with ''''quotes''''",
+  "@doubleQuotes": {
+    "description": "A message with double quotes."
+  },
+
+  "escapedMessage": "This '{isn''t}' obvious, '}is it?{'",
+  "@escapedMessage": {
+    "description": "A message with an quoted/escaped part"
+  },
+
+  "nonEscapingDoubleQuotes": "Hello quoted ''{world}''",
+  "@nonEscapingDoubleQuotes": {
+    "description": "A message with placeholder and non-escaping braces",
+    "placeholders": {
+      "world": {}
+    }
+  },
+
+  "quotingInsideSelect": "The {fruit, select, apple{quoted ''apples''} banana{braced '{bananas}'}  peach{double-quoted ''''peaches''''}}.",
+  "@quotingInsideSelect": {
+    "placeholders": {
+      "fruit": {}
+    }
+  },
+
+  "escapingInsideSelect": "'Testing {test, select, a{'A''} b{'} B {'} c{' '}' C '{' ''} d{'''{D}'''}}'",
+  "@escapingInsideSelect": {
+    "placeholders": {
+      "test": {}
+    }
+  },
+
+  "noNameCollision": "The value of {valueString} is approximately {value}",
+  "@noNameCollision": {
+    "placeholders": {
+      "valueString": {},
+      "value": {
+        "type": "double",
+        "format": "decimalPattern"
+      }
+    }
   }
 }
-''';
+""";
 
   final String appEnCa = r'''
 {
@@ -687,7 +791,7 @@ void main() {
   /// All messages are simply the template language's message with 'ES - '
   /// appended. This makes validating test behavior easier. The interpolated
   /// messages are different where applicable.
-  final String appEs = r'''
+  final String appEs = r"""
 {
   "@@locale": "es",
   "helloWorld": "ES - Hello world",
@@ -715,9 +819,18 @@ void main() {
   "singleQuoteSelect": "{vehicleType, select, sedan{ES - Sedan's elegance} cabriolet{ES - Cabriolet' acceleration} truck{ES - truck's heavy duty} other{ES - Other's mirrors!}}",
   "doubleQuoteSelect": "{vehicleType, select, sedan{ES - Sedan has \"elegance\"} cabriolet{ES - Cabriolet has \"acceleration\"} truck{ES - truck is \"heavy duty\"} other{ES - Other have \"mirrors\"!}}",
   "pluralInString": "ES - Oh, she found {count, plural, =1 {ES - 1 item} other {ES - all {count} items} }ES - !",
-  "selectInString": "ES - Indeed, {gender, select, male {ES - he likes} female {ES - she likes} other {ES - they like} } ES - Flutter!"
+  "selectInString": "ES - Indeed, {gender, select, male {ES - he likes} female {ES - she likes} other {ES - they like} } ES - Flutter!",
+  "pluralThenString": "ES - Indeed, {count, plural, =1 {ES - she likes} other {ES - they like} } ES - {project} a lot!",
+  "multiplePlurals": "ES - There {count, plural, =1{ES - is} other{ES - are}} {count} world{count, plural, =1{ - ES} other{s - ES}}.",
+  "pluralInSelect": "ES - I can see {fruit, select, apple{{count, plural, =0{ES - no apple} =1{ES - one apple} other{ES - some apples}}} banana{{count, plural, =0{ES - no banana} =1{ES - one banana} other{ES - {count} bananas}}}}.",
+  "doubleQuotes": "ES - Some ''message'' with ''''quotes''''",
+  "escapedMessage": "ES - This '{isn''t}' obvious, '}is it?{'",
+  "nonEscapingDoubleQuotes": "ES - Hello quoted ''{world}''",
+  "quotingInsideSelect": "ES - The {fruit, select, apple{quoted ''apples''} banana{braced '{bananas}'} peach{double-quoted ''''peaches''''}}.",
+  "escapingInsideSelect": "ES - 'Testing {test, select, a{'A''} b{'} B {'} c{' '}' C '{' ''} d{'''{D}'''}}'",
+  "noNameCollision": "ES - The value of {valueString} is approximately {value}"
 }
-''';
+""";
 
   final String appEs419 = r'''
 {


### PR DESCRIPTION
This PR is intended to fix https://github.com/flutter/flutter/issues/86906.

This is a continuation a PR I opened a few months ago but which I had not completed entirely and which had therefore been closed: https://github.com/flutter/flutter/pull/86909

I'm quoting the relevant part regarding the implementation:

> Currently, the l10n generator is implemented using regexes which makes it hard to handle multiple plurals in the same string. The solution proposed is to use a parser to extract the `{}` components one by one. For simplicity, there are two passes on the string: the first one to extract the fields, the second one to format them in the message. Meanwhile, the variables used in the final string are generated according to the fields extracted by the first pass.
> 
> Main change is the following: instead of iterating through the placeholders and replacing their corresponding field in the string, we iterate through the fields and replace them according to the corresponding placeholder.

To summarize the implementation:
1. Recursively extract all placeholders from the message string
    - Parse the message to find all placeholders
    - For each plural/select placeholder, extract its nested placeholders and so on
2. Generate a list of variable names corresponding to each extracted placeholder
    - Variables will be used while filling the method template
    - Variables are re-used when possible (even if same placeholder appears multiple time in the message)
    - Avoid name clashing
 3. Generate a list of formatting directive for each generated variables
    - Select a template type depending on the variable type
    - Re-parse the placeholder arguments and replace them with variable name previously generated
 4. Construct the final string to be returned based on top placeholders and variables

As suggested by @asashour in https://github.com/flutter/flutter/pull/86909#issuecomment-920672056 I also implemented escaping mechanism described [here](https://unicode-org.github.io/icu/userguide/format_parse/messages/#quotingescaping). This complicated the `_parseMessage()` quite a lot compared to my initial PR. I'm not sure how I ended up with such convoluted implementation. It was a "fun" exercise but surely we could re-consider it.

This PR introduces breaking changes:
* Missing `}` at the end of a plural/select message throws an exception
* Non-escaped braces in simple messages throws an exception
* Pair of quotes `''` are converted to `'` in the messages

@HansMuller I understand perfectly that you lacked of time to review my previous draft PR, there is no problem. It's a big modification that should be reviewed with care. It changes the logic of how the generator works, but I think it's the most practical solution in the long run.

Please let me know of anything that may need more details or improvements. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
