### PR TITLE
Support material state color for background color in Chip

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1757,21 +1757,24 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
   /// Picks between three different colors, depending upon the state of two
   /// different animations.
   Color? _getBackgroundColor(ThemeData theme, ChipThemeData chipTheme, ChipThemeData chipDefaults) {
-    final ColorTween backgroundTween = ColorTween(
-      begin: widget.disabledColor
-        ?? chipTheme.disabledColor
-        ?? theme.disabledColor,
-      end: widget.backgroundColor
+    final Color? beginBackgroundColor = MaterialStateProperty.resolveAs<Color?>(widget.disabledColor ?? chipTheme.disabledColor ?? theme.disabledColor, materialStates);
+    final Color? endBackgroundColor = MaterialStateProperty.resolveAs<Color?>(widget.backgroundColor
         ?? chipTheme.backgroundColor
         ?? theme.chipTheme.backgroundColor
-        ?? chipDefaults.backgroundColor,
-    );
-    final ColorTween selectTween = ColorTween(
-      begin: backgroundTween.evaluate(enableController),
-      end: widget.selectedColor
+        ?? chipDefaults.backgroundColor, materialStates);
+    final Color? selectedColor = MaterialStateProperty.resolveAs<Color?>(widget.selectedColor
         ?? chipTheme.selectedColor
         ?? theme.chipTheme.selectedColor
         ?? chipDefaults.selectedColor,
+        materialStates);
+
+    final ColorTween backgroundTween = ColorTween(
+      begin: beginBackgroundColor,
+      end: endBackgroundColor,
+    );
+    final ColorTween selectTween = ColorTween(
+      begin: backgroundTween.evaluate(enableController),
+      end: selectedColor,
     );
     return selectTween.evaluate(selectionFade);
   }


### PR DESCRIPTION
Enable Chip background color to have different state by using MaterialStateProperty

*List which issues are fixed by this PR. You must list at least one issue.*
- #101325

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
