### PR TITLE
Enforce cpu explicitly for Mac devicelab test beds

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -85,7 +85,7 @@ platform_properties:
         []
       os: Mac-12
       device_type: none
-      mac_model: Macmini8,1
+      cpu: x86
       xcode: 13a233
   mac_android:
     properties:
@@ -106,7 +106,7 @@ platform_properties:
           {"dependency": "open_jdk", "version": "11"}
         ]
       os: Mac-12
-      mac_model: Macmini8,1
+      cpu: x86
       device_os: N
   mac_ios:
     properties:
@@ -128,7 +128,7 @@ platform_properties:
           {"dependency": "ios_signing"}
         ]
       os: Mac-12
-      mac_model: Macmini8,1
+      cpu: x86
       device_os: iOS-15.1
       xcode: 13a233
   windows:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -106,6 +106,7 @@ platform_properties:
           {"dependency": "open_jdk", "version": "11"}
         ]
       os: Mac-12
+      mac_model: Macmini8,1
       device_os: N
   mac_ios:
     properties:
@@ -127,6 +128,7 @@ platform_properties:
           {"dependency": "ios_signing"}
         ]
       os: Mac-12
+      mac_model: Macmini8,1
       device_os: iOS-15.1
       xcode: 13a233
   windows:


### PR DESCRIPTION
All existing devicelab testbeds are `Macmini8,1` now, but from tests config side, we are not enforcing the mac_model.

On the other hand, we are enabling M1 tests and M1 bots in `prod`, this will cause existing Mac devicelab tests to run against M1 bots. However, not all tests are supported on M1 bots.

This PR tags `mac_model: Macmini8,1` explicitly to avoid interaction between test beds. This will also help avoid potential breakage when model changes in the future.

Context: https://github.com/flutter/flutter/issues/101861