### PR TITLE
[flutter_tools] port bash script to use sysctl not uname on macOS

### DIFF
--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -20,12 +20,13 @@ DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
 DART_SDK_PATH_OLD="$DART_SDK_PATH.old"
 ENGINE_STAMP="$FLUTTER_ROOT/bin/cache/engine-dart-sdk.stamp"
 ENGINE_VERSION=`cat "$FLUTTER_ROOT/bin/internal/engine.version"`
+OS="$(uname -s)"
 
 if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; then
   command -v curl > /dev/null 2>&1 || {
     >&2 echo
     >&2 echo 'Missing "curl" tool. Unable to download Dart SDK.'
-    case "$(uname -s)" in
+    case "$OS" in
       Darwin)
         >&2 echo 'Consider running "brew install curl".'
         ;;
@@ -42,7 +43,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   command -v unzip > /dev/null 2>&1 || {
     >&2 echo
     >&2 echo 'Missing "unzip" tool. Unable to extract Dart SDK.'
-    case "$(uname -s)" in
+    case "$OS" in
       Darwin)
         echo 'Consider running "brew install unzip".'
         ;;
@@ -57,7 +58,6 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     exit 1
   }
 
-  OS="$(uname -s)"
   # `uname -m` may be running in Rosetta mode, instead query sysctl
   if [ "$OS" = 'Darwin' ]; then
     # Allow non-zero exit so we can do control flow
@@ -76,7 +76,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
     elif [ "$QUERY_RESULT" = '1' ]; then
       ARCH='arm64'
     else
-      >&2 echo "$QUERY returned unexpected output: $QUERY_RESULT"
+      >&2 echo "'$QUERY' returned unexpected output: '$QUERY_RESULT'"
       exit 1
     fi
     set -e

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -61,7 +61,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   # `uname -m` may be running in Rosetta mode, instead query sysctl
   if [ "$OS" = 'Darwin' ]; then
     ARCH="arm64"
-    # This will return 1 on x64
+    # This will exit 1 if the CPU arch is not ARM64
     sysctl hw.optional.arm64 >/dev/null 2>&1 || {
       ARCH="x64"
     }

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -58,9 +58,10 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
   }
 
   OS="$(uname -s)"
+  # `uname -m` may be running in Rosetta mode, instead query sysctl
   if [ "$OS" = 'Darwin' ]; then
     ARCH="arm64"
-    # `uname -m` may be running in Rosetta mode, instead query sysctl
+    # This will return 1 on x64
     sysctl hw.optional.arm64 >/dev/null 2>&1 || {
       ARCH="x64"
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/101243

For context, a similar Flutter tool change was made in https://github.com/flutter/flutter/pull/67970/files

To test the bash logic, you can update line 66:

To test `sysctl` returning exit code 1 on x64 and newer macOS: `QUERY="false"`

It should log: `Downloading Darwin x64 Dart SDK from Flutter engine $ENGINE_VERSION...`

To test `sysctl` returning exit code 0 (success) but printing 0 (arm64 not present) on x64 and older macOS: `QUERY="echo 0"`

It should log: `Downloading Darwin x64 Dart SDK from Flutter engine $ENGINE_VERSION...`

To test `sysctl` returning exit code 0 (success) and printing 1 (arm64 present) on arm64: `QUERY="echo 1"`

It should log: `Downloading Darwin arm64 Dart SDK from Flutter engine $ENGINE_VERSION...`