### PR TITLE
Remove redundant timeline_summary benchmarks from ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1472,16 +1472,6 @@ targets:
       task_name: backdrop_filter_perf__e2e_summary
     scheduler: luci
 
-  - name: Linux_android backdrop_filter_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: backdrop_filter_perf__timeline_summary
-    scheduler: luci
-
   - name: Linux_samsung_s10 backdrop_filter_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1520,16 +1510,6 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: color_filter_and_fade_perf__e2e_summary
-    scheduler: luci
-
-  - name: Linux_android color_filter_and_fade_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: color_filter_and_fade_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_android color_filter_cache_perf__e2e_summary
@@ -1718,26 +1698,6 @@ targets:
       task_name: cubic_bezier_perf_sksl_warmup__e2e_summary
     scheduler: luci
 
-  - name: Linux_android cubic_bezier_perf_sksl_warmup__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: cubic_bezier_perf_sksl_warmup__timeline_summary
-    scheduler: luci
-
-  - name: Linux_android cubic_bezier_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: cubic_bezier_perf__timeline_summary
-    scheduler: luci
-
   - name: Linux_samsung_s10 cubic_bezier_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -1756,16 +1716,6 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: cull_opacity_perf__e2e_summary
-    scheduler: luci
-
-  - name: Linux_android cull_opacity_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: cull_opacity_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_samsung_s10 cull_opacity_perf__timeline_summary
@@ -1998,16 +1948,6 @@ targets:
       task_name: fullscreen_textfield_perf__e2e_summary
     scheduler: luci
 
-  - name: Linux_android fullscreen_textfield_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: fullscreen_textfield_perf__timeline_summary
-    scheduler: luci
-
   - name: Linux_android hello_world__memory
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2200,16 +2140,6 @@ targets:
       task_name: picture_cache_perf__e2e_summary
     scheduler: luci
 
-  - name: Linux_android picture_cache_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: picture_cache_perf__timeline_summary
-    scheduler: luci
-
   - name: Linux_samsung_s10 picture_cache_perf__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -2318,16 +2248,6 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: textfield_perf__e2e_summary
-    scheduler: luci
-
-  - name: Linux_android textfield_perf__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: textfield_perf__timeline_summary
     scheduler: luci
 
   - name: Linux_samsung_s10 textfield_perf__timeline_summary


### PR DESCRIPTION
I have gone over the results of these benchmarks in SkiaPerf, and the new `e2e` versions appear to have been producing results that are consistent with the `_timeline_summary` versions for quite some time.

I am not deleting the benchmark code in this PR on the off chance that we need to run them locally to debug any weirdness that we might only notice now that the e2e versions of these are the only ones.