### PR TITLE
Revert "Reland: "Use texture layer when displaying an Android view" "

### DIFF
--- a/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
+++ b/dev/integration_tests/hybrid_android_views/android/app/src/main/AndroidManifest.xml
@@ -16,8 +16,7 @@ found in the LICENSE file. -->
             android:launchMode="singleTop"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale|screenLayout|density"
             android:hardwareAccelerated="true"
-            android:windowSoftInputMode="adjustResize"
-            android:exported="true">
+            android:windowSoftInputMode="adjustResize">
             <meta-data
                 android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
                 android:value="true" />
@@ -29,5 +28,9 @@ found in the LICENSE file. -->
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Hybrid composition -->
+        <meta-data
+            android:name="io.flutter.embedded_views_preview"
+            android:value="true" />
     </application>
 </manifest>

--- a/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
@@ -17,7 +17,6 @@ class AndroidPlatformView extends StatelessWidget {
   const AndroidPlatformView({
     Key? key,
     this.onPlatformViewCreated,
-    this.useHybridComposition = false,
     required this.viewType,
   })  : assert(viewType != null),
         super(key: key);
@@ -32,9 +31,6 @@ class AndroidPlatformView extends StatelessWidget {
   /// May be null.
   final PlatformViewCreatedCallback? onPlatformViewCreated;
 
-  // Use hybrid composition.
-  final bool useHybridComposition;
-
   @override
   Widget build(BuildContext context) {
     return PlatformViewLink(
@@ -48,27 +44,17 @@ class AndroidPlatformView extends StatelessWidget {
         );
       },
       onCreatePlatformView: (PlatformViewCreationParams params) {
-        print('useHybridComposition=$useHybridComposition');
-        late AndroidViewController controller;
-        if (useHybridComposition) {
-          controller = PlatformViewsService.initExpensiveAndroidView(
+        final AndroidViewController controller =
+          PlatformViewsService.initSurfaceAndroidView(
             id: params.id,
             viewType: params.viewType,
             layoutDirection: TextDirection.ltr,
-          );
-        } else {
-          controller = PlatformViewsService.initSurfaceAndroidView(
-            id: params.id,
-            viewType: params.viewType,
-            layoutDirection: TextDirection.ltr,
-          );
-        }
+          )
+          ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated);
         if (onPlatformViewCreated != null) {
           controller.addOnPlatformViewCreatedListener(onPlatformViewCreated!);
         }
-        return controller
-          ..addOnPlatformViewCreatedListener(params.onPlatformViewCreated)
-          ..create();
+        return controller..create();
       },
     );
   }

--- a/dev/integration_tests/hybrid_android_views/lib/nested_view_event_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/nested_view_event_page.dart
@@ -39,7 +39,6 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
   int? id;
   int nestedViewClickCount = 0;
   bool showPlatformView = true;
-  bool useHybridComposition = false;
 
   @override
   Widget build(BuildContext context) {
@@ -56,7 +55,6 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
                   key: const ValueKey<String>('PlatformView'),
                   viewType: 'simple_view',
                   onPlatformViewCreated: onPlatformViewCreated,
-                  useHybridComposition: useHybridComposition,
                 ) : null,
           ),
           if (_lastTestStatus != _LastTestStatus.pending) _statusWidget(),
@@ -70,15 +68,6 @@ class NestedViewEventBodyState extends State<NestedViewEventBody> {
               key: const ValueKey<String>('TogglePlatformView'),
               onPressed: onTogglePlatformView,
               child: const Text('TOGGLE PLATFORM VIEW'),
-            ),
-            ElevatedButton(
-              key: const ValueKey<String>('ToggleHybridComposition'),
-              child: const Text('TOGGLE HYBRID COMPOSITION'),
-              onPressed: () {
-                setState(() {
-                  useHybridComposition = !useHybridComposition;
-                });
-              },
             ),
             Row(
               children: <Widget>[

--- a/dev/integration_tests/hybrid_android_views/test_driver/main_test.dart
+++ b/dev/integration_tests/hybrid_android_views/test_driver/main_test.dart
@@ -59,58 +59,10 @@ Future<void> main() async {
     }, timeout: Timeout.none);
   });
 
-  group('Flutter surface without hybrid composition', () {
+  group('Flutter surface switch', () {
     setUpAll(() async {
-      await driver.tap(find.byValueKey('NestedViewEventTile'));
-    });
-
-    tearDownAll(() async {
-      await driver.waitFor(find.pageBack());
-      await driver.tap(find.pageBack());
-    });
-
-    test('Uses FlutterSurfaceView when Android view is on the screen', () async {
-      await driver.waitFor(find.byValueKey('PlatformView'));
-
-      expect(
-        await driver.requestData('hierarchy'),
-        '|-FlutterView\n'
-        '  |-FlutterSurfaceView\n' // Flutter UI
-        '  |-ViewGroup\n'  // Platform View
-        '    |-ViewGroup\n'
-      );
-
-      // Hide platform view.
-      final SerializableFinder togglePlatformView = find.byValueKey('TogglePlatformView');
-      await driver.tap(togglePlatformView);
-      await driver.waitForAbsent(find.byValueKey('PlatformView'));
-
-      expect(
-        await driver.requestData('hierarchy'),
-        '|-FlutterView\n'
-        '  |-FlutterSurfaceView\n' // Just the Flutter UI
-      );
-
-      // Show platform view again.
-      await driver.tap(togglePlatformView);
-      await driver.waitFor(find.byValueKey('PlatformView'));
-
-      expect(
-        await driver.requestData('hierarchy'),
-        '|-FlutterView\n'
-        '  |-FlutterSurfaceView\n' // Flutter UI
-        '  |-ViewGroup\n' // Platform View
-        '    |-ViewGroup\n'
-      );
-    }, timeout: Timeout.none);
-  });
-
-  group('Flutter surface with hybrid composition', () {
-    setUpAll(() async {
-      await driver.tap(find.byValueKey('NestedViewEventTile'));
-      await driver.tap(find.byValueKey('ToggleHybridComposition'));
-      await driver.tap(find.byValueKey('TogglePlatformView'));
-      await driver.tap(find.byValueKey('TogglePlatformView'));
+      final SerializableFinder wmListTile = find.byValueKey('NestedViewEventTile');
+      await driver.tap(wmListTile);
     });
 
     tearDownAll(() async {

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -151,38 +151,6 @@ void main() {
     // Passes if no crashes.
   });
 
-  test('created callback is reset when controller is changed', () {
-    final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
-    viewsController.registerViewType('webview');
-    final AndroidViewController firstController = PlatformViewsService.initAndroidView(
-      id: 0,
-      viewType: 'webview',
-      layoutDirection: TextDirection.rtl,
-    );
-    final RenderAndroidView renderBox = RenderAndroidView(
-      viewController: firstController,
-      hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-      gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
-    );
-    layout(renderBox);
-    pumpFrame(phase: EnginePhase.flushSemantics);
-
-    expect(firstController.createdCallbacks, isNotEmpty);
-    expect(firstController.createdCallbacks.length, 1);
-
-    final AndroidViewController secondController = PlatformViewsService.initAndroidView(
-      id: 0,
-      viewType: 'webview',
-      layoutDirection: TextDirection.rtl,
-    );
-    // Reset controller.
-    renderBox.controller = secondController;
-
-    expect(firstController.createdCallbacks, isEmpty);
-    expect(secondController.createdCallbacks, isNotEmpty);
-    expect(secondController.createdCallbacks.length, 1);
-  });
-
   test('render object changed its visual appearance after texture is created', () {
     FakeAsync().run((FakeAsync async) {
       final AndroidViewController viewController =

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -84,22 +84,23 @@ class FakeAndroidViewController implements AndroidViewController {
 
   @override
   Future<Size> setSize(Size size) {
-    return Future<Size>.value(size);
+    throw UnimplementedError();
   }
 
   @override
-  Future<void> setOffset(Offset off) async {}
-
-  @override
-  int get textureId => 0;
-
-  @override
-  bool get isCreated => created;
-
-  @override
-  void addOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) {
-    created = true;
+  Future<void> setOffset(Offset off) {
+    throw UnimplementedError();
   }
+
+  @override
+  int get textureId => throw UnimplementedError();
+
+  @override
+  bool get isCreated => throw UnimplementedError();
+
+  @override
+  void addOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) =>
+      throw UnimplementedError();
 
   @override
   void removeOnPlatformViewCreatedListener(PlatformViewCreatedCallback listener) {
@@ -117,10 +118,9 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  Future<void> create() async {}
-
-  @override
-  List<PlatformViewCreatedCallback> get createdCallbacks => <PlatformViewCreatedCallback>[];
+  Future<void> create() async {
+    created = true;
+  }
 }
 
 class FakeAndroidPlatformViewsController {
@@ -142,6 +142,8 @@ class FakeAndroidPlatformViewsController {
   Completer<void>? createCompleter;
 
   int? lastClearedFocusViewId;
+
+  bool synchronizeToNativeViewHierarchy = true;
 
   Map<int, Offset> offsets = <int, Offset>{};
 
@@ -172,6 +174,8 @@ class FakeAndroidPlatformViewsController {
         return _clearFocus(call);
       case 'offset':
         return _offset(call);
+      case 'synchronizeToNativeViewHierarchy':
+        return _synchronizeToNativeViewHierarchy(call);
     }
     return Future<dynamic>.sync(() => null);
   }
@@ -312,6 +316,11 @@ class FakeAndroidPlatformViewsController {
       );
 
     lastClearedFocusViewId = id;
+    return Future<dynamic>.sync(() => null);
+  }
+
+  Future<dynamic> _synchronizeToNativeViewHierarchy(MethodCall call) {
+    synchronizeToNativeViewHierarchy = call.arguments as bool;
     return Future<dynamic>.sync(() => null);
   }
 }

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('create Android view of unregistered type', () async {
-      expectLater(
+      expect(
         () {
           return PlatformViewsService.initAndroidView(
             id: 0,
@@ -29,25 +29,16 @@ void main() {
         throwsA(isA<PlatformException>()),
       );
 
-      try {
-        await PlatformViewsService.initSurfaceAndroidView(
-          id: 0,
-          viewType: 'web',
-          layoutDirection: TextDirection.ltr,
-        ).create();
-      } catch (e) {
-        expect(false, isTrue, reason: 'did not expected any exception, but instead got `$e`');
-      }
-
-      try {
-        await PlatformViewsService.initAndroidView(
-          id: 0,
-          viewType: 'web',
-          layoutDirection: TextDirection.ltr,
-        ).create();
-      } catch (e) {
-        expect(false, isTrue, reason: 'did not expected any exception, but instead got `$e`');
-      }
+      expect(
+        () {
+          return PlatformViewsService.initSurfaceAndroidView(
+            id: 0,
+            viewType: 'web',
+            layoutDirection: TextDirection.ltr,
+          ).create();
+        },
+        throwsA(isA<PlatformException>()),
+      );
     });
 
     test('create Android views', () async {
@@ -56,13 +47,13 @@ void main() {
           .setSize(const Size(100.0, 100.0));
       await PlatformViewsService.initAndroidView( id: 1, viewType: 'webview', layoutDirection: TextDirection.rtl)
           .setSize(const Size(200.0, 300.0));
-      // This platform view isn't created until the size is set.
       await PlatformViewsService.initSurfaceAndroidView(id: 2, viewType: 'webview', layoutDirection: TextDirection.rtl).create();
       expect(
         viewsController.views,
         unorderedEquals(<FakeAndroidPlatformView>[
           const FakeAndroidPlatformView(0, 'webview', Size(100.0, 100.0), AndroidViewController.kAndroidLayoutDirectionLtr, null),
           const FakeAndroidPlatformView(1, 'webview', Size(200.0, 300.0), AndroidViewController.kAndroidLayoutDirectionRtl, null),
+          const FakeAndroidPlatformView(2, 'webview', null, AndroidViewController.kAndroidLayoutDirectionRtl, true),
         ]),
       );
     });
@@ -74,12 +65,26 @@ void main() {
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
       ).setSize(const Size(100.0, 100.0));
-      expectLater(
+      expect(
         () => PlatformViewsService.initAndroidView(
           id: 0,
           viewType: 'web',
           layoutDirection: TextDirection.ltr,
         ).setSize(const Size(100.0, 100.0)),
+        throwsA(isA<PlatformException>()),
+      );
+
+      await PlatformViewsService.initSurfaceAndroidView(
+        id: 1,
+        viewType: 'webview',
+        layoutDirection: TextDirection.ltr,
+      ).create();
+      expect(
+        () => PlatformViewsService.initSurfaceAndroidView(
+          id: 1,
+          viewType: 'web',
+          layoutDirection: TextDirection.ltr,
+        ).create(),
         throwsA(isA<PlatformException>()),
       );
     });
@@ -234,6 +239,11 @@ void main() {
       PlatformViewsService.initAndroidView(id: 7, viewType: 'webview', layoutDirection: TextDirection.ltr);
       await viewController.setOffset(const Offset(10, 20));
       expect(viewsController.offsets, equals(<int, Offset>{}));
+    });
+
+    test('synchronizeToNativeViewHierarchy', () async {
+      await PlatformViewsService.synchronizeToNativeViewHierarchy(false);
+      expect(viewsController.synchronizeToNativeViewHierarchy, false);
     });
   });
 


### PR DESCRIPTION
Reverts flutter/flutter#100934

It looks like [android hybrid_android_views_integration_test](https://ci.chromium.org/p/flutter/builders/prod/Linux_android%20hybrid_android_views_integration_test) is failing consistently after this change.