### PR TITLE
Expose `Duration` after which dragging is enabled in `ReorderableList` and add default drag handles on mobile

### DIFF
--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart
@@ -39,7 +39,8 @@ class _ReorderableExampleState extends State<ReorderableExample> {
     final Color evenItemColor = colorScheme.primary.withOpacity(0.15);
 
     return ReorderableListView(
-      buildDefaultDragHandles: false,
+      buildDefaultDragHandlesOnDesktop: false,
+      delayedDragStartDuration: null,
       children: <Widget>[
         for (int index = 0; index < _items.length; index++)
           Container(

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -82,6 +82,7 @@ class ReorderableListView extends StatefulWidget {
     this.anchor = 0.0,
     this.cacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.delayedDragStartDuration = kLongPressTimeout,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.restorationId,
     this.clipBehavior = Clip.hardEdge,
@@ -151,6 +152,7 @@ class ReorderableListView extends StatefulWidget {
     this.anchor = 0.0,
     this.cacheExtent,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.delayedDragStartDuration = kLongPressTimeout,
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.restorationId,
     this.clipBehavior = Clip.hardEdge,
@@ -248,6 +250,10 @@ class ReorderableListView extends StatefulWidget {
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
+
+  /// The delay after which the user is able to drag the element.
+  /// By default, this is [kLongPressTimeout].
+  final Duration delayedDragStartDuration;
 
   /// {@macro flutter.widgets.scroll_view.keyboardDismissBehavior}
   ///
@@ -397,11 +403,18 @@ class _ReorderableListViewState extends State<ReorderableListView> {
         case TargetPlatform.iOS:
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
-          return ReorderableDelayedDragStartListener(
-            key: itemGlobalKey,
-            index: index,
-            child: itemWithSemantics,
-          );
+          return widget.delayedDragStartDuration == Duration.zero
+              ? ReorderableDragStartListener(
+                  key: itemGlobalKey,
+                  index: index,
+                  child: itemWithSemantics,
+                )
+              : ReorderableDelayedDragStartListener(
+                  key: itemGlobalKey,
+                  index: index,
+                  delay: widget.delayedDragStartDuration,
+                  child: itemWithSemantics,
+                );
       }
     }
 

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -457,7 +457,6 @@ class _ReorderableListViewState extends State<ReorderableListView> {
                 child: itemWithSemantics,
               );
     }
-    
 
     return KeyedSubtree(
       key: itemGlobalKey,

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1310,8 +1310,9 @@ class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
     this.delay = kLongPressTimeout,
   });
 
-  /// The [Duration] it takes for the press gesture to be promoted into a long
-  /// press gesture and enable a drag ability.
+  /// The amount of time the pointer must remain in the same place for the drag to be recognized.
+  ///
+  /// The default is [kLongPressTimeOut].
   final Duration delay;
 
   @override

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1296,7 +1296,7 @@ class ReorderableDragStartListener extends StatelessWidget {
 class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
   /// Creates a listener for a drag following a long press event over the
   /// given child widget.
-  /// 
+  ///
   /// The [delay] specifies the [Duration] it takes for the press gesture to be
   /// considered a long press. The [delay] defaults to [kLongPressTimeout].
   ///

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -1294,8 +1294,11 @@ class ReorderableDragStartListener extends StatelessWidget {
 ///  * [ReorderableListView], a Material Design list that allows the user to
 ///    reorder its items.
 class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
-  /// Creates a listener for an drag following a long press event over the
+  /// Creates a listener for a drag following a long press event over the
   /// given child widget.
+  /// 
+  /// The [delay] specifies the [Duration] it takes for the press gesture to be
+  /// considered a long press. The [delay] defaults to [kLongPressTimeout].
   ///
   /// This is most commonly used to wrap an entire list item in a reorderable
   /// list.
@@ -1304,11 +1307,16 @@ class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
     required super.child,
     required super.index,
     super.enabled,
+    this.delay = kLongPressTimeout,
   });
+
+  /// The [Duration] it takes for the press gesture to be promoted into a long
+  /// press gesture and enable a drag ability.
+  final Duration delay;
 
   @override
   MultiDragGestureRecognizer createRecognizer() {
-    return DelayedMultiDragGestureRecognizer(debugOwner: this);
+    return DelayedMultiDragGestureRecognizer(debugOwner: this, delay: delay);
   }
 }
 


### PR DESCRIPTION
The `ReorderableDelayedDragStartListener` now takes `Duration delay` as an argument that is passed into `DelayedMultiDragGestureRecognizer`. This gives an option to manually change the duration a user needs to press on an item before user can drag the element around.

The `ReorderableList` now takes `bool buildDefaultDragHandlesOnDesktop` and `bool buildDefaultDragHandlesOnMobile` which indicate whether the default drag handles should be build or not on respective platforms. The somewhat ambiguous member `bool buildDefaultDragHandles` has been removed

Fixing issue: #25065 (and others linked in this issue).

flutter/tests repo left intact.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
