### PR TITLE
Delete deferred component test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2304,21 +2304,6 @@ targets:
     scheduler: luci
     timeout: 60
 
-  - name: Linux deferred components
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/96403
-    recipe: flutter/deferred_components
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "android_virtual_device", "version": "31"},
-          {"dependency": "curl"}
-        ]
-      tags: >
-        ["framework","hostonly"]
-    scheduler: luci
-    timeout: 60
-
   - name: Linux_android opacity_peephole_one_rect_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/96403

The emulator installation is too flaky on infra. We are basically already getting no signal from this test.

@keyonghan is this all that's needed to stop this test from running?