### PR TITLE
Increased WriteBuffers starting capacity to 64 bytes.

### DIFF
--- a/packages/flutter/lib/src/foundation/serialization.dart
+++ b/packages/flutter/lib/src/foundation/serialization.dart
@@ -16,6 +16,7 @@ class WriteBuffer {
   /// [startCapacity] determines the start size of the [WriteBuffer].  The closer
   /// that value is to the real size used, the better the performance.
   factory WriteBuffer({int startCapacity = 8}) {
+    assert(startCapacity > 0);
     final ByteData eightBytes = ByteData(8);
     final Uint8List eightBytesAsList = eightBytes.buffer.asUint8List();
     return WriteBuffer._(Uint8List(startCapacity), eightBytes, eightBytesAsList);

--- a/packages/flutter/lib/src/foundation/serialization.dart
+++ b/packages/flutter/lib/src/foundation/serialization.dart
@@ -13,8 +13,9 @@ import 'dart:typed_data';
 /// The byte order used is [Endian.host] throughout.
 class WriteBuffer {
   /// Creates an interface for incrementally building a [ByteData] instance.
-  /// [startCapacity] determines the start size of the [WriteBuffer].  The closer
-  /// that value is to the real size used, the better the performance.
+  /// [startCapacity] determines the start size of the [WriteBuffer] in bytes.
+  /// The closer that value is to the real size used, the better the
+  /// performance.
   factory WriteBuffer({int startCapacity = 8}) {
     assert(startCapacity > 0);
     final ByteData eightBytes = ByteData(8);

--- a/packages/flutter/lib/src/foundation/serialization.dart
+++ b/packages/flutter/lib/src/foundation/serialization.dart
@@ -13,10 +13,12 @@ import 'dart:typed_data';
 /// The byte order used is [Endian.host] throughout.
 class WriteBuffer {
   /// Creates an interface for incrementally building a [ByteData] instance.
-  factory WriteBuffer() {
+  /// [startCapacity] determines the start size of the [WriteBuffer].  The closer
+  /// that value is to the real size used, the better the performance.
+  factory WriteBuffer({int startCapacity = 8}) {
     final ByteData eightBytes = ByteData(8);
     final Uint8List eightBytesAsList = eightBytes.buffer.asUint8List();
-    return WriteBuffer._(Uint8List(8), eightBytes, eightBytesAsList);
+    return WriteBuffer._(Uint8List(startCapacity), eightBytes, eightBytesAsList);
   }
 
   WriteBuffer._(this._buffer, this._eightBytes, this._eightBytesAsList);

--- a/packages/flutter/lib/src/services/message_codecs.dart
+++ b/packages/flutter/lib/src/services/message_codecs.dart
@@ -310,7 +310,7 @@ class StandardMessageCodec implements MessageCodec<Object?> {
   ByteData? encodeMessage(Object? message) {
     if (message == null)
       return null;
-    final WriteBuffer buffer = WriteBuffer();
+    final WriteBuffer buffer = WriteBuffer(startCapacity: 64);
     writeValue(buffer, message);
     return buffer.done();
   }

--- a/packages/flutter/test/foundation/serialization_test.dart
+++ b/packages/flutter/test/foundation/serialization_test.dart
@@ -127,5 +127,8 @@ void main() {
     test('empty WriteBuffer', () {
       expect(() => WriteBuffer(startCapacity: 0), throwsAssertionError);
     });
+    test('size 1', () {
+      expect(() => WriteBuffer(startCapacity: 1), returnsNormally);
+    });
   });
 }

--- a/packages/flutter/test/foundation/serialization_test.dart
+++ b/packages/flutter/test/foundation/serialization_test.dart
@@ -124,5 +124,8 @@ void main() {
       write.done();
       expect(() => write.done(), throwsStateError);
     });
+    test('empty WriteBuffer', () {
+      expect(() => WriteBuffer(startCapacity: 0), throwsAssertionError);
+    });
   });
 }


### PR DESCRIPTION
By selecting a larger starting buffer size we get a 28% speed increase on `StandardMessageCodec_heterogenous_list` and a 13% speed increase on `StandardMessageCodec_heterogenous_map`.

The reason this is faster is that the buffer was so small that we were resizing the buffer a lot and the resizes are exponentially more expensive since they are copying the last region that was copied.  By starting at a larger size we are removing that feedback.

It probably has the best performance gains for payloads that are between 8 bytes and 256 bytes.  Smaller than that and we won't be resizing, larger than that and the savings becomes insignificant to larger resizing.  It didn't noticeably effect payloads <= 8bytes

Do not land until https://github.com/flutter/flutter/pull/101767 lands.

This should also be covered by previous tests, it's just a performance change.

before:
```
flutter: :::JSON::: {"StandardMessageCodec_null":0.00137,"StandardMessageCodec_int":0.26432,"StandardMessageCodec_string":0.59417,"StandardMessageCodec_heterogenous_list":1.21914,"StandardMessageCodec_heterogenous_map":2.28828}
```

after:
```
flutter: :::JSON::: {"StandardMessageCodec_null":0.00096,"StandardMessageCodec_int":0.26681,"StandardMessageCodec_string":0.52084,"StandardMessageCodec_heterogenous_list":0.87832,"StandardMessageCodec_heterogenous_map":1.97065}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
