### PR TITLE
Provide common interface for gestures that provide position

### DIFF
--- a/packages/flutter/lib/src/gestures/details_with_position.dart
+++ b/packages/flutter/lib/src/gestures/details_with_position.dart
@@ -1,0 +1,10 @@
+import 'dart:ui';
+
+/// Details object for gesture callbacks that provides local and global positions.
+abstract class GestureDetailsWithPosition {
+  /// The global position at which the pointer contacted the screen.
+  Offset get globalPosition;
+
+  /// The local position at which the pointer contacted the screen.
+  Offset get localPosition;
+}

--- a/packages/flutter/lib/src/gestures/details_with_position.dart
+++ b/packages/flutter/lib/src/gestures/details_with_position.dart
@@ -1,3 +1,8 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
 import 'dart:ui';
 
 /// Details object for gesture callbacks that provides local and global positions.

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -7,6 +7,7 @@ import 'dart:ui' show Offset, PointerDeviceKind;
 
 import 'package:flutter/foundation.dart';
 
+import 'details_with_position.dart';
 import 'velocity_tracker.dart';
 
 /// Details object for callbacks that use [GestureDragDownCallback].
@@ -17,7 +18,7 @@ import 'velocity_tracker.dart';
 ///  * [DragStartDetails], the details for [GestureDragStartCallback].
 ///  * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
 ///  * [DragEndDetails], the details for [GestureDragEndCallback].
-class DragDownDetails {
+class DragDownDetails implements GestureDetailsWithPosition {
   /// Creates details for a [GestureDragDownCallback].
   ///
   /// The [globalPosition] argument must not be null.
@@ -35,12 +36,14 @@ class DragDownDetails {
   ///
   ///  * [localPosition], which is the [globalPosition] transformed to the
   ///    coordinate space of the event receiver.
+  @override
   final Offset globalPosition;
 
   /// The local position in the coordinate system of the event receiver at
   /// which the pointer contacted the screen.
   ///
   /// Defaults to [globalPosition] if not specified in the constructor.
+  @override
   final Offset localPosition;
 
   @override
@@ -63,7 +66,7 @@ typedef GestureDragDownCallback = void Function(DragDownDetails details);
 ///  * [DragDownDetails], the details for [GestureDragDownCallback].
 ///  * [DragUpdateDetails], the details for [GestureDragUpdateCallback].
 ///  * [DragEndDetails], the details for [GestureDragEndCallback].
-class DragStartDetails {
+class DragStartDetails implements GestureDetailsWithPosition {
   /// Creates details for a [GestureDragStartCallback].
   ///
   /// The [globalPosition] argument must not be null.
@@ -89,12 +92,14 @@ class DragStartDetails {
   ///
   ///  * [localPosition], which is the [globalPosition] transformed to the
   ///    coordinate space of the event receiver.
+  @override
   final Offset globalPosition;
 
   /// The local position in the coordinate system of the event receiver at
   /// which the pointer contacted the screen.
   ///
   /// Defaults to [globalPosition] if not specified in the constructor.
+  @override
   final Offset localPosition;
 
   /// The kind of the device that initiated the event.
@@ -124,7 +129,7 @@ typedef GestureDragStartCallback = void Function(DragStartDetails details);
 ///  * [DragDownDetails], the details for [GestureDragDownCallback].
 ///  * [DragStartDetails], the details for [GestureDragStartCallback].
 ///  * [DragEndDetails], the details for [GestureDragEndCallback].
-class DragUpdateDetails {
+class DragUpdateDetails implements GestureDetailsWithPosition {
   /// Creates details for a [DragUpdateDetails].
   ///
   /// The [delta] argument must not be null.
@@ -182,12 +187,14 @@ class DragUpdateDetails {
   ///
   ///  * [localPosition], which is the [globalPosition] transformed to the
   ///    coordinate space of the event receiver.
+  @override
   final Offset globalPosition;
 
   /// The local position in the coordinate system of the event receiver at
   /// which the pointer contacted the screen.
   ///
   /// Defaults to [globalPosition] if not specified in the constructor.
+  @override
   final Offset localPosition;
 
   @override

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'arena.dart';
+import 'details_with_position.dart';
 import 'events.dart';
 import 'recognizer.dart';
 
@@ -38,7 +39,7 @@ enum _ForceState {
 ///  * [ForcePressGestureRecognizer.onStart], [ForcePressGestureRecognizer.onPeak],
 ///    [ForcePressGestureRecognizer.onEnd], and [ForcePressGestureRecognizer.onUpdate]
 ///    which use [ForcePressDetails].
-class ForcePressDetails {
+class ForcePressDetails implements GestureDetailsWithPosition {
   /// Creates details for a [GestureForcePressStartCallback],
   /// [GestureForcePressPeakCallback] or [GestureForcePressEndCallback].
   ///
@@ -52,9 +53,11 @@ class ForcePressDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the function was called.
+  @override
   final Offset globalPosition;
 
   /// The local position at which the function was called.
+  @override
   final Offset localPosition;
 
   /// The pressure of the pointer on the screen.

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -5,6 +5,7 @@
 
 import 'arena.dart';
 import 'constants.dart';
+import 'details_with_position.dart';
 import 'events.dart';
 import 'recognizer.dart';
 import 'velocity_tracker.dart';
@@ -100,7 +101,7 @@ typedef GestureLongPressEndCallback = void Function(LongPressEndDetails details)
 ///    passes these details.
 ///  * [LongPressGestureRecognizer.onTertiaryLongPressDown], whose callback
 ///    passes these details.
-class LongPressDownDetails {
+class LongPressDownDetails implements GestureDetailsWithPosition {
   /// Creates the details for a [GestureLongPressDownCallback].
   ///
   /// The `globalPosition` argument must not be null.
@@ -115,12 +116,14 @@ class LongPressDownDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer contacted the screen.
+  @override
   final Offset globalPosition;
 
   /// The kind of the device that initiated the event.
   final PointerDeviceKind? kind;
 
   /// The local position at which the pointer contacted the screen.
+  @override
   final Offset localPosition;
 }
 
@@ -131,7 +134,7 @@ class LongPressDownDetails {
 ///  * [LongPressGestureRecognizer.onLongPressStart], which uses [GestureLongPressStartCallback].
 ///  * [LongPressMoveUpdateDetails], the details for [GestureLongPressMoveUpdateCallback]
 ///  * [LongPressEndDetails], the details for [GestureLongPressEndCallback].
-class LongPressStartDetails {
+class LongPressStartDetails implements GestureDetailsWithPosition {
   /// Creates the details for a [GestureLongPressStartCallback].
   ///
   /// The [globalPosition] argument must not be null.
@@ -142,9 +145,11 @@ class LongPressStartDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer initially contacted the screen.
+  @override
   final Offset globalPosition;
 
   /// The local position at which the pointer initially contacted the screen.
+  @override
   final Offset localPosition;
 }
 
@@ -155,7 +160,7 @@ class LongPressStartDetails {
 ///  * [LongPressGestureRecognizer.onLongPressMoveUpdate], which uses [GestureLongPressMoveUpdateCallback].
 ///  * [LongPressEndDetails], the details for [GestureLongPressEndCallback]
 ///  * [LongPressStartDetails], the details for [GestureLongPressStartCallback].
-class LongPressMoveUpdateDetails {
+class LongPressMoveUpdateDetails implements GestureDetailsWithPosition {
   /// Creates the details for a [GestureLongPressMoveUpdateCallback].
   ///
   /// The [globalPosition] and [offsetFromOrigin] arguments must not be null.
@@ -170,9 +175,11 @@ class LongPressMoveUpdateDetails {
        localOffsetFromOrigin = localOffsetFromOrigin ?? offsetFromOrigin;
 
   /// The global position of the pointer when it triggered this update.
+  @override
   final Offset globalPosition;
 
   /// The local position of the pointer when it triggered this update.
+  @override
   final Offset localPosition;
 
   /// A delta offset from the point where the long press drag initially contacted
@@ -193,7 +200,7 @@ class LongPressMoveUpdateDetails {
 ///  * [LongPressGestureRecognizer.onLongPressEnd], which uses [GestureLongPressEndCallback].
 ///  * [LongPressMoveUpdateDetails], the details for [GestureLongPressMoveUpdateCallback].
 ///  * [LongPressStartDetails], the details for [GestureLongPressStartCallback].
-class LongPressEndDetails {
+class LongPressEndDetails implements GestureDetailsWithPosition {
   /// Creates the details for a [GestureLongPressEndCallback].
   ///
   /// The [globalPosition] argument must not be null.
@@ -205,9 +212,11 @@ class LongPressEndDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer lifted from the screen.
+  @override
   final Offset globalPosition;
 
   /// The local position at which the pointer contacted the screen.
+  @override
   final Offset localPosition;
 
   /// The pointer's velocity when it stopped contacting the screen.

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math_64.dart';
 import 'arena.dart';
 import 'binding.dart';
 import 'constants.dart';
+import 'details_with_position.dart';
 import 'events.dart';
 import 'gesture_settings.dart';
 import 'pointer_router.dart';
@@ -607,7 +608,7 @@ typedef GestureSerialTapDownCallback = void Function(SerialTapDownDetails detail
 ///
 ///  * [SerialTapGestureRecognizer], which passes this information to its
 ///    [SerialTapGestureRecognizer.onSerialTapDown] callback.
-class SerialTapDownDetails {
+class SerialTapDownDetails implements GestureDetailsWithPosition {
   /// Creates details for a [GestureSerialTapDownCallback].
   ///
   /// The `count` argument must be greater than zero.
@@ -621,9 +622,11 @@ class SerialTapDownDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer contacted the screen.
+  @override
   final Offset globalPosition;
 
   /// The local position at which the pointer contacted the screen.
+  @override
   final Offset localPosition;
 
   /// The kind of the device that initiated the event.
@@ -690,7 +693,7 @@ typedef GestureSerialTapUpCallback = void Function(SerialTapUpDetails details);
 ///
 ///  * [SerialTapGestureRecognizer], which passes this information to its
 ///    [SerialTapGestureRecognizer.onSerialTapUp] callback.
-class SerialTapUpDetails {
+class SerialTapUpDetails implements GestureDetailsWithPosition {
   /// Creates details for a [GestureSerialTapUpCallback].
   ///
   /// The `count` argument must be greater than zero.
@@ -703,9 +706,11 @@ class SerialTapUpDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer contacted the screen.
+  @override
   final Offset globalPosition;
 
   /// The local position at which the pointer contacted the screen.
+  @override
   final Offset localPosition;
 
   /// The kind of the device that initiated the event.

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -8,6 +8,7 @@ import 'package:vector_math/vector_math_64.dart' show Matrix4;
 
 import 'arena.dart';
 import 'constants.dart';
+import 'details_with_position.dart';
 import 'events.dart';
 import 'recognizer.dart';
 
@@ -17,7 +18,7 @@ import 'recognizer.dart';
 ///
 ///  * [GestureDetector.onTapDown], which receives this information.
 ///  * [TapGestureRecognizer], which passes this information to one of its callbacks.
-class TapDownDetails {
+class TapDownDetails implements GestureDetailsWithPosition{
   /// Creates details for a [GestureTapDownCallback].
   ///
   /// The [globalPosition] argument must not be null.
@@ -29,12 +30,14 @@ class TapDownDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer contacted the screen.
+  @override
   final Offset globalPosition;
 
   /// The kind of the device that initiated the event.
   final PointerDeviceKind? kind;
 
   /// The local position at which the pointer contacted the screen.
+  @override
   final Offset localPosition;
 }
 
@@ -56,7 +59,7 @@ typedef GestureTapDownCallback = void Function(TapDownDetails details);
 ///
 ///  * [GestureDetector.onTapUp], which receives this information.
 ///  * [TapGestureRecognizer], which passes this information to one of its callbacks.
-class TapUpDetails {
+class TapUpDetails implements GestureDetailsWithPosition {
   /// The [globalPosition] argument must not be null.
   TapUpDetails({
     required this.kind,
@@ -66,9 +69,11 @@ class TapUpDetails {
        localPosition = localPosition ?? globalPosition;
 
   /// The global position at which the pointer contacted the screen.
+  @override
   final Offset globalPosition;
 
   /// The local position at which the pointer contacted the screen.
+  @override
   final Offset localPosition;
 
   /// The kind of the device that initiated the event.


### PR DESCRIPTION
Provide an interface `GestureDetailsWithPosition` as a common interface between gesture details that provides position.

Fixes #101530 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
