### PR TITLE
Made flag for debugging build time of user created widgets

### DIFF
--- a/dev/tracing_tests/test/timeline_test.dart
+++ b/dev/tracing_tests/test/timeline_test.dart
@@ -61,7 +61,6 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   initTimelineTests();
   test('Timeline', () async {
-    debugProfileBuildsEnabledUserWidgets = false;
     // We don't have expectations around the first frame because there's a race around
     // the warm-up frame that we don't want to get involved in here.
     await runFrame(() { runApp(const TestRoot()); });

--- a/dev/tracing_tests/test/timeline_test.dart
+++ b/dev/tracing_tests/test/timeline_test.dart
@@ -61,9 +61,9 @@ void main() {
   WidgetsFlutterBinding.ensureInitialized();
   initTimelineTests();
   test('Timeline', () async {
+    debugProfileBuildsEnabledUserWidgets = false;
     // We don't have expectations around the first frame because there's a race around
     // the warm-up frame that we don't want to get involved in here.
-    debugProfileBuildsEnabledUserWidgets = false;
     await runFrame(() { runApp(const TestRoot()); });
     await SchedulerBinding.instance.endOfFrame;
     await fetchInterestingEvents(interestingLabels);

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -114,17 +114,16 @@ bool debugPrintGlobalKeyedWidgetLifecycle = false;
 ///  * [debugProfileLayoutsEnabled], which does something similar for layout,
 ///    and [debugPrintLayouts], its console equivalent.
 ///  * [debugProfilePaintsEnabled], which does something similar for painting.
-///  * [debugProfileBuildsEnabledUserWidgets], which filters user generated
-///    [Widget]s.
+///  * [debugProfileBuildsEnabledUserWidgets], adds events for user generated
+///    [Widget] build.
 bool debugProfileBuildsEnabled = false;
 
-/// Filters [debugProfileBuildsEnabled] events to user generated [Widget]s.
+/// Adds [Timeline] events for every user created [Widget] built.
 ///
-/// When [debugProfileBuildsEnabledUserWidgets] is true,
-/// [debugProfileBuildsEnabled] will only add [Timeline] events for user created
-/// widgets.  This reduces noise in the output and overhead from the [Timeline]
-/// events.
-bool debugProfileBuildsEnabledUserWidgets = false;
+/// See also:
+///  * [debugProfileBuildsEnabled], functions similarly but shows events for
+///    every widget with a higher overhead cost.
+bool debugProfileBuildsEnabledUserWidgets = true;
 
 /// Show banners for deprecated widgets.
 bool debugHighlightDeprecatedWidgets = false;

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -121,7 +121,10 @@ bool debugProfileBuildsEnabled = false;
 /// Adds [Timeline] events for every user-created [Widget] built.
 ///
 /// A user-created [Widget] is any [Widget] that is constructed in the root
-/// library.
+/// library. Often [Widget]s contain child [Widget]s that are constructed in
+/// libraries (for example, a [TextButton] having a [RichText] child). Timeline
+/// events for those children will be omitted with this flag. This works for any
+/// [Widget] not just ones declared in the root library.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -114,8 +114,8 @@ bool debugPrintGlobalKeyedWidgetLifecycle = false;
 ///  * [debugProfileLayoutsEnabled], which does something similar for layout,
 ///    and [debugPrintLayouts], its console equivalent.
 ///  * [debugProfilePaintsEnabled], which does something similar for painting.
-///  * [debugProfileBuildsEnabledUserWidgets], adds events for user-created
-///    [Widget] build.
+///  * [debugProfileBuildsEnabledUserWidgets], which adds events for user-created
+///    [Widget] build times and incurs less overhead.
 bool debugProfileBuildsEnabled = false;
 
 /// Adds [Timeline] events for every user-created [Widget] built.
@@ -127,7 +127,7 @@ bool debugProfileBuildsEnabled = false;
 ///
 ///  * [debugProfileBuildsEnabled], which functions similarly but shows events
 ///    for every widget and has a higher overhead cost.
-bool debugProfileBuildsEnabledUserWidgets = true;
+bool debugProfileBuildsEnabledUserWidgets = false;
 
 /// Show banners for deprecated widgets.
 bool debugHighlightDeprecatedWidgets = false;
@@ -437,7 +437,7 @@ bool debugAssertAllWidgetVarsUnset(String reason) {
         debugPrintGlobalKeyedWidgetLifecycle ||
         debugProfileBuildsEnabled ||
         debugHighlightDeprecatedWidgets ||
-        !debugProfileBuildsEnabledUserWidgets) {
+        debugProfileBuildsEnabledUserWidgets) {
       throw FlutterError(reason);
     }
     return true;

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -122,7 +122,7 @@ bool debugProfileBuildsEnabled = false;
 ///
 /// See also:
 ///  * [debugProfileBuildsEnabled], functions similarly but shows events for
-///    every widget with a higher overhead cost.
+///    every widget and has a higher overhead cost.
 bool debugProfileBuildsEnabledUserWidgets = true;
 
 /// Show banners for deprecated widgets.

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -114,15 +114,19 @@ bool debugPrintGlobalKeyedWidgetLifecycle = false;
 ///  * [debugProfileLayoutsEnabled], which does something similar for layout,
 ///    and [debugPrintLayouts], its console equivalent.
 ///  * [debugProfilePaintsEnabled], which does something similar for painting.
-///  * [debugProfileBuildsEnabledUserWidgets], adds events for user generated
+///  * [debugProfileBuildsEnabledUserWidgets], adds events for user-created
 ///    [Widget] build.
 bool debugProfileBuildsEnabled = false;
 
-/// Adds [Timeline] events for every user created [Widget] built.
+/// Adds [Timeline] events for every user-created [Widget] built.
+///
+/// A user-created [Widget] is any [Widget] that is constructed in the root
+/// library.
 ///
 /// See also:
-///  * [debugProfileBuildsEnabled], functions similarly but shows events for
-///    every widget and has a higher overhead cost.
+/// 
+///  * [debugProfileBuildsEnabled], which functions similarly but shows events
+///    for every widget and has a higher overhead cost.
 bool debugProfileBuildsEnabledUserWidgets = true;
 
 /// Show banners for deprecated widgets.

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -124,7 +124,7 @@ bool debugProfileBuildsEnabled = false;
 /// library.
 ///
 /// See also:
-/// 
+///
 ///  * [debugProfileBuildsEnabled], which functions similarly but shows events
 ///    for every widget and has a higher overhead cost.
 bool debugProfileBuildsEnabledUserWidgets = true;
@@ -436,7 +436,8 @@ bool debugAssertAllWidgetVarsUnset(String reason) {
         debugPrintScheduleBuildForStacks ||
         debugPrintGlobalKeyedWidgetLifecycle ||
         debugProfileBuildsEnabled ||
-        debugHighlightDeprecatedWidgets) {
+        debugHighlightDeprecatedWidgets ||
+        !debugProfileBuildsEnabledUserWidgets) {
       throw FlutterError(reason);
     }
     return true;

--- a/packages/flutter/lib/src/widgets/debug.dart
+++ b/packages/flutter/lib/src/widgets/debug.dart
@@ -114,7 +114,17 @@ bool debugPrintGlobalKeyedWidgetLifecycle = false;
 ///  * [debugProfileLayoutsEnabled], which does something similar for layout,
 ///    and [debugPrintLayouts], its console equivalent.
 ///  * [debugProfilePaintsEnabled], which does something similar for painting.
+///  * [debugProfileBuildsEnabledUserWidgets], which filters user generated
+///    [Widget]s.
 bool debugProfileBuildsEnabled = false;
+
+/// Filters [debugProfileBuildsEnabled] events to user generated [Widget]s.
+///
+/// When [debugProfileBuildsEnabledUserWidgets] is true,
+/// [debugProfileBuildsEnabled] will only add [Timeline] events for user created
+/// widgets.  This reduces noise in the output and overhead from the [Timeline]
+/// events.
+bool debugProfileBuildsEnabledUserWidgets = false;
 
 /// Show banners for deprecated widgets.
 bool debugHighlightDeprecatedWidgets = false;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3081,10 +3081,8 @@ class _NotificationNode {
 }
 
 bool _isProfileBuildsEnabledFor(Widget widget) {
-  // ignore: avoid_bool_literals_in_conditional_expressions
-  return debugProfileBuildsEnabled && debugProfileBuildsEnabledUserWidgets
-      ? debugIsWidgetLocalCreation(widget)
-      : true;
+  return debugProfileBuildsEnabled || (debugProfileBuildsEnabledUserWidgets
+      && debugIsWidgetLocalCreation(widget));
 }
 
 /// An instantiation of a [Widget] at a particular location in the tree.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2645,7 +2645,9 @@ class BuildOwner {
         if (isTimelineTracked) {
           Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
           assert(() {
-            debugTimelineArguments = element.widget.toDiagnosticsNode().toTimelineArguments();
+            if (kDebugMode) {
+              debugTimelineArguments = element.widget.toDiagnosticsNode().toTimelineArguments();
+            }
             return true;
           }());
           Timeline.startSync(
@@ -3514,7 +3516,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
         if (isTimelineTracked) {
           Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
           assert(() {
-            debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
+            if (kDebugMode) {
+              debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
+            }
             return true;
           }());
           Timeline.startSync(
@@ -3777,7 +3781,9 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     if (isTimelineTracked) {
       Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
       assert(() {
-        debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
+        if (kDebugMode) {
+          debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
+        }
         return true;
       }());
       Timeline.startSync(

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3083,8 +3083,9 @@ class _NotificationNode {
 }
 
 bool _isProfileBuildsEnabledFor(Widget widget) {
-  return debugProfileBuildsEnabled || (debugProfileBuildsEnabledUserWidgets
-      && debugIsWidgetLocalCreation(widget));
+  return debugProfileBuildsEnabled ||
+      (debugProfileBuildsEnabledUserWidgets &&
+          debugIsWidgetLocalCreation(widget));
 }
 
 /// An instantiation of a [Widget] at a particular location in the tree.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -14,6 +14,7 @@ import 'debug.dart';
 import 'focus_manager.dart';
 import 'inherited_model.dart';
 import 'notification_listener.dart';
+import 'widget_inspector.dart';
 
 export 'package:flutter/foundation.dart' show
   factory,
@@ -2640,7 +2641,8 @@ class BuildOwner {
           }
           return true;
         }());
-        if (!kReleaseMode && debugProfileBuildsEnabled) {
+        final bool isTimelineTracked = !kReleaseMode && _isProfileBuildsEnabledFor(element.widget);
+        if (isTimelineTracked) {
           Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
           assert(() {
             debugTimelineArguments = element.widget.toDiagnosticsNode().toTimelineArguments();
@@ -2668,7 +2670,7 @@ class BuildOwner {
             ],
           );
         }
-        if (!kReleaseMode && debugProfileBuildsEnabled)
+        if (isTimelineTracked)
           Timeline.finishSync();
         index += 1;
         if (dirtyCount < _dirtyElements.length || _dirtyElementsNeedsResorting!) {
@@ -3076,6 +3078,13 @@ class _NotificationNode {
     }
     parent?.dispatchNotification(notification);
   }
+}
+
+bool _isProfileBuildsEnabledFor(Widget widget) {
+  // ignore: avoid_bool_literals_in_conditional_expressions
+  return debugProfileBuildsEnabled && debugProfileBuildsEnabledUserWidgets
+      ? debugIsWidgetLocalCreation(widget)
+      : true;
 }
 
 /// An instantiation of a [Widget] at a particular location in the tree.
@@ -3503,7 +3512,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       } else if (hasSameSuperclass && Widget.canUpdate(child.widget, newWidget)) {
         if (child.slot != newSlot)
           updateSlotForChild(child, newSlot);
-        if (!kReleaseMode && debugProfileBuildsEnabled) {
+        final bool isTimelineTracked = !kReleaseMode && _isProfileBuildsEnabledFor(newWidget);
+        if (isTimelineTracked) {
           Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
           assert(() {
             debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
@@ -3515,7 +3525,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
           );
         }
         child.update(newWidget);
-        if (!kReleaseMode && debugProfileBuildsEnabled)
+        if (isTimelineTracked)
           Timeline.finishSync();
         assert(child.widget == newWidget);
         assert(() {
@@ -3765,7 +3775,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   Element inflateWidget(Widget newWidget, Object? newSlot) {
     assert(newWidget != null);
 
-    if (!kReleaseMode && debugProfileBuildsEnabled) {
+    final bool isTimelineTracked = !kReleaseMode && _isProfileBuildsEnabledFor(newWidget);
+    if (isTimelineTracked) {
       Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
       assert(() {
         debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
@@ -3800,7 +3811,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     newChild.mount(this, newSlot);
     assert(newChild._lifecycleState == _ElementLifecycle.active);
 
-    if (!kReleaseMode && debugProfileBuildsEnabled)
+    if (isTimelineTracked)
       Timeline.finishSync();
 
     return newChild;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:collection' show HashMap;
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:math' as math;
@@ -743,7 +744,7 @@ mixin WidgetInspectorService {
 
   List<String>? _pubRootDirectories;
   /// Memoization for [_isLocalCreationLocation].
-  final Map<String, bool> _isLocalCreationCache = <String, bool>{};
+  final HashMap<String, bool> _isLocalCreationCache = HashMap<String, bool>();
 
   bool _trackRebuildDirtyWidgets = false;
   bool _trackRepaintWidgets = false;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -3097,10 +3097,8 @@ bool debugIsLocalCreationLocation(Object object) {
 /// This is a faster variant of `debugIsLocalCreationLocation` that is available
 /// in debug and profile builds.
 bool debugIsWidgetLocalCreation(Widget widget) {
-  final _Location? location = _getWidgetCreationLocation(widget);
-  // ignore: avoid_bool_literals_in_conditional_expressions
-  return location == null ?
-      false :
+  final _Location? location = _getObjectCreationLocation(widget);
+  return location != null &&
       WidgetInspectorService.instance._isLocalCreationLocation(location.file);
 }
 
@@ -3116,8 +3114,7 @@ String? _describeCreationLocation(Object object) {
   return location?.toString();
 }
 
-_Location? _getWidgetCreationLocation(Widget widget) {
-  final Object object = widget;
+_Location? _getObjectCreationLocation(Object object) {
   return object is _HasCreationLocation ? object._location : null;
 }
 
@@ -3127,10 +3124,8 @@ _Location? _getWidgetCreationLocation(Widget widget) {
 ///
 /// Currently creation locations are only available for [Widget] and [Element].
 _Location? _getCreationLocation(Object? object) {
-  final Widget? widget = object is Element
-      ? (object.debugIsDefunct ? null : object.widget)
-      : (object is Widget ? object : null);
-  return widget == null ? null :  _getWidgetCreationLocation(widget);
+  final Object? candidate =  object is Element && !object.debugIsDefunct ? object.widget : object;
+  return candidate == null ? null : _getObjectCreationLocation(candidate);
 }
 
 // _Location objects are always const so we don't need to worry about the GC

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -742,6 +742,8 @@ mixin WidgetInspectorService {
   int _nextId = 0;
 
   List<String>? _pubRootDirectories;
+  /// Memoization for [_isLocalCreationLocation].
+  final Map<String, bool> _isLocalCreationCache = <String, bool>{};
 
   bool _trackRebuildDirtyWidgets = false;
   bool _trackRepaintWidgets = false;
@@ -1345,6 +1347,7 @@ mixin WidgetInspectorService {
     _pubRootDirectories = pubRootDirectories
       .map<String>((String directory) => Uri.parse(directory).path)
       .toList();
+    _isLocalCreationCache.clear();
   }
 
   /// Set the [WidgetInspector] selection to the object matching the specified
@@ -1518,14 +1521,11 @@ mixin WidgetInspectorService {
     if (creationLocation == null) {
       return false;
     }
-    return _isLocalCreationLocation(creationLocation);
+    return _isLocalCreationLocation(creationLocation.file);
   }
 
-  bool _isLocalCreationLocation(_Location? location) {
-    if (location == null) {
-      return false;
-    }
-    final String file = Uri.parse(location.file).path;
+  bool _isLocalCreationLocationImpl(String locationUri) {
+    final String file = Uri.parse(locationUri).path;
 
     // By default check whether the creation location was within package:flutter.
     if (_pubRootDirectories == null) {
@@ -1539,6 +1539,17 @@ mixin WidgetInspectorService {
       }
     }
     return false;
+  }
+
+  /// Memoized version of [_isLocalCreationLocationImpl].
+  bool _isLocalCreationLocation(String locationUri) {
+    final bool? cachedValue = _isLocalCreationCache[locationUri];
+    if (cachedValue != null) {
+      return cachedValue;
+    }
+    final bool result = _isLocalCreationLocationImpl(locationUri);
+    _isLocalCreationCache[locationUri] = result;
+    return result;
   }
 
   /// Wrapper around `json.encode` that uses a ring of cached values to prevent
@@ -2066,7 +2077,7 @@ class _ElementLocationStatsTracker {
       entry = _LocationCount(
         location: location,
         id: id,
-        local: WidgetInspectorService.instance._isLocalCreationLocation(location),
+        local: WidgetInspectorService.instance._isLocalCreationLocation(location.file),
       );
       if (entry.local) {
         newLocations.add(entry);
@@ -3072,12 +3083,24 @@ bool debugIsLocalCreationLocation(Object object) {
   bool isLocal = false;
   assert(() {
     final _Location? location = _getCreationLocation(object);
-    if (location == null)
-      isLocal =  false;
-    isLocal = WidgetInspectorService.instance._isLocalCreationLocation(location);
+    if (location != null) {
+      isLocal = WidgetInspectorService.instance._isLocalCreationLocation(location.file);
+    }
     return true;
   }());
   return isLocal;
+}
+
+/// Returns true if a [Widget] is user created.
+///
+/// This is a faster variant of `debugIsLocalCreationLocation` that is available
+/// in debug and profile builds.
+bool debugIsWidgetLocalCreation(Widget widget) {
+  final _Location? location = _getWidgetCreationLocation(widget);
+  // ignore: avoid_bool_literals_in_conditional_expressions
+  return location == null ?
+      false :
+      WidgetInspectorService.instance._isLocalCreationLocation(location.file);
 }
 
 /// Returns the creation location of an object in String format if one is available.
@@ -3092,14 +3115,21 @@ String? _describeCreationLocation(Object object) {
   return location?.toString();
 }
 
+_Location? _getWidgetCreationLocation(Widget widget) {
+  final Object object = widget;
+  return object is _HasCreationLocation ? object._location : null;
+}
+
 /// Returns the creation location of an object if one is available.
 ///
 /// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
 ///
 /// Currently creation locations are only available for [Widget] and [Element].
 _Location? _getCreationLocation(Object? object) {
-  final Object? candidate =  object is Element && !object.debugIsDefunct ? object.widget : object;
-  return candidate is _HasCreationLocation ? candidate._location : null;
+  final Widget? widget = object is Element
+      ? (object.debugIsDefunct ? null : object.widget)
+      : (object is Widget ? object : null);
+  return widget == null ? null :  _getWidgetCreationLocation(widget);
 }
 
 // _Location objects are always const so we don't need to worry about the GC
@@ -3226,7 +3256,7 @@ class InspectorSerializationDelegate implements DiagnosticsSerializationDelegate
     if (creationLocation != null) {
       result['locationId'] = _toLocationId(creationLocation);
       result['creationLocation'] = creationLocation.toJsonMap();
-      if (service._isLocalCreationLocation(creationLocation)) {
+      if (service._isLocalCreationLocation(creationLocation.file)) {
         _nodesCreatedByLocalProject.add(node);
         result['createdByLocalProject'] = true;
       }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -3095,7 +3095,7 @@ bool debugIsLocalCreationLocation(Object object) {
 /// Returns true if a [Widget] is user created.
 ///
 /// This is a faster variant of `debugIsLocalCreationLocation` that is available
-/// in debug and profile builds.
+/// in debug and profile builds but only works for [Widget].
 bool debugIsWidgetLocalCreation(Widget widget) {
   final _Location? location = _getObjectCreationLocation(widget);
   return location != null &&
@@ -3124,7 +3124,7 @@ _Location? _getObjectCreationLocation(Object object) {
 ///
 /// Currently creation locations are only available for [Widget] and [Element].
 _Location? _getCreationLocation(Object? object) {
-  final Object? candidate =  object is Element && !object.debugIsDefunct ? object.widget : object;
+  final Object? candidate = object is Element && !object.debugIsDefunct ? object.widget : object;
   return candidate == null ? null : _getObjectCreationLocation(candidate);
 }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -3014,13 +3014,29 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       );
 
       final Element element = key.currentContext! as Element;
-      expect(debugIsWidgetLocalCreation(element.widget),
-          equals(WidgetInspectorService.instance.isWidgetCreationTracked()));
+      expect(debugIsWidgetLocalCreation(element.widget), isTrue);
 
       final Finder paddingFinder = find.byType(Padding);
       final Element paddingElement = paddingFinder.evaluate().first;
       expect(debugIsWidgetLocalCreation(paddingElement.widget), isFalse);
-    });
+    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
+
+    testWidgets('debugIsWidgetLocalCreation false test', (WidgetTester tester) async {
+      final GlobalKey key = GlobalKey();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            child: Text('target', key: key, textDirection: TextDirection.ltr),
+          ),
+        ),
+      );
+
+      final Element element = key.currentContext! as Element;
+      expect(debugIsWidgetLocalCreation(element.widget), isFalse);
+    }, skip: WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --no-track-widget-creation flag.
 
     test('devToolsInspectorUri test', () {
       activeDevToolsServerAddress = 'http://127.0.0.1:9100';

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2998,6 +2998,30 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(debugIsLocalCreationLocation(paddingElement.widget), isFalse);
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
 
+    testWidgets('debugIsWidgetLocalCreation test', (WidgetTester tester) async {
+      setupDefaultPubRootDirectory(service);
+
+      final GlobalKey key = GlobalKey();
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Container(
+            padding: const EdgeInsets.all(8),
+            child: Text('target', key: key, textDirection: TextDirection.ltr),
+          ),
+        ),
+      );
+
+      final Element element = key.currentContext! as Element;
+      expect(debugIsWidgetLocalCreation(element.widget),
+          equals(WidgetInspectorService.instance.isWidgetCreationTracked()));
+
+      final Finder paddingFinder = find.byType(Padding);
+      final Element paddingElement = paddingFinder.evaluate().first;
+      expect(debugIsWidgetLocalCreation(paddingElement.widget), isFalse);
+    });
+
     test('devToolsInspectorUri test', () {
       activeDevToolsServerAddress = 'http://127.0.0.1:9100';
       connectedVmServiceUri = 'http://127.0.0.1:55269/798ay5al_FM=/';

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -222,7 +222,7 @@ class KernelSnapshot extends Target {
       ),
       aot: buildMode.isPrecompiled,
       buildMode: buildMode,
-      trackWidgetCreation: trackWidgetCreation && buildMode == BuildMode.debug,
+      trackWidgetCreation: trackWidgetCreation && buildMode != BuildMode.release,
       targetModel: targetModel,
       outputFilePath: environment.buildDir.childFile('app.dill').path,
       packagesPath: packagesFile.path,

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -93,6 +93,7 @@ void main() {
         '--target=flutter',
         '--no-print-incremental-dependencies',
         ...buildModeOptions(BuildMode.profile, <String>[]),
+        '--track-widget-creation',
         '--aot',
         '--tfa',
         '--packages',
@@ -109,7 +110,7 @@ void main() {
     expect(processManager, hasNoRemainingExpectations);
   });
 
-  testWithoutContext('KernelSnapshot does not use track widget creation on profile builds', () async {
+  testWithoutContext('KernelSnapshot does use track widget creation on profile builds', () async {
     fileSystem.file('.dart_tool/package_config.json')
       ..createSync(recursive: true)
       ..writeAsStringSync('{"configVersion": 2, "packages":[]}');
@@ -129,6 +130,7 @@ void main() {
         '--target=flutter',
         '--no-print-incremental-dependencies',
         ...buildModeOptions(BuildMode.profile, <String>[]),
+        '--track-widget-creation',
         '--aot',
         '--tfa',
         '--packages',
@@ -166,6 +168,7 @@ void main() {
         '--target=flutter',
         '--no-print-incremental-dependencies',
         ...buildModeOptions(BuildMode.profile, <String>[]),
+        '--track-widget-creation',
         '--aot',
         '--tfa',
         '--packages',
@@ -204,6 +207,7 @@ void main() {
         '--target=flutter',
         '--no-print-incremental-dependencies',
         ...buildModeOptions(BuildMode.profile, <String>[]),
+        '--track-widget-creation',
         '--aot',
         '--tfa',
         '--packages',


### PR DESCRIPTION
Turning on widget creation tracking for profile builds allows us to do performance evaluation techniques that wouldn't scale across all widgets.  In this case we are using it to track build time for widgets on the CPU but it will also allow us to start tracking raster performance of widgets (cc @iskakaushik)

Added overhead (profile builds):
 * memory
   * ~50 bytes per widget for the construction location (I don't believe we are taking advantage of `const` to reduce this)
   * Memoization of `_isLocalCreationLocation`, ~5 bytes per source file used in the app that constructs widgets.
 * cpu
   *  An extra timeline event for each user created widget's `build`
   * Extra parameter for each widget constructor call
   * String comparisons against construction file uri (memoized with HashMap) for build of each widget

fixes https://github.com/flutter/flutter/issues/100928

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
