### PR TITLE
Prepare `dev` (minus `flutter_gallery`) for `use_super_parameters`

### DIFF
--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_automated_tests
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: complex_layout
 description: A benchmark of a relatively complex layout.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/macrobenchmarks/pubspec.yaml
+++ b/dev/benchmarks/macrobenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: macrobenchmarks
 description: Performance benchmarks using flutter drive.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: microbenchmarks
 description: Small benchmarks for very specific parts of the Flutter framework.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   meta: 1.7.0

--- a/dev/benchmarks/multiple_flutters/module/pubspec.yaml
+++ b/dev/benchmarks/multiple_flutters/module/pubspec.yaml
@@ -4,7 +4,7 @@ description: A module that is embedded in the multiple_flutters benchmark test.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
+++ b/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout/lib/main.dart
@@ -15,8 +15,8 @@ void main() {
 
 class PlatformViewApp extends StatefulWidget {
   const PlatformViewApp({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   PlatformViewAppState createState() => PlatformViewAppState();
@@ -40,7 +40,7 @@ class PlatformViewAppState extends State<PlatformViewApp> {
 }
 
 class PlatformViewLayout extends StatelessWidget {
-  const PlatformViewLayout({ Key? key }) : super(key: key);
+  const PlatformViewLayout({ super.key });
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +70,7 @@ class PlatformViewLayout extends StatelessWidget {
 }
 
 class DummyPlatformView extends StatelessWidget {
-  const DummyPlatformView({Key? key}) : super(key: key);
+  const DummyPlatformView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -96,7 +96,7 @@ class DummyPlatformView extends StatelessWidget {
 }
 
 class RotationContainer extends StatefulWidget {
-  const RotationContainer({Key? key}) : super(key: key);
+  const RotationContainer({super.key});
 
   @override
   State<RotationContainer> createState() => _RotationContainerState();

--- a/dev/benchmarks/platform_views_layout/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout
 description: A benchmark for platform views.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/android_platform_view.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/android_platform_view.dart
@@ -12,9 +12,9 @@ class AndroidPlatformView extends StatelessWidget {
   /// Creates a platform view for Android, which is rendered as a
   /// native view.
   const AndroidPlatformView({
-    Key? key,
+    super.key,
     required this.viewType,
-  }) : super(key: key);
+  });
 
   /// The unique identifier for the view type to be embedded by this widget.
   ///

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
@@ -19,8 +19,8 @@ void main() {
 
 class PlatformViewApp extends StatefulWidget {
   const PlatformViewApp({
-    Key? key
-  }) : super(key: key);
+    super.key
+  });
 
   @override
   PlatformViewAppState createState() => PlatformViewAppState();
@@ -44,7 +44,7 @@ class PlatformViewAppState extends State<PlatformViewApp> {
 }
 
 class PlatformViewLayout extends StatelessWidget {
-  const PlatformViewLayout({ Key? key }) : super(key: key);
+  const PlatformViewLayout({ super.key });
 
   @override
   Widget build(BuildContext context) {
@@ -74,7 +74,7 @@ class PlatformViewLayout extends StatelessWidget {
 }
 
 class DummyPlatformView extends StatelessWidget {
-  const DummyPlatformView({Key? key}) : super(key: key);
+  const DummyPlatformView({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -101,7 +101,7 @@ class DummyPlatformView extends StatelessWidget {
 }
 
 class RotationContainer extends StatefulWidget {
-  const RotationContainer({Key? key}) : super(key: key);
+  const RotationContainer({super.key});
 
   @override
   State<RotationContainer> createState() => _RotationContainerState();

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout_hybrid_composition
 description: A benchmark for platform views, using hybrid composition on android.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/benchmarks/test_apps/stocks/pubspec.yaml
+++ b/dev/benchmarks/test_apps/stocks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stocks
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -16,6 +16,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:crypto/crypto.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
 
 import 'allowlist.dart';
 import 'run_command.dart';
@@ -523,7 +524,7 @@ class _TestSkip {
 
 Iterable<_TestSkip> _getTestSkips(File file) {
   final ParseStringResult parseResult = parseFile(
-    featureSet: FeatureSet.latestLanguageVersion(),
+    featureSet: FeatureSet.fromEnableFlags2(sdkLanguageVersion: Version.parse('2.17.0-0'), flags: <String>['super-parameters']),
     path: file.absolute.path,
   );
   final _TestSkipLinesVisitor<CompilationUnit> visitor = _TestSkipLinesVisitor<CompilationUnit>(parseResult);

--- a/dev/bots/pubspec.yaml
+++ b/dev/bots/pubspec.yaml
@@ -2,7 +2,7 @@ name: tests_on_bots
 description: Scripts which run on bots.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   args: 2.3.0

--- a/dev/conductor/core/pubspec.yaml
+++ b/dev/conductor/core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter Automated Release Tool
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   archive: 3.1.11

--- a/dev/devicelab/bin/tasks/smoke_test_build_test.dart
+++ b/dev/devicelab/bin/tasks/smoke_test_build_test.dart
@@ -14,7 +14,7 @@ Future<void> main(List<String> args) async {
 }
 
 class FakeBuildTestTask extends BuildTestTask {
-  FakeBuildTestTask(List<String> args) : super(args, runFlutterClean: false) {
+  FakeBuildTestTask(super.args) : super(runFlutterClean: false) {
     deviceOperatingSystem = DeviceOperatingSystem.fake;
   }
 

--- a/dev/devicelab/lib/tasks/analysis.dart
+++ b/dev/devicelab/lib/tasks/analysis.dart
@@ -84,7 +84,7 @@ abstract class _Benchmark {
 
 /// Times how long it takes to analyze the Flutter repository.
 class _FlutterRepoBenchmark extends _Benchmark {
-  _FlutterRepoBenchmark({bool watch = false}) : super(watch: watch);
+  _FlutterRepoBenchmark({super.watch});
 
   @override
   String get title => 'Flutter repo';
@@ -100,7 +100,7 @@ class _FlutterRepoBenchmark extends _Benchmark {
 
 /// Times how long it takes to analyze the generated "mega_gallery" app.
 class _MegaGalleryBenchmark extends _Benchmark {
-  _MegaGalleryBenchmark({bool watch = false}) : super(watch: watch);
+  _MegaGalleryBenchmark({super.watch});
 
   @override
   String get title => 'mega gallery';

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1029,35 +1029,23 @@ const List<String> _kCommonScoreKeys = <String>[
 
 class PerfTestWithSkSL extends PerfTest {
   PerfTestWithSkSL(
-    String testDirectory,
-    String testTarget,
-    String timelineFileName, {
-    bool measureCpuGpu = false,
-    String? testDriver,
-    bool needsFullTimeline = true,
-    List<String>? benchmarkScoreKeys,
-  }) : super(
-    testDirectory,
-    testTarget,
-    timelineFileName,
-    measureCpuGpu: measureCpuGpu,
-    testDriver: testDriver,
-    needsFullTimeline: needsFullTimeline,
-    benchmarkScoreKeys: benchmarkScoreKeys,
-  );
+    super.testDirectory,
+    super.testTarget,
+    String super.timelineFileName, {
+    super.measureCpuGpu = false,
+    super.testDriver,
+    super.needsFullTimeline,
+    super.benchmarkScoreKeys,
+  });
 
 
   PerfTestWithSkSL.e2e(
-    String testDirectory,
-    String testTarget, {
-    String testDriver =  'test_driver/e2e_test.dart',
-    String resultFilename = 'e2e_perf_summary',
+    super.testDirectory,
+    super.testTarget, {
+    String super.testDriver,
+    super.resultFilename,
   }) : super.e2e(
-    testDirectory,
-    testTarget,
-    testDriver: testDriver,
     needsFullTimeline: false,
-    resultFilename: resultFilename,
   );
 
   @override

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   archive: 3.1.11

--- a/dev/devicelab/test/adb_test.dart
+++ b/dev/devicelab/test/adb_test.dart
@@ -180,7 +180,7 @@ class CommandArgs {
 }
 
 class FakeDevice extends AndroidDevice {
-  FakeDevice({required String deviceId}) : super(deviceId: deviceId);
+  FakeDevice({required super.deviceId});
 
   static String output = '';
 

--- a/dev/docs/platform_integration/pubspec.yaml
+++ b/dev/docs/platform_integration/pubspec.yaml
@@ -1,4 +1,4 @@
 name: platform_integration
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"

--- a/dev/integration_tests/abstract_method_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/abstract_method_smoke_test/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/android_embedding_v2_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/channels/pubspec.yaml
+++ b/dev/integration_tests/channels/pubspec.yaml
@@ -2,7 +2,7 @@ name: channels
 description: Integration test for platform channels.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/external_ui/pubspec.yaml
+++ b/dev/integration_tests/external_ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: external_ui
 description: A test of Flutter integrating external UIs.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/flavors/pubspec.yaml
+++ b/dev/integration_tests/flavors/pubspec.yaml
@@ -2,7 +2,7 @@ name: flavors
 description: Integration test for build flavors.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/gradle_deprecated_settings/pubspec.yaml
+++ b/dev/integration_tests/gradle_deprecated_settings/pubspec.yaml
@@ -2,7 +2,7 @@ name: gradle_deprecated_settings
 description: Integration test for the current settings.gradle.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new flutter module project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -13,7 +13,7 @@ name: ios_app_with_extensions
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
+++ b/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
@@ -3,7 +3,7 @@ name: ios_platform_view_tests
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/non_nullable/lib/main.dart
+++ b/dev/integration_tests/non_nullable/lib/main.dart
@@ -11,7 +11,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/dev/integration_tests/non_nullable/pubspec.yaml
+++ b/dev/integration_tests/non_nullable/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/platform_interaction/pubspec.yaml
+++ b/dev/integration_tests/platform_interaction/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_interaction
 description: Integration test for platform interactions.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/release_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/release_smoke_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: release_smoke_test
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: integration_ui
 description: Flutter non-plugin UI integration tests.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 # The "image" dependency below seems to only be needed for test_driver/screenshot_test.dart
 # It can probably be removed, see the comment in that file.

--- a/dev/integration_tests/web/pubspec.yaml
+++ b/dev/integration_tests/web/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_integration
 description: Integration test for web compilation.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 flutter:
   assets:

--- a/dev/integration_tests/web_e2e_tests/pubspec.yaml
+++ b/dev/integration_tests/web_e2e_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_e2e_tests
 publish_to: none
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 flutter:
   assets:

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: manual_tests
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/missing_dependency_tests/pubspec.yaml
+++ b/dev/missing_dependency_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: missing_dependency_tests
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/tools/gen_defaults/lib/surface_tint.dart
+++ b/dev/tools/gen_defaults/lib/surface_tint.dart
@@ -5,7 +5,7 @@
 import 'template.dart';
 
 class SurfaceTintTemplate extends TokenTemplate {
-  const SurfaceTintTemplate(String fileName, Map<String, dynamic> tokens) : super(fileName, tokens);
+  const SurfaceTintTemplate(super.fileName, super.tokens);
 
   @override
   String generate() => '''

--- a/dev/tools/gen_defaults/lib/typography_template.dart
+++ b/dev/tools/gen_defaults/lib/typography_template.dart
@@ -5,7 +5,7 @@
 import 'template.dart';
 
 class TypographyTemplate extends TokenTemplate {
-  const TypographyTemplate(String fileName, Map<String, dynamic> tokens) : super(fileName, tokens);
+  const TypographyTemplate(super.fileName, super.tokens);
 
   @override
   String generate() => '''

--- a/dev/tools/gen_defaults/pubspec.yaml
+++ b/dev/tools/gen_defaults/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command line script to generate Material component defaults from 
 version: 1.0.0
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
 

--- a/dev/tools/gen_defaults/test/gen_defaults_test.dart
+++ b/dev/tools/gen_defaults/test/gen_defaults_test.dart
@@ -120,7 +120,7 @@ static final String tokenBar = 'bar';
 }
 
 class TestTemplate extends TokenTemplate {
-  TestTemplate(String fileName, Map<String, dynamic> tokens) : super(fileName, tokens);
+  TestTemplate(super.fileName, super.tokens);
 
   @override
   String generate() => '''

--- a/dev/tools/gen_keycodes/lib/android_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/android_code_gen.dart
@@ -13,8 +13,7 @@ import 'utils.dart';
 /// Generates the key mapping for Android, based on the information in the key
 /// data structure given to it.
 class AndroidCodeGenerator extends PlatformCodeGenerator {
-  AndroidCodeGenerator(PhysicalKeyData physicalData, LogicalKeyData logicalData)
-    : super(physicalData, logicalData);
+  AndroidCodeGenerator(super.physicalData, super.logicalData);
 
   /// This generates the map of Android key codes to logical keys.
   String get _androidKeyCodeMap {

--- a/dev/tools/gen_keycodes/lib/base_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/base_code_gen.dart
@@ -48,8 +48,7 @@ abstract class BaseCodeGenerator {
 
 /// A code generator which also defines platform-based behavior.
 abstract class PlatformCodeGenerator extends BaseCodeGenerator {
-  PlatformCodeGenerator(PhysicalKeyData keyData, LogicalKeyData logicalData)
-    : super(keyData, logicalData);
+  PlatformCodeGenerator(super.keyData, super.logicalData);
 
   /// Absolute path to the output file.
   ///

--- a/dev/tools/gen_keycodes/lib/gtk_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/gtk_code_gen.dart
@@ -15,13 +15,12 @@ import 'utils.dart';
 /// data structure given to it.
 class GtkCodeGenerator extends PlatformCodeGenerator {
   GtkCodeGenerator(
-    PhysicalKeyData keyData,
-    LogicalKeyData logicalData,
+    super.keyData,
+    super.logicalData,
     String modifierBitMapping,
     String lockBitMapping,
   ) : _modifierBitMapping = parseMapOfListOfString(modifierBitMapping),
-      _lockBitMapping = parseMapOfListOfString(lockBitMapping),
-      super(keyData, logicalData);
+      _lockBitMapping = parseMapOfListOfString(lockBitMapping);
 
   /// This generates the map of XKB scan codes to Flutter physical keys.
   String get _xkbScanCodeMap {

--- a/dev/tools/gen_keycodes/lib/ios_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/ios_code_gen.dart
@@ -28,8 +28,7 @@ const List<String> kSpecialLogicalKeys = <String>['CapsLock'];
 /// Generates the key mapping for iOS, based on the information in the key
 /// data structure given to it.
 class IOSCodeGenerator extends PlatformCodeGenerator {
-  IOSCodeGenerator(PhysicalKeyData keyData, LogicalKeyData logicalData)
-      : super(keyData, logicalData);
+  IOSCodeGenerator(super.keyData, super.logicalData);
 
   /// This generates the map of iOS key codes to physical keys.
   String get _scanCodeMap {

--- a/dev/tools/gen_keycodes/lib/keyboard_keys_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/keyboard_keys_code_gen.dart
@@ -49,7 +49,7 @@ class SynonymKeyInfo {
 /// Generates the keyboard_key.dart based on the information in the key data
 /// structure given to it.
 class KeyboardKeysCodeGenerator extends BaseCodeGenerator {
-  KeyboardKeysCodeGenerator(PhysicalKeyData keyData, LogicalKeyData logicalData) : super(keyData, logicalData);
+  KeyboardKeysCodeGenerator(super.keyData, super.logicalData);
 
   /// Gets the generated definitions of PhysicalKeyboardKeys.
   String get _physicalDefinitions {

--- a/dev/tools/gen_keycodes/lib/keyboard_maps_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/keyboard_maps_code_gen.dart
@@ -37,8 +37,7 @@ bool _isDigit(String? char) {
 /// Generates the keyboard_maps.dart files, based on the information in the key
 /// data structure given to it.
 class KeyboardMapsCodeGenerator extends BaseCodeGenerator {
-  KeyboardMapsCodeGenerator(PhysicalKeyData keyData, LogicalKeyData logicalData)
-    : super(keyData, logicalData);
+  KeyboardMapsCodeGenerator(super.keyData, super.logicalData);
 
   List<PhysicalKeyEntry> get _numpadKeyData {
     return keyData.entries.where((PhysicalKeyEntry entry) {

--- a/dev/tools/gen_keycodes/lib/macos_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/macos_code_gen.dart
@@ -28,8 +28,7 @@ const List<String> kSpecialLogicalKeys = <String>['CapsLock'];
 /// Generates the key mapping for macOS, based on the information in the key
 /// data structure given to it.
 class MacOSCodeGenerator extends PlatformCodeGenerator {
-  MacOSCodeGenerator(PhysicalKeyData keyData, LogicalKeyData logicalData)
-    : super(keyData, logicalData);
+  MacOSCodeGenerator(super.keyData, super.logicalData);
 
   /// This generates the map of macOS key codes to physical keys.
   String get _scanCodeMap {

--- a/dev/tools/gen_keycodes/lib/testing_key_codes_gen.dart
+++ b/dev/tools/gen_keycodes/lib/testing_key_codes_gen.dart
@@ -16,7 +16,7 @@ String _toUpperCammel(String lowerCammel) {
 /// Generates the common/testing/key_codes.h based on the information in the key
 /// data structure given to it.
 class KeyCodesCcGenerator extends BaseCodeGenerator {
-  KeyCodesCcGenerator(PhysicalKeyData keyData, LogicalKeyData logicalData) : super(keyData, logicalData);
+  KeyCodesCcGenerator(super.keyData, super.logicalData);
 
   /// Gets the generated definitions of PhysicalKeyboardKeys.
   String get _physicalDefinitions {

--- a/dev/tools/gen_keycodes/lib/web_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/web_code_gen.dart
@@ -14,11 +14,10 @@ import 'utils.dart';
 /// data structure given to it.
 class WebCodeGenerator extends PlatformCodeGenerator {
   WebCodeGenerator(
-    PhysicalKeyData keyData,
-    LogicalKeyData logicalData,
+    super.keyData,
+    super.logicalData,
     String logicalLocationMap,
-  ) : _logicalLocationMap = parseMapOfListOfNullableString(logicalLocationMap),
-      super(keyData, logicalData);
+  ) : _logicalLocationMap = parseMapOfListOfNullableString(logicalLocationMap);
 
   /// This generates the map of Web KeyboardEvent codes to logical key ids.
   String get _webLogicalKeyCodeMap {

--- a/dev/tools/gen_keycodes/lib/windows_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/windows_code_gen.dart
@@ -14,11 +14,10 @@ import 'utils.dart';
 /// data structure given to it.
 class WindowsCodeGenerator extends PlatformCodeGenerator {
   WindowsCodeGenerator(
-    PhysicalKeyData keyData,
-    LogicalKeyData logicalData,
+    super.keyData,
+    super.logicalData,
     String scancodeToLogical,
-  ) : _scancodeToLogical = parseMapOfString(scancodeToLogical),
-      super(keyData, logicalData);
+  ) : _scancodeToLogical = parseMapOfString(scancodeToLogical);
 
   /// This generates the map of Windows scan codes to physical keys.
   String get _windowsScanCodeMap {

--- a/dev/tools/gen_keycodes/pubspec.yaml
+++ b/dev/tools/gen_keycodes/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_keycodes
 description: Generates keycode source files from various resources.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   args: 2.3.0

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/tracing_tests/lib/test.dart
+++ b/dev/tracing_tests/lib/test.dart
@@ -10,8 +10,8 @@ import 'package:flutter/widgets.dart';
 
 class TestWidget extends LeafRenderObjectWidget {
   const TestWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   RenderObject createRenderObject(BuildContext context) => RenderTest();

--- a/dev/tracing_tests/pubspec.yaml
+++ b/dev/tracing_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracing_tests
 description: Various tests for tracing in flutter/flutter
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.17.0-0 <3.0.0"
 
 dependencies:
   flutter:

--- a/dev/tracing_tests/test/inflate_widget_tracing_test.dart
+++ b/dev/tracing_tests/test/inflate_widget_tracing_test.dart
@@ -40,7 +40,7 @@ void main() {
 }
 
 class TestRoot extends StatefulWidget {
-  const TestRoot({Key? key}) : super(key: key);
+  const TestRoot({super.key});
 
   static late TestRootState state;
 
@@ -76,7 +76,7 @@ class TestRootState extends State<TestRoot> {
 }
 
 class TestChildWidget extends StatelessWidget {
-  const TestChildWidget({Key? key}) : super(key: key);
+  const TestChildWidget({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/dev/tracing_tests/test/timeline_test.dart
+++ b/dev/tracing_tests/test/timeline_test.dart
@@ -22,7 +22,7 @@ final Set<String> interestingLabels = <String>{
 };
 
 class TestRoot extends StatefulWidget {
-  const TestRoot({ Key? key }) : super(key: key);
+  const TestRoot({ super.key });
 
   static late final TestRootState state;
 


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/100575

Once all code in the repo has been migrated, we can turn on the use_super_parameters lint.

`flutter_gallery` done separately in https://github.com/flutter/flutter/pull/100515.