### PR TITLE
Register a service extension for `profileUserWidgetBuilds`

### DIFF
--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -435,6 +435,14 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
             debugProfileBuildsEnabled = value;
         },
       );
+      registerBoolServiceExtension(
+        name: 'profileUserWidgetBuilds',
+        getter: () async => debugProfileBuildsEnabledUserWidgets,
+        setter: (bool value) async {
+          if (debugProfileBuildsEnabledUserWidgets != value)
+            debugProfileBuildsEnabledUserWidgets = value;
+        },
+      );
     }
 
     assert(() {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -171,9 +171,14 @@ void main() {
     // 1. exit
     // 2. showPerformanceOverlay
     const int disabledExtensions = kIsWeb ? 2 : 0;
-    // If you add a service extension... TEST IT! :-)
-    // ...then increment this number.
-    expect(binding.extensions.length, 36 + widgetInspectorExtensionCount - disabledExtensions);
+
+    // The expected number of registered service extensions in the Flutter
+    // framework, excluding any that for the widget inspector
+    // (see widget_inspector_test.dart for tests of the ext.flutter.inspector
+    // service extensions).
+    const int serviceExtensionCount = 36;
+
+    expect(binding.extensions.length, serviceExtensionCount + widgetInspectorExtensionCount - disabledExtensions);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -173,7 +173,7 @@ void main() {
     const int disabledExtensions = kIsWeb ? 2 : 0;
 
     // The expected number of registered service extensions in the Flutter
-    // framework, excluding any that for the widget inspector
+    // framework, excluding any that are for the widget inspector
     // (see widget_inspector_test.dart for tests of the ext.flutter.inspector
     // service extensions).
     const int serviceExtensionCount = 36;

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -173,7 +173,7 @@ void main() {
     const int disabledExtensions = kIsWeb ? 2 : 0;
     // If you add a service extension... TEST IT! :-)
     // ...then increment this number.
-    expect(binding.extensions.length, 35 + widgetInspectorExtensionCount - disabledExtensions);
+    expect(binding.extensions.length, 36 + widgetInspectorExtensionCount - disabledExtensions);
 
     expect(console, isEmpty);
     debugPrint = debugPrintThrottled;
@@ -438,6 +438,35 @@ void main() {
     result = await binding.testExtension('profileWidgetBuilds', <String, String>{});
     expect(result, <String, String>{'enabled': 'false'});
     expect(debugProfileBuildsEnabled, false);
+
+    expect(binding.frameScheduled, isFalse);
+  });
+
+  test('Service extensions - profileUserWidgetBuilds', () async {
+    Map<String, dynamic> result;
+
+    expect(binding.frameScheduled, isFalse);
+    expect(debugProfileBuildsEnabledUserWidgets, false);
+
+    result = await binding.testExtension('profileUserWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfileBuildsEnabledUserWidgets, false);
+
+    result = await binding.testExtension('profileUserWidgetBuilds', <String, String>{'enabled': 'true'});
+    expect(result, <String, String>{'enabled': 'true'});
+    expect(debugProfileBuildsEnabledUserWidgets, true);
+
+    result = await binding.testExtension('profileUserWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'true'});
+    expect(debugProfileBuildsEnabledUserWidgets, true);
+
+    result = await binding.testExtension('profileUserWidgetBuilds', <String, String>{'enabled': 'false'});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfileBuildsEnabledUserWidgets, false);
+
+    result = await binding.testExtension('profileUserWidgetBuilds', <String, String>{});
+    expect(result, <String, String>{'enabled': 'false'});
+    expect(debugProfileBuildsEnabledUserWidgets, false);
 
     expect(binding.frameScheduled, isFalse);
   });


### PR DESCRIPTION
Adds a service extension for the `debugProfileBuildsEnabledUserWidgets` flag. This service extension will be used in DevTools as part of https://github.com/flutter/devtools/issues/3966. 