### PR TITLE
[flutter_tools] boolArg refactor

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze.dart
@@ -105,7 +105,7 @@ class AnalyzeCommand extends FlutterCommand {
   @override
   bool get shouldRunPub {
     // If they're not analyzing the current project.
-    if (!boolArg('current-package')) {
+    if (!boolArgDeprecated('current-package')) {
       return false;
     }
 
@@ -119,7 +119,7 @@ class AnalyzeCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (boolArg('watch')) {
+    if (boolArgDeprecated('watch')) {
       await AnalyzeContinuously(
         argResults!,
         runner!.getRepoRoots(),

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -234,7 +234,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
   Future<void> _attachToDevice(Device device) async {
     final FlutterProject flutterProject = FlutterProject.current();
 
-    final Daemon daemon = boolArg('machine')
+    final Daemon daemon = boolArgDeprecated('machine')
       ? Daemon(
           DaemonConnection(
             daemonStreams: DaemonStreams.fromStdio(globals.stdio, logger: globals.logger),
@@ -336,7 +336,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
                 connectionInfoCompleter: connectionInfoCompleter,
                 appStartedCompleter: appStartedCompleter,
                 allowExistingDdsInstance: true,
-                enableDevTools: boolArg(FlutterCommand.kEnableDevTools),
+                enableDevTools: boolArgDeprecated(FlutterCommand.kEnableDevTools),
               );
             },
             device,
@@ -369,7 +369,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
             terminal: globals.terminal,
             signals: globals.signals,
             processInfo: globals.processInfo,
-            reportReady: boolArg('report-ready'),
+            reportReady: boolArgDeprecated('report-ready'),
             pidFile: stringArgDeprecated('pid-file'),
           )
             ..registerSignalHandlers()
@@ -378,7 +378,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
         result = await runner.attach(
           appStartedCompleter: onAppStart,
           allowExistingDdsInstance: true,
-          enableDevTools: boolArg(FlutterCommand.kEnableDevTools),
+          enableDevTools: boolArgDeprecated(FlutterCommand.kEnableDevTools),
         );
         if (result != 0) {
           throwToolExit(null, exitCode: result);

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -121,7 +121,7 @@ class BuildAarCommand extends BuildSubCommand {
 
     final File targetFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'));
     for (final String buildMode in const <String>['debug', 'profile', 'release']) {
-      if (boolArg(buildMode)) {
+      if (boolArgDeprecated(buildMode)) {
         androidBuildInfo.add(
           AndroidBuildInfo(
             await getBuildInfo(

--- a/packages/flutter_tools/lib/src/commands/build_apk.dart
+++ b/packages/flutter_tools/lib/src/commands/build_apk.dart
@@ -53,7 +53,7 @@ class BuildApkCommand extends BuildSubCommand {
   final String name = 'apk';
 
   @override
-  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : DeprecationBehavior.exit;
+  DeprecationBehavior get deprecationBehavior => boolArgDeprecated('ignore-deprecation') ? DeprecationBehavior.ignore : DeprecationBehavior.exit;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
@@ -73,11 +73,11 @@ class BuildApkCommand extends BuildSubCommand {
   Future<CustomDimensions> get usageValues async {
     String buildMode;
 
-    if (boolArg('release')) {
+    if (boolArgDeprecated('release')) {
       buildMode = 'release';
-    } else if (boolArg('debug')) {
+    } else if (boolArgDeprecated('debug')) {
       buildMode = 'debug';
-    } else if (boolArg('profile')) {
+    } else if (boolArgDeprecated('profile')) {
       buildMode = 'profile';
     } else {
       // The build defaults to release.
@@ -87,7 +87,7 @@ class BuildApkCommand extends BuildSubCommand {
     return CustomDimensions(
       commandBuildApkTargetPlatform: stringsArg('target-platform').join(','),
       commandBuildApkBuildMode: buildMode,
-      commandBuildApkSplitPerAbi: boolArg('split-per-abi'),
+      commandBuildApkSplitPerAbi: boolArgDeprecated('split-per-abi'),
     );
   }
 
@@ -99,9 +99,9 @@ class BuildApkCommand extends BuildSubCommand {
     final BuildInfo buildInfo = await getBuildInfo();
     final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(
       buildInfo,
-      splitPerAbi: boolArg('split-per-abi'),
+      splitPerAbi: boolArgDeprecated('split-per-abi'),
       targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
-      multidexEnabled: boolArg('multidex'),
+      multidexEnabled: boolArgDeprecated('multidex'),
     );
     validateBuild(androidBuildInfo);
     displayNullSafetyMode(androidBuildInfo.buildInfo);

--- a/packages/flutter_tools/lib/src/commands/build_appbundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_appbundle.dart
@@ -69,7 +69,7 @@ class BuildAppBundleCommand extends BuildSubCommand {
   final String name = 'appbundle';
 
   @override
-  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : DeprecationBehavior.exit;
+  DeprecationBehavior get deprecationBehavior => boolArgDeprecated('ignore-deprecation') ? DeprecationBehavior.ignore : DeprecationBehavior.exit;
 
   @override
   Future<Set<DevelopmentArtifact>> get requiredArtifacts async => <DevelopmentArtifact>{
@@ -87,11 +87,11 @@ class BuildAppBundleCommand extends BuildSubCommand {
   Future<CustomDimensions> get usageValues async {
     String buildMode;
 
-    if (boolArg('release')) {
+    if (boolArgDeprecated('release')) {
       buildMode = 'release';
-    } else if (boolArg('debug')) {
+    } else if (boolArgDeprecated('debug')) {
       buildMode = 'debug';
-    } else if (boolArg('profile')) {
+    } else if (boolArgDeprecated('profile')) {
       buildMode = 'profile';
     } else {
       // The build defaults to release.
@@ -112,12 +112,12 @@ class BuildAppBundleCommand extends BuildSubCommand {
 
     final AndroidBuildInfo androidBuildInfo = AndroidBuildInfo(await getBuildInfo(),
       targetArchs: stringsArg('target-platform').map<AndroidArch>(getAndroidArchForName),
-      multidexEnabled: boolArg('multidex'),
+      multidexEnabled: boolArgDeprecated('multidex'),
     );
     // Do all setup verification that doesn't involve loading units. Checks that
     // require generated loading units are done after gen_snapshot in assemble.
     final List<DeferredComponent>? deferredComponents = FlutterProject.current().manifest.deferredComponents;
-    if (deferredComponents != null && boolArg('deferred-components') && boolArg('validate-deferred-components') && !boolArg('debug')) {
+    if (deferredComponents != null && boolArgDeprecated('deferred-components') && boolArgDeprecated('validate-deferred-components') && !boolArgDeprecated('debug')) {
       final DeferredComponentsPrebuildValidator validator = DeferredComponentsPrebuildValidator(
         FlutterProject.current().directory,
         globals.logger,
@@ -153,8 +153,8 @@ class BuildAppBundleCommand extends BuildSubCommand {
       project: FlutterProject.current(),
       target: targetFile,
       androidBuildInfo: androidBuildInfo,
-      validateDeferredComponents: boolArg('validate-deferred-components'),
-      deferredComponentsEnabled: boolArg('deferred-components') && !boolArg('debug'),
+      validateDeferredComponents: boolArgDeprecated('validate-deferred-components'),
+      deferredComponentsEnabled: boolArgDeprecated('deferred-components') && !boolArgDeprecated('debug'),
     );
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -87,7 +87,7 @@ class BuildBundleCommand extends BuildSubCommand {
 
   @override
   Future<void> validateCommand() async {
-    if (boolArg('tree-shake-icons')) {
+    if (boolArgDeprecated('tree-shake-icons')) {
       throwToolExit('The "--tree-shake-icons" flag is deprecated for "build bundle" and will be removed in a future version of Flutter.');
     }
     return super.validateCommand();

--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -44,10 +44,10 @@ class BuildIOSCommand extends _BuildIOSSubCommand {
   final XcodeBuildAction xcodeBuildAction = XcodeBuildAction.build;
 
   @override
-  EnvironmentType get environmentType => boolArg('simulator') ? EnvironmentType.simulator : EnvironmentType.physical;
+  EnvironmentType get environmentType => boolArgDeprecated('simulator') ? EnvironmentType.simulator : EnvironmentType.physical;
 
   @override
-  bool get configOnly => boolArg('config-only');
+  bool get configOnly => boolArgDeprecated('config-only');
 
   @override
   Directory _outputAppDirectory(String xcodeResultOutput) => globals.fs.directory(xcodeResultOutput).parent;
@@ -305,7 +305,7 @@ abstract class _BuildIOSSubCommand extends BuildSubCommand {
   EnvironmentType get environmentType;
   bool get configOnly;
 
-  bool get shouldCodesign => boolArg('codesign');
+  bool get shouldCodesign => boolArgDeprecated('codesign');
 
   late final Future<BuildInfo> cachedBuildInfo = getBuildInfo();
 

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -126,13 +126,13 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
   Future<List<BuildInfo>> getBuildInfos() async {
     final List<BuildInfo> buildInfos = <BuildInfo>[];
 
-    if (boolArg('debug')) {
+    if (boolArgDeprecated('debug')) {
       buildInfos.add(await getBuildInfo(forcedBuildMode: BuildMode.debug));
     }
-    if (boolArg('profile')) {
+    if (boolArgDeprecated('profile')) {
       buildInfos.add(await getBuildInfo(forcedBuildMode: BuildMode.profile));
     }
-    if (boolArg('release')) {
+    if (boolArgDeprecated('release')) {
       buildInfos.add(await getBuildInfo(forcedBuildMode: BuildMode.release));
     }
 
@@ -149,7 +149,7 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       throwToolExit('Building frameworks for iOS is only supported on the Mac.');
     }
 
-    if (boolArg('universal')) {
+    if (boolArgDeprecated('universal')) {
       throwToolExit('--universal has been deprecated, only XCFrameworks are supported.');
     }
     if ((await getBuildInfos()).isEmpty) {
@@ -183,8 +183,8 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
         modeDirectory.deleteSync(recursive: true);
       }
 
-      if (boolArg('cocoapods')) {
-        produceFlutterPodspec(buildInfo.mode, modeDirectory, force: boolArg('force'));
+      if (boolArgDeprecated('cocoapods')) {
+        produceFlutterPodspec(buildInfo.mode, modeDirectory, force: boolArgDeprecated('force'));
       } else {
         // Copy Flutter.xcframework.
         await _produceFlutterFramework(buildInfo, modeDirectory);
@@ -503,7 +503,7 @@ end
 
   Future<void> _produceXCFramework(Iterable<Directory> frameworks,
       String frameworkBinaryName, Directory outputDirectory) async {
-    if (!boolArg('xcframework')) {
+    if (!boolArgDeprecated('xcframework')) {
       return;
     }
     final List<String> xcframeworkCommand = <String>[

--- a/packages/flutter_tools/lib/src/commands/build_web.dart
+++ b/packages/flutter_tools/lib/src/commands/build_web.dart
@@ -118,10 +118,10 @@ class BuildWebCommand extends BuildSubCommand {
       flutterProject,
       target,
       buildInfo,
-      boolArg('csp'),
+      boolArgDeprecated('csp'),
       stringArgDeprecated('pwa-strategy')!,
-      boolArg('source-maps'),
-      boolArg('native-null-assertions'),
+      boolArgDeprecated('source-maps'),
+      boolArgDeprecated('native-null-assertions'),
       baseHref,
       stringArgDeprecated('dart2js-optimization'),
     );

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -39,7 +39,7 @@ class ChannelCommand extends FlutterCommand {
     switch (rest.length) {
       case 0:
         await _listChannels(
-          showAll: boolArg('all'),
+          showAll: boolArgDeprecated('all'),
           verbose: globalResults?['verbose'] == true,
         );
         return FlutterCommandResult.success();

--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -101,12 +101,12 @@ class ConfigCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    if (boolArg('machine')) {
+    if (boolArgDeprecated('machine')) {
       await handleMachine();
       return FlutterCommandResult.success();
     }
 
-    if (boolArg('clear-features')) {
+    if (boolArgDeprecated('clear-features')) {
       for (final Feature feature in allFeatures) {
         final String? configSetting = feature.configSetting;
         if (configSetting != null) {
@@ -117,7 +117,7 @@ class ConfigCommand extends FlutterCommand {
     }
 
     if (argResults?.wasParsed('analytics') ?? false) {
-      final bool value = boolArg('analytics');
+      final bool value = boolArgDeprecated('analytics');
       // The tool sends the analytics event *before* toggling the flag
       // intentionally to be sure that opt-out events are sent correctly.
       AnalyticsConfigEvent(enabled: value).send();
@@ -157,7 +157,7 @@ class ConfigCommand extends FlutterCommand {
         continue;
       }
       if (argResults?.wasParsed(configSetting) ?? false) {
-        final bool keyValue = boolArg(configSetting);
+        final bool keyValue = boolArgDeprecated(configSetting);
         globals.config.setValue(configSetting, keyValue);
         globals.printStatus('Setting "$configSetting" value to "$keyValue".');
       }

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -245,10 +245,10 @@ class CreateCommand extends CreateBase {
 
     final String organization = await getOrganization();
 
-    final bool overwrite = boolArg('overwrite');
+    final bool overwrite = boolArgDeprecated('overwrite');
     validateProjectDir(overwrite: overwrite);
 
-    if (boolArg('with-driver-test')) {
+    if (boolArgDeprecated('with-driver-test')) {
       globals.printWarning(
         'The "--with-driver-test" argument has been deprecated and will no longer add a flutter '
         'driver template. Instead, learn how to use package:integration_test by '
@@ -291,7 +291,7 @@ class CreateCommand extends CreateBase {
       windows: featureFlags.isWindowsEnabled && platforms.contains('windows'),
       // Enable null safety everywhere.
       dartSdkVersionBounds: "'>=$dartSdk <3.0.0'",
-      implementationTests: boolArg('implementation-tests'),
+      implementationTests: boolArgDeprecated('implementation-tests'),
       agpVersion: gradle.templateAndroidGradlePluginVersion,
       kotlinVersion: gradle.templateKotlinGradlePluginVersion,
       gradleVersion: gradle.templateDefaultGradleVersion,
@@ -448,11 +448,11 @@ Your $application code is in $relativeAppMain.
       overwrite: overwrite,
       printStatusWhenWriting: printStatusWhenWriting,
     );
-    if (boolArg('pub')) {
+    if (boolArgDeprecated('pub')) {
       await pub.get(
         context: PubContext.create,
         directory: directory.path,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         generateSyntheticPackage: false,
       );
       final FlutterProject project = FlutterProject.fromDirectory(directory);
@@ -482,11 +482,11 @@ Your $application code is in $relativeAppMain.
       overwrite: overwrite,
       printStatusWhenWriting: printStatusWhenWriting,
     );
-    if (boolArg('pub')) {
+    if (boolArgDeprecated('pub')) {
       await pub.get(
         context: PubContext.createPackage,
         directory: directory.path,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         generateSyntheticPackage: false,
       );
     }
@@ -529,11 +529,11 @@ Your $application code is in $relativeAppMain.
       printStatusWhenWriting: printStatusWhenWriting,
     );
 
-    if (boolArg('pub')) {
+    if (boolArgDeprecated('pub')) {
       await pub.get(
         context: PubContext.createPlugin,
         directory: directory.path,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         generateSyntheticPackage: false,
       );
     }
@@ -608,11 +608,11 @@ Your $application code is in $relativeAppMain.
       printStatusWhenWriting: printStatusWhenWriting,
     );
 
-    if (boolArg('pub')) {
+    if (boolArgDeprecated('pub')) {
       await pub.get(
         context: PubContext.createPlugin,
         directory: directory.path,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         generateSyntheticPackage: false,
       );
     }

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -316,7 +316,7 @@ abstract class CreateBase extends FlutterCommand {
   String get projectName {
     final String projectName =
         stringArgDeprecated('project-name') ?? globals.fs.path.basename(projectDirPath);
-    if (!boolArg('skip-name-checks')) {
+    if (!boolArgDeprecated('skip-name-checks')) {
       final String error = _validateProjectName(projectName);
       if (error != null) {
         throwToolExit(error);
@@ -515,7 +515,7 @@ abstract class CreateBase extends FlutterCommand {
     final bool windowsPlatform = templateContext['windows'] as bool ?? false;
     final bool webPlatform = templateContext['web'] as bool ?? false;
 
-    if (boolArg('pub')) {
+    if (boolArgDeprecated('pub')) {
       final Environment environment = Environment(
         artifacts: globals.artifacts,
         logger: globals.logger,
@@ -540,7 +540,7 @@ abstract class CreateBase extends FlutterCommand {
       await pub.get(
         context: PubContext.create,
         directory: directory.path,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         // For templates that use the l10n localization tooling, make sure
         // importing the generated package works right after `flutter create`.
         generateSyntheticPackage: true,

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -483,7 +483,7 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
   /// Only check if `--check` is explicitly specified. (Don't check by default)
   Future<FlutterCommandResult> runNonInteractively() async {
     final String jsonStr = stringArgDeprecated(_kJson);
-    final bool shouldCheck = boolArg(_kCheck) ?? false;
+    final bool shouldCheck = boolArgDeprecated(_kCheck) ?? false;
 
     dynamic json;
     try {
@@ -591,7 +591,7 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
   /// Run interactively (with user prompts), the target device should be
   /// connected to via ssh.
   Future<FlutterCommandResult> runInteractivelySsh() async {
-    final bool shouldCheck = boolArg(_kCheck) ?? true;
+    final bool shouldCheck = boolArgDeprecated(_kCheck) ?? true;
 
     // Listen to the keystrokes stream as late as possible, since it's a
     // single-subscription stream apparently.
@@ -806,7 +806,7 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
     if (stringArgDeprecated(_kJson) != null) {
       return runNonInteractively();
     }
-    if (boolArg(_kSsh) == true) {
+    if (boolArgDeprecated(_kSsh) == true) {
       return runInteractivelySsh();
     }
     throw FallThroughError();

--- a/packages/flutter_tools/lib/src/commands/debug_adapter.dart
+++ b/packages/flutter_tools/lib/src/commands/debug_adapter.dart
@@ -58,7 +58,7 @@ class DebugAdapterCommand extends FlutterCommand {
       platform: globals.platform,
       ipv6: ipv6 ?? false,
       enableDds: enableDds,
-      test: boolArg('test'),
+      test: boolArgDeprecated('test'),
     );
 
     await server.channel.closed;

--- a/packages/flutter_tools/lib/src/commands/devices.dart
+++ b/packages/flutter_tools/lib/src/commands/devices.dart
@@ -64,7 +64,7 @@ class DevicesCommand extends FlutterCommand {
 
     final List<Device> devices = await globals.deviceManager?.refreshAllConnectedDevices(timeout: deviceDiscoveryTimeout) ?? <Device>[];
 
-    if (boolArg('machine')) {
+    if (boolArgDeprecated('machine')) {
       await printDevicesAsJson(devices);
     } else {
       if (devices.isEmpty) {

--- a/packages/flutter_tools/lib/src/commands/doctor.dart
+++ b/packages/flutter_tools/lib/src/commands/doctor.dart
@@ -48,7 +48,7 @@ class DoctorCommand extends FlutterCommand {
       }
     }
     final bool success = await globals.doctor?.diagnose(
-      androidLicenses: boolArg('android-licenses'),
+      androidLicenses: boolArgDeprecated('android-licenses'),
       verbose: verbose,
       androidLicenseValidator: androidLicenseValidator,
     ) ?? false;

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -129,7 +129,7 @@ class DowngradeCommand extends FlutterCommand {
     final Stdio stdio = _stdio!;
     final Terminal terminal = _terminal!;
     final Logger logger = _logger!;
-    if (stdio.hasTerminal && boolArg('prompt')) {
+    if (stdio.hasTerminal && boolArgDeprecated('prompt')) {
       terminal.usesTerminalUi = true;
       final String result = await terminal.promptForCharInput(
         const <String>['y', 'n'],

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -156,7 +156,7 @@ class DriveCommand extends RunCommandBase {
   // specified not to.
   @override
   bool get shouldRunPub {
-    if (argResults.wasParsed('pub') && !boolArg('pub')) {
+    if (argResults.wasParsed('pub') && !boolArgDeprecated('pub')) {
       return false;
     }
     return true;
@@ -255,7 +255,7 @@ class DriveCommand extends RunCommandBase {
               'trace-startup': traceStartup,
             if (web)
               '--no-launch-chrome': true,
-            if (boolArg('multidex'))
+            if (boolArgDeprecated('multidex'))
               'multidex': true,
           }
         );
@@ -278,13 +278,13 @@ class DriveCommand extends RunCommandBase {
         <String, String>{},
         packageConfig,
         chromeBinary: stringArgDeprecated('chrome-binary'),
-        headless: boolArg('headless'),
+        headless: boolArgDeprecated('headless'),
         browserDimension: stringArgDeprecated('browser-dimension').split(','),
         browserName: stringArgDeprecated('browser-name'),
         driverPort: stringArgDeprecated('driver-port') != null
           ? int.tryParse(stringArgDeprecated('driver-port'))
           : null,
-        androidEmulator: boolArg('android-emulator'),
+        androidEmulator: boolArgDeprecated('android-emulator'),
         profileMemory: stringArgDeprecated('profile-memory'),
       );
       if (testResult != 0 && screenshot != null) {
@@ -293,7 +293,7 @@ class DriveCommand extends RunCommandBase {
         screenshotTaken = true;
       }
 
-      if (boolArg('keep-app-running') ?? (argResults['use-existing-app'] != null)) {
+      if (boolArgDeprecated('keep-app-running') ?? (argResults['use-existing-app'] != null)) {
         _logger.printStatus('Leaving the application running.');
       } else {
         final File skslFile = stringArgDeprecated('write-sksl-on-exit') != null

--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -225,12 +225,12 @@ class GenerateLocalizationsCommand extends FlutterCommand {
     final List<String> preferredSupportedLocales = stringsArg('preferred-supported-locales');
     final String? headerString = stringArgDeprecated('header');
     final String? headerFile = stringArgDeprecated('header-file');
-    final bool useDeferredLoading = boolArg('use-deferred-loading');
+    final bool useDeferredLoading = boolArgDeprecated('use-deferred-loading');
     final String? inputsAndOutputsListPath = stringArgDeprecated('gen-inputs-and-outputs-list');
-    final bool useSyntheticPackage = boolArg('synthetic-package');
+    final bool useSyntheticPackage = boolArgDeprecated('synthetic-package');
     final String? projectPathString = stringArgDeprecated('project-dir');
-    final bool areResourceAttributesRequired = boolArg('required-resource-attributes');
-    final bool usesNullableGetter = boolArg('nullable-getter');
+    final bool areResourceAttributesRequired = boolArgDeprecated('required-resource-attributes');
+    final bool usesNullableGetter = boolArgDeprecated('nullable-getter');
 
     precacheLanguageAndRegionTags();
 

--- a/packages/flutter_tools/lib/src/commands/ide_config.dart
+++ b/packages/flutter_tools/lib/src/commands/ide_config.dart
@@ -153,7 +153,7 @@ class IdeConfigCommand extends FlutterCommand {
           manifest.add('$relativePath${Template.copyTemplateExtension}');
           continue;
         }
-        if (boolArg('overwrite')) {
+        if (boolArgDeprecated('overwrite')) {
           finalDestinationFile.deleteSync();
           globals.printStatus('  $relativeDestination (overwritten)');
         } else {
@@ -174,7 +174,7 @@ class IdeConfigCommand extends FlutterCommand {
     }
 
     // If we're not overwriting, then we're not going to remove missing items either.
-    if (!boolArg('overwrite')) {
+    if (!boolArgDeprecated('overwrite')) {
       return;
     }
 
@@ -213,7 +213,7 @@ class IdeConfigCommand extends FlutterCommand {
       throwToolExit('Currently, the only supported IDE is IntelliJ\n$usage', exitCode: 2);
     }
 
-    if (boolArg('update-templates')) {
+    if (boolArgDeprecated('update-templates')) {
       _handleTemplateUpdate();
       return FlutterCommandResult.success();
     }
@@ -231,7 +231,7 @@ class IdeConfigCommand extends FlutterCommand {
     globals.printStatus('Updating IDE configuration for Flutter tree at $dirPath...');
     int generatedCount = 0;
     generatedCount += _renderTemplate(_ideName, dirPath, <String, Object>{
-      'withRootModule': boolArg('with-root-module'),
+      'withRootModule': boolArgDeprecated('with-root-module'),
       'android': true,
     });
 
@@ -254,7 +254,7 @@ class IdeConfigCommand extends FlutterCommand {
     return template.render(
       globals.fs.directory(dirPath),
       context,
-      overwriteExisting: boolArg('overwrite'),
+      overwriteExisting: boolArgDeprecated('overwrite'),
     );
   }
 }

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -33,7 +33,7 @@ class InstallCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts
 
   Device? device;
 
-  bool get uninstallOnly => boolArg('uninstall-only');
+  bool get uninstallOnly => boolArgDeprecated('uninstall-only');
   String? get userIdentifier => stringArgDeprecated(FlutterOptions.kDeviceUser);
 
   String? get _applicationBinaryPath => stringArgDeprecated(FlutterOptions.kUseApplicationBinary);

--- a/packages/flutter_tools/lib/src/commands/logs.dart
+++ b/packages/flutter_tools/lib/src/commands/logs.dart
@@ -46,7 +46,7 @@ class LogsCommand extends FlutterCommand {
   @override
   Future<FlutterCommandResult> runCommand() async {
     final Device cachedDevice = device!;
-    if (boolArg('clear')) {
+    if (boolArgDeprecated('clear')) {
       cachedDevice.clearLogs();
     }
 

--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -143,7 +143,7 @@ class PackagesGetCommand extends FlutterCommand {
         directory: directory,
         upgrade: upgrade,
         shouldSkipThirdPartyGenerator: false,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         generateSyntheticPackage: flutterProject.manifest.generateSyntheticPackage,
       );
       pubGetTimer.stop();

--- a/packages/flutter_tools/lib/src/commands/precache.dart
+++ b/packages/flutter_tools/lib/src/commands/precache.dart
@@ -106,7 +106,7 @@ class PrecacheCommand extends FlutterCommand {
   Set<String> _explicitArtifactSelections() {
     final Map<String, String> umbrellaForArtifact = _umbrellaForArtifactMap();
     final Set<String> selections = <String>{};
-    bool explicitlySelected(String name) => boolArg(name) && argResults.wasParsed(name);
+    bool explicitlySelected(String name) => boolArgDeprecated(name) && argResults.wasParsed(name);
     for (final DevelopmentArtifact artifact in DevelopmentArtifact.values) {
       final String umbrellaName = umbrellaForArtifact[artifact.name];
       if (explicitlySelected(artifact.name) ||
@@ -139,15 +139,15 @@ class PrecacheCommand extends FlutterCommand {
     if (_platform.environment['FLUTTER_ALREADY_LOCKED'] != 'true') {
       await _cache.lock();
     }
-    if (boolArg('force')) {
+    if (boolArgDeprecated('force')) {
       _cache.clearStampFiles();
     }
 
-    final bool includeAllPlatforms = boolArg('all-platforms');
+    final bool includeAllPlatforms = boolArgDeprecated('all-platforms');
     if (includeAllPlatforms) {
       _cache.includeAllPlatforms = true;
     }
-    if (boolArg('use-unsigned-mac-binaries')) {
+    if (boolArgDeprecated('use-unsigned-mac-binaries')) {
       _cache.useUnsignedMacBinaries = true;
     }
     final Set<String> explicitlyEnabled = _explicitArtifactSelections();
@@ -164,7 +164,7 @@ class PrecacheCommand extends FlutterCommand {
       }
 
       final String argumentName = umbrellaForArtifact[artifact.name] ?? artifact.name;
-      if (includeAllPlatforms || boolArg(argumentName) || downloadDefaultArtifacts) {
+      if (includeAllPlatforms || boolArgDeprecated(argumentName) || downloadDefaultArtifacts) {
         requiredArtifacts.add(artifact);
       }
     }

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -162,16 +162,16 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     addEnableImpellerFlag(verboseHelp: verboseHelp);
   }
 
-  bool get traceStartup => boolArg('trace-startup');
-  bool get cacheSkSL => boolArg('cache-sksl');
-  bool get dumpSkpOnShaderCompilation => boolArg('dump-skp-on-shader-compilation');
-  bool get purgePersistentCache => boolArg('purge-persistent-cache');
-  bool get disableServiceAuthCodes => boolArg('disable-service-auth-codes');
-  bool get cacheStartupProfile => boolArg('cache-startup-profile');
+  bool get traceStartup => boolArgDeprecated('trace-startup');
+  bool get cacheSkSL => boolArgDeprecated('cache-sksl');
+  bool get dumpSkpOnShaderCompilation => boolArgDeprecated('dump-skp-on-shader-compilation');
+  bool get purgePersistentCache => boolArgDeprecated('purge-persistent-cache');
+  bool get disableServiceAuthCodes => boolArgDeprecated('disable-service-auth-codes');
+  bool get cacheStartupProfile => boolArgDeprecated('cache-startup-profile');
   bool get runningWithPrebuiltApplication => argResults[FlutterOptions.kUseApplicationBinary] != null;
-  bool get trackWidgetCreation => boolArg('track-widget-creation');
-  bool get enableImpeller => boolArg('enable-impeller');
-  bool get uninstallFirst => boolArg('uninstall-first');
+  bool get trackWidgetCreation => boolArgDeprecated('track-widget-creation');
+  bool get enableImpeller => boolArgDeprecated('enable-impeller');
+  bool get uninstallFirst => boolArgDeprecated('uninstall-first');
 
   @override
   bool get reportNullSafety => true;
@@ -198,8 +198,8 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webUseSseForDebugProxy: featureFlags.isWebEnabled && stringArgDeprecated('web-server-debug-protocol') == 'sse',
         webUseSseForDebugBackend: featureFlags.isWebEnabled && stringArgDeprecated('web-server-debug-backend-protocol') == 'sse',
         webUseSseForInjectedClient: featureFlags.isWebEnabled && stringArgDeprecated('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        webEnableExposeUrl: featureFlags.isWebEnabled && boolArgDeprecated('web-allow-expose-url'),
+        webRunHeadless: featureFlags.isWebEnabled && boolArgDeprecated('web-run-headless'),
         webBrowserDebugPort: browserDebugPort,
         enableImpeller: enableImpeller,
         uninstallFirst: uninstallFirst,
@@ -207,20 +207,20 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
     } else {
       return DebuggingOptions.enabled(
         buildInfo,
-        startPaused: boolArg('start-paused'),
-        disableServiceAuthCodes: boolArg('disable-service-auth-codes'),
+        startPaused: boolArgDeprecated('start-paused'),
+        disableServiceAuthCodes: boolArgDeprecated('disable-service-auth-codes'),
         cacheStartupProfile: cacheStartupProfile,
         enableDds: enableDds,
         dartEntrypointArgs: stringsArg('dart-entrypoint-args'),
         dartFlags: stringArgDeprecated('dart-flags') ?? '',
-        useTestFonts: argParser.options.containsKey('use-test-fonts') && boolArg('use-test-fonts'),
-        enableSoftwareRendering: argParser.options.containsKey('enable-software-rendering') && boolArg('enable-software-rendering'),
-        skiaDeterministicRendering: argParser.options.containsKey('skia-deterministic-rendering') && boolArg('skia-deterministic-rendering'),
-        traceSkia: boolArg('trace-skia'),
+        useTestFonts: argParser.options.containsKey('use-test-fonts') && boolArgDeprecated('use-test-fonts'),
+        enableSoftwareRendering: argParser.options.containsKey('enable-software-rendering') && boolArgDeprecated('enable-software-rendering'),
+        skiaDeterministicRendering: argParser.options.containsKey('skia-deterministic-rendering') && boolArgDeprecated('skia-deterministic-rendering'),
+        traceSkia: boolArgDeprecated('trace-skia'),
         traceAllowlist: traceAllowlist,
         traceSkiaAllowlist: stringArgDeprecated('trace-skia-allowlist'),
-        traceSystrace: boolArg('trace-systrace'),
-        endlessTraceBuffer: boolArg('endless-trace-buffer'),
+        traceSystrace: boolArgDeprecated('trace-systrace'),
+        endlessTraceBuffer: boolArgDeprecated('endless-trace-buffer'),
         dumpSkpOnShaderCompilation: dumpSkpOnShaderCompilation,
         cacheSkSL: cacheSkSL,
         purgePersistentCache: purgePersistentCache,
@@ -229,23 +229,23 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         disablePortPublication: disablePortPublication,
         ddsPort: ddsPort,
         devToolsServerAddress: devToolsServerAddress,
-        verboseSystemLogs: boolArg('verbose-system-logs'),
+        verboseSystemLogs: boolArgDeprecated('verbose-system-logs'),
         hostname: featureFlags.isWebEnabled ? stringArgDeprecated('web-hostname') : '',
         port: featureFlags.isWebEnabled ? stringArgDeprecated('web-port') : '',
         webUseSseForDebugProxy: featureFlags.isWebEnabled && stringArgDeprecated('web-server-debug-protocol') == 'sse',
         webUseSseForDebugBackend: featureFlags.isWebEnabled && stringArgDeprecated('web-server-debug-backend-protocol') == 'sse',
         webUseSseForInjectedClient: featureFlags.isWebEnabled && stringArgDeprecated('web-server-debug-injected-client-protocol') == 'sse',
-        webEnableExposeUrl: featureFlags.isWebEnabled && boolArg('web-allow-expose-url'),
-        webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
+        webEnableExposeUrl: featureFlags.isWebEnabled && boolArgDeprecated('web-allow-expose-url'),
+        webRunHeadless: featureFlags.isWebEnabled && boolArgDeprecated('web-run-headless'),
         webBrowserDebugPort: browserDebugPort,
-        webEnableExpressionEvaluation: featureFlags.isWebEnabled && boolArg('web-enable-expression-evaluation'),
+        webEnableExpressionEvaluation: featureFlags.isWebEnabled && boolArgDeprecated('web-enable-expression-evaluation'),
         webLaunchUrl: featureFlags.isWebEnabled ? stringArgDeprecated('web-launch-url') : null,
         vmserviceOutFile: stringArgDeprecated('vmservice-out-file'),
         fastStart: argParser.options.containsKey('fast-start')
-          && boolArg('fast-start')
+          && boolArgDeprecated('fast-start')
           && !runningWithPrebuiltApplication,
-        nullAssertions: boolArg('null-assertions'),
-        nativeNullAssertions: boolArg('native-null-assertions'),
+        nullAssertions: boolArgDeprecated('null-assertions'),
+        nativeNullAssertions: boolArgDeprecated('native-null-assertions'),
         enableImpeller: enableImpeller,
         uninstallFirst: uninstallFirst,
       );
@@ -359,7 +359,7 @@ class RunCommand extends RunCommandBase {
   final String name = 'run';
 
   @override
-  DeprecationBehavior get deprecationBehavior => boolArg('ignore-deprecation') ? DeprecationBehavior.ignore : _deviceDeprecationBehavior;
+  DeprecationBehavior get deprecationBehavior => boolArgDeprecated('ignore-deprecation') ? DeprecationBehavior.ignore : _deviceDeprecationBehavior;
   DeprecationBehavior _deviceDeprecationBehavior = DeprecationBehavior.none;
 
   @override
@@ -466,13 +466,13 @@ class RunCommand extends RunCommandBase {
   }
 
   bool shouldUseHotMode(BuildInfo buildInfo) {
-    final bool hotArg = boolArg('hot') ?? false;
+    final bool hotArg = boolArgDeprecated('hot') ?? false;
     final bool shouldUseHotMode = hotArg && !traceStartup;
     return buildInfo.isDebug && shouldUseHotMode;
   }
 
-  bool get stayResident => boolArg('resident');
-  bool get awaitFirstFrameWhenTracing => boolArg('await-first-frame-when-tracing');
+  bool get stayResident => boolArgDeprecated('resident');
+  bool get awaitFirstFrameWhenTracing => boolArgDeprecated('await-first-frame-when-tracing');
 
   @override
   Future<void> validateCommand() async {
@@ -519,7 +519,7 @@ class RunCommand extends RunCommandBase {
         flutterDevices,
         target: targetFile,
         debuggingOptions: await createDebuggingOptions(webMode),
-        benchmarkMode: boolArg('benchmark'),
+        benchmarkMode: boolArgDeprecated('benchmark'),
         applicationBinary: applicationBinaryPath == null
             ? null
             : globals.fs.file(applicationBinaryPath),
@@ -527,7 +527,7 @@ class RunCommand extends RunCommandBase {
         dillOutputPath: stringArgDeprecated('output-dill'),
         stayResident: stayResident,
         ipv6: ipv6,
-        multidexEnabled: boolArg('multidex'),
+        multidexEnabled: boolArgDeprecated('multidex'),
       );
     } else if (webMode) {
       return webRunnerFactory.createWebRunner(
@@ -555,7 +555,7 @@ class RunCommand extends RunCommandBase {
           : globals.fs.file(applicationBinaryPath),
       ipv6: ipv6,
       stayResident: stayResident,
-      multidexEnabled: boolArg('multidex'),
+      multidexEnabled: boolArgDeprecated('multidex'),
     );
   }
 
@@ -582,7 +582,7 @@ class RunCommand extends RunCommandBase {
     final bool hotMode = shouldUseHotMode(buildInfo);
     final String applicationBinaryPath = stringArgDeprecated(FlutterOptions.kUseApplicationBinary);
 
-    if (boolArg('machine')) {
+    if (boolArgDeprecated('machine')) {
       if (devices.length > 1) {
         throwToolExit('"--machine" does not support "-d all".');
       }
@@ -600,7 +600,7 @@ class RunCommand extends RunCommandBase {
           packagesFilePath: globalResults['packages'] as String,
           dillOutputPath: stringArgDeprecated('output-dill'),
           ipv6: ipv6,
-          multidexEnabled: boolArg('multidex'),
+          multidexEnabled: boolArgDeprecated('multidex'),
         );
       } on Exception catch (error) {
         throwToolExit(error.toString());
@@ -632,7 +632,7 @@ class RunCommand extends RunCommandBase {
         }
       }
       if (await device.isLocalEmulator && await device.supportsHardwareRendering) {
-        if (boolArg('enable-software-rendering')) {
+        if (boolArgDeprecated('enable-software-rendering')) {
           globals.printStatus(
             'Using software rendering with device ${device.name}. You may get better performance '
             'with hardware mode by configuring hardware rendering for your device.'
@@ -690,7 +690,7 @@ class RunCommand extends RunCommandBase {
             terminal: globals.terminal,
             signals: globals.signals,
             processInfo: globals.processInfo,
-            reportReady: boolArg('report-ready'),
+            reportReady: boolArgDeprecated('report-ready'),
             pidFile: stringArgDeprecated('pid-file'),
           )
             ..registerSignalHandlers()
@@ -701,7 +701,7 @@ class RunCommand extends RunCommandBase {
     try {
       final int result = await runner.run(
         appStartedCompleter: appStartedTimeRecorder,
-        enableDevTools: stayResident && boolArg(FlutterCommand.kEnableDevTools),
+        enableDevTools: stayResident && boolArgDeprecated(FlutterCommand.kEnableDevTools),
         route: route,
       );
       handler?.stop();

--- a/packages/flutter_tools/lib/src/commands/shell_completion.dart
+++ b/packages/flutter_tools/lib/src/commands/shell_completion.dart
@@ -54,7 +54,7 @@ class ShellCompletionCommand extends FlutterCommand {
     }
 
     final File outputFile = globals.fs.file(rest.first);
-    if (outputFile.existsSync() && !boolArg('overwrite')) {
+    if (outputFile.existsSync() && !boolArgDeprecated('overwrite')) {
       throwToolExit(
         'Output file ${outputFile.path} already exists, will not overwrite. '
             'Use --overwrite to force overwriting existing output file.',

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -302,7 +302,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
         'directory (or one of its subdirectories).');
     }
     final FlutterProject flutterProject = FlutterProject.current();
-    final bool buildTestAssets = boolArg('test-assets');
+    final bool buildTestAssets = boolArgDeprecated('test-assets');
     final List<String> names = stringsArg('name');
     final List<String> plainNames = stringsArg('plain-name');
     final String tags = stringArgDeprecated('tags');
@@ -324,7 +324,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       await _buildTestAsset();
     }
 
-    final bool startPaused = boolArg('start-paused');
+    final bool startPaused = boolArgDeprecated('start-paused');
     if (startPaused && _testFiles.length != 1) {
       throwToolExit(
         'When using --start-paused, you must specify a single test file to run.',
@@ -371,9 +371,9 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           'If you set --shard-index you need to also set --total-shards.');
     }
 
-    final bool machine = boolArg('machine');
+    final bool machine = boolArgDeprecated('machine');
     CoverageCollector collector;
-    if (boolArg('coverage') || boolArg('merge-coverage')) {
+    if (boolArgDeprecated('coverage') || boolArgDeprecated('merge-coverage')) {
       final String projectName = flutterProject.manifest.appName;
       collector = CoverageCollector(
         verbose: !machine,
@@ -392,11 +392,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(
       buildInfo,
       startPaused: startPaused,
-      disableServiceAuthCodes: boolArg('disable-service-auth-codes'),
+      disableServiceAuthCodes: boolArgDeprecated('disable-service-auth-codes'),
       // On iOS >=14, keeping this enabled will leave a prompt on the screen.
       disablePortPublication: true,
       enableDds: enableDds,
-      nullAssertions: boolArg(FlutterOptions.kNullAssertions),
+      nullAssertions: boolArgDeprecated(FlutterOptions.kNullAssertions),
     );
 
     Device integrationTestDevice;
@@ -439,10 +439,10 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       tags: tags,
       excludeTags: excludeTags,
       watcher: watcher,
-      enableObservatory: collector != null || startPaused || boolArg('enable-vmservice'),
-      ipv6: boolArg('ipv6'),
+      enableObservatory: collector != null || startPaused || boolArgDeprecated('enable-vmservice'),
+      ipv6: boolArgDeprecated('ipv6'),
       machine: machine,
-      updateGoldens: boolArg('update-goldens'),
+      updateGoldens: boolArgDeprecated('update-goldens'),
       concurrency: jobs,
       buildTestAssets: buildTestAssets,
       flutterProject: flutterProject,
@@ -450,7 +450,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       randomSeed: stringArgDeprecated('test-randomize-ordering-seed'),
       reporter: stringArgDeprecated('reporter'),
       timeout: stringArgDeprecated('timeout'),
-      runSkipped: boolArg('run-skipped'),
+      runSkipped: boolArgDeprecated('run-skipped'),
       shardIndex: shardIndex,
       totalShards: totalShards,
       integrationTestDevice: integrationTestDevice,
@@ -460,7 +460,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     if (collector != null) {
       final bool collectionResult = collector.collectCoverageData(
         stringArgDeprecated('coverage-path'),
-        mergeCoverageData: boolArg('merge-coverage'),
+        mergeCoverageData: boolArgDeprecated('merge-coverage'),
       );
       if (!collectionResult) {
         throwToolExit(null);

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -145,15 +145,15 @@ class UpdatePackagesCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     final List<Directory> packages = runner!.getRepoPackages();
 
-    final bool forceUpgrade = boolArg('force-upgrade');
-    final bool isPrintPaths = boolArg('paths');
-    final bool isPrintTransitiveClosure = boolArg('transitive-closure');
-    final bool isVerifyOnly = boolArg('verify-only');
-    final bool isConsumerOnly = boolArg('consumer-only');
-    final bool offline = boolArg('offline');
+    final bool forceUpgrade = boolArgDeprecated('force-upgrade');
+    final bool isPrintPaths = boolArgDeprecated('paths');
+    final bool isPrintTransitiveClosure = boolArgDeprecated('transitive-closure');
+    final bool isVerifyOnly = boolArgDeprecated('verify-only');
+    final bool isConsumerOnly = boolArgDeprecated('consumer-only');
+    final bool offline = boolArgDeprecated('offline');
     final bool doUpgrade = forceUpgrade || isPrintPaths || isPrintTransitiveClosure;
 
-    if (boolArg('crash')) {
+    if (boolArgDeprecated('crash')) {
       throw StateError('test crash please ignore.');
     }
 
@@ -403,7 +403,7 @@ class UpdatePackagesCommand extends FlutterCommand {
         context: PubContext.updatePackages,
         directory: tempDir.path,
         upgrade: doUpgrade,
-        offline: boolArg('offline'),
+        offline: boolArgDeprecated('offline'),
         flutterRootOverride: temporaryFlutterSdk?.path,
       );
       // Cleanup the temporary SDK
@@ -454,14 +454,14 @@ class UpdatePackagesCommand extends FlutterCommand {
       }
     }
 
-    if (boolArg('transitive-closure')) {
+    if (boolArgDeprecated('transitive-closure')) {
       tree._dependencyTree.forEach((String from, Set<String> to) {
         globals.printStatus('$from -> $to');
       });
       return true;
     }
 
-    if (boolArg('paths')) {
+    if (boolArgDeprecated('paths')) {
       showDependencyPaths(from: stringArgDeprecated('from')!, to: stringArgDeprecated('to')!, tree: tree);
       return true;
     }

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -72,14 +72,14 @@ class UpgradeCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() {
     _commandRunner.workingDirectory = stringArgDeprecated('working-directory') ?? Cache.flutterRoot!;
     return _commandRunner.runCommand(
-      force: boolArg('force'),
-      continueFlow: boolArg('continue'),
+      force: boolArgDeprecated('force'),
+      continueFlow: boolArgDeprecated('continue'),
       testFlow: stringArgDeprecated('working-directory') != null,
       gitTagVersion: GitTagVersion.determine(globals.processUtils, globals.platform),
       flutterVersion: stringArgDeprecated('working-directory') == null
         ? globals.flutterVersion
         : FlutterVersion(workingDirectory: _commandRunner.workingDirectory),
-      verifyOnly: boolArg('verify-only'),
+      verifyOnly: boolArgDeprecated('verify-only'),
     );
   }
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -185,7 +185,7 @@ abstract class FlutterCommand extends Command<void> {
 
   DeprecationBehavior get deprecationBehavior => DeprecationBehavior.none;
 
-  bool get shouldRunPub => _usesPubOption && boolArg('pub');
+  bool get shouldRunPub => _usesPubOption && boolArgDeprecated('pub');
 
   bool get shouldUpdateCache => true;
 
@@ -429,7 +429,7 @@ abstract class FlutterCommand extends Command<void> {
         throwToolExit(
             'The "--[no-]dds" and "--[no-]disable-dds" arguments are mutually exclusive. Only specify "--[no-]dds".');
       }
-      ddsEnabled = !boolArg('disable-dds');
+      ddsEnabled = !boolArgDeprecated('disable-dds');
       // TODO(ianh): enable the following code once google3 is migrated away from --disable-dds (and add test to flutter_command_test.dart)
       if (false) { // ignore: dead_code
         if (ddsEnabled) {
@@ -441,7 +441,7 @@ abstract class FlutterCommand extends Command<void> {
         }
       }
     } else {
-      ddsEnabled = boolArg('dds');
+      ddsEnabled = boolArgDeprecated('dds');
     }
     return ddsEnabled;
   }();
@@ -533,7 +533,7 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
-  bool get disablePortPublication => !boolArg('publish-port');
+  bool get disablePortPublication => !boolArgDeprecated('publish-port');
 
   void usesIpv6Flag({required bool verboseHelp}) {
     argParser.addFlag(ipv6Flag,
@@ -546,7 +546,7 @@ abstract class FlutterCommand extends Command<void> {
     _usesIpv6Flag = true;
   }
 
-  bool? get ipv6 => _usesIpv6Flag ? boolArg('ipv6') : null;
+  bool? get ipv6 => _usesIpv6Flag ? boolArgDeprecated('ipv6') : null;
 
   void usesBuildNumberOption() {
     argParser.addOption('build-number',
@@ -893,13 +893,13 @@ abstract class FlutterCommand extends Command<void> {
   BuildMode getBuildMode() {
     // No debug when _excludeDebug is true.
     // If debug is not excluded, then take the command line flag.
-    final bool debugResult = !_excludeDebug && boolArg('debug');
-    final bool jitReleaseResult = !_excludeRelease && boolArg('jit-release');
-    final bool releaseResult = !_excludeRelease && boolArg('release');
+    final bool debugResult = !_excludeDebug && boolArgDeprecated('debug');
+    final bool jitReleaseResult = !_excludeRelease && boolArgDeprecated('jit-release');
+    final bool releaseResult = !_excludeRelease && boolArgDeprecated('release');
     final List<bool> modeFlags = <bool>[
       debugResult,
       jitReleaseResult,
-      boolArg('profile'),
+      boolArgDeprecated('profile'),
       releaseResult,
     ];
     if (modeFlags.where((bool flag) => flag).length > 1) {
@@ -909,7 +909,7 @@ abstract class FlutterCommand extends Command<void> {
     if (debugResult) {
       return BuildMode.debug;
     }
-    if (boolArg('profile')) {
+    if (boolArgDeprecated('profile')) {
       return BuildMode.profile;
     }
     if (releaseResult) {
@@ -977,7 +977,7 @@ abstract class FlutterCommand extends Command<void> {
   /// each other.
   Future<BuildInfo> getBuildInfo({ BuildMode? forcedBuildMode, File? forcedTargetFile }) async {
     final bool trackWidgetCreation = argParser.options.containsKey('track-widget-creation') &&
-      boolArg('track-widget-creation');
+      boolArgDeprecated('track-widget-creation');
 
     final String? buildNumber = argParser.options.containsKey('build-number')
       ? stringArgDeprecated('build-number')
@@ -1010,7 +1010,7 @@ abstract class FlutterCommand extends Command<void> {
     }
 
     String? codeSizeDirectory;
-    if (argParser.options.containsKey(FlutterOptions.kAnalyzeSize) && boolArg(FlutterOptions.kAnalyzeSize)) {
+    if (argParser.options.containsKey(FlutterOptions.kAnalyzeSize) && boolArgDeprecated(FlutterOptions.kAnalyzeSize)) {
       Directory directory = globals.fsUtils.getUniqueDirectory(
         globals.fs.directory(getBuildDirectory()),
         'flutter_size',
@@ -1046,7 +1046,7 @@ abstract class FlutterCommand extends Command<void> {
         // This mode is only used for commands which do not build a single target like
         // 'flutter test'.
         nullSafetyMode = NullSafetyMode.autodetect;
-      } else if (boolArg(FlutterOptions.kNullSafety)) {
+      } else if (boolArgDeprecated(FlutterOptions.kNullSafety)) {
         nullSafetyMode = NullSafetyMode.sound;
         extraFrontEndOptions.add('--sound-null-safety');
       } else {
@@ -1056,14 +1056,14 @@ abstract class FlutterCommand extends Command<void> {
     }
 
     final bool dartObfuscation = argParser.options.containsKey(FlutterOptions.kDartObfuscationOption)
-      && boolArg(FlutterOptions.kDartObfuscationOption);
+      && boolArgDeprecated(FlutterOptions.kDartObfuscationOption);
 
     final String? splitDebugInfoPath = argParser.options.containsKey(FlutterOptions.kSplitDebugInfoOption)
       ? stringArgDeprecated(FlutterOptions.kSplitDebugInfoOption)
       : null;
 
     final bool androidGradleDaemon = !argParser.options.containsKey(FlutterOptions.kAndroidGradleDaemon)
-      || boolArg(FlutterOptions.kAndroidGradleDaemon);
+      || boolArgDeprecated(FlutterOptions.kAndroidGradleDaemon);
 
     final List<String> androidProjectArgs = argParser.options.containsKey(FlutterOptions.kAndroidProjectArgs)
       ? stringsArg(FlutterOptions.kAndroidProjectArgs)
@@ -1085,7 +1085,7 @@ abstract class FlutterCommand extends Command<void> {
 
     final bool treeShakeIcons = argParser.options.containsKey('tree-shake-icons')
       && buildMode.isPrecompiled == true
-      && boolArg('tree-shake-icons');
+      && boolArgDeprecated('tree-shake-icons');
 
     final String? bundleSkSLPath = argParser.options.containsKey(FlutterOptions.kBundleSkSLPathOption)
       ? stringArgDeprecated(FlutterOptions.kBundleSkSLPathOption)
@@ -1141,7 +1141,7 @@ abstract class FlutterCommand extends Command<void> {
           ? stringArgDeprecated(FlutterOptions.kInitializeFromDill)
           : null,
       assumeInitializeFromDillUpToDate: argParser.options.containsKey(FlutterOptions.kAssumeInitializeFromDillUpToDate)
-          && boolArg(FlutterOptions.kAssumeInitializeFromDillUpToDate),
+          && boolArgDeprecated(FlutterOptions.kAssumeInitializeFromDillUpToDate),
     );
   }
 
@@ -1180,7 +1180,7 @@ abstract class FlutterCommand extends Command<void> {
       overrides: <Type, Generator>{FlutterCommand: () => this},
       body: () async {
         if (_usesFatalWarnings) {
-          globals.logger.fatalWarnings = boolArg(FlutterOptions.kFatalWarnings);
+          globals.logger.fatalWarnings = boolArgDeprecated(FlutterOptions.kFatalWarnings);
         }
         // Prints the welcome message if needed.
         globals.flutterUsage.printWelcome();
@@ -1303,7 +1303,7 @@ abstract class FlutterCommand extends Command<void> {
       // ios-deploy on macOS) are required to determine `requiredArtifacts`.
       final bool offline;
       if (argParser.options.containsKey('offline')) {
-        offline = boolArg('offline');
+        offline = boolArgDeprecated('offline');
       } else {
         offline = false;
       }
@@ -1519,7 +1519,16 @@ abstract class FlutterCommand extends Command<void> {
   ApplicationPackageFactory? applicationPackages;
 
   /// Gets the parsed command-line option named [name] as a `bool`.
-  bool boolArg(String name) => argResults?[name] as bool? ?? false;
+  /// This has been deprecated, use [boolArgDeprecated] instead.
+  bool boolArgDeprecated(String name) => argResults?[name] as bool? ?? false;
+
+  /// Gets the parsed command-line option named [name] as a `bool?`.
+  bool? boolArg(String name) {
+    if (argResults == null || !argParser.options.containsKey(name)) {
+      return null;
+    }
+    return argResults?[name] as bool?;
+  }
 
   /// Gets the parsed command-line option named [name] as a `String`.
   String? stringArgDeprecated(String name) => argResults?[name] as String?;

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -46,6 +46,8 @@ void main() {
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addFlag('key');
+    command.argParser.addFlag('key-false');
+
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key']);
 
@@ -54,6 +56,9 @@ void main() {
 
     expect(command.boolArgDeprecated('key'), true);
     expect(() => command.boolArgDeprecated('empty'), throwsA(const TypeMatcher<ArgumentError>()));
+
+    expect(command.boolArg('key-false'), false);
+    expect(command.boolArgDeprecated('key-false'), false);
   });
 
   testUsingContext('String? safe argResults', () async {

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -45,9 +45,9 @@ void main() {
         }
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
-    command.argParser.addOption('key');
+    command.argParser.addFlag('key');
     runner.addCommand(command);
-    await runner.run(<String>['dummy', '--key=true']);
+    await runner.run(<String>['dummy', '--key']);
 
     expect(command.boolArg('key'), true);
     expect(command.boolArg('empty'), null);

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/runner/flutter_command_runner.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/testbed.dart';
+import 'runner/utils.dart';
 
 class CommandDummy extends FlutterCommand{
   @override
@@ -36,6 +37,24 @@ void main() {
     ).forEach(runner.addCommand);
     verifyCommandRunner(runner);
   }));
+
+  testUsingContext('bool? safe argResults', () async {
+    final DummyFlutterCommand command = DummyFlutterCommand(
+        commandFunction: () async {
+          return const FlutterCommandResult(ExitStatus.success);
+        }
+    );
+    final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
+    command.argParser.addOption('key');
+    runner.addCommand(command);
+    await runner.run(<String>['dummy', '--key=true']);
+
+    expect(command.boolArg('key'), true);
+    expect(command.boolArg('empty'), null);
+
+    expect(command.boolArgDeprecated('key'), true);
+    expect(() => command.boolArgDeprecated('empty'), throwsA(const TypeMatcher<ArgumentError>()));
+  });
 
   testUsingContext('String? safe argResults', () async {
     final CommandDummy command = CommandDummy();


### PR DESCRIPTION
Deprecate the boolArg function, machine replace its usages, make new function handling nulls bool? boolArg

part of #101595

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
