### PR TITLE
[framework] use Uint8List for SMC

### DIFF
--- a/packages/flutter/test/foundation/serialization_test.dart
+++ b/packages/flutter/test/foundation/serialization_test.dart
@@ -9,6 +9,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Write and read buffer round-trip', () {
+    test('of empty buffer', () {
+      final WriteBuffer write = WriteBuffer();
+      final ByteData written = write.done();
+
+      expect(written.lengthInBytes, 0);
+    });
     test('of single byte', () {
       final WriteBuffer write = WriteBuffer();
       write.putUint8(201);


### PR DESCRIPTION
b/225970174  - the change to remove package:typed_data regressed several gpay benchmarks. Instead use a Uint8List like package:typed_data was using - but don't add the dependency back since the change is fairly small.
