### PR TITLE
Create configuration to automatically generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,10 +2,17 @@ changelog:
   exclude:
     authors:
       - engine-flutter-autoroll
+      - fluttergithubbot
     labels:
       - passed first triage
       - passed secondary triage
   categories:
-    - title: Breaking Changes
+    - title: Framework
       labels:
-        -
+        - framework
+    - title: Tooling
+      labels:
+        - tool
+    - title: MacOS
+      labels:
+        - platform-mac

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  exclude:
+    authors:
+      - engine-flutter-autoroll
+    labels:
+      - passed first triage
+      - passed secondary triage
+  categories:
+    - title: Breaking Changes
+      labels:
+        -


### PR DESCRIPTION
Github provides an API for [automatically generating release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). 

The structure of these release notes can be configured with a yml file. 

This PR is experimental and a step toward creating better release notes. 

This is a work in progress and subject to change as we understand how we want to organize the information provided.