### PR TITLE
`Tooltip`: Add an example for `TooltipTriggerMode.manual` and add tests for existing `Tooltip` examples

### DIFF
--- a/examples/api/lib/material/tooltip/tooltip.0.dart
+++ b/examples/api/lib/material/tooltip/tooltip.0.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
   static const String _title = 'Tooltip Sample';
 
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
 }
 
 class TooltipSample extends StatelessWidget {
-  const TooltipSample({super.key});
+  const TooltipSample({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.0.dart
+++ b/examples/api/lib/material/tooltip/tooltip.0.dart
@@ -9,9 +9,9 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
-  static const String _title = 'Flutter Code Sample';
+  static const String _title = 'Tooltip Sample';
 
   @override
   Widget build(BuildContext context) {
@@ -20,15 +20,15 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
         body: const Center(
-          child: MyStatelessWidget(),
+          child: TooltipSample(),
         ),
       ),
     );
   }
 }
 
-class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({Key? key}) : super(key: key);
+class TooltipSample extends StatelessWidget {
+  const TooltipSample({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.1.dart
+++ b/examples/api/lib/material/tooltip/tooltip.1.dart
@@ -11,7 +11,7 @@ void main() => runApp(const MyApp());
 class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
-  static const String _title = 'Flutter Code Sample';
+  static const String _title = 'Tooltip Sample';
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.1.dart
+++ b/examples/api/lib/material/tooltip/tooltip.1.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   static const String _title = 'Flutter Code Sample';
 
@@ -20,15 +20,15 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
         body: const Center(
-          child: MyStatelessWidget(),
+          child: TooltipSample(),
         ),
       ),
     );
   }
 }
 
-class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({Key? key}) : super(key: key);
+class TooltipSample extends StatelessWidget {
+  const TooltipSample({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.1.dart
+++ b/examples/api/lib/material/tooltip/tooltip.1.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
   static const String _title = 'Flutter Code Sample';
 
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
 }
 
 class TooltipSample extends StatelessWidget {
-  const TooltipSample({super.key});
+  const TooltipSample({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.2.dart
+++ b/examples/api/lib/material/tooltip/tooltip.2.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
   static const String _title = 'Tooltip Sample';
 
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
 }
 
 class TooltipSample extends StatelessWidget {
-  const TooltipSample({super.key});
+  const TooltipSample({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.2.dart
+++ b/examples/api/lib/material/tooltip/tooltip.2.dart
@@ -9,9 +9,9 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
-  static const String _title = 'Flutter Code Sample';
+  static const String _title = 'Tooltip Sample';
 
   @override
   Widget build(BuildContext context) {
@@ -20,15 +20,15 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
         body: const Center(
-          child: MyStatelessWidget(),
+          child: TooltipSample(),
         ),
       ),
     );
   }
 }
 
-class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({Key? key}) : super(key: key);
+class TooltipSample extends StatelessWidget {
+  const TooltipSample({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/tooltip/tooltip.3.dart
+++ b/examples/api/lib/material/tooltip/tooltip.3.dart
@@ -1,0 +1,55 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for Tooltip
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  static const String _title = 'Tooltip Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      title: _title,
+      home: TooltipSample(title: _title),
+    );
+  }
+}
+
+class TooltipSample extends StatelessWidget {
+  const TooltipSample({super.key, required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final GlobalKey<TooltipState> tooltipkey = GlobalKey<TooltipState>();
+
+    return Scaffold(
+      body: Center(
+        child: Tooltip(
+          // Provide a global key with the "TooltipState" type to show
+          // the tooltip manually when trigger mode is set to manual.
+          key: tooltipkey,
+          triggerMode: TooltipTriggerMode.manual,
+          showDuration: const Duration(seconds: 1),
+          message: 'I am a Tooltip',
+          child: const Text('Tap on the FAB'),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          // Show Tooltip programmatically on button tap.
+          tooltipkey.currentState?.ensureTooltipVisible();
+        },
+        label: const Text('Show Tooltip'),
+      ),
+    );
+  }
+}

--- a/examples/api/lib/material/tooltip/tooltip.3.dart
+++ b/examples/api/lib/material/tooltip/tooltip.3.dart
@@ -9,7 +9,7 @@ import 'package:flutter/material.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({Key? key}) : super(key: key);
 
   static const String _title = 'Tooltip Sample';
 
@@ -23,7 +23,7 @@ class MyApp extends StatelessWidget {
 }
 
 class TooltipSample extends StatelessWidget {
-  const TooltipSample({super.key, required this.title});
+  const TooltipSample({Key? key, required this.title}) : super(key: key);
 
   final String title;
 

--- a/examples/api/lib/material/tooltip/tooltip.3.dart
+++ b/examples/api/lib/material/tooltip/tooltip.3.dart
@@ -32,6 +32,7 @@ class TooltipSample extends StatelessWidget {
     final GlobalKey<TooltipState> tooltipkey = GlobalKey<TooltipState>();
 
     return Scaffold(
+      appBar: AppBar(title: Text(title)),
       body: Center(
         child: Tooltip(
           // Provide a global key with the "TooltipState" type to show

--- a/examples/api/test/material/tooltip/tooltip.0_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.0_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/tooltip/tooltip.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Tooltip is visible when hovering over text', (WidgetTester tester) async {
+    const String tooltipText = 'I am a Tooltip';
+
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      if (gesture != null)
+        return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    expect(find.text(tooltipText), findsNothing);
+    // Move the mouse over the text and wait for the tooltip to appear.
+    final Finder tooltip = find.byType(Tooltip);
+    await gesture.moveTo(tester.getCenter(tooltip));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tooltipText), findsOneWidget);
+    // Move the mouse away and wait for the tooltip to disappear.
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pumpAndSettle();
+    await gesture.removePointer();
+    gesture = null;
+    expect(find.text(tooltipText), findsNothing);
+  });
+}

--- a/examples/api/test/material/tooltip/tooltip.1_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.1_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/tooltip/tooltip.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Tooltip wait and show duration', (WidgetTester tester) async {
+    const String tooltipText = 'I am a Tooltip';
+
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      if (gesture != null)
+        return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    expect(find.text(tooltipText), findsNothing);
+
+    // Move the mouse over the text and wait for the tooltip to appear.
+    final Finder tooltip = find.byType(Tooltip);
+    await gesture.moveTo(tester.getCenter(tooltip));
+    // Wait half a second and tooltip should still not be visible.
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text(tooltipText), findsNothing);
+    // Wait another half a second and tooltip should be visible now.
+    await tester.pump(const Duration(milliseconds: 500));
+    expect(find.text(tooltipText), findsOneWidget);
+    // Move the mouse away and wait for the tooltip to disappear.
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    // Wait a second and tooltip should still be visible.
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text(tooltipText), findsOneWidget);
+    // Wait another second and tooltip should be gone.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+    await gesture.removePointer();
+    gesture = null;
+    expect(find.text(tooltipText), findsNothing);
+  });
+}

--- a/examples/api/test/material/tooltip/tooltip.1_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.1_test.dart
@@ -28,19 +28,19 @@ void main() {
     // Move the mouse over the text and wait for the tooltip to appear.
     final Finder tooltip = find.byType(Tooltip);
     await gesture.moveTo(tester.getCenter(tooltip));
-    // Wait half a second and tooltip should still not be visible.
+    // Wait half a second and the tooltip should still not be visible.
     await tester.pump(const Duration(milliseconds: 500));
     expect(find.text(tooltipText), findsNothing);
-    // Wait another half a second and tooltip should be visible now.
+    // Wait another half a second and the tooltip should be visible now.
     await tester.pump(const Duration(milliseconds: 500));
     expect(find.text(tooltipText), findsOneWidget);
     // Move the mouse away and wait for the tooltip to disappear.
     await gesture.moveTo(const Offset(1.0, 1.0));
     await tester.pump();
-    // Wait a second and tooltip should still be visible.
+    // Wait a second and the tooltip should still be visible.
     await tester.pump(const Duration(seconds: 1));
     expect(find.text(tooltipText), findsOneWidget);
-    // Wait another second and tooltip should be gone.
+    // Wait another second and the tooltip should be gone.
     await tester.pump(const Duration(seconds: 1));
     await tester.pumpAndSettle();
     await gesture.removePointer();

--- a/examples/api/test/material/tooltip/tooltip.2_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.2_test.dart
@@ -1,0 +1,39 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/tooltip/tooltip.2.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Tooltip is visible when hovering over text', (WidgetTester tester) async {
+    const String tooltipText = 'I am a rich tooltip. I am another span of this rich tooltip';
+
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    TestGesture? gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    addTearDown(() async {
+      if (gesture != null)
+        return gesture.removePointer();
+    });
+    await gesture.addPointer();
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pump();
+    expect(find.text(tooltipText), findsNothing);
+    // Move the mouse over the text and wait for the tooltip to appear.
+    final Finder tooltip = find.byType(Tooltip);
+    await gesture.moveTo(tester.getCenter(tooltip));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tooltipText), findsOneWidget);
+    // Move the mouse away and wait for the tooltip to disappear.
+    await gesture.moveTo(const Offset(1.0, 1.0));
+    await tester.pumpAndSettle();
+    await gesture.removePointer();
+    gesture = null;
+    expect(find.text(tooltipText), findsNothing);
+  });
+}

--- a/examples/api/test/material/tooltip/tooltip.3_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.3_test.dart
@@ -20,7 +20,7 @@ void main() {
     await tester.tap(find.byType(FloatingActionButton));
     await tester.pump(const Duration(milliseconds: 10));
     expect(find.text(tooltipText), findsOneWidget);
-
+    // Wait for the tooltip to disappear.
     await tester.pump(const Duration(seconds: 1));
     expect(find.text(tooltipText), findsNothing);
   });

--- a/examples/api/test/material/tooltip/tooltip.3_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.3_test.dart
@@ -1,0 +1,27 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/tooltip/tooltip.3.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Tooltip is visible when tapping button', (WidgetTester tester) async {
+    const String tooltipText = 'I am a Tooltip';
+
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    // Tooltip is not visible before tapping button.
+    expect(find.text(tooltipText), findsNothing);
+    // Tap on the button and wait for the tooltip to appear.
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tooltipText), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 1));
+    expect(find.text(tooltipText), findsNothing);
+  });
+}

--- a/examples/api/test/material/tooltip/tooltip.3_test.dart
+++ b/examples/api/test/material/tooltip/tooltip.3_test.dart
@@ -14,7 +14,7 @@ void main() {
       const example.MyApp(),
     );
 
-    // Tooltip is not visible before tapping button.
+    // Tooltip is not visible before tapping the button.
     expect(find.text(tooltipText), findsNothing);
     // Tap on the button and wait for the tooltip to appear.
     await tester.tap(find.byType(FloatingActionButton));

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -66,6 +66,13 @@ import 'tooltip_visibility.dart';
 /// ** See code in examples/api/lib/material/tooltip/tooltip.2.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example shows how [Tooltip] can be shown manually with [TooltipTriggerMode.manual]
+/// by calling the [TooltipState.ensureTooltipVisible] function.
+///
+/// ** See code in examples/api/lib/material/tooltip/tooltip.3.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * <https://material.io/design/components/tooltips.html>


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/100552

Note:
~This will land after https://github.com/flutter/flutter/pull/100553 is merged~

 
`TooltipTriggerMode.manual` example is similar an [example](https://master-api.flutter.dev/flutter/material/RefreshIndicator-class.html) for `RefreshIndicator`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
