### PR TITLE
Enable strict-casts (as replacement for implicit-casts)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,8 +1,5 @@
 # Specify analysis options.
 #
-# Until there are meta linter rules, each desired lint must be explicitly enabled.
-# See: https://github.com/dart-lang/linter/issues/288
-#
 # For a list of lints, see: http://dart-lang.github.io/linter/lints/
 # See the configuration guide for more
 # https://github.com/dart-lang/sdk/tree/main/pkg/analyzer#configuring-the-analyzer
@@ -15,11 +12,12 @@
 #   - https://github.com/flutter/engine/blob/master/analysis_options.yaml
 #   - https://github.com/flutter/packages/blob/master/analysis_options.yaml
 #
-# This file contains the analysis options used by Flutter tools, such as IntelliJ,
-# Android Studio, and the `flutter analyze` command.
+# This file contains the analysis options used for code in the flutter/flutter
+# repository.
 
 analyzer:
   language:
+    strict-casts: true
     strict-raw-types: true
   errors:
     # treat missing required parameters as a warning (not a hint)
@@ -43,8 +41,7 @@ analyzer:
 
 linter:
   rules:
-    # these rules are documented on and in the same order as
-    # the Dart Lint rules page to make maintenance easier
+    # This list is derived from the list of all available lints located at
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml
     - always_declare_return_types
     - always_put_control_body_on_new_line

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1735,7 +1735,7 @@ class TextInput {
 
         final Map<String, dynamic> encoded = args[1] as Map<String, dynamic>;
 
-        for (final dynamic encodedDelta in encoded['deltas']) {
+        for (final dynamic encodedDelta in encoded['deltas'] as List<dynamic>) {
           final TextEditingDelta delta = TextEditingDelta.fromJSON(encodedDelta as Map<String, dynamic>);
           deltas.add(delta);
         }

--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -234,7 +234,7 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
         return loadingUnits;
       }
       if (data['loading-units'] != null) {
-        for (final Object? loadingUnitData in data['loading-units']) {
+        for (final Object? loadingUnitData in data['loading-units'] as List<Object?>) {
           if (loadingUnitData is! YamlMap) {
             invalidFiles[cacheFile.path] = "Invalid loading units yaml file, 'loading-units' "
                                              'is not a list of maps.';
@@ -267,7 +267,7 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
     // Parse out validated yaml.
     if (data.containsKey('loading-units')) {
       if (data['loading-units'] != null) {
-        for (final Object? loadingUnitData in data['loading-units']) {
+        for (final Object? loadingUnitData in data['loading-units'] as List<Object?>) {
           final YamlMap? loadingUnitDataMap = loadingUnitData as YamlMap?;
           final List<String> libraries = <String>[];
           final YamlList? nodes = loadingUnitDataMap?['libraries'] as YamlList?;

--- a/packages/flutter_tools/lib/src/base/deferred_component.dart
+++ b/packages/flutter_tools/lib/src/base/deferred_component.dart
@@ -195,7 +195,7 @@ class LoadingUnit {
     final List<LoadingUnit> loadingUnits = <LoadingUnit>[];
     // Setup android source directory
     if (manifest != null) {
-      for (final dynamic loadingUnitMetadata in manifest['loadingUnits']) {
+      for (final dynamic loadingUnitMetadata in manifest['loadingUnits'] as List<dynamic>) {
         final Map<String, dynamic> loadingUnitMap = loadingUnitMetadata as Map<String, dynamic>;
         if (loadingUnitMap['id'] == 1) {
           continue; // Skip base unit

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -636,7 +636,7 @@ void _validateFonts(YamlList fonts, List<String> errors) {
       errors.add('Expected "fonts" to either be null or a list.');
       continue;
     }
-    for (final Object? fontMapList in fontMap['fonts']) {
+    for (final Object? fontMapList in fontMap['fonts'] as List<Object?>) {
       if (fontMapList is! YamlMap) {
         errors.add('Expected "fonts" to be a list of maps.');
         continue;


### PR DESCRIPTION
The (deprecated) `implicit-casts: false` option was disabled in https://github.com/flutter/flutter/pull/100862 - unfortunately without enabling its replacement `strict-casts: true`.

See also https://dart.googlesource.com/sdk.git/+/6a54fdd46e2df14c9a7b4fd9d6b2d6e181ca0b7a.

This PR also updates some minor comments in the analysis_options file.