### PR TITLE
Fix constructor doc for ScrollView.primary

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -71,7 +71,11 @@ enum ScrollViewKeyboardDismissBehavior {
 abstract class ScrollView extends StatelessWidget {
   /// Creates a widget that scrolls.
   ///
-  /// If the [primary] argument is true, the [controller] must be null.
+  /// The [ScrollView.primary] argument defaults to true for vertical
+  /// scroll views if no [controller] has been provided. The [controller] argument
+  /// must be null if [primary] is explicitly set to true. If [primary] is true,
+  /// the nearest [PrimaryScrollController] surrounding the widget is attached
+  /// to this scroll view.
   ///
   /// If the [shrinkWrap] argument is true, the [center] argument must be null.
   ///


### PR DESCRIPTION
Fixes that the `ScrollView` constructor docs [1] are not linking to the `primary` member, which has more information about what `primary` means. Also adds a little bit of that information (including the default value) to the constructor for context.

[1] https://master-api.flutter.dev/flutter/widgets/ScrollView/ScrollView.html