### PR TITLE
[flutter_tools] Fix VersionUpstreamValidator to respect FLUTTER_GIT_URL

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -449,15 +449,16 @@ class VersionUpstreamValidator {
 
     // Strip `.git` suffix before comparing the remotes
     final List<String> sanitizedStandardRemotes = <String>[
-      if (flutterGit != null) flutterGit,
-      'https://github.com/flutter/flutter.git',
-      'git@github.com:flutter/flutter.git',
+      // If `FLUTTER_GIT_URL` is set, use that as standard remote.
+      if (flutterGit != null) flutterGit
+      // Else use the predefined standard remotes.
+      else ..._standardRemotes,
     ].map((String remote) => stripDotGit(remote)).toList();
 
     final String sanitizedRepositoryUrl = stripDotGit(repositoryUrl);
 
     if (!sanitizedStandardRemotes.contains(sanitizedRepositoryUrl)) {
-      if (platform.environment.containsKey('FLUTTER_GIT_URL')) {
+      if (flutterGit != null) {
         // If `FLUTTER_GIT_URL` is set, inform to either remove the
         // `FLUTTER_GIT_URL` environment variable or set it to the current
         // tracking remote.
@@ -481,6 +482,12 @@ class VersionUpstreamValidator {
     }
     return null;
   }
+
+  // The predefined list of remotes that are considered to be standard.
+  static final List<String> _standardRemotes = <String>[
+    'https://github.com/flutter/flutter.git',
+    'git@github.com:flutter/flutter.git',
+  ];
 
   // Strips ".git" suffix from a given string, preferably an url.
   // For example, changes 'https://github.com/flutter/flutter.git' to 'https://github.com/flutter/flutter'.

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -379,17 +379,17 @@ void main() {
         ), isNull);
       });
 
-      testWithoutContext('returns error at remote url and FLUTTER_GIT_URL set to different urls', () {
+      testWithoutContext('respects FLUTTER_GIT_URL even if upstream remote url is standard', () {
         final VersionCheckError error = runUpstreamValidator(
-            versionUpstreamUrl: flutterNonStandardUrlDotGit,
-            flutterGitUrl: flutterStandardUrlDotGit,
+            versionUpstreamUrl: flutterStandardUrlDotGit,
+            flutterGitUrl: flutterNonStandardUrlDotGit,
         );
         expect(error, isNotNull);
         expect(
           error.message,
           contains(
-            'The Flutter SDK is tracking "$flutterNonStandardUrlDotGit" but "FLUTTER_GIT_URL" is set to "$flutterStandardUrlDotGit".\n'
-            'Either remove "FLUTTER_GIT_URL" from the environment or set it to "$flutterNonStandardUrlDotGit". '
+            'The Flutter SDK is tracking "$flutterStandardUrlDotGit" but "FLUTTER_GIT_URL" is set to "$flutterNonStandardUrlDotGit".\n'
+            'Either remove "FLUTTER_GIT_URL" from the environment or set it to "$flutterStandardUrlDotGit". '
             'If this is intentional, it is recommended to use "git" directly to manage the SDK.'
           ),
         );


### PR DESCRIPTION
Fixes `VersionUpstreamValidator` to always respect `FLUTTER_GIT_URL` for checking whether the current channel tracks a standard remote.

Fixes #100604.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
