### PR TITLE
Set the Clipboard more reliably in android semantics integration test.

### DIFF
--- a/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
+++ b/dev/integration_tests/android_semantics_testing/android/app/src/main/java/com/yourcompany/platforminteraction/MainActivity.java
@@ -15,6 +15,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.util.DisplayMetrics;
 import android.view.WindowManager;
+import android.content.ClipboardManager;
+import android.content.ClipData;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
@@ -64,6 +66,16 @@ public class MainActivity extends FlutterActivity {
             }
             AccessibilityNodeInfo node = provider.createAccessibilityNodeInfo(id);
             result.success(convertSemantics(node, id));
+            return;
+        }
+        if (methodCall.method.equals("setClipboard")) {
+            Map<String, Object> data = methodCall.arguments();
+            @SuppressWarnings("unchecked")
+            String message = (String) data.get("message");
+            ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+            ClipData clip = ClipData.newPlainText("message", message);
+            clipboard.setPrimaryClip(clip);
+            result.success(null);
             return;
         }
         result.notImplemented();

--- a/dev/integration_tests/android_semantics_testing/lib/main.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/main.dart
@@ -39,6 +39,21 @@ Future<String> dataHandler(String message) async {
       completeSemantics();
     return completer.future;
   }
+  if (message.contains('setClipboard')) {
+    final Completer<String> completer = Completer<String>();
+    final String str = message.split('#')[1];
+    Future<void> completeSetClipboard([Object _]) async {
+      await kSemanticsChannel.invokeMethod<dynamic>('setClipboard', <String, dynamic>{
+        'message': str,
+      });
+      completer.complete('');
+    }
+    if (SchedulerBinding.instance.hasScheduledFrame)
+      SchedulerBinding.instance.addPostFrameCallback(completeSetClipboard);
+    else
+      completeSetClipboard();
+    return completer.future;
+  }
   throw UnimplementedError();
 }
 

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -120,29 +120,7 @@ void main() {
         // Ideally this should test the case where there is nothing on the
         // clipboard as well, but there is no reliable way to clear the
         // clipboard on Android devices.
-        final SerializableFinder normalTextField = find.descendant(
-          of: find.byValueKey(normalTextFieldKeyValue),
-          matching: find.byType('Semantics'),
-          firstMatchOnly: true,
-        );
-        await driver.tap(normalTextField);
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        await driver.enterText('hello world');
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        await driver.tap(normalTextField);
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        await driver.tap(normalTextField);
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        await driver.tap(find.text('Select all'));
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        await driver.tap(find.text('Copy'));
-        await Future<void>.delayed(const Duration(milliseconds: 50));
-        await driver.enterText('');
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        // Go back to previous page and forward again to unfocus the field.
-        await driver.tap(find.byValueKey(backButtonKeyValue));
-        await Future<void>.delayed(const Duration(milliseconds: 500));
-        await driver.tap(find.text(textFieldRoute));
+        await driver.requestData('setClipboard#Hello World');
         await Future<void>.delayed(const Duration(milliseconds: 500));
       });
 


### PR DESCRIPTION
The flake happens when it try to store text into clipboard. This pr simplifies this process.

https://github.com/flutter/flutter/issues/98417

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
