### PR TITLE
Partial revert of super params in tools

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -21,14 +21,20 @@ import 'mixins.dart';
 class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments, FlutterAttachRequestArguments>
     with PidTracker {
   FlutterDebugAdapter(
-    super.channel, {
+    ByteStreamServerChannel channel, {
     required this.fileSystem,
     required this.platform,
-    super.ipv6,
-    super.enableDds,
-    super.enableAuthCodes,
-    super.logger,
-  });
+    bool ipv6 = false,
+    bool enableDds = true,
+    bool enableAuthCodes = true,
+    Logger? logger,
+  }) : super(
+    channel,
+    ipv6: ipv6,
+    enableDds: enableDds,
+    enableAuthCodes: enableAuthCodes,
+    logger: logger,
+  );
 
   FileSystem fileSystem;
   Platform platform;

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -21,14 +21,20 @@ import 'mixins.dart';
 class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments, FlutterAttachRequestArguments>
     with PidTracker, TestAdapter {
   FlutterTestDebugAdapter(
-    super.channel, {
+    ByteStreamServerChannel channel, {
     required this.fileSystem,
     required this.platform,
-    super.ipv6,
-    super.enableDds,
-    super.enableAuthCodes,
-    super.logger,
-  });
+    bool ipv6 = false,
+    bool enableDds = true,
+    bool enableAuthCodes = true,
+    Logger? logger,
+  }) : super(
+    channel,
+    ipv6: ipv6,
+    enableDds: enableDds,
+    enableAuthCodes: enableAuthCodes,
+    logger: logger,
+  );
 
   FileSystem fileSystem;
   Platform platform;


### PR DESCRIPTION
Google3 is failing on this:

```
google3:///[third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart:27](https://cs.corp.google.com/piper///depot/google3/third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart?l=27&ws=tap-prod-presubmit/179932707&snapshot=7):11: Error: The parameter 'ipv6' can't have a value of 'null' because of its type 'bool', but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    super.ipv6,
          ^^^^
google3:///[third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart:28](https://cs.corp.google.com/piper///depot/google3/third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart?l=28&ws=tap-prod-presubmit/179932707&snapshot=7):11: Error: The parameter 'enableDds' can't have a value of 'null' because of its type 'bool', but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    super.enableDds,
          ^^^^^^^^^
google3:///[third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart:29](https://cs.corp.google.com/piper///depot/google3/third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart?l=29&ws=tap-prod-presubmit/179932707&snapshot=7):11: Error: The parameter 'enableAuthCodes' can't have a value of 'null' because of its type 'bool', but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    super.enableAuthCodes,
          ^^^^^^^^^^^^^^^
google3:///[third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart:27](https://cs.corp.google.com/piper///depot/google3/third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart?l=27&ws=tap-prod-presubmit/179932707&snapshot=7):11: Error: The parameter 'ipv6' can't have a value of 'null' because of its type 'bool', but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    super.ipv6,
          ^^^^
google3:///[third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart:28](https://cs.corp.google.com/piper///depot/google3/third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart?l=28&ws=tap-prod-presubmit/179932707&snapshot=7):11: Error: The parameter 'enableDds' can't have a value of 'null' because of its type 'bool', but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    super.enableDds,
          ^^^^^^^^^
google3:///[third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart:29](https://cs.corp.google.com/piper///depot/google3/third_party/dart/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart?l=29&ws=tap-prod-presubmit/179932707&snapshot=7):11: Error: The parameter 'enableAuthCodes' can't have a value of 'null' because of its type 'bool', but the implicit default value is 'null'.
Try adding either an explicit non-'null' default value or the 'required' modifier.
    super.enableAuthCodes,
          ^^^^^^^^^^^^^^^
```