### PR TITLE
Filter out some stray Xcode logging during macOS builds

### DIFF
--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -16,9 +16,13 @@ import '../project.dart';
 import 'cocoapod_utils.dart';
 import 'migrations/remove_macos_framework_link_and_embedding_migration.dart';
 
-/// When run in -quiet mode, Xcode only prints from the underlying tasks to stdout.
+/// When run in -quiet mode, Xcode should only print from the underlying tasks to stdout.
 /// Passing this regexp to trace moves the stdout output to stderr.
-final RegExp _anyOutput = RegExp('.*');
+///
+/// Filter out xcodebuild logging unrelated to macOS builds:
+/// xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
+/// note: Using new build system
+final RegExp _filteredOutput = RegExp(r'^((?!Requested but did not find extension point with identifier|note\:).)*$');
 
 /// Builds the macOS project through xcodebuild.
 // TODO(zanderso): refactor to share code with the existing iOS code.
@@ -113,7 +117,8 @@ Future<void> buildMacOS({
       ...environmentVariablesAsXcodeBuildSettings(globals.platform)
     ],
     trace: true,
-    stdoutErrorMatcher: verboseLogging ? null : _anyOutput,
+    stdoutErrorMatcher: verboseLogging ? null : _filteredOutput,
+    mapFunction: verboseLogging ? null : (String line) => _filteredOutput.hasMatch(line) ? line : null,
   );
   } finally {
     status.cancel();

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -113,7 +113,18 @@ void main() {
           '-quiet',
         'COMPILER_INDEX_STORE_ENABLE=NO',
       ],
-      stdout: 'STDOUT STUFF',
+      stdout: '''
+STDOUT STUFF
+note: Using new build system
+note: Planning
+note: Build preparation complete
+note: Building targets in dependency order
+''',
+        stderr: '''
+2022-03-24 10:07:21.954 xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
+2022-03-24 10:07:21.954 xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension Xcode.DebuggerFoundation.AppExtensionToBundleIdentifierMap.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
+STDERR STUFF
+''',
       onRun: () {
         fileSystem.file(fileSystem.path.join('macos', 'Flutter', 'ephemeral', '.app_filename'))
           ..createSync(recursive: true)
@@ -183,6 +194,11 @@ void main() {
     expect(testLogger.statusText, isNot(contains('STDOUT STUFF')));
     expect(testLogger.traceText, isNot(contains('STDOUT STUFF')));
     expect(testLogger.errorText, contains('STDOUT STUFF'));
+    expect(testLogger.errorText, contains('STDERR STUFF'));
+    // Filters out some xcodebuild logging spew.
+    expect(testLogger.errorText, isNot(contains('xcodebuild[2096:1927385]')));
+    expect(testLogger.errorText, isNot(contains('Using new build system')));
+    expect(testLogger.errorText, isNot(contains('Building targets in dependency order')));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.list(<FakeCommand>[


### PR DESCRIPTION
Filter out some of Xcode's confusing and unrelated warning messages.

macOS variant of https://github.com/flutter/flutter/issues/98298

Before this "fix":
```
Running pod install...                                           1,383ms
2022-03-24 10:07:21.954 xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionSentinelHostApplications for extension Xcode.DebuggerFoundation.AppExtensionHosts.watchOS of plug-in com.apple.dt.IDEWatchSupportCore
2022-03-24 10:07:21.954 xcodebuild[2096:1927385] Requested but did not find extension point with identifier Xcode.IDEKit.ExtensionPointIdentifierToBundleIdentifier for extension 
note: Using new build system
note: Planning
note: Build preparation complete
note: Building targets in dependency order
/Users/m/Projects/flutter/dev/integration_tests/flutter_gallery/macos/Pods/Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.8, but the range of supported deployment target versions is 10.9 to 12.3.99. (in target 'Reachability' from project 'Pods')
Building macOS application...
```
after:
```
Running pod install...                                           1,383ms
/Users/m/Projects/flutter/dev/integration_tests/flutter_gallery/macos/Pods/Pods.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.8, but the range of supported deployment target versions is 10.9 to 12.3.99. (in target 'Reachability' from project 'Pods')
Building macOS application...
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
