### PR TITLE
fix about page status bar icon colors for darkmode

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -1342,6 +1342,7 @@ class _MasterDetailScaffoldState extends State<_MasterDetailScaffold>
         Scaffold(
           floatingActionButtonLocation: floatingActionButtonLocation,
           appBar: AppBar(
+            systemOverlayStyle: Theme.of(context).brightness == Brightness.dark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
             title: widget.title,
             actions: widget.actionBuilder!(context, _ActionLevel.top),
             automaticallyImplyLeading: widget.automaticallyImplyLeading,


### PR DESCRIPTION
On the license page on dark mode the status bar icons are black on black so you cannot see (time, battery, LTE, etc..) this checks the theme's brightness and changes the AppBar accordingly.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

