### PR TITLE
Updating PrimaryScrollController for Desktop

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/colors_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/colors_demo.dart
@@ -96,6 +96,7 @@ class PaletteTabView extends StatelessWidget {
     final TextStyle blackTextStyle = textTheme.bodyText2!.copyWith(color: Colors.black);
     return Scrollbar(
       child: ListView(
+        primary: true,
         itemExtent: kColorItemHeight,
         children: <Widget>[
           ...primaryKeys.map<Widget>((int index) {

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_alert_demo.dart
@@ -60,6 +60,7 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo> {
               children: <Widget>[
                 CupertinoScrollbar(
                   child: ListView(
+                    primary: true,
                     // Add more padding to the normal safe area.
                     padding: const EdgeInsets.symmetric(vertical: 24.0, horizontal: 72.0)
                         + MediaQuery.of(context).padding,

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_navigation_demo.dart
@@ -446,6 +446,7 @@ class CupertinoDemoTab2 extends StatelessWidget {
       ),
       child: CupertinoScrollbar(
         child: ListView(
+          primary: true,
           children: <Widget>[
             const CupertinoUserInterfaceLevel(
               data: CupertinoUserInterfaceLevelData.elevated,

--- a/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/cupertino/cupertino_text_field_demo.dart
@@ -168,6 +168,7 @@ class _CupertinoTextFieldDemoState extends State<CupertinoTextFieldDemo> {
         ),
         child: CupertinoScrollbar(
           child: ListView(
+            primary: true,
             children: <Widget>[
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 32.0, horizontal: 16.0),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/backdrop_demo.dart
@@ -104,6 +104,7 @@ class CategoryView extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     return Scrollbar(
       child: ListView(
+        primary: true,
         key: PageStorageKey<Category?>(category),
         padding: const EdgeInsets.symmetric(
           vertical: 16.0,

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/bottom_app_bar_demo.dart
@@ -161,6 +161,7 @@ class _BottomAppBarDemoState extends State<BottomAppBarDemo> {
           ),
           body: Scrollbar(
             child: ListView(
+              primary: true,
               padding: const EdgeInsets.only(bottom: 88.0),
               children: <Widget>[
                 const _Heading('FAB Shape'),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -375,6 +375,7 @@ class _CardsDemoState extends State<CardsDemo> {
       ),
       body: Scrollbar(
         child: ListView(
+          primary: true,
           padding: const EdgeInsets.only(top: 8.0, left: 8.0, right: 8.0),
           children: destinations.map<Widget>((TravelDestination destination) {
             Widget? child;

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/chip_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/chip_demo.dart
@@ -347,7 +347,12 @@ class _ChipDemoState extends State<ChipDemo> {
                 borderRadius: BorderRadius.circular(10.0),
               ))
             : theme.chipTheme,
-        child: Scrollbar(child: ListView(children: tiles)),
+        child: Scrollbar(
+          child: ListView(
+            primary: true,
+            children: tiles,
+          )
+        ),
       ),
       floatingActionButton: FloatingActionButton(
         onPressed: () => setState(_reset),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/data_table_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/data_table_demo.dart
@@ -175,6 +175,7 @@ class _DataTableDemoState extends State<DataTableDemo> {
       ),
       body: Scrollbar(
         child: ListView(
+          primary: true,
           padding: const EdgeInsets.all(20.0),
           children: <Widget>[
             PaginatedDataTable(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/elevation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/elevation_demo.dart
@@ -64,7 +64,7 @@ class _ElevationDemoState extends State<ElevationDemo> {
           ),
         ],
       ),
-      body: Scrollbar(child: ListView(children: buildCards())),
+      body: Scrollbar(child: ListView(primary: true, children: buildCards())),
     );
   }
 }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/elevation_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/elevation_demo.dart
@@ -64,7 +64,12 @@ class _ElevationDemoState extends State<ElevationDemo> {
           ),
         ],
       ),
-      body: Scrollbar(child: ListView(primary: true, children: buildCards())),
+      body: Scrollbar(
+        child: ListView(
+          primary: true,
+          children: buildCards(),
+        ),
+      ),
     );
   }
 }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/expansion_tile_list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/expansion_tile_list_demo.dart
@@ -20,6 +20,7 @@ class ExpansionTileListDemo extends StatelessWidget {
       ),
       body: Scrollbar(
         child: ListView(
+          primary: true,
           children: <Widget>[
             const ListTile(title: Text('Top')),
             ExpansionTile(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/full_screen_dialog_demo.dart
@@ -162,6 +162,7 @@ class FullScreenDialogDemoState extends State<FullScreenDialogDemo> {
         onWillPop: _onWillPop,
         child: Scrollbar(
           child: ListView(
+            primary: true,
             padding: const EdgeInsets.all(16.0),
             children: <Widget>[
               Container(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/icons_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/icons_demo.dart
@@ -62,6 +62,7 @@ class IconsDemoState extends State<IconsDemo> {
           bottom: false,
           child: Scrollbar(
             child: ListView(
+              primary: true,
               padding: const EdgeInsets.all(24.0),
               children: <Widget>[
                 _IconsDemoCard(handleIconButtonPress, Icons.face), // direction-agnostic icon

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/leave_behind_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/leave_behind_demo.dart
@@ -131,6 +131,7 @@ class LeaveBehindDemoState extends State<LeaveBehindDemo> {
     } else {
       body = Scrollbar(
         child: ListView(
+          primary: true,
           children: leaveBehindItems.map<Widget>((LeaveBehindItem item) {
             return _LeaveBehindListItem(
               confirmDismiss: _confirmDismiss,

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/list_demo.dart
@@ -256,6 +256,7 @@ class _ListDemoState extends State<ListDemo> {
       ),
       body: Scrollbar(
         child: ListView(
+          primary: true,
           padding: EdgeInsets.symmetric(vertical: _dense != null ? 4.0 : 8.0),
           children: listTiles.toList(),
         ),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/overscroll_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/overscroll_demo.dart
@@ -64,6 +64,7 @@ class OverscrollDemoState extends State<OverscrollDemo> {
         onRefresh: _handleRefresh,
         child: Scrollbar(
           child: ListView.builder(
+            primary: true,
             padding: kMaterialListPadding,
             itemCount: _items.length,
             itemBuilder: (BuildContext context, int index) {

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/reorderable_list_demo.dart
@@ -208,6 +208,7 @@ class _ListDemoState extends State<ReorderableListDemo> {
       ),
       body: Scrollbar(
         child: ReorderableListView(
+          primary: true,
           header: _itemType != _ReorderableListType.threeLine
               ? Padding(
                   padding: const EdgeInsets.all(8.0),

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/text_form_field_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/text_form_field_demo.dart
@@ -182,6 +182,7 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
           onWillPop: _warnUserAboutInvalidData,
           child: Scrollbar(
             child: SingleChildScrollView(
+              primary: true,
               dragStartBehavior: DragStartBehavior.down,
               padding: const EdgeInsets.symmetric(horizontal: 16.0),
               child: Column(

--- a/dev/integration_tests/flutter_gallery/lib/demo/typography_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/typography_demo.dart
@@ -66,7 +66,7 @@ class TypographyDemo extends StatelessWidget {
       body: SafeArea(
         top: false,
         bottom: false,
-        child: Scrollbar(child: ListView(children: styleItems)),
+        child: Scrollbar(child: ListView(primary: true, children: styleItems)),
       ),
     );
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/typography_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/typography_demo.dart
@@ -66,7 +66,12 @@ class TypographyDemo extends StatelessWidget {
       body: SafeArea(
         top: false,
         bottom: false,
-        child: Scrollbar(child: ListView(primary: true, children: styleItems)),
+        child: Scrollbar(
+          child: ListView(
+            primary: true,
+            children: styleItems,
+          ),
+        ),
       ),
     );
   }

--- a/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/video_demo.dart
@@ -418,6 +418,7 @@ class _VideoDemoState extends State<VideoDemo> with SingleTickerProviderStateMix
             connectedCompleter: connectedCompleter,
             child: Scrollbar(
               child: ListView(
+                primary: true,
                 children: <Widget>[
                   VideoCard(
                     title: 'Butterfly',

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.0.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.0.dart
@@ -45,8 +45,9 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
         children: <Widget>[
           SizedBox(
               width: constraints.maxWidth / 2,
-              // Only one scroll position can be attached to the
-              // PrimaryScrollController if using Scrollbars. Providing a
+              // When using the PrimaryScrollController and a Scrollbar
+              // together, only one ScrollPosition can be attached to the
+              // PrimaryScrollController at a time. Providing a
               // unique scroll controller to this scroll view prevents it
               // from attaching to the PrimaryScrollController.
               child: Scrollbar(
@@ -64,12 +65,15 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
               )),
           SizedBox(
               width: constraints.maxWidth / 2,
-              // This vertical scroll view has not been provided a
-              // ScrollController, so it is using the
-              // PrimaryScrollController.
+              // This vertical scroll view has primary set to true, so it is
+              // using the PrimaryScrollController. On mobile platforms, the
+              // PrimaryScrollController automatically attaches to vertical
+              // ScrollViews, unlike on Desktop platforms, where the primary
+              // parameter is required.
               child: Scrollbar(
                 thumbVisibility: true,
                 child: ListView.builder(
+                    primary: true,
                     itemCount: 100,
                     itemBuilder: (BuildContext context, int index) {
                       return Container(

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.shape.0.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.shape.0.dart
@@ -35,6 +35,11 @@ class MyStatelessWidget extends StatelessWidget {
         thumbColor: Colors.blue,
         thumbVisibility: true,
         child: ListView(
+          // On mobile platforms, setting primary to true is not required, as
+          // the PrimaryScrollController automatically attaches to vertical
+          // ScrollPositions. On desktop platforms however, using the
+          // PrimaryScrollController requires ScrollView.primary be set.
+          primary: true,
           physics: const BouncingScrollPhysics(),
           children: List<Text>.generate(
               100, (int index) => Text((index * index).toString())),

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -309,6 +309,8 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
                   child: Scrollbar(
                     thumbVisibility: true,
                     child: ListView(
+                      // Ensure this always inherits the PrimaryScrollController
+                      primary: true,
                       padding: kMaterialListPadding,
                       shrinkWrap: true,
                       children: children,

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -317,7 +317,7 @@ class NestedScrollView extends StatefulWidget {
         child: PrimaryScrollController(
           // The inner scroll view should always inherit this
           // PrimaryScrollController, on every platform.
-          autoForPlatforms: TargetPlatform.values.toSet(),
+          automaticallyInheritForPlatforms: TargetPlatform.values.toSet(),
           // `PrimaryScrollController.scrollDirection` is not set, and so it is
           // restricted to the default Axis.vertical.
           // Ideally the inner and outer views would have the same

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -312,7 +312,19 @@ class NestedScrollView extends StatefulWidget {
     return <Widget>[
       ...headerSliverBuilder(context, bodyIsScrolled),
       SliverFillRemaining(
+        // The inner (body) scroll view must use this scroll controller so that
+        // the independent scroll positions can be kept in sync.
         child: PrimaryScrollController(
+          // The inner scroll view should always inherit this
+          // PrimaryScrollController, on every platform.
+          autoForPlatforms: TargetPlatform.values.toSet(),
+          // `PrimaryScrollController.scrollDirection` is not set, and so it is
+          // restricted to the default Axis.vertical.
+          // Ideally the inner and outer views would have the same
+          // scroll direction, and so we could assume
+          // `NestedScrollView.scrollDirection` for the PrimaryScrollController,
+          // but use cases already exist where the axes are mismatched.
+          // https://github.com/flutter/flutter/issues/102001
           controller: innerController,
           child: body,
         ),

--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -17,15 +17,20 @@ const Set<TargetPlatform> _kMobilePlatforms = <TargetPlatform>{
 
 /// Associates a [ScrollController] with a subtree.
 ///
-// TODO(Piinks): update docs if this concept tracks
+/// When a [ScrollView] has [ScrollView.primary] set to true, the [ScrollView]
+/// uses [of] to inherit the [PrimaryScrollController] associated with its
+/// subtree.
 ///
-/// When a [ScrollView] has [ScrollView.primary] set to true and is not given
-/// an explicit [ScrollController], the [ScrollView] uses [of] to find the
-/// [ScrollController] associated with its subtree.
+/// The PrimaryScrollController can be automatically inherited
+/// based on the [scrollDirection] and [TargetPlatform]. A [ScrollView] that has
+/// not been provided a controller, or set [ScrollView.primary], will evaluate
+/// this inheritance option using [shouldInherit]. By default, an [Axis.vertical]
+/// ScrollView on mobile platforms will automatically inherit the
+/// PrimaryScrollController.
 ///
-/// This mechanism can be used to provide default behavior for scroll views in a
-/// subtree. For example, the [Scaffold] uses this mechanism to implement the
-/// scroll-to-top gesture on iOS.
+/// Inheriting this ScrollController can provide default behavior for scroll
+/// views in a subtree. For example, the [Scaffold] uses this mechanism to
+/// implement the scroll-to-top gesture on iOS.
 ///
 /// Another default behavior handled by the PrimaryScrollController is default
 /// [ScrollAction]s. If a ScrollAction is not handled by an otherwise focused
@@ -83,7 +88,6 @@ class PrimaryScrollController extends InheritedWidget {
   ///
   /// When empty, no ScrollView in any Axis will automatically inherit this
   /// controller. Defaults to [TargetPlatformVariant.mobile].
-  // TODO(Piinks): Consider a better name if this concept tracks
   final Set<TargetPlatform> autoForPlatforms;
 
   /// Returns true if this PrimaryScrollController is configured to be

--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -3,11 +3,21 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
 
 import 'framework.dart';
+import 'scroll_configuration.dart';
 import 'scroll_controller.dart';
 
+const Set<TargetPlatform> _kMobilePlatforms = <TargetPlatform>{
+  TargetPlatform.android,
+  TargetPlatform.iOS,
+  TargetPlatform.fuchsia,
+};
+
 /// Associates a [ScrollController] with a subtree.
+///
+// TODO(Piinks): update docs if this concept tracks
 ///
 /// When a [ScrollView] has [ScrollView.primary] set to true and is not given
 /// an explicit [ScrollController], the [ScrollView] uses [of] to find the
@@ -34,6 +44,8 @@ class PrimaryScrollController extends InheritedWidget {
   const PrimaryScrollController({
     super.key,
     required ScrollController this.controller,
+    this.autoForPlatforms = _kMobilePlatforms,
+    this.scrollDirection = Axis.vertical,
     required super.child,
   }) : assert(controller != null);
 
@@ -41,7 +53,9 @@ class PrimaryScrollController extends InheritedWidget {
   const PrimaryScrollController.none({
     super.key,
     required super.child,
-  }) : controller = null;
+  }) : autoForPlatforms = const <TargetPlatform>{},
+       scrollDirection = null,
+       controller = null;
 
   /// The [ScrollController] associated with the subtree.
   ///
@@ -50,6 +64,45 @@ class PrimaryScrollController extends InheritedWidget {
   ///  * [ScrollView.controller], which discusses the purpose of specifying a
   ///    scroll controller.
   final ScrollController? controller;
+
+  /// The [Axis] this controller is configured for [ScrollView]s to
+  /// automatically inherit.
+  ///
+  /// Used in conjunction with [autoForPlatforms]. If the current
+  /// [TargetPlatform] is not included in [autoForPlatforms], this is ignored.
+  ///
+  /// When null, no ScrollView in any Axis will automatically inherit this
+  /// controller. Defaults to [Axis.vertical].
+  final Axis? scrollDirection;
+
+  /// The [TargetPlatform]s this controller is configured for [ScrollView]s to
+  /// automatically inherit.
+  ///
+  /// Used in conjunction with [scrollDirection]. If the given [Axis] is not
+  /// [scrollDirection], this is ignored.
+  ///
+  /// When empty, no ScrollView in any Axis will automatically inherit this
+  /// controller. Defaults to [TargetPlatformVariant.mobile].
+  // TODO(Piinks): Consider a better name if this concept tracks
+  final Set<TargetPlatform> autoForPlatforms;
+
+  /// Returns true if this PrimaryScrollController is configured to be
+  /// automatically inherited for the current [TargetPlatform] and the given
+  /// [Axis].
+  ///
+  /// If a [ScrollController] has already been provided to
+  /// [ScrollView.controller], or [ScrollView.primary] is false, this is
+  /// disregarded.
+  static bool shouldInherit(BuildContext context, Axis scrollDirection) {
+    final PrimaryScrollController? result = context.findAncestorWidgetOfExactType<PrimaryScrollController>();
+    final TargetPlatform platform = ScrollConfiguration.of(context).getPlatform(context);
+    if (result == null)
+      return false;
+
+    if (result.autoForPlatforms.contains(platform))
+      return result.scrollDirection == scrollDirection;
+    return false;
+  }
 
   /// Returns the [ScrollController] most closely associated with the given
   /// context.

--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -109,12 +109,14 @@ class PrimaryScrollController extends InheritedWidget {
   /// inherit the PrimaryScrollController.
   static bool shouldInherit(BuildContext context, Axis scrollDirection) {
     final PrimaryScrollController? result = context.findAncestorWidgetOfExactType<PrimaryScrollController>();
-    if (result == null)
+    if (result == null) {
       return false;
+    }
 
     final TargetPlatform platform = ScrollConfiguration.of(context).getPlatform(context);
-    if (result.automaticallyInheritForPlatforms.contains(platform))
+    if (result.automaticallyInheritForPlatforms.contains(platform)) {
       return result.scrollDirection == scrollDirection;
+    }
     return false;
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -179,9 +179,13 @@ abstract class ScrollView extends StatelessWidget {
   ///
   /// Defaults to null. When null, and a controller is not provided,
   /// [PrimaryScrollController.shouldInherit] is used to decide automatic
-  /// inheritance. By default, a [PrimaryScrollController] is configured to
-  /// automatically be inherited on [TargetPlatformVariant.mobile] for
-  /// ScrollViews in the [Axis.vertical] scroll direction.
+  /// inheritance.
+  ///
+  /// By default, the [PrimaryScrollController] that is injected by each
+  /// [ModalRoute] is configured to automatically be inherited on
+  /// [TargetPlatformVariant.mobile] for ScrollViews in the [Axis.vertical]
+  /// scroll direction. Adding another to your app will override the
+  /// PrimaryScrollController above it.
   /// {@endtemplate}
   final bool? primary;
 

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -177,7 +177,7 @@ abstract class ScrollView extends StatelessWidget {
   /// Setting to false will explicitly prevent inheriting any
   /// [PrimaryScrollController].
   ///
-  /// Defaults to null. In the case of null,
+  /// Defaults to null. When null, and a controller is not provided,
   /// [PrimaryScrollController.shouldInherit] is used to decide automatic
   /// inheritance. By default, a [PrimaryScrollController] is configured to
   /// automatically be inherited on [TargetPlatformVariant.mobile] for

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1685,7 +1685,7 @@ class ScrollAction extends Action<ScrollIntent> {
             ),
             ErrorDescription(
               'Only one ScrollPosition can be manipulated by a ScrollAction at '
-              'a time. ',
+              'a time.',
             ),
             ErrorHint(
               'The PrimaryScrollController can be inherited automatically by '

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1586,13 +1586,8 @@ class ScrollAction extends Action<ScrollIntent> {
         return true;
       }
       // Check for fallback scrollable with context from PrimaryScrollController
-      if (PrimaryScrollController.of(focus.context!) != null) {
-        final ScrollController? primaryScrollController = PrimaryScrollController.of(focus.context!);
-        return primaryScrollController != null
-          && primaryScrollController.hasClients
-          && primaryScrollController.position.context.notificationContext != null
-          && Scrollable.of(primaryScrollController.position.context.notificationContext!) != null;
-      }
+      final ScrollController? primaryScrollController = PrimaryScrollController.of(focus.context!);
+      return primaryScrollController != null && primaryScrollController.hasClients;
     }
     return false;
   }
@@ -1681,7 +1676,34 @@ class ScrollAction extends Action<ScrollIntent> {
     ScrollableState? state = Scrollable.of(primaryFocus!.context!);
     if (state == null) {
       final ScrollController? primaryScrollController = PrimaryScrollController.of(primaryFocus!.context!);
-      state = Scrollable.of(primaryScrollController!.position.context.notificationContext!);
+      assert (() {
+        if (primaryScrollController!.positions.length != 1) {
+          throw FlutterError.fromParts(<DiagnosticsNode>[
+            ErrorSummary(
+              'A ScrollAction was invoked with the PrimaryScrollController, but '
+              'more than one ScrollPosition is attached.',
+            ),
+            ErrorDescription(
+              'Only one ScrollPosition can be manipulated by a ScrollAction at '
+              'a time. ',
+            ),
+            ErrorHint(
+              'The PrimaryScrollController can be inherited automatically by '
+              'descendant ScrollViews based on the TargetPlatform and scroll '
+              'direction. By default, the PrimaryScrollController is '
+              'automatically inherited on mobile platforms for vertical '
+              'ScrollViews. ScrollView.primary can also override this behavior.',
+            ),
+          ]);
+        }
+        return true;
+      }());
+
+      if (primaryScrollController!.position.context.notificationContext == null
+        && Scrollable.of(primaryScrollController.position.context.notificationContext!) == null) {
+        return;
+      }
+      state = Scrollable.of(primaryScrollController.position.context.notificationContext!);
     }
     assert(state != null, '$ScrollAction was invoked on a context that has no scrollable parent');
     assert(state!.position.hasPixels, 'Scrollable must be laid out before it can be scrolled via a ScrollAction');

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1700,7 +1700,7 @@ class ScrollAction extends Action<ScrollIntent> {
       }());
 
       if (primaryScrollController!.position.context.notificationContext == null
-        && Scrollable.of(primaryScrollController.position.context.notificationContext!) == null) {
+          && Scrollable.of(primaryScrollController.position.context.notificationContext!) == null) {
         return;
       }
       state = Scrollable.of(primaryScrollController.position.context.notificationContext!);

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1512,12 +1512,12 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
             'ScrollController should be associated with the ScrollView that '
             'the Scrollbar is being applied to. '
             '${tryPrimary
-              ? 'A ScrollView with an Axis.vertical '
-                'ScrollDirection will automatically use the '
+              ? 'A ScrollView with an Axis.vertical ScrollDirection on mobile '
+                'platforms will automatically use the '
                 'PrimaryScrollController if the user has not provided a '
-                'ScrollController, but a ScrollDirection of Axis.horizontal will '
-                'not. To use the PrimaryScrollController explicitly, set ScrollView.primary '
-                'to true for the Scrollable widget.'
+                'ScrollController. To use the PrimaryScrollController '
+                'explicitly, set ScrollView.primary  to true for the Scrollable '
+                'widget.'
               : 'When providing your own ScrollController, ensure both the '
                 'Scrollbar and the Scrollable widget use the same one.'
             }',
@@ -1542,16 +1542,17 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
             'The Scrollbar requires a single ScrollPosition in order to be painted.',
           ),
           ErrorHint(
-            'When $when, the associated Scrollable '
-            'widgets must have unique ScrollControllers. '
+            'When $when, the associated ScrollController should only have one '
+            'ScrollPosition attached. '
             '${tryPrimary
-              ? 'The PrimaryScrollController is used by default for '
-                'ScrollViews with an Axis.vertical ScrollDirection, '
-                'unless the ScrollView has been provided its own '
-                'ScrollController. More than one Scrollable may have tried '
-                'to use the PrimaryScrollController of the current context.'
-              : 'The provided ScrollController must be unique to a '
-                'Scrollable widget.'
+              ? 'If a ScrollController has not been provided, the '
+                'PrimaryScrollController is used by default on mobile platforms '
+                'for ScrollViews with an Axis.vertical scroll direction. More '
+                'than one ScrollView may have tried to use the '
+                'PrimaryScrollController of the current context. '
+                'ScrollView.primary can override this behavior.'
+              : 'The provided ScrollController must be unique to one '
+                'ScrollView widget.'
             }',
           ),
         ]);

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1510,7 +1510,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
           ErrorHint(
             'The Scrollbar attempted to use the $controllerForError. This '
             'ScrollController should be associated with the ScrollView that '
-            'the Scrollbar is being applied to. '
+            'the Scrollbar is being applied to.'
             '${tryPrimary
               ? 'A ScrollView with an Axis.vertical ScrollDirection on mobile '
                 'platforms will automatically use the '
@@ -1542,8 +1542,8 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
             'The Scrollbar requires a single ScrollPosition in order to be painted.',
           ),
           ErrorHint(
-            'When $when, the associated ScrollController should only have one '
-            'ScrollPosition attached. '
+            'When $when, the associated ScrollController must only have one '
+            'ScrollPosition attached.'
             '${tryPrimary
               ? 'If a ScrollController has not been provided, the '
                 'PrimaryScrollController is used by default on mobile platforms '

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -849,9 +849,12 @@ class ScrollbarPainter extends ChangeNotifier implements CustomPainter {
 /// This sample shows an app with two scrollables in the same route. Since by
 /// default, there is one [PrimaryScrollController] per route, and they both have a
 /// scroll direction of [Axis.vertical], they would both try to attach to that
-/// controller. The [Scrollbar] cannot support multiple positions attached to
-/// the same controller, so one [ListView], and its [Scrollbar] have been
-/// provided a unique [ScrollController].
+/// controller on mobile platforms. The [Scrollbar] cannot support multiple
+/// positions attached to the same controller, so one [ListView], and its
+/// [Scrollbar] have been provided a unique [ScrollController]. Desktop
+/// platforms do not automatically attach to the PrimaryScrollController,
+/// requiring [ScrollView.primary] to be true instead in order to use the
+/// PrimaryScrollController.
 ///
 /// Alternatively, a new PrimaryScrollController could be created above one of
 /// the [ListView]s.

--- a/packages/flutter/lib/src/widgets/scrollbar.dart
+++ b/packages/flutter/lib/src/widgets/scrollbar.dart
@@ -1516,7 +1516,7 @@ class RawScrollbarState<T extends RawScrollbar> extends State<T> with TickerProv
                 'platforms will automatically use the '
                 'PrimaryScrollController if the user has not provided a '
                 'ScrollController. To use the PrimaryScrollController '
-                'explicitly, set ScrollView.primary  to true for the Scrollable '
+                'explicitly, set ScrollView.primary to true for the Scrollable '
                 'widget.'
               : 'When providing your own ScrollController, ensure both the '
                 'Scrollbar and the Scrollable widget use the same one.'

--- a/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/range_maintaining_scroll_physics_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -377,7 +378,7 @@ class RangeMaintainingTestScrollBehavior extends ScrollBehavior {
   const RangeMaintainingTestScrollBehavior();
 
   @override
-  TargetPlatform getPlatform(BuildContext context) => throw 'should not be called';
+  TargetPlatform getPlatform(BuildContext context) => defaultTargetPlatform;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -900,6 +900,17 @@ void main() {
     expect(log, isEmpty);
   });
 
+  test('PrimaryScrollController.automaticallyInheritOnPlatforms defaults to all mobile platforms', (){
+     final PrimaryScrollController primaryScrollController = PrimaryScrollController(
+        controller: ScrollController(),
+       child: const SizedBox(),
+     );
+     expect(
+       primaryScrollController.automaticallyInheritForPlatforms,
+       TargetPlatformVariant.mobile().values,
+     );
+  });
+
   testWidgets('Vertical CustomScrollViews are not primary by default', (WidgetTester tester) async {
     const CustomScrollView view = CustomScrollView();
     expect(view.primary, isNull);
@@ -951,7 +962,7 @@ void main() {
     expect(view.primary, isNull);
   });
 
-  testWidgets('Vertical GRidViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
+  testWidgets('Vertical GridViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(primaryScrollControllerBoilerplate(
       child: GridView.count(crossAxisCount: 1),

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -54,6 +54,19 @@ Widget textFieldBoilerplate({ required Widget child }) {
   );
 }
 
+Widget primaryScrollControllerBoilerplate({ required Widget child, required ScrollController controller }) {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: PrimaryScrollController(
+        controller: controller,
+        child: child,
+      ),
+    ),
+  );
+}
+
 void main() {
   testWidgets('ListView control test', (WidgetTester tester) async {
     final List<String> log = <String>[];
@@ -887,61 +900,144 @@ void main() {
     expect(log, isEmpty);
   });
 
-  testWidgets('Vertical CustomScrollViews are primary by default', (WidgetTester tester) async {
+  testWidgets('Vertical CustomScrollViews are not primary by default', (WidgetTester tester) async {
     const CustomScrollView view = CustomScrollView();
-    expect(view.primary, isTrue);
+    expect(view.primary, isNull);
   });
 
-  testWidgets('Vertical ListViews are primary by default', (WidgetTester tester) async {
+  testWidgets('Vertical CustomScrollViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: const CustomScrollView(),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isTrue);
+  }, variant: TargetPlatformVariant.mobile());
+
+  testWidgets("Vertical CustomScrollViews don't use PrimaryScrollController by default on desktop", (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+        child: const CustomScrollView(),
+        controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
+  }, variant: TargetPlatformVariant.desktop());
+
+  testWidgets('Vertical ListViews are not primary by default', (WidgetTester tester) async {
     final ListView view = ListView();
-    expect(view.primary, isTrue);
+    expect(view.primary, isNull);
   });
 
-  testWidgets('Vertical GridViews are primary by default', (WidgetTester tester) async {
-    final GridView view = GridView.count(
-      crossAxisCount: 1,
-    );
-    expect(view.primary, isTrue);
+  testWidgets('Vertical ListViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: ListView(),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isTrue);
+  }, variant: TargetPlatformVariant.mobile());
+
+  testWidgets("Vertical ListViews don't use PrimaryScrollController by default on desktop", (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: ListView(),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
+  }, variant: TargetPlatformVariant.desktop());
+
+  testWidgets('Vertical GridViews are not primary by default', (WidgetTester tester) async {
+    final GridView view = GridView.count(crossAxisCount: 1);
+    expect(view.primary, isNull);
   });
+
+  testWidgets('Vertical GRidViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: GridView.count(crossAxisCount: 1),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isTrue);
+  }, variant: TargetPlatformVariant.mobile());
+
+  testWidgets("Vertical GridViews don't use PrimaryScrollController by default on desktop", (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: GridView.count(crossAxisCount: 1),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets('Horizontal CustomScrollViews are non-primary by default', (WidgetTester tester) async {
-    const CustomScrollView view = CustomScrollView(scrollDirection: Axis.horizontal);
-    expect(view.primary, isFalse);
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: CustomScrollView(
+        scrollDirection: Axis.horizontal,
+        controller: ScrollController(),
+      ),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
   });
 
   testWidgets('Horizontal ListViews are non-primary by default', (WidgetTester tester) async {
-    final ListView view = ListView(scrollDirection: Axis.horizontal);
-    expect(view.primary, isFalse);
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: ListView(
+        scrollDirection: Axis.horizontal,
+        controller: ScrollController(),
+      ),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
   });
 
   testWidgets('Horizontal GridViews are non-primary by default', (WidgetTester tester) async {
-    final GridView view = GridView.count(
-      scrollDirection: Axis.horizontal,
-      crossAxisCount: 1,
-    );
-    expect(view.primary, isFalse);
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: GridView.count(
+        scrollDirection: Axis.horizontal,
+        controller: ScrollController(),
+        crossAxisCount: 1,
+      ),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
   });
 
   testWidgets('CustomScrollViews with controllers are non-primary by default', (WidgetTester tester) async {
-    final CustomScrollView view = CustomScrollView(
-      controller: ScrollController(),
-    );
-    expect(view.primary, isFalse);
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: CustomScrollView(
+        controller: ScrollController(),
+      ),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
   });
 
   testWidgets('ListViews with controllers are non-primary by default', (WidgetTester tester) async {
-    final ListView view = ListView(
-      controller: ScrollController(),
-    );
-    expect(view.primary, isFalse);
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: ListView(
+        controller: ScrollController(),
+      ),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
   });
 
   testWidgets('GridViews with controllers are non-primary by default', (WidgetTester tester) async {
-    final GridView view = GridView.count(
-      controller: ScrollController(),
-      crossAxisCount: 1,
-    );
-    expect(view.primary, isFalse);
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: GridView.count(
+        controller: ScrollController(),
+        crossAxisCount: 1,
+      ),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
   });
 
   testWidgets('CustomScrollView sets PrimaryScrollController when primary', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/scroll_view_test.dart
+++ b/packages/flutter/test/widgets/scroll_view_test.dart
@@ -1444,9 +1444,6 @@ void main() {
         ),
       ),
     );
-    final ScrollController controller = PrimaryScrollController.of(
-      tester.element(find.byType(CustomScrollView).first),
-    )!;
     await tester.pumpAndSettle();
     expect(
       tester.getRect(

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -2203,7 +2203,89 @@ void main() {
     await tester.pumpAndSettle();
   });
 
-  testWidgets('Scrollbar thumb can be dragged when the scrollable widget has a negative minScrollExtent', (WidgetTester tester) async {
+  testWidgets('Scrollbar thumb can be dragged when the scrollable widget has a negative minScrollExtent - desktop', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/95840
+
+    final ScrollController scrollController = ScrollController();
+    final UniqueKey uniqueKey = UniqueKey();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: ScrollConfiguration(
+            behavior: const ScrollBehavior().copyWith(
+              scrollbars: false,
+            ),
+            child: PrimaryScrollController(
+              controller: scrollController,
+              child: RawScrollbar(
+                isAlwaysShown: true,
+                controller: scrollController,
+                child: CustomScrollView(
+                  primary: true,
+                  center: uniqueKey,
+                  slivers: <Widget>[
+                    SliverToBoxAdapter(
+                      child: Container(
+                        height: 600.0,
+                      ),
+                    ),
+                    SliverToBoxAdapter(
+                      key: uniqueKey,
+                      child: Container(
+                        height: 600.0,
+                      ),
+                    ),
+                    SliverToBoxAdapter(
+                      child: Container(
+                        height: 600.0,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    expect(scrollController.offset, 0.0);
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0))
+        ..rect(
+          rect: const Rect.fromLTRB(794.0, 200.0, 800.0, 400.0),
+          color: const Color(0x66BCBCBC),
+        ),
+    );
+
+    // Drag the thumb up to scroll up.
+    const double scrollAmount = -10.0;
+    final TestGesture dragScrollbarGesture = await tester.startGesture(const Offset(797.0, 300.0));
+    await tester.pumpAndSettle();
+    await dragScrollbarGesture.moveBy(const Offset(0.0, scrollAmount));
+    await tester.pumpAndSettle();
+    await dragScrollbarGesture.up();
+    await tester.pumpAndSettle();
+
+    // The view has scrolled more than it would have by a swipe gesture of the
+    // same distance.
+    expect(scrollController.offset, lessThan(scrollAmount * 2));
+    expect(
+      find.byType(RawScrollbar),
+      paints
+        ..rect(rect: const Rect.fromLTRB(794.0, 0.0, 800.0, 600.0))
+        ..rect(
+          rect: const Rect.fromLTRB(794.0, 190.0, 800.0, 390.0),
+          color: const Color(0x66BCBCBC),
+        ),
+    );
+  }, variant: TargetPlatformVariant.desktop());
+
+  testWidgets('Scrollbar thumb can be dragged when the scrollable widget has a negative minScrollExtent - mobile', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/95840
 
     final ScrollController scrollController = ScrollController();
@@ -2282,7 +2364,7 @@ void main() {
           color: const Color(0x66BCBCBC),
         ),
     );
-  }, variant: TargetPlatformVariant.all());
+  }, variant: TargetPlatformVariant.mobile());
 
   test('ScrollbarPainter.shouldRepaint returns true when any of the properties changes', () {
     ScrollbarPainter createPainter({


### PR DESCRIPTION
This updates the PrimaryScrollController to not automatically attach to scroll views on desktop as it does on mobile platforms.
This behavior has caused a lot of issues for users developing desktop applications that have multiple parallel vertical ScrollViews.
This adds two parameters to PrimaryScrollController
- `automaticallyInheritForPlatforms`
  - specifies a set of TargetPlatforms that will engage automatic inheritance
- `scrollDirection`
  - This adds the ability to specify which axis the PrimaryScrollController should be inherited for.

Also adds static method `shouldInherit`, which uses the two properties above to determine if automatically inheriting the ScrollController is appropriate for the current configuration.

This design and other approaches is discussed at length in [this design document](https://docs.google.com/document/d/12OQx7h8UQzzAi0Kxh-saDC2dg7h2fghCCzwJ0ysPmZE/edit?usp=sharing&resourcekey=0-ATO-1Er3HO2HITm59I0IdA).

Fixes https://github.com/flutter/flutter/issues/100264
Related (among others):
- https://github.com/flutter/flutter/pull/100388
- #81152
- #86549
- #83671
- #82846
- #80664
- #79443
- #74372
- #71946
- #71682
- #70764
- #63359

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
