### PR TITLE
Fix `LicensePage` too much spacing padding when `applicationVersion` and  `applicationLegalese` are empty

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -493,18 +493,28 @@ class _AboutProgram extends StatelessWidget {
           ),
           if (icon != null)
             IconTheme(data: Theme.of(context).iconTheme, child: icon!),
-          Text(
-            version,
-            style: Theme.of(context).textTheme.bodyText2,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: _textVerticalSeparation),
-          Text(
-            legalese ?? '',
-            style: Theme.of(context).textTheme.caption,
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: _textVerticalSeparation),
+          if (version != null && version != '')
+            Padding(
+              padding: const EdgeInsets.only(bottom: _textVerticalSeparation),
+              child: Text(
+                version,
+                style: Theme.of(context).textTheme.bodyText2,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          if (legalese != null && legalese != '')
+            Padding(
+              padding: const EdgeInsets.only(bottom: _textVerticalSeparation),
+              child: Text(
+                legalese!,
+                style: Theme.of(context).textTheme.caption,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          // When both app version and legalese are missing, the padding is provided between the
+          // app icon and powered by line.
+          if ((version == null || version == '') && (legalese == null || legalese == ''))
+            const SizedBox(height: _textVerticalSeparation),
           Text(
             'Powered by Flutter',
             style: Theme.of(context).textTheme.bodyText2,

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -503,18 +503,12 @@ class _AboutProgram extends StatelessWidget {
               ),
             ),
           if (legalese != null && legalese != '')
-            Padding(
-              padding: const EdgeInsets.only(bottom: _textVerticalSeparation),
-              child: Text(
-                legalese!,
-                style: Theme.of(context).textTheme.caption,
-                textAlign: TextAlign.center,
-              ),
+            Text(
+              legalese!,
+              style: Theme.of(context).textTheme.caption,
+              textAlign: TextAlign.center,
             ),
-          // When both app version and legalese are missing, the padding is provided between the
-          // app icon and powered by line.
-          if ((version == null || version == '') && (legalese == null || legalese == ''))
-            const SizedBox(height: _textVerticalSeparation),
+          const SizedBox(height: _textVerticalSeparation),
           Text(
             'Powered by Flutter',
             style: Theme.of(context).textTheme.bodyText2,

--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -493,7 +493,7 @@ class _AboutProgram extends StatelessWidget {
           ),
           if (icon != null)
             IconTheme(data: Theme.of(context).iconTheme, child: icon!),
-          if (version != null && version != '')
+          if (version != '')
             Padding(
               padding: const EdgeInsets.only(bottom: _textVerticalSeparation),
               child: Text(

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -881,6 +881,83 @@ void main() {
     expect(find.byType(RawScrollbar), findsNothing);
 
   }, variant: TargetPlatformVariant.all());
+
+  testWidgets('LicensePage padding', (WidgetTester tester) async {
+    const FlutterLogo logo = FlutterLogo();
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        title: 'Pirate app',
+        home: Center(
+          child: LicensePage(
+            applicationName: 'LicensePage test app',
+            applicationIcon: logo,
+            applicationVersion: '0.1.2',
+            applicationLegalese: 'I am the very model of a modern major general.',
+          ),
+        ),
+      ),
+    );
+
+    final Finder appName = find.text('LicensePage test app');
+    final Finder appIcon = find.byType(FlutterLogo);
+    final Finder appVersion = find.text('0.1.2');
+    final Finder appLegalese = find.text('I am the very model of a modern major general.');
+    final Finder appPowered = find.text('Powered by Flutter');
+
+    expect(appName, findsOneWidget);
+    expect(appIcon, findsOneWidget);
+    expect(appVersion, findsOneWidget);
+    expect(appLegalese, findsOneWidget);
+    expect(appPowered, findsOneWidget);
+
+    // Bottom padding is applied to the app version and app legalese text.
+    final double appNameBottomPadding = tester.getTopLeft(appIcon).dy - tester.getBottomLeft(appName).dy;
+    expect(appNameBottomPadding, 0.0);
+
+    final double appIconBottomPadding = tester.getTopLeft(appVersion).dy - tester.getBottomLeft(appIcon).dy;
+    expect(appIconBottomPadding, 0.0);
+
+    final double appVersionBottomPadding = tester.getTopLeft(appLegalese).dy - tester.getBottomLeft(appVersion).dy;
+    expect(appVersionBottomPadding, 18.0);
+
+    final double appLegaleseBottomPadding = tester.getTopLeft(appPowered).dy - tester.getBottomLeft(appLegalese).dy;
+    expect(appLegaleseBottomPadding, 18.0);
+  });
+
+  testWidgets('LicensePage has no extra padding between app icon and app powered text', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/99559
+
+    const FlutterLogo logo = FlutterLogo();
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        title: 'Pirate app',
+        home: Center(
+          child: LicensePage(
+            applicationIcon: logo,
+          ),
+        ),
+      ),
+    );
+
+    final Finder appName = find.text('LicensePage test app');
+    final Finder appIcon = find.byType(FlutterLogo);
+    final Finder appVersion = find.text('0.1.2');
+    final Finder appLegalese = find.text('I am the very model of a modern major general.');
+    final Finder appPowered = find.text('Powered by Flutter');
+
+    expect(appName, findsNothing);
+    expect(appIcon, findsOneWidget);
+    expect(appVersion, findsNothing);
+    expect(appLegalese, findsNothing);
+    expect(appPowered, findsOneWidget);
+
+    // Padding between app icon and app powered text.
+    final double appIconBottomPadding = tester.getTopLeft(appPowered).dy - tester.getBottomLeft(appIcon).dy;
+    expect(appIconBottomPadding, 18.0);
+  });
+
 }
 
 class FakeLicenseEntry extends LicenseEntry {

--- a/packages/flutter/test/material/about_test.dart
+++ b/packages/flutter/test/material/about_test.dart
@@ -957,7 +957,6 @@ void main() {
     final double appIconBottomPadding = tester.getTopLeft(appPowered).dy - tester.getBottomLeft(appIcon).dy;
     expect(appIconBottomPadding, 18.0);
   });
-
 }
 
 class FakeLicenseEntry extends LicenseEntry {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/99559

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      debugShowCheckedModeBanner: false,
      title: 'Material App',
      home: Sample(),
    );
  }
}

class Sample extends StatelessWidget {
  const Sample({Key? key}) : super(key: key);

  @override
  Widget build(BuildContext context) {
    return const Scaffold(
      body: Center(
        child: LicensePage(
          // applicationName: 'LicensePage test app',
          // applicationVersion: '0.1.2',
          applicationIcon: FlutterLogo(size: 100),
          // applicationLegalese: 'I am the very model of a modern major general.',
        ),
      ),
    );
  }
}
``` 
	

</details>

| Before | After |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/160794855-132f8c54-8f9e-4b64-97db-3a4e09c76d54.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/160794871-fa396d8e-a666-4f1f-ae6e-6f2751d1de42.png" height="450" /> |



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
