### PR TITLE
made ascii string encoding faster

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/foundation/standard_message_codec_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/standard_message_codec_bench.dart
@@ -92,5 +92,20 @@ void main() {
 
   watch.reset();
 
+  watch.start();
+  for (int i = 0; i < _kNumIterations; i += 1) {
+    codec.encodeMessage('special chars >\u263A\u{1F602}<');
+  }
+  watch.stop();
+
+  printer.addResult(
+    description: 'StandardMessageCodec unicode',
+    value: watch.elapsedMicroseconds.toDouble() / _kNumIterations,
+    unit: 'us per iteration',
+    name: 'StandardMessageCodec_unicode',
+  );
+
+  watch.reset();
+
   printer.printToStdout();
 }

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -390,7 +390,7 @@ class StandardMessageCodec implements MessageCodec<Object?> {
       Uint8List? utf8Bytes;
       int utf8Offset = 0;
       // Only do utf8 encoding if we encounter non-ascii characters.
-      for(int i = 0; i < value.length; i += 1) {
+      for (int i = 0; i < value.length; i += 1) {
         final int char = value.codeUnitAt(i);
         if (char <= 0x7f) {
           asciiBytes[i] = char;

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -390,7 +390,7 @@ class StandardMessageCodec implements MessageCodec<Object?> {
       Uint8List? utf8Bytes;
       int utf8Offset = 0;
       // Only do utf8 encoding if we encounter non-ascii characters.
-      for(int i = 0; i < value.length; ++i) {
+      for(int i = 0; i < value.length; i += 1) {
         final int char = value.codeUnitAt(i);
         if (char <= 0x7f) {
           asciiBytes[i] = char;

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -386,9 +386,28 @@ class StandardMessageCodec implements MessageCodec<Object?> {
       }
     } else if (value is String) {
       buffer.putUint8(_valueString);
-      final Uint8List bytes = utf8.encoder.convert(value);
-      writeSize(buffer, bytes.length);
-      buffer.putUint8List(bytes);
+      final Uint8List asciiBytes = Uint8List(value.length);
+      Uint8List? utf8Bytes;
+      int utf8Offset = 0;
+      // Only do utf8 encoding if we encounter non-ascii characters.
+      for(int i = 0; i < value.length; ++i) {
+        final int char = value.codeUnitAt(i);
+        if (char <= 0x7f) {
+          asciiBytes[i] = char;
+        } else {
+          utf8Bytes = utf8.encoder.convert(value.substring(i));
+          utf8Offset = i;
+          break;
+        }
+      }
+      if (utf8Bytes != null) {
+        writeSize(buffer, utf8Offset + utf8Bytes.length);
+        buffer.putUint8List(asciiBytes.sublist(0, utf8Offset));
+        buffer.putUint8List(utf8Bytes);
+      } else {
+        writeSize(buffer, asciiBytes.length);
+        buffer.putUint8List(asciiBytes);
+      }
     } else if (value is Uint8List) {
       buffer.putUint8(_valueUint8List);
       writeSize(buffer, value.length);

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -402,7 +402,7 @@ class StandardMessageCodec implements MessageCodec<Object?> {
       }
       if (utf8Bytes != null) {
         writeSize(buffer, utf8Offset + utf8Bytes.length);
-        buffer.putUint8List(asciiBytes.sublist(0, utf8Offset));
+        buffer.putUint8List(Uint8List.sublistView(asciiBytes, 0, utf8Offset));
         buffer.putUint8List(utf8Bytes);
       } else {
         writeSize(buffer, asciiBytes.length);


### PR DESCRIPTION
In local testing this made the StandardMessageCodec_string benchmark go from 0.51338 µs to 0.34857µs (33% decrease).

Don't land before https://github.com/flutter/flutter/pull/101767

Test coverage already exists, this is just a performance change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
