### PR TITLE
Enable track widget creation when generating Generated.xcconfig

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -164,7 +164,7 @@ class BuildInfo {
   /// and skips the check and potential invalidation of files.
   final bool assumeInitializeFromDillUpToDate;
 
-  static const BuildInfo debug = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
+  static const BuildInfo debug = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
   static const BuildInfo profile = BuildInfo(BuildMode.profile, null, treeShakeIcons: kIconTreeShakerEnabledDefault);
   static const BuildInfo jitRelease = BuildInfo(BuildMode.jitRelease, null, treeShakeIcons: kIconTreeShakerEnabledDefault);
   static const BuildInfo release = BuildInfo(BuildMode.release, null, treeShakeIcons: kIconTreeShakerEnabledDefault);

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -107,6 +107,17 @@ void main() {
     expect(() => getIOSArchForName('bogus'), throwsException);
   });
 
+  testWithoutContext('named BuildInfo has correct defaults', () {
+    expect(BuildInfo.debug.mode, BuildMode.debug);
+    expect(BuildInfo.debug.trackWidgetCreation, true);
+
+    expect(BuildInfo.profile.mode, BuildMode.profile);
+    expect(BuildInfo.profile.trackWidgetCreation, false);
+
+    expect(BuildInfo.release.mode, BuildMode.release);
+    expect(BuildInfo.release.trackWidgetCreation, false);
+  });
+
   testWithoutContext('toBuildSystemEnvironment encoding of standard values', () {
     const BuildInfo buildInfo = BuildInfo(BuildMode.debug, '',
       treeShakeIcons: true,

--- a/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/xcodeproj_test.dart
@@ -956,7 +956,7 @@ Build settings for action build and target plugin2:
     });
 
     testUsingOsxContext('sets TRACK_WIDGET_CREATION=true when trackWidgetCreation is true', () async {
-      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, trackWidgetCreation: true, treeShakeIcons: false);
+      const BuildInfo buildInfo = BuildInfo.debug;
       final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,
@@ -977,7 +977,7 @@ Build settings for action build and target plugin2:
     });
 
     testUsingOsxContext('does not set TRACK_WIDGET_CREATION when trackWidgetCreation is false', () async {
-      const BuildInfo buildInfo = BuildInfo.debug;
+      const BuildInfo buildInfo = BuildInfo(BuildMode.debug, null, treeShakeIcons: false);
       final FlutterProject project = FlutterProject.fromDirectoryTest(fs.directory('path/to/project'));
       await updateGeneratedXcodeProperties(
         project: project,

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -1573,7 +1573,7 @@ flutter:
       debuggingOptions: DebuggingOptions.enabled(
         const BuildInfo(
           BuildMode.debug,
-          '',
+          null,
           treeShakeIcons: false,
         )
       ),

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -256,7 +256,10 @@ void main() {
   });
 
   testUsingContext('WebRunner copies compiled app.dill to cache during startup', () async {
-    final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+    final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(
+      const BuildInfo(BuildMode.debug, null, treeShakeIcons: false),
+    );
+    final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice, debuggingOptions: debuggingOptions);
     fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
     _setupMocks();
 
@@ -268,6 +271,24 @@ void main() {
     await connectionInfoCompleter.future;
 
     expect(await fileSystem.file(fileSystem.path.join('build', 'cache.dill')).readAsString(), 'ABC');
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+  });
+
+  testUsingContext('WebRunner copies compiled app.dill to cache during startup with track-widget-creation', () async {
+    final ResidentRunner residentWebRunner = setUpResidentRunner(flutterDevice);
+    fakeVmServiceHost = FakeVmServiceHost(requests: kAttachExpectations.toList());
+    _setupMocks();
+
+    residentWebRunner.artifactDirectory.childFile('app.dill').writeAsStringSync('ABC');
+    final Completer<DebugConnectionInfo> connectionInfoCompleter = Completer<DebugConnectionInfo>();
+    unawaited(residentWebRunner.run(
+      connectionInfoCompleter: connectionInfoCompleter,
+    ));
+    await connectionInfoCompleter.future;
+
+    expect(await fileSystem.file(fileSystem.path.join('build', 'cache.dill.track.dill')).readAsString(), 'ABC');
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -1048,11 +1069,12 @@ void main() {
 ResidentRunner setUpResidentRunner(FlutterDevice flutterDevice, {
   Logger logger,
   SystemClock systemClock,
+  DebuggingOptions debuggingOptions,
 }) {
   return ResidentWebRunner(
     flutterDevice,
     flutterProject: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
-    debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+    debuggingOptions: debuggingOptions ?? DebuggingOptions.enabled(BuildInfo.debug),
     ipv6: true,
     urlTunneller: null,
     usage: globals.flutterUsage,

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -161,6 +161,39 @@ Hello!
 
       final LaunchResult result = await device.startApp(app,
         mainPath: mainPath,
+        debuggingOptions: DebuggingOptions.enabled(const BuildInfo(BuildMode.debug, null, treeShakeIcons: false)),
+      );
+
+      expect(result.started, isTrue);
+      expect(result.observatoryUri, observatoryUri);
+      expect(logLines.last, 'Hello!');
+      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    }, overrides: startOverrides);
+
+    testUsingContext('performs a build and starts in debug mode with track-widget-creation', () async {
+      final FlutterTesterApp app = FlutterTesterApp.fromCurrentDirectory(fileSystem);
+      final Uri observatoryUri = Uri.parse('http://127.0.0.1:6666/');
+      final Completer<void> completer = Completer<void>();
+      fakeProcessManager.addCommand(FakeCommand(
+        command: const <String>[
+          'Artifact.flutterTester',
+          '--run-forever',
+          '--non-interactive',
+          '--enable-dart-profiling',
+          '--packages=.dart_tool/package_config.json',
+          '--flutter-assets-dir=/.tmp_rand0/flutter_tester.rand0',
+          '/.tmp_rand0/flutter_tester.rand0/flutter-tester-app.dill.track.dill',
+        ],
+        completer: completer,
+        stdout:
+        '''
+The Dart VM service is listening on $observatoryUri
+Hello!
+''',
+      ));
+
+      final LaunchResult result = await device.startApp(app,
+        mainPath: mainPath,
         debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       );
 


### PR DESCRIPTION
When initializing a flutter module project, flutter will generate a `Generated.xcconfig` for iOS, setting `TRACK_WIDGET_CREATION=false`. This file is used to generate `flutter_export_environment.sh`, and finally loaded by `podhelper.rb` to build into the host app. However when we run `flutter attach` to it, `track-widget-creation` defaults to true so hot reload breaks until we hot restart it.

This fix set `TRACK_WIDGET_CREATION=true` in `Generated.xcconfig`, making hot reload in add-to-app work as expected.

Fixes #94681

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
