### PR TITLE
Migrate common buttons to Material 3

### DIFF
--- a/dev/tools/gen_defaults/bin/gen_defaults.dart
+++ b/dev/tools/gen_defaults/bin/gen_defaults.dart
@@ -17,6 +17,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:gen_defaults/button_template.dart';
 import 'package:gen_defaults/card_template.dart';
 import 'package:gen_defaults/dialog_template.dart';
 import 'package:gen_defaults/fab_template.dart';
@@ -77,6 +78,9 @@ Future<void> main(List<String> args) async {
   tokens['colorsLight'] = _readTokenFile('color_light.json');
   tokens['colorsDark'] = _readTokenFile('color_dark.json');
 
+  ButtonTemplate('md.comp.elevated-button', '$materialLib/elevated_button.dart', tokens).updateFile();
+  ButtonTemplate('md.comp.outlined-button', '$materialLib/outlined_button.dart', tokens).updateFile();
+  ButtonTemplate('md.comp.text-button', '$materialLib/text_button.dart', tokens).updateFile();
   CardTemplate('$materialLib/card.dart', tokens).updateFile();
   DialogTemplate('$materialLib/dialog.dart', tokens).updateFile();
   FABTemplate('$materialLib/floating_action_button.dart', tokens).updateFile();

--- a/dev/tools/gen_defaults/lib/button_template.dart
+++ b/dev/tools/gen_defaults/lib/button_template.dart
@@ -106,12 +106,7 @@ ${tokens.containsKey("$tokenGroup.container.surface-tint-layer.color") ? '''
 
   @override
   MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
-    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
-      const EdgeInsets.symmetric(horizontal: 16),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    ));
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(_scaledPadding(context));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>

--- a/dev/tools/gen_defaults/lib/button_template.dart
+++ b/dev/tools/gen_defaults/lib/button_template.dart
@@ -12,132 +12,52 @@ class ButtonTemplate extends TokenTemplate {
 
   final String tokenGroup;
 
-  String get _backgroundColor {
+  String _backgroundColor() {
     if (tokens.containsKey('$tokenGroup.container.color')) {
-      final String enabledColor = color('$tokenGroup.container.color');
-      final String? enabledOpacity = opacity('$tokenGroup.container.opacity');
-      final String disabledColor = color('$tokenGroup.disabled.container.color');
-      final String? disabledOpacity = opacity('$tokenGroup.disabled.container.opacity');
       return '''
-  static MaterialStateProperty<Color?>? backgroundColorFor(Color? enabled, Color? disabled) {
-    return (enabled == null && disabled == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.disabled))
-            return disabled${disabledOpacity != null ? '?.withOpacity($disabledOpacity)' : ''};
-          return enabled${enabledOpacity != null ? '?.withOpacity($enabledOpacity)' : ''};
-        });
-  }
 
-  @override
-  MaterialStateProperty<Color?>? get backgroundColor {
-    return backgroundColorFor($enabledColor, $disabledColor);
-  }''';
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return ${componentColor('$tokenGroup.disabled.container')};
+      return ${componentColor('$tokenGroup.container')};
+    })''';
     }
     return '''
-  @override
-  MaterialStateProperty<Color?>? get backgroundColor =>
-    ButtonStyleButton.allOrNull<Color>(Colors.transparent);''';
+
+    ButtonStyleButton.allOrNull<Color>(Colors.transparent)''';
   }
 
-  String get _foregroundColor {
-    final String enabledColor = color('$tokenGroup.label-text.color');
-    final String? enabledOpacity = opacity('$tokenGroup.label-text.opacity');
-    final String disabledColor = color('$tokenGroup.disabled.label-text.color');
-    final String? disabledOpacity = opacity('$tokenGroup.disabled.label-text.opacity');
-    return '''
-  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
-    return (enabled == null && disabled == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.disabled))
-            return disabled${disabledOpacity != null ? '?.withOpacity($disabledOpacity)' : ''};
-          return enabled${enabledOpacity != null ? '?.withOpacity($enabledOpacity)' : ''};
-        });
-  }
-
-  @override
-  MaterialStateProperty<Color?>? get foregroundColor {
-    return foregroundColorFor($enabledColor, $disabledColor);
-  }''';
-    }
-
-  String get _overlayColor {
-    final String hoverColor = color('$tokenGroup.hover.state-layer.color');
-    final String? hoverOpacity = opacity('$tokenGroup.hover.state-layer.opacity');
-    final String focusColor = color('$tokenGroup.focus.state-layer.color');
-    final String? focusOpacity = opacity('$tokenGroup.focus.state-layer.opacity');
-    final String pressedColor = color('$tokenGroup.pressed.state-layer.color');
-    final String? pressedOpacity = opacity('$tokenGroup.pressed.state-layer.opacity');
-    return '''
-  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus, Color? pressed) {
-    return (hover == null && focus == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.hovered))
-            return hover${hoverOpacity != null ? '?.withOpacity($hoverOpacity)' : ''};
-          else if (states.contains(MaterialState.focused))
-            return focus${focusOpacity != null ? '?.withOpacity($focusOpacity)' : ''};
-          else if (states.contains(MaterialState.pressed))
-            return pressed${pressedOpacity != null ? '?.withOpacity($pressedOpacity)' : ''};
-          else
-            return null;
-        });
-  }
-
-  @override
-  MaterialStateProperty<Color?>? get overlayColor {
-    return overlayColorFor($hoverColor, $focusColor, $pressedColor);
-  }''';
-  }
-
-  String get _elevation {
+  String _elevation() {
     if (tokens.containsKey('$tokenGroup.container.elevation')) {
       return '''
-  @override
-  MaterialStateProperty<double>? get elevation {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled))
         return ${elevation("$tokenGroup.disabled.container")};
-      else if (states.contains(MaterialState.hovered))
+      if (states.contains(MaterialState.hovered))
         return ${elevation("$tokenGroup.hover.container")};
-      else if (states.contains(MaterialState.focused))
+      if (states.contains(MaterialState.focused))
         return ${elevation("$tokenGroup.focus.container")};
-      else if (states.contains(MaterialState.pressed))
+      if (states.contains(MaterialState.pressed))
         return ${elevation("$tokenGroup.pressed.container")};
       return ${elevation("$tokenGroup.container")};
-    });
-  }''';
+    })''';
     }
     return '''
-  @override
-  MaterialStateProperty<double>? get elevation =>
-    ButtonStyleButton.allOrNull<double>(0.0);''';
-  }
 
-  String get _side {
-    if (tokens.containsKey('$tokenGroup.outline.color')) {
-      return '''
-  @override
-  MaterialStateProperty<BorderSide>? get side {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
-        return ${border("$tokenGroup.disabled.outline")};
-      }
-      return ${border("$tokenGroup.outline")};
-    });
-  }''';
-    }
-    return '''
-  @override
-  MaterialStateProperty<BorderSide>? get side => null;''';
+    ButtonStyleButton.allOrNull<double>(0.0)''';
   }
 
   @override
   String generate() => '''
 // Generated version ${tokens["version"]}
 class _TokenDefaultsM3 extends ButtonStyle {
-  _TokenDefaultsM3(this.context);
+  _TokenDefaultsM3(this.context)
+   : super(
+       animationDuration: kThemeChangeDuration,
+       enableFeedback: true,
+       alignment: Alignment.center,
+     );
 
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
@@ -146,76 +66,90 @@ class _TokenDefaultsM3 extends ButtonStyle {
   MaterialStateProperty<TextStyle?> get textStyle =>
     MaterialStateProperty.all<TextStyle?>(${textStyle("$tokenGroup.label-text")});
 
-$_backgroundColor
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor =>${_backgroundColor()};
 
-$_foregroundColor
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return ${componentColor('$tokenGroup.disabled.label-text')};
+      return ${componentColor('$tokenGroup.label-text')};
+    });
 
-$_overlayColor
+  @override
+  MaterialStateProperty<Color?>? get overlayColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.hovered))
+        return ${componentColor('$tokenGroup.hover.state-layer')};
+      if (states.contains(MaterialState.focused))
+        return ${componentColor('$tokenGroup.focus.state-layer')};
+      if (states.contains(MaterialState.pressed))
+        return ${componentColor('$tokenGroup.pressed.state-layer')};
+      return null;
+    });
 
+${tokens.containsKey("$tokenGroup.container.shadow-color") ? '''
   @override
   MaterialStateProperty<Color>? get shadowColor =>
-    ButtonStyleButton.allOrNull<Color>(${color("$tokenGroup.container.shadow-color")});
+    ButtonStyleButton.allOrNull<Color>(${color("$tokenGroup.container.shadow-color")});''' : '''
+  // No default shadow color'''}
 
+${tokens.containsKey("$tokenGroup.container.surface-tint-layer.color") ? '''
   @override
   MaterialStateProperty<Color>? get surfaceTintColor =>
-    ButtonStyleButton.allOrNull<Color>(${color("$tokenGroup.container.surface-tint-layer.color")});
-
-$_elevation
+    ButtonStyleButton.allOrNull<Color>(${color("$tokenGroup.container.surface-tint-layer.color")});''' : '''
+  // No default surface tint color'''}
 
   @override
-  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+  MaterialStateProperty<double>? get elevation =>${_elevation()};
+
+  @override
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
       const EdgeInsets.symmetric(horizontal: 16),
       const EdgeInsets.symmetric(horizontal: 8),
       const EdgeInsets.symmetric(horizontal: 4),
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
-    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
-  }
+    ));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>
-    ButtonStyleButton.allOrNull<Size>(const Size(64, ${tokens["$tokenGroup.container.height"]}));
+    ButtonStyleButton.allOrNull<Size>(const Size(64.0, ${tokens["$tokenGroup.container.height"]}));
 
-  @override
-  MaterialStateProperty<Size>? get fixedSize =>
-    ButtonStyleButton.allOrNull<Size>(null);
+  // No default fixedSize
 
   @override
   MaterialStateProperty<Size>? get maximumSize =>
     ButtonStyleButton.allOrNull<Size>(Size.infinite);
 
-$_side
+${tokens.containsKey("$tokenGroup.outline.color") ? '''
+  @override
+  MaterialStateProperty<BorderSide>? get side =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+    if (states.contains(MaterialState.disabled))
+      return ${border("$tokenGroup.disabled.outline")};
+    return ${border("$tokenGroup.outline")};
+  });''' : '''
+  // No default side'''}
 
   @override
   MaterialStateProperty<OutlinedBorder>? get shape =>
     ButtonStyleButton.allOrNull<OutlinedBorder>(${shape("$tokenGroup.container")});
 
   @override
-  MaterialStateProperty<MouseCursor?>? get mouseCursor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+  MaterialStateProperty<MouseCursor?>? get mouseCursor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
         return SystemMouseCursors.basic;
-      }
       return SystemMouseCursors.click;
     });
-  }
 
   @override
   VisualDensity? get visualDensity => Theme.of(context).visualDensity;
 
   @override
   MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
-
-  @override
-  Duration? get animationDuration => kThemeChangeDuration;
-
-  @override
-  bool? get enableFeedback => true;
-
-  @override
-  AlignmentGeometry? get alignment => Alignment.center;
 
   @override
   InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;

--- a/dev/tools/gen_defaults/lib/button_template.dart
+++ b/dev/tools/gen_defaults/lib/button_template.dart
@@ -1,0 +1,204 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'template.dart';
+
+class ButtonTemplate extends TokenTemplate {
+  const ButtonTemplate(this.tokenGroup, String fileName, Map<String, dynamic> tokens)
+    : super(fileName, tokens,
+        colorSchemePrefix: '_colors.',
+      );
+
+  final String tokenGroup;
+
+  String get _backgroundColor {
+    if (tokens.containsKey('$tokenGroup.container.color')) {
+      final String enabledColor = color('$tokenGroup.container.color');
+      final String? enabledOpacity = opacity('$tokenGroup.container.opacity');
+      final String disabledColor = color('$tokenGroup.disabled.container.color');
+      final String? disabledOpacity = opacity('$tokenGroup.disabled.container.opacity');
+      return '''
+  static MaterialStateProperty<Color?>? backgroundColorFor(Color? enabled, Color? disabled) {
+    return (enabled == null && disabled == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.disabled))
+            return disabled${disabledOpacity != null ? '?.withOpacity($disabledOpacity)' : ''};
+          return enabled${enabledOpacity != null ? '?.withOpacity($enabledOpacity)' : ''};
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor {
+    return backgroundColorFor($enabledColor, $disabledColor);
+  }''';
+    } else {
+      return '''
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor {
+    return ButtonStyleButton.allOrNull<Color>(Colors.transparent);
+  }''';
+    }
+  }
+
+  String get _foregroundColor {
+    final String enabledColor = color('$tokenGroup.label-text.color');
+    final String? enabledOpacity = opacity('$tokenGroup.label-text.opacity');
+    final String disabledColor = color('$tokenGroup.disabled.label-text.color');
+    final String? disabledOpacity = opacity('$tokenGroup.disabled.label-text.opacity');
+    return '''
+  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
+    return (enabled == null && disabled == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.disabled))
+            return disabled${disabledOpacity != null ? '?.withOpacity($disabledOpacity)' : ''};
+          return enabled${enabledOpacity != null ? '?.withOpacity($enabledOpacity)' : ''};
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor {
+    return foregroundColorFor($enabledColor, $disabledColor);
+  }''';
+    }
+
+  String get _overlayColor {
+    final String hoverColor = color('$tokenGroup.hover.state-layer.color');
+    final String? hoverOpacity = opacity('$tokenGroup.hover.state-layer.opacity');
+    final String focusColor = color('$tokenGroup.focus.state-layer.color');
+    final String? focusOpacity = opacity('$tokenGroup.focus.state-layer.opacity');
+    return '''
+  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus) {
+    return (hover == null && focus == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.hovered))
+            return hover${hoverOpacity != null ? '?.withOpacity($hoverOpacity)' : ''};
+          else if (states.contains(MaterialState.focused))
+            return focus${focusOpacity != null ? '?.withOpacity($focusOpacity)' : ''};
+          else
+            return null;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get overlayColor {
+    return overlayColorFor($hoverColor, $focusColor);
+  }''';
+  }
+
+  String get _elevation {
+    if (tokens.containsKey('$tokenGroup.container.elevation')) {
+      return '''
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return ${elevation("$tokenGroup.disabled.container")};
+      else if (states.contains(MaterialState.hovered))
+        return ${elevation("$tokenGroup.hover.container")};
+      else if (states.contains(MaterialState.focused))
+        return ${elevation("$tokenGroup.focus.container")};
+      else if (states.contains(MaterialState.pressed))
+        return ${elevation("$tokenGroup.pressed.container")};
+      return ${elevation("$tokenGroup.container")};
+    });''';
+    }
+    return '''
+    return ButtonStyleButton.allOrNull<double>(0.0);''';
+  }
+
+  @override
+  String generate() => '''
+// Generated version ${tokens["version"]}
+class _TokenDefaultsM3 extends ButtonStyle {
+  _TokenDefaultsM3(this.context);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  MaterialStateProperty<TextStyle?> get textStyle =>
+    MaterialStateProperty.all<TextStyle?>(${textStyle("$tokenGroup.label-text")});
+
+$_backgroundColor
+
+$_foregroundColor
+
+$_overlayColor
+
+  @override
+  MaterialStateProperty<Color>? get shadowColor =>
+    ButtonStyleButton.allOrNull<Color>(${color("$tokenGroup.container.shadow-color")});
+
+  @override
+  MaterialStateProperty<Color>? get surfaceTintColor =>
+    ButtonStyleButton.allOrNull<Color>(${color("$tokenGroup.container.surface-tint-layer.color")});
+
+  @override
+  MaterialStateProperty<double>? get elevation {
+$_elevation
+  }
+
+  @override
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
+    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+      const EdgeInsets.symmetric(horizontal: 16),
+      const EdgeInsets.symmetric(horizontal: 8),
+      const EdgeInsets.symmetric(horizontal: 4),
+      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    );
+
+    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
+  }
+
+  @override
+  MaterialStateProperty<Size>? get minimumSize =>
+    ButtonStyleButton.allOrNull<Size>(const Size(64, ${tokens["$tokenGroup.container.height"]}));
+
+  @override
+  MaterialStateProperty<Size>? get fixedSize =>
+    ButtonStyleButton.allOrNull<Size>(null);
+
+  @override
+  MaterialStateProperty<Size>? get maximumSize =>
+    ButtonStyleButton.allOrNull<Size>(Size.infinite);
+
+  @override
+  MaterialStateProperty<BorderSide>? get side =>
+    ButtonStyleButton.allOrNull<BorderSide>(${border("$tokenGroup.outline")});
+
+  @override
+  MaterialStateProperty<OutlinedBorder>? get shape =>
+    ButtonStyleButton.allOrNull<OutlinedBorder>(${shape("$tokenGroup.container")});
+
+  @override
+  MaterialStateProperty<MouseCursor?>? get mouseCursor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return SystemMouseCursors.basic;
+      }
+      return SystemMouseCursors.click;
+    });
+  }
+
+  @override
+  VisualDensity? get visualDensity => Theme.of(context).visualDensity;
+
+  @override
+  MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
+
+  @override
+  Duration? get animationDuration => kThemeChangeDuration;
+
+  @override
+  bool? get enableFeedback => true;
+
+  @override
+  AlignmentGeometry? get alignment => Alignment.center;
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+''';
+}

--- a/dev/tools/gen_defaults/lib/template.dart
+++ b/dev/tools/gen_defaults/lib/template.dart
@@ -70,8 +70,8 @@ abstract class TokenTemplate {
   ///   * [componentColor], that provides support for an optional opacity.
   String color(String colorToken) {
     return tokens.containsKey(colorToken)
-        ? '$colorSchemePrefix${tokens[colorToken]}'
-        : 'null';
+      ? '$colorSchemePrefix${tokens[colorToken]}'
+      : 'null';
   }
 
   /// Generate a [ColorScheme] color name for the given component's color
@@ -91,15 +91,23 @@ abstract class TokenTemplate {
     if (!tokens.containsKey(colorToken))
       return 'null';
     String value = color(colorToken);
-    final String tokenOpacity = '$componentToken.opacity';
-    if (tokens.containsKey(tokenOpacity)) {
-      final dynamic opacityValue = tokens[tokenOpacity];
-      final String opacity = opacityValue is double
-       ? opacityValue.toString()
-       : tokens[tokens[tokenOpacity]!]!.toString();
-      value += '.withOpacity($opacity)';
+    final String opacityToken = '$componentToken.opacity';
+    if (tokens.containsKey(opacityToken)) {
+      value += '.withOpacity(${opacity(opacityToken)})';
     }
     return value;
+  }
+
+  /// Generate the opacity value for the given token.
+  String? opacity(String token) {
+    final dynamic value = tokens[token];
+    if (value == null) {
+      return null;
+    }
+    if (value is double) {
+      return value.toString();
+    }
+    return tokens[value].toString();
   }
 
   /// Generate an elevation value for the given component token.

--- a/dev/tools/gen_defaults/lib/template.dart
+++ b/dev/tools/gen_defaults/lib/template.dart
@@ -143,7 +143,7 @@ abstract class TokenTemplate {
       return 'null';
     }
     final String borderColor = componentColor(componentToken);
-    final double width = tokens['$componentToken.width'] as double;
+    final double width = (tokens['$componentToken.width'] ?? 1.0) as double;
     return 'BorderSide(color: $borderColor${width != 1.0 ? ", width: $width" : ""})';
   }
 

--- a/examples/api/lib/material/button_style/button_style.0.dart
+++ b/examples/api/lib/material/button_style/button_style.0.dart
@@ -11,16 +11,13 @@ void main() => runApp(const ButtonApp());
 class ButtonApp extends StatelessWidget {
   const ButtonApp({Key? key}) : super(key: key);
 
-  static const String _title = 'Button Types';
-
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       theme: ThemeData(colorSchemeSeed: const Color(0xff6750a4), useMaterial3: true),
-      title: _title,
-      home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const ButtonTypesExample(),
+      title: 'Button Types',
+      home: const Scaffold(
+        body: ButtonTypesExample(),
       ),
     );
   }
@@ -31,16 +28,15 @@ class ButtonTypesExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(4.0),
-        child: Column(
-          children: const <Widget>[
-            SizedBox(height: 10),
-            ButtonTypesGroup(enabled: true),
-            ButtonTypesGroup(enabled: false),
-          ],
-        ),
+    return Padding(
+      padding: const EdgeInsets.all(4.0),
+      child: Row(
+        children: const <Widget>[
+          Spacer(),
+          ButtonTypesGroup(enabled: true),
+          ButtonTypesGroup(enabled: false),
+          Spacer(),
+        ],
       ),
     );
   }
@@ -56,11 +52,11 @@ class ButtonTypesGroup extends StatelessWidget {
     final VoidCallback? onPressed = enabled ? () {} : null;
     return Padding(
       padding: const EdgeInsets.all(4.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
-          const SizedBox(width: 10),
           ElevatedButton(onPressed: onPressed, child: const Text('Elevated')),
+
           // Use an ElevatedButton with specific style to implement the
           // 'Filled' type.
           ElevatedButton(
@@ -73,6 +69,7 @@ class ButtonTypesGroup extends StatelessWidget {
             onPressed: onPressed,
             child: const Text('Filled'),
           ),
+
           // Use an ElevatedButton with specific style to implement the
           // 'Filled Tonal' type.
           ElevatedButton(
@@ -85,9 +82,10 @@ class ButtonTypesGroup extends StatelessWidget {
             onPressed: onPressed,
             child: const Text('Filled Tonal'),
           ),
+
           OutlinedButton(onPressed: onPressed, child: const Text('Outlined')),
+
           TextButton(onPressed: onPressed, child: const Text('Text')),
-          const SizedBox(width: 10),
         ],
       ),
     );

--- a/examples/api/lib/material/button_style/button_style.0.dart
+++ b/examples/api/lib/material/button_style/button_style.0.dart
@@ -6,7 +6,9 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const ButtonApp());
+void main() {
+  runApp(const ButtonApp());
+}
 
 class ButtonApp extends StatelessWidget {
   const ButtonApp({Key? key}) : super(key: key);

--- a/examples/api/lib/material/elevated_button/elevated_button.1.dart
+++ b/examples/api/lib/material/elevated_button/elevated_button.1.dart
@@ -65,11 +65,11 @@ class ButtonTypesGroup extends StatelessWidget {
           // 'Filled' type.
           ElevatedButton(
             style: ElevatedButton.styleFrom(
-              useMaterial3: true,
-              elevation: 0,
-              baseForegroundColor: Theme.of(context).colorScheme.onPrimary,
-              baseBackgroundColor: Theme.of(context).colorScheme.primary,
-            ),
+              // Foreground color
+              onPrimary: Theme.of(context).colorScheme.onPrimary,
+              // Background color
+              primary: Theme.of(context).colorScheme.primary,
+            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
             onPressed: onPressed,
             child: const Text('Filled'),
           ),
@@ -77,11 +77,11 @@ class ButtonTypesGroup extends StatelessWidget {
           // 'Filled Tonal' type.
           ElevatedButton(
             style: ElevatedButton.styleFrom(
-              useMaterial3: true,
-              elevation: 0,
-              baseForegroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
-              baseBackgroundColor: Theme.of(context).colorScheme.secondaryContainer,
-            ),
+              // Foreground color
+              onPrimary: Theme.of(context).colorScheme.onSecondaryContainer,
+              // Background color
+              primary: Theme.of(context).colorScheme.secondaryContainer,
+            ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
             onPressed: onPressed,
             child: const Text('Filled Tonal'),
           ),

--- a/examples/api/lib/material/elevated_button/elevated_button.1.dart
+++ b/examples/api/lib/material/elevated_button/elevated_button.1.dart
@@ -6,12 +6,12 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const ButtonApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+class ButtonApp extends StatelessWidget {
+  const ButtonApp({Key? key}) : super(key: key);
 
-  static const String _title = 'Flutter Code Sample';
+  static const String _title = 'Button Types';
 
   @override
   Widget build(BuildContext context) {
@@ -20,62 +20,74 @@ class MyApp extends StatelessWidget {
       title: _title,
       home: Scaffold(
         appBar: AppBar(title: const Text(_title)),
-        body: const MyStatefulWidget(),
+        body: const ButtonTypesExample(),
       ),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({Key? key}) : super(key: key);
+class ButtonTypesExample extends StatelessWidget {
+  const ButtonTypesExample({Key? key}) : super(key: key);
 
-  @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
-}
-
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
   @override
   Widget build(BuildContext context) {
-    final ButtonStyle filledStyle = ElevatedButton.styleFrom(
-      useMaterial3Colors: true,
-      elevation: 0,
-      primary: Theme.of(context).colorScheme.onPrimary,
-      surface: Theme.of(context).colorScheme.primary,
-    );
-    final ButtonStyle filledTonalStyle = ElevatedButton.styleFrom(
-      useMaterial3Colors: true,
-      elevation: 0,
-      primary: Theme.of(context).colorScheme.onSecondaryContainer,
-      surface: Theme.of(context).colorScheme.secondaryContainer,
-    );
-
     return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
+      child: Padding(
+        padding: const EdgeInsets.all(4.0),
+        child: Column(
+          children: const <Widget>[
+            SizedBox(height: 10),
+            ButtonTypesGroup(enabled: true),
+            ButtonTypesGroup(enabled: false),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ButtonTypesGroup extends StatelessWidget {
+  const ButtonTypesGroup({ Key? key, required this.enabled }) : super(key: key);
+
+  final bool enabled;
+
+  @override
+  Widget build(BuildContext context) {
+    final VoidCallback? onPressed = enabled ? () {} : null;
+    return Padding(
+      padding: const EdgeInsets.all(4.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: <Widget>[
+          const SizedBox(width: 10),
+          ElevatedButton(onPressed: onPressed, child: const Text('Elevated')),
+          // Use an ElevatedButton with specific style to implement the
+          // 'Filled' type.
           ElevatedButton(
-            style: filledStyle,
-            onPressed: () {},
-            child: const Text('Filled enabled'),
+            style: ElevatedButton.styleFrom(
+              useMaterial3: true,
+              elevation: 0,
+              baseForegroundColor: Theme.of(context).colorScheme.onPrimary,
+              baseBackgroundColor: Theme.of(context).colorScheme.primary,
+            ),
+            onPressed: onPressed,
+            child: const Text('Filled'),
           ),
-          const SizedBox(height: 30),
+          // Use an ElevatedButton with specific style to implement the
+          // 'Filled Tonal' type.
           ElevatedButton(
-            style: filledStyle,
-            onPressed: null,
-            child: const Text('Filled disabled'),
+            style: ElevatedButton.styleFrom(
+              useMaterial3: true,
+              elevation: 0,
+              baseForegroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
+              baseBackgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+            ),
+            onPressed: onPressed,
+            child: const Text('Filled Tonal'),
           ),
-          const SizedBox(height: 30),
-          ElevatedButton(
-            style: filledTonalStyle,
-            onPressed: () {},
-            child: const Text('Filled Tonal enabled'),
-          ),
-          const SizedBox(height: 30),
-          ElevatedButton(
-            style: filledTonalStyle,
-            onPressed: null,
-            child: const Text('Filled Tonal disabled'),
-          ),
+          OutlinedButton(onPressed: onPressed, child: const Text('Outlined')),
+          TextButton(onPressed: onPressed, child: const Text('Text')),
+          const SizedBox(width: 10),
         ],
       ),
     );

--- a/examples/api/lib/material/elevated_button/elevated_button.1.dart
+++ b/examples/api/lib/material/elevated_button/elevated_button.1.dart
@@ -1,0 +1,83 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for ElevatedButton
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(colorSchemeSeed: const Color(0xff6750a4), useMaterial3: true),
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const MyStatefulWidget(),
+      ),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({Key? key}) : super(key: key);
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final ButtonStyle filledStyle = ElevatedButton.styleFrom(
+      useMaterial3Colors: true,
+      elevation: 0,
+      primary: Theme.of(context).colorScheme.onPrimary,
+      surface: Theme.of(context).colorScheme.primary,
+    );
+    final ButtonStyle filledTonalStyle = ElevatedButton.styleFrom(
+      useMaterial3Colors: true,
+      elevation: 0,
+      primary: Theme.of(context).colorScheme.onSecondaryContainer,
+      surface: Theme.of(context).colorScheme.secondaryContainer,
+    );
+
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          ElevatedButton(
+            style: filledStyle,
+            onPressed: () {},
+            child: const Text('Filled enabled'),
+          ),
+          const SizedBox(height: 30),
+          ElevatedButton(
+            style: filledStyle,
+            onPressed: null,
+            child: const Text('Filled disabled'),
+          ),
+          const SizedBox(height: 30),
+          ElevatedButton(
+            style: filledTonalStyle,
+            onPressed: () {},
+            child: const Text('Filled Tonal enabled'),
+          ),
+          const SizedBox(height: 30),
+          ElevatedButton(
+            style: filledTonalStyle,
+            onPressed: null,
+            child: const Text('Filled Tonal disabled'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -153,7 +153,7 @@ class ButtonStyle with Diagnosticable {
 
   /// The surface tint color of the button's [Material].
   ///
-  /// See [Material.surfaceTint] for more details.
+  /// See [Material.surfaceTintColor] for more details.
   final MaterialStateProperty<Color?>? surfaceTintColor;
 
   /// The elevation of the button's [Material].

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -105,6 +105,7 @@ class ButtonStyle with Diagnosticable {
     this.foregroundColor,
     this.overlayColor,
     this.shadowColor,
+    this.surfaceTintColor,
     this.elevation,
     this.padding,
     this.minimumSize,
@@ -149,6 +150,11 @@ class ButtonStyle with Diagnosticable {
   /// semi-transparent overlay to indicate elevation. See
   /// [ThemeData.applyElevationOverlayColor].
   final MaterialStateProperty<Color?>? shadowColor;
+
+  /// The surface tint color of the button's [Material].
+  ///
+  /// See [Material.surfaceTint] for more details.
+  final MaterialStateProperty<Color?>? surfaceTintColor;
 
   /// The elevation of the button's [Material].
   final MaterialStateProperty<double?>? elevation;
@@ -267,6 +273,7 @@ class ButtonStyle with Diagnosticable {
     MaterialStateProperty<Color?>? foregroundColor,
     MaterialStateProperty<Color?>? overlayColor,
     MaterialStateProperty<Color?>? shadowColor,
+    MaterialStateProperty<Color?>? surfaceTintColor,
     MaterialStateProperty<double?>? elevation,
     MaterialStateProperty<EdgeInsetsGeometry?>? padding,
     MaterialStateProperty<Size?>? minimumSize,
@@ -288,6 +295,7 @@ class ButtonStyle with Diagnosticable {
       foregroundColor: foregroundColor ?? this.foregroundColor,
       overlayColor: overlayColor ?? this.overlayColor,
       shadowColor: shadowColor ?? this.shadowColor,
+      surfaceTintColor: surfaceTintColor ?? this.surfaceTintColor,
       elevation: elevation ?? this.elevation,
       padding: padding ?? this.padding,
       minimumSize: minimumSize ?? this.minimumSize,
@@ -319,6 +327,7 @@ class ButtonStyle with Diagnosticable {
       foregroundColor: foregroundColor ?? style.foregroundColor,
       overlayColor: overlayColor ?? style.overlayColor,
       shadowColor: shadowColor ?? style.shadowColor,
+      surfaceTintColor: surfaceTintColor ?? style.surfaceTintColor,
       elevation: elevation ?? style.elevation,
       padding: padding ?? style.padding,
       minimumSize: minimumSize ?? style.minimumSize,
@@ -343,6 +352,7 @@ class ButtonStyle with Diagnosticable {
     foregroundColor,
     overlayColor,
     shadowColor,
+    surfaceTintColor,
     elevation,
     padding,
     minimumSize,
@@ -371,6 +381,7 @@ class ButtonStyle with Diagnosticable {
         && other.foregroundColor == foregroundColor
         && other.overlayColor == overlayColor
         && other.shadowColor == shadowColor
+        && other.surfaceTintColor == surfaceTintColor
         && other.elevation == elevation
         && other.padding == padding
         && other.minimumSize == minimumSize
@@ -395,6 +406,7 @@ class ButtonStyle with Diagnosticable {
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('foregroundColor', foregroundColor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('overlayColor', overlayColor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('shadowColor', shadowColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('surfaceTintColor', surfaceTintColor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<double?>>('elevation', elevation, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<EdgeInsetsGeometry?>>('padding', padding, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Size?>>('minimumSize', minimumSize, defaultValue: null));
@@ -421,6 +433,7 @@ class ButtonStyle with Diagnosticable {
       foregroundColor:  _lerpProperties<Color?>(a?.foregroundColor, b?.foregroundColor, t, Color.lerp),
       overlayColor: _lerpProperties<Color?>(a?.overlayColor, b?.overlayColor, t, Color.lerp),
       shadowColor: _lerpProperties<Color?>(a?.shadowColor, b?.shadowColor, t, Color.lerp),
+      surfaceTintColor: _lerpProperties<Color?>(a?.surfaceTintColor, b?.surfaceTintColor, t, Color.lerp),
       elevation: _lerpProperties<double?>(a?.elevation, b?.elevation, t, lerpDouble),
       padding:  _lerpProperties<EdgeInsetsGeometry?>(a?.padding, b?.padding, t, EdgeInsetsGeometry.lerp),
       minimumSize: _lerpProperties<Size?>(a?.minimumSize, b?.minimumSize, t, Size.lerp),

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -91,6 +91,27 @@ import 'theme_data.dart';
 ///   home: MyAppHome(),
 /// )
 /// ```
+///
+/// ## Material 3 button types
+///
+/// Material Design 3 specifies five types of common buttons. Flutter provides
+/// support for these using the following button classes:
+/// <style>table,td,th { border-collapse: collapse; padding: 0.45em; } td { border: 1px solid }</style>
+///
+/// | Type         | Flutter implementation  |
+/// | :----------- | :---------------------- |
+/// | Elevated     | [ElevatedButton]        |
+/// | Filled       | Styled [ElevatedButton] |
+/// | Filled Tonal | Styled [ElevatedButton] |
+/// | Outlined     | [OutlinedButton]        |
+/// | Text         | [TextButton]            |
+///
+/// {@tool dartpad}
+/// This sample shows how to create each of the Material 3 button types with Flutter.
+///
+/// ** See code in examples/api/lib/material/button_style/button_style.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [TextButtonTheme], the theme for [TextButton]s.

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -247,6 +247,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with MaterialStateMixin
     Color? resolvedBackgroundColor = resolve<Color?>((ButtonStyle? style) => style?.backgroundColor);
     final Color? resolvedForegroundColor = resolve<Color?>((ButtonStyle? style) => style?.foregroundColor);
     final Color? resolvedShadowColor = resolve<Color?>((ButtonStyle? style) => style?.shadowColor);
+    final Color? resolvedSurfaceTintColor = resolve<Color?>((ButtonStyle? style) => style?.surfaceTintColor);
     final EdgeInsetsGeometry? resolvedPadding = resolve<EdgeInsetsGeometry?>((ButtonStyle? style) => style?.padding);
     final Size? resolvedMinimumSize = resolve<Size?>((ButtonStyle? style) => style?.minimumSize);
     final Size? resolvedFixedSize = resolve<Size?>((ButtonStyle? style) => style?.fixedSize);
@@ -343,6 +344,7 @@ class _ButtonStyleState extends State<ButtonStyleButton> with MaterialStateMixin
         shape: resolvedShape!.copyWith(side: resolvedSide),
         color: resolvedBackgroundColor,
         shadowColor: resolvedShadowColor,
+        surfaceTintColor: resolvedSurfaceTintColor,
         type: resolvedBackgroundColor == null ? MaterialType.transparency : MaterialType.button,
         animationDuration: resolvedAnimationDuration,
         clipBehavior: widget.clipBehavior,

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -470,7 +470,12 @@ class _ElevatedButtonWithIconChild extends StatelessWidget {
 
 // Generated version v0_92
 class _TokenDefaultsM3 extends ButtonStyle {
-  _TokenDefaultsM3(this.context);
+  _TokenDefaultsM3(this.context)
+   : super(
+       animationDuration: kThemeChangeDuration,
+       enableFeedback: true,
+       alignment: Alignment.center,
+     );
 
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
@@ -479,55 +484,33 @@ class _TokenDefaultsM3 extends ButtonStyle {
   MaterialStateProperty<TextStyle?> get textStyle =>
     MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
 
-  static MaterialStateProperty<Color?>? backgroundColorFor(Color? enabled, Color? disabled) {
-    return (enabled == null && disabled == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.disabled))
-            return disabled?.withOpacity(0.12);
-          return enabled;
-        });
-  }
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return _colors.onSurface.withOpacity(0.12);
+      return _colors.surface;
+    });
 
   @override
-  MaterialStateProperty<Color?>? get backgroundColor {
-    return backgroundColorFor(_colors.surface, _colors.onSurface);
-  }
-
-  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
-    return (enabled == null && disabled == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.disabled))
-            return disabled?.withOpacity(0.38);
-          return enabled;
-        });
-  }
+  MaterialStateProperty<Color?>? get foregroundColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return _colors.onSurface.withOpacity(0.38);
+      return _colors.primary;
+    });
 
   @override
-  MaterialStateProperty<Color?>? get foregroundColor {
-    return foregroundColorFor(_colors.primary, _colors.onSurface);
-  }
-
-  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus, Color? pressed) {
-    return (hover == null && focus == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.hovered))
-            return hover?.withOpacity(0.08);
-          else if (states.contains(MaterialState.focused))
-            return focus?.withOpacity(0.12);
-          else if (states.contains(MaterialState.pressed))
-            return pressed?.withOpacity(0.12);
-          else
-            return null;
-        });
-  }
-
-  @override
-  MaterialStateProperty<Color?>? get overlayColor {
-    return overlayColorFor(_colors.primary, _colors.primary, _colors.primary);
-  }
+  MaterialStateProperty<Color?>? get overlayColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.hovered))
+        return _colors.primary.withOpacity(0.08);
+      if (states.contains(MaterialState.focused))
+        return _colors.primary.withOpacity(0.12);
+      if (states.contains(MaterialState.pressed))
+        return _colors.primary.withOpacity(0.12);
+      return null;
+    });
 
   @override
   MaterialStateProperty<Color>? get shadowColor =>
@@ -538,75 +521,57 @@ class _TokenDefaultsM3 extends ButtonStyle {
     ButtonStyleButton.allOrNull<Color>(_colors.surfaceTint);
 
   @override
-  MaterialStateProperty<double>? get elevation {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+  MaterialStateProperty<double>? get elevation =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled))
         return 0.0;
-      else if (states.contains(MaterialState.hovered))
+      if (states.contains(MaterialState.hovered))
         return 3.0;
-      else if (states.contains(MaterialState.focused))
+      if (states.contains(MaterialState.focused))
         return 1.0;
-      else if (states.contains(MaterialState.pressed))
+      if (states.contains(MaterialState.pressed))
         return 1.0;
       return 1.0;
     });
-  }
 
   @override
-  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
       const EdgeInsets.symmetric(horizontal: 16),
       const EdgeInsets.symmetric(horizontal: 8),
       const EdgeInsets.symmetric(horizontal: 4),
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
-    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
-  }
+    ));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>
-    ButtonStyleButton.allOrNull<Size>(const Size(64, 40.0));
+    ButtonStyleButton.allOrNull<Size>(const Size(64.0, 40.0));
 
-  @override
-  MaterialStateProperty<Size>? get fixedSize =>
-    ButtonStyleButton.allOrNull<Size>(null);
+  // No default fixedSize
 
   @override
   MaterialStateProperty<Size>? get maximumSize =>
     ButtonStyleButton.allOrNull<Size>(Size.infinite);
 
-  @override
-  MaterialStateProperty<BorderSide>? get side => null;
+  // No default side
 
   @override
   MaterialStateProperty<OutlinedBorder>? get shape =>
     ButtonStyleButton.allOrNull<OutlinedBorder>(const StadiumBorder());
 
   @override
-  MaterialStateProperty<MouseCursor?>? get mouseCursor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+  MaterialStateProperty<MouseCursor?>? get mouseCursor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
         return SystemMouseCursors.basic;
-      }
       return SystemMouseCursors.click;
     });
-  }
 
   @override
   VisualDensity? get visualDensity => Theme.of(context).visualDensity;
 
   @override
   MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
-
-  @override
-  Duration? get animationDuration => kThemeChangeDuration;
-
-  @override
-  bool? get enableFeedback => true;
-
-  @override
-  AlignmentGeometry? get alignment => Alignment.center;
 
   @override
   InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -163,7 +163,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// This sample will create 'Filled' and 'Filled Tonal' buttons using
   /// [ElevatedButton].
   ///
-  /// ** See code in examples/api/lib/material/elevated_button.1.dart **
+  /// ** See code in examples/api/lib/material/elevated_button/elevated_button.1.dart **
   /// {@end-tool}
   ///
   /// ```

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -230,6 +230,8 @@ class ElevatedButton extends ButtonStyleButton {
   /// The color of the [ButtonStyle.textStyle] is not used, the
   /// [ButtonStyle.foregroundColor] color is used instead.
   ///
+  /// ## Material 2 defaults
+  ///
   /// * `textStyle` - Theme.textTheme.button
   /// * `backgroundColor`
   ///   * disabled - Theme.colorScheme.onSurface(0.12)
@@ -247,7 +249,7 @@ class ElevatedButton extends ButtonStyleButton {
   ///   * hovered or focused - 4
   ///   * pressed - 8
   /// * `padding`
-  ///   * textScaleFactor <= 1 - horizontal(16)
+  ///   * `textScaleFactor <= 1` - horizontal(16)
   ///   * `1 < textScaleFactor <= 2` - lerp(horizontal(16), horizontal(8))
   ///   * `2 < textScaleFactor <= 3` - lerp(horizontal(8), horizontal(4))
   ///   * `3 < textScaleFactor` - horizontal(4)
@@ -278,6 +280,48 @@ class ElevatedButton extends ButtonStyleButton {
   /// outline, is null. That means that the outline is defined by the button
   /// shape's [OutlinedBorder.side]. Typically the default value of an
   /// [OutlinedBorder]'s side is [BorderSide.none], so an outline is not drawn.
+  ///
+  /// ## Material 3 defaults
+  ///
+  /// If [ThemeData.useMaterial3] is set to true the following defaults will
+  /// be used:
+  ///
+  /// * `textStyle` - Theme.textTheme.labelLarge
+  /// * `backgroundColor`
+  ///   * disabled - Theme.colorScheme.onSurface(0.12)
+  ///   * others - Theme.colorScheme.surface
+  /// * `foregroundColor`
+  ///   * disabled - Theme.colorScheme.onSurface(0.38)
+  ///   * others - Theme.colorScheme.primary
+  /// * `overlayColor`
+  ///   * hovered - Theme.colorScheme.primary(0.08)
+  ///   * focused or pressed - Theme.colorScheme.primary(0.12)
+  /// * `shadowColor` - Theme.colorScheme.shadow
+  /// * `surfaceTintColor` - Theme.colorScheme.surfaceTint
+  /// * `elevation`
+  ///   * disabled - 0
+  ///   * default - 1
+  ///   * hovered - 3
+  ///   * focused or pressed - 1
+  /// * `padding`
+  ///   * `textScaleFactor <= 1` - horizontal(16)
+  ///   * `1 < textScaleFactor <= 2` - lerp(horizontal(16), horizontal(8))
+  ///   * `2 < textScaleFactor <= 3` - lerp(horizontal(8), horizontal(4))
+  ///   * `3 < textScaleFactor` - horizontal(4)
+  /// * `minimumSize` - Size(64, 40)
+  /// * `fixedSize` - null
+  /// * `maximumSize` - Size.infinite
+  /// * `side` - null
+  /// * `shape` - StadiumBorder()
+  /// * `mouseCursor`
+  ///   * disabled - SystemMouseCursors.basic
+  ///   * others - SystemMouseCursors.click
+  /// * `visualDensity` - Theme.visualDensity
+  /// * `tapTargetSize` - Theme.materialTapTargetSize
+  /// * `animationDuration` - kThemeChangeDuration
+  /// * `enableFeedback` - true
+  /// * `alignment` - Alignment.center
+  /// * `splashFactory` - Theme.splashFactory
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -118,6 +118,17 @@ class ElevatedButton extends ButtonStyleButton {
   /// fill color and [onSurface] to specify the button's disabled text, icon,
   /// and fill color.
   ///
+  /// With Material 3, the roles for the colors have changed.
+  /// [ButtonStyle.foregroundColor] is now based on [primary] instead of
+  /// [onPrimary] and [ButtonStyle.backgroundColor] is based on [surface]
+  /// instead [primary]. If you are migrating from Material 2, you will
+  /// probably need to change the colors you are using to maintain the colors
+  /// scheme for the button style.
+  ///
+  /// To use these new Material 3 color roles, applications should set
+  /// the [useMaterial3Colors] parameter to true. In addition the app's
+  /// theme should have [ThemeData.useMaterial3] set to true.
+  ///
   /// The button's elevations are defined relative to the [elevation]
   /// parameter. The disabled elevation is the same as the parameter
   /// value, [elevation] + 2 is used when the button is hovered
@@ -146,8 +157,10 @@ class ElevatedButton extends ButtonStyleButton {
   static ButtonStyle styleFrom({
     Color? primary,
     Color? onPrimary,
+    Color? surface,
     Color? onSurface,
     Color? shadowColor,
+    Color? surfaceTintColor,
     double? elevation,
     TextStyle? textStyle,
     EdgeInsetsGeometry? padding,
@@ -164,16 +177,26 @@ class ElevatedButton extends ButtonStyleButton {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
+    bool useMaterial3Colors = false,
   }) {
-    final MaterialStateProperty<Color?>? backgroundColor = (onSurface == null && primary == null)
-      ? null
-      : _ElevatedButtonDefaultBackground(primary, onSurface);
-    final MaterialStateProperty<Color?>? foregroundColor = (onSurface == null && onPrimary == null)
-      ? null
-      : _ElevatedButtonDefaultForeground(onPrimary, onSurface);
-    final MaterialStateProperty<Color?>? overlayColor = (onPrimary == null)
-      ? null
-      : _ElevatedButtonDefaultOverlay(onPrimary);
+    late final MaterialStateProperty<Color?>? backgroundColor;
+    late final MaterialStateProperty<Color?>? foregroundColor;
+    late final MaterialStateProperty<Color?>? overlayColor;
+    if (useMaterial3Colors) {
+      backgroundColor = _TokenDefaultsM3.backgroundColorFor(surface, onSurface);
+      foregroundColor = _TokenDefaultsM3.backgroundColorFor(primary, onSurface);
+      overlayColor = _TokenDefaultsM3.overlayColorFor(primary, primary);
+    } else {
+      backgroundColor = (onSurface == null && primary == null)
+        ? null
+        : _ElevatedButtonDefaultBackground(primary, onSurface);
+      foregroundColor = (onSurface == null && onPrimary == null)
+        ? null
+        : _ElevatedButtonDefaultForeground(onPrimary, onSurface);
+      overlayColor = (onPrimary == null)
+        ? null
+        : _ElevatedButtonDefaultOverlay(onPrimary);
+    }
     final MaterialStateProperty<double>? elevationValue = (elevation == null)
       ? null
       : _ElevatedButtonDefaultElevation(elevation);
@@ -187,6 +210,7 @@ class ElevatedButton extends ButtonStyleButton {
       foregroundColor: foregroundColor,
       overlayColor: overlayColor,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
+      surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
       elevation: elevationValue,
       padding: ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(padding),
       minimumSize: ButtonStyleButton.allOrNull<Size>(minimumSize),
@@ -288,26 +312,28 @@ class ElevatedButton extends ButtonStyleButton {
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
     );
 
-    return styleFrom(
-      primary: colorScheme.primary,
-      onPrimary: colorScheme.onPrimary,
-      onSurface: colorScheme.onSurface,
-      shadowColor: theme.shadowColor,
-      elevation: 2,
-      textStyle: theme.textTheme.button,
-      padding: scaledPadding,
-      minimumSize: const Size(64, 36),
-      maximumSize: Size.infinite,
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
-      enabledMouseCursor: SystemMouseCursors.click,
-      disabledMouseCursor: SystemMouseCursors.basic,
-      visualDensity: theme.visualDensity,
-      tapTargetSize: theme.materialTapTargetSize,
-      animationDuration: kThemeChangeDuration,
-      enableFeedback: true,
-      alignment: Alignment.center,
-      splashFactory: theme.useMaterial3 ? theme.splashFactory : InkRipple.splashFactory,
-    );
+    return Theme.of(context).useMaterial3
+      ? _TokenDefaultsM3(context)
+      : styleFrom(
+          primary: colorScheme.primary,
+          onPrimary: colorScheme.onPrimary,
+          onSurface: colorScheme.onSurface,
+          shadowColor: theme.shadowColor,
+          elevation: 2,
+          textStyle: theme.textTheme.button,
+          padding: scaledPadding,
+          minimumSize: const Size(64, 36),
+          maximumSize: Size.infinite,
+          shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
+          enabledMouseCursor: SystemMouseCursors.click,
+          disabledMouseCursor: SystemMouseCursors.basic,
+          visualDensity: theme.visualDensity,
+          tapTargetSize: theme.materialTapTargetSize,
+          animationDuration: kThemeChangeDuration,
+          enableFeedback: true,
+          alignment: Alignment.center,
+          splashFactory: InkRipple.splashFactory,
+        );
   }
 
   /// Returns the [ElevatedButtonThemeData.style] of the closest
@@ -457,3 +483,154 @@ class _ElevatedButtonWithIconChild extends StatelessWidget {
     );
   }
 }
+
+// BEGIN GENERATED TOKEN PROPERTIES
+
+// Generated code to the end of this file. Do not edit by hand.
+// These defaults are generated from the Material Design Token
+// database by the script dev/tools/gen_defaults/bin/gen_defaults.dart.
+
+// Generated version v0_92
+class _TokenDefaultsM3 extends ButtonStyle {
+  _TokenDefaultsM3(this.context);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  MaterialStateProperty<TextStyle?> get textStyle =>
+    MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+
+  static MaterialStateProperty<Color?>? backgroundColorFor(Color? enabled, Color? disabled) {
+    return (enabled == null && disabled == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.disabled))
+            return disabled?.withOpacity(0.12);
+          return enabled;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor {
+    return backgroundColorFor(_colors.surface, _colors.onSurface);
+  }
+
+  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
+    return (enabled == null && disabled == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.disabled))
+            return disabled?.withOpacity(0.38);
+          return enabled;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor {
+    return foregroundColorFor(_colors.primary, _colors.onSurface);
+  }
+
+  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus) {
+    return (hover == null && focus == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.hovered))
+            return hover?.withOpacity(0.08);
+          else if (states.contains(MaterialState.focused))
+            return focus?.withOpacity(0.12);
+          else
+            return null;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get overlayColor {
+    return overlayColorFor(_colors.primary, _colors.primary);
+  }
+
+  @override
+  MaterialStateProperty<Color>? get shadowColor =>
+    ButtonStyleButton.allOrNull<Color>(_colors.shadow);
+
+  @override
+  MaterialStateProperty<Color>? get surfaceTintColor =>
+    ButtonStyleButton.allOrNull<Color>(_colors.surfaceTint);
+
+  @override
+  MaterialStateProperty<double>? get elevation {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return 0.0;
+      else if (states.contains(MaterialState.hovered))
+        return 3.0;
+      else if (states.contains(MaterialState.focused))
+        return 1.0;
+      else if (states.contains(MaterialState.pressed))
+        return 1.0;
+      return 1.0;
+    });
+  }
+
+  @override
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
+    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+      const EdgeInsets.symmetric(horizontal: 16),
+      const EdgeInsets.symmetric(horizontal: 8),
+      const EdgeInsets.symmetric(horizontal: 4),
+      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    );
+
+    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
+  }
+
+  @override
+  MaterialStateProperty<Size>? get minimumSize =>
+    ButtonStyleButton.allOrNull<Size>(const Size(64, 40.0));
+
+  @override
+  MaterialStateProperty<Size>? get fixedSize =>
+    ButtonStyleButton.allOrNull<Size>(null);
+
+  @override
+  MaterialStateProperty<Size>? get maximumSize =>
+    ButtonStyleButton.allOrNull<Size>(Size.infinite);
+
+  @override
+  MaterialStateProperty<BorderSide>? get side =>
+    ButtonStyleButton.allOrNull<BorderSide>(null);
+
+  @override
+  MaterialStateProperty<OutlinedBorder>? get shape =>
+    ButtonStyleButton.allOrNull<OutlinedBorder>(const StadiumBorder());
+
+  @override
+  MaterialStateProperty<MouseCursor?>? get mouseCursor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return SystemMouseCursors.basic;
+      }
+      return SystemMouseCursors.click;
+    });
+  }
+
+  @override
+  VisualDensity? get visualDensity => Theme.of(context).visualDensity;
+
+  @override
+  MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
+
+  @override
+  Duration? get animationDuration => kThemeChangeDuration;
+
+  @override
+  bool? get enableFeedback => true;
+
+  @override
+  AlignmentGeometry? get alignment => Alignment.center;
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+
+// END GENERATED TOKEN PROPERTIES

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -122,7 +122,7 @@ class ElevatedButton extends ButtonStyleButton {
   /// [ButtonStyle.foregroundColor] is now based on [primary] instead of
   /// [onPrimary] and [ButtonStyle.backgroundColor] is based on [surface]
   /// instead [primary]. If you are migrating from Material 2, you will
-  /// probably need to change the colors you are using to maintain the colors
+  /// probably need to change the colors you are using to maintain your color
   /// scheme for the button style.
   ///
   /// To use these new Material 3 color roles, applications should set
@@ -153,6 +153,19 @@ class ElevatedButton extends ButtonStyleButton {
   /// ElevatedButton(
   ///   style: ElevatedButton.styleFrom(primary: Colors.green),
   /// )
+  ///
+  /// ## Filled and Filled Tonal styles
+  ///
+  /// Material 3 introduced two new styles that can be achieved with
+  /// [ElevatedButton].
+  ///
+  /// {@tool dartpad}
+  /// This sample will create 'Filled' and 'Filled Tonal' buttons using
+  /// [ElevatedButton].
+  ///
+  /// ** See code in examples/api/lib/material/elevated_button.1.dart **
+  /// {@end-tool}
+  ///
   /// ```
   static ButtonStyle styleFrom({
     Color? primary,
@@ -184,7 +197,7 @@ class ElevatedButton extends ButtonStyleButton {
     late final MaterialStateProperty<Color?>? overlayColor;
     if (useMaterial3Colors) {
       backgroundColor = _TokenDefaultsM3.backgroundColorFor(surface, onSurface);
-      foregroundColor = _TokenDefaultsM3.backgroundColorFor(primary, onSurface);
+      foregroundColor = _TokenDefaultsM3.foregroundColorFor(primary, onSurface);
       overlayColor = _TokenDefaultsM3.overlayColorFor(primary, primary);
     } else {
       backgroundColor = (onSurface == null && primary == null)

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -283,13 +283,6 @@ class ElevatedButton extends ButtonStyleButton {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
 
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
-      const EdgeInsets.symmetric(horizontal: 16),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
     return Theme.of(context).useMaterial3
       ? _TokenDefaultsM3(context)
       : styleFrom(
@@ -299,7 +292,7 @@ class ElevatedButton extends ButtonStyleButton {
           shadowColor: theme.shadowColor,
           elevation: 2,
           textStyle: theme.textTheme.button,
-          padding: scaledPadding,
+          padding: _scaledPadding(context),
           minimumSize: const Size(64, 36),
           maximumSize: Size.infinite,
           shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
@@ -320,6 +313,15 @@ class ElevatedButton extends ButtonStyleButton {
   ButtonStyle? themeStyleOf(BuildContext context) {
     return ElevatedButtonTheme.of(context).style;
   }
+}
+
+EdgeInsetsGeometry _scaledPadding(BuildContext context) {
+  return ButtonStyleButton.scaledPadding(
+    const EdgeInsets.symmetric(horizontal: 16),
+    const EdgeInsets.symmetric(horizontal: 8),
+    const EdgeInsets.symmetric(horizontal: 4),
+    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+  );
 }
 
 @immutable
@@ -536,12 +538,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
-    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
-      const EdgeInsets.symmetric(horizontal: 16),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    ));
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(_scaledPadding(context));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -221,6 +221,8 @@ class OutlinedButton extends ButtonStyleButton {
   /// The color of the [ButtonStyle.textStyle] is not used, the
   /// [ButtonStyle.foregroundColor] is used instead.
   ///
+  /// ## Material 2 defaults
+  ///
   /// * `textStyle` - Theme.textTheme.button
   /// * `backgroundColor` - transparent
   /// * `foregroundColor`
@@ -250,6 +252,45 @@ class OutlinedButton extends ButtonStyleButton {
   /// * `enableFeedback` - true
   /// * `alignment` - Alignment.center
   /// * `splashFactory` - InkRipple.splashFactory
+  ///
+  /// ## Material 3 defaults
+  ///
+  /// If [ThemeData.useMaterial3] is set to true the following defaults will
+  /// be used:
+  ///
+  /// * `textStyle` - Theme.textTheme.labelLarge
+  /// * `backgroundColor` - transparent
+  /// * `foregroundColor`
+  ///   * disabled - Theme.colorScheme.onSurface(0.38)
+  ///   * others - Theme.colorScheme.primary
+  /// * `overlayColor`
+  ///   * hovered - Theme.colorScheme.primary(0.08)
+  ///   * focused or pressed - Theme.colorScheme.primary(0.12)
+  ///   * others - null
+  /// * `shadowColor` - null
+  /// * `surfaceTintColor` - null
+  /// * `elevation` - 0
+  /// * `padding`
+  ///   * `textScaleFactor <= 1` - horizontal(16)
+  ///   * `1 < textScaleFactor <= 2` - lerp(horizontal(16), horizontal(8))
+  ///   * `2 < textScaleFactor <= 3` - lerp(horizontal(8), horizontal(4))
+  ///   * `3 < textScaleFactor` - horizontal(4)
+  /// * `minimumSize` - Size(64, 40)
+  /// * `fixedSize` - null
+  /// * `maximumSize` - Size.infinite
+  /// * `side`
+  ///   * disabled - BorderSide(color: Theme.colorScheme.onSurface(0.12))
+  ///   * others - BorderSide(color: Theme.colorScheme.outline)
+  /// * `shape` - StadiumBorder()
+  /// * `mouseCursor`
+  ///   * disabled - SystemMouseCursors.basic
+  ///   * others - SystemMouseCursors.click
+  /// * `visualDensity` - theme.visualDensity
+  /// * `tapTargetSize` - theme.materialTapTargetSize
+  /// * `animationDuration` - kThemeChangeDuration
+  /// * `enableFeedback` - true
+  /// * `alignment` - Alignment.center
+  /// * `splashFactory` - Theme.splashFactory
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -146,6 +146,7 @@ class OutlinedButton extends ButtonStyleButton {
     Color? onSurface,
     Color? backgroundColor,
     Color? shadowColor,
+    Color? surfaceTintColor,
     double? elevation,
     TextStyle? textStyle,
     EdgeInsetsGeometry? padding,
@@ -179,6 +180,7 @@ class OutlinedButton extends ButtonStyleButton {
       backgroundColor: ButtonStyleButton.allOrNull<Color>(backgroundColor),
       overlayColor: overlayColor,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
+      surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
       elevation: ButtonStyleButton.allOrNull<double>(elevation),
       padding: ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(padding),
       minimumSize: ButtonStyleButton.allOrNull<Size>(minimumSize),
@@ -260,29 +262,31 @@ class OutlinedButton extends ButtonStyleButton {
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
     );
 
-    return styleFrom(
-      primary: colorScheme.primary,
-      onSurface: colorScheme.onSurface,
-      backgroundColor: Colors.transparent,
-      shadowColor: theme.shadowColor,
-      elevation: 0,
-      textStyle: theme.textTheme.button,
-      padding: scaledPadding,
-      minimumSize: const Size(64, 36),
-      maximumSize: Size.infinite,
-      side: BorderSide(
-        color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
-      ),
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
-      enabledMouseCursor: SystemMouseCursors.click,
-      disabledMouseCursor: SystemMouseCursors.basic,
-      visualDensity: theme.visualDensity,
-      tapTargetSize: theme.materialTapTargetSize,
-      animationDuration: kThemeChangeDuration,
-      enableFeedback: true,
-      alignment: Alignment.center,
-      splashFactory: theme.useMaterial3 ? theme.splashFactory : InkRipple.splashFactory,
-    );
+    return Theme.of(context).useMaterial3
+      ? _TokenDefaultsM3(context)
+      : styleFrom(
+          primary: colorScheme.primary,
+          onSurface: colorScheme.onSurface,
+          backgroundColor: Colors.transparent,
+          shadowColor: theme.shadowColor,
+          elevation: 0,
+          textStyle: theme.textTheme.button,
+          padding: scaledPadding,
+          minimumSize: const Size(64, 36),
+          maximumSize: Size.infinite,
+          side: BorderSide(
+            color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
+          ),
+          shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
+          enabledMouseCursor: SystemMouseCursors.click,
+          disabledMouseCursor: SystemMouseCursors.basic,
+          visualDensity: theme.visualDensity,
+          tapTargetSize: theme.materialTapTargetSize,
+          animationDuration: kThemeChangeDuration,
+          enableFeedback: true,
+          alignment: Alignment.center,
+          splashFactory: InkRipple.splashFactory,
+        );
   }
 
   @override
@@ -382,3 +386,134 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
     );
   }
 }
+
+// BEGIN GENERATED TOKEN PROPERTIES
+
+// Generated code to the end of this file. Do not edit by hand.
+// These defaults are generated from the Material Design Token
+// database by the script dev/tools/gen_defaults/bin/gen_defaults.dart.
+
+// Generated version v0_92
+class _TokenDefaultsM3 extends ButtonStyle {
+  _TokenDefaultsM3(this.context);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  MaterialStateProperty<TextStyle?> get textStyle =>
+    MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor {
+    return ButtonStyleButton.allOrNull<Color>(Colors.transparent);
+  }
+
+  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
+    return (enabled == null && disabled == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.disabled))
+            return disabled?.withOpacity(0.38);
+          return enabled;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor {
+    return foregroundColorFor(_colors.primary, _colors.onSurface);
+  }
+
+  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus) {
+    return (hover == null && focus == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.hovered))
+            return hover?.withOpacity(0.08);
+          else if (states.contains(MaterialState.focused))
+            return focus?.withOpacity(0.12);
+          else
+            return null;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get overlayColor {
+    return overlayColorFor(_colors.primary, _colors.primary);
+  }
+
+  @override
+  MaterialStateProperty<Color>? get shadowColor =>
+    ButtonStyleButton.allOrNull<Color>(null);
+
+  @override
+  MaterialStateProperty<Color>? get surfaceTintColor =>
+    ButtonStyleButton.allOrNull<Color>(null);
+
+  @override
+  MaterialStateProperty<double>? get elevation {
+    return ButtonStyleButton.allOrNull<double>(0.0);
+  }
+
+  @override
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
+    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+      const EdgeInsets.symmetric(horizontal: 16),
+      const EdgeInsets.symmetric(horizontal: 8),
+      const EdgeInsets.symmetric(horizontal: 4),
+      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    );
+
+    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
+  }
+
+  @override
+  MaterialStateProperty<Size>? get minimumSize =>
+    ButtonStyleButton.allOrNull<Size>(const Size(64, 40.0));
+
+  @override
+  MaterialStateProperty<Size>? get fixedSize =>
+    ButtonStyleButton.allOrNull<Size>(null);
+
+  @override
+  MaterialStateProperty<Size>? get maximumSize =>
+    ButtonStyleButton.allOrNull<Size>(Size.infinite);
+
+  @override
+  MaterialStateProperty<BorderSide>? get side =>
+    ButtonStyleButton.allOrNull<BorderSide>(BorderSide(color: _colors.outline));
+
+  @override
+  MaterialStateProperty<OutlinedBorder>? get shape =>
+    ButtonStyleButton.allOrNull<OutlinedBorder>(const StadiumBorder());
+
+  @override
+  MaterialStateProperty<MouseCursor?>? get mouseCursor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return SystemMouseCursors.basic;
+      }
+      return SystemMouseCursors.click;
+    });
+  }
+
+  @override
+  VisualDensity? get visualDensity => Theme.of(context).visualDensity;
+
+  @override
+  MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
+
+  @override
+  Duration? get animationDuration => kThemeChangeDuration;
+
+  @override
+  bool? get enableFeedback => true;
+
+  @override
+  AlignmentGeometry? get alignment => Alignment.center;
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+
+// END GENERATED TOKEN PROPERTIES

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -405,9 +405,8 @@ class _TokenDefaultsM3 extends ButtonStyle {
     MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
 
   @override
-  MaterialStateProperty<Color?>? get backgroundColor {
-    return ButtonStyleButton.allOrNull<Color>(Colors.transparent);
-  }
+  MaterialStateProperty<Color?>? get backgroundColor =>
+    ButtonStyleButton.allOrNull<Color>(Colors.transparent);
 
   static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
     return (enabled == null && disabled == null)
@@ -424,7 +423,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
     return foregroundColorFor(_colors.primary, _colors.onSurface);
   }
 
-  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus) {
+  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus, Color? pressed) {
     return (hover == null && focus == null)
       ? null
       : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
@@ -432,6 +431,8 @@ class _TokenDefaultsM3 extends ButtonStyle {
             return hover?.withOpacity(0.08);
           else if (states.contains(MaterialState.focused))
             return focus?.withOpacity(0.12);
+          else if (states.contains(MaterialState.pressed))
+            return pressed?.withOpacity(0.12);
           else
             return null;
         });
@@ -439,7 +440,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<Color?>? get overlayColor {
-    return overlayColorFor(_colors.primary, _colors.primary);
+    return overlayColorFor(_colors.primary, _colors.primary, _colors.primary);
   }
 
   @override
@@ -451,9 +452,8 @@ class _TokenDefaultsM3 extends ButtonStyle {
     ButtonStyleButton.allOrNull<Color>(null);
 
   @override
-  MaterialStateProperty<double>? get elevation {
-    return ButtonStyleButton.allOrNull<double>(0.0);
-  }
+  MaterialStateProperty<double>? get elevation =>
+    ButtonStyleButton.allOrNull<double>(0.0);
 
   @override
   MaterialStateProperty<EdgeInsetsGeometry>? get padding {
@@ -480,8 +480,14 @@ class _TokenDefaultsM3 extends ButtonStyle {
     ButtonStyleButton.allOrNull<Size>(Size.infinite);
 
   @override
-  MaterialStateProperty<BorderSide>? get side =>
-    ButtonStyleButton.allOrNull<BorderSide>(BorderSide(color: _colors.outline));
+  MaterialStateProperty<BorderSide>? get side {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return BorderSide(color: _colors.onSurface.withOpacity(0.12));
+      }
+      return BorderSide(color: _colors.outline);
+    });
+  }
 
   @override
   MaterialStateProperty<OutlinedBorder>? get shape =>

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -255,13 +255,6 @@ class OutlinedButton extends ButtonStyleButton {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
 
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
-      const EdgeInsets.symmetric(horizontal: 16),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
     return Theme.of(context).useMaterial3
       ? _TokenDefaultsM3(context)
       : styleFrom(
@@ -271,7 +264,7 @@ class OutlinedButton extends ButtonStyleButton {
           shadowColor: theme.shadowColor,
           elevation: 0,
           textStyle: theme.textTheme.button,
-          padding: scaledPadding,
+          padding: _scaledPadding(context),
           minimumSize: const Size(64, 36),
           maximumSize: Size.infinite,
           side: BorderSide(
@@ -293,6 +286,15 @@ class OutlinedButton extends ButtonStyleButton {
   ButtonStyle? themeStyleOf(BuildContext context) {
     return OutlinedButtonTheme.of(context).style;
   }
+}
+
+EdgeInsetsGeometry _scaledPadding(BuildContext context) {
+  return ButtonStyleButton.scaledPadding(
+    const EdgeInsets.symmetric(horizontal: 16),
+    const EdgeInsets.symmetric(horizontal: 8),
+    const EdgeInsets.symmetric(horizontal: 4),
+    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+  );
 }
 
 @immutable
@@ -443,12 +445,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
-    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
-      const EdgeInsets.symmetric(horizontal: 16),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    ));
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(_scaledPadding(context));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -395,7 +395,12 @@ class _OutlinedButtonWithIconChild extends StatelessWidget {
 
 // Generated version v0_92
 class _TokenDefaultsM3 extends ButtonStyle {
-  _TokenDefaultsM3(this.context);
+  _TokenDefaultsM3(this.context)
+   : super(
+       animationDuration: kThemeChangeDuration,
+       enableFeedback: true,
+       alignment: Alignment.center,
+     );
 
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
@@ -408,115 +413,78 @@ class _TokenDefaultsM3 extends ButtonStyle {
   MaterialStateProperty<Color?>? get backgroundColor =>
     ButtonStyleButton.allOrNull<Color>(Colors.transparent);
 
-  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
-    return (enabled == null && disabled == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.disabled))
-            return disabled?.withOpacity(0.38);
-          return enabled;
-        });
-  }
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return _colors.onSurface.withOpacity(0.38);
+      return _colors.primary;
+    });
 
   @override
-  MaterialStateProperty<Color?>? get foregroundColor {
-    return foregroundColorFor(_colors.primary, _colors.onSurface);
-  }
+  MaterialStateProperty<Color?>? get overlayColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.hovered))
+        return _colors.primary.withOpacity(0.08);
+      if (states.contains(MaterialState.focused))
+        return _colors.primary.withOpacity(0.12);
+      if (states.contains(MaterialState.pressed))
+        return _colors.primary.withOpacity(0.12);
+      return null;
+    });
 
-  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus, Color? pressed) {
-    return (hover == null && focus == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.hovered))
-            return hover?.withOpacity(0.08);
-          else if (states.contains(MaterialState.focused))
-            return focus?.withOpacity(0.12);
-          else if (states.contains(MaterialState.pressed))
-            return pressed?.withOpacity(0.12);
-          else
-            return null;
-        });
-  }
+  // No default shadow color
 
-  @override
-  MaterialStateProperty<Color?>? get overlayColor {
-    return overlayColorFor(_colors.primary, _colors.primary, _colors.primary);
-  }
-
-  @override
-  MaterialStateProperty<Color>? get shadowColor =>
-    ButtonStyleButton.allOrNull<Color>(null);
-
-  @override
-  MaterialStateProperty<Color>? get surfaceTintColor =>
-    ButtonStyleButton.allOrNull<Color>(null);
+  // No default surface tint color
 
   @override
   MaterialStateProperty<double>? get elevation =>
     ButtonStyleButton.allOrNull<double>(0.0);
 
   @override
-  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
       const EdgeInsets.symmetric(horizontal: 16),
       const EdgeInsets.symmetric(horizontal: 8),
       const EdgeInsets.symmetric(horizontal: 4),
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
-    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
-  }
+    ));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>
-    ButtonStyleButton.allOrNull<Size>(const Size(64, 40.0));
+    ButtonStyleButton.allOrNull<Size>(const Size(64.0, 40.0));
 
-  @override
-  MaterialStateProperty<Size>? get fixedSize =>
-    ButtonStyleButton.allOrNull<Size>(null);
+  // No default fixedSize
 
   @override
   MaterialStateProperty<Size>? get maximumSize =>
     ButtonStyleButton.allOrNull<Size>(Size.infinite);
 
   @override
-  MaterialStateProperty<BorderSide>? get side {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
-        return BorderSide(color: _colors.onSurface.withOpacity(0.12));
-      }
-      return BorderSide(color: _colors.outline);
-    });
-  }
+  MaterialStateProperty<BorderSide>? get side =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+    if (states.contains(MaterialState.disabled))
+      return BorderSide(color: _colors.onSurface.withOpacity(0.12));
+    return BorderSide(color: _colors.outline);
+  });
 
   @override
   MaterialStateProperty<OutlinedBorder>? get shape =>
     ButtonStyleButton.allOrNull<OutlinedBorder>(const StadiumBorder());
 
   @override
-  MaterialStateProperty<MouseCursor?>? get mouseCursor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+  MaterialStateProperty<MouseCursor?>? get mouseCursor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
         return SystemMouseCursors.basic;
-      }
       return SystemMouseCursors.click;
     });
-  }
 
   @override
   VisualDensity? get visualDensity => Theme.of(context).visualDensity;
 
   @override
   MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
-
-  @override
-  Duration? get animationDuration => kThemeChangeDuration;
-
-  @override
-  bool? get enableFeedback => true;
-
-  @override
-  AlignmentGeometry? get alignment => Alignment.center;
 
   @override
   InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -225,6 +225,8 @@ class TextButton extends ButtonStyleButton {
   /// The color of the [ButtonStyle.textStyle] is not used, the
   /// [ButtonStyle.foregroundColor] color is used instead.
   ///
+  /// ## Material 2 defaults
+  ///
   /// * `textStyle` - Theme.textTheme.button
   /// * `backgroundColor` - transparent
   /// * `foregroundColor`
@@ -266,6 +268,43 @@ class TextButton extends ButtonStyleButton {
   /// outline, is null. That means that the outline is defined by the button
   /// shape's [OutlinedBorder.side]. Typically the default value of an
   /// [OutlinedBorder]'s side is [BorderSide.none], so an outline is not drawn.
+  ///
+  /// ## Material 3 defaults
+  ///
+  /// If [ThemeData.useMaterial3] is set to true the following defaults will
+  /// be used:
+  ///
+  /// * `textStyle` - Theme.textTheme.labelLarge
+  /// * `backgroundColor` - transparent
+  /// * `foregroundColor`
+  ///   * disabled - Theme.colorScheme.onSurface(0.38)
+  ///   * others - Theme.colorScheme.primary
+  /// * `overlayColor`
+  ///   * hovered - Theme.colorScheme.primary(0.08)
+  ///   * focused or pressed - Theme.colorScheme.primary(0.12)
+  ///   * others - null
+  /// * `shadowColor` - null
+  /// * `surfaceTintColor` - null
+  /// * `elevation` - 0
+  /// * `padding`
+  ///   * `textScaleFactor <= 1` - all(8)
+  ///   * `1 < textScaleFactor <= 2` - lerp(all(8), horizontal(8))
+  ///   * `2 < textScaleFactor <= 3` - lerp(horizontal(8), horizontal(4))
+  ///   * `3 < textScaleFactor` - horizontal(4)
+  /// * `minimumSize` - Size(64, 40)
+  /// * `fixedSize` - null
+  /// * `maximumSize` - Size.infinite
+  /// * `side` - null
+  /// * `shape` - StadiumBorder()
+  /// * `mouseCursor`
+  ///   * disabled - SystemMouseCursors.basic
+  ///   * others - SystemMouseCursors.click
+  /// * `visualDensity` - theme.visualDensity
+  /// * `tapTargetSize` - theme.materialTapTargetSize
+  /// * `animationDuration` - kThemeChangeDuration
+  /// * `enableFeedback` - true
+  /// * `alignment` - Alignment.center
+  /// * `splashFactory` - Theme.splashFactory
   @override
   ButtonStyle defaultStyleOf(BuildContext context) {
     final ThemeData theme = Theme.of(context);

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -147,6 +147,7 @@ class TextButton extends ButtonStyleButton {
     Color? onSurface,
     Color? backgroundColor,
     Color? shadowColor,
+    Color? surfaceTintColor,
     double? elevation,
     TextStyle? textStyle,
     EdgeInsetsGeometry? padding,
@@ -180,6 +181,7 @@ class TextButton extends ButtonStyleButton {
       foregroundColor: foregroundColor,
       overlayColor: overlayColor,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
+      surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
       elevation: ButtonStyleButton.allOrNull<double>(elevation),
       padding: ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(padding),
       minimumSize: ButtonStyleButton.allOrNull<Size>(minimumSize),
@@ -276,26 +278,28 @@ class TextButton extends ButtonStyleButton {
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
     );
 
-    return styleFrom(
-      primary: colorScheme.primary,
-      onSurface: colorScheme.onSurface,
-      backgroundColor: Colors.transparent,
-      shadowColor: theme.shadowColor,
-      elevation: 0,
-      textStyle: theme.textTheme.button,
-      padding: scaledPadding,
-      minimumSize: const Size(64, 36),
-      maximumSize: Size.infinite,
-      shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
-      enabledMouseCursor: SystemMouseCursors.click,
-      disabledMouseCursor: SystemMouseCursors.basic,
-      visualDensity: theme.visualDensity,
-      tapTargetSize: theme.materialTapTargetSize,
-      animationDuration: kThemeChangeDuration,
-      enableFeedback: true,
-      alignment: Alignment.center,
-      splashFactory: theme.useMaterial3 ? theme.splashFactory : InkRipple.splashFactory,
-    );
+    return Theme.of(context).useMaterial3
+      ? _TokenDefaultsM3(context)
+      : styleFrom(
+          primary: colorScheme.primary,
+          onSurface: colorScheme.onSurface,
+          backgroundColor: Colors.transparent,
+          shadowColor: theme.shadowColor,
+          elevation: 0,
+          textStyle: theme.textTheme.button,
+          padding: scaledPadding,
+          minimumSize: const Size(64, 36),
+          maximumSize: Size.infinite,
+          shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
+          enabledMouseCursor: SystemMouseCursors.click,
+          disabledMouseCursor: SystemMouseCursors.basic,
+          visualDensity: theme.visualDensity,
+          tapTargetSize: theme.materialTapTargetSize,
+          animationDuration: kThemeChangeDuration,
+          enableFeedback: true,
+          alignment: Alignment.center,
+          splashFactory: InkRipple.splashFactory,
+        );
   }
 
   /// Returns the [TextButtonThemeData.style] of the closest
@@ -424,3 +428,134 @@ class _TextButtonWithIconChild extends StatelessWidget {
     );
   }
 }
+
+// BEGIN GENERATED TOKEN PROPERTIES
+
+// Generated code to the end of this file. Do not edit by hand.
+// These defaults are generated from the Material Design Token
+// database by the script dev/tools/gen_defaults/bin/gen_defaults.dart.
+
+// Generated version v0_92
+class _TokenDefaultsM3 extends ButtonStyle {
+  _TokenDefaultsM3(this.context);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+
+  @override
+  MaterialStateProperty<TextStyle?> get textStyle =>
+    MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+
+  @override
+  MaterialStateProperty<Color?>? get backgroundColor {
+    return ButtonStyleButton.allOrNull<Color>(Colors.transparent);
+  }
+
+  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
+    return (enabled == null && disabled == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.disabled))
+            return disabled?.withOpacity(0.38);
+          return enabled;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor {
+    return foregroundColorFor(_colors.primary, _colors.onSurface);
+  }
+
+  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus) {
+    return (hover == null && focus == null)
+      ? null
+      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.hovered))
+            return hover?.withOpacity(0.08);
+          else if (states.contains(MaterialState.focused))
+            return focus?.withOpacity(0.12);
+          else
+            return null;
+        });
+  }
+
+  @override
+  MaterialStateProperty<Color?>? get overlayColor {
+    return overlayColorFor(_colors.primary, _colors.primary);
+  }
+
+  @override
+  MaterialStateProperty<Color>? get shadowColor =>
+    ButtonStyleButton.allOrNull<Color>(null);
+
+  @override
+  MaterialStateProperty<Color>? get surfaceTintColor =>
+    ButtonStyleButton.allOrNull<Color>(null);
+
+  @override
+  MaterialStateProperty<double>? get elevation {
+    return ButtonStyleButton.allOrNull<double>(0.0);
+  }
+
+  @override
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
+    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+      const EdgeInsets.symmetric(horizontal: 16),
+      const EdgeInsets.symmetric(horizontal: 8),
+      const EdgeInsets.symmetric(horizontal: 4),
+      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+    );
+
+    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
+  }
+
+  @override
+  MaterialStateProperty<Size>? get minimumSize =>
+    ButtonStyleButton.allOrNull<Size>(const Size(64, 40.0));
+
+  @override
+  MaterialStateProperty<Size>? get fixedSize =>
+    ButtonStyleButton.allOrNull<Size>(null);
+
+  @override
+  MaterialStateProperty<Size>? get maximumSize =>
+    ButtonStyleButton.allOrNull<Size>(Size.infinite);
+
+  @override
+  MaterialStateProperty<BorderSide>? get side =>
+    ButtonStyleButton.allOrNull<BorderSide>(null);
+
+  @override
+  MaterialStateProperty<OutlinedBorder>? get shape =>
+    ButtonStyleButton.allOrNull<OutlinedBorder>(const StadiumBorder());
+
+  @override
+  MaterialStateProperty<MouseCursor?>? get mouseCursor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return SystemMouseCursors.basic;
+      }
+      return SystemMouseCursors.click;
+    });
+  }
+
+  @override
+  VisualDensity? get visualDensity => Theme.of(context).visualDensity;
+
+  @override
+  MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
+
+  @override
+  Duration? get animationDuration => kThemeChangeDuration;
+
+  @override
+  bool? get enableFeedback => true;
+
+  @override
+  AlignmentGeometry? get alignment => Alignment.center;
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+
+// END GENERATED TOKEN PROPERTIES

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -271,13 +271,6 @@ class TextButton extends ButtonStyleButton {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
 
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
-      const EdgeInsets.all(8),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
     return Theme.of(context).useMaterial3
       ? _TokenDefaultsM3(context)
       : styleFrom(
@@ -287,7 +280,7 @@ class TextButton extends ButtonStyleButton {
           shadowColor: theme.shadowColor,
           elevation: 0,
           textStyle: theme.textTheme.button,
-          padding: scaledPadding,
+          padding: _scaledPadding(context),
           minimumSize: const Size(64, 36),
           maximumSize: Size.infinite,
           shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))),
@@ -308,6 +301,15 @@ class TextButton extends ButtonStyleButton {
   ButtonStyle? themeStyleOf(BuildContext context) {
     return TextButtonTheme.of(context).style;
   }
+}
+
+EdgeInsetsGeometry _scaledPadding(BuildContext context) {
+  return ButtonStyleButton.scaledPadding(
+    const EdgeInsets.all(8),
+    const EdgeInsets.symmetric(horizontal: 8),
+    const EdgeInsets.symmetric(horizontal: 4),
+    MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
+  );
 }
 
 @immutable
@@ -485,12 +487,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
-    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
-      const EdgeInsets.symmetric(horizontal: 16),
-      const EdgeInsets.symmetric(horizontal: 8),
-      const EdgeInsets.symmetric(horizontal: 4),
-      MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    ));
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(_scaledPadding(context));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -437,7 +437,12 @@ class _TextButtonWithIconChild extends StatelessWidget {
 
 // Generated version v0_92
 class _TokenDefaultsM3 extends ButtonStyle {
-  _TokenDefaultsM3(this.context);
+  _TokenDefaultsM3(this.context)
+   : super(
+       animationDuration: kThemeChangeDuration,
+       enableFeedback: true,
+       alignment: Alignment.center,
+     );
 
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
@@ -450,108 +455,72 @@ class _TokenDefaultsM3 extends ButtonStyle {
   MaterialStateProperty<Color?>? get backgroundColor =>
     ButtonStyleButton.allOrNull<Color>(Colors.transparent);
 
-  static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
-    return (enabled == null && disabled == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.disabled))
-            return disabled?.withOpacity(0.38);
-          return enabled;
-        });
-  }
+  @override
+  MaterialStateProperty<Color?>? get foregroundColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
+        return _colors.onSurface.withOpacity(0.38);
+      return _colors.primary;
+    });
 
   @override
-  MaterialStateProperty<Color?>? get foregroundColor {
-    return foregroundColorFor(_colors.primary, _colors.onSurface);
-  }
+  MaterialStateProperty<Color?>? get overlayColor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.hovered))
+        return _colors.primary.withOpacity(0.08);
+      if (states.contains(MaterialState.focused))
+        return _colors.primary.withOpacity(0.12);
+      if (states.contains(MaterialState.pressed))
+        return _colors.primary.withOpacity(0.12);
+      return null;
+    });
 
-  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus, Color? pressed) {
-    return (hover == null && focus == null)
-      ? null
-      : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-          if (states.contains(MaterialState.hovered))
-            return hover?.withOpacity(0.08);
-          else if (states.contains(MaterialState.focused))
-            return focus?.withOpacity(0.12);
-          else if (states.contains(MaterialState.pressed))
-            return pressed?.withOpacity(0.12);
-          else
-            return null;
-        });
-  }
+  // No default shadow color
 
-  @override
-  MaterialStateProperty<Color?>? get overlayColor {
-    return overlayColorFor(_colors.primary, _colors.primary, _colors.primary);
-  }
-
-  @override
-  MaterialStateProperty<Color>? get shadowColor =>
-    ButtonStyleButton.allOrNull<Color>(null);
-
-  @override
-  MaterialStateProperty<Color>? get surfaceTintColor =>
-    ButtonStyleButton.allOrNull<Color>(null);
+  // No default surface tint color
 
   @override
   MaterialStateProperty<double>? get elevation =>
     ButtonStyleButton.allOrNull<double>(0.0);
 
   @override
-  MaterialStateProperty<EdgeInsetsGeometry>? get padding {
-    final EdgeInsetsGeometry scaledPadding = ButtonStyleButton.scaledPadding(
+  MaterialStateProperty<EdgeInsetsGeometry>? get padding =>
+    ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(ButtonStyleButton.scaledPadding(
       const EdgeInsets.symmetric(horizontal: 16),
       const EdgeInsets.symmetric(horizontal: 8),
       const EdgeInsets.symmetric(horizontal: 4),
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
-    );
-
-    return ButtonStyleButton.allOrNull<EdgeInsetsGeometry>(scaledPadding);
-  }
+    ));
 
   @override
   MaterialStateProperty<Size>? get minimumSize =>
-    ButtonStyleButton.allOrNull<Size>(const Size(64, 40.0));
+    ButtonStyleButton.allOrNull<Size>(const Size(64.0, 40.0));
 
-  @override
-  MaterialStateProperty<Size>? get fixedSize =>
-    ButtonStyleButton.allOrNull<Size>(null);
+  // No default fixedSize
 
   @override
   MaterialStateProperty<Size>? get maximumSize =>
     ButtonStyleButton.allOrNull<Size>(Size.infinite);
 
-  @override
-  MaterialStateProperty<BorderSide>? get side => null;
+  // No default side
 
   @override
   MaterialStateProperty<OutlinedBorder>? get shape =>
     ButtonStyleButton.allOrNull<OutlinedBorder>(const StadiumBorder());
 
   @override
-  MaterialStateProperty<MouseCursor?>? get mouseCursor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled)) {
+  MaterialStateProperty<MouseCursor?>? get mouseCursor =>
+    MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled))
         return SystemMouseCursors.basic;
-      }
       return SystemMouseCursors.click;
     });
-  }
 
   @override
   VisualDensity? get visualDensity => Theme.of(context).visualDensity;
 
   @override
   MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;
-
-  @override
-  Duration? get animationDuration => kThemeChangeDuration;
-
-  @override
-  bool? get enableFeedback => true;
-
-  @override
-  AlignmentGeometry? get alignment => Alignment.center;
 
   @override
   InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -447,9 +447,8 @@ class _TokenDefaultsM3 extends ButtonStyle {
     MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
 
   @override
-  MaterialStateProperty<Color?>? get backgroundColor {
-    return ButtonStyleButton.allOrNull<Color>(Colors.transparent);
-  }
+  MaterialStateProperty<Color?>? get backgroundColor =>
+    ButtonStyleButton.allOrNull<Color>(Colors.transparent);
 
   static MaterialStateProperty<Color?>? foregroundColorFor(Color? enabled, Color? disabled) {
     return (enabled == null && disabled == null)
@@ -466,7 +465,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
     return foregroundColorFor(_colors.primary, _colors.onSurface);
   }
 
-  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus) {
+  static MaterialStateProperty<Color?>? overlayColorFor(Color? hover, Color? focus, Color? pressed) {
     return (hover == null && focus == null)
       ? null
       : MaterialStateProperty.resolveWith((Set<MaterialState> states) {
@@ -474,6 +473,8 @@ class _TokenDefaultsM3 extends ButtonStyle {
             return hover?.withOpacity(0.08);
           else if (states.contains(MaterialState.focused))
             return focus?.withOpacity(0.12);
+          else if (states.contains(MaterialState.pressed))
+            return pressed?.withOpacity(0.12);
           else
             return null;
         });
@@ -481,7 +482,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<Color?>? get overlayColor {
-    return overlayColorFor(_colors.primary, _colors.primary);
+    return overlayColorFor(_colors.primary, _colors.primary, _colors.primary);
   }
 
   @override
@@ -493,9 +494,8 @@ class _TokenDefaultsM3 extends ButtonStyle {
     ButtonStyleButton.allOrNull<Color>(null);
 
   @override
-  MaterialStateProperty<double>? get elevation {
-    return ButtonStyleButton.allOrNull<double>(0.0);
-  }
+  MaterialStateProperty<double>? get elevation =>
+    ButtonStyleButton.allOrNull<double>(0.0);
 
   @override
   MaterialStateProperty<EdgeInsetsGeometry>? get padding {
@@ -522,8 +522,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
     ButtonStyleButton.allOrNull<Size>(Size.infinite);
 
   @override
-  MaterialStateProperty<BorderSide>? get side =>
-    ButtonStyleButton.allOrNull<BorderSide>(null);
+  MaterialStateProperty<BorderSide>? get side => null;
 
   @override
   MaterialStateProperty<OutlinedBorder>? get shape =>

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1201,7 +1201,7 @@ class ThemeData with Diagnosticable {
   ///   * [AlertDialog]
   ///   * [Card]
   ///   * [Dialog]
-  ///   * [ElevatedButton], see [Elevated.styleFrom] for important details on color
+  ///   * [ElevatedButton], see [ElevatedButton.styleFrom] for important details on color
   ///     changes for M3.
   ///   * [FloatingActionButton]
   ///   * [Material]

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1201,12 +1201,16 @@ class ThemeData with Diagnosticable {
   ///   * [AlertDialog]
   ///   * [Card]
   ///   * [Dialog]
+  ///   * [ElevatedButton], see [Elevated.styleFrom] for important details on color
+  ///     changes for M3.
   ///   * [FloatingActionButton]
   ///   * [Material]
   ///   * [NavigationBar]
   ///   * [NavigationRail]
+  ///   * [OutlinedButton]
   ///   * [StretchingOverscrollIndicator], replacing the
   ///     [GlowingOverscrollIndicator]
+  ///   * [TextButton]
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1170,21 +1170,25 @@ class ThemeData with Diagnosticable {
   /// {@endtemplate}
   final VisualDensity visualDensity;
 
-  /// A temporary flag used to opt-in to new Material 3 features.
+  /// A temporary flag used to opt-in to Material 3 features.
   ///
   /// If true, then components that have been migrated to Material 3 will
-  /// start using new colors, typography and other features of Material 3.
+  /// use new colors, typography and other features of Material 3.
   /// If false, they will use the Material 2 look and feel.
   ///
   /// If a [ThemeData] is constructed with [useMaterial3] set to true, then
   /// some properties will get special defaults. However, just copying a [ThemeData]
   /// with [useMaterial3] set to true will not change any of these properties in the
   /// resulting [ThemeData]. These properties are:
-  /// | Property | [useMaterial3] default | fallback default |
-  /// |:---|:---|:---|
-  /// | [typography] | [Typography.material2021] | [Typography.material2014] |
-  /// | [splashFactory] | [InkSparkle]* | [InkSplash] |
-  /// *if and only if the target platform is Android and the app is not running on the web.
+  /// <style>table,td,th { border-collapse: collapse; padding: 0.45em; } td { border: 1px solid }</style>
+  ///
+  /// | Property        | Material 3 default           | Fallback default          |
+  /// | :-------------- | :--------------------------- | :------------------------ |
+  /// | [typography]    | [Typography.material2021]    | [Typography.material2014] |
+  /// | [splashFactory] | [InkSparkle]* or [InkRipple] | [InkSplash]               |
+  ///
+  /// \* if and only if the target platform is Android and the app is not
+  /// running on the web, otherwise it will fallback to [InkRipple].
   ///
   /// During the migration to Material 3, turning this on may yield
   /// inconsistent look and feel in your app. Some components will be migrated
@@ -1201,8 +1205,7 @@ class ThemeData with Diagnosticable {
   ///   * [AlertDialog]
   ///   * [Card]
   ///   * [Dialog]
-  ///   * [ElevatedButton], see [ElevatedButton.styleFrom] for important details on color
-  ///     changes for M3.
+  ///   * [ElevatedButton]
   ///   * [FloatingActionButton]
   ///   * [Material]
   ///   * [NavigationBar]

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -20,6 +20,8 @@ void main() {
     expect(style.backgroundColor, null);
     expect(style.foregroundColor, null);
     expect(style.overlayColor, null);
+    expect(style.shadowColor, null);
+    expect(style.surfaceTintColor, null);
     expect(style.elevation, null);
     expect(style.padding, null);
     expect(style.minimumSize, null);
@@ -53,10 +55,12 @@ void main() {
       backgroundColor: MaterialStateProperty.all<Color>(const Color(0xfffffff1)),
       foregroundColor: MaterialStateProperty.all<Color>(const Color(0xfffffff2)),
       overlayColor: MaterialStateProperty.all<Color>(const Color(0xfffffff3)),
+      shadowColor: MaterialStateProperty.all<Color>(const Color(0xfffffff4)),
+      surfaceTintColor: MaterialStateProperty.all<Color>(const Color(0xfffffff5)),
       elevation: MaterialStateProperty.all<double>(1.5),
       padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(1.0)),
       minimumSize: MaterialStateProperty.all<Size>(const Size(1.0, 2.0)),
-      side: MaterialStateProperty.all<BorderSide>(const BorderSide(width: 4.0, color: Color(0xfffffff4))),
+      side: MaterialStateProperty.all<BorderSide>(const BorderSide(width: 4.0, color: Color(0xfffffff6))),
       maximumSize: MaterialStateProperty.all<Size>(const Size(100.0, 200.0)),
       shape: MaterialStateProperty.all<OutlinedBorder>(const StadiumBorder()),
       mouseCursor: MaterialStateProperty.all<MouseCursor>(SystemMouseCursors.forbidden),
@@ -75,11 +79,13 @@ void main() {
       'backgroundColor: MaterialStateProperty.all(Color(0xfffffff1))',
       'foregroundColor: MaterialStateProperty.all(Color(0xfffffff2))',
       'overlayColor: MaterialStateProperty.all(Color(0xfffffff3))',
+      'shadowColor: MaterialStateProperty.all(Color(0xfffffff4))',
+      'surfaceTintColor: MaterialStateProperty.all(Color(0xfffffff5))',
       'elevation: MaterialStateProperty.all(1.5)',
       'padding: MaterialStateProperty.all(EdgeInsets.all(1.0))',
       'minimumSize: MaterialStateProperty.all(Size(1.0, 2.0))',
       'maximumSize: MaterialStateProperty.all(Size(100.0, 200.0))',
-      'side: MaterialStateProperty.all(BorderSide(Color(0xfffffff4), 4.0, BorderStyle.solid))',
+      'side: MaterialStateProperty.all(BorderSide(Color(0xfffffff6), 4.0, BorderStyle.solid))',
       'shape: MaterialStateProperty.all(StadiumBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none)))',
       'mouseCursor: MaterialStateProperty.all(SystemMouseCursor(forbidden))',
       'tapTargetSize: shrinkWrap',
@@ -93,6 +99,8 @@ void main() {
     final MaterialStateProperty<Color> backgroundColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff1));
     final MaterialStateProperty<Color> foregroundColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff2));
     final MaterialStateProperty<Color> overlayColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff3));
+    final MaterialStateProperty<Color> shadowColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff4));
+    final MaterialStateProperty<Color> surfaceTintColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff5));
     final MaterialStateProperty<double> elevation =  MaterialStateProperty.all<double>(1);
     final MaterialStateProperty<EdgeInsets> padding = MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(1));
     final MaterialStateProperty<Size> minimumSize = MaterialStateProperty.all<Size>(const Size(1, 2));
@@ -111,6 +119,8 @@ void main() {
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
       overlayColor: overlayColor,
+      shadowColor: shadowColor,
+      surfaceTintColor: surfaceTintColor,
       elevation: elevation,
       padding: padding,
       minimumSize: minimumSize,
@@ -132,6 +142,8 @@ void main() {
         backgroundColor: backgroundColor,
         foregroundColor: foregroundColor,
         overlayColor: overlayColor,
+        shadowColor: shadowColor,
+        surfaceTintColor: surfaceTintColor,
         elevation: elevation,
         padding: padding,
         minimumSize: minimumSize,

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -14,11 +14,13 @@ import '../widgets/semantics_tester.dart';
 void main() {
   testWidgets('OutlinedButton, OutlinedButton.icon defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
+    final ThemeData theme = ThemeData.from(colorScheme: colorScheme);
+    final bool material3 = theme.useMaterial3;
 
     // Enabled OutlinedButton
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
+        theme: theme,
         home: Center(
           child: OutlinedButton(
             onPressed: () { },
@@ -40,12 +42,14 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
 
-    expect(material.shape, isInstanceOf<RoundedRectangleBorder>());
-    RoundedRectangleBorder materialShape = material.shape! as RoundedRectangleBorder;
-    expect(materialShape.side, BorderSide(color: colorScheme.onSurface.withOpacity(0.12)));
-    expect(materialShape.borderRadius, const BorderRadius.all(Radius.circular(4.0)));
+    expect(material.shape, material3
+      ? StadiumBorder(side: BorderSide(color: colorScheme.outline))
+      : RoundedRectangleBorder(
+          side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)),
+          borderRadius: const BorderRadius.all(Radius.circular(4))
+        ));
 
     expect(material.textStyle!.color, colorScheme.primary);
     expect(material.textStyle!.fontFamily, 'Roboto');
@@ -60,8 +64,13 @@ void main() {
     final TestGesture gesture = await tester.startGesture(center);
     await tester.pump(); // start the splash animation
     await tester.pump(const Duration(milliseconds: 100)); // splash is underway
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
-    expect(inkFeatures, paints..circle(color: colorScheme.primary.withAlpha(0x1f))); // splash color is primary(0.12)
+
+    // Material 3 uses the InkSparkle which uses a shader, so we can't capture
+    // the effect with paint methods.
+    if (!material3) {
+      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+      expect(inkFeatures, paints..circle(color: colorScheme.primary.withOpacity(0.12)));
+    }
 
     await gesture.up();
     await tester.pumpAndSettle();
@@ -73,12 +82,14 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
 
-    expect(material.shape, isInstanceOf<RoundedRectangleBorder>());
-    materialShape = material.shape! as RoundedRectangleBorder;
-    expect(materialShape.side, BorderSide(color: colorScheme.onSurface.withOpacity(0.12)));
-    expect(materialShape.borderRadius, const BorderRadius.all(Radius.circular(4.0)));
+    expect(material.shape, material3
+      ? StadiumBorder(side: BorderSide(color: colorScheme.outline))
+      : RoundedRectangleBorder(
+          side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)),
+          borderRadius: const BorderRadius.all(Radius.circular(4))
+        ));
 
     expect(material.textStyle!.color, colorScheme.primary);
     expect(material.textStyle!.fontFamily, 'Roboto');
@@ -90,7 +101,7 @@ void main() {
     final Key iconButtonKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
+        theme: theme,
         home: Center(
           child: OutlinedButton.icon(
             key: iconButtonKey,
@@ -114,12 +125,14 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
 
-    expect(material.shape, isInstanceOf<RoundedRectangleBorder>());
-    materialShape = material.shape! as RoundedRectangleBorder;
-    expect(materialShape.side, BorderSide(color: colorScheme.onSurface.withOpacity(0.12)));
-    expect(materialShape.borderRadius, const BorderRadius.all(Radius.circular(4.0)));
+    expect(material.shape, material3
+        ? StadiumBorder(side: BorderSide(color: colorScheme.outline))
+        : RoundedRectangleBorder(
+            side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)),
+            borderRadius: const BorderRadius.all(Radius.circular(4))
+        ));
 
     expect(material.textStyle!.color, colorScheme.primary);
     expect(material.textStyle!.fontFamily, 'Roboto');
@@ -130,7 +143,7 @@ void main() {
     // Disabled OutlinedButton
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
+        theme: theme,
         home: const Center(
           child: OutlinedButton(
             onPressed: null,
@@ -147,12 +160,14 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
 
-    expect(material.shape, isInstanceOf<RoundedRectangleBorder>());
-    materialShape = material.shape! as RoundedRectangleBorder;
-    expect(materialShape.side, BorderSide(color: colorScheme.onSurface.withOpacity(0.12)));
-    expect(materialShape.borderRadius, const BorderRadius.all(Radius.circular(4.0)));
+    expect(material.shape, material3
+        ? StadiumBorder(side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)))
+        : RoundedRectangleBorder(
+        side: BorderSide(color: colorScheme.onSurface.withOpacity(0.12)),
+        borderRadius: const BorderRadius.all(Radius.circular(4))
+    ));
 
     expect(material.textStyle!.color, colorScheme.onSurface.withOpacity(0.38));
     expect(material.textStyle!.fontFamily, 'Roboto');
@@ -531,6 +546,10 @@ void main() {
             child: OutlinedButton(
               style: ButtonStyle(
                 side: MaterialStateProperty.resolveWith<BorderSide>(getBorderSide),
+                // Test assumes a rounded rect for the shape
+                shape: ButtonStyleButton.allOrNull(
+                  const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4)))
+                ),
               ),
               onPressed: () {},
               focusNode: focusNode,
@@ -808,13 +827,14 @@ void main() {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Theme(
-          data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap),
+          data: ThemeData(materialTapTargetSize: MaterialTapTargetSize.shrinkWrap, textTheme: Typography.englishLike2014),
           child: Container(
             alignment: Alignment.topLeft,
             child: OutlinedButton(
               style: OutlinedButton.styleFrom(
                 shape: const RoundedRectangleBorder(), // default border radius is 0
                 backgroundColor: fillColor,
+                minimumSize: const Size(64, 36),
               ).copyWith(
                 side: MaterialStateProperty.resolveWith<BorderSide>((Set<MaterialState> states) {
                   if (states.contains(MaterialState.disabled))
@@ -964,20 +984,24 @@ void main() {
 
   testWidgets('OutlinedButton scales textScaleFactor', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: Center(
-            child: OutlinedButton(
-              style: ButtonStyle(
-                // Specifying minimumSize to mimic the original minimumSize for
-                // RaisedButton so that the corresponding button size matches
-                // the original version of this test.
-                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+      Theme(
+        // Force Material 2 typography.
+        data: ThemeData(textTheme: Typography.englishLike2014),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: Center(
+              child: OutlinedButton(
+                style: ButtonStyle(
+                  // Specifying minimumSize to mimic the original minimumSize for
+                  // RaisedButton so that the corresponding button size matches
+                  // the original version of this test.
+                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+                ),
+                onPressed: () {},
+                child: const Text('ABC'),
               ),
-              onPressed: () {},
-              child: const Text('ABC'),
             ),
           ),
         ),
@@ -989,20 +1013,24 @@ void main() {
 
     // textScaleFactor expands text, but not button.
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(textScaleFactor: 1.3),
-          child: Center(
-            child: OutlinedButton(
-              style: ButtonStyle(
-                // Specifying minimumSize to mimic the original minimumSize for
-                // RaisedButton so that the corresponding button size matches
-                // the original version of this test.
-                minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+      Theme(
+        // Force Material 2 typography.
+        data: ThemeData(textTheme: Typography.englishLike2014),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(textScaleFactor: 1.3),
+            child: Center(
+              child: OutlinedButton(
+                style: ButtonStyle(
+                  // Specifying minimumSize to mimic the original minimumSize for
+                  // RaisedButton so that the corresponding button size matches
+                  // the original version of this test.
+                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+                ),
+                onPressed: () {},
+                child: const Text('ABC'),
               ),
-              onPressed: () {},
-              child: const Text('ABC'),
             ),
           ),
         ),
@@ -1017,14 +1045,18 @@ void main() {
 
     // Set text scale large enough to expand text and button.
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(textScaleFactor: 3.0),
-          child: Center(
-            child: OutlinedButton(
-              onPressed: () {},
-              child: const Text('ABC'),
+      Theme(
+        // Force Material 2 typography.
+        data: ThemeData(textTheme: Typography.englishLike2014),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(textScaleFactor: 3.0),
+            child: Center(
+              child: OutlinedButton(
+                onPressed: () {},
+                child: const Text('ABC'),
+              ),
             ),
           ),
         ),
@@ -1038,7 +1070,6 @@ void main() {
     expect(tester.getSize(find.byType(Text)).width, isIn(<double>[126.0, 127.0]));
     expect(tester.getSize(find.byType(Text)).height, equals(42.0));
   });
-
 
   testWidgets('OutlinedButton onPressed and onLongPress callbacks are distinctly recognized', (WidgetTester tester) async {
     bool didPressButton = false;
@@ -1078,11 +1109,15 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, {bool useText = false}) async {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(textTheme: Typography.englishLike2014),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(
               child: OutlinedButton(
-                style: ButtonStyle(visualDensity: visualDensity),
+                style: ButtonStyle(
+                  visualDensity: visualDensity,
+                  minimumSize: ButtonStyleButton.allOrNull(const Size(64, 36)),
+                ),
                 key: key,
                 onPressed: () {},
                 child: useText
@@ -1203,7 +1238,15 @@ void main() {
           testWidgets(testName, (WidgetTester tester) async {
             await tester.pumpWidget(
               MaterialApp(
-                theme: ThemeData.from(colorScheme: const ColorScheme.light()),
+                theme: ThemeData(
+                  colorScheme: const ColorScheme.light(),
+                  // Force Material 2 defaults for the typography and size
+                  // default values as the test was designed against these settings.
+                  textTheme: Typography.englishLike2014,
+                  outlinedButtonTheme: OutlinedButtonThemeData(
+                    style: OutlinedButton.styleFrom(minimumSize: const Size(64, 36)),
+                  ),
+                ),
                 home: Builder(
                   builder: (BuildContext context) {
                     return MediaQuery(
@@ -1434,8 +1477,8 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    // Default splashFactory (from Theme.of().splashFactory), one splash circle drawn.
-    await tester.pumpWidget(buildFrame());
+    // InkRipple.splashFactory, one splash circle drawn.
+    await tester.pumpWidget(buildFrame(splashFactory: InkRipple.splashFactory));
     {
       final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('test')));
       final MaterialInkController material = Material.of(tester.element(find.text('test')))!;
@@ -1559,6 +1602,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(textTheme: Typography.englishLike2014),
         home: Scaffold(
           body: Center(
             child: Column(

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -14,11 +14,13 @@ import '../widgets/semantics_tester.dart';
 void main() {
   testWidgets('TextButton, TextButton.icon defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
+    final ThemeData theme = ThemeData.from(colorScheme: colorScheme);
+    final bool material3 = theme.useMaterial3;
 
     // Enabled TextButton
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
+        theme: theme,
         home: Center(
           child: TextButton(
             onPressed: () { },
@@ -40,8 +42,10 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shape, material3
+      ? const StadiumBorder()
+      : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
     expect(material.textStyle!.color, colorScheme.primary);
     expect(material.textStyle!.fontFamily, 'Roboto');
     expect(material.textStyle!.fontSize, 14);
@@ -55,8 +59,13 @@ void main() {
     final TestGesture gesture = await tester.startGesture(center);
     await tester.pump(); // start the splash animation
     await tester.pump(const Duration(milliseconds: 100)); // splash is underway
-    final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
-    expect(inkFeatures, paints..circle(color: colorScheme.primary.withAlpha(0x1f))); // splash color is primary(0.12)
+
+    // Material 3 uses the InkSparkle which uses a shader, so we can't capture
+    // the effect with paint methods.
+    if (!material3) {
+      final RenderObject inkFeatures = tester.allRenderObjects.firstWhere((RenderObject object) => object.runtimeType.toString() == '_RenderInkFeatures');
+      expect(inkFeatures, paints..circle(color: colorScheme.primary.withOpacity(0.12)));
+    }
 
     await gesture.up();
     await tester.pumpAndSettle();
@@ -68,8 +77,10 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shape, material3
+      ? const StadiumBorder()
+      : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
     expect(material.textStyle!.color, colorScheme.primary);
     expect(material.textStyle!.fontFamily, 'Roboto');
     expect(material.textStyle!.fontSize, 14);
@@ -80,7 +91,7 @@ void main() {
     final Key iconButtonKey = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
+        theme: theme,
         home: Center(
           child: TextButton.icon(
             key: iconButtonKey,
@@ -104,8 +115,10 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shape, material3
+      ? const StadiumBorder()
+      : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
     expect(material.textStyle!.color, colorScheme.primary);
     expect(material.textStyle!.fontFamily, 'Roboto');
     expect(material.textStyle!.fontSize, 14);
@@ -115,7 +128,7 @@ void main() {
     // Disabled TextButton
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData.from(colorScheme: colorScheme),
+        theme: theme,
         home: const Center(
           child: TextButton(
             onPressed: null,
@@ -132,8 +145,10 @@ void main() {
     expect(material.clipBehavior, Clip.none);
     expect(material.color, Colors.transparent);
     expect(material.elevation, 0.0);
-    expect(material.shadowColor, const Color(0xff000000));
-    expect(material.shape, const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4.0))));
+    expect(material.shadowColor, material3 ? null : const Color(0xff000000));
+    expect(material.shape, material3
+      ? const StadiumBorder()
+      : const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(4))));
     expect(material.textStyle!.color, colorScheme.onSurface.withOpacity(0.38));
     expect(material.textStyle!.fontFamily, 'Roboto');
     expect(material.textStyle!.fontSize, 14);
@@ -517,14 +532,18 @@ void main() {
 
   testWidgets('Does TextButton scale with font scale changes', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: Center(
-            child: TextButton(
-              onPressed: () { },
-              child: const Text('ABC'),
+      Theme(
+        // Force Material 2 typography.
+        data: ThemeData(textTheme: Typography.englishLike2014),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(),
+            child: Center(
+              child: TextButton(
+                onPressed: () { },
+                child: const Text('ABC'),
+              ),
             ),
           ),
         ),
@@ -536,14 +555,18 @@ void main() {
 
     // textScaleFactor expands text, but not button.
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(textScaleFactor: 1.3),
-          child: Center(
-            child: TextButton(
-              onPressed: () { },
-              child: const Text('ABC'),
+      Theme(
+        // Force Material 2 typography.
+        data: ThemeData(textTheme: Typography.englishLike2014),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(textScaleFactor: 1.3),
+            child: Center(
+              child: TextButton(
+                onPressed: () { },
+                child: const Text('ABC'),
+              ),
             ),
           ),
         ),
@@ -559,14 +582,18 @@ void main() {
 
     // Set text scale large enough to expand text and button.
     await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: const MediaQueryData(textScaleFactor: 3.0),
-          child: Center(
-            child: TextButton(
-              onPressed: () { },
-              child: const Text('ABC'),
+      Theme(
+        // Force Material 2 typography.
+        data: ThemeData(textTheme: Typography.englishLike2014),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: MediaQuery(
+            data: const MediaQueryData(textScaleFactor: 3.0),
+            child: Center(
+              child: TextButton(
+                onPressed: () { },
+                child: const Text('ABC'),
+              ),
             ),
           ),
         ),
@@ -581,7 +608,6 @@ void main() {
     expect(tester.getSize(find.byType(Text)).height, equals(42.0));
   });
 
-
   testWidgets('TextButton size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
       return Theme(
@@ -591,6 +617,7 @@ void main() {
           child: Center(
             child: TextButton(
               key: key,
+              style: TextButton.styleFrom(minimumSize: const Size(64, 36)),
               child: const SizedBox(width: 50.0, height: 8.0),
               onPressed: () { },
             ),
@@ -855,6 +882,7 @@ void main() {
     Future<void> buildTest(VisualDensity visualDensity, { bool useText = false }) async {
       return tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(textTheme: Typography.englishLike2014),
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: Center(
@@ -993,7 +1021,15 @@ void main() {
           testWidgets(testName, (WidgetTester tester) async {
             await tester.pumpWidget(
               MaterialApp(
-                theme: ThemeData.from(colorScheme: const ColorScheme.light()),
+                theme: ThemeData(
+                  colorScheme: const ColorScheme.light(),
+                  // Force Material 2 defaults for the typography and size
+                  // default values as the test was designed against these settings.
+                  textTheme: Typography.englishLike2014,
+                  textButtonTheme: TextButtonThemeData(
+                    style: TextButton.styleFrom(minimumSize: const Size(64, 36)),
+                  ),
+                ),
                 home: Builder(
                   builder: (BuildContext context) {
                     return MediaQuery(
@@ -1227,8 +1263,8 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    // Default splashFactory (from Theme.of().splashFactory), one splash circle drawn.
-    await tester.pumpWidget(buildFrame());
+    // InkRipple.splashFactory, one splash circle drawn.
+    await tester.pumpWidget(buildFrame(splashFactory: InkRipple.splashFactory));
     {
       final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('test')));
       final MaterialInkController material = Material.of(tester.element(find.text('test')))!;
@@ -1352,6 +1388,7 @@ void main() {
 
     await tester.pumpWidget(
       MaterialApp(
+        theme: ThemeData(textTheme: Typography.englishLike2014),
         home: Scaffold(
           body: Center(
             child: Column(


### PR DESCRIPTION
Part of: https://github.com/flutter/flutter/issues/91605

Updated the common buttons: `ElevatedButton`, `OutlinedButton`, and `TextButton` with support for [Material Design 3](https://m3.material.io/components/buttons/overview).

<img width="568" alt="M3 Buttons" src="https://user-images.githubusercontent.com/19588/161684063-e116cefc-8780-44b1-ab8f-13753c710d7e.png">
<img width="569" alt="M3 Buttons Dark" src="https://user-images.githubusercontent.com/19588/161684079-e5bd67b3-d62b-4a90-8e4a-16508a367401.png">

In order to use the common buttons with the new Material 3 defaults, turn on the `useMaterial3` flag in the `ThemeData`:

```dart
  return MaterialApp(
    theme: ThemeData(useMaterial3: true),
    // ...
  );
```

Also, if you use `ElevatedButton.styleFrom` please read the documentation about color role changes in M3 that you may need to account for.

Fixes: #99022
Fixes: #99884

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
