### PR TITLE
Unpause and remove breakpoints when detaching from Flutter process with DAP

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -205,6 +205,9 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   /// quickly and therefore may leave orphaned processes.
   @override
   Future<void> disconnectImpl() async {
+    if (isAttach) {
+      await preventBreakingAndResume();
+    }
     terminatePids(ProcessSignal.sigkill);
   }
 
@@ -379,6 +382,9 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   /// Called by [terminateRequest] to request that we gracefully shut down the app being run (or in the case of an attach, disconnect).
   @override
   Future<void> terminateImpl() async {
+    if (isAttach) {
+      await preventBreakingAndResume();
+    }
     terminatePids(ProcessSignal.sigterm);
     await _process?.exitCode;
   }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -380,13 +380,35 @@ void main() {
         stoppedFuture,
         dap.client.setBreakpoint(breakpointFilePath, breakpointLine),
       ], eagerError: true);
-      final int threadId = (await stoppedFuture).threadId!;
+    });
 
-      // Remove the breakpoint and resume.
-      await dap.client.clearBreakpoints(breakpointFilePath);
-      await dap.client.continue_(threadId);
+    testWithoutContext('resumes and removes breakpoints on detach', () async {
+      final Uri vmServiceUri = await testProcess.vmServiceUri;
 
+      // Launch the app and wait for it to print "topLevelFunction".
+      await Future.wait(<Future<void>>[
+        dap.client.stdoutOutput.firstWhere((String output) => output.startsWith('topLevelFunction')),
+        dap.client.start(
+          launch: () => dap.client.attach(
+            cwd: project.dir.path,
+            toolArgs: <String>['-d', 'flutter-tester'],
+            vmServiceUri: vmServiceUri.toString(),
+          ),
+        ),
+      ], eagerError: true);
+
+      // Set a breakpoint and expect to hit it.
+      final Future<StoppedEventBody> stoppedFuture = dap.client.stoppedEvents.firstWhere((StoppedEventBody e) => e.reason == 'breakpoint');
+      await Future.wait(<Future<void>>[
+        stoppedFuture,
+        dap.client.setBreakpoint(breakpointFilePath, breakpointLine),
+      ], eagerError: true);
+
+      // Detach.
       await dap.client.terminate();
+
+      // Ensure we get additional output (confirming the process resumed).
+      await testProcess.output.first;
     });
   });
 }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -63,6 +63,11 @@ class SimpleFlutterRunner {
     unawaited(process.exitCode.then(_handleExitCode));
   }
 
+  final StreamController<String> _output = StreamController<String>.broadcast();
+
+  /// A broadcast stream of any non-JSON output from the process.
+  Stream<String> get output => _output.stream;
+
   void _handleExitCode(int code) {
       if (!_vmServiceUriCompleter.isCompleted) {
         _vmServiceUriCompleter.completeError('Flutter process ended without producing a VM Service URI');
@@ -91,8 +96,9 @@ class SimpleFlutterRunner {
         }
       }
     } on FormatException {
-      // `flutter run` writes a lot of text to stdout so just ignore anything
-      // that's not valid JSON.
+      // `flutter run` writes a lot of text to stdout that isn't daemon messages
+      //  (not valid JSON), so just pass that one for tests that may want it.
+      _output.add(outputLine);
     }
   }
 


### PR DESCRIPTION
This cleans up by removing breakpoints, disabling pause-on-exceptions and resuming threads when detaching from a Flutter process you attached to to debug (this matches the Dart DAP behaviour).

This prevents a user attaching, setting a bunch of breakpoints to debug, then detaching and finding the app is still unresponsive because it's hitting breakpoints without a debugger attached.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
