### PR TITLE
Clear the baseline cache when RenderBox is laid out

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1803,8 +1803,6 @@ abstract class RenderBox extends RenderObject {
   Map<BoxConstraints, Size>? _cachedDryLayoutSizes;
   bool _computingThisDryLayout = false;
 
-  bool _notifyParentIfDirty = false;
-
   /// Returns the [Size] that this [RenderBox] would like to be given the
   /// provided [BoxConstraints].
   ///
@@ -2350,7 +2348,7 @@ abstract class RenderBox extends RenderObject {
     }());
   }
 
-  void _clearCachedData() {
+  bool _clearCachedData() {
     if ((_cachedBaselines != null && _cachedBaselines!.isNotEmpty) ||
         (_cachedIntrinsicDimensions != null && _cachedIntrinsicDimensions!.isNotEmpty) ||
         (_cachedDryLayoutSizes != null && _cachedDryLayoutSizes!.isNotEmpty)) {
@@ -2362,16 +2360,15 @@ abstract class RenderBox extends RenderObject {
       _cachedBaselines?.clear();
       _cachedIntrinsicDimensions?.clear();
       _cachedDryLayoutSizes?.clear();
-      _notifyParentIfDirty = true;
+      return true;
     }
+    return false;
   }
 
   @override
   void markNeedsLayout() {
-    _clearCachedData();
-    if (_notifyParentIfDirty && parent is RenderObject) {
+    if (_clearCachedData() && parent is RenderObject) {
       markParentNeedsLayout();
-      _notifyParentIfDirty = false;
       return;
     }
     super.markNeedsLayout();
@@ -2383,7 +2380,6 @@ abstract class RenderBox extends RenderObject {
         _cachedBaselines != null && _cachedBaselines!.isNotEmpty) {
       // The cached baselines data may need update if the constraints change.
       _cachedBaselines?.clear();
-      _notifyParentIfDirty = true;
     }
     super.layout(constraints, parentUsesSize: parentUsesSize);
   }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2348,8 +2348,7 @@ abstract class RenderBox extends RenderObject {
     }());
   }
 
-  @override
-  void markNeedsLayout() {
+  bool _clearCachedData() {
     if ((_cachedBaselines != null && _cachedBaselines!.isNotEmpty) ||
         (_cachedIntrinsicDimensions != null && _cachedIntrinsicDimensions!.isNotEmpty) ||
         (_cachedDryLayoutSizes != null && _cachedDryLayoutSizes!.isNotEmpty)) {
@@ -2361,12 +2360,24 @@ abstract class RenderBox extends RenderObject {
       _cachedBaselines?.clear();
       _cachedIntrinsicDimensions?.clear();
       _cachedDryLayoutSizes?.clear();
-      if (parent is RenderObject) {
-        markParentNeedsLayout();
-        return;
-      }
+      return true;
+    }
+    return false;
+  }
+
+  @override
+  void markNeedsLayout() {
+    if (_clearCachedData() && parent is RenderObject) {
+      markParentNeedsLayout();
+      return;
     }
     super.markNeedsLayout();
+  }
+
+  @override
+  void layout(Constraints constraints, {bool parentUsesSize = false}) {
+    _clearCachedData();
+    super.layout(constraints, parentUsesSize: parentUsesSize);
   }
 
   /// {@macro flutter.rendering.RenderObject.performResize}

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1804,7 +1804,6 @@ abstract class RenderBox extends RenderObject {
   bool _computingThisDryLayout = false;
 
   bool _notifyParentIfDirty = false;
-  Constraints? _lastConstraints;
 
   /// Returns the [Size] that this [RenderBox] would like to be given the
   /// provided [BoxConstraints].
@@ -2380,9 +2379,8 @@ abstract class RenderBox extends RenderObject {
 
   @override
   void layout(Constraints constraints, {bool parentUsesSize = false}) {
-    if (constraints != _lastConstraints) {
+    if (hasSize && constraints != this.constraints) {
       _clearCachedData();
-      _lastConstraints = constraints;
     }
     super.layout(constraints, parentUsesSize: parentUsesSize);
   }

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -2379,8 +2379,11 @@ abstract class RenderBox extends RenderObject {
 
   @override
   void layout(Constraints constraints, {bool parentUsesSize = false}) {
-    if (hasSize && constraints != this.constraints) {
-      _clearCachedData();
+    if (hasSize && constraints != this.constraints &&
+        _cachedBaselines != null && _cachedBaselines!.isNotEmpty) {
+      // The cached baselines data may need update if the constraints change.
+      _cachedBaselines?.clear();
+      _notifyParentIfDirty = true;
     }
     super.layout(constraints, parentUsesSize: parentUsesSize);
   }

--- a/packages/flutter/test/rendering/cached_intrinsics_test.dart
+++ b/packages/flutter/test/rendering/cached_intrinsics_test.dart
@@ -86,7 +86,7 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/101179
-  test('Cached baselines should be clear if its parent re-layout', () {
+  test('Cached baselines should be cleared if its parent re-layout', () {
     double viewHeight =  200.0;
     final RenderBox test = RenderTestBox();
     final RenderBox baseline = RenderBaseline(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/101179#issuecomment-1091049520

Currently,  we only clear the cached data when the render self was marked dirty. 
We should also reset the data if its parent was re-layout directly.