### PR TITLE
Add Gradle stacktrace and debug log level to verbose builds

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -268,6 +268,8 @@ class AndroidGradleBuilder implements AndroidBuilder {
       _gradleUtils.getExecutable(project),
     ];
     if (_logger.isVerbose) {
+      command.add('--full-stacktrace');
+      command.add('--debug');
       command.add('-Pverbose=true');
     } else {
       command.add('-q');
@@ -590,6 +592,8 @@ class AndroidGradleBuilder implements AndroidBuilder {
       '-PbuildNumber=$buildNumber'
     ];
     if (_logger.isVerbose) {
+      command.add('--full-stacktrace');
+      command.add('--debug');
       command.add('-Pverbose=true');
     } else {
       command.add('-q');

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -732,16 +732,20 @@ class BufferLogger extends Logger {
     required this.terminal,
     required OutputPreferences outputPreferences,
     StopwatchFactory stopwatchFactory = const StopwatchFactory(),
+    bool verbose = false,
   }) : _outputPreferences = outputPreferences,
-       _stopwatchFactory = stopwatchFactory;
+       _stopwatchFactory = stopwatchFactory,
+       _verbose = verbose;
 
   /// Create a [BufferLogger] with test preferences.
   BufferLogger.test({
     Terminal? terminal,
     OutputPreferences? outputPreferences,
+    bool verbose = false,
   }) : terminal = terminal ?? Terminal.test(),
        _outputPreferences = outputPreferences ?? OutputPreferences.test(),
-       _stopwatchFactory = const StopwatchFactory();
+       _stopwatchFactory = const StopwatchFactory(),
+       _verbose = verbose;
 
   @override
   final OutputPreferences _outputPreferences;
@@ -751,8 +755,10 @@ class BufferLogger extends Logger {
 
   final StopwatchFactory _stopwatchFactory;
 
+  final bool _verbose;
+
   @override
-  bool get isVerbose => false;
+  bool get isVerbose => _verbose;
 
   @override
   bool get supportsColor => terminal.supportsColor;

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -188,6 +188,7 @@ void main() {
         isBuildingBundle: false,
         localGradleErrors: <GradleHandledError>[],
       );
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('Can retry build on recognized exit code/stderr', () async {

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -128,6 +128,68 @@ void main() {
       ));
     });
 
+    testUsingContext('Verbose mode for APKs includes Gradle stacktrace and sets debug log level', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: BufferLogger.test(verbose: true),
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        usage: testUsage,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+      );
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+         'gradlew',
+          '--full-stacktrace',
+          '--debug',
+          '-Pverbose=true',
+          '-Ptarget-platform=android-arm,android-arm64,android-x64',
+          '-Ptarget=lib/main.dart',
+          '-Pbase-application-name=io.flutter.app.FlutterApplication',
+          '-Pdart-obfuscation=false',
+          '-Ptrack-widget-creation=false',
+          '-Ptree-shake-icons=false',
+          'assembleRelease'
+        ],
+      ));
+
+      fileSystem.directory('android')
+        .childFile('build.gradle')
+        .createSync(recursive: true);
+
+      fileSystem.directory('android')
+        .childFile('gradle.properties')
+        .createSync(recursive: true);
+
+      fileSystem.directory('android')
+        .childDirectory('app')
+        .childFile('build.gradle')
+        ..createSync(recursive: true)
+        ..writeAsStringSync('apply from: irrelevant/flutter.gradle');
+
+      fileSystem.directory('build')
+        .childDirectory('app')
+        .childDirectory('outputs')
+        .childDirectory('flutter-apk')
+        .childFile('app-release.apk')
+        .createSync(recursive: true);
+
+      await builder.buildGradleApp(
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        androidBuildInfo: const AndroidBuildInfo(
+          BuildInfo(
+            BuildMode.release,
+            null,
+            treeShakeIcons: false,
+          ),
+        ),
+        target: 'lib/main.dart',
+        isBuildingBundle: false,
+        localGradleErrors: <GradleHandledError>[],
+      );
+    });
+
     testUsingContext('Can retry build on recognized exit code/stderr', () async {
       final AndroidGradleBuilder builder = AndroidGradleBuilder(
         logger: logger,
@@ -696,6 +758,61 @@ void main() {
       expect(
         logger.statusText.contains('Consuming the Module'),
         isFalse,
+      );
+      expect(processManager, hasNoRemainingExpectations);
+    });
+
+    testUsingContext('Verbose mode for AARs includes Gradle stacktrace and sets debug log level', () async {
+      final AndroidGradleBuilder builder = AndroidGradleBuilder(
+        logger: BufferLogger.test(verbose: true),
+        processManager: processManager,
+        fileSystem: fileSystem,
+        artifacts: Artifacts.test(),
+        usage: testUsage,
+        gradleUtils: FakeGradleUtils(),
+        platform: FakePlatform(),
+      );
+      processManager.addCommand(const FakeCommand(
+        command: <String>[
+          'gradlew',
+          '-I=/packages/flutter_tools/gradle/aar_init_script.gradle',
+          '-Pflutter-root=/',
+          '-Poutput-dir=build/',
+          '-Pis-plugin=false',
+          '-PbuildNumber=1.0',
+          '--full-stacktrace',
+          '--debug',
+          '-Pverbose=true',
+          '-Pdart-obfuscation=false',
+          '-Ptrack-widget-creation=false',
+          '-Ptree-shake-icons=false',
+          '-Ptarget-platform=android-arm,android-arm64,android-x64',
+          'assembleAarRelease'
+        ],
+      ));
+
+      final File manifestFile = fileSystem.file('pubspec.yaml');
+      manifestFile.createSync(recursive: true);
+      manifestFile.writeAsStringSync('''
+        flutter:
+          module:
+            androidPackage: com.example.test
+        '''
+      );
+
+      fileSystem.file('.android/gradlew').createSync(recursive: true);
+      fileSystem.file('.android/gradle.properties')
+          .writeAsStringSync('irrelevant');
+      fileSystem.file('.android/build.gradle')
+          .createSync(recursive: true);
+      fileSystem.directory('build/outputs/repo').createSync(recursive: true);
+
+      await builder.buildGradleAar(
+        androidBuildInfo: const AndroidBuildInfo(BuildInfo(BuildMode.release, null, treeShakeIcons: false)),
+        project: FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+        outputDirectory: fileSystem.directory('build/'),
+        target: '',
+        buildNumber: '1.0',
       );
       expect(processManager, hasNoRemainingExpectations);
     });


### PR DESCRIPTION
When the --verbose flag is used also set the Gradle --stacktrace and --verbose flags.

This hopefully helps figure out the race in the following failures:
https://github.com/flutter/flutter/issues/101432
https://github.com/flutter/flutter/issues/101431
https://github.com/flutter/flutter/issues/101430
https://github.com/flutter/flutter/issues/101428

