### PR TITLE
updated the dependencies for the Mac entrypoint_dart_registrant

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2666,7 +2666,10 @@ targets:
           {"name":"gradle","path":"gradle"}
         ]
       dependencies: >-
-        []
+        [
+          {"dependency": "open_jdk", "version": "11"},
+          {"dependency": "android_sdk", "version": "version:31v8"}
+        ]
       tags: >
         ["devicelab","hostonly"]
       task_name: entrypoint_dart_registrant


### PR DESCRIPTION
This test is failing from `ANDROID_SDK_ROOT environment variable is missing`

https://ci.chromium.org/ui/p/flutter/builders/staging/Mac%20entrypoint_dart_registrant/669/overview

Test exempt: Is a test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
