### PR TITLE
Use separate metric file names for same tests running on different platforms

### DIFF
--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -133,5 +133,43 @@ Future<void> uploadToSkiaPerf(String? resultsPath, String? commitTime, String? t
   resultsJson = json.decode(await resultFile.readAsString()) as Map<String, dynamic>;
   final List<MetricPoint> metricPoints = parse(resultsJson, benchmarkTagsMap, taskName);
   final FlutterDestination metricsDestination = await connectFlutterDestination();
-  await upload(metricsDestination, metricPoints, commitTimeSinceEpoch, taskName);
+  await upload(
+    metricsDestination,
+    metricPoints,
+    commitTimeSinceEpoch,
+    metricFileName(taskName, benchmarkTagsMap),
+  );
+}
+
+/// Create metric file name based on `taskName`, `arch`, `host type`, and `device type`.
+///
+/// Same `taskName` may run on different platforms. Considering host/device tags to
+/// use different metric file names.
+///
+/// This affects only the metric file name which contains metric data, and does not affect
+/// real host/device tags.
+/// 
+/// For example:
+///   Old file name: `backdrop_filter_perf__timeline_summary`
+///   New file name: `backdrop_filter_perf__timeline_summary_intel_linux_motoG4`
+String metricFileName(
+  String taskName,
+  Map<String, dynamic> benchmarkTagsMap,
+) {
+  String fileName = taskName;
+  if (benchmarkTagsMap.containsKey('arch')) {
+    fileName = '${fileName}_${_fileNameFormat(benchmarkTagsMap['arch'] as String)}';
+  }
+  if (benchmarkTagsMap.containsKey('host_type')) {
+    fileName = '${fileName}_${_fileNameFormat(benchmarkTagsMap['host_type'] as String)}';
+  }
+  if (benchmarkTagsMap.containsKey('device_type')) {
+    fileName = '${fileName}_${_fileNameFormat(benchmarkTagsMap['device_type'] as String)}';
+  }
+  return fileName;
+}
+
+/// Format `fileName` removing non letter and number characters.
+String _fileNameFormat(String fileName) {
+  return fileName.replaceAll(RegExp('[^a-zA-Z0-9]'), '');
 }

--- a/dev/devicelab/lib/framework/metrics_center.dart
+++ b/dev/devicelab/lib/framework/metrics_center.dart
@@ -148,7 +148,7 @@ Future<void> uploadToSkiaPerf(String? resultsPath, String? commitTime, String? t
 ///
 /// This affects only the metric file name which contains metric data, and does not affect
 /// real host/device tags.
-/// 
+///
 /// For example:
 ///   Old file name: `backdrop_filter_perf__timeline_summary`
 ///   New file name: `backdrop_filter_perf__timeline_summary_intel_linux_motoG4`
@@ -156,17 +156,23 @@ String metricFileName(
   String taskName,
   Map<String, dynamic> benchmarkTagsMap,
 ) {
-  String fileName = taskName;
+  final StringBuffer fileName = StringBuffer(taskName);
   if (benchmarkTagsMap.containsKey('arch')) {
-    fileName = '${fileName}_${_fileNameFormat(benchmarkTagsMap['arch'] as String)}';
+    fileName
+      ..write('_')
+      ..write(_fileNameFormat(benchmarkTagsMap['arch'] as String));
   }
   if (benchmarkTagsMap.containsKey('host_type')) {
-    fileName = '${fileName}_${_fileNameFormat(benchmarkTagsMap['host_type'] as String)}';
+    fileName
+      ..write('_')
+      ..write(_fileNameFormat(benchmarkTagsMap['host_type'] as String));
   }
   if (benchmarkTagsMap.containsKey('device_type')) {
-    fileName = '${fileName}_${_fileNameFormat(benchmarkTagsMap['device_type'] as String)}';
+    fileName
+      ..write('_')
+      ..write(_fileNameFormat(benchmarkTagsMap['device_type'] as String));
   }
-  return fileName;
+  return fileName.toString();
 }
 
 /// Format `fileName` removing non letter and number characters.

--- a/dev/devicelab/test/metrics_center_test.dart
+++ b/dev/devicelab/test/metrics_center_test.dart
@@ -155,4 +155,24 @@ void main() {
       expect(flutterDestination.name, taskName);
     });
   });
+
+  group('metric file name', () {
+    test('without tags', () async {
+      final Map<String, dynamic> tags = <String, dynamic>{};
+      final String fileName = metricFileName('test', tags);
+      expect(fileName, 'test');
+    });
+
+    test('with device tags', () async {
+      final Map<String, dynamic> tags = <String, dynamic>{'device_type': 'ab-c'};
+      final String fileName = metricFileName('test', tags);
+      expect(fileName, 'test_abc');
+    });
+
+    test('with device host and arch tags', () async {
+      final Map<String, dynamic> tags = <String, dynamic>{'device_type': 'ab-c', 'host_type': 'de-f', 'arch': 'm1'};
+      final String fileName = metricFileName('test', tags);
+      expect(fileName, 'test_m1_def_abc');
+    });
+  });
 }


### PR DESCRIPTION
Same tests may run on different platforms, for example: `backdrop_filter_perf__timeline_summary` is running on both `motoG4` and `samsungS10`.

Existing logic shares same metric file for both platforms, and causes confusion. This PR uses separate metric files for different cases.

Potential fix: https://github.com/flutter/flutter/issues/101220