### PR TITLE
Migrate AppBar to Material 3

### DIFF
--- a/dev/tools/gen_defaults/bin/gen_defaults.dart
+++ b/dev/tools/gen_defaults/bin/gen_defaults.dart
@@ -17,6 +17,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:gen_defaults/app_bar_template.dart';
 import 'package:gen_defaults/button_template.dart';
 import 'package:gen_defaults/card_template.dart';
 import 'package:gen_defaults/dialog_template.dart';
@@ -78,6 +79,7 @@ Future<void> main(List<String> args) async {
   tokens['colorsLight'] = _readTokenFile('color_light.json');
   tokens['colorsDark'] = _readTokenFile('color_dark.json');
 
+  AppBarTemplate('$materialLib/app_bar.dart', tokens).updateFile();
   ButtonTemplate('md.comp.elevated-button', '$materialLib/elevated_button.dart', tokens).updateFile();
   ButtonTemplate('md.comp.outlined-button', '$materialLib/outlined_button.dart', tokens).updateFile();
   ButtonTemplate('md.comp.text-button', '$materialLib/text_button.dart', tokens).updateFile();

--- a/dev/tools/gen_defaults/lib/app_bar_template.dart
+++ b/dev/tools/gen_defaults/lib/app_bar_template.dart
@@ -1,0 +1,58 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'template.dart';
+
+class AppBarTemplate extends TokenTemplate {
+  const AppBarTemplate(super.fileName, super.tokens)
+    : super(
+      colorSchemePrefix: '_colors.',
+      textThemePrefix: '_textTheme.',
+    );
+
+  @override
+  String generate() => '''
+// Generated version ${tokens["version"]}
+class _TokenDefaultsM3 extends AppBarTheme {
+  _TokenDefaultsM3(this.context)
+    : super(
+      elevation: ${elevation('md.comp.top-app-bar.small.container')},
+      scrolledUnderElevation: ${elevation('md.comp.top-app-bar.small.on-scroll.container')},
+      titleSpacing: NavigationToolbar.kMiddleSpacing,
+      toolbarHeight: ${tokens['md.comp.top-app-bar.small.container.height']},
+    );
+
+  final BuildContext context;
+  late final ThemeData _theme = Theme.of(context);
+  late final ColorScheme _colors = _theme.colorScheme;
+  late final TextTheme _textTheme = _theme.textTheme;
+
+  @override
+  Color? get backgroundColor => ${componentColor('md.comp.top-app-bar.small.container')};
+
+  @override
+  Color? get foregroundColor => ${color('md.comp.top-app-bar.small.headline.color')};
+
+  @override
+  Color? get surfaceTintColor => ${componentColor('md.comp.top-app-bar.small.container.surface-tint-layer')};
+
+  @override
+  IconThemeData? get iconTheme => IconThemeData(
+    color: ${componentColor('md.comp.top-app-bar.small.leading-icon')},
+    size: ${tokens['md.comp.top-app-bar.small.leading-icon.size']},
+  );
+
+  @override
+  IconThemeData? get actionsIconTheme => IconThemeData(
+    color: ${componentColor('md.comp.top-app-bar.small.trailing-icon')},
+    size: ${tokens['md.comp.top-app-bar.small.trailing-icon.size']},
+  );
+
+  @override
+  TextStyle? get toolbarTextStyle => _textTheme.bodyText2;
+
+  @override
+  TextStyle? get titleTextStyle => ${textStyle('md.comp.top-app-bar.small.headline')};
+}''';
+}

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -390,7 +390,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///
   /// See also:
   ///
-  ///  * [scrolledUnderElevation], which will be used when the App Bar has
+  ///  * [scrolledUnderElevation], which will be used when the app bar has
   ///    something scrolled underneath it.
   ///  * [shadowColor], which is the color of the shadow below the app bar.
   ///  * [surfaceTintColor], which determines the elevation overlay that will
@@ -400,7 +400,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   final double? elevation;
 
   /// {@template flutter.material.appbar.scrolledUnderElevation}
-  /// The elevation that will be used if this App Bar has something
+  /// The elevation that will be used if this app bar has something
   /// scrolled underneath it.
   ///
   /// If non-null then it [AppBarTheme.scrolledUnderElevation] of

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -435,10 +435,12 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [shape], which defines the shape of the app bar and its shadow.
   final Color? shadowColor;
 
+  /// {@template flutter.material.appbar.surfaceTintColor}
   /// The color of the surface tint overlay applied to the app bar's
   /// background color to indicate elevation.
   ///
   /// If null no overlay will be applied.
+  /// {@endtemplate}
   ///
   /// See also:
   ///   * [Material.surfaceTintColor], which described this feature in more detail.
@@ -872,7 +874,7 @@ class _AppBarState extends State<AppBar> {
       ?? appBarTheme.elevation
       ?? defaults.elevation!;
 
-    final double effectiveElevation = _scrolledUnder
+    final double effectiveElevation = states.contains(MaterialState.scrolledUnder)
       ? widget.scrolledUnderElevation
         ?? appBarTheme.scrolledUnderElevation
         ?? defaults.scrolledUnderElevation
@@ -1140,7 +1142,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
     required this.flexibleSpace,
     required this.bottom,
     required this.elevation,
+    required this.scrolledUnderElevation,
     required this.shadowColor,
+    required this.surfaceTintColor,
     required this.forceElevated,
     required this.backgroundColor,
     required this.foregroundColor,
@@ -1182,7 +1186,9 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   final Widget? flexibleSpace;
   final PreferredSizeWidget? bottom;
   final double? elevation;
+  final double? scrolledUnderElevation;
   final Color? shadowColor;
+  final Color? surfaceTintColor;
   final bool forceElevated;
   final Color? backgroundColor;
   final Color? foregroundColor;
@@ -1256,8 +1262,10 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
             )
           : flexibleSpace,
         bottom: bottom,
-        elevation: forceElevated || isScrolledUnder ? elevation : 0.0,
+        elevation: forceElevated ? elevation : 0,
+        scrolledUnderElevation: scrolledUnderElevation,
         shadowColor: shadowColor,
+        surfaceTintColor: surfaceTintColor,
         backgroundColor: backgroundColor,
         foregroundColor: foregroundColor,
         brightness: brightness,
@@ -1424,7 +1432,9 @@ class SliverAppBar extends StatefulWidget {
     this.flexibleSpace,
     this.bottom,
     this.elevation,
+    this.scrolledUnderElevation,
     this.shadowColor,
+    this.surfaceTintColor,
     this.forceElevated = false,
     this.backgroundColor,
     this.foregroundColor,
@@ -1510,10 +1520,20 @@ class SliverAppBar extends StatefulWidget {
   /// This property is used to configure an [AppBar].
   final double? elevation;
 
+  /// {@macro flutter.material.appbar.scrolledUnderElevation}
+  ///
+  /// This property is used to configure an [AppBar].
+  final double? scrolledUnderElevation;
+
   /// {@macro flutter.material.appbar.shadowColor}
   ///
   /// This property is used to configure an [AppBar].
   final Color? shadowColor;
+
+  /// {@macro flutter.material.appbar.surfaceTintColor}
+  ///
+  /// This property is used to configure an [AppBar].
+  final Color? surfaceTintColor;
 
   /// Whether to show the shadow appropriate for the [elevation] even if the
   /// content is not scrolled under the [AppBar].
@@ -1816,7 +1836,9 @@ class _SliverAppBarState extends State<SliverAppBar> with TickerProviderStateMix
           flexibleSpace: widget.flexibleSpace,
           bottom: widget.bottom,
           elevation: widget.elevation,
+          scrolledUnderElevation: widget.scrolledUnderElevation,
           shadowColor: widget.shadowColor,
+          surfaceTintColor: widget.surfaceTintColor,
           forceElevated: widget.forceElevated,
           backgroundColor: widget.backgroundColor,
           foregroundColor: widget.foregroundColor,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1262,7 +1262,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
             )
           : flexibleSpace,
         bottom: bottom,
-        elevation: forceElevated ? elevation : 0,
+        elevation: forceElevated || isScrolledUnder ? elevation : 0.0,
         scrolledUnderElevation: scrolledUnderElevation,
         shadowColor: shadowColor,
         surfaceTintColor: surfaceTintColor,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -377,7 +377,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   /// This property controls the size of the shadow below the app bar if
   /// [shadowColor] is not null.
   ///
-  /// If [surfaceTint] is not null then it will apply a surface tint overlay
+  /// If [surfaceTintColor] is not null then it will apply a surface tint overlay
   /// to the background color (see [Material.surfaceTintColor] for more
   /// detail).
   ///
@@ -394,7 +394,8 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///    something scrolled underneath it.
   ///  * [shadowColor], which is the color of the shadow below the app bar.
   ///  * [surfaceTintColor], which determines the elevation overlay that will
-  ///    be applied to the background of the app bar.  ///  * [shape], which defines the shape of the app bar's [Material] and its
+  ///    be applied to the background of the app bar.
+  ///  * [shape], which defines the shape of the app bar's [Material] and its
   ///    shadow.
   final double? elevation;
 

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -335,6 +335,7 @@ class AppBarTheme with Diagnosticable {
     backgroundColor,
     foregroundColor,
     elevation,
+    scrolledUnderElevation,
     shadowColor,
     surfaceTintColor,
     shape,

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -37,7 +37,9 @@ class AppBarTheme with Diagnosticable {
     Color? backgroundColor,
     this.foregroundColor,
     this.elevation,
+    this.scrolledUnderElevation,
     this.shadowColor,
+    this.surfaceTintColor,
     this.shape,
     this.iconTheme,
     this.actionsIconTheme,
@@ -121,9 +123,17 @@ class AppBarTheme with Diagnosticable {
   /// descendant [AppBar] widgets.
   final double? elevation;
 
+  /// Overrides the default value of [AppBar.scrolledUnderElevation] in all
+  /// descendant [AppBar] widgets.
+  final double? scrolledUnderElevation;
+
   /// Overrides the default value for [AppBar.shadowColor] in all
   /// descendant widgets.
   final Color? shadowColor;
+
+  /// Overrides the default value for [AppBar.surfaceTintColor] in all
+  /// descendant widgets.
+  final Color? surfaceTintColor;
 
   /// Overrides the default value for [AppBar.shape] in all
   /// descendant widgets.
@@ -237,7 +247,9 @@ class AppBarTheme with Diagnosticable {
     Color? backgroundColor,
     Color? foregroundColor,
     double? elevation,
+    double? scrolledUnderElevation,
     Color? shadowColor,
+    Color? surfaceTintColor,
     ShapeBorder? shape,
     IconThemeData? iconTheme,
     @Deprecated(
@@ -266,7 +278,9 @@ class AppBarTheme with Diagnosticable {
       backgroundColor: backgroundColor ?? color ?? this.backgroundColor,
       foregroundColor: foregroundColor ?? this.foregroundColor,
       elevation: elevation ?? this.elevation,
+      scrolledUnderElevation: scrolledUnderElevation ?? this.scrolledUnderElevation,
       shadowColor: shadowColor ?? this.shadowColor,
+      surfaceTintColor: surfaceTintColor ?? this.surfaceTintColor,
       shape: shape ?? this.shape,
       iconTheme: iconTheme ?? this.iconTheme,
       actionsIconTheme: actionsIconTheme ?? this.actionsIconTheme,
@@ -298,7 +312,9 @@ class AppBarTheme with Diagnosticable {
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       foregroundColor: Color.lerp(a?.foregroundColor, b?.foregroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
+      scrolledUnderElevation: lerpDouble(a?.scrolledUnderElevation, b?.scrolledUnderElevation, t),
       shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
+      surfaceTintColor: Color.lerp(a?.surfaceTintColor, b?.surfaceTintColor, t),
       shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
       iconTheme: IconThemeData.lerp(a?.iconTheme, b?.iconTheme, t),
       actionsIconTheme: IconThemeData.lerp(a?.actionsIconTheme, b?.actionsIconTheme, t),
@@ -320,6 +336,7 @@ class AppBarTheme with Diagnosticable {
     foregroundColor,
     elevation,
     shadowColor,
+    surfaceTintColor,
     shape,
     iconTheme,
     actionsIconTheme,
@@ -344,7 +361,9 @@ class AppBarTheme with Diagnosticable {
         && other.backgroundColor == backgroundColor
         && other.foregroundColor == foregroundColor
         && other.elevation == elevation
+        && other.scrolledUnderElevation == scrolledUnderElevation
         && other.shadowColor == shadowColor
+        && other.surfaceTintColor == surfaceTintColor
         && other.shape == shape
         && other.iconTheme == iconTheme
         && other.actionsIconTheme == actionsIconTheme
@@ -365,7 +384,9 @@ class AppBarTheme with Diagnosticable {
     properties.add(ColorProperty('backgroundColor', backgroundColor, defaultValue: null));
     properties.add(ColorProperty('foregroundColor', foregroundColor, defaultValue: null));
     properties.add(DiagnosticsProperty<double>('elevation', elevation, defaultValue: null));
+    properties.add(DiagnosticsProperty<double>('scrolledUnderElevation', scrolledUnderElevation, defaultValue: null));
     properties.add(ColorProperty('shadowColor', shadowColor, defaultValue: null));
+    properties.add(ColorProperty('surfaceTintColor', surfaceTintColor, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<IconThemeData>('iconTheme', iconTheme, defaultValue: null));
     properties.add(DiagnosticsProperty<IconThemeData>('actionsIconTheme', actionsIconTheme, defaultValue: null));

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1203,6 +1203,7 @@ class ThemeData with Diagnosticable {
   /// Components that have been migrated to Material 3 are:
   ///
   ///   * [AlertDialog]
+  ///   * [AppBar]
   ///   * [Card]
   ///   * [Dialog]
   ///   * [ElevatedButton]

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -954,6 +954,8 @@ void main() {
   });
 
   testWidgets('AppBar uses the specified elevation or defaults to 4.0', (WidgetTester tester) async {
+    final bool useMaterial3 = ThemeData().useMaterial3;
+
     Widget buildAppBar([double? elevation]) {
       return MaterialApp(
         home: Scaffold(
@@ -967,13 +969,46 @@ void main() {
       matching: find.byType(Material),
     ));
 
-    // Default elevation should be _AppBarState._defaultElevation = 4.0
+    // Default elevation should be used for the material.
     await tester.pumpWidget(buildAppBar());
-    expect(getMaterial().elevation, 4.0);
+    expect(getMaterial().elevation, useMaterial3 ? 0 : 4);
 
     // AppBar should use the specified elevation.
     await tester.pumpWidget(buildAppBar(8.0));
     expect(getMaterial().elevation, 8.0);
+  });
+
+  testWidgets('scrolledUnderElevation', (WidgetTester tester) async {
+    Widget buildAppBar({double? elevation, double? scrolledUnderElevation}) {
+      return MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text('Title'),
+            elevation: elevation,
+            scrolledUnderElevation: scrolledUnderElevation,
+          ),
+          body: ListView.builder(
+            itemCount: 100,
+            itemBuilder: (BuildContext context, int index) => ListTile(title: Text('Item $index')),
+          ),
+        ),
+      );
+    }
+
+    Material getMaterial() => tester.widget<Material>(find.descendant(
+      of: find.byType(AppBar),
+      matching: find.byType(Material),
+    ));
+
+    await tester.pumpWidget(buildAppBar(elevation: 2, scrolledUnderElevation: 10));
+    // Starts with the base elevation.
+    expect(getMaterial().elevation, 2);
+
+    await tester.fling(find.text('Item 2'), const Offset(0.0, -600.0), 2000.0);
+    await tester.pumpAndSettle();
+
+    // After scrolling it should be the scrolledUnderElevation.
+    expect(getMaterial().elevation, 10);
   });
 
   group('SliverAppBar elevation', () {
@@ -996,15 +1031,16 @@ void main() {
       // Regression test for https://github.com/flutter/flutter/issues/59158.
       AppBar getAppBar() => tester.widget<AppBar>(find.byType(AppBar));
       Material getMaterial() => tester.widget<Material>(find.byType(Material));
+      final bool useMaterial3 = ThemeData().useMaterial3;
 
       // When forceElevated is off, SliverAppBar should not be elevated.
       await tester.pumpWidget(buildSliverAppBar(false));
       expect(getMaterial().elevation, 0.0);
 
-      // Default elevation should be _AppBarState._defaultElevation = 4.0, and
+      // Default elevation should be used by the material, but
       // the AppBar's elevation should not be specified by SliverAppBar.
       await tester.pumpWidget(buildSliverAppBar(true));
-      expect(getMaterial().elevation, 4.0);
+      expect(getMaterial().elevation, useMaterial3 ? 0.0 : 4.0);
       expect(getAppBar().elevation, null);
 
       // SliverAppBar should use the specified elevation.
@@ -1312,6 +1348,8 @@ void main() {
     final Key key = UniqueKey();
     await tester.pumpWidget(
       MaterialApp(
+        // Test was designed against InkSplash so need to make sure that is used.
+        theme: ThemeData(splashFactory: InkSplash.splashFactory),
         home: Center(
           child: AppBar(
             title: const Text('Abc'),
@@ -2005,44 +2043,55 @@ void main() {
     ));
   });
 
-  testWidgets('AppBar draws a light system bar for a light theme with a dark background', (WidgetTester tester) async {
-    final ThemeData lightTheme = ThemeData(primarySwatch: Colors.deepOrange);
-    await tester.pumpWidget(MaterialApp(
-      theme: lightTheme,
-      home: Scaffold(
-        appBar: AppBar(
-          title: const Text('test'),
-        ),
-      ),
-    ));
-
-    expect(lightTheme.primaryColorBrightness, Brightness.dark);
-    expect(lightTheme.colorScheme.brightness, Brightness.light);
-    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
-      statusBarBrightness: Brightness.dark,
-      statusBarIconBrightness: Brightness.light,
-    ));
-  });
-
-  testWidgets('AppBar draws a dark system bar for a dark theme with a light background', (WidgetTester tester) async {
-    final ThemeData darkTheme = ThemeData(brightness: Brightness.dark, cardColor: Colors.white);
-    await tester.pumpWidget(
-      MaterialApp(
-        theme: darkTheme,
+  testWidgets('Default system bar brightness based on AppBar background color brightness.', (WidgetTester tester) async {
+    Widget buildAppBar(ThemeData theme) {
+      return MaterialApp(
+        theme: theme,
         home: Scaffold(
-          appBar: AppBar(
-            title: const Text('test'),
-          ),
+          appBar: AppBar(title: const Text('Title')),
         ),
-      ),
-    );
+      );
+    }
 
-    expect(darkTheme.primaryColorBrightness, Brightness.dark);
-    expect(darkTheme.colorScheme.brightness, Brightness.dark);
-    expect(SystemChrome.latestStyle, const SystemUiOverlayStyle(
-      statusBarBrightness: Brightness.light,
-      statusBarIconBrightness: Brightness.dark,
-    ));
+    // Using a light theme.
+    {
+      await tester.pumpWidget(buildAppBar(ThemeData.from(colorScheme: const ColorScheme.light())));
+      final Material appBarMaterial = tester.widget<Material>(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byType(Material),
+        ),
+      );
+      final Brightness appBarBrightness = ThemeData.estimateBrightnessForColor(appBarMaterial.color!);
+      final Brightness onAppBarBrightness = appBarBrightness == Brightness.light
+        ? Brightness.dark
+        : Brightness.light;
+
+      expect(SystemChrome.latestStyle, SystemUiOverlayStyle(
+        statusBarBrightness: appBarBrightness,
+        statusBarIconBrightness: onAppBarBrightness,
+      ));
+    }
+
+    // Using a dark theme.
+    {
+      await tester.pumpWidget(buildAppBar(ThemeData.from(colorScheme: const ColorScheme.dark())));
+      final Material appBarMaterial = tester.widget<Material>(
+        find.descendant(
+          of: find.byType(AppBar),
+          matching: find.byType(Material),
+        ),
+      );
+      final Brightness appBarBrightness = ThemeData.estimateBrightnessForColor(appBarMaterial.color!);
+      final Brightness onAppBarBrightness = appBarBrightness == Brightness.light
+          ? Brightness.dark
+          : Brightness.light;
+
+      expect(SystemChrome.latestStyle, SystemUiOverlayStyle(
+        statusBarBrightness: appBarBrightness,
+        statusBarIconBrightness: onAppBarBrightness,
+      ));
+    }
   });
 
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
@@ -2207,6 +2256,8 @@ void main() {
 
     Widget buildFrame() {
       return MaterialApp(
+        // Test designed against 2014 font sizes.
+        theme: ThemeData(textTheme: Typography.englishLike2014),
         home: Builder(
           builder: (BuildContext context) {
             return MediaQuery(
@@ -2245,6 +2296,8 @@ void main() {
 
     Widget buildFrame() {
       return MaterialApp(
+        // Test designed against 2014 font sizes.
+        theme: ThemeData(textTheme: Typography.englishLike2014),
         home: Builder(
           builder: (BuildContext context) {
             return Directionality(
@@ -2536,6 +2589,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData.light().copyWith(
+          useMaterial3: false,
           appBarTheme: const AppBarTheme(
             backwardsCompatibility: false,
           ),

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -15,8 +15,10 @@ void main() {
   });
 
   testWidgets('Passing no AppBarTheme returns defaults', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData();
     await tester.pumpWidget(
       MaterialApp(
+        theme: theme,
         home: Scaffold(
           appBar: AppBar(
             actions: <Widget>[
@@ -33,17 +35,33 @@ void main() {
     final RichText actionIconText = _getAppBarIconRichText(tester);
     final DefaultTextStyle text = _getAppBarText(tester);
 
-    expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
-    expect(widget.color, Colors.blue);
-    expect(widget.elevation, 4.0);
-    expect(widget.shadowColor, Colors.black);
-    expect(widget.shape, null);
-    expect(iconTheme.data, const IconThemeData(color: Colors.white));
-    expect(actionsIconTheme.data, const IconThemeData(color: Colors.white));
-    expect(actionIconText.text.style!.color, Colors.white);
-    expect(text.style, Typography.material2014().englishLike.bodyText2!.merge(Typography.material2014().white.bodyText2));
-    expect(tester.getSize(find.byType(AppBar)).height, kToolbarHeight);
-    expect(tester.getSize(find.byType(AppBar)).width, 800);
+    if (theme.useMaterial3) {
+      expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.light);
+      expect(widget.color, theme.colorScheme.surface);
+      expect(widget.elevation, 0);
+      expect(widget.shadowColor, null);
+      expect(widget.surfaceTintColor, theme.colorScheme.surfaceTint);
+      expect(widget.shape, null);
+      expect(iconTheme.data, IconThemeData(color: theme.colorScheme.onSurface, size: 24));
+      expect(actionsIconTheme.data, IconThemeData(color: theme.colorScheme.onSurfaceVariant, size: 24));
+      expect(actionIconText.text.style!.color, Colors.black);
+      expect(text.style, Typography.material2021().englishLike.bodyText2!.merge(Typography.material2021().black.bodyText2).copyWith(color: theme.colorScheme.onSurface));
+      expect(tester.getSize(find.byType(AppBar)).height, kToolbarHeight);
+      expect(tester.getSize(find.byType(AppBar)).width, 800);
+    } else {
+      expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
+      expect(widget.color, Colors.blue);
+      expect(widget.elevation, 4.0);
+      expect(widget.shadowColor, Colors.black);
+      expect(widget.surfaceTintColor, null);
+      expect(widget.shape, null);
+      expect(iconTheme.data, const IconThemeData(color: Colors.white));
+      expect(actionsIconTheme.data, const IconThemeData(color: Colors.white));
+      expect(actionIconText.text.style!.color, Colors.white);
+      expect(text.style, Typography.material2014().englishLike.bodyText2!.merge(Typography.material2014().white.bodyText2));
+      expect(tester.getSize(find.byType(AppBar)).height, kToolbarHeight);
+      expect(tester.getSize(find.byType(AppBar)).width, 800);
+    }
   });
 
   testWidgets('AppBar uses values from AppBarTheme', (WidgetTester tester) async {
@@ -73,6 +91,7 @@ void main() {
     expect(widget.color, appBarTheme.backgroundColor);
     expect(widget.elevation, appBarTheme.elevation);
     expect(widget.shadowColor, appBarTheme.shadowColor);
+    expect(widget.surfaceTintColor, appBarTheme.surfaceTintColor);
     expect(widget.shape, const StadiumBorder());
     expect(iconTheme.data, appBarTheme.iconTheme);
     expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
@@ -132,7 +151,8 @@ void main() {
     const SystemUiOverlayStyle systemOverlayStyle = SystemUiOverlayStyle.light;
     const Color color = Colors.orange;
     const double elevation = 3.0;
-    const Color shadowColor = Colors.red;
+    const Color shadowColor = Colors.purple;
+    const Color surfaceTintColor = Colors.brown;
     const ShapeBorder shape = RoundedRectangleBorder();
     const IconThemeData iconThemeData = IconThemeData(color: Colors.green);
     const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.lightBlue);
@@ -151,6 +171,7 @@ void main() {
             systemOverlayStyle: systemOverlayStyle,
             elevation: elevation,
             shadowColor: shadowColor,
+            surfaceTintColor: surfaceTintColor,
             shape: shape,
             iconTheme: iconThemeData,
             actionsIconTheme: actionsIconThemeData,
@@ -174,6 +195,7 @@ void main() {
     expect(widget.color, color);
     expect(widget.elevation, elevation);
     expect(widget.shadowColor, shadowColor);
+    expect(widget.surfaceTintColor, surfaceTintColor);
     expect(widget.shape, shape);
     expect(iconTheme.data, iconThemeData);
     expect(actionsIconTheme.data, actionsIconThemeData);
@@ -228,6 +250,7 @@ void main() {
     expect(widget.color, appBarTheme.backgroundColor);
     expect(widget.elevation, appBarTheme.elevation);
     expect(widget.shadowColor, appBarTheme.shadowColor);
+    expect(widget.surfaceTintColor, appBarTheme.surfaceTintColor);
     expect(iconTheme.data, appBarTheme.iconTheme);
     expect(actionsIconTheme.data, appBarTheme.actionsIconTheme);
     expect(actionIconText.text.style!.color, appBarTheme.actionsIconTheme!.color);
@@ -235,15 +258,13 @@ void main() {
   });
 
   testWidgets('ThemeData colorScheme is used when no AppBarTheme is set', (WidgetTester tester) async {
-    late ThemeData theme;
+    final ThemeData lightTheme = ThemeData.from(colorScheme: const ColorScheme.light());
+    final ThemeData darkTheme = ThemeData.from(colorScheme: const ColorScheme.dark());
     Widget buildFrame(ThemeData appTheme) {
       return MaterialApp(
         theme: appTheme,
         home: Builder(
           builder: (BuildContext context) {
-            // This ThemeData has been localized with ThemeData.localize. The
-            // appTheme parameter has not, so its textTheme is incomplete.
-            theme = Theme.of(context);
             return Scaffold(
               appBar: AppBar(
                 actions: <Widget>[
@@ -256,57 +277,120 @@ void main() {
       );
     }
 
-    // AppBar defaults for light themes:
-    // - elevation: 4
-    // - shadow color: black
-    // - background color: ColorScheme.primary
-    // - foreground color: ColorScheme.onPrimary
-    // - actions text: style bodyText2, foreground color
-    // - status bar brightness: light (based on color scheme brightness)
-    {
-      await tester.pumpWidget(buildFrame(ThemeData.from(colorScheme: const ColorScheme.light())));
+    if (lightTheme.useMaterial3) {
+      // M3 AppBar defaults for light themes:
+      // - elevation: 0
+      // - shadow color: null
+      // - surface tint color: ColorScheme.surfaceTint
+      // - background color: ColorScheme.surface
+      // - foreground color: ColorScheme.onSurface
+      // - actions text: style bodyText2, foreground color
+      // - status bar brightness: light (based on color scheme brightness)
+      {
+        await tester.pumpWidget(buildFrame(lightTheme));
 
-      final Material widget = _getAppBarMaterial(tester);
-      final IconTheme iconTheme = _getAppBarIconTheme(tester);
-      final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
-      final RichText actionIconText = _getAppBarIconRichText(tester);
-      final DefaultTextStyle text = _getAppBarText(tester);
+        final Material widget = _getAppBarMaterial(tester);
+        final IconTheme iconTheme = _getAppBarIconTheme(tester);
+        final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+        final RichText actionIconText = _getAppBarIconRichText(tester);
+        final DefaultTextStyle text = _getAppBarText(tester);
 
-      expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
-      expect(widget.color, theme.colorScheme.primary);
-      expect(widget.elevation, 4.0);
-      expect(widget.shadowColor, Colors.black);
-      expect(iconTheme.data.color, theme.colorScheme.onPrimary);
-      expect(actionsIconTheme.data.color, theme.colorScheme.onPrimary);
-      expect(actionIconText.text.style!.color, theme.colorScheme.onPrimary);
-      expect(text.style.compareTo(theme.textTheme.bodyText2!.copyWith(color: theme.colorScheme.onPrimary)), RenderComparison.identical);
-    }
+        expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.light);
+        expect(widget.color, lightTheme.colorScheme.surface);
+        expect(widget.elevation, 0);
+        expect(widget.shadowColor, null);
+        expect(widget.surfaceTintColor, lightTheme.colorScheme.surfaceTint);
+        expect(iconTheme.data.color, lightTheme.colorScheme.onSurface);
+        expect(actionsIconTheme.data.color, lightTheme.colorScheme.onSurface);
+        expect(actionIconText.text.style!.color, lightTheme.colorScheme.onSurface);
+        expect(text.style, Typography.material2021().englishLike.bodyText2!.merge(Typography.material2021().black.bodyText2).copyWith(color: lightTheme.colorScheme.onSurface));
+      }
 
-    // AppBar defaults for dark themes:
-    // - elevation: 4
-    // - shadow color: black
-    // - background color: ColorScheme.surface
-    // - foreground color: ColorScheme.onSurface
-    // - actions text: style bodyText2, foreground color
-    // - status bar brightness: dark (based on background color)
-    {
-      await tester.pumpWidget(buildFrame(ThemeData.from(colorScheme: const ColorScheme.dark())));
-      await tester.pumpAndSettle(); // Theme change animation
+      // M3 AppBar defaults for dark themes:
+      // - elevation: 0
+      // - shadow color: null
+      // - surface tint color: ColorScheme.surfaceTint
+      // - background color: ColorScheme.surface
+      // - foreground color: ColorScheme.onSurface
+      // - actions text: style bodyText2, foreground color
+      // - status bar brightness: dark (based on background color)
+      {
+        await tester.pumpWidget(buildFrame(ThemeData.from(colorScheme: const ColorScheme.dark())));
+        await tester.pumpAndSettle(); // Theme change animation
 
-      final Material widget = _getAppBarMaterial(tester);
-      final IconTheme iconTheme = _getAppBarIconTheme(tester);
-      final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
-      final RichText actionIconText = _getAppBarIconRichText(tester);
-      final DefaultTextStyle text = _getAppBarText(tester);
+        final Material widget = _getAppBarMaterial(tester);
+        final IconTheme iconTheme = _getAppBarIconTheme(tester);
+        final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+        final RichText actionIconText = _getAppBarIconRichText(tester);
+        final DefaultTextStyle text = _getAppBarText(tester);
 
-      expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
-      expect(widget.color, theme.colorScheme.surface);
-      expect(widget.elevation, 4.0);
-      expect(widget.shadowColor, Colors.black);
-      expect(iconTheme.data.color, theme.colorScheme.onSurface);
-      expect(actionsIconTheme.data.color, theme.colorScheme.onSurface);
-      expect(actionIconText.text.style!.color, theme.colorScheme.onSurface);
-      expect(text.style.compareTo(theme.textTheme.bodyText2!.copyWith(color: theme.colorScheme.onSurface)), RenderComparison.identical);
+        expect(SystemChrome.latestStyle!.statusBarBrightness, Brightness.dark);
+        expect(widget.color, darkTheme.colorScheme.surface);
+        expect(widget.elevation, 0);
+        expect(widget.shadowColor, null);
+        expect(widget.surfaceTintColor, darkTheme.colorScheme.surfaceTint);
+        expect(iconTheme.data.color, darkTheme.colorScheme.onSurface);
+        expect(actionsIconTheme.data.color, darkTheme.colorScheme.onSurface);
+        expect(actionIconText.text.style!.color, darkTheme.colorScheme.onSurface);
+        expect(text.style, Typography.material2021().englishLike.bodyText2!.merge(Typography.material2021().black.bodyText2).copyWith(color: darkTheme.colorScheme.onSurface));
+      }
+    } else {
+      // AppBar defaults for light themes:
+      // - elevation: 4
+      // - shadow color: black
+      // - surface tint color: null
+      // - background color: ColorScheme.primary
+      // - foreground color: ColorScheme.onPrimary
+      // - actions text: style bodyText2, foreground color
+      // - status bar brightness: light (based on color scheme brightness)
+      {
+        await tester.pumpWidget(buildFrame(lightTheme));
+
+        final Material widget = _getAppBarMaterial(tester);
+        final IconTheme iconTheme = _getAppBarIconTheme(tester);
+        final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+        final RichText actionIconText = _getAppBarIconRichText(tester);
+        final DefaultTextStyle text = _getAppBarText(tester);
+
+        expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
+        expect(widget.color, lightTheme.colorScheme.primary);
+        expect(widget.elevation, 4.0);
+        expect(widget.shadowColor, Colors.black);
+        expect(widget.surfaceTintColor, null);
+        expect(iconTheme.data.color, lightTheme.colorScheme.onPrimary);
+        expect(actionsIconTheme.data.color, lightTheme.colorScheme.onPrimary);
+        expect(actionIconText.text.style!.color, lightTheme.colorScheme.onPrimary);
+        expect(text.style, Typography.material2014().englishLike.bodyText2!.merge(Typography.material2014().black.bodyText2).copyWith(color: lightTheme.colorScheme.onPrimary));
+      }
+
+      // AppBar defaults for dark themes:
+      // - elevation: 4
+      // - shadow color: black
+      // - surface tint color: null
+      // - background color: ColorScheme.surface
+      // - foreground color: ColorScheme.onSurface
+      // - actions text: style bodyText2, foreground color
+      // - status bar brightness: dark (based on background color)
+      {
+        await tester.pumpWidget(buildFrame(darkTheme));
+        await tester.pumpAndSettle(); // Theme change animation
+
+        final Material widget = _getAppBarMaterial(tester);
+        final IconTheme iconTheme = _getAppBarIconTheme(tester);
+        final IconTheme actionsIconTheme = _getAppBarActionsIconTheme(tester);
+        final RichText actionIconText = _getAppBarIconRichText(tester);
+        final DefaultTextStyle text = _getAppBarText(tester);
+
+        expect(SystemChrome.latestStyle!.statusBarBrightness, SystemUiOverlayStyle.light.statusBarBrightness);
+        expect(widget.color, darkTheme.colorScheme.surface);
+        expect(widget.elevation, 4.0);
+        expect(widget.shadowColor, Colors.black);
+        expect(widget.surfaceTintColor, null);
+        expect(iconTheme.data.color, darkTheme.colorScheme.onSurface);
+        expect(actionsIconTheme.data.color, darkTheme.colorScheme.onSurface);
+        expect(actionIconText.text.style!.color, darkTheme.colorScheme.onSurface);
+        expect(text.style, Typography.material2014().englishLike.bodyText2!.merge(Typography.material2014().black.bodyText2).copyWith(color: darkTheme.colorScheme.onSurface));
+      }
     }
   });
 
@@ -315,7 +399,7 @@ void main() {
 
     Widget buildFrame({ Color? appIconColor, Color? appBarIconColor }) {
       return MaterialApp(
-        theme: ThemeData.from(colorScheme: const ColorScheme.light()),
+        theme: ThemeData.from(useMaterial3: false, colorScheme: const ColorScheme.light()),
         home: IconTheme(
           data: IconThemeData(color: appIconColor),
           child: Builder(
@@ -408,6 +492,22 @@ void main() {
     expect(appBar.shadowColor, Colors.yellow);
   });
 
+  testWidgets('AppBar.surfaceTintColor takes priority over AppBarTheme.surfaceTintColor', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(appBarTheme: const AppBarTheme(surfaceTintColor: Colors.red)),
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Title'),
+          surfaceTintColor: Colors.yellow,
+        ),
+      ),
+    ));
+
+    final AppBar appBar = tester.widget(find.byType(AppBar));
+    // The AppBar.surfaceTintColor should be used instead of AppBarTheme.surfaceTintColor.
+    expect(appBar.surfaceTintColor, Colors.yellow);
+  });
+
   testWidgets('AppBar uses AppBarTheme.titleSpacing', (WidgetTester tester) async {
     const double kTitleSpacing = 10;
     await tester.pumpWidget(MaterialApp(
@@ -493,6 +593,7 @@ void main() {
       backgroundColor: Color(0xff000001),
       elevation: 8.0,
       shadowColor: Color(0xff000002),
+      surfaceTintColor: Color(0xff000003),
       centerTitle: true,
       titleSpacing: 40.0,
     ).debugFillProperties(builder);
@@ -507,6 +608,7 @@ void main() {
       'backgroundColor: Color(0xff000001)',
       'elevation: 8.0',
       'shadowColor: Color(0xff000002)',
+      'surfaceTintColor: Color(0xff000003)',
       'centerTitle: true',
       'titleSpacing: 40.0',
     ]);
@@ -524,6 +626,7 @@ AppBarTheme _appBarTheme() {
   const Color backgroundColor = Colors.lightBlue;
   const double elevation = 6.0;
   const Color shadowColor = Colors.red;
+  const Color surfaceTintColor = Colors.green;
   const IconThemeData iconThemeData = IconThemeData(color: Colors.black);
   const IconThemeData actionsIconThemeData = IconThemeData(color: Colors.pink);
   return const AppBarTheme(
@@ -532,6 +635,7 @@ AppBarTheme _appBarTheme() {
     backgroundColor: backgroundColor,
     elevation: elevation,
     shadowColor: shadowColor,
+    surfaceTintColor: surfaceTintColor,
     shape: StadiumBorder(),
     iconTheme: iconThemeData,
     toolbarHeight: 96,


### PR DESCRIPTION
Part of: https://github.com/flutter/flutter/issues/91605

Updated the common buttons: `ElevatedButton`, `OutlinedButton`, and `TextButton` with support for [Material Design 3](https://m3.material.io/components/top-app-bar/overview).

<img width="350" alt="AppBarM3_1649919991939_0" src="https://user-images.githubusercontent.com/19588/163495860-b13fe7b1-ae06-4424-ae43-9de811688dc6.png"><img width="350" alt="AppBarM3Dark_1649920013722_0" src="https://user-images.githubusercontent.com/19588/163495861-2c8d1f7d-1ffa-4e51-bdd8-83b5630cdba9.png">

In order to use the common buttons with the new Material 3 defaults, turn on the `useMaterial3` flag in the `ThemeData`:

```dart
  return MaterialApp(
    theme: ThemeData(useMaterial3: true),
    // ...
  );
```

In addition to the new look, the `AppBar` and `AppBarTheme` now support `surfaceTintColor` and `scrolledUnderElevation` properties to support the new elevation visuals needed for Material 3.

By default in Material 3, the app bar will no longer have a drop shadow, but instead will show changes in elevation by applying a surface tint overlay with and opacity based on the elevation on top of the background color. In addition the default elevation is 0 when there is nothing under the app bar. This changes to 3 when something is scrolled beneath the app bar.  Example of this behaviour:

![AppBarScrollUnder](https://user-images.githubusercontent.com/19588/163331702-482033f1-af80-478e-9ab1-4a537a8597f4.gif)

Fixes: #92093

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
