### PR TITLE
Migrate `ListTile` unselected icon color to Material 3

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -596,6 +596,9 @@ class ListTile extends StatelessWidget {
     final Color? color = iconColor
       ?? tileTheme.iconColor
       ?? theme.listTileTheme.iconColor
+      // If [ThemeData.useMaterial3] is set to true the disabled icon color
+      // will be set to Theme.colorScheme.onSurface(0.38), if false, defaults to null,
+      // as described in: https://m3.material.io/components/icon-buttons/specs.
       ?? (theme.useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.38) : null);
     if (color != null) {
       return color;

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -593,7 +593,10 @@ class ListTile extends StatelessWidget {
       return selectedColor ?? tileTheme.selectedColor ?? theme.listTileTheme.selectedColor ?? theme.colorScheme.primary;
     }
 
-    final Color? color = iconColor ?? tileTheme.iconColor ?? theme.listTileTheme.iconColor;
+    final Color? color = iconColor
+      ?? tileTheme.iconColor
+      ?? theme.listTileTheme.iconColor
+      ?? (theme.useMaterial3 ? theme.colorScheme.onSurface.withOpacity(0.38) : null);
     if (color != null) {
       return color;
     }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2037,8 +2037,6 @@ void main() {
   });
 
   testWidgets('selected, enabled ListTile default icon color, light and dark themes', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/pull/77004
-
     const ColorScheme lightColorScheme = ColorScheme.light();
     const ColorScheme darkColorScheme = ColorScheme.dark();
     final Key leadingKey = UniqueKey();
@@ -2048,8 +2046,8 @@ void main() {
 
     Widget buildFrame({ required Brightness brightness, required bool selected }) {
       final ThemeData theme = brightness == Brightness.light
-        ? ThemeData.from(colorScheme: const ColorScheme.light())
-        : ThemeData.from(colorScheme: const ColorScheme.dark());
+        ? ThemeData.from(colorScheme: const ColorScheme.light(), useMaterial3: true)
+        : ThemeData.from(colorScheme: const ColorScheme.dark(), useMaterial3: true);
       return MaterialApp(
         theme: theme,
         home: Material(
@@ -2075,10 +2073,10 @@ void main() {
     expect(iconColor(trailingKey), lightColorScheme.primary);
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: false));
-    expect(iconColor(leadingKey), Colors.black45);
-    expect(iconColor(titleKey), Colors.black45);
-    expect(iconColor(subtitleKey), Colors.black45);
-    expect(iconColor(trailingKey), Colors.black45);
+    expect(iconColor(leadingKey), lightColorScheme.onSurface.withOpacity(0.38));
+    expect(iconColor(titleKey), lightColorScheme.onSurface.withOpacity(0.38));
+    expect(iconColor(subtitleKey), lightColorScheme.onSurface.withOpacity(0.38));
+    expect(iconColor(trailingKey), lightColorScheme.onSurface.withOpacity(0.38));
 
     await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: true));
     await tester.pumpAndSettle(); // Animated theme change
@@ -2090,10 +2088,10 @@ void main() {
     // For this configuration, ListTile defers to the default IconTheme.
     // The default dark theme's IconTheme has color:white
     await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: false));
-    expect(iconColor(leadingKey),  Colors.white);
-    expect(iconColor(titleKey),  Colors.white);
-    expect(iconColor(subtitleKey),  Colors.white);
-    expect(iconColor(trailingKey), Colors.white);
+    expect(iconColor(leadingKey), darkColorScheme.onSurface.withOpacity(0.38));
+    expect(iconColor(titleKey), darkColorScheme.onSurface.withOpacity(0.38));
+    expect(iconColor(subtitleKey), darkColorScheme.onSurface.withOpacity(0.38));
+    expect(iconColor(trailingKey), darkColorScheme.onSurface.withOpacity(0.38));
   });
 
   testWidgets('ListTile font size', (WidgetTester tester) async {
@@ -2441,6 +2439,66 @@ void main() {
       expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
       trailing = _getTextRenderObject(tester, 'trailing');
       expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
+    });
+
+    testWidgets('selected, enabled ListTile default icon color, light and dark themes', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/pull/77004
+
+      const ColorScheme lightColorScheme = ColorScheme.light();
+      const ColorScheme darkColorScheme = ColorScheme.dark();
+      final Key leadingKey = UniqueKey();
+      final Key titleKey = UniqueKey();
+      final Key subtitleKey = UniqueKey();
+      final Key trailingKey = UniqueKey();
+
+      Widget buildFrame({ required Brightness brightness, required bool selected }) {
+        final ThemeData theme = brightness == Brightness.light
+          ? ThemeData.from(colorScheme: const ColorScheme.light())
+          : ThemeData.from(colorScheme: const ColorScheme.dark());
+        return MaterialApp(
+          theme: theme,
+          home: Material(
+            child: Center(
+              child: ListTile(
+                selected: selected,
+                leading: TestIcon(key: leadingKey),
+                title: TestIcon(key: titleKey),
+                subtitle: TestIcon(key: subtitleKey),
+                trailing: TestIcon(key: trailingKey),
+              ),
+            ),
+          ),
+        );
+      }
+
+      Color iconColor(Key key) => tester.state<TestIconState>(find.byKey(key)).iconTheme.color!;
+
+      await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: true));
+      expect(iconColor(leadingKey), lightColorScheme.primary);
+      expect(iconColor(titleKey), lightColorScheme.primary);
+      expect(iconColor(subtitleKey), lightColorScheme.primary);
+      expect(iconColor(trailingKey), lightColorScheme.primary);
+
+      await tester.pumpWidget(buildFrame(brightness: Brightness.light, selected: false));
+      expect(iconColor(leadingKey), Colors.black45);
+      expect(iconColor(titleKey), Colors.black45);
+      expect(iconColor(subtitleKey), Colors.black45);
+      expect(iconColor(trailingKey), Colors.black45);
+
+      await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: true));
+      await tester.pumpAndSettle(); // Animated theme change
+      expect(iconColor(leadingKey), darkColorScheme.primary);
+      expect(iconColor(titleKey), darkColorScheme.primary);
+      expect(iconColor(subtitleKey), darkColorScheme.primary);
+      expect(iconColor(trailingKey), darkColorScheme.primary);
+
+      // For this configuration, ListTile defers to the default IconTheme.
+      // The default dark theme's IconTheme has color:white
+      await tester.pumpWidget(buildFrame(brightness: Brightness.dark, selected: false));
+      expect(iconColor(leadingKey),  Colors.white);
+      expect(iconColor(titleKey),  Colors.white);
+      expect(iconColor(subtitleKey),  Colors.white);
+      expect(iconColor(trailingKey), Colors.white);
     });
   });
 }


### PR DESCRIPTION
Updates `ListTile` default unselected icon color to Material 3.

Fixes https://github.com/flutter/flutter/issues/99400

Part of: https://github.com/flutter/flutter/issues/91605

Disabled icon specs from https://m3.material.io/components/buttons/specs

![Screenshot 2022-04-18 at 15 02 39](https://user-images.githubusercontent.com/48603081/163823262-b0a4310d-36e2-4fb7-a7bc-a0b81fb4c41c.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
