### PR TITLE
Use single quotes for `dartSdkVersionBounds`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -291,7 +291,7 @@ class CreateCommand extends CreateBase {
       windows: featureFlags.isWindowsEnabled && platforms.contains('windows'),
       windowsUwp: featureFlags.isWindowsUwpEnabled && platforms.contains('winuwp'),
       // Enable null safety everywhere.
-      dartSdkVersionBounds: '">=$dartSdk <3.0.0"',
+      dartSdkVersionBounds: "'>=$dartSdk <3.0.0'",
       implementationTests: boolArg('implementation-tests'),
       agpVersion: gradle.templateAndroidGradlePluginVersion,
       kotlinVersion: gradle.templateKotlinGradlePluginVersion,

--- a/packages/flutter_tools/test/general.shard/update_packages_test.dart
+++ b/packages/flutter_tools/test/general.shard/update_packages_test.dart
@@ -19,7 +19,7 @@ description: A framework for writing Flutter applications
 homepage: http://flutter.dev
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -731,7 +731,7 @@ class TestProject extends Project {
   final String pubspec = '''
     name: test
     environment:
-      sdk: ">=2.12.0-0 <3.0.0"
+      sdk: '>=2.12.0-0 <3.0.0'
 
     dependencies:
       flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/basic_project.dart
@@ -10,7 +10,7 @@ class BasicProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:
@@ -63,7 +63,7 @@ class BasicProjectThatThrows extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:
@@ -120,7 +120,7 @@ class BasicProjectWithTimelineTraces extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:
@@ -169,7 +169,7 @@ class BasicProjectWithFlutterGen extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:
@@ -196,7 +196,7 @@ class BasicProjectWithUnaryMain extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
   dependencies:
     flutter:
       sdk: flutter

--- a/packages/flutter_tools/test/integration.shard/test_data/compile_error_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/compile_error_project.dart
@@ -10,7 +10,7 @@ class CompileErrorProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/hot_reload_with_asset.dart
@@ -10,7 +10,7 @@ class HotReloadWithAssetProject extends Project {
   final String pubspec = '''
 name: test
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/test_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/test_project.dart
@@ -10,7 +10,7 @@ class TestProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:

--- a/packages/flutter_tools/test/integration.shard/test_data/tests_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/tests_project.dart
@@ -13,7 +13,7 @@ class TestsProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: ">=2.12.0-0 <3.0.0"
+    sdk: '>=2.12.0-0 <3.0.0'
 
   dependencies:
     flutter:


### PR DESCRIPTION
## Background

This reopens #99906 where Flutter CI was broken.

## Motivation

In all templates, the `dartSdkVersionBounds` are inserted with **double quotes**. This, however, is inconsistent with the rest of the (app) template:

```yml
...
publish_to: 'none' # Remove this line if you wish to publish to pub.dev
...
environment:
  sdk: ">=2.16.1 <3.0.0"
```

After this PR, the environment would be generated as:

```yml
environment:
  sdk: '>=2.16.1 <3.0.0'
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
