### PR TITLE
Tighten text contrast bounds, fall back to larger bounds

### DIFF
--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:io';
-import 'dart:ui';
-
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -695,14 +692,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         await binding.pump(interval);
         elapsed += interval;
       }
-    });
-  }
-
-  Future<void> dumpScreenshot() {
-    return TestAsyncUtils.guard<void>(() async {
-      final image = await (binding.renderView.layer as OffsetLayer).toImage(binding.renderView.paintBounds);
-      final data = await image.toByteData(format: ImageByteFormat.png);
-      File('foo_bar_bazz.png').writeAsBytesSync(data!.buffer.asUint8List());
     });
   }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+import 'dart:ui';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -692,6 +695,14 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
         await binding.pump(interval);
         elapsed += interval;
       }
+    });
+  }
+
+  Future<void> dumpScreenshot() {
+    return TestAsyncUtils.guard<void>(() async {
+      final image = await (binding.renderView.layer as OffsetLayer).toImage(binding.renderView.paintBounds);
+      final data = await image.toByteData(format: ImageByteFormat.png);
+      File('foo_bar_bazz.png').writeAsBytesSync(data!.buffer.asUint8List());
     });
   }
 

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -126,9 +126,9 @@ void main() {
       expect(result.reason,
         'SemanticsNode#4(Rect.fromLTRB(300.0, 200.0, 500.0, 400.0), label: "this is a test",'
         ' textDirection: ltr):\nExpected contrast ratio of at least '
-        '4.5 but found 1.17 for a font size of 14.0. The '
-        'computed light color was: Color(0xfffafafa), The computed dark color was:'
-        ' Color(0xffffeb3b)\n'
+        '4.5 but found 0.88 for a font size of 14.0. The '
+        'computed light color was: Color(0xffffeb3b), The computed dark color was:'
+        ' Color(0xffffff00)\n'
         'See also: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html');
       handle.dispose();
     });
@@ -647,6 +647,37 @@ void main() {
       ),
     ));
     await expectLater(tester, meetsGuideline(textContrastGuideline));
+    handle.dispose();
+  });
+
+  testWidgets('Blue contrast check with text background', (WidgetTester tester) async {
+    /// Shades of blue with contrast ratio of 2.9, 4.4, 4.5 from [surface].
+    const Color blue29 = Color(0xFF7E7EFB);
+    const Color blue44 = Color(0xFF5757FF);
+    const Color blue45 = Color(0xFF5252FF);
+    const Color surface = Color(0xFFF0F0F0);
+
+    const List<TextStyle> meetStyle = <TextStyle>[
+      TextStyle(color: blue44, backgroundColor: surface, fontSize: 18),
+      TextStyle(color: blue44, backgroundColor: surface, fontSize: 14, fontWeight: FontWeight.bold),
+      TextStyle(color: blue45, backgroundColor: surface),
+    ];
+
+    const List<TextStyle> doesNotMeetStyle = <TextStyle>[
+      TextStyle(color: blue44, backgroundColor: surface),
+      TextStyle(color: blue29, backgroundColor: surface, fontSize: 18)
+    ];
+
+    final SemanticsHandle handle = tester.ensureSemantics();
+    for (final TextStyle style in meetStyle) {
+      await tester.pumpWidget(_boilerplate(Text('Hello World', style: style)));
+      await expectLater(tester, meetsGuideline(textContrastGuideline));
+    }
+    for (final TextStyle style in doesNotMeetStyle) {
+      await tester.pumpWidget(_boilerplate(Text('Hello World', style: style)));
+      await expectLater(tester, doesNotMeetGuideline(textContrastGuideline));
+    }
+
     handle.dispose();
   });
 }


### PR DESCRIPTION
Fixes the issues outlined in https://github.com/flutter/flutter/pull/100267


Historically, we implemented text contrast checking assuming that we were only really looking at text color in comparison to a larger background surface. Thus it made sense to expand the area sampled from slightly to ensure that we picked up enough of this color - especially considering that flutter test will use ahem by default which is quite large and blocky.

Nevertheless, there are some cases where this doesn't work well -  such as through the usage of the text background color which is _extremely_ tight to the text bounds themselves.

To adjust for this, we can expand the heuristic to first consider tighter bounds, and then if it fails to find multiple colors or only finds colors that extremely close, fall back to the historical larger bounds.

This also takes an opportunity to correct two instances of `>` that should be `>=` when determining minimum text size

Example of AA on Ahem, see the very last set of boxes:
![foo_bar_bazz](https://user-images.githubusercontent.com/8975114/160481238-92201f66-699b-4313-9a60-ca53e9942356.png)

