### PR TITLE
Removes soon to be deprecated analyzer option

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,8 +21,6 @@
 analyzer:
   language:
     strict-raw-types: true
-  strong-mode:
-    implicit-casts: false
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning


### PR DESCRIPTION
From https://dart.googlesource.com/sdk.git/+/6a54fdd46e2df14c9a7b4fd9d6b2d6e181ca0b7a

See Engine roll failures starting in https://github.com/flutter/flutter/pull/100846

FYI @srawlins did this not turn Dart's Flutter analysis bot red?