### PR TITLE
Add `flutter build ipa --no-codesign` flag

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -31,10 +31,6 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
       ..addFlag('simulator',
         help: 'Build for the iOS simulator instead of the device. This changes '
           'the default build mode to debug if otherwise unspecified.',
-      )
-      ..addFlag('codesign',
-        defaultsTo: true,
-        help: 'Codesign the application bundle (only available on device builds).',
       );
   }
 
@@ -52,9 +48,6 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
 
   @override
   bool get configOnly => boolArg('config-only');
-
-  @override
-  bool get shouldCodesign => boolArg('codesign');
 
   @override
   Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs.directory(xcodeResultOutput).parent;
@@ -104,9 +97,6 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
 
   @override
   final bool configOnly = false;
-
-  @override
-  final bool shouldCodesign = true;
 
   String? get exportOptionsPlist => stringArg('export-options-plist');
 
@@ -291,6 +281,10 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
     addBundleSkSLPathOption(hide: !verboseHelp);
     addNullSafetyModeOptions(hide: !verboseHelp);
     usesAnalyzeSizeFlag();
+    argParser.addFlag('codesign',
+      defaultsTo: true,
+      help: 'Codesign the application bundle (only available on device builds).',
+    );
   }
 
   @override
@@ -305,7 +299,8 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   XcodeBuildResult? xcodeBuildResult;
   EnvironmentType get environmentType;
   bool get configOnly;
-  bool get shouldCodesign;
+
+  bool get shouldCodesign => boolArg('codesign');
 
   late final Future<BuildInfo> cachedBuildInfo = getBuildInfo();
 

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -131,13 +131,18 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final FlutterCommandResult xcarchiveResult = await super.runCommand();
-    final BuildInfo buildInfo = await getBuildInfo();
+    final BuildInfo buildInfo = await cachedBuildInfo;
     displayNullSafetyMode(buildInfo);
+    final FlutterCommandResult xcarchiveResult = await super.runCommand();
 
     // xcarchive failed or not at expected location.
     if (xcarchiveResult.exitStatus != ExitStatus.success) {
-      globals.printStatus('Skipping IPA');
+      globals.printStatus('Skipping IPA.');
+      return xcarchiveResult;
+    }
+
+    if (!shouldCodesign) {
+      globals.printStatus('Codesigning disabled with --no-codesign, skipping IPA.');
       return xcarchiveResult;
     }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -501,7 +501,7 @@ void main() {
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
 
-  testUsingContext('ipa build --no-codesign skips codesigning', () async {
+  testUsingContext('ipa build --no-codesign skips codesigning and IPA creation', () async {
     final BuildCommand command = BuildCommand();
     fakeProcessManager.addCommands(<FakeCommand>[
       xattrCommand,
@@ -519,25 +519,14 @@ void main() {
           'CODE_SIGNING_ALLOWED=NO',
           'CODE_SIGNING_REQUIRED=NO',
           'CODE_SIGNING_IDENTITY=""',
-          '-resultBundlePath', '/.tmp_rand0/flutter_ios_build_temp_dirrand0/temporary_xcresult_bundle',
+          '-resultBundlePath',
+          '/.tmp_rand0/flutter_ios_build_temp_dirrand0/temporary_xcresult_bundle',
           '-resultBundleVersion', '3',
           'FLUTTER_SUPPRESS_ANALYTICS=true',
           'COMPILER_INDEX_STORE_ENABLE=NO',
-          '-archivePath', '/build/ios/archive/Runner',
-          'archive',
-        ],
-      ),
-      const FakeCommand(
-        command: <String>[
-          'xcrun',
-          'xcodebuild',
-          '-exportArchive',
           '-archivePath',
-          '/build/ios/archive/Runner.xcarchive',
-          '-exportPath',
-          '/build/ios/ipa',
-          '-exportOptionsPlist',
-          _exportOptionsPlist,
+          '/build/ios/archive/Runner',
+          'archive',
         ],
       ),
     ]);
@@ -547,6 +536,7 @@ void main() {
       const <String>['build', 'ipa', '--no-pub', '--no-codesign']
     );
     expect(fakeProcessManager, hasNoRemainingExpectations);
+    expect(testLogger.statusText, contains('Codesigning disabled with --no-codesign, skipping IPA'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,


### PR DESCRIPTION
Move the `--no-codesign` flag from `BuildIOSCommand` to its base class `_BuildIOSSubCommand` so it can also be used by `BuildIOSArchiveCommand`.

When flag is set, skip the IPA creation step since that cannot be built without the codesigning settings.

```
$ flutter build ipa --export-method development --no-codesign

💪 Building with sound null safety 💪

Warning: Building for device with codesigning disabled. You will have to manually codesign before deploying to device.
Archiving io.flutter.examples.gallery...
Warning: Missing build name (CFBundleShortVersionString).
Warning: Missing build number (CFBundleVersion).
Action Required: You must set a build name and number in the pubspec.yaml file version field before submitting to the App Store.
Running Xcode build...
 └─Compiling, linking and signing...                      2,967ms
Xcode archive done.                                         32.8s
Built /Users/magder/Projects/flutter/dev/integration_tests/flutter_gallery/build/ios/archive/Flutter Gallery.xcarchive.
Codesigning disabled with --no-codesign, skipping IPA.
```

Also, while we're here, rearrange the `Building with sound null safety` message to happen before the build starts so it isn't just randomly printed at the end.  Before that change it looked like:
```
Built /Users/magder/Projects/flutter/dev/integration_tests/flutter_gallery/build/ios/archive/Flutter Gallery.xcarchive.

💪 Building with sound null safety 💪

Codesigning disabled with --no-codesign, skipping IPA.
```

Fixes https://github.com/flutter/flutter/issues/101765

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
