### PR TITLE
Enable DeviceLab arm64 ios tests as `bringup: true`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -131,6 +131,29 @@ platform_properties:
       cpu: x86
       device_os: iOS-15.1
       xcode: 13a233
+  mac_arm64_ios:
+    properties:
+      caches: >-
+          [
+            {"name":"builder_mac_devicelab","path":"builder"},
+            {"name":"chrome_and_driver_96","path":"chrome"},
+            {"name":"flutter_sdk","path":"flutter sdk"},
+            {"name":"gradle","path":"gradle"},
+            {"name":"openjdk","path":"java11"},
+            {"name":"pub_cache","path":".pub-cache"},
+            {"name":"xcode_binary","path":"xcode_binary"},
+            {"name":"osx_sdk_13a233","path":"osx_sdk"}
+          ]
+      dependencies: >-
+        [
+          {"dependency": "xcode"},
+          {"dependency": "gems"},
+          {"dependency": "ios_signing"}
+        ]
+      os: Mac-12
+      cpu: arm64
+      device_os: iOS-15.1
+      xcode: 13a233
   windows:
     properties:
       caches: >-
@@ -2478,6 +2501,18 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Mac_arm64_ios build_ios_framework_module_test
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: build_ios_framework_module_test
+    runIf:
+      - dev/**
+    scheduler: luci
+
   - name: Mac build_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
@@ -3325,6 +3360,18 @@ targets:
       task_name: flutter_gallery_ios__compile
     scheduler: luci
 
+  - name: Mac_arm64_ios flutter_gallery_ios__compile
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: flutter_gallery_ios__compile
+    runIf:
+      - dev/**
+    scheduler: luci
+
   - name: Mac_ios flutter_gallery_ios__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3355,12 +3402,36 @@ targets:
       task_name: hello_world_ios__compile
     scheduler: luci
 
+  - name: Mac_arm64_ios hello_world_ios__compile
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: hello_world_ios__compile
+    runIf:
+      - dev/**
+    scheduler: luci
+
   - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       tags: >
         ["devicelab","ios","mac"]
+      task_name: hot_mode_dev_cycle_macos_target__benchmark
+    runIf:
+      - dev/**
+    scheduler: luci
+
+  - name: Mac_arm64_ios hot_mode_dev_cycle_macos_target__benchmark
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - dev/**
@@ -3436,6 +3507,18 @@ targets:
       task_name: ios_app_with_extensions_test
     scheduler: luci
 
+  - name: Mac_arm64_ios ios_app_with_extensions_test
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: ios_app_with_extensions_test
+    runIf:
+      - dev/**
+    scheduler: luci
+
   - name: Mac_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3444,6 +3527,18 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: ios_content_validation_test
+    scheduler: luci
+
+  - name: Mac_arm64_ios ios_content_validation_test
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: ios_content_validation_test
+    runIf:
+      - dev/**
     scheduler: luci
 
   - name: Mac_ios ios_defines_test
@@ -3485,6 +3580,18 @@ targets:
       tags: >
         ["devicelab","ios","mac"]
       task_name: macos_chrome_dev_mode
+    scheduler: luci
+
+  - name: Mac_arm64_ios macos_chrome_dev_mode
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: macos_chrome_dev_mode
+    runIf:
+      - dev/**
     scheduler: luci
 
   - name: Mac_ios microbenchmarks_ios
@@ -3640,6 +3747,18 @@ targets:
       task_name: native_ui_tests_ios
     scheduler: luci
 
+  - name: Mac_arm64_ios native_ui_tests_ios
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: native_ui_tests_ios
+    runIf:
+      - dev/**
+    scheduler: luci
+
   - name: Mac native_ui_tests_macos
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -3676,6 +3795,18 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
+    scheduler: luci
+
+  - name: Mac_arm64_ios run_release_test_macos
+    recipe: devicelab/devicelab_drone
+    bringup: true # https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","ios","mac","arm64"]
+      task_name: run_release_test_macos
+    runIf:
+      - dev/**
     scheduler: luci
 
   - name: Windows build_aar_module_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -148,7 +148,7 @@ platform_properties:
         [
           {"dependency": "xcode"},
           {"dependency": "gems"},
-          {"dependency": "ios_signing"}
+          {"dependency": "apple_signing"}
         ]
       os: Mac-12
       cpu: arm64

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2512,6 +2512,9 @@ targets:
       task_name: build_ios_framework_module_test
     runIf:
       - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
     scheduler: luci
 
   - name: Mac build_tests_1_4
@@ -3370,8 +3373,6 @@ targets:
       tags: >
         ["devicelab","ios","mac","arm64"]
       task_name: flutter_gallery_ios__compile
-    runIf:
-      - dev/**
     scheduler: luci
 
   - name: Mac_ios flutter_gallery_ios__start_up
@@ -3413,8 +3414,6 @@ targets:
       tags: >
         ["devicelab","ios","mac","arm64"]
       task_name: hello_world_ios__compile
-    runIf:
-      - dev/**
     scheduler: luci
 
   - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
@@ -3520,8 +3519,6 @@ targets:
       tags: >
         ["devicelab","ios","mac","arm64"]
       task_name: ios_app_with_extensions_test
-    runIf:
-      - dev/**
     scheduler: luci
 
   - name: Mac_ios ios_content_validation_test
@@ -3543,8 +3540,6 @@ targets:
       tags: >
         ["devicelab","ios","mac","arm64"]
       task_name: ios_content_validation_test
-    runIf:
-      - dev/**
     scheduler: luci
 
   - name: Mac_ios ios_defines_test
@@ -3597,8 +3592,6 @@ targets:
       tags: >
         ["devicelab","ios","mac","arm64"]
       task_name: macos_chrome_dev_mode
-    runIf:
-      - dev/**
     scheduler: luci
 
   - name: Mac_ios microbenchmarks_ios
@@ -3763,8 +3756,6 @@ targets:
       tags: >
         ["devicelab","ios","mac","arm64"]
       task_name: native_ui_tests_ios
-    runIf:
-      - dev/**
     scheduler: luci
 
   - name: Mac native_ui_tests_macos
@@ -3816,6 +3807,9 @@ targets:
       task_name: run_release_test_macos
     runIf:
       - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
     scheduler: luci
 
   - name: Windows build_aar_module_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2503,6 +2503,7 @@ targets:
 
   - name: Mac_arm64_ios build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3362,6 +3363,7 @@ targets:
 
   - name: Mac_arm64_ios flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3404,6 +3406,7 @@ targets:
 
   - name: Mac_arm64_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3427,6 +3430,7 @@ targets:
 
   - name: Mac_arm64_ios hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3509,6 +3513,7 @@ targets:
 
   - name: Mac_arm64_ios ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3531,6 +3536,7 @@ targets:
 
   - name: Mac_arm64_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3584,6 +3590,7 @@ targets:
 
   - name: Mac_arm64_ios macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3749,6 +3756,7 @@ targets:
 
   - name: Mac_arm64_ios native_ui_tests_ios
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
@@ -3799,6 +3807,7 @@ targets:
 
   - name: Mac_arm64_ios run_release_test_macos
     recipe: devicelab/devicelab_drone
+    presubmit: false
     bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:


### PR DESCRIPTION
This PR enables passing arm64 tests (staging) in prod. Initially as `bringup: true`, they will be marked as blocking when validated.

Context:
https://flutter-review.googlesource.com/c/infra/+/26927 enabled m1 tests in staging.
https://chrome-internal-review.googlesource.com/c/infradata/config/+/4680019 brought up 4 m1/ios testbeds in prod.
These tests have been passing consistently in staging:
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20hot_mode_dev_cycle_macos_target__benchmark
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20flutter_gallery_ios__compile
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20hello_world_ios__compile
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20native_ui_tests_ios
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20build_ios_framework_module_test
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20run_release_test_macos
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20ios_app_with_extensions_test
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20ios_content_validation_test
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_staging%20macos_chrome_dev_mode

Issue: https://github.com/flutter/flutter/issues/87508