### PR TITLE
[ci.yaml] Revert all devicelab tests back to LUCI scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2,6 +2,7 @@
 #
 # Flutter infra uses this file to generate a checklist of tasks to be performed
 # for every commit.
+    scheduler: luci
 #
 # More information at:
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md
@@ -2475,6 +2476,7 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: android_choreographer_do_frame_test
+    scheduler: luci
 
   - name: Linux_android android_lifecycles_test
     bringup: true
@@ -2485,6 +2487,7 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: android_lifecycles_test
+    scheduler: luci
 
   - name: Mac build_aar_module_test
     recipe: devicelab/devicelab_drone
@@ -3427,6 +3430,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: flutter_view_ios__start_up
+    scheduler: luci
 
   - name: Mac_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3589,6 +3593,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: new_gallery_ios__transition_perf
+    scheduler: luci
 
   - name: Mac_ios new_gallery_impeller_ios__transition_perf
     bringup: true # Flaky https://github.com/flutter/flutter/issues/96401
@@ -3610,6 +3615,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: ios_picture_cache_complexity_scoring_perf__timeline_summary
+    scheduler: luci
 
   - name: Mac_ios platform_channel_sample_test_ios
     recipe: devicelab/devicelab_drone
@@ -3679,6 +3685,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: post_backdrop_filter_perf_ios__timeline_summary
+    scheduler: luci
 
   - name: Mac_ios simple_animation_perf_ios
     recipe: devicelab/devicelab_drone
@@ -3699,6 +3706,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
+    scheduler: luci
 
   - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3719,6 +3727,7 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: native_ui_tests_ios
+    scheduler: luci
 
   - name: Mac native_ui_tests_macos
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2,7 +2,6 @@
 #
 # Flutter infra uses this file to generate a checklist of tasks to be performed
 # for every commit.
-    scheduler: luci
 #
 # More information at:
 #  * https://github.com/flutter/cocoon/blob/main/CI_YAML.md


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/100866