### PR TITLE
[WIP] Add an option to use space out trailing widget

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -98,6 +98,7 @@ class NavigationRail extends StatefulWidget {
     this.minExtendedWidth,
     this.useIndicator,
     this.indicatorColor,
+    this.spacedTrailing = false,
   }) :  assert(destinations != null && destinations.length >= 2),
         assert(selectedIndex == null || (0 <= selectedIndex && selectedIndex < destinations.length)),
         assert(elevation == null || elevation > 0),
@@ -106,6 +107,7 @@ class NavigationRail extends StatefulWidget {
         assert((minWidth == null || minExtendedWidth == null) || minExtendedWidth >= minWidth),
         assert(extended != null),
         assert(!extended || (labelType == null || labelType == NavigationRailLabelType.none)),
+        assert(spacedTrailing != null),
         super(key: key);
 
   /// Sets the color of the Container that holds all of the [NavigationRail]'s
@@ -297,6 +299,13 @@ class NavigationRail extends StatefulWidget {
   /// when [useIndicator] is true.
   final Color? indicatorColor;
 
+  /// When `true`, the [NavigationRail.trailing] will be placed below the [destinations]
+  /// group and [groupAlignment] will not effect the alignment of the [trailing] widget.
+  /// The [trailing] widget will be placed at the bottom of the rail.
+  ///
+  /// Defaults to `false`, which places the [trailing] widget at the bottom of the [destinations] group.
+  final bool spacedTrailing;
+
   /// Returns the animation that controls the [NavigationRail.extended] state.
   ///
   /// This can be used to synchronize animations in the [leading] or [trailing]
@@ -438,12 +447,18 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
                             tabCount: widget.destinations.length,
                           ),
                         ),
-                      if (widget.trailing != null)
+                      if (widget.trailing != null && !widget.spacedTrailing)
                         widget.trailing!,
                     ],
                   ),
                 ),
               ),
+              if (widget.trailing != null && widget.spacedTrailing)
+                ...<Widget>[
+                  _verticalSpacer,
+                  widget.trailing!,
+                  _verticalSpacer,
+                ],
             ],
           ),
         ),

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -1513,10 +1513,26 @@ void main() {
       ),
     );
 
-    final RenderBox leading = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(0));
-    final RenderBox trailing = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(1));
+    RenderBox leading = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(0));
+    RenderBox trailing = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(1));
     expect(leading.localToGlobal(Offset.zero), Offset((80 - leading.size.width) / 2, 8.0));
     expect(trailing.localToGlobal(Offset.zero), Offset((80 - trailing.size.width) / 2, 248.0));
+
+    await _pumpNavigationRail(
+      tester,
+      navigationRail: NavigationRail(
+        selectedIndex: 0,
+        leading: FloatingActionButton(onPressed: () { }),
+        trailing: FloatingActionButton(onPressed: () { }),
+        spacedTrailing: true,
+        destinations: _destinations(),
+      ),
+    );
+
+    leading = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(0));
+    trailing = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(1));
+    expect(leading.localToGlobal(Offset.zero), Offset((80 - leading.size.width) / 2, 8.0));
+    expect(trailing.localToGlobal(Offset.zero), Offset((80 - trailing.size.width) / 2, 536.0));
   });
 
   testWidgets('Extended rail animates the width and labels appear - [textDirection]=LTR', (WidgetTester tester) async {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/100944

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key, this.dark = true, this.useMaterial3 = true})
      : super(key: key);

  final bool dark;
  final bool useMaterial3;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      title: 'Material App',
      themeMode: dark ? ThemeMode.dark : ThemeMode.light,
      theme:  ThemeData.light().copyWith(useMaterial3: useMaterial3),
      darkTheme: ThemeData.dark().copyWith(useMaterial3: useMaterial3),
      home: NavigationRailSample(),
    );
  }
}

class NavigationRailSample extends StatelessWidget {
  NavigationRailSample({Key? key}) : super(key: key);
  final ValueNotifier<int> _railIndex = ValueNotifier<int>(0);

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text(' NavigationRail Sample'),
      ),
      body: ValueListenableBuilder(
        valueListenable: _railIndex,
        builder: (BuildContext context, int railIndex, Widget? child) {
          return Row(
            children: <Widget>[
              NavigationRail(
                leading: DecoratedBox(
                  decoration: BoxDecoration(
                    border: Border.all(
                      color: Colors.black,
                      width: 2,
                    ),
                    shape: BoxShape.circle,
                    color: Theme.of(context).colorScheme.secondaryContainer,
                  ),
                  child: const Padding(
                    padding: EdgeInsets.all(6.0),
                    child: FlutterLogo(
                      size: 40.0,
                    ),
                  ),
                ),
                trailing: DecoratedBox(
                  decoration: BoxDecoration(
                    border: Border.all(
                      color: Colors.black,
                      width: 2,
                    ),
                    shape: BoxShape.circle,
                    color: Theme.of(context).colorScheme.secondaryContainer,
                  ),
                  child: const Padding(
                    padding: EdgeInsets.all(6.0),
                    child: FlutterLogo(
                      size: 40.0,
                    ),
                  ),
                ),
                spacedTrailing: false,
                selectedIndex: railIndex,
                onDestinationSelected: (int newIndex) =>
                    _railIndex.value = newIndex,
                labelType: NavigationRailLabelType.all,
                destinations: const <NavigationRailDestination>[
                  NavigationRailDestination(
                    icon: Icon(Icons.favorite_border),
                    selectedIcon: Icon(Icons.favorite),
                    label: Text('First'),
                  ),
                  NavigationRailDestination(
                    icon: Icon(Icons.bookmark_border),
                    selectedIcon: Icon(Icons.book),
                    label: Text('Second'),
                  ),
                  NavigationRailDestination(
                    icon: Icon(Icons.star_border),
                    selectedIcon: Icon(Icons.star),
                    label: Text('Third'),
                  ),
                ],
              ),
              const VerticalDivider(thickness: 1, width: 1),
              Expanded(
                child: Center(
                  child: Text('selectedIndex: ${_railIndex.value}'),
                ),
              )
            ],
          );
        },
      ),
    );
  }
}
``` 
	


</details>

<details> 
<summary>Preview</summary> 
	
![Screenshot 2022-03-29 at 13 41 43](https://user-images.githubusercontent.com/48603081/160601597-ed59f8c7-8f64-4129-ad89-5da588345b33.png)
![Screenshot 2022-03-29 at 13 41 57](https://user-images.githubusercontent.com/48603081/160601605-d08b8d21-8f22-4dc1-bdea-4d08d1692417.png)
	
</details>



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
