### PR TITLE
Roll gallery to d63bd9200b6a8ad69d47bdc5e4059fadb9c962c1

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = '0e7835661dad4af7d745d4751fd1958a66fc03e1';
+const String galleryVersion = 'd63bd9200b6a8ad69d47bdc5e4059fadb9c962c1';


### PR DESCRIPTION
Fixes the tree: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux_samsung_s10%20new_gallery__transition_perf/279/overview

Will be submitted on red to fix the tree.