### PR TITLE
[flutter_conductor] Add candidate branch version to releases

### DIFF
--- a/dev/conductor/core/lib/src/repository.dart
+++ b/dev/conductor/core/lib/src/repository.dart
@@ -635,7 +635,7 @@ class FrameworkRepository extends Repository {
         .childDirectory('bin')
         .childDirectory('internal')
         .childFile('release-candidate-branch.version');
-    if(versionFile.existsSync()) {
+    if (versionFile.existsSync()) {
       final String oldCandidateBranch = versionFile.readAsStringSync();
       if (oldCandidateBranch.trim() == branch.trim()) {
         stdio.printTrace(

--- a/dev/conductor/core/lib/src/repository.dart
+++ b/dev/conductor/core/lib/src/repository.dart
@@ -620,6 +620,39 @@ class FrameworkRepository extends Repository {
     return Version.fromString(versionJson['frameworkVersion'] as String);
   }
 
+  /// Create a release candidate branch version file.
+  ///
+  /// This file allows for easily traversing what candidadate branch was used
+  /// from a release channel.
+  ///
+  /// Returns [true] if the version file was updated and a commit is needed.
+  Future<bool> updateCandidateBranchVersion(
+    String branch, {
+    @visibleForTesting File? versionFile,
+  }) async {
+    assert(branch.isNotEmpty);
+    versionFile ??= (await checkoutDirectory)
+        .childDirectory('bin')
+        .childDirectory('internal')
+        .childFile('release-candidate-branch.version');
+    if(versionFile.existsSync()) {
+      final String oldCandidateBranch = versionFile.readAsStringSync();
+      if (oldCandidateBranch.trim() == branch.trim()) {
+        stdio.printTrace(
+          'Tried to update the candidate branch but version file is already up to date at: $branch',
+        );
+        return false;
+      }
+    }
+    stdio.printStatus('Create ${versionFile.path} containing $branch');
+    versionFile.writeAsStringSync(
+      // Version files have trailing newlines
+      '${branch.trim()}\n',
+      flush: true,
+    );
+    return true;
+  }
+
   /// Update this framework's engine version file.
   ///
   /// Returns [true] if the version file was updated and a commit is needed.

--- a/dev/conductor/core/test/next_test.dart
+++ b/dev/conductor/core/test/next_test.dart
@@ -25,6 +25,7 @@ void main() {
   const String remoteUrl = 'https://github.com/org/repo.git';
   const String revision1 = 'd3af60d18e01fcb36e0c0fa06c8502e4935ed095';
   const String revision2 = 'f99555c1e1392bf2a8135056b9446680c2af4ddf';
+  const String revision3 = 'ffffffffffffffffffffffffffffffffffffffff';
   const String revision4 = '280e23318a0d8341415c66aa32581352a421d974';
   const String releaseVersion = '1.2.0-3.0.pre';
   const String releaseChannel = 'beta';
@@ -495,7 +496,21 @@ void main() {
           ),
           const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
-            stdout: 'MM /path/to/engine.version',
+            stdout: 'MM bin/internal/release-candidate-branch.version',
+          ),
+          const FakeCommand(command: <String>['git', 'add', '--all']),
+          const FakeCommand(command: <String>[
+            'git',
+            'commit',
+            "--message='Create candidate branch version $candidateBranch for $releaseChannel'",
+          ]),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', 'HEAD'],
+            stdout: revision3,
+          ),
+          const FakeCommand(
+            command: <String>['git', 'status', '--porcelain'],
+            stdout: 'MM bin/internal/engine.version',
           ),
           const FakeCommand(command: <String>['git', 'add', '--all']),
           const FakeCommand(command: <String>[
@@ -571,7 +586,21 @@ void main() {
           const FakeCommand(command: <String>['git', 'checkout', workingBranch]),
           const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
-            stdout: 'MM path/to/engine.version',
+            stdout: 'MM bin/internal/release-candidate-branch.version',
+          ),
+          const FakeCommand(command: <String>['git', 'add', '--all']),
+          const FakeCommand(command: <String>[
+            'git',
+            'commit',
+            "--message='Create candidate branch version $candidateBranch for $releaseChannel'",
+          ]),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', 'HEAD'],
+            stdout: revision3,
+          ),
+          const FakeCommand(
+            command: <String>['git', 'status', '--porcelain'],
+            stdout: 'MM bin/internal/engine.version',
           ),
           const FakeCommand(command: <String>['git', 'add', '--all']),
           const FakeCommand(command: <String>[
@@ -635,7 +664,21 @@ void main() {
           ),
           const FakeCommand(
             command: <String>['git', 'status', '--porcelain'],
-            stdout: 'MM path/to/.ci.yaml',
+            stdout: 'MM bin/internal/release-candidate-branch.version',
+          ),
+          const FakeCommand(command: <String>['git', 'add', '--all']),
+          const FakeCommand(command: <String>[
+            'git',
+            'commit',
+            "--message='Create candidate branch version $candidateBranch for $releaseChannel'",
+          ]),
+          const FakeCommand(
+            command: <String>['git', 'rev-parse', 'HEAD'],
+            stdout: revision3,
+          ),
+          const FakeCommand(
+            command: <String>['git', 'status', '--porcelain'],
+            stdout: 'MM bin/internal/engine.version',
           ),
           const FakeCommand(command: <String>['git', 'add', '--all']),
           const FakeCommand(command: <String>[

--- a/dev/conductor/core/test/repository_test.dart
+++ b/dev/conductor/core/test/repository_test.dart
@@ -340,6 +340,23 @@ vars = {
       expect(processManager.hasRemainingExpectations, false);
     });
 
+    test('updateCandidateBranchVersion() returns false if branch is the same as version file', () async {
+      const String branch = 'flutter-2.15-candidate.3';
+      final File versionFile = fileSystem.file('/release-candidate-branch.version')..writeAsStringSync(branch);
+
+      final Checkouts checkouts = Checkouts(
+        fileSystem: fileSystem,
+        parentDirectory: fileSystem.directory(rootDir),
+        platform: platform,
+        processManager: processManager,
+        stdio: stdio,
+      );
+
+      final FrameworkRepository repo = FrameworkRepository(checkouts);
+      final bool didUpdate = await repo.updateCandidateBranchVersion(branch, versionFile: versionFile);
+      expect(didUpdate, false);
+    });
+
     test('updateEngineRevision() returns false if newCommit is the same as version file', () async {
       const String commit1 = 'abc123';
       const String commit2 = 'def456';


### PR DESCRIPTION
This will allow developers to go to something like https://github.com/flutter/flutter/blob/stable/bin/internal/engine.version to find what candidate branch is being used for the release channel. Developers will be able to send their CPs to this branch without needing to involve a release engineer.

Fixes https://github.com/flutter/flutter/issues/100713

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
