### PR TITLE
Does not replace the root layer unnecessarily

### DIFF
--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -38,14 +38,6 @@ class ViewConfiguration {
     return Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1.0);
   }
 
-  /// Whether the root render object needs to replace the root transform layer.
-  ///
-  /// By default, the root layer will only be replaced when [devicePixelRatio]
-  /// changes.
-  bool shouldReplaceRootLayer(ViewConfiguration oldConfiguration) {
-    return oldConfiguration.devicePixelRatio != devicePixelRatio;
-  }
-
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType)
@@ -101,9 +93,8 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
       return;
     final ViewConfiguration oldConfiguration = _configuration;
     _configuration = value;
-    _updateMatrices();
-    if (_configuration.shouldReplaceRootLayer(oldConfiguration)) {
-      replaceRootLayer(_createNewRootLayer());
+    if (oldConfiguration.toMatrix() != _configuration.toMatrix()) {
+      replaceRootLayer(_updateMatricesAndCreateNewRootLayer());
     }
     assert(_rootTransform != null);
     markNeedsLayout();
@@ -144,18 +135,17 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     assert(owner != null);
     assert(_rootTransform == null);
     scheduleInitialLayout();
-    _updateMatrices();
-    scheduleInitialPaint(_createNewRootLayer());
+    scheduleInitialPaint(_updateMatricesAndCreateNewRootLayer());
     assert(_rootTransform != null);
   }
 
   Matrix4? _rootTransform;
-  void _updateMatrices() => _rootTransform = configuration.toMatrix();
 
-  TransformLayer _createNewRootLayer() {
-    assert(_rootTransform != null);
+  TransformLayer _updateMatricesAndCreateNewRootLayer() {
+    _rootTransform = configuration.toMatrix();
     final TransformLayer rootLayer = TransformLayer(transform: _rootTransform);
     rootLayer.attach(this);
+    assert(_rootTransform != null);
     return rootLayer;
   }
 

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -101,8 +101,9 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
       return;
     final ViewConfiguration oldConfiguration = _configuration;
     _configuration = value;
+    _updateMatrices();
     if (_configuration.shouldReplaceRootLayer(oldConfiguration)) {
-      replaceRootLayer(_updateMatricesAndCreateNewRootLayer());
+      replaceRootLayer(_createNewRootLayer());
     }
     assert(_rootTransform != null);
     markNeedsLayout();
@@ -143,17 +144,18 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     assert(owner != null);
     assert(_rootTransform == null);
     scheduleInitialLayout();
-    scheduleInitialPaint(_updateMatricesAndCreateNewRootLayer());
+    _updateMatrices();
+    scheduleInitialPaint(_createNewRootLayer());
     assert(_rootTransform != null);
   }
 
   Matrix4? _rootTransform;
+  void _updateMatrices() => _rootTransform = configuration.toMatrix();
 
-  TransformLayer _updateMatricesAndCreateNewRootLayer() {
-    _rootTransform = configuration.toMatrix();
+  TransformLayer _createNewRootLayer() {
+    assert(_rootTransform != null);
     final TransformLayer rootLayer = TransformLayer(transform: _rootTransform);
     rootLayer.attach(this);
-    assert(_rootTransform != null);
     return rootLayer;
   }
 

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -82,6 +82,7 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
   /// The constraints used for the root layout.
   ViewConfiguration get configuration => _configuration;
   ViewConfiguration _configuration;
+
   /// The configuration is initially set by the `configuration` argument
   /// passed to the constructor.
   ///
@@ -90,8 +91,11 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     assert(value != null);
     if (configuration == value)
       return;
+    final double oldDevicePixelRatio = _configuration.devicePixelRatio;
     _configuration = value;
-    replaceRootLayer(_updateMatricesAndCreateNewRootLayer());
+    if (oldDevicePixelRatio != value.devicePixelRatio) {
+      replaceRootLayer(_updateMatricesAndCreateNewRootLayer());
+    }
     assert(_rootTransform != null);
     markNeedsLayout();
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -38,6 +38,14 @@ class ViewConfiguration {
     return Matrix4.diagonal3Values(devicePixelRatio, devicePixelRatio, 1.0);
   }
 
+  /// Whether the root render object needs to replace the root transform layer.
+  ///
+  /// By default, the root layer will only be replaced when [devicePixelRatio]
+  /// changes.
+  bool shouldReplaceRootLayer(ViewConfiguration oldConfiguration) {
+    return oldConfiguration.devicePixelRatio != devicePixelRatio;
+  }
+
   @override
   bool operator ==(Object other) {
     if (other.runtimeType != runtimeType)
@@ -91,9 +99,9 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     assert(value != null);
     if (configuration == value)
       return;
-    final double oldDevicePixelRatio = _configuration.devicePixelRatio;
+    final ViewConfiguration oldConfiguration = _configuration;
     _configuration = value;
-    if (oldDevicePixelRatio != value.devicePixelRatio) {
+    if (_configuration.shouldReplaceRootLayer(oldConfiguration)) {
       replaceRootLayer(_updateMatricesAndCreateNewRootLayer());
     }
     assert(_rootTransform != null);

--- a/packages/flutter/test/rendering/view_test.dart
+++ b/packages/flutter/test/rendering/view_test.dart
@@ -47,6 +47,20 @@ void main() {
       view.configuration = createViewConfiguration(devicePixelRatio: 5.0);
       expect(identical(view.debugLayer, firstLayer), false);
     });
+
+    test('does not replace the root layer unnecessarily when window resize', () {
+      final ui.FlutterView window = TestWindow(window: RendererBinding.instance.window);
+      final RenderView view = RenderView(
+        configuration: createViewConfiguration(size: const Size(100.0, 100.0)),
+        window: window,
+      );
+      final PipelineOwner owner = PipelineOwner();
+      view.attach(owner);
+      view.prepareInitialFrame();
+      final ContainerLayer firstLayer = view.debugLayer!;
+      view.configuration = createViewConfiguration(size: const Size(100.0, 1117.0));
+      expect(identical(view.debugLayer, firstLayer), true);
+    });
   });
 
   test('ViewConfiguration == and hashCode', () {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1779,7 +1779,7 @@ class TestViewConfiguration extends ViewConfiguration {
   TestViewConfiguration._(Size size, ui.FlutterView window)
     : _paintMatrix = _getMatrix(size, window.devicePixelRatio, window),
       _hitTestMatrix = _getMatrix(size, 1.0, window),
-      super(size: size);
+      super(size: size, devicePixelRatio: window.devicePixelRatio);
 
   static Matrix4 _getMatrix(Size size, double devicePixelRatio, ui.FlutterView window) {
     final double inverseRatio = devicePixelRatio / window.devicePixelRatio;


### PR DESCRIPTION
I found that the root layer of `RenderView` was replaced frequently when resizing the app window(web or desktop).

This is not necessary if the device pixel ratio does not change.