### PR TITLE
Make hybrid_android_views_integration_test fail the build

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1984,7 +1984,6 @@ targets:
   - name: Linux_android hybrid_android_views_integration_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/100991
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100991

This test is consistently passing after the latest changes https://ci.chromium.org/p/flutter/builders/prod/Linux_android%20hybrid_android_views_integration_test

