### PR TITLE
MigrateUtils and MigrateManifest classes

### DIFF
--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -2,12 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:process/process.dart';
+// import 'package:process/process.dart';
 
-import '../base/file_system.dart';
+// import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../base/platform.dart';
-import '../base/process.dart';
+// import '../base/platform.dart';
 import '../base/terminal.dart';
 import '../migrate/migrate_utils.dart';
 import '../runner/flutter_command.dart';
@@ -21,21 +20,21 @@ import '../runner/flutter_command.dart';
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
   MigrateCommand({
-    bool verbose = false,
+    // bool verbose = false,
     required this.logger,
-    required FileSystem fileSystem,
-    required Terminal terminal,
-    required Platform platform,
-    required ProcessManager processManager,
-  }) : _verbose = verbose {
+    // TODO(garyq): Add each of these back in as they land.
+    // required FileSystem fileSystem,
+    // required Terminal terminal,
+    // required Platform platform,
+    // required ProcessManager processManager,
+  }) {
+    // TODO(garyq): Add each of these back in as they land.
     // addSubcommand(MigrateAbandonCommand(logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
-    // addSubcommand(MigrateApplyCommand(verbose: _verbose, logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
+    // addSubcommand(MigrateApplyCommand(verbose: verbose, logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
     // addSubcommand(MigrateResolveConflictsCommand(logger: logger, fileSystem: fileSystem, terminal: terminal));
-    // addSubcommand(MigrateStartCommand(verbose: _verbose, logger: logger, fileSystem: fileSystem, platform: platform, processManager: processManager));
-    // addSubcommand(MigrateStatusCommand(verbose: _verbose, logger: logger, fileSystem: fileSystem, platform: platform, processManager: processManager));
+    // addSubcommand(MigrateStartCommand(verbose: verbose, logger: logger, fileSystem: fileSystem, platform: platform, processManager: processManager));
+    // addSubcommand(MigrateStatusCommand(verbose: verbose, logger: logger, fileSystem: fileSystem, platform: platform, processManager: processManager));
   }
-
-  final bool _verbose;
 
   final Logger logger;
 

--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -1,0 +1,85 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:process/process.dart';
+
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/platform.dart';
+import '../base/process.dart';
+import '../base/terminal.dart';
+import '../migrate/migrate_utils.dart';
+import '../runner/flutter_command.dart';
+// TODO(garyq): Add each of these back in as they land.
+// import 'migrate_abandon.dart';
+// import 'migrate_apply.dart';
+// import 'migrate_resolve_conflicts.dart';
+// import 'migrate_start.dart';
+// import 'migrate_status.dart';
+
+/// Base command for the migration tool.
+class MigrateCommand extends FlutterCommand {
+  MigrateCommand({
+    bool verbose = false,
+    required this.logger,
+    required FileSystem fileSystem,
+    required Terminal terminal,
+    required Platform platform,
+    required ProcessManager processManager,
+  }) : _verbose = verbose {
+    // addSubcommand(MigrateAbandonCommand(logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
+    // addSubcommand(MigrateApplyCommand(verbose: _verbose, logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
+    // addSubcommand(MigrateResolveConflictsCommand(logger: logger, fileSystem: fileSystem, terminal: terminal));
+    // addSubcommand(MigrateStartCommand(verbose: _verbose, logger: logger, fileSystem: fileSystem, platform: platform, processManager: processManager));
+    // addSubcommand(MigrateStatusCommand(verbose: _verbose, logger: logger, fileSystem: fileSystem, platform: platform, processManager: processManager));
+  }
+
+  final bool _verbose;
+
+  final Logger logger;
+
+  @override
+  final String name = 'migrate';
+
+  @override
+  final String description = 'Migrates flutter generated project files to the current flutter version';
+
+  @override
+  String get category => FlutterCommandCategory.project;
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    return const FlutterCommandResult(ExitStatus.fail);
+  }
+}
+
+Future<bool> gitRepoExists(String projectDirectory, Logger logger, MigrateUtils migrateUtils) async {
+  if (await migrateUtils.isGitRepo(projectDirectory)) {
+    return true;
+  }
+  logger.printStatus('Project is not a git repo. Please initialize a git repo and try again.');
+  printCommandText('git init', logger);
+  return false;
+}
+
+Future<bool> hasUncommittedChanges(String projectDirectory, Logger logger, MigrateUtils migrateUtils) async {
+  if (await migrateUtils.hasUncommittedChanges(projectDirectory)) {
+    logger.printStatus('There are uncommitted changes in your project. Please git commit, abandon, or stash your changes before trying again.');
+    return true;
+  }
+  return false;
+}
+
+/// Prints a command to logger with appropriate formatting.
+void printCommandText(String command, Logger logger) {
+  logger.printStatus(
+    '\n\$ $command\n',
+    color: TerminalColor.grey,
+    indent: 4,
+    newline: false,
+  );
+}

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -11,7 +11,12 @@ import '../base/terminal.dart';
 import 'migrate_result.dart';
 import 'migrate_utils.dart';
 
-/// Represents the mamifest file that tracks the contents of the current
+const String _kMergedFilesKey = 'merged_files';
+const String _kConflictFilesKey = 'conflict_files';
+const String _kAddedFilesKey = 'added_files';
+const String _kDeletedFilesKey = 'deleted_files';
+
+/// Represents the manifest file that tracks the contents of the current
 /// migration working directory.
 ///
 /// This manifest file is created with the MigrateResult of a computeMigration run.
@@ -29,14 +34,14 @@ class MigrateManifest {
       throwToolExit('Invalid .migrate_manifest file in the migrate working directory. File is not a Yaml map.', exitCode: 1);
     }
     final YamlMap map = yamlContents;
-    bool valid = map.containsKey('merged_files') && map.containsKey('conflict_files') && map.containsKey('added_files') && map.containsKey('deleted_files');
+    bool valid = map.containsKey(_kMergedFilesKey) && map.containsKey(_kConflictFilesKey) && map.containsKey(_kAddedFilesKey) && map.containsKey(_kDeletedFilesKey);
     if (!valid) {
       throwToolExit('Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.', exitCode: 1);
     }
-    final Object? mergedFilesYaml = map['merged_files'];
-    final Object? conflictFilesYaml = map['conflict_files'];
-    final Object? addedFilesYaml = map['added_files'];
-    final Object? deletedFilesYaml = map['deleted_files'];
+    final Object? mergedFilesYaml = map[_kMergedFilesKey];
+    final Object? conflictFilesYaml = map[_kConflictFilesKey];
+    final Object? addedFilesYaml = map[_kAddedFilesKey];
+    final Object? deletedFilesYaml = map[_kDeletedFilesKey];
     valid = valid && (mergedFilesYaml is YamlList || mergedFilesYaml == null);
     valid = valid && (conflictFilesYaml is YamlList || conflictFilesYaml == null);
     valid = valid && (addedFilesYaml is YamlList || addedFilesYaml == null);
@@ -174,7 +179,7 @@ class MigrateManifest {
   }
 }
 
-/// Returns true if the file does not contain any git conflit markers.
+/// Returns true if the file does not contain any git conflict markers.
 bool _conflictsResolved(String contents) {
   if (contents.contains('>>>>>>>') && contents.contains('=======') && contents.contains('<<<<<<<')) {
     return false;

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -4,7 +4,6 @@
 
 import 'package:yaml/yaml.dart';
 
-import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/terminal.dart';

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -203,7 +203,7 @@ bool checkAndPrintMigrateStatus(MigrateManifest manifest, Directory workingDir, 
       mergedFiles.add(localPath);
     }
   }
-  
+
   mergedFiles.addAll(manifest.mergedFiles);
   if (manifest.addedFiles.isNotEmpty) {
     printout.write('Added files:\n');

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -31,12 +31,12 @@ class MigrateManifest {
   MigrateManifest.fromFile(File manifestFile) : migrateResult = MigrateResult.empty(), migrateRootDir = manifestFile.parent {
     final Object? yamlContents = loadYaml(manifestFile.readAsStringSync());
     if (yamlContents is! YamlMap) {
-      throwToolExit('Invalid .migrate_manifest file in the migrate working directory. File is not a Yaml map.', exitCode: 1);
+      throw Exception('Invalid .migrate_manifest file in the migrate working directory. File is not a Yaml map.');
     }
     final YamlMap map = yamlContents;
     bool valid = map.containsKey(_kMergedFilesKey) && map.containsKey(_kConflictFilesKey) && map.containsKey(_kAddedFilesKey) && map.containsKey(_kDeletedFilesKey);
     if (!valid) {
-      throwToolExit('Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.', exitCode: 1);
+      throw Exception('Invalid .migrate_manifest file in the migrate working directory. File is missing an entry.');
     }
     final Object? mergedFilesYaml = map[_kMergedFilesKey];
     final Object? conflictFilesYaml = map[_kConflictFilesKey];
@@ -47,7 +47,7 @@ class MigrateManifest {
     valid = valid && (addedFilesYaml is YamlList || addedFilesYaml == null);
     valid = valid && (deletedFilesYaml is YamlList || deletedFilesYaml == null);
     if (!valid) {
-      throwToolExit('Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list. Fix the manifest or abandon the migration and try again.', exitCode: 1);
+      throw Exception('Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list.');
     }
     if (mergedFilesYaml != null) {
       for (final Object? localPath in mergedFilesYaml as YamlList) {

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -1,0 +1,237 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:yaml/yaml.dart';
+
+import '../base/common.dart';
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/terminal.dart';
+import 'migrate_result.dart';
+import 'migrate_utils.dart';
+
+/// Represents the mamifest file that tracks the contents of the current
+/// migration working directory.
+///
+/// This manifest file is created with the MigrateResult of a computeMigration run.
+class MigrateManifest {
+  /// Creates a new manifest from a MigrateResult.
+  MigrateManifest({
+    required this.migrateRootDir,
+    required this.migrateResult,
+  });
+
+  /// Parses an existing migrate manifest.
+  MigrateManifest.fromFile(File manifestFile) : migrateResult = MigrateResult.empty(), migrateRootDir = manifestFile.parent {
+    final Object? yamlContents = loadYaml(manifestFile.readAsStringSync());
+    if (yamlContents is! YamlMap) {
+      throwToolExit('Invalid .migrate_manifest file in the migrate working directory. File is not a Yaml map.', exitCode: 1);
+    }
+    final YamlMap map = yamlContents;
+    bool valid = map.containsKey('merged_files') && map.containsKey('conflict_files') && map.containsKey('added_files') && map.containsKey('deleted_files');
+    if (!valid) {
+      throwToolExit('Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.', exitCode: 1);
+    }
+    final Object? mergedFilesYaml = map['merged_files'];
+    final Object? conflictFilesYaml = map['conflict_files'];
+    final Object? addedFilesYaml = map['added_files'];
+    final Object? deletedFilesYaml = map['deleted_files'];
+    valid = valid && (mergedFilesYaml is YamlList || mergedFilesYaml == null);
+    valid = valid && (conflictFilesYaml is YamlList || conflictFilesYaml == null);
+    valid = valid && (addedFilesYaml is YamlList || addedFilesYaml == null);
+    valid = valid && (deletedFilesYaml is YamlList || deletedFilesYaml == null);
+    if (!valid) {
+      throwToolExit('Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list. Fix the manifest or abandon the migration and try again.', exitCode: 1);
+    }
+    // We can fill the maps with partially dummy data as not all properties are used by the manifest.
+    if (mergedFilesYaml != null) {
+      for (final Object? localPath in mergedFilesYaml as YamlList) {
+        if (localPath is String) {
+          migrateResult.mergeResults.add(StringMergeResult.explicit(mergedString: '', hasConflict: false, exitCode: 0, localPath: localPath));
+        }
+      }
+    }
+    if (conflictFilesYaml != null) {
+      for (final Object? localPath in conflictFilesYaml as YamlList) {
+        if (localPath is String) {
+          migrateResult.mergeResults.add(StringMergeResult.explicit(mergedString: '', hasConflict: true, exitCode: 1, localPath: localPath));
+        }
+      }
+    }
+    if (addedFilesYaml != null) {
+      for (final Object? localPath in addedFilesYaml as YamlList) {
+        if (localPath is String) {
+          migrateResult.addedFiles.add(FilePendingMigration(localPath, migrateRootDir.childFile(localPath)));
+        }
+      }
+    }
+    if (deletedFilesYaml != null) {
+      for (final Object? localPath in deletedFilesYaml as YamlList) {
+        if (localPath is String) {
+          migrateResult.deletedFiles.add(FilePendingMigration(localPath, migrateRootDir.childFile(localPath)));
+        }
+      }
+    }
+  }
+
+  final Directory migrateRootDir;
+  final MigrateResult migrateResult;
+
+  /// A list of local paths of files that require conflict resolution.
+  List<String> get conflictFiles {
+    final List<String> output = <String>[];
+    for (final MergeResult result in migrateResult.mergeResults) {
+      if (result.hasConflict) {
+        output.add(result.localPath);
+      }
+    }
+    return output;
+  }
+
+  /// A list of local paths of files that require conflict resolution.
+  List<String> remainingConflictFiles(Directory workingDir) {
+    final List<String> output = <String>[];
+    for (final String localPath in conflictFiles) {
+      if (!_conflictsResolved(workingDir.childFile(localPath).readAsStringSync())) {
+        output.add(localPath);
+      }
+    }
+    return output;
+  }
+
+  // A list of local paths of files that had conflicts and are now fully resolved.
+  List<String> resolvedConflictFiles(Directory workingDir) {
+    final List<String> output = <String>[];
+    for (final String localPath in conflictFiles) {
+      if (_conflictsResolved(workingDir.childFile(localPath).readAsStringSync())) {
+        output.add(localPath);
+      }
+    }
+    return output;
+  }
+
+  /// A list of local paths of files that were automatically merged.
+  List<String> get mergedFiles {
+    final List<String> output = <String>[];
+    for (final MergeResult result in migrateResult.mergeResults) {
+      if (!result.hasConflict) {
+        output.add(result.localPath);
+      }
+    }
+    return output;
+  }
+
+  /// A list of local paths of files that were newly added.
+  List<String> get addedFiles {
+    final List<String> output = <String>[];
+    for (final FilePendingMigration file in migrateResult.addedFiles) {
+      output.add(file.localPath);
+    }
+    return output;
+  }
+
+  /// A list of local paths of files that are marked for deletion.
+  List<String> get deletedFiles {
+    final List<String> output = <String>[];
+    for (final FilePendingMigration file in migrateResult.deletedFiles) {
+      output.add(file.localPath);
+    }
+    return output;
+  }
+
+  /// Returns the manifest file given a migration workind directory.
+  static File getManifestFileFromDirectory(Directory workingDir) {
+    return workingDir.childFile('.migrate_manifest');
+  }
+
+  /// Writes the manifest yaml file in the working directory.
+  void writeFile() {
+    String mergedFileManifestContents = '';
+    String conflictFilesManifestContents = '';
+    for (final MergeResult result in migrateResult.mergeResults) {
+      if (result.hasConflict) {
+        conflictFilesManifestContents += '  - ${result.localPath}\n';
+      } else {
+        mergedFileManifestContents += '  - ${result.localPath}\n';
+      }
+    }
+
+    String newFileManifestContents = '';
+    for (final String localPath in addedFiles) {
+      newFileManifestContents += '  - $localPath\n';
+    }
+
+    String deletedFileManifestContents = '';
+    for (final String localPath in deletedFiles) {
+      deletedFileManifestContents += '  - $localPath\n';
+    }
+
+    final String migrateManifestContents = 'merged_files:\n${mergedFileManifestContents}conflict_files:\n${conflictFilesManifestContents}added_files:\n${newFileManifestContents}deleted_files:\n$deletedFileManifestContents';
+    final File migrateManifest = getManifestFileFromDirectory(migrateRootDir);
+    migrateManifest.createSync(recursive: true);
+    migrateManifest.writeAsStringSync(migrateManifestContents, flush: true);
+  }
+}
+
+/// Returns true if the file does not contain any git conflit markers.
+bool _conflictsResolved(String contents) {
+  if (contents.contains('>>>>>>>') && contents.contains('=======') && contents.contains('<<<<<<<')) {
+    return false;
+  }
+  return true;
+}
+
+/// Returns true if the migration working directory has all conflicts resolved and prints the migration status.
+///
+/// The migration status printout lists all added, deleted, merged, and conflicted files.
+bool checkAndPrintMigrateStatus(MigrateManifest manifest, Directory workingDir, {bool warnConflict = false, Logger? logger}) {
+  String printout = '';
+  String redPrintout = '';
+  bool result = true;
+  final List<String> remainingConflicts = <String>[];
+  final List<String> mergedFiles = <String>[];
+  for (final String localPath in manifest.conflictFiles) {
+    if (!_conflictsResolved(workingDir.childFile(localPath).readAsStringSync())) {
+      remainingConflicts.add(localPath);
+    } else {
+      mergedFiles.add(localPath);
+    }
+  }
+  
+  mergedFiles.addAll(manifest.mergedFiles);
+  if (manifest.addedFiles.isNotEmpty) {
+    printout += 'Added files:\n';
+    for (final String localPath in manifest.addedFiles) {
+      printout += '  - $localPath\n';
+    }
+  }
+  if (manifest.deletedFiles.isNotEmpty) {
+    printout += 'Deleted files:\n';
+    for (final String localPath in manifest.deletedFiles) {
+      printout += '  - $localPath\n';
+    }
+  }
+  if (mergedFiles.isNotEmpty) {
+    printout += 'Modified files:\n';
+    for (final String localPath in mergedFiles) {
+      printout += '  - $localPath\n';
+    }
+  }
+  if (remainingConflicts.isNotEmpty) {
+    if (warnConflict) {
+      printout += 'Unable to apply migration. The following files in the migration working directory still have unresolved conflicts:';
+    } else {
+      printout += 'Merge conflicted files:';
+    }
+    for (final String localPath in remainingConflicts) {
+      redPrintout += '  - $localPath\n';
+    }
+    result = false;
+  }
+  if (logger != null) {
+    logger.printStatus(printout);
+    logger.printStatus(redPrintout, color: TerminalColor.red, newline: false);
+  }
+  return result;
+}

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -44,10 +44,10 @@ class MigrateManifest {
     if (!valid) {
       throwToolExit('Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list. Fix the manifest or abandon the migration and try again.', exitCode: 1);
     }
-    // We can fill the maps with partially dummy data as not all properties are used by the manifest.
     if (mergedFilesYaml != null) {
       for (final Object? localPath in mergedFilesYaml as YamlList) {
         if (localPath is String) {
+          // We can fill the maps with partially dummy data as not all properties are used by the manifest.
           migrateResult.mergeResults.add(StringMergeResult.explicit(mergedString: '', hasConflict: false, exitCode: 0, localPath: localPath));
         }
       }

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -147,8 +147,8 @@ class MigrateManifest {
 
   /// Writes the manifest yaml file in the working directory.
   void writeFile() {
-    final StringBuffer mergedFileManifestContents = '';
-    final StringBuffer conflictFilesManifestContents = '';
+    final StringBuffer mergedFileManifestContents = StringBuffer();
+    final StringBuffer conflictFilesManifestContents = StringBuffer();
     for (final MergeResult result in migrateResult.mergeResults) {
       if (result.hasConflict) {
         conflictFilesManifestContents.write('  - ${result.localPath}\n');
@@ -157,12 +157,12 @@ class MigrateManifest {
       }
     }
 
-    final StringBuffer newFileManifestContents = '';
+    final StringBuffer newFileManifestContents = StringBuffer();
     for (final String localPath in addedFiles) {
-      newFileManifestContents.write('  - $localPath\n)';
+      newFileManifestContents.write('  - $localPath\n)');
     }
 
-    final StringBuffer deletedFileManifestContents = '';
+    final StringBuffer deletedFileManifestContents = StringBuffer();
     for (final String localPath in deletedFiles) {
       deletedFileManifestContents.write('  - $localPath\n');
     }
@@ -186,8 +186,8 @@ bool _conflictsResolved(String contents) {
 ///
 /// The migration status printout lists all added, deleted, merged, and conflicted files.
 bool checkAndPrintMigrateStatus(MigrateManifest manifest, Directory workingDir, {bool warnConflict = false, Logger? logger}) {
-  final StringBuffer printout = '';
-  final StringBuffer redPrintout = '';
+  final StringBuffer printout = StringBuffer();
+  final StringBuffer redPrintout = StringBuffer();
   bool result = true;
   final List<String> remainingConflicts = <String>[];
   final List<String> mergedFiles = <String>[];
@@ -201,31 +201,31 @@ bool checkAndPrintMigrateStatus(MigrateManifest manifest, Directory workingDir, 
   
   mergedFiles.addAll(manifest.mergedFiles);
   if (manifest.addedFiles.isNotEmpty) {
-    printout.write('Added files:\n';
+    printout.write('Added files:\n');
     for (final String localPath in manifest.addedFiles) {
-      printout.write('  - $localPath\n';
+      printout.write('  - $localPath\n');
     }
   }
   if (manifest.deletedFiles.isNotEmpty) {
-    printout += 'Deleted files:\n';
+    printout.write('Deleted files:\n');
     for (final String localPath in manifest.deletedFiles) {
-      printout.write('  - $localPath\n';
+      printout.write('  - $localPath\n');
     }
   }
   if (mergedFiles.isNotEmpty) {
-    printout.write('Modified files:\n';
+    printout.write('Modified files:\n');
     for (final String localPath in mergedFiles) {
-      printout.write('  - $localPath\n';
+      printout.write('  - $localPath\n');
     }
   }
   if (remainingConflicts.isNotEmpty) {
     if (warnConflict) {
-      printout.write('Unable to apply migration. The following files in the migration working directory still have unresolved conflicts:';
+      printout.write('Unable to apply migration. The following files in the migration working directory still have unresolved conflicts:');
     } else {
-      printout.write('Merge conflicted files:';
+      printout.write('Merge conflicted files:');
     }
     for (final String localPath in remainingConflicts) {
-      redPrintout.write('  - $localPath\n';
+      redPrintout.write('  - $localPath\n');
     }
     result = false;
   }

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -147,27 +147,27 @@ class MigrateManifest {
 
   /// Writes the manifest yaml file in the working directory.
   void writeFile() {
-    String mergedFileManifestContents = '';
-    String conflictFilesManifestContents = '';
+    final StringBuffer mergedFileManifestContents = '';
+    final StringBuffer conflictFilesManifestContents = '';
     for (final MergeResult result in migrateResult.mergeResults) {
       if (result.hasConflict) {
-        conflictFilesManifestContents += '  - ${result.localPath}\n';
+        conflictFilesManifestContents.write('  - ${result.localPath}\n');
       } else {
-        mergedFileManifestContents += '  - ${result.localPath}\n';
+        mergedFileManifestContents.write('  - ${result.localPath}\n');
       }
     }
 
-    String newFileManifestContents = '';
+    final StringBuffer newFileManifestContents = '';
     for (final String localPath in addedFiles) {
-      newFileManifestContents += '  - $localPath\n';
+      newFileManifestContents.write('  - $localPath\n)';
     }
 
-    String deletedFileManifestContents = '';
+    final StringBuffer deletedFileManifestContents = '';
     for (final String localPath in deletedFiles) {
-      deletedFileManifestContents += '  - $localPath\n';
+      deletedFileManifestContents.write('  - $localPath\n');
     }
 
-    final String migrateManifestContents = 'merged_files:\n${mergedFileManifestContents}conflict_files:\n${conflictFilesManifestContents}added_files:\n${newFileManifestContents}deleted_files:\n$deletedFileManifestContents';
+    final String migrateManifestContents = 'merged_files:\n${mergedFileManifestContents.toString()}conflict_files:\n${conflictFilesManifestContents.toString()}added_files:\n${newFileManifestContents.toString()}deleted_files:\n${deletedFileManifestContents.toString()}';
     final File migrateManifest = getManifestFileFromDirectory(migrateRootDir);
     migrateManifest.createSync(recursive: true);
     migrateManifest.writeAsStringSync(migrateManifestContents, flush: true);
@@ -186,8 +186,8 @@ bool _conflictsResolved(String contents) {
 ///
 /// The migration status printout lists all added, deleted, merged, and conflicted files.
 bool checkAndPrintMigrateStatus(MigrateManifest manifest, Directory workingDir, {bool warnConflict = false, Logger? logger}) {
-  String printout = '';
-  String redPrintout = '';
+  final StringBuffer printout = '';
+  final StringBuffer redPrintout = '';
   bool result = true;
   final List<String> remainingConflicts = <String>[];
   final List<String> mergedFiles = <String>[];
@@ -201,37 +201,37 @@ bool checkAndPrintMigrateStatus(MigrateManifest manifest, Directory workingDir, 
   
   mergedFiles.addAll(manifest.mergedFiles);
   if (manifest.addedFiles.isNotEmpty) {
-    printout += 'Added files:\n';
+    printout.write('Added files:\n';
     for (final String localPath in manifest.addedFiles) {
-      printout += '  - $localPath\n';
+      printout.write('  - $localPath\n';
     }
   }
   if (manifest.deletedFiles.isNotEmpty) {
     printout += 'Deleted files:\n';
     for (final String localPath in manifest.deletedFiles) {
-      printout += '  - $localPath\n';
+      printout.write('  - $localPath\n';
     }
   }
   if (mergedFiles.isNotEmpty) {
-    printout += 'Modified files:\n';
+    printout.write('Modified files:\n';
     for (final String localPath in mergedFiles) {
-      printout += '  - $localPath\n';
+      printout.write('  - $localPath\n';
     }
   }
   if (remainingConflicts.isNotEmpty) {
     if (warnConflict) {
-      printout += 'Unable to apply migration. The following files in the migration working directory still have unresolved conflicts:';
+      printout.write('Unable to apply migration. The following files in the migration working directory still have unresolved conflicts:';
     } else {
-      printout += 'Merge conflicted files:';
+      printout.write('Merge conflicted files:';
     }
     for (final String localPath in remainingConflicts) {
-      redPrintout += '  - $localPath\n';
+      redPrintout.write('  - $localPath\n';
     }
     result = false;
   }
   if (logger != null) {
-    logger.printStatus(printout);
-    logger.printStatus(redPrintout, color: TerminalColor.red, newline: false);
+    logger.printStatus(printout.toString());
+    logger.printStatus(redPrintout.toString(), color: TerminalColor.red, newline: false);
   }
   return result;
 }

--- a/packages/flutter_tools/lib/src/migrate/migrate_result.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_result.dart
@@ -3,12 +3,6 @@
 // found in the LICENSE file.
 
 import '../base/file_system.dart';
-import '../base/logger.dart';
-import '../base/terminal.dart';
-import '../cache.dart';
-import '../commands/migrate.dart';
-import '../flutter_project_metadata.dart';
-import '../project.dart';
 import 'migrate_utils.dart';
 
 /// Data class that holds all results and generated directories from a computeMigration run.

--- a/packages/flutter_tools/lib/src/migrate/migrate_result.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_result.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/terminal.dart';
+import '../cache.dart';
+import '../commands/migrate.dart';
+import '../flutter_project_metadata.dart';
+import '../project.dart';
+import 'migrate_utils.dart';
+
+/// Data class that holds all results and generated directories from a computeMigration run.
+///
+/// mergeResults, addedFiles, and deletedFiles includes the sets of files to be migrated while
+/// the other members track the temporary sdk and generated app directories created by the tool.
+///
+/// The compute function does not clean up the temp directories, as the directories may be reused,
+/// so this must be done manually afterwards.
+class MigrateResult {
+  MigrateResult({
+    required this.mergeResults,
+    required this.addedFiles,
+    required this.deletedFiles,
+    required this.tempDirectories,
+    required this.sdkDirs,
+    required this.mergeTypeMap,
+    required this.diffMap,
+    this.generatedBaseTemplateDirectory,
+    this.generatedTargetTemplateDirectory});
+
+  /// Creates a MigrateResult with all empty members.
+  MigrateResult.empty()
+    : mergeResults = <MergeResult>[],
+      addedFiles = <FilePendingMigration>[],
+      deletedFiles = <FilePendingMigration>[],
+      tempDirectories = <Directory>[],
+      mergeTypeMap = <String, MergeType>{},
+      diffMap = <String, DiffResult>{},
+      sdkDirs = <String, Directory>{};
+
+  final List<MergeResult> mergeResults;
+  final List<FilePendingMigration> addedFiles;
+  final List<FilePendingMigration> deletedFiles;
+  final List<Directory> tempDirectories;
+  final Map<String, MergeType> mergeTypeMap;
+  final Map<String, DiffResult> diffMap;
+  Directory? generatedBaseTemplateDirectory;
+  Directory? generatedTargetTemplateDirectory;
+  Map<String, Directory> sdkDirs;
+}
+
+/// Defines available merge techniques.
+enum MergeType {
+  threeWay,
+  twoWay,
+  custom,
+}
+
+/// Stores a file that has been marked for migration and metadata about the file.
+class FilePendingMigration {
+  FilePendingMigration(this.localPath, this.file);
+  String localPath;
+  File file;
+}

--- a/packages/flutter_tools/lib/src/migrate/migrate_result.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_result.dart
@@ -13,6 +13,7 @@ import 'migrate_utils.dart';
 /// The compute function does not clean up the temp directories, as the directories may be reused,
 /// so this must be done manually afterwards.
 class MigrateResult {
+  /// Explicitly initialize the MigrateResult.
   MigrateResult({
     required this.mergeResults,
     required this.addedFiles,
@@ -34,21 +35,42 @@ class MigrateResult {
       diffMap = <String, DiffResult>{},
       sdkDirs = <String, Directory>{};
 
+  /// The results of merging existing files with the target files.
   final List<MergeResult> mergeResults;
+
+  /// Tracks the files that are to be newly added to the project.
   final List<FilePendingMigration> addedFiles;
+
+  /// Tracks the files that are to be deleted from the project.
   final List<FilePendingMigration> deletedFiles;
+
+  /// Tracks the temporary directories created during the migrate compute process.
   final List<Directory> tempDirectories;
+
+  /// Mapping between the local path of a file and the type of merge that should be used.
   final Map<String, MergeType> mergeTypeMap;
+
+  /// Mapping between the local path of a file and the diff between the base and target
+  /// versions of the file.
   final Map<String, DiffResult> diffMap;
+
+  /// The root directory of the base app.
   Directory? generatedBaseTemplateDirectory;
+
+  /// The root directory of the target app.
   Directory? generatedTargetTemplateDirectory;
+
+  /// The root directories of the Flutter SDK for each revision.
   Map<String, Directory> sdkDirs;
 }
 
 /// Defines available merge techniques.
 enum MergeType {
+  /// A standard three-way merge.
   threeWay,
+  /// A two way merge that ignores the base version of the file.
   twoWay,
+  /// A `CustomMerge` manually handles the merge.
   custom,
 }
 

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -194,8 +194,6 @@ class MigrateUtils {
     }
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
     checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: cmdArgs.join(' '));
-    print(result.stdout);
-    print(result.stderr);
     if (result.exitCode == 0) {
       return false;
     }

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -53,14 +53,14 @@ class MigrateUtils {
   /// Clones a copy of the flutter repo into the destination directory. Returns false if unsucessful.
   Future<bool> cloneFlutter(String revision, String destination) async {
     // Use https url instead of ssh to avoid need to setup ssh on git.
-    List<String> cmdArgs = <String>['git', 'clone', '--single-branch', '--filter=blob:none', '--shallow-exclude=v1.0.0', 'https://github.com/flutter/flutter.git', destination];
+    List<String> cmdArgs = <String>['git', 'clone', '--filter=blob:none', 'https://github.com/flutter/flutter.git', destination];
     RunResult result = await _processUtils.run(cmdArgs);
-    checkForErrors(result, commandDescription: '${cmdArgs.join(' ')}');
+    checkForErrors(result, commandDescription: cmdArgs.join(' '));
 
     cmdArgs.clear();
     cmdArgs = <String>['git', 'reset', '--hard', revision];
     result = await _processUtils.run(cmdArgs, workingDirectory: destination);
-    if (!checkForErrors(result, commandDescription: '${cmdArgs.join(' ')}', exit: false)) {
+    if (!checkForErrors(result, commandDescription: cmdArgs.join(' '), exit: false)) {
       return false;
     }
     return true;
@@ -148,7 +148,7 @@ class MigrateUtils {
         );
       }
     }
-    checkForErrors(result, commandDescription: '${cmdArgs.join(' ')}', silent: true);
+    checkForErrors(result, commandDescription: cmdArgs.join(' '), silent: true);
 
     if (legacyNameParameter) {
       return _fileSystem.path.join(outputDirectory, name);
@@ -167,7 +167,7 @@ class MigrateUtils {
   }) async {
     final List<String> cmdArgs = <String>['git', 'merge-file', '-p', current, base, target];
     final RunResult result = await _processUtils.run(cmdArgs);
-    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: cmdArgs.join(' '));
     return StringMergeResult(result, localPath);
   }
 
@@ -175,14 +175,14 @@ class MigrateUtils {
   Future<void> gitInit(String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'init'];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, commandDescription: 'git ${cmdArgs.join(' ')}');
+    checkForErrors(result, commandDescription: cmdArgs.join(' '));
   }
 
   /// Returns true if the workingDirectory git repo has any uncommited changes.
   Future<bool> hasUncommitedChanges(String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'diff', '--quiet', 'HEAD', '--', '.', "':(exclude)$kDefaultMigrateWorkingDirectoryName'"];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: '${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: cmdArgs.join(' '));
     if (result.exitCode == 0) {
       return false;
     }
@@ -193,7 +193,7 @@ class MigrateUtils {
   Future<bool> isGitRepo(String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'rev-parse', '--is-inside-work-tree'];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: '${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: cmdArgs.join(' '));
     if (result.exitCode == 0) {
       return true;
     }
@@ -204,7 +204,7 @@ class MigrateUtils {
   Future<bool> isGitIgnored(String filePath, String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'check-ignore', filePath];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, allowedExitCodes: <int>[0, 1, 128], commandDescription: '${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[0, 1, 128], commandDescription: cmdArgs.join(' '));
     return result.exitCode == 0;
   }
 
@@ -212,7 +212,7 @@ class MigrateUtils {
   Future<void> flutterPubUpgrade(String workingDirectory) async {
     final List<String> cmdArgs = <String>['flutter', 'pub', 'upgrade', '--major-versions'];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory, allowReentrantFlutter: true);
-    checkForErrors(result, commandDescription: 'flutter ${cmdArgs.join(' ')}');
+    checkForErrors(result, commandDescription: cmdArgs.join(' '));
   }
 
   /// Runs `./gradlew tasks` in the android directory of a flutter project.
@@ -220,7 +220,7 @@ class MigrateUtils {
     final String baseCommand = _platform.isWindows ? 'gradlew.bat' : './gradlew';
     final List<String> cmdArgs = <String>[baseCommand, 'tasks'];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, commandDescription: '$baseCommand ${cmdArgs.join(' ')}');
+    checkForErrors(result, commandDescription: cmdArgs.join(' '));
   }
 
   /// Verifies that the RunResult does not contain an error.

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -67,7 +67,7 @@ class MigrateUtils {
   }
 
   /// Calls `flutter create` as a re-entrant command.
-  Future<String> createFromTemplates(String flutterBinPath, {
+  Future<void> createFromTemplates(String flutterBinPath, {
     required String name,
     bool legacyNameParameter = false,
     required String androidLanguage,
@@ -75,7 +75,14 @@ class MigrateUtils {
     required String outputDirectory,
     String? createVersion,
     List<String> platforms = const <String>[],
+    int iterationsAllowed = 5,
   }) async {
+    // Limit the number of iterations this command is allowed to attempt to prevent infinite looping.
+    if (iterationsAllowed <= 0) {
+      _logger.printError('Unable to `flutter create` with the version of flutter at $flutterBinPath');
+      return;
+    }
+
     final List<String> cmdArgs = <String>['$flutterBinPath/flutter', 'create'];
     if (!legacyNameParameter) {
       cmdArgs.add('--project-name=$name');
@@ -112,6 +119,7 @@ class MigrateUtils {
         androidLanguage: androidLanguage,
         iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
+        iterationsAllowed: iterationsAllowed--;
       );
     }
     // Old versions of the tool does not include the project-name option.
@@ -124,6 +132,7 @@ class MigrateUtils {
         iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
         platforms: platforms,
+        iterationsAllowed: iterationsAllowed--;
       );
     }
     if (error.contains('Multiple output directories specified.')) {
@@ -135,6 +144,7 @@ class MigrateUtils {
           androidLanguage: androidLanguage,
           iosLanguage: iosLanguage,
           outputDirectory: outputDirectory,
+          iterationsAllowed: iterationsAllowed--;
         );
       }
     }

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -267,7 +267,7 @@ class DiffResult {
   /// Creates a DiffResult that represents a deleted file.
   DiffResult.deletion() :
     diff = '',
-    isDeletion = true, 
+    isDeletion = true,
     isAddition = false,
     isIgnored = false,
     exitCode = 0;
@@ -275,7 +275,7 @@ class DiffResult {
   /// Creates a DiffResult that represents an ignored file.
   DiffResult.ignored() :
     diff = '',
-    isDeletion = false, 
+    isDeletion = false,
     isAddition = false,
     isIgnored = true,
     exitCode = 0;

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -5,12 +5,11 @@
 import 'dart:async';
 import 'dart:typed_data';
 
-import 'package:process/process.dart';
 import 'package:platform/platform.dart';
+import 'package:process/process.dart';
 
 import '../base/common.dart';
 import '../base/file_system.dart';
-import '../base/io.dart';
 import '../base/logger.dart';
 import '../base/process.dart';
 
@@ -48,7 +47,7 @@ class MigrateUtils {
 
     // diff exits with 1 if diffs are found.
     checkForErrors(result, allowedExitCodes: <int>[1], commandDescription: 'git ${cmdArgs.join(' ')}');
-    return DiffResult(diffType: DiffType.modification, diff: result.stdout as String, exitCode: result.exitCode);
+    return DiffResult(diffType: DiffType.modification, diff: result.stdout, exitCode: result.exitCode);
   }
 
   /// Clones a copy of the flutter repo into the destination directory. Returns false if unsucessful.
@@ -100,7 +99,7 @@ class MigrateUtils {
       cmdArgs.add(outputDirectory);
     }
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: outputDirectory, allowReentrantFlutter: true);
-    final String error = result.stderr as String;
+    final String error = result.stderr;
 
     // Catch errors due to parameters not existing.
 
@@ -116,7 +115,7 @@ class MigrateUtils {
       );
     }
     // Old versions of the tool does not include the project-name option.
-    if ((result.stderr as String).contains('Could not find an option named "project-name".')) {
+    if ((result.stderr).contains('Could not find an option named "project-name".')) {
       return createFromTemplates(
         flutterBinPath,
         name: name,
@@ -234,9 +233,9 @@ class MigrateUtils {
           _logger.printError(commandDescription, indent: 2);
         }
         _logger.printError('Stdout:');
-        _logger.printError(result.stdout as String, indent: 2);
+        _logger.printError(result.stdout, indent: 2);
         _logger.printError('Stderr:');
-        _logger.printError(result.stderr as String, indent: 2);
+        _logger.printError(result.stderr, indent: 2);
       }
       if (exit) {
         throwToolExit('Command failed with exit code ${result.exitCode}', exitCode: result.exitCode);
@@ -306,40 +305,30 @@ abstract class MergeResult {
 
 class StringMergeResult extends MergeResult {
   /// Initializes a BinaryMergeResult based off of a RunResult.
-  StringMergeResult(RunResult result, String localPath) :
-    mergedString = result.stdout as String,
-    super(result, localPath);
+  StringMergeResult(super.result, super.localPath) :
+    mergedString = result.stdout;
 
   StringMergeResult.explicit({
     required this.mergedString,
-    required bool hasConflict,
-    required int exitCode,
-    required String localPath,
-  }) : super.explicit(
-         hasConflict: hasConflict,
-         exitCode: exitCode,
-         localPath: localPath,
-       );
+    required super.hasConflict,
+    required super.exitCode,
+    required super.localPath,
+  }) : super.explicit();
   /// The final merged string.
   String mergedString;
 }
 
 class BinaryMergeResult extends MergeResult {
   /// Initializes a BinaryMergeResult based off of a RunResult.
-  BinaryMergeResult(RunResult result, String localPath) :
-    mergedBytes = result.stdout as Uint8List,
-    super(result, localPath);
+  BinaryMergeResult(super.result, super.localPath) :
+    mergedBytes = result.stdout as Uint8List;
 
   BinaryMergeResult.explicit({
     required this.mergedBytes,
-    required bool hasConflict,
-    required int exitCode,
-    required String localPath,
-  }) : super.explicit(
-         hasConflict: hasConflict,
-         exitCode: exitCode,
-         localPath: localPath,
-       );
+    required super.hasConflict,
+    required super.exitCode,
+    required super.localPath,
+  }) : super.explicit();
   /// The final merged bytes.
   Uint8List mergedBytes;
 }

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -1,0 +1,326 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import '../base/common.dart';
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../commands/migrate.dart';
+
+/// The default name of the migrate working directory used to stage proposed changes.
+const String kDefaultMigrateWorkingDirectoryName = 'migrate_working_dir';
+
+/// Utility class that contains static methods that wrap git and other shell commands.
+class MigrateUtils {
+  MigrateUtils();
+
+  /// Calls `git diff` on two files and returns the diff as a DiffResult.
+  static Future<DiffResult> diffFiles(File one, File two, Logger logger) async {
+    if (one.existsSync() && !two.existsSync()) {
+      return DiffResult.deletion();
+    }
+    if (!one.existsSync() && two.existsSync()) {
+      return DiffResult.addition();
+    }
+    final List<String> cmdArgs = <String>['diff', '--no-index', one.absolute.path, two.absolute.path];
+    final ProcessResult result = await Process.run('git', cmdArgs);
+
+    // diff exits with 1 if diffs are found.
+    checkForErrors(result, logger, allowedExitCodes: <int>[1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    return DiffResult(result);
+  }
+
+  // Clones a copy of the flutter repo into the destination directory. Returns false if unsucessful.
+  static Future<bool> cloneFlutter(String revision, String destination, String flutterDirectory, Logger logger) async {
+    // Use https url instead of ssh to avoid need to setup ssh on git.
+    List<String> cmdArgs = <String>['clone', '--single-branch', '--filter=blob:none', '--shallow-exclude=v1.0.0', 'https://github.com/flutter/flutter.git', destination];
+    ProcessResult result = await Process.run('git', cmdArgs);
+    checkForErrors(result, logger, commandDescription: 'git ${cmdArgs.join(' ')}');
+
+    cmdArgs.clear();
+    cmdArgs = <String>['reset', '--hard', revision];
+    result = await Process.run('git', cmdArgs, workingDirectory: destination);
+    if (!checkForErrors(result, logger, commandDescription: 'git ${cmdArgs.join(' ')}', exit: false)) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Calls `flutter create` as a re-entrant command.
+  static Future<String> createFromTemplates(String flutterBinPath, {
+    required String name,
+    bool legacyNameParameter = false,
+    required String androidLanguage,
+    required String iosLanguage,
+    required String outputDirectory,
+    String? createVersion,
+    List<String> platforms = const <String>[],
+    required Logger logger,
+    required FileSystem fileSystem,
+  }) async {
+    final List<String> cmdArgs = <String>['create'];
+    if (!legacyNameParameter) {
+      cmdArgs.add('--project-name=$name');
+    }
+    cmdArgs.add('--android-language=$androidLanguage');
+    cmdArgs.add('--ios-language=$iosLanguage');
+    if (platforms.isNotEmpty) {
+      String platformsArg = '--platforms=';
+      for (int i = 0; i < platforms.length; i++) {
+        if (i > 0) {
+          platformsArg += ',';
+        }
+        platformsArg += platforms[i];
+      }
+      cmdArgs.add(platformsArg);
+    }
+    cmdArgs.add('--no-pub');
+    if (legacyNameParameter) {
+      cmdArgs.add(name);
+    } else {
+      cmdArgs.add(outputDirectory);
+    }
+    final ProcessResult result = await Process.run('$flutterBinPath/flutter', cmdArgs, workingDirectory: outputDirectory);
+    final String error = result.stderr as String;
+
+    // Catch errors due to parameters not existing.
+
+    // Old versions of the tool does not include the platforms option.
+    if (error.contains('Could not find an option named "platforms".')) {
+      return createFromTemplates(
+        flutterBinPath,
+        name: name,
+        legacyNameParameter: legacyNameParameter,
+        androidLanguage: androidLanguage,
+        iosLanguage: iosLanguage,
+        outputDirectory: outputDirectory,
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+    }
+    // Old versions of the tool does not include the project-name option.
+    if ((result.stderr as String).contains('Could not find an option named "project-name".')) {
+      return createFromTemplates(
+        name: name,
+        legacyNameParameter: true,
+        flutterBinPath,
+        androidLanguage: androidLanguage,
+        iosLanguage: iosLanguage,
+        outputDirectory: outputDirectory,
+        platforms: platforms,
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+    }
+    if (error.contains('Multiple output directories specified.')) {
+      if (error.contains('Try moving --platforms')) {
+        return createFromTemplates(
+          flutterBinPath,
+          name: name,
+          legacyNameParameter: legacyNameParameter,
+          androidLanguage: androidLanguage,
+          iosLanguage: iosLanguage,
+          outputDirectory: outputDirectory,
+          logger: logger,
+          fileSystem: fileSystem,
+        );
+      }
+    }
+    checkForErrors(result, logger, commandDescription: '${flutterBinPath}flutter ${cmdArgs.join(' ')}', silent: true);
+
+    if (legacyNameParameter) {
+      return fileSystem.path.join(outputDirectory, name);
+    }
+    return outputDirectory;
+  }
+
+  /// Runs the git 3-way merge on three files and returns the results as a MergeResult.
+  ///
+  /// Passing the same path for base and current will perform a two-way fast forward merge.
+  static Future<MergeResult> gitMergeFile({
+    required String base,
+    required String current,
+    required String target,
+    required String localPath,
+    required Logger logger
+  }) async {
+    final List<String> cmdArgs = <String>['merge-file', '-p', current, base, target];
+    final ProcessResult result = await Process.run('git', cmdArgs);
+    checkForErrors(result, logger, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    return MergeResult(result, localPath);
+  }
+
+  /// Calls `git init` on the workingDirectory.
+  static Future<void> gitInit(String workingDirectory, Logger logger) async {
+    final List<String> cmdArgs = <String>['init'];
+    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, logger, allowedExitCodes: <int>[0], commandDescription: 'git ${cmdArgs.join(' ')}');
+  }
+
+  /// Returns true if the workingDirectory git repo has any uncommited changes.
+  static Future<bool> hasUncommitedChanges(String workingDirectory, Logger logger) async {
+    final List<String> cmdArgs = <String>['diff', '--quiet', 'HEAD', '--', '.', "':(exclude)$kDefaultMigrateWorkingDirectoryName'"];
+    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, logger, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    if (result.exitCode == 0) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Returns true if the workingDirectory is a git repo.
+  static Future<bool> isGitRepo(String workingDirectory, Logger logger) async {
+    final List<String> cmdArgs = <String>['rev-parse', '--is-inside-work-tree'];
+    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, logger, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    if (result.exitCode == 0) {
+      return true;
+    }
+    return false;
+  }
+
+  /// Returns true if the file at `filePath` is covered by the `.gitignore`
+  static Future<bool> isGitIgnored(String filePath, String workingDirectory, Logger logger) async {
+    final List<String> cmdArgs = <String>['check-ignore', filePath];
+    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, logger, allowedExitCodes: <int>[0, 1, 128], commandDescription: 'git ${cmdArgs.join(' ')}');
+    return result.exitCode == 0;
+  }
+
+  /// Runs `flutter pub upgrate --major-revisions`.
+  static Future<void> flutterPubUpgrade(String workingDirectory, Logger logger) async {
+    final List<String> cmdArgs = <String>['pub', 'upgrade', '--major-versions'];
+    final ProcessResult result = await Process.run('flutter', cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, logger, allowedExitCodes: <int>[0], commandDescription: 'flutter ${cmdArgs.join(' ')}');
+  }
+
+  /// Runs `./gradlew tasks` in the android directory of a flutter project.
+  static Future<void> gradlewTasks(String workingDirectory, Logger logger) async {
+    final String baseCommand = Platform.isWindows ? 'gradlew.bat' : './gradlew';
+    final List<String> cmdArgs = <String>['tasks'];
+    final ProcessResult result = await Process.run(baseCommand, cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, logger, allowedExitCodes: <int>[0], commandDescription: '$baseCommand ${cmdArgs.join(' ')}');
+  }
+
+  /// Verifies that the ProcessResult does not contain an error.
+  ///
+  /// If an error is detected, the error can be optionally logged or exit the tool.
+  static bool checkForErrors(
+    ProcessResult result,
+    Logger logger, {
+    List<int> allowedExitCodes = const <int>[],
+    String? commandDescription,
+    bool exit = true,
+    bool silent = false
+  }) {
+    // -1 in allowed exit codes means all exit codes are valid.
+    if ((result.exitCode != 0 && !allowedExitCodes.contains(result.exitCode)) && !allowedExitCodes.contains(-1)) {
+      if (!silent) {
+        logger.printError('Command encountered an error with exit code ${result.exitCode}.');
+        if (commandDescription != null) {
+          logger.printError('Command:');
+          logger.printError(commandDescription, indent: 2);
+        }
+        logger.printError('Stdout:');
+        logger.printStatus(result.stdout as String, indent: 2);
+        logger.printError('Stderr:');
+        logger.printError(result.stderr as String, indent: 2);
+      }
+      if (exit) {
+        throwToolExit('Command failed with exit code ${result.exitCode}', exitCode: result.exitCode);
+      }
+      return false;
+    }
+    return true;
+  }
+
+  /// Returns true if the file does not contain any git conflit markers.
+  static bool conflictsResolved(String contents) {
+    if (contents.contains('>>>>>>>') || contents.contains('=======') || contents.contains('<<<<<<<')) {
+      return false;
+    }
+    return true;
+  }
+}
+
+/// Tracks the output of a git diff command or any special cases such as addition of a new
+/// file or deletion of an existing file.
+class DiffResult {
+  DiffResult(ProcessResult result) :
+    diff = result.stdout as String,
+    isDeletion = false,
+    isAddition = false,
+    isIgnored = false,
+    exitCode = result.exitCode;
+
+  /// Creates a DiffResult that represents a newly added file.
+  DiffResult.addition() :
+    diff = '',
+    isDeletion = false,
+    isAddition = true,
+    isIgnored = false,
+    exitCode = 0;
+
+  /// Creates a DiffResult that represents a deleted file.
+  DiffResult.deletion() :
+    diff = '',
+    isDeletion = true, 
+    isAddition = false,
+    isIgnored = false,
+    exitCode = 0;
+
+  /// Creates a DiffResult that represents an ignored file.
+  DiffResult.ignored() :
+    diff = '',
+    isDeletion = false, 
+    isAddition = false,
+    isIgnored = true,
+    exitCode = 0;
+
+  /// The diff string output by git.
+  final String diff;
+
+  final bool isDeletion;
+  final bool isAddition;
+  final bool isIgnored;
+
+  /// The exitcode of the command. This is zero when no diffs are found.
+  final int exitCode;
+}
+
+/// Data class to hold the results of a merge.
+class MergeResult {
+  /// Initializes a MergeResult based off of a ProcessResult.
+  MergeResult(ProcessResult result, this.localPath) :
+    mergedString = result.stdout as String,
+    hasConflict = result.exitCode != 0,
+    exitCode = result.exitCode;
+
+  /// Manually initializes a MergeResult with explicit values.
+  MergeResult.explicit({
+    this.mergedString,
+    this.mergedBytes,
+    required this.hasConflict,
+    required this.exitCode,
+    required this.localPath,
+  }) : assert(mergedString == null && mergedBytes != null || mergedString != null && mergedBytes == null);
+
+  /// The final merged string.
+  String? mergedString;
+
+  /// If the file was a binary file, then this field is non-null while mergedString is null.
+  Uint8List? mergedBytes;
+
+  /// True when there is a merge conflict.
+  bool hasConflict;
+
+  /// The exitcode of the merge command.
+  int exitCode;
+
+  /// The local path relative to the project root of the file.
+  String localPath;
+}

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -183,7 +183,7 @@ class MigrateUtils {
     final List<String> cmdArgs = <String>['git', 'diff', '--quiet', 'HEAD', '--', '.'];
     // windows uses double quotes.
     if (_platform.isWindows) {
-      final String path = _fileSystem.path.join(workingDirectory, kDefaultMigrateWorkingDirectoryName);
+      String path = _fileSystem.path.join(workingDirectory, kDefaultMigrateWorkingDirectoryName);
       // Trim off any drive labels such as 'C:'
       if (path.contains(':')) {
         path = path.substring(path.indexOf(':') + 1);

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -182,7 +182,16 @@ class MigrateUtils {
   Future<bool> hasUncommitedChanges(String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'diff', '--quiet', 'HEAD', '--', '.'];
     // windows uses double quotes.
-    cmdArgs.add(_platform.isWindows ? '":(exclude)${kDefaultMigrateWorkingDirectoryName}"' : "':(exclude)${_fileSystem.path.join(workingDirectory, kDefaultMigrateWorkingDirectoryName)}'");
+    if (_platform.isWindows) {
+      final String path = _fileSystem.path.join(workingDirectory, kDefaultMigrateWorkingDirectoryName);
+      // Trim off any drive labels such as 'C:'
+      if (path.contains(':')) {
+        path = path.substring(path.indexOf(':') + 1);
+      }
+      cmdArgs.add('":(exclude)$path"');
+    } else {
+      cmdArgs.add("':(exclude)${_fileSystem.path.join(workingDirectory, kDefaultMigrateWorkingDirectoryName)}'");
+    }
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
     checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: cmdArgs.join(' '));
     print(result.stdout);

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -183,6 +183,8 @@ class MigrateUtils {
     final List<String> cmdArgs = <String>['git', 'diff', '--quiet', 'HEAD', '--', '.', "':(exclude)$kDefaultMigrateWorkingDirectoryName'"];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
     checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: cmdArgs.join(' '));
+    print(result.stdout);
+    print(result.stderr);
     if (result.exitCode == 0) {
       return false;
     }

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -3,54 +3,72 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:typed_data';
+
+import 'package:process/process.dart';
+import 'package:platform/platform.dart';
 
 import '../base/common.dart';
 import '../base/file_system.dart';
+import '../base/io.dart';
 import '../base/logger.dart';
+import '../base/process.dart';
 
 /// The default name of the migrate working directory used to stage proposed changes.
 const String kDefaultMigrateWorkingDirectoryName = 'migrate_working_dir';
 
-/// Utility class that contains static methods that wrap git and other shell commands.
+/// Utility class that contains methods that wrap git and other shell commands.
 class MigrateUtils {
-  MigrateUtils();
+  MigrateUtils({
+    required Logger logger,
+    required FileSystem fileSystem,
+    required Platform platform,
+    required ProcessManager processManager,
+  }) : 
+       _processUtils = ProcessUtils(processManager: processManager, logger: logger),
+       _logger = logger,
+       _fileSystem = fileSystem,
+       _platform = platform;
+
+  final Logger _logger;
+  final FileSystem _fileSystem;
+  final Platform _platform;
+  final ProcessUtils _processUtils;
 
   /// Calls `git diff` on two files and returns the diff as a DiffResult.
-  static Future<DiffResult> diffFiles(File one, File two, Logger logger) async {
+  Future<DiffResult> diffFiles(File one, File two) async {
     if (one.existsSync() && !two.existsSync()) {
-      return DiffResult.deletion();
+      return DiffResult(diffType: DiffType.deletion);
     }
     if (!one.existsSync() && two.existsSync()) {
-      return DiffResult.addition();
+      return DiffResult(diffType: DiffType.addition);
     }
-    final List<String> cmdArgs = <String>['diff', '--no-index', one.absolute.path, two.absolute.path];
-    final ProcessResult result = await Process.run('git', cmdArgs);
+    final List<String> cmdArgs = <String>['git', 'diff', '--no-index', one.absolute.path, two.absolute.path];
+    final RunResult result = await _processUtils.run(cmdArgs);
 
     // diff exits with 1 if diffs are found.
-    checkForErrors(result, logger, allowedExitCodes: <int>[1], commandDescription: 'git ${cmdArgs.join(' ')}');
-    return DiffResult(result);
+    checkForErrors(result, allowedExitCodes: <int>[1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    return DiffResult(diffType: DiffType.modification, diff: result.stdout as String, exitCode: result.exitCode);
   }
 
-  // Clones a copy of the flutter repo into the destination directory. Returns false if unsucessful.
-  static Future<bool> cloneFlutter(String revision, String destination, Logger logger) async {
+  /// Clones a copy of the flutter repo into the destination directory. Returns false if unsucessful.
+  Future<bool> cloneFlutter(String revision, String destination) async {
     // Use https url instead of ssh to avoid need to setup ssh on git.
-    List<String> cmdArgs = <String>['clone', '--single-branch', '--filter=blob:none', '--shallow-exclude=v1.0.0', 'https://github.com/flutter/flutter.git', destination];
-    ProcessResult result = await Process.run('git', cmdArgs);
-    checkForErrors(result, logger, commandDescription: 'git ${cmdArgs.join(' ')}');
+    List<String> cmdArgs = <String>['git', 'clone', '--single-branch', '--filter=blob:none', '--shallow-exclude=v1.0.0', 'https://github.com/flutter/flutter.git', destination];
+    RunResult result = await _processUtils.run(cmdArgs);
+    checkForErrors(result, commandDescription: 'git ${cmdArgs.join(' ')}');
 
     cmdArgs.clear();
-    cmdArgs = <String>['reset', '--hard', revision];
-    result = await Process.run('git', cmdArgs, workingDirectory: destination);
-    if (!checkForErrors(result, logger, commandDescription: 'git ${cmdArgs.join(' ')}', exit: false)) {
+    cmdArgs = <String>['git', 'reset', '--hard', revision];
+    result = await _processUtils.run(cmdArgs, workingDirectory: destination);
+    if (!checkForErrors(result, commandDescription: 'git ${cmdArgs.join(' ')}', exit: false)) {
       return false;
     }
     return true;
   }
 
   /// Calls `flutter create` as a re-entrant command.
-  static Future<String> createFromTemplates(String flutterBinPath, {
+  Future<String> createFromTemplates(String flutterBinPath, {
     required String name,
     bool legacyNameParameter = false,
     required String androidLanguage,
@@ -58,10 +76,8 @@ class MigrateUtils {
     required String outputDirectory,
     String? createVersion,
     List<String> platforms = const <String>[],
-    required Logger logger,
-    required FileSystem fileSystem,
   }) async {
-    final List<String> cmdArgs = <String>['create'];
+    final List<String> cmdArgs = <String>['$flutterBinPath/flutter', 'create'];
     if (!legacyNameParameter) {
       cmdArgs.add('--project-name=$name');
     }
@@ -83,7 +99,7 @@ class MigrateUtils {
     } else {
       cmdArgs.add(outputDirectory);
     }
-    final ProcessResult result = await Process.run('$flutterBinPath/flutter', cmdArgs, workingDirectory: outputDirectory);
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: outputDirectory, allowReentrantFlutter: true);
     final String error = result.stderr as String;
 
     // Catch errors due to parameters not existing.
@@ -97,22 +113,18 @@ class MigrateUtils {
         androidLanguage: androidLanguage,
         iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
-        logger: logger,
-        fileSystem: fileSystem,
       );
     }
     // Old versions of the tool does not include the project-name option.
     if ((result.stderr as String).contains('Could not find an option named "project-name".')) {
       return createFromTemplates(
+        flutterBinPath,
         name: name,
         legacyNameParameter: true,
-        flutterBinPath,
         androidLanguage: androidLanguage,
         iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
         platforms: platforms,
-        logger: logger,
-        fileSystem: fileSystem,
       );
     }
     if (error.contains('Multiple output directories specified.')) {
@@ -124,15 +136,13 @@ class MigrateUtils {
           androidLanguage: androidLanguage,
           iosLanguage: iosLanguage,
           outputDirectory: outputDirectory,
-          logger: logger,
-          fileSystem: fileSystem,
         );
       }
     }
-    checkForErrors(result, logger, commandDescription: '${flutterBinPath}flutter ${cmdArgs.join(' ')}', silent: true);
+    checkForErrors(result, commandDescription: '${flutterBinPath}flutter ${cmdArgs.join(' ')}', silent: true);
 
     if (legacyNameParameter) {
-      return fileSystem.path.join(outputDirectory, name);
+      return _fileSystem.path.join(outputDirectory, name);
     }
     return outputDirectory;
   }
@@ -140,31 +150,30 @@ class MigrateUtils {
   /// Runs the git 3-way merge on three files and returns the results as a MergeResult.
   ///
   /// Passing the same path for base and current will perform a two-way fast forward merge.
-  static Future<MergeResult> gitMergeFile({
+  Future<MergeResult> gitMergeFile({
     required String base,
     required String current,
     required String target,
     required String localPath,
-    required Logger logger
   }) async {
-    final List<String> cmdArgs = <String>['merge-file', '-p', current, base, target];
-    final ProcessResult result = await Process.run('git', cmdArgs);
-    checkForErrors(result, logger, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
-    return MergeResult(result, localPath);
+    final List<String> cmdArgs = <String>['git', 'merge-file', '-p', current, base, target];
+    final RunResult result = await _processUtils.run(cmdArgs);
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    return StringMergeResult(result, localPath);
   }
 
   /// Calls `git init` on the workingDirectory.
-  static Future<void> gitInit(String workingDirectory, Logger logger) async {
-    final List<String> cmdArgs = <String>['init'];
-    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, logger, allowedExitCodes: <int>[0], commandDescription: 'git ${cmdArgs.join(' ')}');
+  Future<void> gitInit(String workingDirectory) async {
+    final List<String> cmdArgs = <String>['git', 'init'];
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, commandDescription: 'git ${cmdArgs.join(' ')}');
   }
 
   /// Returns true if the workingDirectory git repo has any uncommited changes.
-  static Future<bool> hasUncommitedChanges(String workingDirectory, Logger logger) async {
-    final List<String> cmdArgs = <String>['diff', '--quiet', 'HEAD', '--', '.', "':(exclude)$kDefaultMigrateWorkingDirectoryName'"];
-    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, logger, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+  Future<bool> hasUncommitedChanges(String workingDirectory) async {
+    final List<String> cmdArgs = <String>['git', 'diff', '--quiet', 'HEAD', '--', '.', "':(exclude)$kDefaultMigrateWorkingDirectoryName'"];
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
     if (result.exitCode == 0) {
       return false;
     }
@@ -172,10 +181,10 @@ class MigrateUtils {
   }
 
   /// Returns true if the workingDirectory is a git repo.
-  static Future<bool> isGitRepo(String workingDirectory, Logger logger) async {
-    final List<String> cmdArgs = <String>['rev-parse', '--is-inside-work-tree'];
-    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, logger, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+  Future<bool> isGitRepo(String workingDirectory) async {
+    final List<String> cmdArgs = <String>['git', 'rev-parse', '--is-inside-work-tree'];
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
     if (result.exitCode == 0) {
       return true;
     }
@@ -183,51 +192,51 @@ class MigrateUtils {
   }
 
   /// Returns true if the file at `filePath` is covered by the `.gitignore`
-  static Future<bool> isGitIgnored(String filePath, String workingDirectory, Logger logger) async {
-    final List<String> cmdArgs = <String>['check-ignore', filePath];
-    final ProcessResult result = await Process.run('git', cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, logger, allowedExitCodes: <int>[0, 1, 128], commandDescription: 'git ${cmdArgs.join(' ')}');
+  Future<bool> isGitIgnored(String filePath, String workingDirectory) async {
+    final List<String> cmdArgs = <String>['git', 'check-ignore', filePath];
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, allowedExitCodes: <int>[0, 1, 128], commandDescription: 'git ${cmdArgs.join(' ')}');
     return result.exitCode == 0;
   }
 
-  /// Runs `flutter pub upgrate --major-revisions`.
-  static Future<void> flutterPubUpgrade(String workingDirectory, Logger logger) async {
-    final List<String> cmdArgs = <String>['pub', 'upgrade', '--major-versions'];
-    final ProcessResult result = await Process.run('flutter', cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, logger, allowedExitCodes: <int>[0], commandDescription: 'flutter ${cmdArgs.join(' ')}');
+  /// Runs `flutter pub upgrade --major-revisions`.
+  Future<void> flutterPubUpgrade(String workingDirectory) async {
+    final List<String> cmdArgs = <String>['flutter', 'pub', 'upgrade', '--major-versions'];
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory, allowReentrantFlutter: true);
+    checkForErrors(result, commandDescription: 'flutter ${cmdArgs.join(' ')}');
   }
 
   /// Runs `./gradlew tasks` in the android directory of a flutter project.
-  static Future<void> gradlewTasks(String workingDirectory, Logger logger) async {
-    final String baseCommand = Platform.isWindows ? 'gradlew.bat' : './gradlew';
-    final List<String> cmdArgs = <String>['tasks'];
-    final ProcessResult result = await Process.run(baseCommand, cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, logger, allowedExitCodes: <int>[0], commandDescription: '$baseCommand ${cmdArgs.join(' ')}');
+  Future<void> gradlewTasks(String workingDirectory) async {
+    final String baseCommand = _platform.isWindows ? 'gradlew.bat' : './gradlew';
+    final List<String> cmdArgs = <String>[baseCommand, 'tasks'];
+    final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
+    checkForErrors(result, commandDescription: '$baseCommand ${cmdArgs.join(' ')}');
   }
 
-  /// Verifies that the ProcessResult does not contain an error.
+  /// Verifies that the RunResult does not contain an error.
   ///
   /// If an error is detected, the error can be optionally logged or exit the tool.
-  static bool checkForErrors(
-    ProcessResult result,
-    Logger logger, {
-    List<int> allowedExitCodes = const <int>[],
+  /// 
+  /// Passing -1 in allowedExitCodes means all exit codes are valid.
+  bool checkForErrors(
+    RunResult result, {
+    List<int> allowedExitCodes = const <int>[0],
     String? commandDescription,
     bool exit = true,
     bool silent = false
   }) {
-    // -1 in allowed exit codes means all exit codes are valid.
     if ((result.exitCode != 0 && !allowedExitCodes.contains(result.exitCode)) && !allowedExitCodes.contains(-1)) {
       if (!silent) {
-        logger.printError('Command encountered an error with exit code ${result.exitCode}.');
+        _logger.printError('Command encountered an error with exit code ${result.exitCode}.');
         if (commandDescription != null) {
-          logger.printError('Command:');
-          logger.printError(commandDescription, indent: 2);
+          _logger.printError('Command:');
+          _logger.printError(commandDescription, indent: 2);
         }
-        logger.printError('Stdout:');
-        logger.printStatus(result.stdout as String, indent: 2);
-        logger.printError('Stderr:');
-        logger.printError(result.stderr as String, indent: 2);
+        _logger.printError('Stdout:');
+        _logger.printError(result.stdout as String, indent: 2);
+        _logger.printError('Stderr:');
+        _logger.printError(result.stderr as String, indent: 2);
       }
       if (exit) {
         throwToolExit('Command failed with exit code ${result.exitCode}', exitCode: result.exitCode);
@@ -238,81 +247,52 @@ class MigrateUtils {
   }
 
   /// Returns true if the file does not contain any git conflit markers.
-  static bool conflictsResolved(String contents) {
-    if (contents.contains('>>>>>>>') || contents.contains('=======') || contents.contains('<<<<<<<')) {
+  bool conflictsResolved(String contents) {
+    if (contents.contains('>>>>>>>') && contents.contains('=======') && contents.contains('<<<<<<<')) {
       return false;
     }
     return true;
   }
 }
 
+enum DiffType {
+  modification,
+  addition,
+  deletion,
+  ignored,
+}
+
 /// Tracks the output of a git diff command or any special cases such as addition of a new
 /// file or deletion of an existing file.
 class DiffResult {
-  DiffResult(ProcessResult result) :
-    diff = result.stdout as String,
-    isDeletion = false,
-    isAddition = false,
-    isIgnored = false,
-    exitCode = result.exitCode;
-
-  /// Creates a DiffResult that represents a newly added file.
-  DiffResult.addition() :
-    diff = '',
-    isDeletion = false,
-    isAddition = true,
-    isIgnored = false,
-    exitCode = 0;
-
-  /// Creates a DiffResult that represents a deleted file.
-  DiffResult.deletion() :
-    diff = '',
-    isDeletion = true,
-    isAddition = false,
-    isIgnored = false,
-    exitCode = 0;
-
-  /// Creates a DiffResult that represents an ignored file.
-  DiffResult.ignored() :
-    diff = '',
-    isDeletion = false,
-    isAddition = false,
-    isIgnored = true,
-    exitCode = 0;
+  DiffResult({
+    required this.diffType,
+    this.diff,
+    this.exitCode,
+  });
 
   /// The diff string output by git.
-  final String diff;
+  final String? diff;
 
-  final bool isDeletion;
-  final bool isAddition;
-  final bool isIgnored;
+  final DiffType diffType;
 
   /// The exitcode of the command. This is zero when no diffs are found.
-  final int exitCode;
+  final int? exitCode;
 }
 
 /// Data class to hold the results of a merge.
-class MergeResult {
-  /// Initializes a MergeResult based off of a ProcessResult.
-  MergeResult(ProcessResult result, this.localPath) :
-    mergedString = result.stdout as String,
+abstract class MergeResult {
+  /// Initializes a MergeResult based off of a RunResult.
+  MergeResult(RunResult result, this.localPath) :
     hasConflict = result.exitCode != 0,
     exitCode = result.exitCode;
 
   /// Manually initializes a MergeResult with explicit values.
   MergeResult.explicit({
-    this.mergedString,
-    this.mergedBytes,
     required this.hasConflict,
     required this.exitCode,
     required this.localPath,
-  }) : assert(mergedString == null && mergedBytes != null || mergedString != null && mergedBytes == null);
-
-  /// The final merged string.
-  String? mergedString;
-
-  /// If the file was a binary file, then this field is non-null while mergedString is null.
-  Uint8List? mergedBytes;
+  });
 
   /// True when there is a merge conflict.
   bool hasConflict;
@@ -322,4 +302,44 @@ class MergeResult {
 
   /// The local path relative to the project root of the file.
   String localPath;
+}
+
+class StringMergeResult extends MergeResult {
+  /// Initializes a BinaryMergeResult based off of a RunResult.
+  StringMergeResult(RunResult result, String localPath) :
+    mergedString = result.stdout as String,
+    super(result, localPath);
+
+  StringMergeResult.explicit({
+    required this.mergedString,
+    required bool hasConflict,
+    required int exitCode,
+    required String localPath,
+  }) : super.explicit(
+         hasConflict: hasConflict,
+         exitCode: exitCode,
+         localPath: localPath,
+       );
+  /// The final merged string.
+  String mergedString;
+}
+
+class BinaryMergeResult extends MergeResult {
+  /// Initializes a BinaryMergeResult based off of a RunResult.
+  BinaryMergeResult(RunResult result, String localPath) :
+    mergedBytes = result.stdout as Uint8List,
+    super(result, localPath);
+
+  BinaryMergeResult.explicit({
+    required this.mergedBytes,
+    required bool hasConflict,
+    required int exitCode,
+    required String localPath,
+  }) : super.explicit(
+         hasConflict: hasConflict,
+         exitCode: exitCode,
+         localPath: localPath,
+       );
+  /// The final merged bytes.
+  Uint8List mergedBytes;
 }

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -55,12 +55,12 @@ class MigrateUtils {
     // Use https url instead of ssh to avoid need to setup ssh on git.
     List<String> cmdArgs = <String>['git', 'clone', '--single-branch', '--filter=blob:none', '--shallow-exclude=v1.0.0', 'https://github.com/flutter/flutter.git', destination];
     RunResult result = await _processUtils.run(cmdArgs);
-    checkForErrors(result, commandDescription: 'git ${cmdArgs.join(' ')}');
+    checkForErrors(result, commandDescription: '${cmdArgs.join(' ')}');
 
     cmdArgs.clear();
     cmdArgs = <String>['git', 'reset', '--hard', revision];
     result = await _processUtils.run(cmdArgs, workingDirectory: destination);
-    if (!checkForErrors(result, commandDescription: 'git ${cmdArgs.join(' ')}', exit: false)) {
+    if (!checkForErrors(result, commandDescription: '${cmdArgs.join(' ')}', exit: false)) {
       return false;
     }
     return true;
@@ -138,7 +138,7 @@ class MigrateUtils {
         );
       }
     }
-    checkForErrors(result, commandDescription: '${flutterBinPath}flutter ${cmdArgs.join(' ')}', silent: true);
+    checkForErrors(result, commandDescription: '${cmdArgs.join(' ')}', silent: true);
 
     if (legacyNameParameter) {
       return _fileSystem.path.join(outputDirectory, name);
@@ -172,7 +172,7 @@ class MigrateUtils {
   Future<bool> hasUncommitedChanges(String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'diff', '--quiet', 'HEAD', '--', '.', "':(exclude)$kDefaultMigrateWorkingDirectoryName'"];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: '${cmdArgs.join(' ')}');
     if (result.exitCode == 0) {
       return false;
     }
@@ -183,7 +183,7 @@ class MigrateUtils {
   Future<bool> isGitRepo(String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'rev-parse', '--is-inside-work-tree'];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: 'git ${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[-1], commandDescription: '${cmdArgs.join(' ')}');
     if (result.exitCode == 0) {
       return true;
     }
@@ -194,7 +194,7 @@ class MigrateUtils {
   Future<bool> isGitIgnored(String filePath, String workingDirectory) async {
     final List<String> cmdArgs = <String>['git', 'check-ignore', filePath];
     final RunResult result = await _processUtils.run(cmdArgs, workingDirectory: workingDirectory);
-    checkForErrors(result, allowedExitCodes: <int>[0, 1, 128], commandDescription: 'git ${cmdArgs.join(' ')}');
+    checkForErrors(result, allowedExitCodes: <int>[0, 1, 128], commandDescription: '${cmdArgs.join(' ')}');
     return result.exitCode == 0;
   }
 

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -34,7 +34,7 @@ class MigrateUtils {
   }
 
   // Clones a copy of the flutter repo into the destination directory. Returns false if unsucessful.
-  static Future<bool> cloneFlutter(String revision, String destination, String flutterDirectory, Logger logger) async {
+  static Future<bool> cloneFlutter(String revision, String destination, Logger logger) async {
     // Use https url instead of ssh to avoid need to setup ssh on git.
     List<String> cmdArgs = <String>['clone', '--single-branch', '--filter=blob:none', '--shallow-exclude=v1.0.0', 'https://github.com/flutter/flutter.git', destination];
     ProcessResult result = await Process.run('git', cmdArgs);

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -9,7 +9,6 @@ import 'dart:typed_data';
 import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../commands/migrate.dart';
 
 /// The default name of the migrate working directory used to stage proposed changes.
 const String kDefaultMigrateWorkingDirectoryName = 'migrate_working_dir';

--- a/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_utils.dart
@@ -23,7 +23,7 @@ class MigrateUtils {
     required FileSystem fileSystem,
     required Platform platform,
     required ProcessManager processManager,
-  }) : 
+  }) :
        _processUtils = ProcessUtils(processManager: processManager, logger: logger),
        _logger = logger,
        _fileSystem = fileSystem,
@@ -67,7 +67,7 @@ class MigrateUtils {
   }
 
   /// Calls `flutter create` as a re-entrant command.
-  Future<void> createFromTemplates(String flutterBinPath, {
+  Future<String> createFromTemplates(String flutterBinPath, {
     required String name,
     bool legacyNameParameter = false,
     required String androidLanguage,
@@ -80,7 +80,7 @@ class MigrateUtils {
     // Limit the number of iterations this command is allowed to attempt to prevent infinite looping.
     if (iterationsAllowed <= 0) {
       _logger.printError('Unable to `flutter create` with the version of flutter at $flutterBinPath');
-      return;
+      return outputDirectory;
     }
 
     final List<String> cmdArgs = <String>['$flutterBinPath/flutter', 'create'];
@@ -119,7 +119,7 @@ class MigrateUtils {
         androidLanguage: androidLanguage,
         iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
-        iterationsAllowed: iterationsAllowed--;
+        iterationsAllowed: iterationsAllowed--,
       );
     }
     // Old versions of the tool does not include the project-name option.
@@ -132,7 +132,7 @@ class MigrateUtils {
         iosLanguage: iosLanguage,
         outputDirectory: outputDirectory,
         platforms: platforms,
-        iterationsAllowed: iterationsAllowed--;
+        iterationsAllowed: iterationsAllowed--,
       );
     }
     if (error.contains('Multiple output directories specified.')) {
@@ -144,7 +144,7 @@ class MigrateUtils {
           androidLanguage: androidLanguage,
           iosLanguage: iosLanguage,
           outputDirectory: outputDirectory,
-          iterationsAllowed: iterationsAllowed--;
+          iterationsAllowed: iterationsAllowed--,
         );
       }
     }
@@ -226,7 +226,7 @@ class MigrateUtils {
   /// Verifies that the RunResult does not contain an error.
   ///
   /// If an error is detected, the error can be optionally logged or exit the tool.
-  /// 
+  ///
   /// Passing -1 in allowedExitCodes means all exit codes are valid.
   bool checkForErrors(
     RunResult result, {

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_manifest_test.dart
@@ -44,7 +44,7 @@ void main() {
        MigrateManifest.fromFile(manifestFile);
       } on Exception catch (e) {
         exceptionFound = true;
-        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.');
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is missing an entry.');
       }
       expect(exceptionFound, true);
     });
@@ -60,7 +60,7 @@ void main() {
         MigrateManifest.fromFile(manifestFile);
       } on Exception catch (e) {
         exceptionFound = true;
-        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.');
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is missing an entry.');
       }
       expect(exceptionFound, true);
     });
@@ -78,7 +78,7 @@ void main() {
         MigrateManifest.fromFile(manifestFile);
       } on Exception catch (e) {
         exceptionFound = true;
-        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list. Fix the manifest or abandon the migration and try again.');
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list.');
       }
       expect(exceptionFound, true);
     });

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_manifest_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/migrate/migrate_compute.dart';
 import 'package:flutter_tools/src/migrate/migrate_manifest.dart';
 import 'package:flutter_tools/src/migrate/migrate_result.dart';
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_manifest_test.dart
@@ -1,0 +1,293 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/migrate/migrate_compute.dart';
+import 'package:flutter_tools/src/migrate/migrate_manifest.dart';
+import 'package:flutter_tools/src/migrate/migrate_result.dart';
+import 'package:flutter_tools/src/migrate/migrate_utils.dart';
+
+import '../../src/common.dart';
+
+void main() {
+  late FileSystem fileSystem;
+  late File manifestFile;
+
+  setUpAll(() {
+    fileSystem = MemoryFileSystem.test();
+    manifestFile = fileSystem.file('.migrate_manifest');
+  });
+
+  group('manifest file parsing', () {
+    testWithoutContext('empty fails', () async {
+      manifestFile.writeAsStringSync('');
+      bool exceptionFound = false;
+      try {
+        MigrateManifest.fromFile(manifestFile);
+      } on Exception catch (e) {
+        exceptionFound = true;
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is not a Yaml map.');
+      }
+      expect(exceptionFound, true);
+    });
+
+    testWithoutContext('invalid name fails', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+        conflict_files:
+        added_filessssss:
+        deleted_files:
+      ''');
+      bool exceptionFound = false;
+      try {
+       MigrateManifest.fromFile(manifestFile);
+      } on Exception catch (e) {
+        exceptionFound = true;
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.');
+      }
+      expect(exceptionFound, true);
+    });
+
+    testWithoutContext('missing name fails', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+        conflict_files:
+        deleted_files:
+      ''');
+      bool exceptionFound = false;
+      try {
+        MigrateManifest.fromFile(manifestFile);
+      } on Exception catch (e) {
+        exceptionFound = true;
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. File is missing an entry. Fix the manifest or abandon the migration and try again.');
+      }
+      expect(exceptionFound, true);
+    });
+
+    testWithoutContext('wrong entry type fails', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+        conflict_files:
+          other_key:
+        added_files:
+        deleted_files:
+      ''');
+      bool exceptionFound = false;
+      try {
+        MigrateManifest.fromFile(manifestFile);
+      } on Exception catch (e) {
+        exceptionFound = true;
+        expect(e.toString(), 'Exception: Invalid .migrate_manifest file in the migrate working directory. Entry is not a Yaml list. Fix the manifest or abandon the migration and try again.');
+      }
+      expect(exceptionFound, true);
+    });
+
+    testWithoutContext('unpopulated succeeds', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+        conflict_files:
+        added_files:
+        deleted_files:
+      ''');
+      final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+      expect(manifest.mergedFiles.isEmpty, true);
+      expect(manifest.conflictFiles.isEmpty, true);
+      expect(manifest.addedFiles.isEmpty, true);
+      expect(manifest.deletedFiles.isEmpty, true);
+    });
+
+    testWithoutContext('order does not matter', () async {
+      manifestFile.writeAsStringSync('''
+        added_files:
+        merged_files:
+        deleted_files:
+        conflict_files:
+      ''');
+      final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+      expect(manifest.mergedFiles.isEmpty, true);
+      expect(manifest.conflictFiles.isEmpty, true);
+      expect(manifest.addedFiles.isEmpty, true);
+      expect(manifest.deletedFiles.isEmpty, true);
+    });
+
+    testWithoutContext('basic succeeds', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+          - file1
+        conflict_files:
+          - file2
+        added_files:
+          - file3
+        deleted_files:
+          - file4
+      ''');
+      final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+      expect(manifest.mergedFiles.isEmpty, false);
+      expect(manifest.conflictFiles.isEmpty, false);
+      expect(manifest.addedFiles.isEmpty, false);
+      expect(manifest.deletedFiles.isEmpty, false);
+
+      expect(manifest.mergedFiles.length, 1);
+      expect(manifest.conflictFiles.length, 1);
+      expect(manifest.addedFiles.length, 1);
+      expect(manifest.deletedFiles.length, 1);
+
+      expect(manifest.mergedFiles[0], 'file1');
+      expect(manifest.conflictFiles[0], 'file2');
+      expect(manifest.addedFiles[0], 'file3');
+      expect(manifest.deletedFiles[0], 'file4');
+    });
+
+    testWithoutContext('basic multi-list succeeds', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+          - file1
+          - file2
+        conflict_files:
+        added_files:
+        deleted_files:
+          - file3
+          - file4
+      ''');
+      final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+      expect(manifest.mergedFiles.isEmpty, false);
+      expect(manifest.conflictFiles.isEmpty, true);
+      expect(manifest.addedFiles.isEmpty, true);
+      expect(manifest.deletedFiles.isEmpty, false);
+
+      expect(manifest.mergedFiles.length, 2);
+      expect(manifest.conflictFiles.length, 0);
+      expect(manifest.addedFiles.length, 0);
+      expect(manifest.deletedFiles.length, 2);
+
+      expect(manifest.mergedFiles[0], 'file1');
+      expect(manifest.mergedFiles[1], 'file2');
+      expect(manifest.deletedFiles[0], 'file3');
+      expect(manifest.deletedFiles[1], 'file4');
+    });
+  });
+
+  group('manifest MigrateResult creation', () {
+    testWithoutContext('empty MigrateResult', () async {
+      final MigrateManifest manifest = MigrateManifest(migrateRootDir: fileSystem.directory('root'), migrateResult: MigrateResult(
+        mergeResults: <MergeResult>[],
+        addedFiles: <FilePendingMigration>[],
+        deletedFiles: <FilePendingMigration>[],
+        mergeTypeMap: <String, MergeType>{},
+        diffMap: <String, DiffResult>{},
+        tempDirectories: <Directory>[],
+        sdkDirs: <String, Directory>{},
+      ));
+      expect(manifest.mergedFiles.isEmpty, true);
+      expect(manifest.conflictFiles.isEmpty, true);
+      expect(manifest.addedFiles.isEmpty, true);
+      expect(manifest.deletedFiles.isEmpty, true);
+    });
+
+    testWithoutContext('simple MigrateResult', () async {
+      final MigrateManifest manifest = MigrateManifest(migrateRootDir: fileSystem.directory('root'), migrateResult: MigrateResult(
+        mergeResults: <MergeResult>[
+          StringMergeResult.explicit(
+            localPath: 'merged_file',
+            mergedString: 'str',
+            hasConflict: false,
+            exitCode: 0,
+          ),
+          StringMergeResult.explicit(
+            localPath: 'conflict_file',
+            mergedString: '<<<<<<<<<<<',
+            hasConflict: true,
+            exitCode: 1,
+          ),
+        ],
+        addedFiles: <FilePendingMigration>[FilePendingMigration('added_file', fileSystem.file('added_file'))],
+        deletedFiles: <FilePendingMigration>[FilePendingMigration('deleted_file', fileSystem.file('deleted_file'))],
+        // The following are ignored by the manifest.
+        mergeTypeMap: <String, MergeType>{'test': MergeType.threeWay},
+        diffMap: <String, DiffResult>{},
+        tempDirectories: <Directory>[],
+        sdkDirs: <String, Directory>{},
+      ));
+      expect(manifest.mergedFiles.isEmpty, false);
+      expect(manifest.conflictFiles.isEmpty, false);
+      expect(manifest.addedFiles.isEmpty, false);
+      expect(manifest.deletedFiles.isEmpty, false);
+
+      expect(manifest.mergedFiles.length, 1);
+      expect(manifest.conflictFiles.length, 1);
+      expect(manifest.addedFiles.length, 1);
+      expect(manifest.deletedFiles.length, 1);
+
+      expect(manifest.mergedFiles[0], 'merged_file');
+      expect(manifest.conflictFiles[0], 'conflict_file');
+      expect(manifest.addedFiles[0], 'added_file');
+      expect(manifest.deletedFiles[0], 'deleted_file');
+    });
+  });
+
+  group('manifest write', () {
+    testWithoutContext('empty', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+        conflict_files:
+        added_files:
+        deleted_files:
+      ''');
+      final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+      expect(manifest.mergedFiles.isEmpty, true);
+      expect(manifest.conflictFiles.isEmpty, true);
+      expect(manifest.addedFiles.isEmpty, true);
+      expect(manifest.deletedFiles.isEmpty, true);
+
+      manifest.writeFile();
+      expect(manifestFile.readAsStringSync(), '''
+merged_files:
+conflict_files:
+added_files:
+deleted_files:
+''');
+    });
+
+    testWithoutContext('basic multi-list', () async {
+      manifestFile.writeAsStringSync('''
+        merged_files:
+          - file1
+          - file2
+        conflict_files:
+        added_files:
+        deleted_files:
+          - file3
+          - file4
+      ''');
+      final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+      expect(manifest.mergedFiles.isEmpty, false);
+      expect(manifest.conflictFiles.isEmpty, true);
+      expect(manifest.addedFiles.isEmpty, true);
+      expect(manifest.deletedFiles.isEmpty, false);
+
+      expect(manifest.mergedFiles.length, 2);
+      expect(manifest.conflictFiles.length, 0);
+      expect(manifest.addedFiles.length, 0);
+      expect(manifest.deletedFiles.length, 2);
+
+      expect(manifest.mergedFiles[0], 'file1');
+      expect(manifest.mergedFiles[1], 'file2');
+      expect(manifest.deletedFiles[0], 'file3');
+      expect(manifest.deletedFiles[1], 'file4');
+
+      manifest.writeFile();
+      expect(manifestFile.readAsStringSync(), '''
+merged_files:
+  - file1
+  - file2
+conflict_files:
+added_files:
+deleted_files:
+  - file3
+  - file4
+''');
+    });
+  });
+}

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
@@ -191,11 +191,28 @@ void main() {
     });
   });
 
-  group('sdk', () {
-    testWithoutContext('clone', () async {
-      projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_sdk_test');;
+  group('legacy app creation', () {
+    testWithoutContext('clone and create', () async {
+      projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_sdk_test');
       expect(await MigrateUtils.cloneFlutter('5391447fae6209bb21a89e6a5a6583cac1af9b4b', projectRoot.path, logger), true);
-      expect(projectRoot.childFile('README.md').existsSync());
+      expect(projectRoot.childFile('README.md').existsSync(), true);
+
+      final Directory appDir = fileSystem.systemTempDirectory.createTempSync('flutter_app');
+      await MigrateUtils.createFromTemplates(
+        projectRoot.childDirectory('bin').path,
+        name: 'testapp',
+        androidLanguage: 'java',
+        iosLanguage: 'objc',
+        outputDirectory: appDir.path,
+        logger: logger,
+        fileSystem: fileSystem,
+      );
+      expect(appDir.childFile('pubspec.yaml').existsSync(), true);
+      expect(appDir.childFile('.metadata').existsSync(), true);
+      expect(appDir.childDirectory('android').existsSync(), true);
+      expect(appDir.childDirectory('ios').existsSync(), true);
+      expect(appDir.childDirectory('web').existsSync(), false);
+
       projectRoot.deleteSync(recursive: true);
     });
   });

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
@@ -4,8 +4,11 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
-import 'package:flutter_tools/src/base/config.dart';
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+// import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
@@ -13,22 +16,93 @@ import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
-import '../../src/fake_process_manager.dart';
 
-  group('Auto signing', () {
-    late Config testConfig;
-    late AnsiTerminal testTerminal;
-    late BufferLogger logger;
+void main() {
+  late BufferLogger logger;
+  late FileSystem fileSystem;
+  late Directory projectRoot;
+  late String projectRootPath;
 
+  setUpAll(() async {
+    fileSystem = LocalFileSystem();
+    logger = BufferLogger.test();
+  });
+
+  group('git', () {
     setUp(() async {
-      logger = BufferLogger.test();
-      testConfig = Config.test();
-      testTerminal = TestTerminal();
-      // testTerminal.usesTerminalUi = true;
+      projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_migrate_utils_test');;
+      projectRoot.createSync(recursive: true);
+      projectRootPath = projectRoot.path;
     });
 
-    testWithoutContext('git init', () async {
-      MigrateUtils.gitInit();
+    testWithoutContext('init', () async {
+      expect(projectRoot.existsSync(), true);
+      expect(projectRoot.childDirectory('.git').existsSync(), false);
+      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(projectRoot.childDirectory('.git').existsSync(), true);
+    });
+
+    testWithoutContext('isGitIgnored', () async {
+      expect(projectRoot.existsSync(), true);
+      expect(projectRoot.childDirectory('.git').existsSync(), false);
+      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(projectRoot.childDirectory('.git').existsSync(), true);
+
+      projectRoot.childFile('.gitignore')
+        ..createSync()
+        ..writeAsStringSync('ignored_file.dart', flush: true);
+
+      expect(await MigrateUtils.isGitIgnored('ignored_file.dart', projectRootPath, logger), true);
+      expect(await MigrateUtils.isGitIgnored('other_file.dart', projectRootPath, logger), false);
+    });
+
+    testWithoutContext('isGitRepo', () async {
+      expect(projectRoot.existsSync(), true);
+      expect(projectRoot.childDirectory('.git').existsSync(), false);
+      expect(await MigrateUtils.isGitRepo(projectRootPath, logger), false);
+      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(projectRoot.childDirectory('.git').existsSync(), true);
+      expect(await MigrateUtils.isGitRepo(projectRootPath, logger), true);
+    });
+
+    testWithoutContext('hasUncommitedChanges', () async {
+      expect(projectRoot.existsSync(), true);
+      expect(projectRoot.childDirectory('.git').existsSync(), false);
+      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(projectRoot.childDirectory('.git').existsSync(), true);
+
+      projectRoot.childFile('some_file.dart')
+        ..createSync()
+        ..writeAsStringSync('void main() {}', flush: true);
+
+      expect(await MigrateUtils.hasUncommitedChanges(projectRootPath, logger), true);
+    });
+
+    testWithoutContext('diffFiles', () async {
+      expect(projectRoot.existsSync(), true);
+      expect(projectRoot.childDirectory('.git').existsSync(), false);
+      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(projectRoot.childDirectory('.git').existsSync(), true);
+
+      final File file1 = projectRoot.childFile('some_file.dart')
+        ..createSync()
+        ..writeAsStringSync('void main() {}', flush: true);
+
+      final File file2 = projectRoot.childFile('some_file.dart')
+        ..createSync()
+        ..writeAsStringSync('void main() {}blak', flush: true);
+
+      DiffResult result = await MigrateUtils.diffFiles(file1, file2, logger);
+      expect(result.diff, '');
+      expect(result.exitCode, 0);
+
+      // print(file2.readAsStringSync());
+
+      // file2.writeAsStringSync('void main() {}\na second line\na third line', flush: true);
+      
+      // result = await MigrateUtils.diffFiles(file1, file2, logger);
+      // expect(result.diff, '');
+      // expect(result.exitCode, 1);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_tools/src/base/config.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/migrate/migrate_utils.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+
+import '../../src/common.dart';
+import '../../src/fake_process_manager.dart';
+
+  group('Auto signing', () {
+    late Config testConfig;
+    late AnsiTerminal testTerminal;
+    late BufferLogger logger;
+
+    setUp(() async {
+      logger = BufferLogger.test();
+      testConfig = Config.test();
+      testTerminal = TestTerminal();
+      // testTerminal.usesTerminalUi = true;
+    });
+
+    testWithoutContext('git init', () async {
+      MigrateUtils.gitInit();
+    });
+  });
+}
+

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
@@ -11,6 +11,7 @@ import 'package:file/local.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
@@ -189,4 +190,14 @@ void main() {
       expect(result.exitCode, 0);
     });
   });
+
+  group('sdk', () {
+    testWithoutContext('clone', () async {
+      projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_sdk_test');;
+      expect(await MigrateUtils.cloneFlutter('5391447fae6209bb21a89e6a5a6583cac1af9b4b', projectRoot.path, logger), true);
+      expect(projectRoot.childFile('README.md').existsSync());
+      projectRoot.deleteSync(recursive: true);
+    });
+  });
+
 }

--- a/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/migrate/migrate_utils_test.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-// import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
@@ -86,24 +85,108 @@ void main() {
 
       final File file1 = projectRoot.childFile('some_file.dart')
         ..createSync()
-        ..writeAsStringSync('void main() {}', flush: true);
+        ..writeAsStringSync('void main() {}\n', flush: true);
 
-      final File file2 = projectRoot.childFile('some_file.dart')
-        ..createSync()
-        ..writeAsStringSync('void main() {}blak', flush: true);
+      final File file2 = projectRoot.childFile('some_other_file.dart');
 
       DiffResult result = await MigrateUtils.diffFiles(file1, file2, logger);
       expect(result.diff, '');
+      expect(result.isAddition, false);
+      expect(result.isIgnored, false);
+      expect(result.isDeletion, true);
       expect(result.exitCode, 0);
 
-      // print(file2.readAsStringSync());
+      result = await MigrateUtils.diffFiles(file2, file1, logger);
+      expect(result.diff, '');
+      expect(result.isAddition, true);
+      expect(result.isIgnored, false);
+      expect(result.isDeletion, false);
+      expect(result.exitCode, 0);
 
-      // file2.writeAsStringSync('void main() {}\na second line\na third line', flush: true);
-      
-      // result = await MigrateUtils.diffFiles(file1, file2, logger);
-      // expect(result.diff, '');
-      // expect(result.exitCode, 1);
+      file2.createSync();
+      file2.writeAsStringSync('void main() {}\n', flush: true);
+
+      result = await MigrateUtils.diffFiles(file1, file2, logger);
+      expect(result.diff, '');
+      expect(result.isAddition, false);
+      expect(result.isIgnored, false);
+      expect(result.isDeletion, false);
+      expect(result.exitCode, 0);
+
+      file2.writeAsStringSync('void main() {}\na second line\na third line\n', flush: true);
+
+      result = await MigrateUtils.diffFiles(file1, file2, logger);
+      expect(result.diff, contains('@@ -1 +1,3 @@\n void main() {}\n+a second line\n+a third line'));
+      expect(result.isAddition, false);
+      expect(result.isIgnored, false);
+      expect(result.isDeletion, false);
+      expect(result.exitCode, 1);
+    });
+
+    testWithoutContext('merge', () async {
+      expect(projectRoot.existsSync(), true);
+      expect(projectRoot.childDirectory('.git').existsSync(), false);
+      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(projectRoot.childDirectory('.git').existsSync(), true);
+
+      final File file1 = projectRoot.childFile('some_file.dart');
+      file1.createSync();
+      file1.writeAsStringSync('void main() {}\n\nline1\nline2\nline3\nline4\nline5\n', flush: true);
+      final File file2 = projectRoot.childFile('some_other_file.dart');
+      file2.createSync();
+      file2.writeAsStringSync('void main() {}\n\nline1\nline2\nline3.0\nline3.5\nline4\nline5\n', flush: true);
+      final File file3 = projectRoot.childFile('some_other_third_file.dart');
+      file3.createSync();
+      file3.writeAsStringSync('void main() {}\n\nline2\nline3\nline4\nline5\n', flush: true);
+
+      MergeResult result = await MigrateUtils.gitMergeFile(
+        base: file1.path,
+        current: file2.path,
+        target: file3.path,
+        localPath: 'some_file.dart',
+        logger: logger,
+      );
+      expect(result.mergedString, 'void main() {}\n\nline2\nline3.0\nline3.5\nline4\nline5\n');
+      expect(result.hasConflict, false);
+      expect(result.exitCode, 0);
+
+      file3.writeAsStringSync('void main() {}\n\nline1\nline2\nline3.1\nline3.5\nline4\nline5\n', flush: true);
+
+      result = await MigrateUtils.gitMergeFile(
+        base: file1.path,
+        current: file2.path,
+        target: file3.path,
+        localPath: 'some_file.dart',
+        logger: logger,
+      );
+      expect(result.mergedString, contains('line3.0\n=======\nline3.1\n>>>>>>>'));
+      expect(result.hasConflict, true);
+      expect(result.exitCode, 1);
+    });
+  });
+
+  group('DiffResult', () {
+    testWithoutContext('init works', () async {
+      DiffResult result = DiffResult.addition();
+      expect(result.diff, '');
+      expect(result.isAddition, true);
+      expect(result.isIgnored, false);
+      expect(result.isDeletion, false);
+      expect(result.exitCode, 0);
+
+      result = DiffResult.deletion();
+      expect(result.diff, '');
+      expect(result.isAddition, false);
+      expect(result.isIgnored, false);
+      expect(result.isDeletion, true);
+      expect(result.exitCode, 0);
+
+      result = DiffResult.ignored();
+      expect(result.diff, '');
+      expect(result.isAddition, false);
+      expect(result.isIgnored, true);
+      expect(result.isDeletion, false);
+      expect(result.exitCode, 0);
     });
   });
 }
-

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -10,7 +10,6 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
-import 'package:platform/platform.dart';
 
 import '../src/common.dart';
 
@@ -28,7 +27,7 @@ void main() {
     utils = MigrateUtils(
       logger: logger,
       fileSystem: fileSystem,
-      platform: FakePlatform(),
+      platform: globals.platform,
       processManager: globals.processManager,
     );
     processUtils = ProcessUtils(processManager: globals.processManager, logger: logger);

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -5,8 +5,8 @@
 // @dart = 2.8
 
 import 'package:file/file.dart';
-import 'package:file/local.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
@@ -23,7 +23,7 @@ void main() {
   ProcessUtils processUtils;
 
   setUpAll(() async {
-    fileSystem = const LocalFileSystem();
+    fileSystem = globals.localFileSystem;
     logger = BufferLogger.test();
     utils = MigrateUtils(
       logger: logger,

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -4,22 +4,14 @@
 
 // @dart = 2.8
 
-import 'dart:async';
-import 'dart:convert';
-
 import 'package:file/file.dart';
 import 'package:file/local.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/process.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/cache.dart';
-import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:platform/platform.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 
 void main() {
   BufferLogger logger;
@@ -29,7 +21,7 @@ void main() {
   MigrateUtils utils;
 
   setUpAll(() async {
-    fileSystem = LocalFileSystem();
+    fileSystem = const LocalFileSystem();
     logger = BufferLogger.test();
     utils = MigrateUtils(
       logger: logger,
@@ -41,7 +33,7 @@ void main() {
 
   group('git', () {
     setUp(() async {
-      projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_migrate_utils_test');;
+      projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_migrate_utils_test');
       projectRoot.createSync(recursive: true);
       projectRootPath = projectRoot.path;
     });
@@ -172,7 +164,7 @@ void main() {
   group('legacy app creation', () {
     testWithoutContext('clone and create', () async {
       projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_sdk_test');
-      final String revision = '5391447fae6209bb21a89e6a5a6583cac1af9b4b';
+      const String revision = '5391447fae6209bb21a89e6a5a6583cac1af9b4b';
 
       expect(await utils.cloneFlutter(revision, projectRoot.path), true);
       expect(projectRoot.childFile('README.md').existsSync(), true);

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart = 2.8
+
 import 'dart:async';
 import 'dart:convert';
 
@@ -20,11 +22,11 @@ import '../src/common.dart';
 import '../src/context.dart';
 
 void main() {
-  late BufferLogger logger;
-  late FileSystem fileSystem;
-  late Directory projectRoot;
-  late String projectRootPath;
-  late MigrateUtils utils;
+  BufferLogger logger;
+  FileSystem fileSystem;
+  Directory projectRoot;
+  String projectRootPath;
+  MigrateUtils utils;
 
   setUpAll(() async {
     fileSystem = LocalFileSystem();
@@ -100,14 +102,14 @@ void main() {
       final File file2 = projectRoot.childFile('some_other_file.dart');
 
       DiffResult result = await utils.diffFiles(file1, file2);
-      expect(result.diff, '');
+      expect(result.diff, null);
       expect(result.diffType, DiffType.deletion);
-      expect(result.exitCode, 0);
+      expect(result.exitCode, null);
 
       result = await utils.diffFiles(file2, file1);
-      expect(result.diff, '');
+      expect(result.diff, null);
       expect(result.diffType, DiffType.addition);
-      expect(result.exitCode, 0);
+      expect(result.exitCode, null);
 
       file2.createSync();
       file2.writeAsStringSync('void main() {}\n', flush: true);

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -4,28 +4,37 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:platform/platform.dart';
 
-import '../../src/common.dart';
+import '../src/common.dart';
+import '../src/context.dart';
 
 void main() {
   late BufferLogger logger;
   late FileSystem fileSystem;
   late Directory projectRoot;
   late String projectRootPath;
+  late MigrateUtils utils;
 
   setUpAll(() async {
     fileSystem = LocalFileSystem();
     logger = BufferLogger.test();
+    utils = MigrateUtils(
+      logger: logger,
+      fileSystem: fileSystem,
+      platform: FakePlatform(),
+      processManager: globals.processManager,
+    );
   });
 
   group('git', () {
@@ -38,50 +47,50 @@ void main() {
     testWithoutContext('init', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
-      await MigrateUtils.gitInit(projectRootPath, logger);
+      await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
     });
 
     testWithoutContext('isGitIgnored', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
-      await MigrateUtils.gitInit(projectRootPath, logger);
+      await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
 
       projectRoot.childFile('.gitignore')
         ..createSync()
         ..writeAsStringSync('ignored_file.dart', flush: true);
 
-      expect(await MigrateUtils.isGitIgnored('ignored_file.dart', projectRootPath, logger), true);
-      expect(await MigrateUtils.isGitIgnored('other_file.dart', projectRootPath, logger), false);
+      expect(await utils.isGitIgnored('ignored_file.dart', projectRootPath), true);
+      expect(await utils.isGitIgnored('other_file.dart', projectRootPath), false);
     });
 
     testWithoutContext('isGitRepo', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
-      expect(await MigrateUtils.isGitRepo(projectRootPath, logger), false);
-      await MigrateUtils.gitInit(projectRootPath, logger);
+      expect(await utils.isGitRepo(projectRootPath), false);
+      await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
-      expect(await MigrateUtils.isGitRepo(projectRootPath, logger), true);
+      expect(await utils.isGitRepo(projectRootPath), true);
     });
 
     testWithoutContext('hasUncommitedChanges', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
-      await MigrateUtils.gitInit(projectRootPath, logger);
+      await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
 
       projectRoot.childFile('some_file.dart')
         ..createSync()
         ..writeAsStringSync('void main() {}', flush: true);
 
-      expect(await MigrateUtils.hasUncommitedChanges(projectRootPath, logger), true);
+      expect(await utils.hasUncommitedChanges(projectRootPath), true);
     });
 
     testWithoutContext('diffFiles', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
-      await MigrateUtils.gitInit(projectRootPath, logger);
+      await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
 
       final File file1 = projectRoot.childFile('some_file.dart')
@@ -90,44 +99,36 @@ void main() {
 
       final File file2 = projectRoot.childFile('some_other_file.dart');
 
-      DiffResult result = await MigrateUtils.diffFiles(file1, file2, logger);
+      DiffResult result = await utils.diffFiles(file1, file2);
       expect(result.diff, '');
-      expect(result.isAddition, false);
-      expect(result.isIgnored, false);
-      expect(result.isDeletion, true);
+      expect(result.diffType, DiffType.deletion);
       expect(result.exitCode, 0);
 
-      result = await MigrateUtils.diffFiles(file2, file1, logger);
+      result = await utils.diffFiles(file2, file1);
       expect(result.diff, '');
-      expect(result.isAddition, true);
-      expect(result.isIgnored, false);
-      expect(result.isDeletion, false);
+      expect(result.diffType, DiffType.addition);
       expect(result.exitCode, 0);
 
       file2.createSync();
       file2.writeAsStringSync('void main() {}\n', flush: true);
 
-      result = await MigrateUtils.diffFiles(file1, file2, logger);
+      result = await utils.diffFiles(file1, file2);
       expect(result.diff, '');
-      expect(result.isAddition, false);
-      expect(result.isIgnored, false);
-      expect(result.isDeletion, false);
+      expect(result.diffType, DiffType.modification);
       expect(result.exitCode, 0);
 
       file2.writeAsStringSync('void main() {}\na second line\na third line\n', flush: true);
 
-      result = await MigrateUtils.diffFiles(file1, file2, logger);
+      result = await utils.diffFiles(file1, file2);
       expect(result.diff, contains('@@ -1 +1,3 @@\n void main() {}\n+a second line\n+a third line'));
-      expect(result.isAddition, false);
-      expect(result.isIgnored, false);
-      expect(result.isDeletion, false);
+      expect(result.diffType, DiffType.modification);
       expect(result.exitCode, 1);
     });
 
     testWithoutContext('merge', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
-      await MigrateUtils.gitInit(projectRootPath, logger);
+      await utils.gitInit(projectRootPath);
       expect(projectRoot.childDirectory('.git').existsSync(), true);
 
       final File file1 = projectRoot.childFile('some_file.dart');
@@ -140,75 +141,51 @@ void main() {
       file3.createSync();
       file3.writeAsStringSync('void main() {}\n\nline2\nline3\nline4\nline5\n', flush: true);
 
-      MergeResult result = await MigrateUtils.gitMergeFile(
+      StringMergeResult result = await utils.gitMergeFile(
         base: file1.path,
         current: file2.path,
         target: file3.path,
         localPath: 'some_file.dart',
-        logger: logger,
-      );
+      ) as StringMergeResult;
+
       expect(result.mergedString, 'void main() {}\n\nline2\nline3.0\nline3.5\nline4\nline5\n');
       expect(result.hasConflict, false);
       expect(result.exitCode, 0);
 
       file3.writeAsStringSync('void main() {}\n\nline1\nline2\nline3.1\nline3.5\nline4\nline5\n', flush: true);
 
-      result = await MigrateUtils.gitMergeFile(
+      result = await utils.gitMergeFile(
         base: file1.path,
         current: file2.path,
         target: file3.path,
         localPath: 'some_file.dart',
-        logger: logger,
-      );
+      ) as StringMergeResult;
+
       expect(result.mergedString, contains('line3.0\n=======\nline3.1\n>>>>>>>'));
       expect(result.hasConflict, true);
       expect(result.exitCode, 1);
     });
   });
 
-  group('DiffResult', () {
-    testWithoutContext('init works', () async {
-      DiffResult result = DiffResult.addition();
-      expect(result.diff, '');
-      expect(result.isAddition, true);
-      expect(result.isIgnored, false);
-      expect(result.isDeletion, false);
-      expect(result.exitCode, 0);
-
-      result = DiffResult.deletion();
-      expect(result.diff, '');
-      expect(result.isAddition, false);
-      expect(result.isIgnored, false);
-      expect(result.isDeletion, true);
-      expect(result.exitCode, 0);
-
-      result = DiffResult.ignored();
-      expect(result.diff, '');
-      expect(result.isAddition, false);
-      expect(result.isIgnored, true);
-      expect(result.isDeletion, false);
-      expect(result.exitCode, 0);
-    });
-  });
-
   group('legacy app creation', () {
     testWithoutContext('clone and create', () async {
       projectRoot = fileSystem.systemTempDirectory.createTempSync('flutter_sdk_test');
-      expect(await MigrateUtils.cloneFlutter('5391447fae6209bb21a89e6a5a6583cac1af9b4b', projectRoot.path, logger), true);
+      final String revision = '5391447fae6209bb21a89e6a5a6583cac1af9b4b';
+
+      expect(await utils.cloneFlutter(revision, projectRoot.path), true);
       expect(projectRoot.childFile('README.md').existsSync(), true);
 
       final Directory appDir = fileSystem.systemTempDirectory.createTempSync('flutter_app');
-      await MigrateUtils.createFromTemplates(
+      await utils.createFromTemplates(
         projectRoot.childDirectory('bin').path,
         name: 'testapp',
         androidLanguage: 'java',
         iosLanguage: 'objc',
         outputDirectory: appDir.path,
-        logger: logger,
-        fileSystem: fileSystem,
       );
       expect(appDir.childFile('pubspec.yaml').existsSync(), true);
       expect(appDir.childFile('.metadata').existsSync(), true);
+      expect(appDir.childFile('.metadata').readAsStringSync(), contains(revision));
       expect(appDir.childDirectory('android').existsSync(), true);
       expect(appDir.childDirectory('ios').existsSync(), true);
       expect(appDir.childDirectory('web').existsSync(), false);
@@ -216,5 +193,4 @@ void main() {
       projectRoot.deleteSync(recursive: true);
     });
   });
-
 }

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -73,7 +73,7 @@ void main() {
       expect(await utils.isGitRepo(projectRoot.parent.path), false);
     });
 
-    testWithoutContext('hasUncommitedChanges false on clean repo', () async {
+    testWithoutContext('hasUncommittedChanges false on clean repo', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
       await utils.gitInit(projectRootPath);
@@ -86,10 +86,10 @@ void main() {
       await processUtils.run(<String>['git', 'add', '.'], workingDirectory: projectRootPath);
       await processUtils.run(<String>['git', 'commit', '-m', 'Initial commit'], workingDirectory: projectRootPath);
 
-      expect(await utils.hasUncommitedChanges(projectRootPath), false);
+      expect(await utils.hasUncommittedChanges(projectRootPath), false);
     });
 
-    testWithoutContext('hasUncommitedChanges true on dirty repo', () async {
+    testWithoutContext('hasUncommittedChanges true on dirty repo', () async {
       expect(projectRoot.existsSync(), true);
       expect(projectRoot.childDirectory('.git').existsSync(), false);
       await utils.gitInit(projectRootPath);
@@ -99,7 +99,7 @@ void main() {
         ..createSync()
         ..writeAsStringSync('void main() {}', flush: true);
 
-      expect(await utils.hasUncommitedChanges(projectRootPath), true);
+      expect(await utils.hasUncommittedChanges(projectRootPath), true);
     });
 
     testWithoutContext('diffFiles', () async {
@@ -129,14 +129,14 @@ void main() {
 
       result = await utils.diffFiles(file1, file2);
       expect(result.diff, '');
-      expect(result.diffType, DiffType.modification);
+      expect(result.diffType, DiffType.command);
       expect(result.exitCode, 0);
 
       file2.writeAsStringSync('void main() {}\na second line\na third line\n', flush: true);
 
       result = await utils.diffFiles(file1, file2);
       expect(result.diff, contains('@@ -1 +1,3 @@\n void main() {}\n+a second line\n+a third line'));
-      expect(result.diffType, DiffType.modification);
+      expect(result.diffType, DiffType.command);
       expect(result.exitCode, 1);
     });
 

--- a/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_utils_test.dart
@@ -5,8 +5,8 @@
 // @dart = 2.8
 
 import 'package:file/file.dart';
-import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';


### PR DESCRIPTION
MigrateUtils is the utility class that handles the git and flutter commands used by the migrate tool.

MigrateManifest is a working metadata file that tracks the files to be changed by the migrate tool.

This code is inaccessible by the rest of the tool as of now.
