### PR TITLE
[macOS] Ignore stderr contents in launch test

### DIFF
--- a/dev/devicelab/bin/tasks/run_release_test_macos.dart
+++ b/dev/devicelab/bin/tasks/run_release_test_macos.dart
@@ -74,10 +74,6 @@ void main() {
 
       await run.exitCode;
 
-      if (stderr.isNotEmpty) {
-        throw 'flutter run --release had output on standard error.';
-      }
-
       _findNextMatcherInList(
         stdout,
         (String line) => line.startsWith('Launching lib/main.dart on ') && line.endsWith(' in release mode...'),


### PR DESCRIPTION
In the run_release_test_macos integration test that verifies that a
release build of an app can be launched (and quit), xcodebuild from the
Xcode install on the macOS bots emits a few info messages about
Simulator SDK versions that are irrelevant to the functioning of this
test.

Ignore these instead of failing the test if they occur.

Related: https://github.com/flutter/flutter/pull/100526

Issue: https://github.com/flutter/flutter/issues/100348 (fix)
Issue: https://github.com/flutter/flutter/issues/97978 (partial fix)
Issue: https://github.com/flutter/flutter/issues/97977 (partial fix)
Umbrella issue: https://github.com/flutter/flutter/issues/60113


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
