### PR TITLE
Pass ARCHS build setting to flutter assemble on macOS

### DIFF
--- a/packages/flutter_tools/bin/macos_assemble.sh
+++ b/packages/flutter_tools/bin/macos_assemble.sh
@@ -70,7 +70,7 @@ BuildApp() {
     "assemble"
     "--no-version-check"
     "-dTargetPlatform=darwin"
-    "-dDarwinArchs=x86_64 arm64"
+    "-dDarwinArchs=${ARCHS}"
     "-dTargetFile=${target_path}"
     "-dBuildMode=${build_mode}"
     "-dTreeShakeIcons=${TREE_SHAKE_ICONS}"

--- a/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/macos_content_validation_test.dart
@@ -79,7 +79,21 @@ void main() {
         'App.framework',
       ));
 
-      expect(outputAppFramework.childFile('App'), exists);
+      final File outputAppFrameworkBinary = outputAppFramework.childFile('App');
+      final String archs = processManager.runSync(
+        <String>['file', outputAppFrameworkBinary.path],
+      ).stdout as String;
+
+      final bool containsX64 = archs.contains('Mach-O 64-bit dynamically linked shared library x86_64');
+      final bool containsArm = archs.contains('Mach-O 64-bit dynamically linked shared library arm64');
+      if (buildModeLower == 'debug') {
+        // Only build the architecture matching the machine running this test, not both.
+        expect(containsX64 ^ containsArm, isTrue, reason: 'Unexpected architecture $archs');
+      } else {
+        expect(containsX64, isTrue, reason: 'Unexpected architecture $archs');
+        expect(containsArm, isTrue, reason: 'Unexpected architecture $archs');
+      }
+
       expect(outputAppFramework.childLink('Resources'), exists);
 
       final File vmSnapshot = fileSystem.file(fileSystem.path.join(


### PR DESCRIPTION
Instead of hard-coding `ARCHS` when building `App.framework`, instead use the build setting from Xcode, which will be set to one architecture in debug mode corresponding to the architecture of the host machine.

Part of https://github.com/flutter/flutter/issues/100804

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
