### PR TITLE
Removed required from deprecated API

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -758,48 +758,48 @@ class ThemeData with Diagnosticable {
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    required this.accentColor,
+    this.accentColor,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    required this.accentColorBrightness,
+    this.accentColorBrightness,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    required this.accentTextTheme,
+    this.accentTextTheme,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    required this.accentIconTheme,
+    this.accentIconTheme,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'This feature was deprecated after v2.3.0-0.2.pre.',
     )
-    required this.buttonColor,
+    this.buttonColor,
     @Deprecated(
       'This "fix" is now enabled by default. '
       'This feature was deprecated after v2.5.0-1.0.pre.',
     )
-    required this.fixTextFieldOutlineLabel,
+    this.fixTextFieldOutlineLabel,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'This feature was deprecated after v2.6.0-11.0.pre.',
     )
-    required this.primaryColorBrightness,
+    this.primaryColorBrightness,
     @Deprecated(
       'Use ThemeData.useMaterial3 or override ScrollBehavior.buildOverscrollIndicator. '
       'This feature was deprecated after v2.13.0-0.0.pre.'
     )
-    required this.androidOverscrollIndicator,
+    this.androidOverscrollIndicator,
   }) : // GENERAL CONFIGURATION
        assert(applyElevationOverlayColor != null),
        assert(extensions != null),
@@ -875,15 +875,7 @@ class ThemeData with Diagnosticable {
        assert(timePickerTheme != null),
        assert(toggleButtonsTheme != null),
        assert(tooltipTheme != null),
-       assert(expansionTileTheme != null),
-        // DEPRECATED (newest deprecations at the bottom)
-       assert(accentColor != null),
-       assert(accentColorBrightness != null),
-       assert(accentTextTheme != null),
-       assert(accentIconTheme != null),
-       assert(buttonColor != null),
-       assert(fixTextFieldOutlineLabel != null),
-       assert(primaryColorBrightness != null);
+       assert(expansionTileTheme != null);
 
   /// Create a [ThemeData] based on the colors in the given [colorScheme] and
   /// text styles of the optional [textTheme].
@@ -1493,7 +1485,7 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final Color accentColor;
+  final Color? accentColor;
 
   /// Obsolete property that was originally used to determine the color
   /// of text and icons placed on top of the accent color (e.g. the
@@ -1509,7 +1501,7 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final Brightness accentColorBrightness;
+  final Brightness? accentColorBrightness;
 
   /// Obsolete property that was originally used when a [TextTheme]
   /// that contrasted well with the [accentColor] was needed.
@@ -1532,7 +1524,7 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final TextTheme accentTextTheme;
+  final TextTheme? accentTextTheme;
 
   /// Obsolete property that was originally used when an [IconTheme]
   /// that contrasted well with the [accentColor] was needed.
@@ -1546,14 +1538,14 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final IconThemeData accentIconTheme;
+  final IconThemeData? accentIconTheme;
 
   /// The default fill color of the [Material].
   @Deprecated(
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.3.0-0.2.pre.',
   )
-  final Color buttonColor;
+  final Color? buttonColor;
 
   /// An obsolete flag to allow apps to opt-out of a
   /// [small fix](https://github.com/flutter/flutter/issues/54028) for the Y
@@ -1567,7 +1559,7 @@ class ThemeData with Diagnosticable {
     'This "fix" is now enabled by default. '
     'This feature was deprecated after v2.5.0-1.0.pre.',
   )
-  final bool fixTextFieldOutlineLabel;
+  final bool? fixTextFieldOutlineLabel;
 
   /// Obsolete property that was originally used to determine the color
   /// of text and icons placed on top of the primary color (e.g. toolbar text).
@@ -1582,7 +1574,7 @@ class ThemeData with Diagnosticable {
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.6.0-11.0.pre.',
   )
-  final Brightness primaryColorBrightness;
+  final Brightness? primaryColorBrightness;
 
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ///
@@ -1994,11 +1986,11 @@ class ThemeData with Diagnosticable {
       tooltipTheme: TooltipThemeData.lerp(a.tooltipTheme, b.tooltipTheme, t)!,
       expansionTileTheme: ExpansionTileThemeData.lerp(a.expansionTileTheme, b.expansionTileTheme, t)!,
       // DEPRECATED (newest deprecations at the bottom)
-      accentColor: Color.lerp(a.accentColor, b.accentColor, t)!,
+      accentColor: Color.lerp(a.accentColor, b.accentColor, t),
       accentColorBrightness: t < 0.5 ? a.accentColorBrightness : b.accentColorBrightness,
       accentTextTheme: TextTheme.lerp(a.accentTextTheme, b.accentTextTheme, t),
       accentIconTheme: IconThemeData.lerp(a.accentIconTheme, b.accentIconTheme, t),
-      buttonColor: Color.lerp(a.buttonColor, b.buttonColor, t)!,
+      buttonColor: Color.lerp(a.buttonColor, b.buttonColor, t),
       fixTextFieldOutlineLabel: t < 0.5 ? a.fixTextFieldOutlineLabel : b.fixTextFieldOutlineLabel,
       primaryColorBrightness: t < 0.5 ? a.primaryColorBrightness : b.primaryColorBrightness,
       androidOverscrollIndicator:t < 0.5 ? a.androidOverscrollIndicator : b.androidOverscrollIndicator,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -758,49 +758,59 @@ class ThemeData with Diagnosticable {
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    this.accentColor,
+    Color? accentColor,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    this.accentColorBrightness,
+    Brightness? accentColorBrightness,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    this.accentTextTheme,
+    TextTheme? accentTextTheme,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
       'This feature was deprecated after v2.3.0-0.1.pre.',
     )
-    this.accentIconTheme,
+    IconThemeData? accentIconTheme,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'This feature was deprecated after v2.3.0-0.2.pre.',
     )
-    this.buttonColor,
+    Color? buttonColor,
     @Deprecated(
       'This "fix" is now enabled by default. '
       'This feature was deprecated after v2.5.0-1.0.pre.',
     )
-    this.fixTextFieldOutlineLabel,
+    bool? fixTextFieldOutlineLabel,
     @Deprecated(
       'No longer used by the framework, please remove any reference to it. '
       'This feature was deprecated after v2.6.0-11.0.pre.',
     )
-    this.primaryColorBrightness,
+    Brightness? primaryColorBrightness,
     @Deprecated(
       'Use ThemeData.useMaterial3 or override ScrollBehavior.buildOverscrollIndicator. '
       'This feature was deprecated after v2.13.0-0.0.pre.'
     )
-    this.androidOverscrollIndicator,
-  }) : // GENERAL CONFIGURATION
+    AndroidOverscrollIndicator? androidOverscrollIndicator,
+  }) : // DEPRECATED (newest deprecations at the bottom)
+       // should not be `required`, use getter pattern to avoid breakages.
+       _accentColor = accentColor,
+       _accentColorBrightness = accentColorBrightness,
+       _accentTextTheme = accentTextTheme,
+       _accentIconTheme = accentIconTheme,
+       _buttonColor = buttonColor,
+       _fixTextFieldOutlineLabel = fixTextFieldOutlineLabel,
+       _primaryColorBrightness = primaryColorBrightness,
+       _androidOverscrollIndicator = androidOverscrollIndicator,
+       // GENERAL CONFIGURATION
        assert(applyElevationOverlayColor != null),
        assert(extensions != null),
        assert(inputDecorationTheme != null),
@@ -993,7 +1003,8 @@ class ThemeData with Diagnosticable {
     'Use ThemeData.useMaterial3 or override ScrollBehavior.buildOverscrollIndicator. '
     'This feature was deprecated after v2.13.0-0.0.pre.'
   )
-  final AndroidOverscrollIndicator? androidOverscrollIndicator;
+  AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator!;
+  final AndroidOverscrollIndicator? _androidOverscrollIndicator;
 
   /// Apply a semi-transparent overlay color on Material surfaces to indicate
   /// elevation for dark themes.
@@ -1485,7 +1496,8 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final Color? accentColor;
+  Color get accentColor => _accentColor!;
+  final Color? _accentColor;
 
   /// Obsolete property that was originally used to determine the color
   /// of text and icons placed on top of the accent color (e.g. the
@@ -1501,7 +1513,8 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final Brightness? accentColorBrightness;
+  Brightness get accentColorBrightness => _accentColorBrightness!;
+  final Brightness? _accentColorBrightness;
 
   /// Obsolete property that was originally used when a [TextTheme]
   /// that contrasted well with the [accentColor] was needed.
@@ -1524,7 +1537,8 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final TextTheme? accentTextTheme;
+  TextTheme get accentTextTheme => _accentTextTheme!;
+  final TextTheme? _accentTextTheme;
 
   /// Obsolete property that was originally used when an [IconTheme]
   /// that contrasted well with the [accentColor] was needed.
@@ -1538,14 +1552,16 @@ class ThemeData with Diagnosticable {
     'https://flutter.dev/docs/release/breaking-changes/theme-data-accent-properties#migration-guide. '
     'This feature was deprecated after v2.3.0-0.1.pre.',
   )
-  final IconThemeData? accentIconTheme;
+  IconThemeData get accentIconTheme => _accentIconTheme!;
+  final IconThemeData? _accentIconTheme;
 
   /// The default fill color of the [Material].
   @Deprecated(
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.3.0-0.2.pre.',
   )
-  final Color? buttonColor;
+  Color get buttonColor => _buttonColor!;
+  final Color? _buttonColor;
 
   /// An obsolete flag to allow apps to opt-out of a
   /// [small fix](https://github.com/flutter/flutter/issues/54028) for the Y
@@ -1559,7 +1575,8 @@ class ThemeData with Diagnosticable {
     'This "fix" is now enabled by default. '
     'This feature was deprecated after v2.5.0-1.0.pre.',
   )
-  final bool? fixTextFieldOutlineLabel;
+  bool get fixTextFieldOutlineLabel => _fixTextFieldOutlineLabel!;
+  final bool? _fixTextFieldOutlineLabel;
 
   /// Obsolete property that was originally used to determine the color
   /// of text and icons placed on top of the primary color (e.g. toolbar text).
@@ -1574,7 +1591,8 @@ class ThemeData with Diagnosticable {
     'No longer used by the framework, please remove any reference to it. '
     'This feature was deprecated after v2.6.0-11.0.pre.',
   )
-  final Brightness? primaryColorBrightness;
+  Brightness get primaryColorBrightness => _primaryColorBrightness!;
+  final Brightness? _primaryColorBrightness;
 
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ///

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -660,9 +660,9 @@ class ThemeData with Diagnosticable {
     );
   }
 
-  /// Create a [ThemeData] given a set of exact values. All the values must be
+  /// Create a [ThemeData] given a set of exact values. Most values must be
   /// specified. They all must also be non-null except for
-  /// [cupertinoOverrideTheme].
+  /// [cupertinoOverrideTheme], and deprecated members.
   ///
   /// This will rarely be used directly. It is used by [lerp] to
   /// create intermediate themes based on two themes created with the

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -799,7 +799,7 @@ class ThemeData with Diagnosticable {
       'Use ThemeData.useMaterial3 or override ScrollBehavior.buildOverscrollIndicator. '
       'This feature was deprecated after v2.13.0-0.0.pre.'
     )
-    AndroidOverscrollIndicator? androidOverscrollIndicator,
+    this.androidOverscrollIndicator,
   }) : // DEPRECATED (newest deprecations at the bottom)
        // should not be `required`, use getter pattern to avoid breakages.
        _accentColor = accentColor,
@@ -809,7 +809,6 @@ class ThemeData with Diagnosticable {
        _buttonColor = buttonColor,
        _fixTextFieldOutlineLabel = fixTextFieldOutlineLabel,
        _primaryColorBrightness = primaryColorBrightness,
-       _androidOverscrollIndicator = androidOverscrollIndicator,
        // GENERAL CONFIGURATION
        assert(applyElevationOverlayColor != null),
        assert(extensions != null),
@@ -1003,8 +1002,7 @@ class ThemeData with Diagnosticable {
     'Use ThemeData.useMaterial3 or override ScrollBehavior.buildOverscrollIndicator. '
     'This feature was deprecated after v2.13.0-0.0.pre.'
   )
-  AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator!;
-  final AndroidOverscrollIndicator? _androidOverscrollIndicator;
+  final AndroidOverscrollIndicator? androidOverscrollIndicator;
 
   /// Apply a semi-transparent overlay color on Material surfaces to indicate
   /// elevation for dark themes.

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -687,7 +687,6 @@ void main() {
       drawerTheme: const DrawerThemeData(),
       listTileTheme: const ListTileThemeData(),
       fixTextFieldOutlineLabel: false,
-      androidOverscrollIndicator: null,
       extensions: const <Object, ThemeExtension<dynamic>>{},
     );
 

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -434,7 +434,7 @@ void main() {
       ];
     }
 
-    for (final TextTheme textTheme in <TextTheme>[theme.textTheme, theme.primaryTextTheme, theme.accentTextTheme!]) {
+    for (final TextTheme textTheme in <TextTheme>[theme.textTheme, theme.primaryTextTheme, theme.accentTextTheme]) {
       for (final TextStyle style in extractStyles(textTheme).map<TextStyle>((TextStyle style) => _TextStyleProxy(style))) {
         expect(style.inherit, false);
         expect(style.color, isNotNull);

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -434,7 +434,7 @@ void main() {
       ];
     }
 
-    for (final TextTheme textTheme in <TextTheme>[theme.textTheme, theme.primaryTextTheme, theme.accentTextTheme]) {
+    for (final TextTheme textTheme in <TextTheme>[theme.textTheme, theme.primaryTextTheme, theme.accentTextTheme!]) {
       for (final TextStyle style in extractStyles(textTheme).map<TextStyle>((TextStyle style) => _TextStyleProxy(style))) {
         expect(style.inherit, false);
         expect(style.color, isNotNull);


### PR DESCRIPTION
This removes the required keyword from deprecated API in the Flutter framework
It does not make sense to require folks to use deprecated API, when they should be migrating to the new code.

Fixes https://github.com/flutter/flutter/issues/102106
Related to https://github.com/dart-lang/sdk/issues/48206

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
