### PR TITLE
Correct docs to refer to replacement render object

### DIFF
--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -85,8 +85,8 @@ class _OverflowRegionData {
 ///
 /// See also:
 ///
-///  * [RenderConstraintsTransformBox], [RenderUnconstrainedBox] and
-///    [RenderFlex], for examples of classes that use this indicator mixin.
+///  * [RenderConstraintsTransformBox] and [RenderFlex] for examples of classes
+///    that use this indicator mixin.
 mixin DebugOverflowIndicatorMixin on RenderObject {
   static const Color _black = Color(0xBF000000);
   static const Color _yellow = Color(0xBFFFFF00);

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -85,8 +85,8 @@ class _OverflowRegionData {
 ///
 /// See also:
 ///
-///  * [RenderConstraintsTransformBox] and [RenderFlex] for examples of classes
-///    that use this indicator mixin.
+///  * [RenderConstraintsTransformBox], [RenderConstraintsTransformBox], and
+///    [RenderFlex] for examples of classes that use this indicator mixin.
 mixin DebugOverflowIndicatorMixin on RenderObject {
   static const Color _black = Color(0xBF000000);
   static const Color _yellow = Color(0xBFFFFF00);

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -538,9 +538,9 @@ class RenderPositionedBox extends RenderAligningShiftedBox {
 ///
 /// See also:
 ///
-///  * [RenderUnconstrainedBox] for a render object that allows its children
-///    to render themselves unconstrained, expands to fit them, and considers
-///    overflow to be an error.
+///  * [RenderConstraintsTransformBox] for a render object that applies an
+///    arbitrary transform to its constraints before sizing its child using
+///    the new constraints, treating any overflow as error.
 ///  * [RenderSizedOverflowBox], a render object that is a specific size but
 ///    passes its original constraints through to its child, which it allows to
 ///    overflow.
@@ -675,8 +675,9 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
 ///  * [RenderConstrainedOverflowBox], which renders a box that imposes different
 ///    constraints on its child than it gets from its parent, possibly allowing
 ///    the child to overflow the parent.
-///  * [RenderUnconstrainedBox] which allows its children to render themselves
-///    unconstrained, expands to fit them, and considers overflow to be an error.
+///  * [RenderConstraintsTransformBox] for a render object that applies an
+///    arbitrary transform to its constraints before sizing its child using
+///    the new constraints, treating any overflow as error.
 class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin {
   /// Creates a [RenderBox] that sizes itself to the child and modifies the
   /// [constraints] before passing it down to that child.
@@ -942,9 +943,9 @@ class RenderUnconstrainedBox extends RenderConstraintsTransformBox {
 ///
 /// See also:
 ///
-///  * [RenderUnconstrainedBox] for a render object that allows its children
-///    to render themselves unconstrained, expands to fit them, and considers
-///    overflow to be an error.
+///  * [RenderConstraintsTransformBox] for a render object that applies an
+///    arbitrary transform to its constraints before sizing its child using
+///    the new constraints, treating any overflow as error.
 ///  * [RenderConstrainedOverflowBox] for a render object that imposes
 ///    different constraints on its child than it gets from its parent,
 ///    possibly allowing the child to overflow the parent.


### PR DESCRIPTION
RenderUnconstrainedBox is deprecated, and will be removed in the near future. This trivial change updates the documentation to refer folks to the replacement API instead of the deprecated one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
