### PR TITLE
[reland] Migrate `ListTile` TextTheme TextStyle references to Material 3

### DIFF
--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -654,10 +654,10 @@ class ListTile extends StatelessWidget {
     final TextStyle textStyle;
     switch(style ?? tileTheme.style ?? theme.listTileTheme.style ?? ListTileStyle.list) {
       case ListTileStyle.drawer:
-        textStyle = theme.textTheme.bodyText1!;
+        textStyle = theme.useMaterial3 ? theme.textTheme.bodyMedium! : theme.textTheme.bodyText1!;
         break;
       case ListTileStyle.list:
-        textStyle = theme.textTheme.subtitle1!;
+        textStyle = theme.useMaterial3 ? theme.textTheme.titleMedium! : theme.textTheme.subtitle1!;
         break;
     }
     final Color? color = _textColor(theme, tileTheme, textStyle.color);
@@ -667,15 +667,19 @@ class ListTile extends StatelessWidget {
   }
 
   TextStyle _subtitleTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
-    final TextStyle textStyle = theme.textTheme.bodyText2!;
-    final Color? color = _textColor(theme, tileTheme, theme.textTheme.caption!.color);
+    final TextStyle textStyle = theme.useMaterial3 ? theme.textTheme.bodyMedium! : theme.textTheme.bodyText2!;
+    final Color? color = _textColor(
+      theme,
+      tileTheme,
+      theme.useMaterial3 ? theme.textTheme.bodySmall!.color : theme.textTheme.caption!.color,
+    );
     return _isDenseLayout(theme, tileTheme)
       ? textStyle.copyWith(color: color, fontSize: 12.0)
       : textStyle.copyWith(color: color);
   }
 
   TextStyle _trailingAndLeadingTextStyle(ThemeData theme, ListTileThemeData tileTheme) {
-    final TextStyle textStyle = theme.textTheme.bodyText2!;
+    final TextStyle textStyle = theme.useMaterial3 ? theme.textTheme.bodyMedium! : theme.textTheme.bodyText2!;
     final Color? color = _textColor(theme, tileTheme, textStyle.color);
     return textStyle.copyWith(color: color);
   }

--- a/packages/flutter/test/material/list_tile_test.dart
+++ b/packages/flutter/test/material/list_tile_test.dart
@@ -2102,6 +2102,7 @@ void main() {
       ListTileStyle? style,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: true),
         home: Material(
           child: Center(
             child: Builder(
@@ -2179,6 +2180,7 @@ void main() {
       ListTileStyle? style,
     }) {
       return MaterialApp(
+        theme: ThemeData(useMaterial3: true),
         home: Material(
           child: Center(
             child: Builder(
@@ -2205,25 +2207,25 @@ void main() {
     // ListTile - ListTileStyle.list (default).
     await tester.pumpWidget(buildFrame());
     RenderParagraph leading = _getTextRenderObject(tester, 'leading');
-    expect(leading.text.style!.color, theme.textTheme.bodyText2!.color);
+    expect(leading.text.style!.color, theme.textTheme.bodyMedium!.color);
     RenderParagraph title = _getTextRenderObject(tester, 'title');
-    expect(title.text.style!.color, theme.textTheme.subtitle1!.color);
+    expect(title.text.style!.color, theme.textTheme.titleMedium!.color);
     RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
-    expect(subtitle.text.style!.color, theme.textTheme.caption!.color);
+    expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
     RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
-    expect(trailing.text.style!.color, theme.textTheme.bodyText2!.color);
+    expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
 
     // ListTile - ListTileStyle.drawer.
     await tester.pumpWidget(buildFrame(style: ListTileStyle.drawer));
     await tester.pumpAndSettle();
     leading = _getTextRenderObject(tester, 'leading');
-    expect(leading.text.style!.color, theme.textTheme.bodyText2!.color);
+    expect(leading.text.style!.color, theme.textTheme.bodyMedium!.color);
     title = _getTextRenderObject(tester, 'title');
-    expect(title.text.style!.color, theme.textTheme.bodyText1!.color);
+    expect(title.text.style!.color, theme.textTheme.bodyLarge!.color);
     subtitle = _getTextRenderObject(tester, 'subtitle');
-    expect(subtitle.text.style!.color, theme.textTheme.caption!.color);
+    expect(subtitle.text.style!.color, theme.textTheme.bodySmall!.color);
     trailing = _getTextRenderObject(tester, 'trailing');
-    expect(trailing.text.style!.color, theme.textTheme.bodyText2!.color);
+    expect(trailing.text.style!.color, theme.textTheme.bodyMedium!.color);
   });
 
   testWidgets('Default ListTile debugFillProperties', (WidgetTester tester) async {
@@ -2296,6 +2298,143 @@ void main() {
     expect(description[21], 'horizontalTitleGap: 4.0');
     expect(description[22], 'minVerticalPadding: 2.0');
     expect(description[23], 'minLeadingWidth: 6.0');
+  });
+
+  group('Material 2', () {
+    // Tests that are only relevant for Material 2. Once ThemeData.useMaterial3
+    // is turned on by default, these tests can be removed.
+
+    testWidgets('ListTile font size', (WidgetTester tester) async {
+      Widget buildFrame({
+        bool dense = false,
+        bool enabled = true,
+        bool selected = false,
+        ListTileStyle? style,
+      }) {
+        return MaterialApp(
+          home: Material(
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ListTile(
+                    dense: dense,
+                    enabled: enabled,
+                    selected: selected,
+                    style: style,
+                    leading: const TestText('leading'),
+                    title: const TestText('title'),
+                    subtitle: const TestText('subtitle') ,
+                    trailing: const TestText('trailing'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      // ListTile - ListTileStyle.list (default).
+      await tester.pumpWidget(buildFrame());
+      RenderParagraph leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.fontSize, 14.0);
+      RenderParagraph title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.fontSize, 16.0);
+      RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.fontSize, 14.0);
+      RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.fontSize, 14.0);
+
+      // ListTile - Densed - ListTileStyle.list (default).
+      await tester.pumpWidget(buildFrame(dense: true));
+      await tester.pumpAndSettle();
+      leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.fontSize, 14.0);
+      title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.fontSize, 13.0);
+      subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.fontSize, 12.0);
+      trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.fontSize, 14.0);
+
+      // ListTile - ListTileStyle.drawer.
+      await tester.pumpWidget(buildFrame(style: ListTileStyle.drawer));
+      await tester.pumpAndSettle();
+      leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.fontSize, 14.0);
+      title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.fontSize, 14.0);
+      subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.fontSize, 14.0);
+      trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.fontSize, 14.0);
+
+      // ListTile - Densed - ListTileStyle.drawer.
+      await tester.pumpWidget(buildFrame(dense: true, style: ListTileStyle.drawer));
+      await tester.pumpAndSettle();
+      leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.fontSize, 14.0);
+      title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.fontSize, 13.0);
+      subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.fontSize, 12.0);
+      trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.fontSize, 14.0);
+    });
+
+    testWidgets('ListTile text color', (WidgetTester tester) async {
+      Widget buildFrame({
+        bool dense = false,
+        bool enabled = true,
+        bool selected = false,
+        ListTileStyle? style,
+      }) {
+        return MaterialApp(
+          home: Material(
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ListTile(
+                    dense: dense,
+                    enabled: enabled,
+                    selected: selected,
+                    style: style,
+                    leading: const TestText('leading'),
+                    title: const TestText('title'),
+                    subtitle: const TestText('subtitle') ,
+                    trailing: const TestText('trailing'),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      final ThemeData theme = ThemeData();
+
+      // ListTile - ListTileStyle.list (default).
+      await tester.pumpWidget(buildFrame());
+      RenderParagraph leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.color, theme.textTheme.bodyText2!.color);
+      RenderParagraph title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.color, theme.textTheme.subtitle1!.color);
+      RenderParagraph subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.color, theme.textTheme.caption!.color);
+      RenderParagraph trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.color, theme.textTheme.bodyText2!.color);
+
+      // ListTile - ListTileStyle.drawer.
+      await tester.pumpWidget(buildFrame(style: ListTileStyle.drawer));
+      await tester.pumpAndSettle();
+      leading = _getTextRenderObject(tester, 'leading');
+      expect(leading.text.style!.color, theme.textTheme.bodyText2!.color);
+      title = _getTextRenderObject(tester, 'title');
+      expect(title.text.style!.color, theme.textTheme.subtitle1!.color);
+      subtitle = _getTextRenderObject(tester, 'subtitle');
+      expect(subtitle.text.style!.color, theme.textTheme.caption!.color);
+      trailing = _getTextRenderObject(tester, 'trailing');
+      expect(trailing.text.style!.color, theme.textTheme.bodyText2!.color);
+    });
   });
 }
 


### PR DESCRIPTION
relands https://github.com/flutter/flutter/pull/101900 with `useMaterial3` condition

fixes https://github.com/flutter/flutter/issues/102075

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
