### PR TITLE
Skip logging stderr/stdout if xcresult parsing is successful

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -411,11 +411,11 @@ Future<XcodeBuildResult> buildXcodeProject({
   }
   if (buildResult != null && buildResult.exitCode != 0) {
     globals.printStatus('Failed to build iOS app');
-    if (buildResult.stderr.isNotEmpty) {
+    if (buildResult.stderr.isNotEmpty && (xcResult == null || !xcResult.parseSuccess)) {
       globals.printStatus('Error output from Xcode build:\n↳');
       globals.printStatus(buildResult.stderr, indent: 4);
     }
-    if (buildResult.stdout.isNotEmpty) {
+    if (buildResult.stdout.isNotEmpty && (xcResult == null || !xcResult.parseSuccess)) {
       globals.printStatus("Xcode's output:\n↳");
       globals.printStatus(buildResult.stdout, indent: 4);
     }


### PR DESCRIPTION
This PR adds a logic to skip the stderr/stdout dumping if xcresult parsing is successful.

Fixes: https://github.com/flutter/flutter/issues/100721

Sample output after the fix:
```
Building flutter tool...
Running "flutter pub get" in keyboard_inset_tests...               736ms
Launching lib/main.dart on iPhone in debug mode...
Automatically signing iOS for device deployment using specified development team in Xcode project: S8QB4VV633
Running Xcode build...                                                  
 └─Compiling, linking and signing...                        913ms
Xcode build done.                                           10.8s
Failed to build iOS app
Could not build the precompiled application for the device.
Swift Compiler Error (Xcode): Cannot find type 'Any1' in scope
/Users/ychris/tmp/keyboard_inset_tests/ios/Runner/AppDelegate.swift:7:82


Swift Compiler Error (Xcode): Method does not override any method from its superclass
/Users/ychris/tmp/keyboard_inset_tests/ios/Runner/AppDelegate.swift:5:16



Error launching application on iPhone.
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
