### PR TITLE
[flutter_conductor] Extend timeout for codesign integration test

### DIFF
--- a/dev/conductor/core/test/codesign_integration_test.dart
+++ b/dev/conductor/core/test/codesign_integration_test.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// This test clones the framework and downloads pre-built binaries; it sometimes
+// times out with the default 5 minutes: https://github.com/flutter/flutter/issues/100937
+@Timeout(Duration(minutes: 10))
+
 import 'package:args/command_runner.dart';
 import 'package:conductor_core/src/codesign.dart' show CodesignCommand;
 import 'package:conductor_core/src/globals.dart';


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100937