### PR TITLE
Replace `ListTile` with `Chip` in the `debugCheckHasMaterial control test`

### DIFF
--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('debugCheckHasMaterial control test', (WidgetTester tester) async {
-    await tester.pumpWidget(const ListTile());
+    await tester.pumpWidget(const Chip(label: Text('label')));
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
     final FlutterError error = exception as FlutterError;
@@ -28,7 +28,7 @@ void main() {
       error.toStringDeep(),
       'FlutterError\n'
       '   No Material widget found.\n'
-      '   ListTile widgets require a Material widget ancestor.\n'
+      '   Chip widgets require a Material widget ancestor.\n'
       '   In material design, most widgets are conceptually "printed" on a\n'
       "   sheet of material. In Flutter's material library, that material\n"
       '   is represented by the Material widget. It is the Material widget\n'
@@ -39,7 +39,7 @@ void main() {
       '   one, or use a widget that contains Material itself, such as a\n'
       '   Card, Dialog, Drawer, or Scaffold.\n'
       '   The specific widget that could not find a Material ancestor was:\n'
-      '     ListTile\n'
+      '     Chip\n'
       '   The ancestors of this widget were:\n'
       '     [root]\n',
     );


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/102308

https://github.com/flutter/flutter/pull/102310 is adding self-contained Material to list_tile.dart to fix multiple ListTile issues.
As a result, ListTile is no longer suitable for this test, as this test needs a widget that needs to be provided Material as one of the ancestors

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
