### PR TITLE
Fix Local `DataTableTheme` not being inherited by `DataTable` Widget

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -733,6 +733,7 @@ class DataTable extends StatelessWidget {
     required MaterialStateProperty<Color?>? overlayColor,
   }) {
     final ThemeData themeData = Theme.of(context);
+    final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
     label = Row(
       textDirection: numeric ? TextDirection.rtl : null,
       children: <Widget>[
@@ -750,9 +751,11 @@ class DataTable extends StatelessWidget {
     );
 
     final TextStyle effectiveHeadingTextStyle = headingTextStyle
+      ?? dataTableTheme.headingTextStyle
       ?? themeData.dataTableTheme.headingTextStyle
       ?? themeData.textTheme.subtitle2!;
     final double effectiveHeadingRowHeight = headingRowHeight
+      ?? dataTableTheme.headingRowHeight
       ?? themeData.dataTableTheme.headingRowHeight
       ?? _headingRowHeight;
     label = Container(
@@ -800,6 +803,7 @@ class DataTable extends StatelessWidget {
     required GestureLongPressCallback? onRowLongPress,
   }) {
     final ThemeData themeData = Theme.of(context);
+    final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
     if (showEditIcon) {
       const Widget icon = Icon(Icons.edit, size: 18.0);
       label = Expanded(child: label);
@@ -810,9 +814,11 @@ class DataTable extends StatelessWidget {
     }
 
     final TextStyle effectiveDataTextStyle = dataTextStyle
+      ?? dataTableTheme.dataTextStyle
       ?? themeData.dataTableTheme.dataTextStyle
       ?? themeData.textTheme.bodyText2!;
     final double effectiveDataRowHeight = dataRowHeight
+      ?? dataTableTheme.dataRowHeight
       ?? themeData.dataTableTheme.dataRowHeight
       ?? kMinInteractiveDimension;
     label = Container(
@@ -856,9 +862,12 @@ class DataTable extends StatelessWidget {
     assert(!_debugInteractive || debugCheckHasMaterial(context));
 
     final ThemeData theme = Theme.of(context);
+    final DataTableThemeData dataTableTheme = DataTableTheme.of(context);
     final MaterialStateProperty<Color?>? effectiveHeadingRowColor = headingRowColor
+      ?? dataTableTheme.headingRowColor
       ?? theme.dataTableTheme.headingRowColor;
     final MaterialStateProperty<Color?>? effectiveDataRowColor = dataRowColor
+      ?? dataTableTheme.dataRowColor
       ?? theme.dataTableTheme.dataRowColor;
     final MaterialStateProperty<Color?> defaultRowColor = MaterialStateProperty.resolveWith(
       (Set<MaterialState> states) {
@@ -876,15 +885,19 @@ class DataTable extends StatelessWidget {
     final bool anyChecked = displayCheckboxColumn && rowsChecked.isNotEmpty;
     final bool someChecked = anyChecked && !allChecked;
     final double effectiveHorizontalMargin = horizontalMargin
+      ?? dataTableTheme.horizontalMargin
       ?? theme.dataTableTheme.horizontalMargin
       ?? _horizontalMargin;
     final double effectiveCheckboxHorizontalMarginStart = checkboxHorizontalMargin
+      ?? dataTableTheme.checkboxHorizontalMargin
       ?? theme.dataTableTheme.checkboxHorizontalMargin
       ?? effectiveHorizontalMargin;
     final double effectiveCheckboxHorizontalMarginEnd = checkboxHorizontalMargin
+      ?? dataTableTheme.checkboxHorizontalMargin
       ?? theme.dataTableTheme.checkboxHorizontalMargin
       ?? effectiveHorizontalMargin / 2.0;
     final double effectiveColumnSpacing = columnSpacing
+      ?? dataTableTheme.columnSpacing
       ?? theme.dataTableTheme.columnSpacing
       ?? _columnSpacing;
 
@@ -906,6 +919,7 @@ class DataTable extends StatelessWidget {
         final BorderSide borderSide = Divider.createBorderSide(
           context,
           width: dividerThickness
+            ?? dataTableTheme.dividerThickness
             ?? theme.dataTableTheme.dividerThickness
             ?? _dividerThickness,
         );
@@ -1017,7 +1031,7 @@ class DataTable extends StatelessWidget {
     }
 
     return Container(
-      decoration: decoration ?? theme.dataTableTheme.decoration,
+      decoration: decoration ?? dataTableTheme.decoration ?? theme.dataTableTheme.decoration,
       child: Material(
         type: MaterialType.transparency,
         child: Table(

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -243,6 +243,98 @@ void main() {
     expect(tester.getTopLeft(find.text('A')).dx, horizontalMargin);
     expect(tester.getTopLeft(find.text('Data 2')).dx - tester.getTopRight(find.text('Data')).dx, columnSpacing);
   });
+
+  testWidgets('Local DataTableTheme can override global DataTableTheme', (WidgetTester tester) async {
+    const BoxDecoration gloablThemeDecoration = BoxDecoration(color: Color(0xfffffff1));
+    final MaterialStateProperty<Color> gloablThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff0));
+    const double gloablThemeDataRowHeight = 50.0;
+    const TextStyle gloablThemeDataTextStyle = TextStyle(fontSize: 11.5);
+    final MaterialStateProperty<Color> gloablThemeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const double gloablThemeHeadingRowHeight = 51.0;
+    const TextStyle gloablThemeHeadingTextStyle = TextStyle(fontSize: 13.5);
+    const double gloablThemeHorizontalMargin = 2.0;
+    const double gloablThemeColumnSpacing = 3.0;
+    const double gloablThemeDividerThickness = 4.0;
+
+    const BoxDecoration localThemeDecoration = BoxDecoration(color: Color(0xfffffff0));
+    final MaterialStateProperty<Color> localThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const double localThemeDataRowHeight = 51.0;
+    const TextStyle localThemeDataTextStyle = TextStyle(fontSize: 12.5);
+    final MaterialStateProperty<Color> localThemeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff2));
+    const double localThemeHeadingRowHeight = 52.0;
+    const TextStyle localThemeHeadingTextStyle = TextStyle(fontSize: 14.5);
+    const double localThemeHorizontalMargin = 3.0;
+    const double localThemeColumnSpacing = 4.0;
+    const double localThemeDividerThickness = 5.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          dataTableTheme: DataTableThemeData(
+            decoration: gloablThemeDecoration,
+            dataRowColor: gloablThemeDataRowColor,
+            dataRowHeight: gloablThemeDataRowHeight,
+            dataTextStyle: gloablThemeDataTextStyle,
+            headingRowColor: gloablThemeHeadingRowColor,
+            headingRowHeight: gloablThemeHeadingRowHeight,
+            headingTextStyle: gloablThemeHeadingTextStyle,
+            horizontalMargin: gloablThemeHorizontalMargin,
+            columnSpacing: gloablThemeColumnSpacing,
+            dividerThickness: gloablThemeDividerThickness,
+          ),
+        ),
+        home: Scaffold(
+          body: DataTableTheme(
+            data: DataTableThemeData(
+              decoration: localThemeDecoration,
+              dataRowColor: localThemeDataRowColor,
+              dataRowHeight: localThemeDataRowHeight,
+              dataTextStyle: localThemeDataTextStyle,
+              headingRowColor: localThemeHeadingRowColor,
+              headingRowHeight: localThemeHeadingRowHeight,
+              headingTextStyle: localThemeHeadingTextStyle,
+              horizontalMargin: localThemeHorizontalMargin,
+              columnSpacing: localThemeColumnSpacing,
+              dividerThickness: localThemeDividerThickness,
+            ),
+            child: DataTable(
+              sortColumnIndex: 0,
+              columns: <DataColumn>[
+                DataColumn(
+                  label: const Text('A'),
+                  onSort: (int columnIndex, bool ascending) {},
+                ),
+                const DataColumn(label: Text('B')),
+              ],
+              rows: const <DataRow>[
+                DataRow(cells: <DataCell>[
+                  DataCell(Text('Data')),
+                  DataCell(Text('Data 2')),
+                ]),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder tableContainerFinder = find.ancestor(of: find.byType(Table), matching: find.byType(Container));
+    expect(tester.widgetList<Container>(tableContainerFinder).first.decoration, localThemeDecoration);
+
+    final TextStyle dataRowTextStyle = tester.renderObject<RenderParagraph>(find.text('Data')).text.style!;
+    expect(dataRowTextStyle.fontSize, localThemeDataTextStyle.fontSize);
+    expect(_tableRowBoxDecoration(tester: tester, index: 1).color, localThemeDataRowColor.resolve(<MaterialState>{}));
+    expect(_tableRowBoxDecoration(tester: tester, index: 1).border!.top.width, localThemeDividerThickness);
+    expect(tester.getSize(_findFirstContainerFor('Data')).height, localThemeDataRowHeight);
+
+    final TextStyle headingRowTextStyle = tester.renderObject<RenderParagraph>(find.text('A')).text.style!;
+    expect(headingRowTextStyle.fontSize, localThemeHeadingTextStyle.fontSize);
+    expect(_tableRowBoxDecoration(tester: tester, index: 0).color, localThemeHeadingRowColor.resolve(<MaterialState>{}));
+
+    expect(tester.getSize(_findFirstContainerFor('A')).height, localThemeHeadingRowHeight);
+    expect(tester.getTopLeft(find.text('A')).dx, localThemeHorizontalMargin);
+    expect(tester.getTopLeft(find.text('Data 2')).dx - tester.getTopRight(find.text('Data')).dx, localThemeColumnSpacing);
+  });
 }
 
 BoxDecoration _tableRowBoxDecoration({required WidgetTester tester, required int index}) {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/101099

similar to https://github.com/flutter/flutter/pull/97715

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
