### PR TITLE
Remove deleted io.flutter.app.FlutterApplication from multidex keepfile

### DIFF
--- a/packages/flutter_tools/gradle/flutter_multidex_keepfile.txt
+++ b/packages/flutter_tools/gradle/flutter_multidex_keepfile.txt
@@ -1,4 +1,3 @@
-io/flutter/app/FlutterApplication.class
 io/flutter/app/FlutterMultiDexApplication.class
 io/flutter/embedding/engine/loader/FlutterLoader.class
 io/flutter/view/FlutterMain.class


### PR DESCRIPTION
Once v1 embedding is deleted in https://github.com/flutter/engine/pull/32236, we can remove this line from the keepfile.
