### PR TITLE
Exclude armv7 from iOS add-to-app plugins

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -265,11 +265,37 @@ dependencies:
       final File objectiveCAnalyticsOutputFile = File(path.join(tempDir.path, 'analytics-objc.log'));
       final Directory objectiveCBuildDirectory = Directory(path.join(tempDir.path, 'build-objc'));
 
-      section('Build iOS Objective-C host app');
-
       final File dummyAppFramework = File(path.join(projectDir.path, '.ios', 'Flutter', 'App.framework', 'App'));
       checkFileNotExists(dummyAppFramework.path);
       await inDirectory(objectiveCHostApp, () async {
+        section('Validate iOS Objective-C host app Podfile');
+
+        final File podfile = File(path.join(objectiveCHostApp.path, 'Podfile'));
+        String podfileContent = await podfile.readAsString();
+        final String podFailure = await eval(
+          'pod',
+          <String>['install'],
+          environment: <String, String>{
+            'LANG': 'en_US.UTF-8',
+          },
+          canFail: true,
+        );
+
+        if (!podFailure.contains('Missing `flutter_post_install(installer)` in Podfile `post_install` block')
+            || !podFailure.contains('Add `flutter_post_install(installer)` to your Podfile `post_install` block to build Flutter plugins')) {
+          print(podfileContent);
+          throw TaskResult.failure('pod install unexpectedly succeed without "flutter_post_install" post_install block');
+        }
+        podfileContent = '''
+$podfileContent
+
+post_install do |installer|
+  flutter_post_install(installer)
+end
+          ''';
+        await podfile.writeAsString(podfileContent, flush: true);
+        print(podfileContent);
+
         await exec(
           'pod',
           <String>['install'],
@@ -297,6 +323,8 @@ dependencies:
         if (version != '9.0') {
           throw TaskResult.failure('Minimum version set to $version, expected 9.0');
         }
+
+        section('Build iOS Objective-C host app');
 
         await exec(
           'xcodebuild',
@@ -377,6 +405,86 @@ dependencies:
           'but not the expected strings: "cd24: ios", "cd25: true", "viewName: assemble"'
         );
       }
+
+      section('Archive iOS Objective-C host app');
+
+      await inDirectory(objectiveCHostApp, () async {
+        final Directory objectiveCBuildArchiveDirectory = Directory(path.join(tempDir.path, 'build-objc-archive'));
+        await exec(
+          'xcodebuild',
+          <String>[
+            '-workspace',
+            'Host.xcworkspace',
+            '-scheme',
+            'Host',
+            '-configuration',
+            'Release',
+            'CODE_SIGNING_ALLOWED=NO',
+            'CODE_SIGNING_REQUIRED=NO',
+            'CODE_SIGN_IDENTITY=-',
+            'EXPANDED_CODE_SIGN_IDENTITY=-',
+            '-archivePath',
+            objectiveCBuildArchiveDirectory.path,
+            'COMPILER_INDEX_STORE_ENABLE=NO',
+            'archive'
+          ],
+          environment: <String, String> {
+            'FLUTTER_ANALYTICS_LOG_FILE': objectiveCAnalyticsOutputFile.path,
+          },
+        );
+
+        final String archivedAppPath = path.join(
+          '${objectiveCBuildArchiveDirectory.path}.xcarchive',
+          'Products',
+          'Applications',
+          'Host.app',
+        );
+
+        checkFileExists(path.join(
+          archivedAppPath,
+          'Host',
+        ));
+
+        checkFileNotExists(path.join(
+          archivedAppPath,
+          'Frameworks',
+          'App.framework',
+          'flutter_assets',
+          'isolate_snapshot_data',
+        ));
+
+        final String builtFlutterBinary = path.join(
+          archivedAppPath,
+          'Frameworks',
+          'Flutter.framework',
+          'Flutter',
+        );
+        checkFileExists(builtFlutterBinary);
+        if ((await fileType(builtFlutterBinary)).contains('armv7')) {
+          throw TaskResult.failure('Unexpected armv7 architecture slice in $builtFlutterBinary');
+        }
+        await containsBitcode(builtFlutterBinary);
+
+        final String builtAppBinary = path.join(
+          archivedAppPath,
+          'Frameworks',
+          'App.framework',
+          'App',
+        );
+        checkFileExists(builtAppBinary);
+        if ((await fileType(builtAppBinary)).contains('armv7')) {
+          throw TaskResult.failure('Unexpected armv7 architecture slice in $builtAppBinary');
+        }
+        await containsBitcode(builtAppBinary);
+
+        // The host app example builds plugins statically, url_launcher_ios.framework
+        // should not exist.
+        checkDirectoryNotExists(path.join(
+          archivedAppPath,
+          'Frameworks',
+          'url_launcher_ios.framework',
+        ));
+      });
 
       section('Run platform unit tests');
 

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -294,7 +294,6 @@ post_install do |installer|
 end
           ''';
         await podfile.writeAsString(podfileContent, flush: true);
-        print(podfileContent);
 
         await exec(
           'pod',

--- a/dev/integration_tests/ios_add2app_life_cycle/Podfile
+++ b/dev/integration_tests/ios_add2app_life_cycle/Podfile
@@ -13,3 +13,7 @@ target 'ios_add2appTests' do
   install_flutter_engine_pod
   pod 'EarlGreyTest'
 end
+
+post_install do |installer|
+  flutter_post_install(installer)
+end

--- a/dev/integration_tests/ios_host_app_swift/Podfile
+++ b/dev/integration_tests/ios_host_app_swift/Podfile
@@ -6,3 +6,7 @@ load File.join(flutter_application_path, '.ios', 'Flutter', 'podhelper.rb')
 target 'Host' do
   install_all_flutter_pods flutter_application_path
 end
+
+post_install do |installer|
+  flutter_post_install(installer)
+end

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -15,6 +15,21 @@ require 'json'
 #                                          Optional, defaults to two levels up from the directory of this script.
 #                                          MyApp/my_flutter/.ios/Flutter/../..
 def install_all_flutter_pods(flutter_application_path = nil)
+  # defined_in_file is a Pathname to the Podfile set by CocoaPods.
+  pod_contents = File.read(defined_in_file)
+  unless pod_contents.include? 'flutter_post_install'
+    puts  <<~POSTINSTALL
+Add `flutter_post_install(installer)` to your Podfile `post_install` block to build Flutter plugins:
+
+post_install do |installer|
+  flutter_post_install(installer)
+end
+POSTINSTALL
+    raise 'Missing `flutter_post_install(installer)` in Podfile `post_install` block'
+  end
+
+  require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
   flutter_application_path ||= File.join('..', '..')
   install_flutter_engine_pod
   install_flutter_plugin_pods(flutter_application_path)
@@ -46,7 +61,7 @@ def install_flutter_engine_pod
   # Keep pod path relative so it can be checked into Podfile.lock.
   # Process will be run from project directory.
   engine_pathname = Pathname.new engine_dir
-  # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
+  # defined_in_file is a Pathname to the Podfile set by CocoaPods.
   project_directory_pathname = defined_in_file.dirname
   relative = engine_pathname.relative_path_from project_directory_pathname
 
@@ -77,7 +92,9 @@ def install_flutter_plugin_pods(flutter_application_path)
   FileUtils.mkdir_p(symlinks_dir)
 
   plugins_file = File.expand_path('.flutter-plugins-dependencies', flutter_application_path)
-  plugin_pods = flutter_parse_dependencies_file_for_ios_plugin(plugins_file)
+
+  # flutter_parse_plugins_file is in Flutter root podhelper.rb
+  plugin_pods = flutter_parse_plugins_file(plugins_file, 'ios')
   plugin_pods.each do |plugin_hash|
     plugin_name = plugin_hash['name']
     plugin_path = plugin_hash['path']
@@ -127,21 +144,6 @@ def install_flutter_application_pod(flutter_application_path)
     :execution_position => :before_compile
 end
 
-# .flutter-plugins-dependencies format documented at
-# https://flutter.dev/go/plugins-list-migration
-def flutter_parse_dependencies_file_for_ios_plugin(file)
-  file_path = File.expand_path(file)
-  return [] unless File.exists? file_path
-
-  dependencies_file = File.read(file)
-  dependencies_hash = JSON.parse(dependencies_file)
-
-  # dependencies_hash.dig('plugins', 'ios') not available until Ruby 2.3
-  return [] unless dependencies_hash.has_key?('plugins')
-  return [] unless dependencies_hash['plugins'].has_key?('ios')
-  dependencies_hash['plugins']['ios'] || []
-end
-
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('..', '..', 'Flutter', 'Generated.xcconfig'), __FILE__)
   unless File.exist?(generated_xcode_build_settings_path)
@@ -154,4 +156,24 @@ def flutter_root
   end
   # This should never happen...
   raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+# Run the post-install script to set build settings on Flutter plugins.
+#
+# @example
+#   post_install do |installer|
+#     flutter_post_install(installer)
+#   end
+# @param [Pod::Installer] installer Passed to the `post_install` block.
+# @param [boolean] skip Do not change any build configurations. Set to suppress
+#                       "Missing `flutter_post_install" exception.
+def flutter_post_install(installer, skip: false)
+  return if skip
+
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |build_configuration|
+      # flutter_additional_ios_build_settings is in Flutter root podhelper.rb
+      flutter_additional_ios_build_settings(target)
+    end
+  end
 end


### PR DESCRIPTION
- In the add-to-app `podhelper.rb` ruby script file `require` (import) the [Flutter SDK `flutter_tools/bin/podhelper.rb` version of this file](https://github.com/flutter/flutter/blob/ae805de4687480beee3c5f46acb84cfc98dd0fed/packages/flutter_tools/bin/podhelper.rb#L1) to push as much logic as possible into the SDK instead of the module project, and allow sharing logic between these scripts.
- Introduce a new `flutter_post_install` method to the add-to-app `podhelper.rb` ruby script file.  This calls the existing `flutter_additional_ios_build_settings` method in the SDK `podhelper.rb` https://github.com/flutter/flutter/blob/ae805de4687480beee3c5f46acb84cfc98dd0fed/packages/flutter_tools/bin/podhelper.rb#L33
This will update the host app Flutter plugin build settings to:

   1. Link against the right version of the Flutter.framework (simulator, debug, etc) in the artifacts cache, see  https://github.com/flutter/flutter/pull/70224.  This will fix https://github.com/flutter/flutter/issues/75296 since the plugin is now linking directly against the correct artifacts version instead of the last engine variant copied into the module project.
   
   1. Set `EXCLUDED_ARCHS[sdk=iphonesimulator*] = $(inherited) i386` (https://github.com/flutter/flutter/pull/85642) and `EXCLUDED_ARCHS[sdk=iphoneos*]= $(inherited) armv7` (https://github.com/flutter/flutter/pull/97341).  This means Flutter plugins will not build for 32-bit `armv7` iOS, unblocking https://github.com/flutter/flutter/issues/101793
   
   1. Set `ONLY_ACTIVE_ARCH = NO` for plugins in debug mode.  This means both `arm64` and `x86_64` simulator versions of the plugins will be built, so if a plugin doesn't support the `arm64` simulators, the app can link against the x64 version of the plugins https://github.com/flutter/flutter/pull/95293
- Add a fatal Ruby exception to fire on `pod install` that will instruct the user to add the following to their host app Podfile if it's missing:

```ruby
post_install do |installer|
  flutter_post_install(installer)
end
```

Error looks like:
```bash
$ pod install
Add `flutter_post_install(installer)` to your Podfile `post_install` block to build Flutter plugins:

post_install do |installer|
  flutter_post_install(installer)
end

[!] Invalid `Podfile` file: Missing `flutter_post_install(installer)` in Podfile `post_install` block.

 #  from /Users/magder/Projects/samples/add_to_app/plugin/ios_using_plugin/Podfile:12
 #  -------------------------------------------
 #    # Pods for IOSUsingPlugin
 >    install_all_flutter_pods(flutter_application_path)
 #
 #  -------------------------------------------
```

Fixes https://github.com/flutter/flutter/issues/101793
Fixes https://github.com/flutter/flutter/issues/75296
Fixes https://github.com/flutter/flutter/issues/78368
Unblocks https://github.com/flutter/flutter/issues/101793

Samples update: https://github.com/flutter/samples/pull/1079
Website update: https://github.com/flutter/website/pull/7032

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
