### PR TITLE
[CODEOWNERS] Remove caseyhillers from ci.yaml

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,7 +7,7 @@
 # Use git ls-files '<pattern>' without a / prefix to see the list of matching files.
 
 /CODEOWNERS @jmagman
-/.ci.yaml @keyonghan @caseyhillers
+/.ci.yaml @keyonghan
 /dev/ci/ @christopherfujino
 /packages/flutter_goldens @Piinks
 /packages/flutter_goldens_client @Piinks


### PR DESCRIPTION
With https://github.com/flutter/flutter/issues/90166 fixed, I don't see a need for me to monitor ci.yaml changes anymore.

