### PR TITLE
Re-enable Gold post-submit fail state

### DIFF
--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -257,46 +257,44 @@ void main() {
       await skiaClient.tryjobInit();
     });
 
-    // TODO(Piinks): Re-enable once https://github.com/flutter/flutter/issues/100304
-    // is resolved.
-    // test('throws for error state from imgtestAdd', () {
-    //   final File goldenFile = fs.file('/workDirectory/temp/golden_file_test.png')
-    //     ..createSync(recursive: true);
-    //   platform = FakePlatform(
-    //       environment: <String, String>{
-    //         'FLUTTER_ROOT': _kFlutterRoot,
-    //         'GOLDCTL' : 'goldctl',
-    //       },
-    //       operatingSystem: 'macos'
-    //   );
-    //
-    //   skiaClient = SkiaGoldClient(
-    //     workDirectory,
-    //     fs: fs,
-    //     process: process,
-    //     platform: platform,
-    //     httpClient: fakeHttpClient,
-    //   );
-    //
-    //   const RunInvocation goldctlInvocation = RunInvocation(
-    //     <String>[
-    //       'goldctl',
-    //       'imgtest', 'add',
-    //       '--work-dir', '/workDirectory/temp',
-    //       '--test-name', 'golden_file_test',
-    //       '--png-file', '/workDirectory/temp/golden_file_test.png',
-    //       '--passfail',
-    //     ],
-    //     null,
-    //   );
-    //   process.processResults[goldctlInvocation] = ProcessResult(123, 1, 'Expected failure', 'Expected failure');
-    //   process.fallbackProcessResult = ProcessResult(123, 1, 'Fallback failure', 'Fallback failure');
-    //
-    //   expect(
-    //     skiaClient.imgtestAdd('golden_file_test', goldenFile),
-    //     throwsException,
-    //   );
-    // });
+    test('throws for error state from imgtestAdd', () {
+      final File goldenFile = fs.file('/workDirectory/temp/golden_file_test.png')
+        ..createSync(recursive: true);
+      platform = FakePlatform(
+          environment: <String, String>{
+            'FLUTTER_ROOT': _kFlutterRoot,
+            'GOLDCTL' : 'goldctl',
+          },
+          operatingSystem: 'macos'
+      );
+
+      skiaClient = SkiaGoldClient(
+        workDirectory,
+        fs: fs,
+        process: process,
+        platform: platform,
+        httpClient: fakeHttpClient,
+      );
+
+      const RunInvocation goldctlInvocation = RunInvocation(
+        <String>[
+          'goldctl',
+          'imgtest', 'add',
+          '--work-dir', '/workDirectory/temp',
+          '--test-name', 'golden_file_test',
+          '--png-file', '/workDirectory/temp/golden_file_test.png',
+          '--passfail',
+        ],
+        null,
+      );
+      process.processResults[goldctlInvocation] = ProcessResult(123, 1, 'Expected failure', 'Expected failure');
+      process.fallbackProcessResult = ProcessResult(123, 1, 'Fallback failure', 'Fallback failure');
+
+      expect(
+        skiaClient.imgtestAdd('golden_file_test', goldenFile),
+        throwsException,
+      );
+    });
 
     test('correctly inits tryjob for luci', () async {
       platform = FakePlatform(

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -212,12 +212,7 @@ class SkiaGoldClient {
         ..writeln('Debug information for Gold:')
         ..writeln('stdout: ${result.stdout}')
         ..writeln('stderr: ${result.stderr}');
-      // Temporarily print logs for issue diagnosis
-      // ignore: avoid_print
-      print(buf.toString());
-      // TODO(Piinks): Re-enable once https://github.com/flutter/flutter/issues/100304
-      // is resolved.
-      // throw Exception(buf.toString());
+      throw Exception(buf.toString());
     }
 
     return true;


### PR DESCRIPTION
Gold post-submit testing has been stable for a while now. It should be safe to re-enable the post-submit fail state.
And issue was causing it to incorrectly close the tree previously, and it has been resolved.
Fixes https://github.com/flutter/flutter/issues/100304

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
