### PR TITLE
Revert some targets back to LUCI scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2489,6 +2489,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+    scheduler: luci
 
   - name: Mac build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
@@ -3456,6 +3457,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: integration_ui_ios_textfield
+    scheduler: luci
 
   - name: Mac_ios ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
@@ -3546,6 +3548,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: new_gallery_impeller_ios__transition_perf
+    scheduler: luci
 
   - name: Mac_ios ios_picture_cache_complexity_scoring_perf__timeline_summary
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
* Reverted the blocking targets
* Reverted an additional bringup target that was mostly green before the scheduler migration

https://github.com/flutter/flutter/issues/100866

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
