### PR TITLE
Retire v1 embedding compatibility from automatic multidex support

### DIFF
--- a/packages/flutter_tools/lib/src/android/multidex.dart
+++ b/packages/flutter_tools/lib/src/android/multidex.dart
@@ -25,25 +25,32 @@ File _getMultiDexApplicationFile(Directory projectDir) {
 void ensureMultiDexApplicationExists(final Directory projectDir) {
   final File applicationFile = _getMultiDexApplicationFile(projectDir);
   if (applicationFile.existsSync()) {
-    return;
+    if (!applicationFile.readAsStringSync().contains('extends FlutterApplication')) {
+      return;
+    }
   }
   applicationFile.createSync(recursive: true);
 
   final StringBuffer buffer = StringBuffer();
   buffer.write('''
 // Generated file.
+//
 // If you wish to remove Flutter's multidex support, delete this entire file.
+//
+// Modifications to this file should be done in a copy under a different name
+// as this file may be regenerated.
 
 package io.flutter.app;
 
+import android.app.application;
 import android.content.Context;
 import androidx.annotation.CallSuper;
 import androidx.multidex.MultiDex;
 
 /**
- * Extension of {@link io.flutter.app.FlutterApplication}, adding multidex support.
+ * Extension of {@link android.app.Application}, adding multidex support.
  */
-public class FlutterMultiDexApplication extends FlutterApplication {
+public class FlutterMultiDexApplication extends Application {
   @Override
   @CallSuper
   protected void attachBaseContext(Context base) {

--- a/packages/flutter_tools/lib/src/android/multidex.dart
+++ b/packages/flutter_tools/lib/src/android/multidex.dart
@@ -25,7 +25,10 @@ File _getMultiDexApplicationFile(Directory projectDir) {
 void ensureMultiDexApplicationExists(final Directory projectDir) {
   final File applicationFile = _getMultiDexApplicationFile(projectDir);
   if (applicationFile.existsSync()) {
-    if (!applicationFile.readAsStringSync().contains('extends FlutterApplication')) {
+    // This checks for instances of legacy versions of this file. Legacy versions maintained
+    // compatibility with v1 embedding by extending FlutterApplication. If we detect this,
+    // we replace the file with the modern v2 embedding version.
+    if (applicationFile.readAsStringSync().contains('android.app.Application;')) {
       return;
     }
   }

--- a/packages/flutter_tools/lib/src/android/multidex.dart
+++ b/packages/flutter_tools/lib/src/android/multidex.dart
@@ -42,7 +42,7 @@ void ensureMultiDexApplicationExists(final Directory projectDir) {
 
 package io.flutter.app;
 
-import android.app.application;
+import android.app.Application;
 import android.content.Context;
 import androidx.annotation.CallSuper;
 import androidx.multidex.MultiDex;

--- a/packages/flutter_tools/test/general.shard/android/multidex_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/multidex_test.dart
@@ -14,7 +14,7 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 
 void main() {
-  testUsingContext('ensureMultidexUtilsExists returns when exists', () async {
+  testUsingContext('ensureMultidexUtilsExists patches file when invalid', () async {
     final Directory directory = globals.fs.currentDirectory;
     final File applicationFile = directory.childDirectory('android')
       .childDirectory('app')
@@ -32,7 +32,33 @@ void main() {
     ensureMultiDexApplicationExists(directory);
 
     // File should remain untouched
-    expect(applicationFile.readAsStringSync(), 'hello');
+    expect(applicationFile.readAsStringSync(), '''
+// Generated file.
+//
+// If you wish to remove Flutter's multidex support, delete this entire file.
+//
+// Modifications to this file should be done in a copy under a different name
+// as this file may be regenerated.
+
+package io.flutter.app;
+
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.CallSuper;
+import androidx.multidex.MultiDex;
+
+/**
+ * Extension of {@link android.app.Application}, adding multidex support.
+ */
+public class FlutterMultiDexApplication extends Application {
+  @Override
+  @CallSuper
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
+  }
+}
+''');
   }, overrides: <Type, Generator>{
     FileSystem: () => MemoryFileSystem.test(),
     ProcessManager: () => FakeProcessManager.any(),

--- a/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
@@ -297,25 +297,30 @@ class MultidexProject extends Project {
   ''';
 
   String get appMultidexApplication => r'''
-  // Generated file.
-  // If you wish to remove Flutter's multidex support, delete this entire file.
+// Generated file.
+//
+// If you wish to remove Flutter's multidex support, delete this entire file.
+//
+// Modifications to this file should be done in a copy under a different name
+// as this file may be regenerated.
 
-  package io.flutter.app;
+package io.flutter.app;
 
-  import android.content.Context;
-  import androidx.annotation.CallSuper;
-  import androidx.multidex.MultiDex;
+import android.app.Application;
+import android.content.Context;
+import androidx.annotation.CallSuper;
+import androidx.multidex.MultiDex;
 
-  /**
-   * Extension of {@link io.flutter.app.FlutterApplication}, adding multidex support.
-   */
-  public class FlutterMultiDexApplication extends FlutterApplication {
-    @Override
-    @CallSuper
-    protected void attachBaseContext(Context base) {
-      super.attachBaseContext(base);
-      MultiDex.install(this);
-    }
+/**
+ * Extension of {@link android.app.Application}, adding multidex support.
+ */
+public class FlutterMultiDexApplication extends Application {
+  @Override
+  @CallSuper
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
   }
+}
   ''';
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
@@ -297,30 +297,30 @@ class MultidexProject extends Project {
   ''';
 
   String get appMultidexApplication => r'''
-// Generated file.
-//
-// If you wish to remove Flutter's multidex support, delete this entire file.
-//
-// Modifications to this file should be done in a copy under a different name
-// as this file may be regenerated.
+  // Generated file.
+  //
+  // If you wish to remove Flutter's multidex support, delete this entire file.
+  //
+  // Modifications to this file should be done in a copy under a different name
+  // as this file may be regenerated.
 
-package io.flutter.app;
+  package io.flutter.app;
 
-import android.app.Application;
-import android.content.Context;
-import androidx.annotation.CallSuper;
-import androidx.multidex.MultiDex;
+  import android.app.Application;
+  import android.content.Context;
+  import androidx.annotation.CallSuper;
+  import androidx.multidex.MultiDex;
 
-/**
- * Extension of {@link android.app.Application}, adding multidex support.
- */
-public class FlutterMultiDexApplication extends Application {
-  @Override
-  @CallSuper
-  protected void attachBaseContext(Context base) {
-    super.attachBaseContext(base);
-    MultiDex.install(this);
+  /**
+   * Extension of {@link android.app.Application}, adding multidex support.
+   */
+  public class FlutterMultiDexApplication extends Application {
+    @Override
+    @CallSuper
+    protected void attachBaseContext(Context base) {
+      super.attachBaseContext(base);
+      MultiDex.install(this);
+    }
   }
-}
   ''';
 }


### PR DESCRIPTION
With the v1 embedding being fully removed, we should no longer support v1 embedding.

This automatically migrates existing apps using multidex support to a v2 embedding only setup.