### PR TITLE
Remove gems dependency from tests that do not use it

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2661,8 +2661,7 @@ targets:
           {"name":"gradle","path":"gradle"}
         ]
       dependencies: >-
-        [
-        ]
+        []
       tags: >
         ["devicelab","hostonly"]
       task_name: entrypoint_dart_registrant

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2500,8 +2500,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2663,7 +2662,6 @@ targets:
         ]
       dependencies: >-
         [
-          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2768,8 +2766,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2791,8 +2788,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2815,8 +2811,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2839,8 +2834,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2864,8 +2858,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2966,8 +2959,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"}
+          {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -3172,7 +3164,6 @@ targets:
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "chrome_and_driver", "version": "version:98.1"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
           {"dependency": "goldctl"}
         ]
       shard: web_tool_tests

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2500,7 +2500,6 @@ targets:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "gems"},
           {"dependency": "open_jdk"},
           {"dependency": "xcode"}
         ]
@@ -2664,8 +2663,7 @@ targets:
         ]
       dependencies: >-
         [
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2771,8 +2769,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2795,8 +2792,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2820,8 +2816,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2845,8 +2840,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2871,8 +2865,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]
@@ -2974,8 +2967,7 @@ targets:
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode"},
-          {"dependency": "gems"}
+          {"dependency": "xcode"}
         ]
       tags: >
         ["devicelab","hostonly"]


### PR DESCRIPTION
Installing the `gems` dependency can take 10-25 seconds.  Remove it for the tests that don't actually need any `gems` installed.

![Screen Shot 2022-04-01 at 5 11 10 PM](https://user-images.githubusercontent.com/682784/161356070-9b305207-ed6a-471f-a78c-e5181986da8f.png)

Also remove `xcode` dependency where unused.  This one only took ~2-10 seconds, but removing it cleans up the task list a bit.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
