### PR TITLE
Don't build surface until the platform view has been created

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -176,7 +176,13 @@ class RenderAndroidView extends PlatformViewRenderBox {
     Size targetSize;
     do {
       targetSize = size;
-      _currentTextureSize = await _viewController.setSize(targetSize);
+      if (_viewController.isCreated) {
+        _currentTextureSize = await _viewController.setSize(targetSize);
+      } else {
+        _viewController.setInitialSize(targetSize);
+        await _viewController.create();
+        _currentTextureSize = targetSize;
+      }
       // We've resized the platform view to targetSize, but it is possible that
       // while we were resizing the render object's size was changed again.
       // In that case we will resize the platform view again.

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -179,8 +179,7 @@ class RenderAndroidView extends PlatformViewRenderBox {
       if (_viewController.isCreated) {
         _currentTextureSize = await _viewController.setSize(targetSize);
       } else {
-        _viewController.setInitialSize(targetSize);
-        await _viewController.create();
+        await _viewController.create(size: targetSize);
         _currentTextureSize = targetSize;
       }
       // We've resized the platform view to targetSize, but it is possible that

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1242,7 +1242,6 @@ abstract class PlatformViewController {
   ///
   /// The size is inferred from the parent widget.
   ///
-  /// [size] is the view's new size in logical pixel, it must not be null and must
-  /// be bigger than zero.
+  /// [size] is the view's initial size in logical pixel.
   void setInitialSize(Size size);
 }

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1060,6 +1060,9 @@ class TextureAndroidViewController extends AndroidViewController {
   @override
   void setInitialSize(Size size) {
     assert(_state == _AndroidViewState.waitingForSize, 'Android view is already sized. View id: $viewId');
+    assert(size != null);
+    assert(!size.isEmpty);
+
     if (!_initialSize.isCompleted)
       _initialSize.complete(size);
   }
@@ -1068,7 +1071,6 @@ class TextureAndroidViewController extends AndroidViewController {
   Future<Size> setSize(Size size) async {
     assert(_state != _AndroidViewState.disposed, 'Android view is disposed. View id: $viewId');
     assert(_state != _AndroidViewState.waitingForSize, 'Android view is must have an initial size. View id: $viewId');
-
     assert(size != null);
     assert(!size.isEmpty);
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1015,13 +1015,9 @@ class ExpensiveAndroidViewController extends AndroidViewController {
 }
 
 /// Controls an Android view that is rendered as a texture.
-///
 /// This is typically used by [AndroidView] to display a View in the Android view hierarchy.
 ///
-/// The platform view is created by calling [create]. However, the platform view won't be
-/// created until an initial size is given.
-///
-/// Calling [setSize] prior to creating the view doesn't resize the view.
+/// The platform view is created by calling [create] with an initial size.
 ///
 /// The controller is typically created with [PlatformViewsService.initAndroidView].
 class TextureAndroidViewController extends AndroidViewController {

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1008,13 +1008,6 @@ class ExpensiveAndroidViewController extends AndroidViewController {
   }
 
   @override
-  void setInitialSize(Size size) {
-    // This is not necessary when a PlatformViewLayer is used.
-    // The initial size is derivated from the ExternalViewEmbedder,
-    // and sent to the platform via JNI.
-  }
-
-  @override
   Future<void> setOffset(Offset off) {
     throw UnimplementedError('Not supported for $SurfaceAndroidViewController.');
   }
@@ -1051,7 +1044,7 @@ class TextureAndroidViewController extends AndroidViewController {
   int? get textureId => _textureId;
 
   /// The size used to create the platform view.
-  Completer<Size> _initialSize = Completer<Size>();
+  final Completer<Size> _initialSize = Completer<Size>();
 
   /// The current offset of the platform view.
   Offset _off = Offset.zero;
@@ -1243,5 +1236,5 @@ abstract class PlatformViewController {
   /// The size is inferred from the parent widget.
   ///
   /// [size] is the view's initial size in logical pixel.
-  void setInitialSize(Size size);
+  void setInitialSize(Size size) {}
 }

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1051,20 +1051,17 @@ class TextureAndroidViewController extends AndroidViewController {
 
   @override
   void setInitialSize(Size size) {
-    assert(_state == _AndroidViewState.waitingForSize);
+    assert(_state == _AndroidViewState.waitingForSize, 'Android view is already sized. View id: $viewId');
     _initialSize.complete(size);
   }
 
   @override
   Future<Size> setSize(Size size) async {
-    assert(_state != _AndroidViewState.disposed, 'trying to size a disposed Android View. View id: $viewId');
+    assert(_state != _AndroidViewState.disposed, 'Android view is disposed. View id: $viewId');
+    assert(_state != _AndroidViewState.waitingForSize, 'Android view is must have an initial size. View id: $viewId');
 
     assert(size != null);
     assert(!size.isEmpty);
-
-    if (_state == _AndroidViewState.waitingForSize) {
-      return size;
-    }
 
     final Map<Object?, Object?>? meta = await SystemChannels.platform_views.invokeMapMethod<Object?, Object?>(
       'resize',

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1013,11 +1013,19 @@ class ExpensiveAndroidViewController extends AndroidViewController {
   }
 }
 
-/// Controls an Android view that is rendered to a texture.
+/// Controls an Android view that is rendered as a texture.
 ///
-/// This is typically used by [AndroidView] to display an Android View in the Android view hierarchy.
+/// This is typically used by [AndroidView] to display a View in the Android view hierarchy.
 ///
-/// Typically created with [PlatformViewsService.initAndroidView].
+/// The platform view is created by calling [create]. However, the platform view won't be
+/// created until an initial size is given.
+///
+/// To set the initial size of the platform view, use [setInitialSize]. After the platform
+/// view is created, it can be resized by calling [setSize].
+///
+/// Calling [setSize] prior to setting an initial size doesn't set the initial size.
+///
+/// The controller is typically created with [PlatformViewsService.initAndroidView].
 class TextureAndroidViewController extends AndroidViewController {
   TextureAndroidViewController._({
     required int viewId,
@@ -1103,7 +1111,7 @@ class TextureAndroidViewController extends AndroidViewController {
 
   @override
   Future<void> _sendCreateMessage() async {
-    // The initial size is set in the first call to setSize.
+    // The initial size is set after calling setInitialSize.
     final Size size = await _initialSize.future;
     assert(!size.isEmpty, 'trying to create $TextureAndroidViewController without setting a valid size.');
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1052,7 +1052,8 @@ class TextureAndroidViewController extends AndroidViewController {
   @override
   void setInitialSize(Size size) {
     assert(_state == _AndroidViewState.waitingForSize, 'Android view is already sized. View id: $viewId');
-    _initialSize.complete(size);
+    if (!_initialSize.isCompleted)
+      _initialSize.complete(size);
   }
 
   @override

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -1051,7 +1051,7 @@ class TextureAndroidViewController extends AndroidViewController {
   @override
   Future<Size> setSize(Size size) async {
     assert(_state != _AndroidViewState.disposed, 'Android view is disposed. View id: $viewId');
-    assert(_state != _AndroidViewState.waitingForSize, 'Android view is must have an initial size. View id: $viewId');
+    assert(_state != _AndroidViewState.waitingForSize, 'Android view must have an initial size. View id: $viewId');
     assert(size != null);
     assert(!size.isEmpty);
 

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -849,7 +849,7 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
   Widget build(BuildContext context) {
     if (!_platformViewCreated) {
       // Depending on the platform, the initial size can be used to size the platform view.
-      return _PlatformViewPlaceHolder(onLayout: _controller?.setInitialSize);
+      return _PlatformViewPlaceHolder(onLayout: _controller!.setInitialSize);
     }
     _surface ??= widget._surfaceFactory(context, _controller!);
     return Focus(
@@ -1082,19 +1082,18 @@ typedef _OnLayoutCallback = void Function(Size size);
 /// A [RenderBox] that notifies its size to the owner after a layout.
 class _PlatformViewPlaceholderBox extends RenderConstrainedBox {
   _PlatformViewPlaceholderBox({
-    this.onLayout,
+    required this.onLayout,
   }) : super(additionalConstraints: const BoxConstraints.tightFor(
       width: double.infinity,
       height: double.infinity,
     ));
 
-  _OnLayoutCallback? onLayout;
+  _OnLayoutCallback onLayout;
 
   @override
   void performLayout() {
     super.performLayout();
-    if (onLayout != null)
-      onLayout!(size);
+    onLayout(size);
   }
 }
 
@@ -1105,10 +1104,10 @@ class _PlatformViewPlaceholderBox extends RenderConstrainedBox {
 class _PlatformViewPlaceHolder extends SingleChildRenderObjectWidget {
   const _PlatformViewPlaceHolder({
     Key? key,
-    this.onLayout,
+    required this.onLayout,
   }) : super(key: key);
 
-  final _OnLayoutCallback? onLayout;
+  final _OnLayoutCallback onLayout;
 
   @override
   _PlatformViewPlaceholderBox createRenderObject(BuildContext context) {

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -892,7 +892,9 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
   }
 
   void _onPlatformViewCreated(int id) {
-    setState(() { print('created'); _platformViewCreated = true; });
+    setState(() {
+      _platformViewCreated = true;
+    });
   }
 
   void _handleFrameworkFocusChanged(bool isFocused) {

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -847,6 +847,9 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
 
   @override
   Widget build(BuildContext context) {
+    if (_controller == null) {
+      return const SizedBox.expand();
+    }
     if (!_platformViewCreated) {
       // Depending on the platform, the initial size can be used to size the platform view.
       return _PlatformViewPlaceHolder(onLayout: (Size size) => _controller!.create(size: size));

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -805,7 +805,6 @@ typedef CreatePlatformViewCallback = PlatformViewController Function(PlatformVie
 /// The `surfaceFactory` and the `onCreatePlatformView` are only called when the
 /// state of this widget is initialized, or when the `viewType` changes.
 class PlatformViewLink extends StatefulWidget {
-
   /// Construct a [PlatformViewLink] widget.
   ///
   /// The `surfaceFactory` and the `onCreatePlatformView` must not be null.
@@ -893,7 +892,7 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
   }
 
   void _onPlatformViewCreated(int id) {
-    setState(() { _platformViewCreated = true; });
+    setState(() { print('created'); _platformViewCreated = true; });
   }
 
   void _handleFrameworkFocusChanged(bool isFocused) {

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -849,7 +849,7 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
   Widget build(BuildContext context) {
     if (!_platformViewCreated) {
       // Depending on the platform, the initial size can be used to size the platform view.
-      return _PlatformViewPlaceHolder(onLayout: _controller!.setInitialSize);
+      return _PlatformViewPlaceHolder(onLayout: (Size size) => _controller!.create(size: size));
     }
     _surface ??= widget._surfaceFactory(context, _controller!);
     return Focus(

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -424,11 +424,6 @@ class _HtmlElementViewController extends PlatformViewController {
   }
 
   @override
-  void setInitialSize(Size size) {
-    // Investigate if Web can use the size from the parent as well.
-  }
-
-  @override
   Future<void> dispose() async {
     if (_initialized) {
       await SystemChannels.platform_views.invokeMethod<void>('dispose', viewId);
@@ -1086,7 +1081,7 @@ typedef _OnLayoutCallback = void Function(Size size);
 /// A [RenderBox] that notifies its size to the owner after a layout.
 class _PlatformViewPlaceholderBox extends RenderConstrainedBox {
   _PlatformViewPlaceholderBox({
-    _OnLayoutCallback? this.onLayout,
+    this.onLayout,
   }) : super(additionalConstraints: const BoxConstraints.tightFor(
       width: double.infinity,
       height: double.infinity,
@@ -1107,9 +1102,9 @@ class _PlatformViewPlaceholderBox extends RenderConstrainedBox {
 /// This placeholder is basically a [SizedBox.expand] with a [onLayout] callback to
 /// notify the size of the render object to its parent.
 class _PlatformViewPlaceHolder extends SingleChildRenderObjectWidget {
-  _PlatformViewPlaceHolder({
+  const _PlatformViewPlaceHolder({
     Key? key,
-    _OnLayoutCallback? this.onLayout,
+    this.onLayout,
   }) : super(key: key);
 
   final _OnLayoutCallback? onLayout;

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -424,6 +424,11 @@ class _HtmlElementViewController extends PlatformViewController {
   }
 
   @override
+  void setInitialSize(Size size) {
+    // Investigate if Web can use the size from the parent as well.
+  }
+
+  @override
   Future<void> dispose() async {
     if (_initialized) {
       await SystemChannels.platform_views.invokeMethod<void>('dispose', viewId);
@@ -842,11 +847,16 @@ class PlatformViewLink extends StatefulWidget {
 class _PlatformViewLinkState extends State<PlatformViewLink> {
   int? _id;
   PlatformViewController? _controller;
+  bool _platformViewCreated = false;
   Widget? _surface;
   FocusNode? _focusNode;
 
   @override
   Widget build(BuildContext context) {
+    if (!_platformViewCreated) {
+      // Depending on the platform, the initial size can be used to size the platform view.
+      return _PlatformViewPlaceHolder(onLayout: _controller?.setInitialSize);
+    }
     _surface ??= widget._surfaceFactory(context, _controller!);
     return Focus(
       focusNode: _focusNode,
@@ -881,10 +891,14 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
       PlatformViewCreationParams._(
         id: _id!,
         viewType: widget.viewType,
-        onPlatformViewCreated: (_) {},
+        onPlatformViewCreated: _onPlatformViewCreated,
         onFocusChanged: _handlePlatformFocusChanged,
       ),
     );
+  }
+
+  void _onPlatformViewCreated(int id) {
+    setState(() { _platformViewCreated = true; });
   }
 
   void _handleFrameworkFocusChanged(bool isFocused) {
@@ -1062,5 +1076,51 @@ class AndroidViewSurface extends PlatformViewSurface {
     viewController.pointTransformer =
         (Offset position) => renderBox.globalToLocal(position);
     return renderBox;
+  }
+}
+
+/// A callback used to notify the size of the platform view placeholder.
+/// This size is the initial size of the platform view.
+typedef _OnLayoutCallback = void Function(Size size);
+
+/// A [RenderBox] that notifies its size to the owner after a layout.
+class _PlatformViewPlaceholderBox extends RenderConstrainedBox {
+  _PlatformViewPlaceholderBox({
+    _OnLayoutCallback? this.onLayout,
+  }) : super(additionalConstraints: const BoxConstraints.tightFor(
+      width: double.infinity,
+      height: double.infinity,
+    ));
+
+  _OnLayoutCallback? onLayout;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    if (onLayout != null)
+      onLayout!(size);
+  }
+}
+
+/// When a platform view is in the widget hierarchy, this widget is used to capture
+/// the size of the platform view after the first layout.
+/// This placeholder is basically a [SizedBox.expand] with a [onLayout] callback to
+/// notify the size of the render object to its parent.
+class _PlatformViewPlaceHolder extends SingleChildRenderObjectWidget {
+  _PlatformViewPlaceHolder({
+    Key? key,
+    _OnLayoutCallback? this.onLayout,
+  }) : super(key: key);
+
+  final _OnLayoutCallback? onLayout;
+
+  @override
+  _PlatformViewPlaceholderBox createRenderObject(BuildContext context) {
+    return _PlatformViewPlaceholderBox(onLayout: onLayout);
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _PlatformViewPlaceholderBox renderObject) {
+    renderObject.onLayout = onLayout;
   }
 }

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -16,6 +16,7 @@ class FakePlatformViewController extends PlatformViewController {
 
   bool disposed = false;
   bool focusCleared = false;
+  Size initialSize = Size.zero;
 
   /// Events that are dispatched.
   List<PointerEvent> dispatchedPointerEvents = <PointerEvent>[];
@@ -42,6 +43,11 @@ class FakePlatformViewController extends PlatformViewController {
   @override
   Future<void> clearFocus() async {
     focusCleared = true;
+  }
+
+  @override
+  void setInitialSize(Size size) {
+    initialSize = size;
   }
 }
 

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -44,11 +44,6 @@ class FakePlatformViewController extends PlatformViewController {
   Future<void> clearFocus() async {
     focusCleared = true;
   }
-
-  @override
-  void setInitialSize(Size size) {
-    initialSize = size;
-  }
 }
 
 class FakeAndroidViewController implements AndroidViewController {
@@ -94,9 +89,6 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  void setInitialSize(Size size) {}
-
-  @override
   Future<void> setOffset(Offset off) async {}
 
   @override
@@ -126,7 +118,7 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  Future<void> create() async {}
+  Future<void> create({Size? size}) async {}
 
   @override
   List<PlatformViewCreatedCallback> get createdCallbacks => <PlatformViewCreatedCallback>[];

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -94,6 +94,9 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
+  void setInitialSize(Size size) {}
+
+  @override
   Future<void> setOffset(Offset off) async {}
 
   @override

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -16,7 +16,6 @@ class FakePlatformViewController extends PlatformViewController {
 
   bool disposed = false;
   bool focusCleared = false;
-  Size initialSize = Size.zero;
 
   /// Events that are dispatched.
   List<PointerEvent> dispatchedPointerEvents = <PointerEvent>[];

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -18,7 +18,7 @@ void main() {
     });
 
     test('create Android view of unregistered type', () async {
-      await expectLater(() => 
+      await expectLater(() =>
         PlatformViewsService.initAndroidView(
           id: 0,
           viewType: 'web',

--- a/packages/flutter/test/services/platform_views_test.dart
+++ b/packages/flutter/test/services/platform_views_test.dart
@@ -18,32 +18,32 @@ void main() {
     });
 
     test('create Android view of unregistered type', () async {
-      await expectLater(() => (
+      await expectLater(() => 
         PlatformViewsService.initAndroidView(
           id: 0,
           viewType: 'web',
           layoutDirection: TextDirection.ltr,
-        )..setInitialSize(const Size(100.0, 100.0))).create(),
+        ).create(size: const Size(100.0, 100.0)),
         throwsA(isA<PlatformException>()),
       );
       viewsController.registerViewType('web');
 
       try {
-        await (PlatformViewsService.initSurfaceAndroidView(
+        await PlatformViewsService.initSurfaceAndroidView(
           id: 0,
           viewType: 'web',
           layoutDirection: TextDirection.ltr,
-        )..setInitialSize(const Size(1.0, 1.0))).create();
+        ).create(size: const Size(1.0, 1.0));
       } catch (e) {
         expect(false, isTrue, reason: 'did not expected any exception, but instead got `$e`');
       }
 
       try {
-        await (PlatformViewsService.initAndroidView(
+        await PlatformViewsService.initAndroidView(
           id: 1,
           viewType: 'web',
           layoutDirection: TextDirection.ltr,
-        )..setInitialSize(const Size(1.0, 1.0))).create();
+        ).create(size: const Size(1.0, 1.0));
       } catch (e) {
         expect(false, isTrue, reason: 'did not expected any exception, but instead got `$e`');
       }
@@ -51,10 +51,10 @@ void main() {
 
     test('create Android views', () async {
       viewsController.registerViewType('webview');
-      await (PlatformViewsService.initAndroidView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr)
-          ..setInitialSize(const Size(100.0, 100.0))).create();
-      await (PlatformViewsService.initAndroidView( id: 1, viewType: 'webview', layoutDirection: TextDirection.rtl)
-          ..setInitialSize(const Size(200.0, 300.0))).create();
+      await PlatformViewsService.initAndroidView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr)
+          .create(size: const Size(100.0, 100.0));
+      await PlatformViewsService.initAndroidView( id: 1, viewType: 'webview', layoutDirection: TextDirection.rtl)
+          .create(size: const Size(200.0, 300.0));
       expect(
         viewsController.views,
         unorderedEquals(<FakeAndroidPlatformView>[
@@ -71,16 +71,15 @@ void main() {
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
       );
-      controller.setInitialSize(const Size(100.0, 100.0));
-      await controller.create();
+      await controller.create(size: const Size(100.0, 100.0));
       expectLater(
         () {
           final AndroidViewController controller = PlatformViewsService.initAndroidView(
             id: 0,
             viewType: 'web',
             layoutDirection: TextDirection.ltr,
-          )..setInitialSize(const Size(100.0, 100.0));
-          return controller.create();
+          );
+          return controller.create(size: const Size(100.0, 100.0));
         },
         throwsA(isA<PlatformException>()),
       );
@@ -88,26 +87,26 @@ void main() {
 
     test('dispose Android view', () async {
       viewsController.registerViewType('webview');
-      await (PlatformViewsService.initAndroidView(
+      await PlatformViewsService.initAndroidView(
         id: 0,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(100.0, 100.0))).create();
+      ).create(size: const Size(100.0, 100.0));
 
       final AndroidViewController viewController = PlatformViewsService.initAndroidView(
         id: 1,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(200.0, 300.0));
-      await viewController.create();
+      );
+      await viewController.create(size: const Size(200.0, 300.0));
       await viewController.dispose();
 
       final AndroidViewController surfaceViewController = PlatformViewsService.initSurfaceAndroidView(
         id: 1,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(200.0, 300.0));
-      await surfaceViewController.create();
+      );
+      await surfaceViewController.create(size: const Size(200.0, 300.0));
       await surfaceViewController.dispose();
 
       expect(
@@ -124,8 +123,8 @@ void main() {
         id: 1,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(200.0, 300.0));
-      await viewController.create();
+      );
+      await viewController.create(size: const Size(200.0, 300.0));
       await viewController.dispose();
       await viewController.dispose();
     });
@@ -138,8 +137,8 @@ void main() {
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
         onFocus: () { didFocus = true; },
-      )..setInitialSize(const Size(100.0, 100.0));
-      await viewController.create();
+      );
+      await viewController.create(size: const Size(100.0, 100.0));
       await viewController.dispose();
       final ByteData message =
           SystemChannels.platform_views.codec.encodeMethodCall(const MethodCall('viewFocused', 0));
@@ -149,18 +148,18 @@ void main() {
 
     test('resize Android view', () async {
       viewsController.registerViewType('webview');
-      await (PlatformViewsService.initAndroidView(
+      await PlatformViewsService.initAndroidView(
         id: 0,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(100.0, 100.0))).create();
+      ).create(size: const Size(100.0, 100.0));
 
       final AndroidViewController androidView = PlatformViewsService.initAndroidView(
         id: 1,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(200.0, 300.0));
-      await androidView.create();
+      );
+      await androidView.create(size: const Size(200.0, 300.0));
       await androidView.setSize(const Size(500.0, 500.0));
 
       expect(
@@ -184,8 +183,7 @@ void main() {
       )..addOnPlatformViewCreatedListener(callback);
       expect(createdViews, isEmpty);
 
-      controller1.setInitialSize(const Size(100.0, 100.0));
-      await controller1.create();
+      await controller1.create(size: const Size(100.0, 100.0));
       expect(createdViews, orderedEquals(<int>[0]));
 
       final AndroidViewController controller2 = PlatformViewsService.initAndroidView(
@@ -195,8 +193,7 @@ void main() {
       )..addOnPlatformViewCreatedListener(callback);
       expect(createdViews, orderedEquals(<int>[0]));
 
-      controller2.setInitialSize(const Size(100.0, 200.0));
-      await controller2.create();
+      await controller2.create(size: const Size(100.0, 200.0));
       expect(createdViews, orderedEquals(<int>[0, 5]));
 
     });
@@ -207,9 +204,9 @@ void main() {
         id: 0,
         viewType: 'webview',
         layoutDirection: TextDirection.rtl,
-      )..setInitialSize(const Size(100.0, 100.0));
+      );
       await viewController.setLayoutDirection(TextDirection.ltr);
-      await viewController.create();
+      await viewController.create(size: const Size(100.0, 100.0));
       expect(
         viewsController.views,
         unorderedEquals(<FakeAndroidPlatformView>[
@@ -224,9 +221,9 @@ void main() {
         id: 0,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(100.0, 100.0));
+      );
       await viewController.setLayoutDirection(TextDirection.rtl);
-      await viewController.create();
+      await viewController.create(size: const Size(100.0, 100.0));
       expect(
         viewsController.views,
         unorderedEquals(<FakeAndroidPlatformView>[
@@ -241,8 +238,8 @@ void main() {
         id: 7,
         viewType: 'webview',
         layoutDirection: TextDirection.ltr,
-      )..setInitialSize(const Size(100.0, 100.0));
-      await viewController.create();
+      );
+      await viewController.create(size: const Size(100.0, 100.0));
       await viewController.setOffset(const Offset(10, 20));
       expect(
         viewsController.offsets,


### PR DESCRIPTION
Builds a placeholder that is used to capture the size of the render object after layout, then
it communicates the size to the controller, so the platform view can be created on platforms 
that need to wait for the creation to happen prior to building the surface.

Fixes a crash issue in Fuchsia:
https://logs.chromium.org/logs/turquoise/buildbucket/cr-buildbucket/8817759165575272161/+/u/failures/AEMU-_1_/attempt_0__fail_/failed:_fuchsia-pkg:__fuchsia.com_touch-input-test-ip_meta_touch-input-test-ip-component.cm/infra_and_test_std_and_klog.txt