### PR TITLE
Added the ability for microbenchmarks to print the probability of the result.

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/common.dart
+++ b/dev/benchmarks/microbenchmarks/lib/common.dart
@@ -96,7 +96,7 @@ class BenchmarkResultPrinter {
     final double probability = _doProbability(mean: mean, stddev: stddev, margin: margin);
     _results.add(_BenchmarkResult(description, mean, unit, name));
     _results.add(_BenchmarkResult('$description - probability margin of error $margin', probability,
-        'percent', '${name}_probability'));
+        'percent', '${name}_probability_5pct'));
   }
 
   /// Prints the results added via [addResult] to standard output, once as JSON

--- a/dev/benchmarks/microbenchmarks/lib/common.dart
+++ b/dev/benchmarks/microbenchmarks/lib/common.dart
@@ -3,6 +3,50 @@
 // found in the LICENSE file.
 
 import 'dart:convert' show json;
+import 'dart:math' as math;
+
+double _doNormal(
+    {required double mean, required double stddev, required double x}) {
+  return (1.0 / (stddev * math.sqrt(2.0 * math.pi))) *
+      math.pow(math.e, -0.5 * math.pow((x - mean) / stddev, 2.0));
+}
+
+double _doMean(List<double> values) =>
+    values.reduce((double x, double y) => x + y) / values.length;
+
+double _doStddev(List<double> values, double mean) {
+  double stddev = 0.0;
+  for (final double value in values) {
+    stddev += (value - mean) * (value - mean);
+  }
+  return math.sqrt(stddev / values.length);
+}
+
+double _doIntegral({
+  required double Function(double) func,
+  required double start,
+  required double stop,
+  required double resolution,
+}) {
+  double result = 0.0;
+  while (start < stop) {
+    final double value = func(start);
+    result += resolution * value;
+    start += resolution;
+  }
+  return result;
+}
+
+/// Probability is defined as the probability that the mean is within the
+/// [margin] of the true value.
+double _doProbability({required double mean, required double stddev, required double margin}) {
+  return _doIntegral(
+    func: (double x) => _doNormal(mean: mean, stddev: stddev, x: x),
+    start: (1.0 - margin) * mean,
+    stop: (1.0 + margin) * mean,
+    resolution: 0.001,
+  );
+}
 
 /// This class knows how to format benchmark results for machine and human
 /// consumption.
@@ -31,6 +75,28 @@ class BenchmarkResultPrinter {
   /// serialization of the results.
   void addResult({ required String description, required double value, required String unit, required String name }) {
     _results.add(_BenchmarkResult(description, value, unit, name));
+  }
+
+  /// Adds a benchmark result to the list of results and a probability of that
+  /// result.
+  ///
+  /// The probably is calculated as the probability that the mean is +- 5% of
+  /// the true value.
+  ///
+  /// See also [addResult].
+  void addResultStatistics({
+    required String description,
+    required List<double> values,
+    required String unit,
+    required String name,
+  }) {
+    final double mean = _doMean(values);
+    final double stddev = _doStddev(values, mean);
+    const double margin = 0.05;
+    final double probability = _doProbability(mean: mean, stddev: stddev, margin: margin);
+    _results.add(_BenchmarkResult(description, mean, unit, name));
+    _results.add(_BenchmarkResult('$description - probability margin of error $margin', probability,
+        'percent', '${name}_probability'));
   }
 
   /// Prints the results added via [addResult] to standard output, once as JSON

--- a/dev/benchmarks/microbenchmarks/lib/common.dart
+++ b/dev/benchmarks/microbenchmarks/lib/common.dart
@@ -80,7 +80,7 @@ class BenchmarkResultPrinter {
   /// Adds a benchmark result to the list of results and a probability of that
   /// result.
   ///
-  /// The probably is calculated as the probability that the mean is +- 5% of
+  /// The probability is calculated as the probability that the mean is +- 5% of
   /// the true value.
   ///
   /// See also [addResult].


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/101147
related https://github.com/flutter/flutter/pull/100926

Probability is measured as the probability that the mean is +-5% of the actual value.

Test exempt: it is a test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
