### PR TITLE
Only run test harness tests in misc shard instead of every shard

### DIFF
--- a/dev/bots/test/test_test.dart
+++ b/dev/bots/test/test_test.dart
@@ -112,13 +112,13 @@ void main() {
       // When updating this test, try to pick shard numbers that ensure we're checking
       // that unequal test distributions don't miss tests.
       ProcessResult result = await runScript(
-        <String, String>{'SHARD': 'smoke_tests', 'SUBSHARD': '1_3'},
+        <String, String>{'SHARD': 'test_harness_tests', 'SUBSHARD': '1_3'},
       );
       expectExitCode(result, 0);
       expect(result.stdout, contains('Selecting subshard 1 of 3 (range 1-3 of 8)'));
 
       result = await runScript(
-        <String, String>{'SHARD': 'smoke_tests', 'SUBSHARD': '3_3'},
+        <String, String>{'SHARD': 'test_harness_tests', 'SUBSHARD': '3_3'},
       );
       expectExitCode(result, 0);
       expect(result.stdout, contains('Selecting subshard 3 of 3 (range 7-8 of 8)'));
@@ -126,7 +126,7 @@ void main() {
 
     test('exits with code 1 when SUBSHARD index greater than total', () async {
       final ProcessResult result = await runScript(
-        <String, String>{'SHARD': 'smoke_tests', 'SUBSHARD': '100_99'},
+        <String, String>{'SHARD': 'test_harness_tests', 'SUBSHARD': '100_99'},
       );
       expectExitCode(result, 1);
       expect(result.stdout, contains('Invalid subshard name'));


### PR DESCRIPTION
Every test run shard first runs a 30 second "smoke test" suite to prove the test harness works.  This suite runs 64 times per commit (once per shard/subshard/platform).  Rename it to a "test harness tests" and only run it in the `misc` shard (which still runs 4 times per commit).

Running and passing in `misc`:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8818037355707764481/+/u/run_test.dart_for_framework_tests_shard_and_subshard_misc/test_stdout

```
Running test harness tests...
▌01:03:31▐ RUNNING: cd .; bin/cache/artifacts/engine/linux-x64/flutter_tester --help
▌01:03:31▐ ELAPSED TIME: 0.050s for bin/cache/artifacts/engine/linux-x64/flutter_tester --help in .
▌01:03:31▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/pass_test.dart
▌01:03:44▐ ELAPSED TIME: 13.296s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/pass_test.dart in dev/automated_tests
▌01:03:44▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/fail_test.dart
▌01:03:48▐ ELAPSED TIME: 3.625s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/fail_test.dart in dev/automated_tests
▌01:03:48▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/pending_timer_fail_test.dart
▌01:03:52▐ ELAPSED TIME: 3.723s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/pending_timer_fail_test.dart in dev/automated_tests
▌01:03:52▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/crash1_test.dart
▌01:03:55▐ ELAPSED TIME: 3.491s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/crash1_test.dart in dev/automated_tests
▌01:03:55▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/crash2_test.dart
▌01:03:59▐ ELAPSED TIME: 3.357s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/crash2_test.dart in dev/automated_tests
▌01:03:59▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/syntax_error_test.broken_dart
▌01:04:01▐ ELAPSED TIME: 2.873s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/syntax_error_test.broken_dart in dev/automated_tests
▌01:04:01▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/missing_import_test.broken_dart
▌01:04:04▐ ELAPSED TIME: 2.831s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/missing_import_test.broken_dart in dev/automated_tests
▌01:04:04▐ RUNNING: cd dev/automated_tests; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/disallow_error_reporter_modification_test.dart
▌01:04:08▐ ELAPSED TIME: 3.885s for ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings test_smoke_test/disallow_error_reporter_modification_test.dart in dev/automated_tests
▌01:04:08▐ RUNNING: cd examples/api; ../../bin/flutter test --test-randomize-ordering-seed=20220401 --fatal-warnings --null-assertions --sound-null-safety
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
