### PR TITLE
Fix `compute` in unsound null safety debug mode

### DIFF
--- a/packages/flutter/lib/src/foundation/_isolates_io.dart
+++ b/packages/flutter/lib/src/foundation/_isolates_io.dart
@@ -65,7 +65,6 @@ Future<R> compute<Q, R>(isolates.ComputeCallback<Q, R> callback, Q message, { St
   switch (type) {
     // success; see _buildSuccessResponse
     case 1:
-      assert(response[0] is R);
       return response[0] as R;
 
     // native error; see Isolate.addErrorListener
@@ -78,10 +77,7 @@ Future<R> compute<Q, R>(isolates.ComputeCallback<Q, R> callback, Q message, { St
     // caught error; see _buildErrorResponse
     case 3:
     default:
-      assert(type == 3);
-      assert(response[0] is Object);
-      assert(response[1] is StackTrace);
-      assert(response[2] == null);
+      assert(type == 3 && response[2] == null);
 
       await Future<Never>.error(
         response[0] as Object,

--- a/packages/flutter/test/foundation/_compute_caller_unsound_null_safety.dart
+++ b/packages/flutter/test/foundation/_compute_caller_unsound_null_safety.dart
@@ -1,0 +1,30 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart=2.9
+
+import 'package:flutter/src/foundation/_isolates_io.dart';
+import 'package:flutter/src/foundation/isolates.dart' as isolates;
+
+
+int returnInt(int arg) {
+  return arg;
+}
+
+Future<int> returnIntAsync(int arg) {
+  return Future<int>.value(arg);
+}
+
+Future<void> testCompute<T>(isolates.ComputeCallback<T, T> callback, T input) async {
+  if (input != await compute(callback, input)) {
+    throw Exception('compute returned bad result');
+  }
+}
+
+void main() async {
+  await testCompute(returnInt, 10);
+  await testCompute(returnInt, null);
+  await testCompute(returnIntAsync, 10);
+  await testCompute(returnIntAsync, null);
+}

--- a/packages/flutter/test/foundation/_compute_caller_unsound_null_safety.dart
+++ b/packages/flutter/test/foundation/_compute_caller_unsound_null_safety.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // @dart=2.9
+// Running in unsound null-safety mode is intended to test for potential miscasts
+// or invalid assertions.
 
 import 'package:flutter/src/foundation/_isolates_io.dart';
 import 'package:flutter/src/foundation/isolates.dart' as isolates;

--- a/packages/flutter/test/foundation/_compute_caller_unsound_null_safety_error.dart
+++ b/packages/flutter/test/foundation/_compute_caller_unsound_null_safety_error.dart
@@ -1,0 +1,21 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart=2.9
+
+import 'package:flutter/src/foundation/_isolates_io.dart';
+
+int throwNull(int arg) {
+  throw null;
+}
+
+void main() async {
+  try {
+    await compute(throwNull, null);
+  } catch (e) {
+    if (e is! NullThrownError) {
+      throw Exception('compute returned bad result');
+    }
+  }
+}

--- a/packages/flutter/test/foundation/_compute_caller_unsound_null_safety_error.dart
+++ b/packages/flutter/test/foundation/_compute_caller_unsound_null_safety_error.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 // @dart=2.9
+// Running in unsound null-safety mode is intended to test for potential miscasts
+// or invalid assertions.
 
 import 'package:flutter/src/foundation/_isolates_io.dart';
 

--- a/packages/flutter/test/foundation/isolates_test.dart
+++ b/packages/flutter/test/foundation/isolates_test.dart
@@ -91,7 +91,7 @@ Future<void> expectFileSuccessfullyCompletes(String filename) async {
   final String packageRoot = fs.path.dirname(fs.path.fromUri(platform.script));
   final String scriptPath = fs.path.join(packageRoot, 'test', 'foundation', filename);
 
-  // enable asserts to also catch potentially wrong assertions
+  // Enable asserts to also catch potentially wrong assertions.
   final ProcessResult result = await Process.run(dartPath, <String>['run', '--enable-asserts', scriptPath]);
   expect(result.exitCode, 0);
 }

--- a/packages/flutter/test/foundation/isolates_test.dart
+++ b/packages/flutter/test/foundation/isolates_test.dart
@@ -91,7 +91,7 @@ Future<void> expectFileSuccessfullyCompletes(String filename) async {
   final String packageRoot = fs.path.dirname(fs.path.fromUri(platform.script));
   final String scriptPath = fs.path.join(packageRoot, 'test', 'foundation', filename);
 
-  // Enable asserts to also catch potentially wrong assertions.
+  // Enable asserts to also catch potentially invalid assertions.
   final ProcessResult result = await Process.run(dartPath, <String>['run', '--enable-asserts', scriptPath]);
   expect(result.exitCode, 0);
 }

--- a/packages/flutter/test/foundation/isolates_test.dart
+++ b/packages/flutter/test/foundation/isolates_test.dart
@@ -90,6 +90,8 @@ Future<void> expectFileSuccessfullyCompletes(String filename) async {
   final String dartPath = fs.path.join(flutterRoot, 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
   final String packageRoot = fs.path.dirname(fs.path.fromUri(platform.script));
   final String scriptPath = fs.path.join(packageRoot, 'test', 'foundation', filename);
+
+  // enable asserts to also catch potentially wrong assertions
   final ProcessResult result = await Process.run(dartPath, <String>['run', '--enable-asserts', scriptPath]);
   expect(result.exitCode, 0);
 }


### PR DESCRIPTION
After @lrhn [explained in my previous pull request](https://github.com/flutter/flutter/pull/99527#issuecomment-1072736904) why he used some assertions, I realized I completely forgot about unsound null-safety. 

Meaning, some of my assertions (those being suggested for removal) would in fact throw an incorrect `AssertionError` when the caller was calling with unsound null-safety. Of course this would only happen in debug mode. But still...

Thus, this pull request:
- removes those assertions and lets `... as Type` calls do all the casting / type checking,
- adds some general tests in a `// @dart=2.9` marked file (testing in unsound null-safety mode),
- sets `--enable-asserts` flag when calling a file in a separate process

Additional note:
I opted to calling just a few tests in unsound null-safety mode instead of copying the full test suite and marking it with `// @dart=2.9`. And, I used a process to spawn the unsound null-safety mode file, instead of creating a new test suite. It made the intention clearer to me.

cc: @goderbauer 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
