### PR TITLE
Prepare `flutter_tools` for `use_super_parameters`

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -56,7 +56,7 @@ const Map<String, HardwareType> kKnownHardware = <String, HardwareType>{
 /// map to specify that they are actually physical devices.
 class AndroidDevice extends Device {
   AndroidDevice(
-    String id, {
+    super.id, {
     this.productID,
     required this.modelID,
     this.deviceCodeName,
@@ -74,7 +74,6 @@ class AndroidDevice extends Device {
        _androidConsoleSocketFactory = androidConsoleSocketFactory,
        _processUtils = ProcessUtils(logger: logger, processManager: processManager),
        super(
-         id,
          category: Category.mobile,
          platformType: PlatformType.android,
          ephemeral: true,

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -23,13 +23,12 @@ import 'gradle.dart';
 /// An application package created from an already built Android APK.
 class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackage {
   AndroidApk({
-    required String id,
+    required super.id,
     required this.applicationPackage,
     required this.versionCode,
     required this.launchActivity,
   }) : assert(applicationPackage != null),
-       assert(launchActivity != null),
-       super(id: id);
+       assert(launchActivity != null);
 
   /// Creates a new AndroidApk from an existing APK.
   ///

--- a/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
@@ -8,7 +8,6 @@ import '../base/deferred_component.dart';
 import '../base/error_handling_io.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../base/platform.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
 import '../template.dart';
@@ -29,12 +28,11 @@ class DeferredComponentsPrebuildValidator extends DeferredComponentsValidator {
   /// When [exitOnFail] is set to true, the [handleResults] and [attemptToolExit]
   /// methods will exit the tool when this validator detects a recommended
   /// change. This defaults to true.
-  DeferredComponentsPrebuildValidator(Directory projectDir, Logger logger, Platform platform, {
-    bool exitOnFail = true,
-    String? title,
+  DeferredComponentsPrebuildValidator(super.projectDir, super.logger, super.platform, {
+    super.exitOnFail,
+    super.title,
     Directory? templatesDir,
-  }) : _templatesDir = templatesDir,
-       super(projectDir, logger, platform, exitOnFail: exitOnFail, title: title);
+  }) : _templatesDir = templatesDir;
 
   final Directory? _templatesDir;
 

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -209,8 +209,7 @@ class ProcessSignal {
 @visibleForTesting
 class PosixProcessSignal extends ProcessSignal {
 
-  const PosixProcessSignal(io.ProcessSignal wrappedSignal, {@visibleForTesting Platform platform = const LocalPlatform()})
-    : super(wrappedSignal, platform: platform);
+  const PosixProcessSignal(super.wrappedSignal, {@visibleForTesting super.platform});
 
   @override
   Stream<ProcessSignal> watch() {

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -706,16 +706,11 @@ int _getColumnSize(String line) {
 /// they will show up as the unrepresentable character symbol '�'.
 class WindowsStdoutLogger extends StdoutLogger {
   WindowsStdoutLogger({
-    required Terminal terminal,
-    required Stdio stdio,
-    required OutputPreferences outputPreferences,
-    StopwatchFactory stopwatchFactory = const StopwatchFactory(),
-  }) : super(
-      terminal: terminal,
-      stdio: stdio,
-      outputPreferences: outputPreferences,
-      stopwatchFactory: stopwatchFactory,
-    );
+    required super.terminal,
+    required super.stdio,
+    required super.outputPreferences,
+    super.stopwatchFactory,
+  });
 
   @override
   void writeToStdOut(String message) {
@@ -906,11 +901,10 @@ class BufferLogger extends Logger {
 }
 
 class VerboseLogger extends DelegatingLogger {
-  VerboseLogger(Logger parent, {
+  VerboseLogger(super.parent, {
     StopwatchFactory stopwatchFactory = const StopwatchFactory()
   }) : _stopwatch = stopwatchFactory.createStopwatch(),
-       _stopwatchFactory = stopwatchFactory,
-       super(parent) {
+       _stopwatchFactory = stopwatchFactory {
     _stopwatch.start();
   }
 
@@ -1081,7 +1075,7 @@ class VerboseLogger extends DelegatingLogger {
 }
 
 class PrefixedErrorLogger extends DelegatingLogger {
-  PrefixedErrorLogger(Logger parent) : super(parent);
+  PrefixedErrorLogger(super.parent);
 
   @override
   void printError(
@@ -1186,12 +1180,9 @@ abstract class Status {
 /// A [Status] that shows nothing.
 class SilentStatus extends Status {
   SilentStatus({
-    required Stopwatch stopwatch,
-    VoidCallback? onFinish,
-  }) : super(
-    onFinish: onFinish,
-    stopwatch: stopwatch,
-  );
+    required super.stopwatch,
+    super.onFinish,
+  });
 
   @override
   void finish() {
@@ -1206,15 +1197,11 @@ const int _kTimePadding = 8; // should fit "99,999ms"
 class SummaryStatus extends Status {
   SummaryStatus({
     this.message = '',
-    required Stopwatch stopwatch,
+    required super.stopwatch,
     this.padding = kDefaultStatusPadding,
-    VoidCallback? onFinish,
+    super.onFinish,
     required Stdio stdio,
-  }) : _stdio = stdio,
-       super(
-         onFinish: onFinish,
-         stopwatch: stopwatch,
-        );
+  }) : _stdio = stdio;
 
   final String message;
   final int padding;
@@ -1270,20 +1257,15 @@ class SummaryStatus extends Status {
 /// Call [pause] before outputting any text while this is running.
 class AnonymousSpinnerStatus extends Status {
   AnonymousSpinnerStatus({
-    VoidCallback? onFinish,
-    required Stopwatch stopwatch,
+    super.onFinish,
+    required super.stopwatch,
     required Stdio stdio,
     required Terminal terminal,
     this.slowWarningCallback,
-    Duration? timeout,
+    super.timeout,
   }) : _stdio = stdio,
        _terminal = terminal,
-       _animation = _selectAnimation(terminal),
-       super(
-         onFinish: onFinish,
-         stopwatch: stopwatch,
-         timeout: timeout,
-       );
+       _animation = _selectAnimation(terminal);
 
   final Stdio _stdio;
   final Terminal _terminal;
@@ -1425,16 +1407,11 @@ class SpinnerStatus extends AnonymousSpinnerStatus {
   SpinnerStatus({
     required this.message,
     this.padding = kDefaultStatusPadding,
-    VoidCallback? onFinish,
-    required Stopwatch stopwatch,
-    required Stdio stdio,
-    required Terminal terminal,
-  }) : super(
-         onFinish: onFinish,
-         stopwatch: stopwatch,
-         stdio: stdio,
-         terminal: terminal,
-        );
+    super.onFinish,
+    required super.stopwatch,
+    required super.stdio,
+    required super.terminal,
+  });
 
   final String message;
   final int padding;

--- a/packages/flutter_tools/lib/src/base/multi_root_file_system.dart
+++ b/packages/flutter_tools/lib/src/base/multi_root_file_system.dart
@@ -212,12 +212,9 @@ abstract class MultiRootFileSystemEntity<T extends FileSystemEntity,
 class MultiRootFile extends MultiRootFileSystemEntity<File, io.File>
     with ForwardingFile {
   MultiRootFile({
-    required MultiRootFileSystem fileSystem,
-    required io.File delegate,
-  }) : super(
-    fileSystem: fileSystem,
-    delegate: delegate,
-  );
+    required super.fileSystem,
+    required super.delegate,
+  });
 
   @override
   String toString() =>
@@ -228,12 +225,9 @@ class MultiRootDirectory
     extends MultiRootFileSystemEntity<Directory, io.Directory>
     with ForwardingDirectory<Directory> {
   MultiRootDirectory({
-    required MultiRootFileSystem fileSystem,
-    required io.Directory delegate,
-  }) : super(
-    fileSystem: fileSystem,
-    delegate: delegate,
-  );
+    required super.fileSystem,
+    required super.delegate,
+  });
 
   // For the childEntity methods, we first obtain an instance of the entity
   // from the underlying file system, then invoke childEntity() on it, then
@@ -258,12 +252,9 @@ class MultiRootDirectory
 class MultiRootLink extends MultiRootFileSystemEntity<Link, io.Link>
     with ForwardingLink {
   MultiRootLink({
-    required MultiRootFileSystem fileSystem,
-    required io.Link delegate,
-  }) : super(
-    fileSystem: fileSystem,
-    delegate: delegate,
-  );
+    required super.fileSystem,
+    required super.delegate,
+  });
 
   @override
   String toString() =>

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -166,16 +166,11 @@ abstract class OperatingSystemUtils {
 
 class _PosixUtils extends OperatingSystemUtils {
   _PosixUtils({
-    required FileSystem fileSystem,
-    required Logger logger,
-    required Platform platform,
-    required ProcessManager processManager,
-  }) : super._private(
-    fileSystem: fileSystem,
-    logger: logger,
-    platform: platform,
-    processManager: processManager,
-  );
+    required super.fileSystem,
+    required super.logger,
+    required super.platform,
+    required super.processManager,
+  }) : super._private();
 
   @override
   void makeExecutable(File file) {
@@ -295,16 +290,11 @@ class _PosixUtils extends OperatingSystemUtils {
 
 class _LinuxUtils extends _PosixUtils {
   _LinuxUtils({
-    required FileSystem fileSystem,
-    required Logger logger,
-    required Platform platform,
-    required ProcessManager processManager,
-  }) : super(
-          fileSystem: fileSystem,
-          logger: logger,
-          platform: platform,
-          processManager: processManager,
-        );
+    required super.fileSystem,
+    required super.logger,
+    required super.platform,
+    required super.processManager,
+  });
 
   String? _name;
 
@@ -367,16 +357,11 @@ class _LinuxUtils extends _PosixUtils {
 
 class _MacOSUtils extends _PosixUtils {
   _MacOSUtils({
-    required FileSystem fileSystem,
-    required Logger logger,
-    required Platform platform,
-    required ProcessManager processManager,
-  }) : super(
-          fileSystem: fileSystem,
-          logger: logger,
-          platform: platform,
-          processManager: processManager,
-        );
+    required super.fileSystem,
+    required super.logger,
+    required super.platform,
+    required super.processManager,
+  });
 
   String? _name;
 
@@ -475,16 +460,11 @@ class _MacOSUtils extends _PosixUtils {
 
 class _WindowsUtils extends OperatingSystemUtils {
   _WindowsUtils({
-    required FileSystem fileSystem,
-    required Logger logger,
-    required Platform platform,
-    required ProcessManager processManager,
-  }) : super._private(
-    fileSystem: fileSystem,
-    logger: logger,
-    platform: platform,
-    processManager: processManager,
-  );
+    required super.fileSystem,
+    required super.logger,
+    required super.platform,
+    required super.processManager,
+  }) : super._private();
 
   @override
   HostPlatform hostPlatform = HostPlatform.windows_x64;

--- a/packages/flutter_tools/lib/src/build_system/targets/linux.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/linux.dart
@@ -193,7 +193,7 @@ class LinuxAotBundle extends Target {
 }
 
 class DebugBundleLinuxAssets extends BundleLinuxAssets {
-  const DebugBundleLinuxAssets(TargetPlatform targetPlatform) : super(targetPlatform);
+  const DebugBundleLinuxAssets(super.targetPlatform);
 
   @override
   String get name => 'debug_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
@@ -210,7 +210,7 @@ class DebugBundleLinuxAssets extends BundleLinuxAssets {
 }
 
 class ProfileBundleLinuxAssets extends BundleLinuxAssets {
-  const ProfileBundleLinuxAssets(TargetPlatform targetPlatform) : super(targetPlatform);
+  const ProfileBundleLinuxAssets(super.targetPlatform);
 
   @override
   String get name => 'profile_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';
@@ -226,7 +226,7 @@ class ProfileBundleLinuxAssets extends BundleLinuxAssets {
 }
 
 class ReleaseBundleLinuxAssets extends BundleLinuxAssets {
-  const ReleaseBundleLinuxAssets(TargetPlatform targetPlatform) : super(targetPlatform);
+  const ReleaseBundleLinuxAssets(super.targetPlatform);
 
   @override
   String get name => 'release_bundle_${getNameForTargetPlatform(targetPlatform)}_assets';

--- a/packages/flutter_tools/lib/src/cmake_project.dart
+++ b/packages/flutter_tools/lib/src/cmake_project.dart
@@ -86,7 +86,7 @@ class WindowsProject extends FlutterProjectPlatform implements CmakeBasedProject
 
 /// The Windows UWP version of the Windows project.
 class WindowsUwpProject extends WindowsProject {
-  WindowsUwpProject.fromFlutter(FlutterProject parent) : super.fromFlutter(parent);
+  WindowsUwpProject.fromFlutter(super.parent) : super.fromFlutter();
 
   @override
   String get _childDirectory => 'winuwp';

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -2,40 +2,28 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/args.dart';
-import 'package:process/process.dart';
 
-import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
-import '../base/platform.dart';
-import '../base/terminal.dart';
 import '../dart/analysis.dart';
 import 'analyze_base.dart';
 
 class AnalyzeContinuously extends AnalyzeBase {
   AnalyzeContinuously(
-    ArgResults argResults,
+    super.argResults,
     List<String> repoRoots,
     List<Directory> repoPackages, {
-    required FileSystem fileSystem,
-    required Logger logger,
-    required Terminal terminal,
-    required Platform platform,
-    required ProcessManager processManager,
-    required Artifacts artifacts,
+    required super.fileSystem,
+    required super.logger,
+    required super.terminal,
+    required super.platform,
+    required super.processManager,
+    required super.artifacts,
   }) : super(
-        argResults,
         repoPackages: repoPackages,
         repoRoots: repoRoots,
-        fileSystem: fileSystem,
-        logger: logger,
-        platform: platform,
-        terminal: terminal,
-        processManager: processManager,
-        artifacts: artifacts,
       );
 
   String? analysisTarget;

--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -4,40 +4,28 @@
 
 import 'dart:async';
 
-import 'package:args/args.dart';
-import 'package:process/process.dart';
 
-import '../artifacts.dart';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../base/platform.dart';
-import '../base/terminal.dart';
 import '../dart/analysis.dart';
 import 'analyze_base.dart';
 
 class AnalyzeOnce extends AnalyzeBase {
   AnalyzeOnce(
-    ArgResults argResults,
+    super.argResults,
     List<String> repoRoots,
     List<Directory> repoPackages, {
-    required FileSystem fileSystem,
-    required Logger logger,
-    required Platform platform,
-    required ProcessManager processManager,
-    required Terminal terminal,
-    required Artifacts artifacts,
+    required super.fileSystem,
+    required super.logger,
+    required super.platform,
+    required super.processManager,
+    required super.terminal,
+    required super.artifacts,
     this.workingDirectory,
   }) : super(
-        argResults,
         repoRoots: repoRoots,
         repoPackages: repoPackages,
-        fileSystem: fileSystem,
-        logger: logger,
-        platform: platform,
-        processManager: processManager,
-        terminal: terminal,
-        artifacts: artifacts,
       );
 
   /// The working directory for testing analysis using dartanalyzer.

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -21,7 +21,7 @@ import 'build.dart';
 /// Builds an .app for an iOS app to be used for local testing on an iOS device
 /// or simulator. Can only be run on a macOS host.
 class BuildIOSCommand extends _BuildIOSSubCommand {
-  BuildIOSCommand({ required bool verboseHelp }) : super(verboseHelp: verboseHelp) {
+  BuildIOSCommand({ required super.verboseHelp }) {
     argParser
       ..addFlag('config-only',
         help: 'Update the project configuration without performing a build. '
@@ -65,8 +65,7 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
 ///
 /// Can only be run on a macOS host.
 class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
-  BuildIOSArchiveCommand({required bool verboseHelp})
-      : super(verboseHelp: verboseHelp) {
+  BuildIOSArchiveCommand({required super.verboseHelp}) {
     argParser.addOption(
       'export-method',
       defaultsTo: 'app-store',

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1082,11 +1082,11 @@ class PubspecChecksum extends PubspecLine {
 /// A header, e.g. "dependencies:".
 class PubspecHeader extends PubspecLine {
   PubspecHeader(
-    String line,
+    super.line,
     this.section, {
     this.name,
     this.value,
-  }) : super(line);
+  });
 
   /// The section of the pubspec where the parse [line] appears.
   final Section section;
@@ -1163,15 +1163,14 @@ class PubspecHeader extends PubspecLine {
 /// A dependency, as represented by a line (or two) from a pubspec.yaml file.
 class PubspecDependency extends PubspecLine {
   PubspecDependency(
-    String line,
+    super.line,
     this.name,
     this.suffix, {
     required this.isTransitive,
     required DependencyKind kind,
     required this.version,
     required this.sourcePath,
-  }) : _kind = kind,
-       super(line);
+  }) : _kind = kind;
 
   static PubspecDependency? parse(String line, { required String filename }) {
     // We recognize any line that:

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -358,14 +358,14 @@ abstract class _CompilationRequest {
 
 class _RecompileRequest extends _CompilationRequest {
   _RecompileRequest(
-    Completer<CompilerOutput?> completer,
+    super.completer,
     this.mainUri,
     this.invalidatedFiles,
     this.outputPath,
     this.packageConfig,
     this.suppressErrors,
     {this.additionalSource}
-  ) : super(completer);
+  );
 
   Uri mainUri;
   List<Uri>? invalidatedFiles;
@@ -381,14 +381,14 @@ class _RecompileRequest extends _CompilationRequest {
 
 class _CompileExpressionRequest extends _CompilationRequest {
   _CompileExpressionRequest(
-    Completer<CompilerOutput?> completer,
+    super.completer,
     this.expression,
     this.definitions,
     this.typeDefinitions,
     this.libraryUri,
     this.klass,
     this.isStatic,
-  ) : super(completer);
+  );
 
   String expression;
   List<String>? definitions;
@@ -404,7 +404,7 @@ class _CompileExpressionRequest extends _CompilationRequest {
 
 class _CompileExpressionToJsRequest extends _CompilationRequest {
   _CompileExpressionToJsRequest(
-    Completer<CompilerOutput?> completer,
+    super.completer,
     this.libraryUri,
     this.line,
     this.column,
@@ -412,7 +412,7 @@ class _CompileExpressionToJsRequest extends _CompilationRequest {
     this.jsFrameValues,
     this.moduleName,
     this.expression,
-  ) : super(completer);
+  );
 
   final String? libraryUri;
   final int line;
@@ -428,7 +428,7 @@ class _CompileExpressionToJsRequest extends _CompilationRequest {
 }
 
 class _RejectRequest extends _CompilationRequest {
-  _RejectRequest(Completer<CompilerOutput?> completer) : super(completer);
+  _RejectRequest(super.completer);
 
   @override
   Future<CompilerOutput?> _run(DefaultResidentCompiler compiler) async =>

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -21,20 +21,14 @@ import 'mixins.dart';
 class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments, FlutterAttachRequestArguments>
     with PidTracker {
   FlutterDebugAdapter(
-    ByteStreamServerChannel channel, {
+    super.channel, {
     required this.fileSystem,
     required this.platform,
-    bool ipv6 = false,
-    bool enableDds = true,
-    bool enableAuthCodes = true,
-    Logger? logger,
-  }) : super(
-          channel,
-          ipv6: ipv6,
-          enableDds: enableDds,
-          enableAuthCodes: enableAuthCodes,
-          logger: logger,
-        );
+    super.ipv6,
+    super.enableDds,
+    super.enableAuthCodes,
+    super.logger,
+  });
 
   FileSystem fileSystem;
   Platform platform;

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -17,33 +17,23 @@ class FlutterAttachRequestArguments
     this.customTool,
     this.customToolReplacesArgs,
     this.vmServiceUri,
-    Object? restart,
-    String? name,
-    String? cwd,
-    List<String>? additionalProjectPaths,
-    bool? debugSdkLibraries,
-    bool? debugExternalPackageLibraries,
-    bool? evaluateGettersInDebugViews,
-    bool? evaluateToStringInDebugViews,
-    bool? sendLogsToClient,
-  }) : super(
-          name: name,
-          cwd: cwd,
-          restart: restart,
-          additionalProjectPaths: additionalProjectPaths,
-          debugSdkLibraries: debugSdkLibraries,
-          debugExternalPackageLibraries: debugExternalPackageLibraries,
-          evaluateGettersInDebugViews: evaluateGettersInDebugViews,
-          evaluateToStringInDebugViews: evaluateToStringInDebugViews,
-          sendLogsToClient: sendLogsToClient,
-        );
+    super.restart,
+    super.name,
+    super.cwd,
+    super.additionalProjectPaths,
+    super.debugSdkLibraries,
+    super.debugExternalPackageLibraries,
+    super.evaluateGettersInDebugViews,
+    super.evaluateToStringInDebugViews,
+    super.sendLogsToClient,
+  });
 
-  FlutterAttachRequestArguments.fromMap(Map<String, Object?> obj)
+  FlutterAttachRequestArguments.fromMap(super.obj)
       : toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
         customTool = obj['customTool'] as String?,
         customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
         vmServiceUri = obj['vmServiceUri'] as String?,
-        super.fromMap(obj);
+        super.fromMap();
 
   static FlutterAttachRequestArguments fromJson(Map<String, Object?> obj) =>
       FlutterAttachRequestArguments.fromMap(obj);
@@ -98,35 +88,25 @@ class FlutterLaunchRequestArguments
     this.toolArgs,
     this.customTool,
     this.customToolReplacesArgs,
-    Object? restart,
-    String? name,
-    String? cwd,
-    List<String>? additionalProjectPaths,
-    bool? debugSdkLibraries,
-    bool? debugExternalPackageLibraries,
-    bool? evaluateGettersInDebugViews,
-    bool? evaluateToStringInDebugViews,
-    bool? sendLogsToClient,
-  }) : super(
-          restart: restart,
-          name: name,
-          cwd: cwd,
-          additionalProjectPaths: additionalProjectPaths,
-          debugSdkLibraries: debugSdkLibraries,
-          debugExternalPackageLibraries: debugExternalPackageLibraries,
-          evaluateGettersInDebugViews: evaluateGettersInDebugViews,
-          evaluateToStringInDebugViews: evaluateToStringInDebugViews,
-          sendLogsToClient: sendLogsToClient,
-        );
+    super.restart,
+    super.name,
+    super.cwd,
+    super.additionalProjectPaths,
+    super.debugSdkLibraries,
+    super.debugExternalPackageLibraries,
+    super.evaluateGettersInDebugViews,
+    super.evaluateToStringInDebugViews,
+    super.sendLogsToClient,
+  });
 
-  FlutterLaunchRequestArguments.fromMap(Map<String, Object?> obj)
+  FlutterLaunchRequestArguments.fromMap(super.obj)
       : noDebug = obj['noDebug'] as bool?,
         program = obj['program'] as String?,
         args = (obj['args'] as List<Object?>?)?.cast<String>(),
         toolArgs = (obj['toolArgs'] as List<Object?>?)?.cast<String>(),
         customTool = obj['customTool'] as String?,
         customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
-        super.fromMap(obj);
+        super.fromMap();
 
   /// If noDebug is true the launch request should launch the program without enabling debugging.
   @override

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -21,20 +21,14 @@ import 'mixins.dart';
 class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments, FlutterAttachRequestArguments>
     with PidTracker, TestAdapter {
   FlutterTestDebugAdapter(
-    ByteStreamServerChannel channel, {
+    super.channel, {
     required this.fileSystem,
     required this.platform,
-    bool ipv6 = false,
-    bool enableDds = true,
-    bool enableAuthCodes = true,
-    Logger? logger,
-  }) : super(
-          channel,
-          ipv6: ipv6,
-          enableDds: enableDds,
-          enableAuthCodes: enableAuthCodes,
-          logger: logger,
-        );
+    super.ipv6,
+    super.enableDds,
+    super.enableAuthCodes,
+    super.logger,
+  });
 
   FileSystem fileSystem;
   Platform platform;

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -22,9 +22,9 @@ import 'protocol_discovery.dart';
 /// A partial implementation of Device for desktop-class devices to inherit
 /// from, containing implementations that are common to all desktop devices.
 abstract class DesktopDevice extends Device {
-  DesktopDevice(String identifier, {
-      required PlatformType platformType,
-      required bool ephemeral,
+  DesktopDevice(super.identifier, {
+      required PlatformType super.platformType,
+      required super.ephemeral,
       required Logger logger,
       required ProcessManager processManager,
       required FileSystem fileSystem,
@@ -34,10 +34,7 @@ abstract class DesktopDevice extends Device {
          _fileSystem = fileSystem,
          _operatingSystemUtils = operatingSystemUtils,
          super(
-          identifier,
           category: Category.desktop,
-          platformType: platformType,
-          ephemeral: ephemeral,
         );
 
   final Logger _logger;

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -304,7 +304,7 @@ class NoIdeValidator extends DoctorValidator {
 }
 
 class ValidatorWithResult extends DoctorValidator {
-  ValidatorWithResult(String title, this.result) : super(title);
+  ValidatorWithResult(super.title, this.result);
 
   final ValidationResult result;
 

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -26,10 +26,10 @@ class FlutterCache extends Cache {
   /// [artifacts] is configurable for testing.
   FlutterCache({
     required Logger logger,
-    required FileSystem fileSystem,
+    required super.fileSystem,
     required Platform platform,
-    required OperatingSystemUtils osUtils,
-  }) : super(logger: logger, fileSystem: fileSystem, platform: platform, osUtils: osUtils, artifacts: <ArtifactSet>[]) {
+    required super.osUtils,
+  }) : super(logger: logger, platform: platform, artifacts: <ArtifactSet>[]) {
     registerArtifact(MaterialFonts(this));
     registerArtifact(GradleWrapper(this));
     registerArtifact(AndroidGenSnapshotArtifacts(this, platform: platform));

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -9,11 +9,8 @@ import 'android/android_sdk.dart';
 import 'android/android_workflow.dart';
 import 'artifacts.dart';
 import 'base/file_system.dart';
-import 'base/logger.dart';
 import 'base/os.dart';
 import 'base/platform.dart';
-import 'base/terminal.dart';
-import 'base/user_messages.dart' hide userMessages;
 import 'custom_devices/custom_device.dart';
 import 'custom_devices/custom_devices_config.dart';
 import 'device.dart';
@@ -39,7 +36,7 @@ import 'windows/windows_workflow.dart';
 /// A provider for all of the device discovery instances.
 class FlutterDeviceManager extends DeviceManager {
   FlutterDeviceManager({
-    required Logger logger,
+    required super.logger,
     required Platform platform,
     required ProcessManager processManager,
     required FileSystem fileSystem,
@@ -54,10 +51,10 @@ class FlutterDeviceManager extends DeviceManager {
     required Artifacts artifacts,
     required MacOSWorkflow macOSWorkflow,
     required FuchsiaSdk fuchsiaSdk,
-    required UserMessages userMessages,
+    required super.userMessages,
     required OperatingSystemUtils operatingSystemUtils,
     required WindowsWorkflow windowsWorkflow,
-    required Terminal terminal,
+    required super.terminal,
     required CustomDevicesConfig customDevicesConfig,
     required UwpTool uwptool,
   }) : deviceDiscoverers =  <DeviceDiscovery>[
@@ -139,11 +136,7 @@ class FlutterDeviceManager extends DeviceManager {
       logger: logger,
       config: customDevicesConfig
     ),
-  ], super(
-      logger: logger,
-      terminal: terminal,
-      userMessages: userMessages,
-    );
+  ];
 
   @override
   final List<DeviceDiscovery> deviceDiscoverers;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -227,8 +227,7 @@ class FuchsiaDevices extends PollingDeviceDiscovery {
 
 
 class FuchsiaDevice extends Device {
-  FuchsiaDevice(String id, {required this.name}) : super(
-      id,
+  FuchsiaDevice(super.id, {required this.name}) : super(
       platformType: PlatformType.fuchsia,
       category: null,
       ephemeral: true,

--- a/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
+++ b/packages/flutter_tools/lib/src/intellij/intellij_validator.dart
@@ -22,12 +22,11 @@ const String _communityEditionId = 'IdeaIC';
 
 /// A doctor validator for both Intellij and Android Studio.
 abstract class IntelliJValidator extends DoctorValidator {
-  IntelliJValidator(String title, this.installPath, {
+  IntelliJValidator(super.title, this.installPath, {
     required FileSystem fileSystem,
     required UserMessages userMessages,
   }) : _fileSystem = fileSystem,
-       _userMessages = userMessages,
-       super(title);
+       _userMessages = userMessages;
 
   final String installPath;
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -157,9 +157,9 @@ class PrebuiltIOSApp extends IOSApp implements PrebuiltApplicationPackage {
   PrebuiltIOSApp({
     required this.uncompressedBundle,
     this.bundleName,
-    required String projectBundleId,
+    required super.projectBundleId,
     required this.applicationPackage,
-  }) : super(projectBundleId: projectBundleId);
+  });
 
   /// The uncompressed bundle of the application.
   ///

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -145,7 +145,7 @@ class IOSDevices extends PollingDeviceDiscovery {
 }
 
 class IOSDevice extends Device {
-  IOSDevice(String id, {
+  IOSDevice(super.id, {
     required FileSystem fileSystem,
     required this.name,
     required this.cpuArchitecture,
@@ -165,7 +165,6 @@ class IOSDevice extends Device {
       _logger = logger,
       _platform = platform,
         super(
-          id,
           category: Category.mobile,
           platformType: PlatformType.ios,
           ephemeral: true,

--- a/packages/flutter_tools/lib/src/ios/migrations/deployment_target_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/deployment_target_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../xcode_project.dart';
 
@@ -11,10 +10,9 @@ import '../../xcode_project.dart';
 class DeploymentTargetMigration extends ProjectMigrator {
   DeploymentTargetMigration(
     IosProject project,
-    Logger logger,
+    super.logger,
   )   : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-        _appFrameworkInfoPlist = project.appFrameworkInfoPlist,
-        super(logger);
+        _appFrameworkInfoPlist = project.appFrameworkInfoPlist;
 
   final File _xcodeProjectInfoFile;
   final File _appFrameworkInfoPlist;

--- a/packages/flutter_tools/lib/src/ios/migrations/minimum_frame_duration_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/minimum_frame_duration_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../xcode_project.dart';
 
@@ -13,9 +12,8 @@ const String _kDisableMinimumFrameDurationKey = 'CADisableMinimumFrameDurationOn
 class MinimumFrameDurationMigration extends ProjectMigrator {
   MinimumFrameDurationMigration(
     IosProject project,
-    Logger logger,
-  ) : _infoPlist = project.defaultHostInfoPlist,
-      super(logger);
+    super.logger,
+  ) : _infoPlist = project.defaultHostInfoPlist;
 
   final File _infoPlist;
 

--- a/packages/flutter_tools/lib/src/ios/migrations/project_base_configuration_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/project_base_configuration_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../xcode_project.dart';
 
@@ -11,9 +10,8 @@ import '../../xcode_project.dart';
 // However the top-level Runner project should not inherit any build configuration so
 // the Flutter build settings do not stomp on non-Flutter targets.
 class ProjectBaseConfigurationMigration extends ProjectMigrator {
-  ProjectBaseConfigurationMigration(IosProject project, Logger logger)
-    : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-      super(logger);
+  ProjectBaseConfigurationMigration(IosProject project, super.logger)
+    : _xcodeProjectInfoFile = project.xcodeProjectInfoFile;
 
   final File _xcodeProjectInfoFile;
 

--- a/packages/flutter_tools/lib/src/ios/migrations/project_build_location_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/project_build_location_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../xcode_project.dart';
 
@@ -11,9 +10,8 @@ import '../../xcode_project.dart';
 class ProjectBuildLocationMigration extends ProjectMigrator {
   ProjectBuildLocationMigration(
     IosProject project,
-    Logger logger,
-  ) : _xcodeProjectWorkspaceData = project.xcodeProjectWorkspaceData,
-      super(logger);
+    super.logger,
+  ) : _xcodeProjectWorkspaceData = project.xcodeProjectWorkspaceData;
 
   final File _xcodeProjectWorkspaceData;
 

--- a/packages/flutter_tools/lib/src/ios/migrations/project_object_version_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/project_object_version_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../xcode_project.dart';
 
@@ -11,10 +10,9 @@ import '../../xcode_project.dart';
 class ProjectObjectVersionMigration extends ProjectMigrator {
   ProjectObjectVersionMigration(
     IosProject project,
-    Logger logger,
+    super.logger,
   )   : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-        _xcodeProjectSchemeFile = project.xcodeProjectSchemeFile,
-        super(logger);
+        _xcodeProjectSchemeFile = project.xcodeProjectSchemeFile;
 
   final File _xcodeProjectInfoFile;
   final File _xcodeProjectSchemeFile;

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_framework_link_and_embedding_migration.dart
@@ -4,7 +4,6 @@
 
 import '../../base/common.dart';
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../reporting/reporting.dart';
 import '../../xcode_project.dart';
@@ -15,11 +14,10 @@ import '../../xcode_project.dart';
 class RemoveFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
   RemoveFrameworkLinkAndEmbeddingMigration(
     IosProject project,
-    Logger logger,
+    super.logger,
     Usage usage,
   ) : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-        _usage = usage,
-        super(logger);
+        _usage = usage;
 
   final File _xcodeProjectInfoFile;
   final Usage _usage;

--- a/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/xcode_build_system_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../xcode_project.dart';
 
@@ -13,9 +12,8 @@ import '../../xcode_project.dart';
 class XcodeBuildSystemMigration extends ProjectMigrator {
   XcodeBuildSystemMigration(
     IosProject project,
-    Logger logger,
-  ) : _xcodeWorkspaceSharedSettings = project.xcodeWorkspaceSharedSettings,
-      super(logger);
+    super.logger,
+  ) : _xcodeWorkspaceSharedSettings = project.xcodeWorkspaceSharedSettings;
 
   final File _xcodeWorkspaceSharedSettings;
 

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -319,13 +319,12 @@ class SimDevice {
 
 class IOSSimulator extends Device {
   IOSSimulator(
-    String id, {
+    super.id, {
       required this.name,
       required this.simulatorCategory,
       required SimControl simControl,
     }) : _simControl = simControl,
          super(
-           id,
            category: Category.mobile,
            platformType: PlatformType.ios,
            ephemeral: true,

--- a/packages/flutter_tools/lib/src/macos/migrations/remove_macos_framework_link_and_embedding_migration.dart
+++ b/packages/flutter_tools/lib/src/macos/migrations/remove_macos_framework_link_and_embedding_migration.dart
@@ -4,7 +4,6 @@
 
 import '../../base/common.dart';
 import '../../base/file_system.dart';
-import '../../base/logger.dart';
 import '../../base/project_migrator.dart';
 import '../../reporting/reporting.dart';
 import '../../xcode_project.dart';
@@ -13,11 +12,10 @@ import '../../xcode_project.dart';
 class RemoveMacOSFrameworkLinkAndEmbeddingMigration extends ProjectMigrator {
   RemoveMacOSFrameworkLinkAndEmbeddingMigration(
     MacOSProject project,
-    Logger logger,
+    super.logger,
     Usage usage,
   )   : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-        _usage = usage,
-        super(logger);
+        _usage = usage;
 
   final File _xcodeProjectInfoFile;
   final Usage _usage;

--- a/packages/flutter_tools/lib/src/migrations/cmake_custom_command_migration.dart
+++ b/packages/flutter_tools/lib/src/migrations/cmake_custom_command_migration.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../base/file_system.dart';
-import '../base/logger.dart';
 import '../base/project_migrator.dart';
 import '../cmake_project.dart';
 
@@ -11,9 +10,8 @@ import '../cmake_project.dart';
 // and special characters correctly.
 // See https://github.com/flutter/flutter/issues/67270.
 class CmakeCustomCommandMigration extends ProjectMigrator {
-  CmakeCustomCommandMigration(CmakeBasedProject project, Logger logger)
-    : _cmakeFile = project.managedCmakeFile,
-      super(logger);
+  CmakeCustomCommandMigration(CmakeBasedProject project, super.logger)
+    : _cmakeFile = project.managedCmakeFile;
 
   final File _cmakeFile;
 

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -190,10 +190,10 @@ class BuildEvent extends UsageEvent {
 
 /// An event that reports the result of a top-level command.
 class CommandResultEvent extends UsageEvent {
-  CommandResultEvent(String commandPath, String result)
+  CommandResultEvent(super.commandPath, super.result)
       : assert(commandPath != null),
         assert(result != null),
-        super(commandPath, result, flutterUsage: globals.flutterUsage);
+        super(flutterUsage: globals.flutterUsage);
 
   @override
   void send() {

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -44,7 +44,7 @@ class FlutterTesterApp extends ApplicationPackage {
 /// also be used as a regular device when `--show-test-device` is provided
 /// to the flutter command.
 class FlutterTesterDevice extends Device {
-  FlutterTesterDevice(String deviceId, {
+  FlutterTesterDevice(super.deviceId, {
     required ProcessManager processManager,
     required FlutterVersion flutterVersion,
     required Logger logger,
@@ -58,7 +58,6 @@ class FlutterTesterDevice extends Device {
        _artifacts = artifacts,
        _operatingSystemUtils = operatingSystemUtils,
        super(
-        deviceId,
         platformType: null,
         category: null,
         ephemeral: false,

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -191,15 +191,13 @@ class GoogleChromeDevice extends ChromiumDevice {
     required Platform platform,
     required ProcessManager processManager,
     required ChromiumLauncher chromiumLauncher,
-    required Logger logger,
-    required FileSystem fileSystem,
+    required super.logger,
+    required super.fileSystem,
   }) : _platform = platform,
        _processManager = processManager,
        super(
           name: 'chrome',
           chromeLauncher: chromiumLauncher,
-          logger: logger,
-          fileSystem: fileSystem,
        );
 
   final Platform _platform;
@@ -247,15 +245,13 @@ class GoogleChromeDevice extends ChromiumDevice {
 class MicrosoftEdgeDevice extends ChromiumDevice {
   MicrosoftEdgeDevice({
     required ChromiumLauncher chromiumLauncher,
-    required Logger logger,
-    required FileSystem fileSystem,
+    required super.logger,
+    required super.fileSystem,
     required ProcessManager processManager,
   }) : _processManager = processManager,
        super(
          name: 'edge',
          chromeLauncher: chromiumLauncher,
-         logger: logger,
-         fileSystem: fileSystem,
        );
 
   final ProcessManager _processManager;

--- a/packages/flutter_tools/lib/src/web/web_validator.dart
+++ b/packages/flutter_tools/lib/src/web/web_validator.dart
@@ -8,7 +8,7 @@ import 'chrome.dart';
 
 /// A validator for Chromium-based browsers.
 abstract class ChromiumValidator extends DoctorValidator {
-  const ChromiumValidator(String title) : super(title);
+  const ChromiumValidator(super.title);
 
   Platform get _platform;
   ChromiumLauncher get _chromiumLauncher;

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tools for building Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/test/general.shard/base/terminal_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/terminal_test.dart
@@ -227,9 +227,9 @@ late Stream<String> mockStdInStream;
 class TestTerminal extends AnsiTerminal {
   TestTerminal({
     Stdio? stdio,
-    Platform platform = const LocalPlatform(),
+    super.platform = const LocalPlatform(),
     DateTime? now,
-  }) : super(stdio: stdio ?? Stdio(), platform: platform, now: now ?? DateTime(2018));
+  }) : super(stdio: stdio ?? Stdio(), now: now ?? DateTime(2018));
 
   @override
   Stream<String> get keystrokes {

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -541,12 +541,12 @@ class TestDeviceManager extends DeviceManager {
   TestDeviceManager(
     List<Device> allDevices, {
     List<DeviceDiscovery>? deviceDiscoveryOverrides,
-    required Logger logger,
-    required Terminal terminal,
+    required super.logger,
+    required super.terminal,
     String? wellKnownId,
   }) : _fakeDeviceDiscoverer = FakePollingDeviceDiscovery(),
        _deviceDiscoverers = <DeviceDiscovery>[],
-       super(logger: logger, terminal: terminal, userMessages: UserMessages()) {
+       super(userMessages: UserMessages()) {
     if (wellKnownId != null) {
       _fakeDeviceDiscoverer.wellKnownIds.add(wellKnownId);
     }

--- a/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/intellij/intellij_validator_test.dart
@@ -374,8 +374,8 @@ void main() {
 }
 
 class IntelliJValidatorTestTarget extends IntelliJValidator {
-  IntelliJValidatorTestTarget(String title, String installPath,  FileSystem fileSystem)
-    : super(title, installPath, fileSystem: fileSystem, userMessages: UserMessages());
+  IntelliJValidatorTestTarget(super.title, super.installPath,  FileSystem fileSystem)
+    : super(fileSystem: fileSystem, userMessages: UserMessages());
 
   @override
   String get pluginsPath => 'plugins';

--- a/packages/flutter_tools/test/general.shard/reporting/events_test.dart
+++ b/packages/flutter_tools/test/general.shard/reporting/events_test.dart
@@ -127,11 +127,11 @@ void main() {
 }
 
 class FakeGroupedValidator extends GroupedValidator {
-  FakeGroupedValidator(List<DoctorValidator> subValidators) : super(subValidators);
+  FakeGroupedValidator(super.subValidators);
 }
 
 class FakeDoctorValidator extends DoctorValidator {
-  FakeDoctorValidator(String title) : super(title);
+  FakeDoctorValidator(super.title);
 
   @override
   Future<ValidationResult> validate() async {

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -489,10 +489,10 @@ abstract class FlutterTestDriver {
 
 class FlutterRunTestDriver extends FlutterTestDriver {
   FlutterRunTestDriver(
-    Directory projectFolder, {
-    String? logPrefix,
+    super.projectFolder, {
+    super.logPrefix,
     this.spawnDdsInstance = true,
-  }) : super(projectFolder, logPrefix: logPrefix);
+  });
 
   String? _currentRunningAppId;
 
@@ -760,8 +760,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
 }
 
 class FlutterTestTestDriver extends FlutterTestDriver {
-  FlutterTestTestDriver(Directory projectFolder, {String? logPrefix})
-    : super(projectFolder, logPrefix: logPrefix);
+  FlutterTestTestDriver(super.projectFolder, {super.logPrefix});
 
   Future<void> test({
     String testFile = 'test/test.dart',

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -487,7 +487,7 @@ class TestFeatureFlags implements FeatureFlags {
 }
 
 class FakeStatusLogger extends DelegatingLogger {
-  FakeStatusLogger(Logger delegate) : super(delegate);
+  FakeStatusLogger(super.delegate);
 
   late Status status;
 


### PR DESCRIPTION
~Blocked on https://github.com/dart-lang/sdk/issues/48708.~ Fixed.

https://github.com/flutter/flutter/issues/100575

Once all code in the repo has been migrated, we can turn on the use_super_parameters lint.