### PR TITLE
[WIP] :bug: (VelocityTracker) Handle case where velocity is infinite

### DIFF
--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'velocity_tracker_data.dart';
@@ -142,5 +143,32 @@ void main() {
         expect(tracker.getVelocity().pixelsPerSecond, positionDelta);
       }
     }
+  });
+
+  group('Velocity', () {
+    group('clampMagnitude', () {
+      const double minValue = 20.0;
+      const double maxValue = 8000.0;
+      test('Clamp the magnitude of infinite velocity with the given max value',
+          () {
+        expect(
+          const Velocity(pixelsPerSecond: Offset(35.0, double.infinity))
+              .clampMagnitude(minValue, maxValue),
+          equals(const Velocity(pixelsPerSecond: Offset(0.0, maxValue))),
+        );
+        expect(
+          const Velocity(pixelsPerSecond: Offset(double.infinity, 653.0))
+              .clampMagnitude(minValue, maxValue),
+          equals(const Velocity(pixelsPerSecond: Offset(maxValue, 0.0))),
+        );
+        expect(
+          const Velocity(pixelsPerSecond: Offset.infinite)
+              .clampMagnitude(minValue, maxValue),
+          equals(
+            Velocity(pixelsPerSecond: Offset.fromDirection(pi / 4, maxValue)),
+          ),
+        );
+      });
+    });
   });
 }

--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -171,4 +171,83 @@ void main() {
       });
     });
   });
+
+  group('VelocityTracker', () {
+    group('getVelocityEstimate', () {
+      void _expectVelocityEstimateToMatch(VelocityEstimate? velocityEstimate,
+          VelocityEstimate velocityEstimateRef) {
+        expect(velocityEstimate, isNotNull);
+        expect(velocityEstimate!.pixelsPerSecond,
+            equals(velocityEstimateRef.pixelsPerSecond));
+        expect(velocityEstimate.confidence,
+            equals(velocityEstimateRef.confidence));
+        expect(velocityEstimate.duration, equals(velocityEstimateRef.duration));
+        expect(velocityEstimate.offset, equals(velocityEstimateRef.offset));
+      }
+
+      test(
+          'Returns an horizontal infinite velocity when the duration is 0.0 for an horizontal trajectory',
+          () {
+        final VelocityTracker velocityTracker = VelocityTracker.withKind(PointerDeviceKind.touch);
+        const List<Offset> trajectory = <Offset>[
+          Offset(10.0, 0.0),
+          Offset(20.0, 0.0),
+          Offset(50.0, 0.0)
+        ];
+        for (final Offset point in trajectory) {
+          velocityTracker.addPosition(Duration.zero, point);
+        }
+        _expectVelocityEstimateToMatch(
+          velocityTracker.getVelocityEstimate(),
+          VelocityEstimate(
+              pixelsPerSecond: const Offset(double.infinity, 0.0),
+              confidence: 1.0,
+              duration: Duration.zero,
+              offset: trajectory.last - trajectory.first),
+        );
+      });
+      test(
+          'Returns a vertical infinite velocity when the duration is 0.0 for an vertical trajectory',
+          () {
+        final VelocityTracker velocityTracker = VelocityTracker.withKind(PointerDeviceKind.touch);
+        const List<Offset> trajectory = <Offset>[
+          Offset(0.0, 329.0),
+          Offset(0.0, 437.0),
+          Offset(0.0, 872.0)
+        ];
+        for (final Offset point in trajectory) {
+          velocityTracker.addPosition(Duration.zero, point);
+        }
+        _expectVelocityEstimateToMatch(
+          velocityTracker.getVelocityEstimate(),
+          VelocityEstimate(
+              pixelsPerSecond: const Offset(0.0, double.infinity),
+              confidence: 1.0,
+              duration: Duration.zero,
+              offset: trajectory.last - trajectory.first),
+        );
+      });
+      test(
+          'Returns an infinite velocity when the duration is 0.0 for a neither horizontal/vertical trajectory',
+          () {
+        final VelocityTracker velocityTracker = VelocityTracker.withKind(PointerDeviceKind.touch);
+        const List<Offset> trajectory = <Offset>[
+          Offset(10.0, 23.0),
+          Offset(20.0, 67.0),
+          Offset(50.0, 118.0)
+        ];
+        for (final Offset point in trajectory) {
+          velocityTracker.addPosition(Duration.zero, point);
+        }
+        _expectVelocityEstimateToMatch(
+          velocityTracker.getVelocityEstimate(),
+          VelocityEstimate(
+              pixelsPerSecond: Offset.infinite,
+              confidence: 1.0,
+              duration: Duration.zero,
+              offset: trajectory.last - trajectory.first),
+        );
+      });
+    });
+  });
 }


### PR DESCRIPTION
This Pull Request aims to fix this issue: [#101579](https://github.com/flutter/flutter/issues/101579)



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
