### PR TITLE
Catch errors in ProxiedDevice to make sure we don't crash on errors.

### DIFF
--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -534,7 +534,7 @@ class ProxiedPortForwarder extends DevicePortForwarder {
       unawaited(socket.done.catchError((Object error, StackTrace stackTrace) {
         // Do nothing here. Everything will be handled in the `then` block below.
         return false;
-      }).then((dynamic value) {
+      }).whenComplete(() {
         // Send a proxy disconnect event just in case.
         unawaited(connection.sendRequest('proxy.disconnect', <String, Object>{
           'id': id,

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -519,21 +519,31 @@ class ProxiedPortForwarder extends DevicePortForwarder {
         // Do nothing here.
       }));
       socket.listen((Uint8List data) {
-        connection.sendRequest('proxy.write', <String, Object>{
+        unawaited(connection.sendRequest('proxy.write', <String, Object>{
           'id': id,
-        }, data);
+        }, data).catchError((Object error, StackTrace stackTrace) {
+          // Log the error, but proceed normally. Network failure should not
+          // crash the tool. If this is critical, the place where the connection
+          // is being used would crash.
+          _logger.printWarning('Write to remote proxy error: $error');
+          _logger.printTrace('Write to remote proxy error: $error, stack trace: $stackTrace');
+        }));
       });
       _connectedSockets.add(socket);
 
-      unawaited(socket.done.then((dynamic value) {
-        connection.sendRequest('proxy.disconnect', <String, Object>{
+      unawaited(socket.done.catchError((Object error, StackTrace stackTrace) {
+        // Do nothing here. Everything will be handled in the `then` block below.
+        return false;
+      }).then((dynamic value) {
+        // Send a proxy disconnect event just in case.
+        unawaited(connection.sendRequest('proxy.disconnect', <String, Object>{
           'id': id,
-        });
-        _connectedSockets.remove(socket);
-      }).onError((Object? error, StackTrace stackTrace) {
-        connection.sendRequest('proxy.disconnect', <String, Object>{
-          'id': id,
-        });
+        }).catchError((Object error, StackTrace stackTrace) {
+          // Ignore the error here. There might be a race condition when the
+          // remote end also disconnects. In any case, this request is just to
+          // notify the remote end to disconnect and we should not crash when
+          // there is an error here.
+        }));
         _connectedSockets.remove(socket);
       }));
     }, onError: (Object error, StackTrace stackTrace) {


### PR DESCRIPTION
When proxied device is used, if a forwarded socket is disconnected, we always send a `proxy.disconnect` request to the daemon. We didn't handle the error coming from the daemon in this case which caused some crashes. This PR catches those errors so that it wouldn't crash.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
