### PR TITLE
Pass multidex flag when using --machine mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -496,6 +496,7 @@ class AppDomain extends Domain {
     String packagesFilePath,
     String dillOutputPath,
     bool ipv6 = false,
+    bool multidexEnabled = false,
     String isolateFilter,
     bool machine = true,
   }) async {
@@ -544,6 +545,7 @@ class AppDomain extends Domain {
         projectRootPath: projectRootPath,
         dillOutputPath: dillOutputPath,
         ipv6: ipv6,
+        multidexEnabled: multidexEnabled,
         hostIsIde: true,
         machine: machine,
       );
@@ -554,6 +556,7 @@ class AppDomain extends Domain {
         debuggingOptions: options,
         applicationBinary: applicationBinary,
         ipv6: ipv6,
+        multidexEnabled: multidexEnabled,
         machine: machine,
       );
     }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -157,12 +157,12 @@ class Daemon {
     this.logToStdout = false,
   }) {
     // Set up domains.
-    _registerDomain(daemonDomain = DaemonDomain(this));
-    _registerDomain(appDomain = AppDomain(this));
-    _registerDomain(deviceDomain = DeviceDomain(this));
-    _registerDomain(emulatorDomain = EmulatorDomain(this));
-    _registerDomain(devToolsDomain = DevToolsDomain(this));
-    _registerDomain(proxyDomain = ProxyDomain(this));
+    registerDomain(daemonDomain = DaemonDomain(this));
+    registerDomain(appDomain ?? AppDomain(this));
+    registerDomain(deviceDomain = DeviceDomain(this));
+    registerDomain(emulatorDomain = EmulatorDomain(this));
+    registerDomain(devToolsDomain = DevToolsDomain(this));
+    registerDomain(proxyDomain = ProxyDomain(this));
 
     // Start listening.
     _commandSubscription = connection.incomingCommands.listen(
@@ -192,7 +192,8 @@ class Daemon {
   final Completer<int> _onExitCompleter = Completer<int>();
   final Map<String, Domain> _domainMap = <String, Domain>{};
 
-  void _registerDomain(Domain domain) {
+  @visibleForTesting
+  void registerDomain(Domain domain) {
     _domainMap[domain.name] = domain;
   }
 

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -158,7 +158,7 @@ class Daemon {
   }) {
     // Set up domains.
     registerDomain(daemonDomain = DaemonDomain(this));
-    registerDomain(appDomain ?? AppDomain(this));
+    registerDomain(appDomain = AppDomain(this));
     registerDomain(deviceDomain = DeviceDomain(this));
     registerDomain(emulatorDomain = EmulatorDomain(this));
     registerDomain(devToolsDomain = DevToolsDomain(this));

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -551,6 +551,21 @@ class RunCommand extends RunCommandBase {
     );
   }
 
+  @visibleForTesting
+  Daemon createMachineDaemon() {
+    final Daemon daemon = Daemon(
+      DaemonConnection(
+        daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
+        logger: globals.logger,
+      ),
+      notifyingLogger: (globals.logger is NotifyingLogger)
+        ? globals.logger as NotifyingLogger
+        : NotifyingLogger(verbose: globals.logger.isVerbose, parent: globals.logger),
+      logToStdout: true,
+    );
+    return daemon;
+  }
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     // Enable hot mode by default if `--no-hot` was not passed and we are in
@@ -563,16 +578,7 @@ class RunCommand extends RunCommandBase {
       if (devices.length > 1) {
         throwToolExit('"--machine" does not support "-d all".');
       }
-      final Daemon daemon = Daemon(
-        DaemonConnection(
-          daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
-          logger: globals.logger,
-        ),
-        notifyingLogger: (globals.logger is NotifyingLogger)
-          ? globals.logger as NotifyingLogger
-          : NotifyingLogger(verbose: globals.logger.isVerbose, parent: globals.logger),
-        logToStdout: true,
-      );
+      final Daemon daemon = createMachineDaemon();
       AppInstance app;
       try {
         app = await daemon.appDomain.startApp(

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -586,6 +586,7 @@ class RunCommand extends RunCommandBase {
           packagesFilePath: globalResults['packages'] as String,
           dillOutputPath: stringArg('output-dill'),
           ipv6: ipv6,
+          multidexEnabled: boolArg('multidex'),
         );
       } on Exception catch (error) {
         throwToolExit(error.toString());

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -26,6 +26,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/daemon.dart';
 import 'package:flutter_tools/src/commands/run.dart';
 import 'package:flutter_tools/src/devfs.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -405,6 +406,67 @@ void main() {
         ProcessManager: () => FakeProcessManager.any(),
         Usage: () => usage,
       });
+
+       group('--machine', () {
+        testUsingContext('enables multidex by default', () async {
+          final DaemonCapturingRunCommand command = DaemonCapturingRunCommand();
+          final FakeDevice device = FakeDevice();
+          mockDeviceManager
+          ..devices = <Device>[device]
+          ..targetDevices = <Device>[device];
+
+          await expectLater(
+                () => createTestCommandRunner(command).run(<String>[
+              'run',
+              '--no-pub',
+              '--machine',
+              '-d',
+              device.id,
+            ]),
+            throwsToolExit(),
+          );
+          expect(command.appDomain.multidexEnabled, isTrue);
+        }, overrides: <Type, Generator>{
+          Artifacts: () => artifacts,
+          Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+          DeviceManager: () => mockDeviceManager,
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Usage: () => usage,
+          Stdio: () => FakeStdio(),
+          Logger: () => AppRunLogger(parent: BufferLogger.test()),
+        });
+
+        testUsingContext('can disable multidex with --no-multidex', () async {
+          final DaemonCapturingRunCommand command = DaemonCapturingRunCommand();
+          final FakeDevice device = FakeDevice();
+          mockDeviceManager
+          ..devices = <Device>[device]
+          ..targetDevices = <Device>[device];
+
+          await expectLater(
+                () => createTestCommandRunner(command).run(<String>[
+              'run',
+              '--no-pub',
+              '--no-multidex',
+              '--machine',
+              '-d',
+              device.id,
+            ]),
+            throwsToolExit(),
+          );
+          expect(command.appDomain.multidexEnabled, isFalse);
+        }, overrides: <Type, Generator>{
+          Artifacts: () => artifacts,
+          Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+          DeviceManager: () => mockDeviceManager,
+          FileSystem: () => fs,
+          ProcessManager: () => FakeProcessManager.any(),
+          Usage: () => usage,
+          Stdio: () => FakeStdio(),
+          Logger: () => AppRunLogger(parent: BufferLogger.test()),
+        });
+      });
     });
 
     group('Fatal Logs', () {
@@ -688,6 +750,13 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   }
 
   @override
+  List<DeviceDiscovery> get deviceDiscoverers {
+    final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
+    devices.forEach(discoverer.addDevice);
+    return <DeviceDiscovery>[discoverer];
+  }
+
+  @override
   Future<List<Device>> getAllConnectedDevices() async => devices;
 }
 
@@ -738,6 +807,9 @@ class FakeDevice extends Fake implements Device {
 
   @override
   bool supportsHotReload = false;
+
+  @override
+  bool get supportsHotRestart => true;
 
   @override
   bool get supportsFastStart => false;
@@ -856,5 +928,46 @@ class FakeResidentRunner extends Fake implements ResidentRunner {
       throw rpcError;
     }
     return 0;
+  }
+}
+
+class DaemonCapturingRunCommand extends RunCommand {
+  /*late*/ Daemon daemon;
+  /*late*/ CapturingAppDomain appDomain;
+
+  @override
+  Daemon createMachineDaemon() {
+    daemon = super.createMachineDaemon();
+    appDomain = daemon.appDomain = CapturingAppDomain(daemon);
+    daemon.registerDomain(appDomain);
+    return daemon;
+  }
+}
+
+class CapturingAppDomain extends AppDomain {
+  CapturingAppDomain(Daemon daemon) : super(daemon);
+
+  bool /*?*/ multidexEnabled;
+
+  @override
+  Future<AppInstance> startApp(
+    Device device,
+    String projectDirectory,
+    String target,
+    String route,
+    DebuggingOptions options,
+    bool enableHotReload, {
+    File applicationBinary,
+    @required bool trackWidgetCreation,
+    String projectRootPath,
+    String packagesFilePath,
+    String dillOutputPath,
+    bool ipv6 = false,
+    bool multidexEnabled = false,
+    String isolateFilter,
+    bool machine = true,
+  }) async {
+    this.multidexEnabled = multidexEnabled;
+    throwToolExit('');
   }
 }


### PR DESCRIPTION
This fixes https://github.com/Dart-Code/Dart-Code/issues/3837 by ensuring the `--[no-]multidex` value (and default) are honoured when using `--machine`.

(Originally opened at https://github.com/flutter/flutter/pull/99010, but I had to re-create my fork which seems to have broken that PR).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
