### PR TITLE
Add missing `ListTile` tests, remove duplicate test and fix typos

### DIFF
--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -245,16 +245,16 @@ void main() {
   });
 
   testWidgets('Local DataTableTheme can override global DataTableTheme', (WidgetTester tester) async {
-    const BoxDecoration gloablThemeDecoration = BoxDecoration(color: Color(0xfffffff1));
-    final MaterialStateProperty<Color> gloablThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff0));
-    const double gloablThemeDataRowHeight = 50.0;
-    const TextStyle gloablThemeDataTextStyle = TextStyle(fontSize: 11.5);
-    final MaterialStateProperty<Color> gloablThemeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
-    const double gloablThemeHeadingRowHeight = 51.0;
-    const TextStyle gloablThemeHeadingTextStyle = TextStyle(fontSize: 13.5);
-    const double gloablThemeHorizontalMargin = 2.0;
-    const double gloablThemeColumnSpacing = 3.0;
-    const double gloablThemeDividerThickness = 4.0;
+    const BoxDecoration globalThemeDecoration = BoxDecoration(color: Color(0xfffffff1));
+    final MaterialStateProperty<Color> globalThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff0));
+    const double globalThemeDataRowHeight = 50.0;
+    const TextStyle globalThemeDataTextStyle = TextStyle(fontSize: 11.5);
+    final MaterialStateProperty<Color> globalThemeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const double globalThemeHeadingRowHeight = 51.0;
+    const TextStyle globalThemeHeadingTextStyle = TextStyle(fontSize: 13.5);
+    const double globalThemeHorizontalMargin = 2.0;
+    const double globalThemeColumnSpacing = 3.0;
+    const double globalThemeDividerThickness = 4.0;
 
     const BoxDecoration localThemeDecoration = BoxDecoration(color: Color(0xfffffff0));
     final MaterialStateProperty<Color> localThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
@@ -271,16 +271,16 @@ void main() {
       MaterialApp(
         theme: ThemeData(
           dataTableTheme: DataTableThemeData(
-            decoration: gloablThemeDecoration,
-            dataRowColor: gloablThemeDataRowColor,
-            dataRowHeight: gloablThemeDataRowHeight,
-            dataTextStyle: gloablThemeDataTextStyle,
-            headingRowColor: gloablThemeHeadingRowColor,
-            headingRowHeight: gloablThemeHeadingRowHeight,
-            headingTextStyle: gloablThemeHeadingTextStyle,
-            horizontalMargin: gloablThemeHorizontalMargin,
-            columnSpacing: gloablThemeColumnSpacing,
-            dividerThickness: gloablThemeDividerThickness,
+            decoration: globalThemeDecoration,
+            dataRowColor: globalThemeDataRowColor,
+            dataRowHeight: globalThemeDataRowHeight,
+            dataTextStyle: globalThemeDataTextStyle,
+            headingRowColor: globalThemeHeadingRowColor,
+            headingRowHeight: globalThemeHeadingRowHeight,
+            headingTextStyle: globalThemeHeadingTextStyle,
+            horizontalMargin: globalThemeHorizontalMargin,
+            columnSpacing: globalThemeColumnSpacing,
+            dividerThickness: globalThemeDividerThickness,
           ),
         ),
         home: Scaffold(

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -397,48 +397,6 @@ void main() {
     expect(right('L'), 790.0); // 800 - contentPadding.start
   });
 
-  testWidgets('ListTile contentPadding', (WidgetTester tester) async {
-    Widget buildFrame(TextDirection textDirection) {
-      return MediaQuery(
-        data: const MediaQueryData(),
-        child: Directionality(
-          textDirection: textDirection,
-          child: Material(
-            child: Container(
-              alignment: Alignment.topLeft,
-              child: const ListTile(
-                contentPadding: EdgeInsetsDirectional.only(
-                  start: 10.0,
-                  end: 20.0,
-                  top: 30.0,
-                  bottom: 40.0,
-                ),
-                leading: Text('L'),
-                title: Text('title'),
-                trailing: Text('T'),
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    double left(String text) => tester.getTopLeft(find.text(text)).dx;
-    double right(String text) => tester.getTopRight(find.text(text)).dx;
-
-    await tester.pumpWidget(buildFrame(TextDirection.ltr));
-
-    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 126.0)); // 126 = 56 + 30 + 40
-    expect(left('L'), 10.0); // contentPadding.start = 10
-    expect(right('T'), 780.0); // 800 - contentPadding.end
-
-    await tester.pumpWidget(buildFrame(TextDirection.rtl));
-
-    expect(tester.getSize(find.byType(ListTile)), const Size(800.0, 126.0)); // 126 = 56 + 30 + 40
-    expect(left('T'), 20.0); // contentPadding.end = 20
-    expect(right('L'), 790.0); // 800 - contentPadding.start
-  });
-
   testWidgets('ListTile wide leading Widget', (WidgetTester tester) async {
     const Key leadingKey = ValueKey<String>('L');
 
@@ -2138,4 +2096,143 @@ void main() {
     expect(iconColor(subtitleKey),  Colors.white);
     expect(iconColor(trailingKey), Colors.white);
   });
+
+  testWidgets('ListTile font size', (WidgetTester tester) async {
+    Widget buildFrame({
+      bool dense = false,
+      bool enabled = true,
+      bool selected = false,
+      ListTileStyle? style,
+    }) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ListTile(
+                  dense: dense,
+                  enabled: enabled,
+                  selected: selected,
+                  style: style,
+                  leading: const TestText('leading'),
+                  title: const TestText('title'),
+                  subtitle: const TestText('subtitle') ,
+                  trailing: const TestText('trailing'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    // ListTile - ListTileStyle.list (default).
+    await tester.pumpWidget(buildFrame());
+    RenderParagraph leading = _getTextRenderObject(tester, 'leading');
+    expect(leading.text.style!.fontSize, 14.0);
+    RenderParagraph title = _getTextRenderObject(tester, 'title');
+    expect(title.text.style!.fontSize, 16.0);
+    RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
+    expect(subtitle.text.style!.fontSize, 14.0);
+    RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
+    expect(trailing.text.style!.fontSize, 14.0);
+
+    // ListTile - Densed - ListTileStyle.list (default).
+    await tester.pumpWidget(buildFrame(dense: true));
+    await tester.pumpAndSettle();
+    leading = _getTextRenderObject(tester, 'leading');
+    expect(leading.text.style!.fontSize, 14.0);
+    title = _getTextRenderObject(tester, 'title');
+    expect(title.text.style!.fontSize, 13.0);
+    subtitle = _getTextRenderObject(tester, 'subtitle');
+    expect(subtitle.text.style!.fontSize, 12.0);
+    trailing = _getTextRenderObject(tester, 'trailing');
+    expect(trailing.text.style!.fontSize, 14.0);
+
+    // ListTile - ListTileStyle.drawer.
+    await tester.pumpWidget(buildFrame(style: ListTileStyle.drawer));
+    await tester.pumpAndSettle();
+    leading = _getTextRenderObject(tester, 'leading');
+    expect(leading.text.style!.fontSize, 14.0);
+    title = _getTextRenderObject(tester, 'title');
+    expect(title.text.style!.fontSize, 14.0);
+    subtitle = _getTextRenderObject(tester, 'subtitle');
+    expect(subtitle.text.style!.fontSize, 14.0);
+    trailing = _getTextRenderObject(tester, 'trailing');
+    expect(trailing.text.style!.fontSize, 14.0);
+
+    // ListTile - Densed - ListTileStyle.drawer.
+    await tester.pumpWidget(buildFrame(dense: true, style: ListTileStyle.drawer));
+    await tester.pumpAndSettle();
+    leading = _getTextRenderObject(tester, 'leading');
+    expect(leading.text.style!.fontSize, 14.0);
+    title = _getTextRenderObject(tester, 'title');
+    expect(title.text.style!.fontSize, 13.0);
+    subtitle = _getTextRenderObject(tester, 'subtitle');
+    expect(subtitle.text.style!.fontSize, 12.0);
+    trailing = _getTextRenderObject(tester, 'trailing');
+    expect(trailing.text.style!.fontSize, 14.0);
+  });
+
+  testWidgets('ListTile text color', (WidgetTester tester) async {
+    Widget buildFrame({
+      bool dense = false,
+      bool enabled = true,
+      bool selected = false,
+      ListTileStyle? style,
+    }) {
+      return MaterialApp(
+        home: Material(
+          child: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return ListTile(
+                  dense: dense,
+                  enabled: enabled,
+                  selected: selected,
+                  style: style,
+                  leading: const TestText('leading'),
+                  title: const TestText('title'),
+                  subtitle: const TestText('subtitle') ,
+                  trailing: const TestText('trailing'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    final ThemeData theme = ThemeData();
+
+    // ListTile - ListTileStyle.list (default).
+    await tester.pumpWidget(buildFrame());
+    RenderParagraph leading = _getTextRenderObject(tester, 'leading');
+    expect(leading.text.style!.color, theme.textTheme.bodyText2!.color);
+    RenderParagraph title = _getTextRenderObject(tester, 'title');
+    expect(title.text.style!.color, theme.textTheme.subtitle1!.color);
+    RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
+    expect(subtitle.text.style!.color, theme.textTheme.caption!.color);
+    RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
+    expect(trailing.text.style!.color, theme.textTheme.bodyText2!.color);
+
+    // ListTile - ListTileStyle.drawer.
+    await tester.pumpWidget(buildFrame(style: ListTileStyle.drawer));
+    await tester.pumpAndSettle();
+    leading = _getTextRenderObject(tester, 'leading');
+    expect(leading.text.style!.color, theme.textTheme.bodyText2!.color);
+    title = _getTextRenderObject(tester, 'title');
+    expect(title.text.style!.color, theme.textTheme.bodyText1!.color);
+    subtitle = _getTextRenderObject(tester, 'subtitle');
+    expect(subtitle.text.style!.color, theme.textTheme.caption!.color);
+    trailing = _getTextRenderObject(tester, 'trailing');
+    expect(trailing.text.style!.color, theme.textTheme.bodyText2!.color);
+  });
+}
+
+RenderParagraph _getTextRenderObject(WidgetTester tester, String text) {
+  return tester.renderObject(find.descendant(
+    of: find.byType(ListTile),
+    matching: find.text(text),
+  ));
 }


### PR DESCRIPTION
### Description

1. While working on another PR for `ListTile`, I noticed tests for `ListTile`s font size and text color are missing.
2. Removing duplicate `ListTile contentPadding`  test

https://github.com/flutter/flutter/blob/master/packages/flutter/test/material/list_tile_test.dart#L358

https://github.com/flutter/flutter/blob/master/packages/flutter/test/material/list_tile_test.dart#L400

3. Fix typos from https://github.com/flutter/flutter/pull/101112




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
