### PR TITLE
removed obsolete timelineArgumentsIndicatingLandmarkEvent

### DIFF
--- a/packages/flutter/lib/src/foundation/debug.dart
+++ b/packages/flutter/lib/src/foundation/debug.dart
@@ -82,23 +82,6 @@ Future<T> debugInstrumentAction<T>(String description, Future<T> Function() acti
   }
 }
 
-/// Argument passed to [dart:developer.Timeline] events in order to cause those
-/// events to be shown in the developer-centric version of the Observatory
-/// Timeline.
-///
-/// Generally these indicate landmark events such as the build phase or layout.
-///
-/// [DiagnosticsNode.toTimelineArguments] includes these properties in its
-/// result.
-///
-/// See also:
-///
-///  * [dart:developer.Timeline.startSync], which typically takes this value as
-///    its `arguments` argument.
-const Map<String, String> timelineArgumentsIndicatingLandmarkEvent = <String, String>{
-  'mode': 'basic',
-};
-
 /// Configure [debugFormatDouble] using [num.toStringAsPrecision].
 ///
 /// Defaults to null, which uses the default logic of [debugFormatDouble].

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1547,14 +1547,10 @@ abstract class DiagnosticsNode {
   /// Converts the properties ([getProperties]) of this node to a form useful
   /// for [Timeline] event arguments (as in [Timeline.startSync]).
   ///
-  /// The properties specified by [timelineArgumentsIndicatingLandmarkEvent] are
-  /// included in the result.
-  ///
   /// Children ([getChildren]) are omitted.
   ///
   /// This method is only valid in debug builds. In profile builds, this method
-  /// throws an exception. In release builds, it returns a copy of
-  /// [timelineArgumentsIndicatingLandmarkEvent] with no arguments added.
+  /// throws an exception. In release builds it returns null.
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/foundation/diagnostics.dart
+++ b/packages/flutter/lib/src/foundation/diagnostics.dart
@@ -1560,8 +1560,7 @@ abstract class DiagnosticsNode {
   ///
   ///  * [toJsonMap], which converts this node to a structured form intended for
   ///    data exchange (e.g. with an IDE).
-  Map<String, String> toTimelineArguments() {
-    final Map<String, String> result = Map<String, String>.of(timelineArgumentsIndicatingLandmarkEvent);
+  Map<String, String>? toTimelineArguments() {
     if (!kReleaseMode) {
       // We don't throw in release builds, to avoid hurting users. We also don't do anything useful.
       if (kProfileMode) {
@@ -1573,13 +1572,15 @@ abstract class DiagnosticsNode {
           'this application is compiled in profile mode and yet still invoked the method.'
         );
       }
+      final Map<String, String> result = <String, String>{};
       for (final DiagnosticsNode property in getProperties()) {
         if (property.name != null) {
           result[property.name!] = property.toDescription(parentConfiguration: singleLineTextConfiguration);
         }
       }
+      return result;
     }
-    return result;
+    return null;
   }
 
   /// Serialize the node to a JSON map according to the configuration provided

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -513,7 +513,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     await super.performReassemble();
     if (BindingBase.debugReassembleConfig?.widgetName == null) {
       if (!kReleaseMode) {
-        Timeline.startSync('Preparing Hot Reload (layout)', arguments: timelineArgumentsIndicatingLandmarkEvent);
+        Timeline.startSync('Preparing Hot Reload (layout)');
       }
       try {
         renderView.reassemble();

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1369,15 +1369,15 @@ abstract class RenderBox extends RenderObject {
       return true;
     }());
     if (shouldCache) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         if (debugProfileLayoutsEnabled) {
           debugTimelineArguments = toDiagnosticsNode().toTimelineArguments();
         } else {
-          debugTimelineArguments = Map<String, String>.of(debugTimelineArguments);
+          debugTimelineArguments = <String, String>{};
         }
-        debugTimelineArguments['intrinsics dimension'] = describeEnum(dimension);
-        debugTimelineArguments['intrinsics argument'] = '$argument';
+        debugTimelineArguments!['intrinsics dimension'] = describeEnum(dimension);
+        debugTimelineArguments!['intrinsics argument'] = '$argument';
         return true;
       }());
       if (!kReleaseMode) {
@@ -1833,14 +1833,14 @@ abstract class RenderBox extends RenderObject {
       return true;
     }());
     if (shouldCache) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         if (debugProfileLayoutsEnabled) {
           debugTimelineArguments = toDiagnosticsNode().toTimelineArguments();
         } else {
-          debugTimelineArguments = Map<String, String>.of(debugTimelineArguments);
+          debugTimelineArguments = <String, String>{};
         }
-        debugTimelineArguments['getDryLayout constraints'] = '$constraints';
+        debugTimelineArguments!['getDryLayout constraints'] = '$constraints';
         return true;
       }());
       if (!kReleaseMode) {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -858,11 +858,10 @@ class PipelineOwner {
   /// See [RendererBinding] for an example of how this function is used.
   void flushLayout() {
     if (!kReleaseMode) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         if (debugProfileLayoutsEnabled) {
           debugTimelineArguments = <String, String>{
-            ...debugTimelineArguments,
             'dirty count': '${_nodesNeedingLayout.length}',
             'dirty list': '$_nodesNeedingLayout',
           };
@@ -931,7 +930,7 @@ class PipelineOwner {
   /// [flushPaint].
   void flushCompositingBits() {
     if (!kReleaseMode) {
-      Timeline.startSync('UPDATING COMPOSITING BITS', arguments: timelineArgumentsIndicatingLandmarkEvent);
+      Timeline.startSync('UPDATING COMPOSITING BITS');
     }
     _nodesNeedingCompositingBitsUpdate.sort((RenderObject a, RenderObject b) => a.depth - b.depth);
     for (final RenderObject node in _nodesNeedingCompositingBitsUpdate) {
@@ -964,11 +963,10 @@ class PipelineOwner {
   /// See [RendererBinding] for an example of how this function is used.
   void flushPaint() {
     if (!kReleaseMode) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         if (debugProfilePaintsEnabled) {
           debugTimelineArguments = <String, String>{
-            ...debugTimelineArguments,
             'dirty count': '${_nodesNeedingPaint.length}',
             'dirty list': '$_nodesNeedingPaint',
           };
@@ -1080,7 +1078,7 @@ class PipelineOwner {
     if (_semanticsOwner == null)
       return;
     if (!kReleaseMode) {
-      Timeline.startSync('SEMANTICS', arguments: timelineArgumentsIndicatingLandmarkEvent);
+      Timeline.startSync('SEMANTICS');
     }
     assert(_semanticsOwner != null);
     assert(() {
@@ -1796,7 +1794,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   void layout(Constraints constraints, { bool parentUsesSize = false }) {
     assert(!_debugDisposed);
     if (!kReleaseMode && debugProfileLayoutsEnabled) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         debugTimelineArguments = toDiagnosticsNode().toTimelineArguments();
         return true;
@@ -2400,7 +2398,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (_needsLayout)
       return;
     if (!kReleaseMode && debugProfilePaintsEnabled) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         debugTimelineArguments = toDiagnosticsNode().toTimelineArguments();
         return true;

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -221,7 +221,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// Actually causes the output of the rendering pipeline to appear on screen.
   void compositeFrame() {
     if (!kReleaseMode) {
-      Timeline.startSync('COMPOSITING', arguments: timelineArgumentsIndicatingLandmarkEvent);
+      Timeline.startSync('COMPOSITING');
     }
     try {
       final ui.SceneBuilder builder = ui.SceneBuilder();

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -1023,7 +1023,7 @@ mixin SchedulerBinding on BindingBase {
   /// statements printed during a frame from those printed between frames (e.g.
   /// in response to events or timers).
   void handleBeginFrame(Duration? rawTimeStamp) {
-    _frameTimelineTask?.start('Frame', arguments: timelineArgumentsIndicatingLandmarkEvent);
+    _frameTimelineTask?.start('Frame');
     _firstRawTimeStampInEpoch ??= rawTimeStamp;
     _currentFrameTimeStamp = _adjustForEpoch(rawTimeStamp ?? _lastRawTimeStamp);
     if (rawTimeStamp != null)
@@ -1050,7 +1050,7 @@ mixin SchedulerBinding on BindingBase {
     _hasScheduledFrame = false;
     try {
       // TRANSIENT FRAME CALLBACKS
-      _frameTimelineTask?.start('Animate', arguments: timelineArgumentsIndicatingLandmarkEvent);
+      _frameTimelineTask?.start('Animate');
       _schedulerPhase = SchedulerPhase.transientCallbacks;
       final Map<int, _FrameCallbackEntry> callbacks = _transientCallbacks;
       _transientCallbacks = <int, _FrameCallbackEntry>{};

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2563,11 +2563,10 @@ class BuildOwner {
       return true;
     }());
     if (!kReleaseMode) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         if (debugProfileBuildsEnabled) {
           debugTimelineArguments = <String, String>{
-            ...debugTimelineArguments,
             'dirty count': '${_dirtyElements.length}',
             'dirty list': '$_dirtyElements',
             'lock level': '$_debugStateLockLevel',
@@ -2643,7 +2642,7 @@ class BuildOwner {
         }());
         final bool isTimelineTracked = !kReleaseMode && _isProfileBuildsEnabledFor(element.widget);
         if (isTimelineTracked) {
-          Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+          Map<String, String>? debugTimelineArguments;
           assert(() {
             if (kDebugMode) {
               debugTimelineArguments = element.widget.toDiagnosticsNode().toTimelineArguments();
@@ -2926,7 +2925,7 @@ class BuildOwner {
   @pragma('vm:notify-debugger-on-exception')
   void finalizeTree() {
     if (!kReleaseMode) {
-      Timeline.startSync('FINALIZE TREE', arguments: timelineArgumentsIndicatingLandmarkEvent);
+      Timeline.startSync('FINALIZE TREE');
     }
     try {
       lockState(_inactiveElements._unmountAll); // this unregisters the GlobalKeys
@@ -3515,7 +3514,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
           updateSlotForChild(child, newSlot);
         final bool isTimelineTracked = !kReleaseMode && _isProfileBuildsEnabledFor(newWidget);
         if (isTimelineTracked) {
-          Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+          Map<String, String>? debugTimelineArguments;
           assert(() {
             if (kDebugMode) {
               debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();
@@ -3780,7 +3779,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
 
     final bool isTimelineTracked = !kReleaseMode && _isProfileBuildsEnabledFor(newWidget);
     if (isTimelineTracked) {
-      Map<String, String> debugTimelineArguments = timelineArgumentsIndicatingLandmarkEvent;
+      Map<String, String>? debugTimelineArguments;
       assert(() {
         if (kDebugMode) {
           debugTimelineArguments = newWidget.toDiagnosticsNode().toTimelineArguments();


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/101313

When this feature was landed in flutter it created a 15% performance regression (https://github.com/flutter/flutter/pull/12058#issuecomment-329841532)

From my local testing with our build_bench.dart microbenchmarks I'm seeing similar results with `debugProfileBuildsEnabled` turned on.  The parameters were added for a feature in the Dart observatory that no longer exists.

test-exempt: no added logic, removed logic for performance reasons

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
