### PR TITLE
`ThemeData`: Fix `ColorScheme` is ignored when provided in the `ThemeData.colorScheme`

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -460,7 +460,9 @@ class ThemeData with Diagnosticable {
     final bool isDark = effectiveBrightness == Brightness.dark;
     if (colorSchemeSeed != null) {
       colorScheme = ColorScheme.fromSeed(seedColor: colorSchemeSeed, brightness: effectiveBrightness);
+    }
 
+    if (colorScheme != null) {
       // For surfaces that use primary color in light themes and surface color in dark
       final Color primarySurfaceColor = isDark ? colorScheme.surface : colorScheme.primary;
       final Color onPrimarySurfaceColor = isDark ? colorScheme.onSurface : colorScheme.onPrimary;

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -266,8 +266,9 @@ void main() {
   });
 
   testWidgets('Scaffold inherits ColorScheme.background', (WidgetTester tester) async {
-    const Color seedColor = Color(0xFF00FF00);
-    const Color backgroundColor = Color(0xFF0000ff);
+    const Color seedColor = Color(0xff00FF00);
+    const Color redColor = Color(0xffff0000);
+    const Color blueColor = Color(0xff0000ff);
 
     Widget buildApp({Color? seedColor, ColorScheme? colorScheme, Color? background}) {
       return MaterialApp(
@@ -309,19 +310,19 @@ void main() {
     expect(materials[0].color, const Color(0xfffcfcf6)); // app scaffold
     expect(materials[1].color, const Color(0xfffcfcf6)); // dialog scaffold
 
-    await tester.pumpWidget(buildApp(colorScheme: const ColorScheme.light().copyWith(background: backgroundColor)));
+    await tester.pumpWidget(buildApp(colorScheme: const ColorScheme.light().copyWith(background: redColor)));
     await tester.pumpAndSettle();
     materials = tester.widgetList<Material>(find.byType(Material)).toList();
     expect(materials.length, equals(2));
-    expect(materials[0].color, backgroundColor); // app scaffold
-    expect(materials[1].color, backgroundColor); // dialog scaffold
+    expect(materials[0].color, redColor); // app scaffold
+    expect(materials[1].color, redColor); // dialog scaffold
 
-    await tester.pumpWidget(buildApp(colorScheme: ColorScheme.fromSeed(seedColor: seedColor, background: backgroundColor)));
+    await tester.pumpWidget(buildApp(colorScheme: ColorScheme.fromSeed(seedColor: seedColor, background: blueColor)));
     await tester.pumpAndSettle();
     materials = tester.widgetList<Material>(find.byType(Material)).toList();
     expect(materials.length, equals(2));
-    expect(materials[0].color, backgroundColor); // app scaffold
-    expect(materials[1].color, backgroundColor); // dialog scaffold
+    expect(materials[0].color, blueColor); // app scaffold
+    expect(materials[1].color, blueColor); // dialog scaffold
   });
 
   testWidgets('IconThemes are applied', (WidgetTester tester) async {

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -265,6 +265,65 @@ void main() {
     expect(materials[1].color, green); // dialog scaffold
   });
 
+  testWidgets('Scaffold inherits ColorScheme.background', (WidgetTester tester) async {
+    const Color seedColor = Color(0xFF00FF00);
+    const Color backgroundColor = Color(0xFF0000ff);
+
+    Widget buildApp({Color? seedColor, ColorScheme? colorScheme, Color? background}) {
+      return MaterialApp(
+        theme: ThemeData(colorSchemeSeed: seedColor, colorScheme: colorScheme),
+        home: Scaffold(
+          body: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return GestureDetector(
+                  onTap: () {
+                    showDialog<void>(
+                      context: context,
+                      builder: (BuildContext context) {
+                        return const Scaffold(
+                          body: SizedBox(
+                            width: 200.0,
+                            height: 200.0,
+                          ),
+                        );
+                      },
+                    );
+                  },
+                  child: const Text('SHOW'),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp(seedColor: seedColor));
+
+    await tester.tap(find.text('SHOW'));
+    await tester.pump(const Duration(seconds: 1));
+
+    List<Material> materials = tester.widgetList<Material>(find.byType(Material)).toList();
+    expect(materials.length, equals(2));
+    expect(materials[0].color, const Color(0xfffcfcf6)); // app scaffold
+    expect(materials[1].color, const Color(0xfffcfcf6)); // dialog scaffold
+
+    await tester.pumpWidget(buildApp(colorScheme: const ColorScheme.light().copyWith(background: backgroundColor)));
+    await tester.pumpAndSettle();
+    materials = tester.widgetList<Material>(find.byType(Material)).toList();
+    expect(materials.length, equals(2));
+    expect(materials[0].color, backgroundColor); // app scaffold
+    expect(materials[1].color, backgroundColor); // dialog scaffold
+
+    await tester.pumpWidget(buildApp(colorScheme: ColorScheme.fromSeed(seedColor: seedColor, background: backgroundColor)));
+    await tester.pumpAndSettle();
+    materials = tester.widgetList<Material>(find.byType(Material)).toList();
+    expect(materials.length, equals(2));
+    expect(materials[0].color, backgroundColor); // app scaffold
+    expect(materials[1].color, backgroundColor); // dialog scaffold
+  });
+
   testWidgets('IconThemes are applied', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/101389



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
