### PR TITLE
Add back Gold `passfail`

### DIFF
--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -181,9 +181,7 @@ void main() {
           '--commit', '1234',
           '--keys-file', '/workDirectory/keys.json',
           '--failure-file', '/workDirectory/failures.json',
-          // TODO(Piinks): Re-enable once https://github.com/flutter/flutter/issues/100304
-          // is resolved.
-          //'--passfail',
+          '--passfail',
         ],
         null,
       );

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -144,9 +144,7 @@ class SkiaGoldClient {
       '--commit', commitHash,
       '--keys-file', keys.path,
       '--failure-file', failures.path,
-      // TODO(Piinks): Re-enable once https://github.com/flutter/flutter/issues/100304
-      // is resolved.
-      //'--passfail',
+      '--passfail',
     ];
 
     if (imgtestInitCommand.contains(null)) {
@@ -193,9 +191,7 @@ class SkiaGoldClient {
         .path,
       '--test-name', cleanTestName(testName),
       '--png-file', goldenFile.path,
-      // TODO(Piinks): Re-enable once https://github.com/flutter/flutter/issues/100304
-      // is resolved.
-      //'--passfail',
+      '--passfail',
     ];
 
     final io.ProcessResult result = await process.run(imgtestCommand);


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/100304

This adds back the `passfail` flag, but it does not re-enable the exception that would be thrown in post submit if the call returns an error. Will continue to monitor before fully restoring.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
