### PR TITLE
[web] reenable canvaskit benchmarks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -889,7 +889,6 @@ targets:
 
   - name: Linux web_benchmarks_canvaskit
     recipe: devicelab/devicelab_drone
-    bringup: true # rolling to Chrome 96: https://github.com/flutter/flutter/issues/98723
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
Migration to Chromium 96 is complete. The benchmark is fixed.