### PR TITLE
[Revert] Skip overall_experience_test.dart: flutter run writes and clears pidfile appropriately

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1634,24 +1634,43 @@ Future<void> _dartRunTest(String workingDirectory, {
     cpus = 1;
   }
 
+  // final List<String> args = <String>[
+  //   'run',
+  //   'test',
+  //   if (shuffleTests) '--test-randomize-ordering-seed=$shuffleSeed',
+  //   if (useFlutterTestFormatter)
+  //     '-rjson'
+  //   else
+  //     '-rcompact',
+  //   '-j$cpus',
+  //   if (!hasColor)
+  //     '--no-color',
+  //   if (coverage != null)
+  //     '--coverage=$coverage',
+  //   if (perTestTimeout != null)
+  //     '--timeout=${perTestTimeout.inMilliseconds.toString()}ms',
+  //   if (testPaths != null)
+  //     for (final String testPath in testPaths)
+  //       testPath,
+  // ];
+
   final List<String> args = <String>[
     'run',
     'test',
-    if (shuffleTests) '--test-randomize-ordering-seed=$shuffleSeed',
-    if (useFlutterTestFormatter)
-      '-rjson'
-    else
-      '-rcompact',
-    '-j$cpus',
-    if (!hasColor)
-      '--no-color',
-    if (coverage != null)
-      '--coverage=$coverage',
-    if (perTestTimeout != null)
-      '--timeout=${perTestTimeout.inMilliseconds.toString()}ms',
-    if (testPaths != null)
-      for (final String testPath in testPaths)
-        testPath,
+    '--test-randomize-ordering-seed=20211102',
+    '-rcompact',
+    '-j1',
+    '--no-color',
+    'test/integration.shard/single_widget_reload_test.dart',
+    'test/integration.shard/xcode_backend_test.dart',
+    'test/integration.shard/ios_content_validation_test.dart',
+    'test/integration.shard/command_output_test.dart',
+    'test/integration.shard/cache_test.dart',
+    'test/integration.shard/expression_evaluation_test.dart',
+    'test/integration.shard/build_ios_config_only_test.dart',
+    'test/integration.shard/overall_experience_test.dart',
+    'test/integration.shard/macos_content_validation_test.dart',
+    'test/integration.shard/generated_plugin_registrant_test.dart'
   ];
   final Map<String, String> environment = <String, String>{
     'FLUTTER_ROOT': flutterRoot,

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1634,43 +1634,24 @@ Future<void> _dartRunTest(String workingDirectory, {
     cpus = 1;
   }
 
-  // final List<String> args = <String>[
-  //   'run',
-  //   'test',
-  //   if (shuffleTests) '--test-randomize-ordering-seed=$shuffleSeed',
-  //   if (useFlutterTestFormatter)
-  //     '-rjson'
-  //   else
-  //     '-rcompact',
-  //   '-j$cpus',
-  //   if (!hasColor)
-  //     '--no-color',
-  //   if (coverage != null)
-  //     '--coverage=$coverage',
-  //   if (perTestTimeout != null)
-  //     '--timeout=${perTestTimeout.inMilliseconds.toString()}ms',
-  //   if (testPaths != null)
-  //     for (final String testPath in testPaths)
-  //       testPath,
-  // ];
-
   final List<String> args = <String>[
     'run',
     'test',
-    '--test-randomize-ordering-seed=20211102',
-    '-rcompact',
-    '-j1',
-    '--no-color',
-    'test/integration.shard/single_widget_reload_test.dart',
-    'test/integration.shard/xcode_backend_test.dart',
-    'test/integration.shard/ios_content_validation_test.dart',
-    'test/integration.shard/command_output_test.dart',
-    'test/integration.shard/cache_test.dart',
-    'test/integration.shard/expression_evaluation_test.dart',
-    'test/integration.shard/build_ios_config_only_test.dart',
-    'test/integration.shard/overall_experience_test.dart',
-    'test/integration.shard/macos_content_validation_test.dart',
-    'test/integration.shard/generated_plugin_registrant_test.dart'
+    if (shuffleTests) '--test-randomize-ordering-seed=$shuffleSeed',
+    if (useFlutterTestFormatter)
+      '-rjson'
+    else
+      '-rcompact',
+    '-j$cpus',
+    if (!hasColor)
+      '--no-color',
+    if (coverage != null)
+      '--coverage=$coverage',
+    if (perTestTimeout != null)
+      '--timeout=${perTestTimeout.inMilliseconds.toString()}ms',
+    if (testPaths != null)
+      for (final String testPath in testPaths)
+        testPath,
   ];
   final Map<String, String> environment = <String, String>{
     'FLUTTER_ROOT': flutterRoot,

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -361,10 +361,7 @@ void main() {
     } finally {
       tryToDelete(fileSystem.directory(tempDirectory));
     }
-    // This test is expected to be skipped when Platform.isWindows:
-    // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
-  }, skip: true); // Flake: https://github.com/flutter/flutter/issues/92042
-
+  }, skip: Platform.isWindows); // [intended] Windows doesn't support sending signals so we don't care if it can store the PID.
   testWithoutContext('flutter run handle SIGUSR1/2', () async {
     final String tempDirectory = fileSystem.systemTempDirectory.createTempSync('flutter_overall_experience_test.').resolveSymbolicLinksSync();
     final String pidFile = fileSystem.path.join(tempDirectory, 'flutter.pid');


### PR DESCRIPTION
Revert https://github.com/flutter/flutter/pull/93026.

Issue: https://github.com/flutter/flutter/issues/92042