### PR TITLE
Ensure that the engine frame callbacks are installed if the first scheduled frame is a forced frame

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -825,6 +825,7 @@ mixin SchedulerBinding on BindingBase {
         debugPrintStack(label: 'scheduleForcedFrame() called. Current phase is $schedulerPhase.');
       return true;
     }());
+    ensureFrameCallbacksRegistered();
     platformDispatcher.scheduleFrame();
     _hasScheduledFrame = true;
   }

--- a/packages/flutter/test/scheduler/binding_test.dart
+++ b/packages/flutter/test/scheduler/binding_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  test('scheduleForcedFrame sets up frame callbacks', () async {
+    SchedulerBinding.instance.scheduleForcedFrame();
+    expect(SchedulerBinding.instance.platformDispatcher.onBeginFrame, isNotNull);
+  });
+}


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/98419
