### PR TITLE
[ci.yaml] Revert every target except roller back to luci scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -904,6 +904,7 @@ targets:
       tags: >
         ["devicelab","hostonly"]
       task_name: web_benchmarks_canvaskit
+    scheduler: luci
 
   - name: Linux web_benchmarks_html
     recipe: devicelab/devicelab_drone
@@ -1421,6 +1422,7 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: android_semantics_integration_test
+    scheduler: luci
 
   - name: Linux_android android_stack_size_test
     recipe: devicelab/devicelab_drone
@@ -1697,6 +1699,7 @@ targets:
         [
           {"name": "openjdk", "path": "java11"}
         ]
+    scheduler: luci
 
   - name: Linux_android cubic_bezier_perf__e2e_summary
     recipe: devicelab/devicelab_drone
@@ -2379,6 +2382,7 @@ targets:
         ]
       tags: >
         ["framework","hostonly"]
+    scheduler: luci
     timeout: 60
 
   - name: Linux deferred components
@@ -2393,6 +2397,7 @@ targets:
         ]
       tags: >
         ["framework","hostonly"]
+    scheduler: luci
     timeout: 60
 
   - name: Linux_android opacity_peephole_one_rect_perf__e2e_summary
@@ -3745,6 +3750,7 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+    scheduler: luci
 
   - name: Windows build_aar_module_test
     recipe: devicelab/devicelab_drone
@@ -4048,6 +4054,7 @@ targets:
       tags: >
         ["devicelab","hostonly"]
       task_name: module_test
+    scheduler: luci
     runIf:
       - dev/**
       - packages/flutter_tools/**


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/100866

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
