### PR TITLE
Roll gallery to 03dedee4bc24878fec1c1d1338daffd5b792a29d

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = 'd63bd9200b6a8ad69d47bdc5e4059fadb9c962c1';
+const String galleryVersion = '03dedee4bc24878fec1c1d1338daffd5b792a29d';


### PR DESCRIPTION
Fixes another tree issue: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8818335435224506209/+/u/run_new_gallery__transition_perf/test_stdout

I plan to submit this on red without waiting for all the checks to get the tree back to green.