### PR TITLE
[flutter_tools] Re-land Dump backtrace on ios app startup timeout

### DIFF
--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -432,12 +432,15 @@ class IOSDevice extends Device {
       }
 
       _logger.printTrace('Application launched on the device. Waiting for observatory url.');
-      final Timer timer = Timer(Duration.zero, () { // TODO
+      final Timer timer = Timer(Duration.zero, () async { // TODO
       //final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
         _logger.printError('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...');
-        iosDeployDebugger?.stopAndDumpBacktrace();
+        await iosDeployDebugger?.pauseDumpBacktraceResume();
+        _logger.printError('log drain finished'); // TODO
       });
+      _logger.printError('Awaiting observatory URI...');
       final Uri? localUri = await observatoryDiscovery?.uri;
+      _logger.printError('Got observatory URI!');
       timer.cancel();
       if (localUri == null) {
         await iosDeployDebugger?.stopAndDumpBacktrace();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -432,10 +432,9 @@ class IOSDevice extends Device {
       }
 
       _logger.printTrace('Application launched on the device. Waiting for observatory url.');
-      final Timer timer = Timer(Duration.zero, () async { // TODO
-      //final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
+      final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
         _logger.printError('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...');
-        await iosDeployDebugger?.pauseDumpBacktraceResume();
+        iosDeployDebugger?.pauseDumpBacktraceResume();
       });
       _logger.printError('Awaiting observatory URI $observatoryDiscovery...');
       final Uri? localUri = await observatoryDiscovery?.uri;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -432,7 +432,8 @@ class IOSDevice extends Device {
       }
 
       _logger.printTrace('Application launched on the device. Waiting for observatory url.');
-      final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
+      final Timer timer = Timer(Duration.zero, () { // TODO
+      //final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
         _logger.printError('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...');
         iosDeployDebugger?.stopAndDumpBacktrace();
       });

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -436,9 +436,8 @@ class IOSDevice extends Device {
       //final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
         _logger.printError('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...');
         await iosDeployDebugger?.pauseDumpBacktraceResume();
-        _logger.printError('log drain finished'); // TODO
       });
-      _logger.printError('Awaiting observatory URI...');
+      _logger.printError('Awaiting observatory URI $observatoryDiscovery...');
       final Uri? localUri = await observatoryDiscovery?.uri;
       _logger.printError('Got observatory URI!');
       timer.cancel();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -436,9 +436,7 @@ class IOSDevice extends Device {
         _logger.printError('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...');
         iosDeployDebugger?.pauseDumpBacktraceResume();
       });
-      _logger.printError('Awaiting observatory URI $observatoryDiscovery...');
       final Uri? localUri = await observatoryDiscovery?.uri;
-      _logger.printError('Got observatory URI!');
       timer.cancel();
       if (localUri == null) {
         await iosDeployDebugger?.stopAndDumpBacktrace();

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -434,6 +434,7 @@ class IOSDevice extends Device {
       _logger.printTrace('Application launched on the device. Waiting for observatory url.');
       final Timer timer = Timer(discoveryTimeout ?? const Duration(seconds: 30), () {
         _logger.printError('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...');
+        iosDeployDebugger?.stopAndDumpBacktrace();
       });
       final Uri? localUri = await observatoryDiscovery?.uri;
       timer.cancel();

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -308,6 +308,9 @@ class IOSDeployDebugger {
   // Print backtrace for all threads while app is stopped.
   static const String _backTraceAll = 'thread backtrace all';
 
+  /// If this is non-null, then the app process is paused and awaiting backtrace logging.
+  ///
+  /// The future should be completed once the backtraces are logged.
   Completer<void>? _processResumeCompleter;
 
   /// Launch the app on the device, and attach the debugger.

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -435,10 +435,8 @@ class IOSDeployDebugger {
 
   Future<void> stopAndDumpBacktrace() async {
     if (!debuggerAttached) {
-      throw 'whoops'; // TODO
       return;
     }
-
     try {
       // Stop the app, which will prompt the backtrace to be printed for all threads in the stdoutSubscription handler.
       _iosDeployProcess?.stdin.writeln(_signalStop);

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -435,6 +435,7 @@ class IOSDeployDebugger {
 
   Future<void> stopAndDumpBacktrace() async {
     if (!debuggerAttached) {
+      throw 'whoops'; // TODO
       return;
     }
 

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -457,6 +457,7 @@ class IOSDeployDebugger {
     return success;
   }
 
+  /// Pause app, dump backtrace for debugging, and resume.
   Future<void> pauseDumpBacktraceResume() async {
     if (!debuggerAttached) {
       return;
@@ -467,7 +468,6 @@ class IOSDeployDebugger {
       // Stop the app, which will prompt the backtrace to be printed for all threads in the stdoutSubscription handler.
       _iosDeployProcess?.stdin.writeln(_processInterrupt);
     } on SocketException catch (error) {
-      // Best effort, try to detach, but maybe the app already exited or already detached.
       _logger.printTrace('Could not stop app from debugger: $error');
     }
     // wait for backtrace to be dumped
@@ -481,12 +481,11 @@ class IOSDeployDebugger {
     }
     try {
       // Stop the app, which will prompt the backtrace to be printed for all threads in the stdoutSubscription handler.
-      _iosDeployProcess?.stdin.writeln(_processInterrupt);
+      _iosDeployProcess?.stdin.writeln(_signalStop);
     } on SocketException catch (error) {
       // Best effort, try to detach, but maybe the app already exited or already detached.
       _logger.printTrace('Could not stop app from debugger: $error');
     }
-
     // Wait for logging to finish on process exit.
     return logLines.drain();
   }

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -296,6 +296,9 @@ class IOSDeployDebugger {
   // (lldb) Process 6152 detached
   static final RegExp _lldbProcessDetached = RegExp(r'Process \d* detached');
 
+  // (lldb) Process 6152 resuming
+  static final RegExp _lldbProcessResuming = RegExp(r'Process \d+ resuming');
+
   // Send signal to stop (pause) the app. Used before a backtrace dump.
   static const String _signalStop = 'process signal SIGSTOP';
 
@@ -385,6 +388,13 @@ class IOSDeployDebugger {
           // The debugger has detached from the app, and there will be no more debugging messages.
           // Kill the ios-deploy process.
           exit();
+          return;
+        }
+
+        if (_lldbProcessResuming.hasMatch(line)) {
+          _logger.printTrace(line);
+          // we marked this detached when we received [_backTraceAll]
+          _debuggerState = _IOSDeployDebuggerState.attached;
           return;
         }
 

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -330,6 +330,71 @@ void main () {
         'process detach',
       ]);
     });
+
+    testWithoutContext('pause with backtrace', () async {
+      final StreamController<List<int>> stdin = StreamController<List<int>>();
+      final Stream<String> stdinStream = stdin.stream.transform<String>(const Utf8Decoder());
+      const String stdout = '''
+(lldb)     run
+success
+Log on attach
+(lldb) Process 6156 stopped
+* thread #1, stop reason = Assertion failed:
+thread backtrace all
+process continue
+* thread #1, stop reason = signal SIGSTOP
+  * frame #0: 0x0000000102eaee80 dyld`dyld3::MachOFile::read_uleb128(Diagnostics&, unsigned char const*&, unsigned char const*) + 36
+    frame #1: 0x0000000102eabbd4 dyld`dyld3::MachOLoaded::trieWalk(Diagnostics&, unsigned char const*, unsigned char const*, char const*) + 332
+    frame #2: 0x0000000102eaa078 dyld`DyldSharedCache::hasImagePath(char const*, unsigned int&) const + 144
+    frame #3: 0x0000000102eaa13c dyld`DyldSharedCache::hasNonOverridablePath(char const*) const + 44
+    frame #4: 0x0000000102ebc404 dyld`dyld3::closure::ClosureBuilder::findImage(char const*, dyld3::closure::ClosureBuilder::LoadedImageChain const&, dyld3::closure::ClosureBuilder::BuilderLoadedImage*&, dyld3::closure::ClosureBuilder::LinkageType, unsigned int, bool) +
+
+    frame #5: 0x0000000102ebd974 dyld`invocation function for block in dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 136
+    frame #6: 0x0000000102eae1b0 dyld`invocation function for block in dyld3::MachOFile::forEachDependentDylib(void (char const*, bool, bool, bool, unsigned int, unsigned int, bool&) block_pointer) const + 136
+    frame #7: 0x0000000102eadc38 dyld`dyld3::MachOFile::forEachLoadCommand(Diagnostics&, void (load_command const*, bool&) block_pointer) const + 168
+    frame #8: 0x0000000102eae108 dyld`dyld3::MachOFile::forEachDependentDylib(void (char const*, bool, bool, bool, unsigned int, unsigned int, bool&) block_pointer) const + 116
+    frame #9: 0x0000000102ebd80c dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 164
+    frame #10: 0x0000000102ebd8a8 dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 320
+    frame #11: 0x0000000102ebd8a8 dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 320
+    frame #12: 0x0000000102ebd8a8 dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 320
+    frame #13: 0x0000000102ebd8a8 dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 320
+    frame #14: 0x0000000102ebd8a8 dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 320
+    frame #15: 0x0000000102ebd8a8 dyld`dyld3::closure::ClosureBuilder::recursiveLoadDependents(dyld3::closure::ClosureBuilder::LoadedImageChain&, bool) + 320
+    frame #16: 0x0000000102ec7638 dyld`dyld3::closure::ClosureBuilder::makeLaunchClosure(dyld3::closure::LoadedFileInfo const&, bool) + 752
+    frame #17: 0x0000000102e8fcf0 dyld`dyld::buildLaunchClosure(unsigned char const*, dyld3::closure::LoadedFileInfo const&, char const**) + 344
+    frame #18: 0x0000000102e8e938 dyld`dyld::_main(macho_header const*, unsigned long, int, char const**, char const**, char const**, unsigned long*) + 2876
+    frame #19: 0x0000000102e8922c dyld`dyldbootstrap::start(dyld3::MachOLoaded const*, int, char const**, dyld3::MachOLoaded const*, unsigned long*) + 432
+    frame #20: 0x0000000102e89038 dyld`_dyld_start + 56
+''';
+      final BufferLogger logger = BufferLogger.test();
+      final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+        FakeCommand(
+          command: const <String>[
+            'ios-deploy',
+          ],
+          stdout: stdout,
+          stdin: IOSink(stdin.sink),
+        ),
+      ]);
+      final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
+        processManager: processManager,
+        logger: logger,
+      );
+      await iosDeployDebugger.launchAndAttach();
+      await iosDeployDebugger.pauseDumpBacktraceResume();
+      // verify stacktrace was logged to trace
+      expect(
+        logger.traceText,
+        contains(
+          'frame #0: 0x0000000102eaee80 dyld`dyld3::MachOFile::read_uleb128(Diagnostics&, unsigned char const*&, unsigned char const*) + 36',
+        ),
+      );
+      expect(await stdinStream.take(3).toList(), <String>[
+        'thread backtrace all',
+        '\n',
+        'process detach',
+      ]);
+    });
   });
 
   group('IOSDeploy.uninstallApp', () {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -230,7 +230,7 @@ void main() {
     expect(launchResult.hasObservatory, true);
     expect(await device.stopApp(iosApp), false);
     expect(logger.errorText, contains('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...'));
-    expect(utf8.decoder.convert(stdin.writes.first), contains('process signal SIGSTOP'));
+    expect(utf8.decoder.convert(stdin.writes.first), contains('process interrupt'));
     completer.complete();
     expect(processManager, hasNoRemainingExpectations);
   });

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -9,6 +9,7 @@ import 'dart:async';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';
@@ -64,26 +65,31 @@ const FakeCommand kLaunchDebugCommand = FakeCommand(command: <String>[
 });
 
 // The command used to actually launch the app and attach the debugger with args in debug.
-const FakeCommand kAttachDebuggerCommand = FakeCommand(command: <String>[
-  'script',
-  '-t',
-  '0',
-  '/dev/null',
-  'HostArtifact.iosDeploy',
-  '--id',
-  '123',
-  '--bundle',
-  '/',
-  '--debug',
-  '--no-wifi',
-  '--args',
-  '--enable-dart-profiling --disable-service-auth-codes --enable-checked-mode --verify-entry-points'
-], environment: <String, String>{
-  'PATH': '/usr/bin:null',
-  'DYLD_LIBRARY_PATH': '/path/to/libraries',
-},
-stdout: '(lldb)     run\nsuccess',
-);
+FakeCommand attachDebuggerCommand({IOSink stdin}) {
+  return FakeCommand(
+    command: const <String>[
+      'script',
+      '-t',
+      '0',
+      '/dev/null',
+      'HostArtifact.iosDeploy',
+      '--id',
+      '123',
+      '--bundle',
+      '/',
+      '--debug',
+      '--no-wifi',
+      '--args',
+      '--enable-dart-profiling --disable-service-auth-codes --enable-checked-mode --verify-entry-points',
+    ],
+    environment: const <String, String>{
+      'PATH': '/usr/bin:null',
+      'DYLD_LIBRARY_PATH': '/path/to/libraries',
+    },
+    stdout: '(lldb)     run\nsuccess',
+    stdin: stdin,
+  );
+}
 
 void main() {
   testWithoutContext('disposing device disposes the portForwarder and logReader', () async {
@@ -108,7 +114,7 @@ void main() {
   testWithoutContext('IOSDevice.startApp attaches in debug mode via log reading on iOS 13+', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kAttachDebuggerCommand,
+      attachDebuggerCommand(),
     ]);
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
@@ -183,8 +189,9 @@ void main() {
   testWithoutContext('IOSDevice.startApp prints warning message if discovery takes longer than configured timeout', () async {
     final FileSystem fileSystem = MemoryFileSystem.test();
     final BufferLogger logger = BufferLogger.test();
+    final CompleterIOSink stdin = CompleterIOSink();
     final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
-      kAttachDebuggerCommand,
+      attachDebuggerCommand(stdin: stdin),
     ]);
     final IOSDevice device = setUpIOSDevice(
       processManager: processManager,
@@ -203,11 +210,8 @@ void main() {
     device.setLogReader(iosApp, deviceLogReader);
 
     // Start writing messages to the log reader.
-    Timer.run(() async {
-      await Future<void>.delayed(const Duration(milliseconds: 1));
-      deviceLogReader.addLine('Foo');
-      deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
-    });
+    deviceLogReader.addLine('Foo');
+    deviceLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:456');
 
     final LaunchResult launchResult = await device.startApp(iosApp,
       prebuiltApplication: true,
@@ -220,6 +224,8 @@ void main() {
     expect(launchResult.hasObservatory, true);
     expect(await device.stopApp(iosApp), false);
     expect(logger.errorText, contains('iOS Observatory not discovered after 30 seconds. This is taking much longer than expected...'));
+    expect(stdin.writes, contains('foo bar'));
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('IOSDevice.startApp succeeds in release mode', () async {

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_start_prebuilt_test.dart
@@ -10,7 +10,6 @@ import 'dart:convert';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/build_info.dart';


### PR DESCRIPTION
This is a re-land of #101610 with an analysis fix (a new lint was enabled upstream).