### PR TITLE
Prevent Mediaquery from losing navigationMode value when removePadding() is called

### DIFF
--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -438,11 +438,7 @@ class MediaQueryData {
   }) {
     if (!(removeLeft || removeTop || removeRight || removeBottom))
       return this;
-    return MediaQueryData(
-      size: size,
-      devicePixelRatio: devicePixelRatio,
-      textScaleFactor: textScaleFactor,
-      platformBrightness: platformBrightness,
+    return copyWith(
       padding: padding.copyWith(
         left: removeLeft ? 0.0 : null,
         top: removeTop ? 0.0 : null,
@@ -455,15 +451,6 @@ class MediaQueryData {
         right: removeRight ? math.max(0.0, viewPadding.right - padding.right) : null,
         bottom: removeBottom ? math.max(0.0, viewPadding.bottom - padding.bottom) : null,
       ),
-      viewInsets: viewInsets,
-      alwaysUse24HourFormat: alwaysUse24HourFormat,
-      highContrast: highContrast,
-      disableAnimations: disableAnimations,
-      invertColors: invertColors,
-      accessibleNavigation: accessibleNavigation,
-      boldText: boldText,
-      gestureSettings: gestureSettings,
-      displayFeatures: displayFeatures,
     );
   }
 
@@ -488,12 +475,7 @@ class MediaQueryData {
   }) {
     if (!(removeLeft || removeTop || removeRight || removeBottom))
       return this;
-    return MediaQueryData(
-      size: size,
-      devicePixelRatio: devicePixelRatio,
-      textScaleFactor: textScaleFactor,
-      platformBrightness: platformBrightness,
-      padding: padding,
+    return copyWith(
       viewPadding: viewPadding.copyWith(
         left: removeLeft ? math.max(0.0, viewPadding.left - viewInsets.left) : null,
         top: removeTop ? math.max(0.0, viewPadding.top - viewInsets.top) : null,
@@ -506,14 +488,6 @@ class MediaQueryData {
         right: removeRight ? 0.0 : null,
         bottom: removeBottom ? 0.0 : null,
       ),
-      alwaysUse24HourFormat: alwaysUse24HourFormat,
-      highContrast: highContrast,
-      disableAnimations: disableAnimations,
-      invertColors: invertColors,
-      accessibleNavigation: accessibleNavigation,
-      boldText: boldText,
-      gestureSettings: gestureSettings,
-      displayFeatures: displayFeatures,
     );
   }
 
@@ -538,32 +512,19 @@ class MediaQueryData {
   }) {
     if (!(removeLeft || removeTop || removeRight || removeBottom))
       return this;
-    return MediaQueryData(
-      size: size,
-      devicePixelRatio: devicePixelRatio,
-      textScaleFactor: textScaleFactor,
-      platformBrightness: platformBrightness,
+    return copyWith(
       padding: padding.copyWith(
         left: removeLeft ? 0.0 : null,
         top: removeTop ? 0.0 : null,
         right: removeRight ? 0.0 : null,
         bottom: removeBottom ? 0.0 : null,
       ),
-      viewInsets: viewInsets,
       viewPadding: viewPadding.copyWith(
         left: removeLeft ? 0.0 : null,
         top: removeTop ? 0.0 : null,
         right: removeRight ? 0.0 : null,
         bottom: removeBottom ? 0.0 : null,
       ),
-      alwaysUse24HourFormat: alwaysUse24HourFormat,
-      highContrast: highContrast,
-      disableAnimations: disableAnimations,
-      invertColors: invertColors,
-      accessibleNavigation: accessibleNavigation,
-      boldText: boldText,
-      gestureSettings: gestureSettings,
-      displayFeatures: displayFeatures,
     );
   }
 

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -171,6 +171,7 @@ void main() {
       boldText: true,
       highContrast: true,
       platformBrightness: Brightness.dark,
+      navigationMode: NavigationMode.directional,
       gestureSettings: gestureSettings,
       displayFeatures: customDisplayFeatures,
     );
@@ -188,6 +189,7 @@ void main() {
     expect(copied.boldText, true);
     expect(copied.highContrast, true);
     expect(copied.platformBrightness, Brightness.dark);
+    expect(copied.navigationMode, NavigationMode.directional);
     expect(copied.gestureSettings, gestureSettings);
     expect(copied.displayFeatures, customDisplayFeatures);
   });
@@ -223,6 +225,7 @@ void main() {
           disableAnimations: true,
           boldText: true,
           highContrast: true,
+          navigationMode: NavigationMode.directional,
           displayFeatures: displayFeatures,
         ),
         child: Builder(
@@ -257,6 +260,7 @@ void main() {
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
+    expect(unpadded.navigationMode, NavigationMode.directional);
     expect(unpadded.displayFeatures, displayFeatures);
   });
 
@@ -291,6 +295,7 @@ void main() {
           disableAnimations: true,
           boldText: true,
           highContrast: true,
+          navigationMode: NavigationMode.directional,
           displayFeatures: displayFeatures,
         ),
         child: Builder(
@@ -322,6 +327,7 @@ void main() {
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
+    expect(unpadded.navigationMode, NavigationMode.directional);
     expect(unpadded.displayFeatures, displayFeatures);
   });
 
@@ -356,6 +362,7 @@ void main() {
           disableAnimations: true,
           boldText: true,
           highContrast: true,
+          navigationMode: NavigationMode.directional,
           displayFeatures: displayFeatures,
         ),
         child: Builder(
@@ -390,6 +397,7 @@ void main() {
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
+    expect(unpadded.navigationMode, NavigationMode.directional);
     expect(unpadded.displayFeatures, displayFeatures);
   });
 
@@ -424,6 +432,7 @@ void main() {
           disableAnimations: true,
           boldText: true,
           highContrast: true,
+          navigationMode: NavigationMode.directional,
           displayFeatures: displayFeatures,
         ),
         child: Builder(
@@ -455,6 +464,7 @@ void main() {
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
+    expect(unpadded.navigationMode, NavigationMode.directional);
     expect(unpadded.displayFeatures, displayFeatures);
   });
 
@@ -489,6 +499,7 @@ void main() {
           disableAnimations: true,
           boldText: true,
           highContrast: true,
+          navigationMode: NavigationMode.directional,
           displayFeatures: displayFeatures,
         ),
         child: Builder(
@@ -523,6 +534,7 @@ void main() {
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
+    expect(unpadded.navigationMode, NavigationMode.directional);
     expect(unpadded.displayFeatures, displayFeatures);
   });
 
@@ -557,6 +569,7 @@ void main() {
           disableAnimations: true,
           boldText: true,
           highContrast: true,
+          navigationMode: NavigationMode.directional,
           displayFeatures: displayFeatures,
         ),
         child: Builder(
@@ -588,6 +601,7 @@ void main() {
     expect(unpadded.disableAnimations, true);
     expect(unpadded.boldText, true);
     expect(unpadded.highContrast, true);
+    expect(unpadded.navigationMode, NavigationMode.directional);
     expect(unpadded.displayFeatures, displayFeatures);
   });
 
@@ -900,7 +914,7 @@ void main() {
     );
     expect(
       subScreenMediaQuery.viewPadding,
-      const EdgeInsets.only(top: 6.0, left:4.0, right: 8.0, bottom: 12.0),
+      const EdgeInsets.only(top: 6.0, left: 4.0, right: 8.0, bottom: 12.0),
     );
     expect(
       subScreenMediaQuery.viewInsets,


### PR DESCRIPTION
Fixing an issue where MediaQuery loses the value of the navigationMode field when removePadding(), removeViewPadding() or removeViewInsets() are called.

Switching those methods to use the copy constructor to prevent similar issues in the future.
