### PR TITLE
Log XCResult before other build issues

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -574,37 +574,14 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
     ).send();
   }
 
-  // Building for iOS Simulator, but the linked and embedded framework 'App.framework' was built for iOS.
-  // or
-  // Building for iOS, but the linked and embedded framework 'App.framework' was built for iOS Simulator.
-  if ((result.stdout?.contains('Building for iOS') ?? false)
-      && (result.stdout?.contains('but the linked and embedded framework') ?? false)
-      && (result.stdout?.contains('was built for iOS') ?? false)) {
-    logger.printError('');
-    logger.printError('Your Xcode project requires migration. See https://flutter.dev/docs/development/ios-project-migration for details.');
-    logger.printError('');
-    logger.printError('You can temporarily work around this issue by running:');
-    logger.printError('  flutter clean');
-    return;
+  // Handle errors.
+  final bool issueDetected = _handleIssues(result.xcResult, logger, xcodeBuildExecution);
+
+  if (!issueDetected && xcodeBuildExecution != null) {
+    // Fallback to use stdout to detect and print issues.
+    _parseIssueInStdout(xcodeBuildExecution, logger, result);
   }
-  if (xcodeBuildExecution != null
-      && xcodeBuildExecution.environmentType == EnvironmentType.physical
-      && (result.stdout?.contains('BCEROR') ?? false)
-      // May need updating if Xcode changes its outputs.
-      && (result.stdout?.contains("Xcode couldn't find a provisioning profile matching") ?? false)) {
-    logger.printError(noProvisioningProfileInstruction, emphasis: true);
-    return;
-  }
-  // Make sure the user has specified one of:
-  // * DEVELOPMENT_TEAM (automatic signing)
-  // * PROVISIONING_PROFILE (manual signing)
-  if (xcodeBuildExecution != null &&
-      xcodeBuildExecution.environmentType == EnvironmentType.physical &&
-      !<String>['DEVELOPMENT_TEAM', 'PROVISIONING_PROFILE'].any(
-        xcodeBuildExecution.buildSettings.containsKey)) {
-    logger.printError(noDevelopmentTeamInstruction, emphasis: true);
-    return;
-  }
+
   if (xcodeBuildExecution != null
       && xcodeBuildExecution.environmentType == EnvironmentType.physical
       && (xcodeBuildExecution.buildSettings['PRODUCT_BUNDLE_IDENTIFIER']?.contains('com.example') ?? false)) {
@@ -613,19 +590,6 @@ Future<void> diagnoseXcodeBuildFailure(XcodeBuildResult result, Usage flutterUsa
     logger.printError("Try replacing 'com.example' with your signing id in Xcode:");
     logger.printError('  open ios/Runner.xcworkspace');
     return;
-  }
-
-  // Handle xcresult errors.
-  final XCResult? xcResult = result.xcResult;
-  if (xcResult == null) {
-    return;
-  }
-  if (!xcResult.parseSuccess) {
-    globals.printTrace('XCResult parsing error: ${xcResult.parsingErrorMessage}');
-    return;
-  }
-  for (final XCResultIssue issue in xcResult.issues) {
-    _handleXCResultIssue(issue: issue, logger: logger);
   }
 }
 
@@ -724,7 +688,7 @@ bool upgradePbxProjWithFlutterAssets(IosProject project, Logger logger) {
   return true;
 }
 
-void _handleXCResultIssue({required XCResultIssue issue, required Logger logger}) {
+_XCResultIssueHandlingResult _handleXCResultIssue({required XCResultIssue issue, required Logger logger}) {
   // Issue summary from xcresult.
   final StringBuffer issueSummaryBuffer = StringBuffer();
   issueSummaryBuffer.write(issue.subType ?? 'Unknown');
@@ -744,16 +708,89 @@ void _handleXCResultIssue({required XCResultIssue issue, required Logger logger}
       break;
   }
 
-  // Add more custom output for flutter users.
-  if (issue.message != null && issue.message!.toLowerCase().contains('provisioning profile')) {
+  final String? message = issue.message;
+  if (message == null) {
+    return _XCResultIssueHandlingResult(requiresProvisioningProfile: false, hasProvisioningProfileIssue: false);
+  }
+
+  // Add more error messages for flutter users for some special errors.
+  if (message.toLowerCase().contains('requires a provisioning profile.')) {
+    return _XCResultIssueHandlingResult(requiresProvisioningProfile: true, hasProvisioningProfileIssue: true);
+  } else if (message.toLowerCase().contains('provisioning profile')) {
+    return _XCResultIssueHandlingResult(requiresProvisioningProfile: false, hasProvisioningProfileIssue: true);
+  }
+  return _XCResultIssueHandlingResult(requiresProvisioningProfile: false, hasProvisioningProfileIssue: false);
+}
+
+// Returns `true` if at least one issue is detected.
+bool _handleIssues(XCResult? xcResult, Logger logger, XcodeBuildExecution? xcodeBuildExecution) {
+  bool requiresProvisioningProfile = false;
+  bool hasProvisioningProfileIssue = false;
+  bool issueDetected = false;
+
+  if (xcResult != null && xcResult.parseSuccess) {
+    for (final XCResultIssue issue in xcResult.issues) {
+      final _XCResultIssueHandlingResult handlingResult = _handleXCResultIssue(issue: issue, logger: logger);
+      if (handlingResult.hasProvisioningProfileIssue) {
+        hasProvisioningProfileIssue = true;
+      }
+      if (handlingResult.requiresProvisioningProfile) {
+        requiresProvisioningProfile = true;
+      }
+      issueDetected = true;
+    }
+  } else if (xcResult != null) {
+    globals.printTrace('XCResult parsing error: ${xcResult.parsingErrorMessage}');
+  }
+
+  if (requiresProvisioningProfile) {
+    logger.printError(noProvisioningProfileInstruction, emphasis: true);
+  } else if (_missingDevelopmentTeam(xcodeBuildExecution)) {
+    issueDetected = true;
+    logger.printError(noDevelopmentTeamInstruction, emphasis: true);
+  } else if (hasProvisioningProfileIssue) {
     logger.printError('');
     logger.printError('It appears that there was a problem signing your application prior to installation on the device.');
     logger.printError('');
     logger.printError('Verify that the Bundle Identifier in your project is your signing id in Xcode');
     logger.printError('  open ios/Runner.xcworkspace');
     logger.printError('');
-    logger.printError("Also try selecting 'Product > Build' to fix the problem:");
+    logger.printError("Also try selecting 'Product > Build' to fix the problem.");
   }
+  return issueDetected;
+}
+
+// Return 'true' a missing development team issue is detected.
+bool _missingDevelopmentTeam(XcodeBuildExecution? xcodeBuildExecution) {
+  // Make sure the user has specified one of:
+  // * DEVELOPMENT_TEAM (automatic signing)
+  // * PROVISIONING_PROFILE (manual signing)
+  return xcodeBuildExecution != null && xcodeBuildExecution.environmentType == EnvironmentType.physical &&
+      !<String>['DEVELOPMENT_TEAM', 'PROVISIONING_PROFILE'].any(
+        xcodeBuildExecution.buildSettings.containsKey);
+}
+// Detects and handles errors from stdout.
+//
+// As detecting issues in stdout is not usually accurate, this should be used as a fallback when other issue detecting methods failed.
+void _parseIssueInStdout(XcodeBuildExecution xcodeBuildExecution, Logger logger, XcodeBuildResult result) {
+  if (xcodeBuildExecution.environmentType == EnvironmentType.physical
+      // May need updating if Xcode changes its outputs.
+      && (result.stdout?.contains('requires a provisioning profile. Select a provisioning profile in the Signing & Capabilities editor') ?? false)) {
+    logger.printError(noProvisioningProfileInstruction, emphasis: true);
+    return;
+  }
+}
+
+// The result of [_handleXCResultIssue].
+class _XCResultIssueHandlingResult {
+
+  _XCResultIssueHandlingResult({required this.requiresProvisioningProfile, required this.hasProvisioningProfileIssue});
+
+  // An issue indicates that user didn't provide the provisioning profile.
+  final bool requiresProvisioningProfile;
+
+  // An issue indicates that there is a provisioning profile issue.
+  final bool hasProvisioningProfileIssue;
 }
 
 const String _kResultBundlePath = 'temporary_xcresult_bundle';

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -721,7 +721,7 @@ void main() {
     expect(testLogger.errorText, contains('It appears that there was a problem signing your application prior to installation on the device.'));
     expect(testLogger.errorText, contains('Verify that the Bundle Identifier in your project is your signing id in Xcode'));
     expect(testLogger.errorText, contains('open ios/Runner.xcworkspace'));
-    expect(testLogger.errorText, contains("Also try selecting 'Product > Build' to fix the problem:"));
+    expect(testLogger.errorText, contains("Also try selecting 'Product > Build' to fix the problem."));
     expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/ios/code_signing.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/project.dart';
@@ -166,7 +167,11 @@ void main() {
       ));
     });
 
-    testWithoutContext('No provisioning profile shows message', () async {
+    testWithoutContext('fallback to stdout: No provisioning profile shows message', () async {
+      final Map<String, String> buildSettingsWithDevTeam = <String, String>{
+        'PRODUCT_BUNDLE_IDENTIFIER': 'test.app',
+        'DEVELOPMENT_TEAM': 'a team',
+      };
       final XcodeBuildResult buildResult = XcodeBuildResult(
         success: false,
         stdout: '''
@@ -194,7 +199,7 @@ Xcode's output:
     === CLEAN TARGET Runner OF PROJECT Runner WITH CONFIGURATION Release ===
 
     Check dependencies
-    [BCEROR]No profiles for 'com.example.test' were found:  Xcode couldn't find a provisioning profile matching 'com.example.test'.
+    [BCEROR]"Runner" requires a provisioning profile. Select a provisioning profile in the Signing & Capabilities editor.
     [BCEROR]Code signing is required for product type 'Application' in SDK 'iOS 10.3'
     [BCEROR]Code signing is required for product type 'Application' in SDK 'iOS 10.3'
     [BCEROR]Code signing is required for product type 'Application' in SDK 'iOS 10.3'
@@ -228,14 +233,14 @@ Error launching application on iPhone.''',
           buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
           appDirectory: '/blah/blah',
           environmentType: EnvironmentType.physical,
-          buildSettings: buildSettings,
+          buildSettings: buildSettingsWithDevTeam,
         ),
       );
 
       await diagnoseXcodeBuildFailure(buildResult, testUsage, logger);
       expect(
         logger.errorText,
-        contains("No Provisioning Profile was found for your project's Bundle Identifier or your \ndevice."),
+        contains(noProvisioningProfileInstruction),
       );
     });
 
@@ -317,80 +322,6 @@ Could not build the precompiled application for the device.''',
       expect(
         logger.errorText,
         contains('Building a deployable iOS app requires a selected Development Team with a \nProvisioning Profile.'),
-      );
-    });
-
-    testWithoutContext('embedded and linked framework iOS mismatch shows message', () async {
-      final XcodeBuildResult buildResult = XcodeBuildResult(
-        success: false,
-        stdout: '''
-Launching lib/main.dart on iPhone in debug mode...
-Automatically signing iOS for device deployment using specified development team in Xcode project: blah
-Xcode build done. 5.7s
-Failed to build iOS app
-Error output from Xcode build:
-↳
-** BUILD FAILED **
-Xcode's output:
-↳
-note: Using new build system
-note: Building targets in parallel
-note: Planning build
-note: Constructing build description
-error: Building for iOS Simulator, but the linked and embedded framework 'App.framework' was built for iOS. (in target 'Runner' from project 'Runner')
-Could not build the precompiled application for the device.
-
-Error launching application on iPhone.
-Exited (sigterm)''',
-        xcodeBuildExecution: XcodeBuildExecution(
-          buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
-          appDirectory: '/blah/blah',
-          environmentType: EnvironmentType.physical,
-          buildSettings: buildSettings,
-        ),
-      );
-
-      await diagnoseXcodeBuildFailure(buildResult, testUsage, logger);
-      expect(
-        logger.errorText,
-        contains('Your Xcode project requires migration.'),
-      );
-    });
-
-    testWithoutContext('embedded and linked framework iOS simulator mismatch shows message', () async {
-      final XcodeBuildResult buildResult = XcodeBuildResult(
-        success: false,
-        stdout: '''
-Launching lib/main.dart on iPhone in debug mode...
-Automatically signing iOS for device deployment using specified development team in Xcode project: blah
-Xcode build done. 5.7s
-Failed to build iOS app
-Error output from Xcode build:
-↳
-** BUILD FAILED **
-Xcode's output:
-↳
-note: Using new build system
-note: Building targets in parallel
-note: Planning build
-note: Constructing build description
-error: Building for iOS, but the linked and embedded framework 'App.framework' was built for iOS Simulator. (in target 'Runner' from project 'Runner')
-Could not build the precompiled application for the device.
-
-Error launching application on iPhone.
-Exited (sigterm)''',
-        xcodeBuildExecution: XcodeBuildExecution(
-          buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
-          appDirectory: '/blah/blah',
-          environmentType: EnvironmentType.physical,
-          buildSettings: buildSettings,
-        ),
-      );
-
-      await diagnoseXcodeBuildFailure(buildResult, testUsage, logger);
-      expect(
-        logger.errorText,
-        contains('Your Xcode project requires migration.'),
       );
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcresult_test_data.dart
@@ -182,6 +182,82 @@ const String kSampleResultJsonWithIssues = r'''
 ''';
 
 /// An example xcresult bundle json that contains some warning and some errors.
+const String kSampleResultJsonWithNoProvisioningProfileIssue = r'''
+{
+  "issues" : {
+    "_type" : {
+      "_name" : "ResultIssueSummaries"
+    },
+    "errorSummaries" : {
+      "_type" : {
+        "_name" : "Array"
+      },
+      "_values" : [
+        {
+          "_type" : {
+            "_name" : "IssueSummary"
+          },
+          "documentLocationInCreatingWorkspace" : {
+            "_type" : {
+              "_name" : "DocumentLocation"
+            },
+            "concreteTypeName" : {
+              "_type" : {
+                "_name" : "String"
+              },
+              "_value" : "DVTTextDocumentLocation"
+            },
+            "url" : {
+              "_type" : {
+                "_name" : "String"
+              },
+              "_value" : "file:\/\/\/Users\/m\/Projects\/test_create\/ios\/Runner\/AppDelegate.m#CharacterRangeLen=0&CharacterRangeLoc=263&EndingColumnNumber=56&EndingLineNumber=7&LocationEncoding=1&StartingColumnNumber=56&StartingLineNumber=7"
+            }
+          },
+          "issueType" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Error"
+          },
+          "message" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Runner requires a provisioning profile. Select a provisioning profile in the Signing & Capabilities editor"
+          }
+        }
+      ]
+    },
+    "warningSummaries" : {
+      "_type" : {
+        "_name" : "Array"
+      },
+      "_values" : [
+        {
+          "_type" : {
+            "_name" : "IssueSummary"
+          },
+          "issueType" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "Warning"
+          },
+          "message" : {
+            "_type" : {
+              "_name" : "String"
+            },
+            "_value" : "The iOS deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99."
+          }
+        }
+      ]
+    }
+  }
+}
+''';
+
+/// An example xcresult bundle json that contains some warning and some errors.
 const String kSampleResultJsonWithIssuesAndInvalidUrl = r'''
 {
   "issues" : {


### PR DESCRIPTION
Always log XCResult first so it won't get lost if there are other issues.

Also updated the order issues are detected.
Some sample error messages after the change are:
1. no provisioning profile:
```
Error (Xcode): "Runner" requires a provisioning profile. Select a provisioning profile in the Signing & Capabilities editor.


════════════════════════════════════════════════════════════════════════════════
No Provisioning Profile was found for your project's Bundle Identifier or your 
device. You can create a new Provisioning Profile for your project in Xcode for 
your team by:
  1- Open the Flutter project's Xcode target with
       open ios/Runner.xcworkspace
  2- Select the 'Runner' project in the navigator then the 'Runner' target
     in the project settings
  3- Make sure a 'Development Team' is selected under Signing & Capabilities > Team. 
     You may need to:
         - Log in with your Apple ID in Xcode first
         - Ensure you have a valid unique Bundle ID
         - Register your device with your Apple Developer Account
         - Let Xcode automatically provision a profile for your app
  4- Build or run your project again

It's also possible that a previously installed app with the same Bundle 
Identifier was signed with a different certificate.

For more information, please visit:
  https://flutter.dev/docs/get-started/install/macos#deploy-to-ios-devices

Or run on an iOS simulator without code signing
════════════════════════════════════════════════════════════════════════════════
```

2. no development team

```
Error (Xcode): Signing for "Runner" requires a development team. Select a development team in the Signing & Capabilities editor.


════════════════════════════════════════════════════════════════════════════════
Building a deployable iOS app requires a selected Development Team with a 
Provisioning Profile. Please ensure that a Development Team is selected by:
  1- Open the Flutter project's Xcode target with
       open ios/Runner.xcworkspace
  2- Select the 'Runner' project in the navigator then the 'Runner' target
     in the project settings
  3- Make sure a 'Development Team' is selected under Signing & Capabilities > Team. 
     You may need to:
         - Log in with your Apple ID in Xcode first
         - Ensure you have a valid unique Bundle ID
         - Register your device with your Apple Developer Account
         - Let Xcode automatically provision a profile for your app
  4- Build or run your project again

For more information, please visit:
  https://flutter.dev/docs/get-started/install/macos#deploy-to-ios-devices

Or run on an iOS simulator without code signing
════════════════════════════════════════════════════════════════════════════════

It appears that your application still contains the default signing identifier.
Try replacing 'com.example' with your signing id in Xcode:
  open ios/Runner.xcworkspace
Encountered error while building for device.
```

Fixes https://github.com/flutter/flutter/issues/100723

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
