### PR TITLE
Revert roller back to LUCI scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -254,6 +254,7 @@ targets:
         ["framework","hostonly","shard"]
     runIf:
       - .ci.yaml
+    scheduler: luci
 
   - name: Linux customer_testing
     recipe: flutter/flutter


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/100866

This is the last one. All of flutter/flutter will be reverted back to the LUCI scheduler.

I didn't realize this was checking out flutter/flutter at ToT to run the generate_jspb script