### PR TITLE
Fix `DrawerHeader` decoration not inheriting `ColorScheme.primary`

### DIFF
--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -369,9 +369,7 @@ class _UserAccountsDrawerHeaderState extends State<UserAccountsDrawerHeader> {
       container: true,
       label: MaterialLocalizations.of(context).signedInLabel,
       child: DrawerHeader(
-        decoration: widget.decoration ?? BoxDecoration(
-          color: Theme.of(context).primaryColor,
-        ),
+        decoration: widget.decoration ?? BoxDecoration(color: Theme.of(context).colorScheme.primary),
         margin: widget.margin,
         padding: const EdgeInsetsDirectional.only(top: 16.0, start: 16.0),
         child: SafeArea(

--- a/packages/flutter/test/material/user_accounts_drawer_header_test.dart
+++ b/packages/flutter/test/material/user_accounts_drawer_header_test.dart
@@ -19,9 +19,15 @@ Future<void> pumpTestWidget(
       bool withOnDetailsPressedHandler = true,
       Size otherAccountsPictureSize = const Size.square(40.0),
       Size currentAccountPictureSize  = const Size.square(72.0),
+      Color? primaryColor,
+      Color? colorSchemePrimary,
     }) async {
   await tester.pumpWidget(
     MaterialApp(
+      theme: ThemeData(
+        primaryColor: primaryColor,
+        colorScheme: const ColorScheme.light().copyWith(primary: colorSchemePrimary),
+      ),
       home: MediaQuery(
         data: const MediaQueryData(
           padding: EdgeInsets.only(
@@ -75,6 +81,19 @@ void main() {
     of: find.byType(UserAccountsDrawerHeader),
     matching: find.byType(Transform),
   );
+
+  testWidgets('UserAccountsDrawerHeader inherits ColorScheme.primary', (WidgetTester tester) async {
+    const Color primaryColor = Color(0xff00ff00);
+    const Color colorSchemePrimary = Color(0xff0000ff);
+
+    await pumpTestWidget(tester, primaryColor: primaryColor, colorSchemePrimary: colorSchemePrimary);
+
+    final BoxDecoration? boxDecoration = tester.widget<DrawerHeader>(
+      find.byType(DrawerHeader),
+    ).decoration as BoxDecoration?;
+    expect(boxDecoration?.color == primaryColor, false);
+    expect(boxDecoration?.color == colorSchemePrimary, true);
+  });
 
   testWidgets('UserAccountsDrawerHeader test', (WidgetTester tester) async {
     await pumpTestWidget(tester);


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/90006

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
