### PR TITLE
Add 'gray' US english spelling to TerminalColor

### DIFF
--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -15,6 +15,7 @@ enum TerminalColor {
   yellow,
   magenta,
   grey,
+  gray,
 }
 
 /// A class that contains the context settings for command text output to the
@@ -173,7 +174,8 @@ class AnsiTerminal implements Terminal {
   static const String cyan = '\u001b[36m';
   static const String magenta = '\u001b[35m';
   static const String yellow = '\u001b[33m';
-  static const String grey = '\u001b[90m';
+  static const String gray = '\u001b[90m';
+  static const String grey = gray; // Prefer American english spelling as per style guide.
 
   static const Map<TerminalColor, String> _colorMap = <TerminalColor, String>{
     TerminalColor.red: red,
@@ -183,6 +185,7 @@ class AnsiTerminal implements Terminal {
     TerminalColor.magenta: magenta,
     TerminalColor.yellow: yellow,
     TerminalColor.grey: grey,
+    TerminalColor.gray: gray,
   };
 
   static String colorCode(TerminalColor color) => _colorMap[color]!;

--- a/packages/flutter_tools/test/general.shard/base/terminal_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/terminal_test.dart
@@ -53,6 +53,13 @@ void main() {
       }
     });
 
+    testWithoutContext('gray equals grey', () {
+      expect(
+        terminal.color('output', TerminalColor.gray),
+        equals(terminal.color('output', TerminalColor.grey)),
+      );
+    });
+
     testWithoutContext('adding bold works', () {
       expect(
         terminal.bolden('output'),


### PR DESCRIPTION
As per https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#naming

> Prefer US English spellings. For example, 'colorize', not 'colourise', and 'canceled', not 'cancelled'.