### PR TITLE
[flutter_tools] add test for dart binary arch

### DIFF
--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -60,10 +60,11 @@ Future<void> main() async {
       logger: BufferLogger.test(),
     );
     expect(dartArch, os.hostPlatform);
-  });
+  }, skip: !platform.isMacOS); // [intended] Calls macOS-specific commands
 }
 
 // Call `file` on the path and parse the output.
+// This is macOS-specific.
 HostPlatform _identifyBinaryArch(String path) {
   // Expect STDOUT like:
   //   bin/cache/dart-sdk/bin/dart: Mach-O 64-bit executable x86_64

--- a/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
+++ b/packages/flutter_tools/test/integration.shard/bash_entrypoint_test.dart
@@ -7,6 +7,8 @@ import 'dart:convert';
 
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/os.dart';
 
 import '../src/common.dart';
 import 'test_utils.dart';
@@ -48,6 +50,39 @@ Future<void> main() async {
     expect(stdout, contains('Successfully received SIGTERM!'));
   },
   skip: platform.isWindows); // [intended] Windows does not use the bash entrypoint
+
+  test('verify the dart binary arch matches the host arch', () async {
+    final HostPlatform dartArch = _identifyBinaryArch(dartBinary.path);
+    final OperatingSystemUtils os = OperatingSystemUtils(
+      processManager: processManager,
+      fileSystem: fileSystem,
+      platform: platform,
+      logger: BufferLogger.test(),
+    );
+    expect(dartArch, os.hostPlatform);
+  });
+}
+
+// Call `file` on the path and parse the output.
+HostPlatform _identifyBinaryArch(String path) {
+  // Expect STDOUT like:
+  //   bin/cache/dart-sdk/bin/dart: Mach-O 64-bit executable x86_64
+  final RegExp pattern = RegExp(r'Mach-O 64-bit executable (\w+)');
+  final ProcessResult result = processManager.runSync(
+    <String>['file', dartBinary.path],
+  );
+  final RegExpMatch? match = pattern.firstMatch(result.stdout as String);
+  if (match == null) {
+    fail('Unrecognized STDOUT from `file`: "${result.stdout}"');
+  }
+  switch (match.group(1)) {
+    case 'x86_64':
+      return HostPlatform.darwin_x64;
+    case 'arm64':
+      return HostPlatform.darwin_arm;
+    default:
+      fail('Unexpected architecture ${match.group(1)}');
+  }
 }
 
 // A test Dart app that will run until it receives SIGTERM
@@ -65,6 +100,17 @@ File get listenForSigtermScript {
 // The executable bash entrypoint for the Dart binary.
 File get dartBash {
   return flutterRoot
+      .childDirectory('bin')
+      .childFile('dart')
+      .absolute;
+}
+
+// The executable bash entrypoint for the Dart binary.
+File get dartBinary {
+  return flutterRoot
+      .childDirectory('bin')
+      .childDirectory('cache')
+      .childDirectory('dart-sdk')
       .childDirectory('bin')
       .childFile('dart')
       .absolute;


### PR DESCRIPTION
This test was accidentally deleted when I rebased https://github.com/flutter/flutter/pull/101308, which landed without tests. It leverages the `_MacOSUtils.hostPlatform` getter, which already implements calling `sysctl hw.optional.arm64` and parses the output.