### PR TITLE
[web] remove timeout when waiting for browser to launch

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -698,10 +698,7 @@ class BrowserManager {
       completer.completeError(error, stackTrace);
     }));
 
-    return completer.future.timeout(const Duration(seconds: 30), onTimeout: () {
-      chrome.close();
-      throwToolExit('Timed out waiting for ${runtime.name} to connect.');
-    });
+    return completer.future;
   }
 
   /// Loads [_BrowserEnvironment].


### PR DESCRIPTION
This timeout seems to be causing severe flakiness in the engine builds.