### PR TITLE
Fix jumping when doing long press for selecting text

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2514,6 +2514,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     _showCaretOnScreenScheduled = true;
     SchedulerBinding.instance.addPostFrameCallback((Duration _) {
       _showCaretOnScreenScheduled = false;
+
+      // if cursor is inactive, e.g. while selecting text, do not jump away
+      if (!_cursorActive) {
+        return;
+      }
       if (_currentCaretRect == null || !_scrollController.hasClients) {
         return;
       }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5183,6 +5183,52 @@ void main() {
     // toolbar. Until we change that, this test should remain skipped.
   }, skip: kIsWeb); // [intended]
 
+
+  testWidgets('text selection handle visibility for long text', (WidgetTester tester) async {
+    // long text which is scrollable based on given box size
+    const String testText =
+        'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.';
+    final TextEditingController controller =
+        TextEditingController(text: testText);
+    final ScrollController scrollController = ScrollController();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: SizedBox(
+          width: 100,
+          height: 100,
+          child: SingleChildScrollView(
+            controller: scrollController,
+            child: EditableText(
+              controller: controller,
+              showSelectionHandles: true,
+              focusNode: FocusNode(),
+              style: Typography.material2018().black.subtitle1!,
+              cursorColor: Colors.blue,
+              backgroundCursorColor: Colors.grey,
+              selectionControls: materialTextSelectionControls,
+              keyboardType: TextInputType.multiline,
+              maxLines: null,
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    // scroll to a text that is outside of the inital visible rect
+    scrollController.jumpTo(151);
+    await tester.pump();
+
+    // long press on a word to trigger a select
+    await tester.longPressAt(const Offset(20, 15));
+    // wait for adjustments of scroll area
+    await tester.pumpAndSettle();
+
+    // assert not jumped to top
+    expect(scrollController.offset, equals(151));
+  });
+
   const String testText = 'Now is the time for\n' // 20
       'all good people\n'                         // 20 + 16 => 36
       'to come to the aid\n'                      // 36 + 19 => 55

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5223,6 +5223,7 @@ void main() {
     // long press on a word to trigger a select
     await tester.longPressAt(const Offset(20, 15));
     // wait for adjustments of scroll area
+    await tester.pump();
     await tester.pumpAndSettle();
 
     // assert not jumped to top


### PR DESCRIPTION
If on an EditableText or SelectableText widget a text is selected, then the viewport will be scrolled to the last cursor position, but while selecting any text, the cursor gets an inactive state `_cursorActive = false`.
With this PR the misbehaviour of jumping to a non existent cursor will be avoided with checking for `!_cursorActive` to interrupt jumping to the non existing cursor.

#91464 will be resolved


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
