### PR TITLE
Fix screenshot web integration testing bug

### DIFF
--- a/packages/integration_test/lib/integration_test_driver_extended.dart
+++ b/packages/integration_test/lib/integration_test_driver_extended.dart
@@ -99,6 +99,7 @@ Future<void> integrationDriver(
     final List<String> failures = <String>[];
     for (final dynamic screenshot in screenshots) {
       final Map<String, dynamic> data = screenshot as Map<String, dynamic>;
+      if (data['screenshotName'] == null) continue;
       final List<dynamic> screenshotBytes = data['bytes'] as List<dynamic>;
       final String screenshotName = data['screenshotName'] as String;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/86985

Taking a screenshot during integration testing for web works when not in null-safe mode but dies with a null-to-string cast when in null-safe mode. This PR adds a null check to bail early in a loop when no screenshots need to be processed.