### PR TITLE
Handle CocoaPods ffi stderr

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -349,10 +349,11 @@ class CocoaPods {
   }
 
   void _diagnosePodInstallFailure(ProcessResult result) {
-    if (result.stdout is! String) {
+    final Object? stdout = result.stdout;
+    final Object? stderr = result.stderr;
+    if (stdout is! String || stderr is! String) {
       return;
     }
-    final String stdout = result.stdout as String;
     if (stdout.contains('out-of-date source repos')) {
       _logger.printError(
         "Error: CocoaPods's specs repository is too out-of-date to satisfy dependencies.\n"
@@ -360,7 +361,7 @@ class CocoaPods {
         '  pod repo update\n',
         emphasis: true,
       );
-    } else if ((stdout.contains('ffi_c.bundle') || stdout.contains('/ffi/')) &&
+    } else if ((stderr.contains('ffi_c.bundle') || stderr.contains('/ffi/')) &&
         _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
       // https://github.com/flutter/flutter/issues/70796
       UsageEvent(

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -514,7 +514,7 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
               'LANG': 'en_US.UTF-8',
             },
             exitCode: 1,
-            stdout: cocoaPodsError,
+            stderr: cocoaPodsError,
           ),
           const FakeCommand(
             command: <String>['which', 'sysctl'],


### PR DESCRIPTION
The CocoaPods ffi stacks are logged to stderr, not stdout.

On this change I see:

<img width="494" alt="Screen Shot 2022-04-21 at 1 14 22 PM" src="https://user-images.githubusercontent.com/682784/164545464-7a965d5d-4d91-4d50-8c2a-b98169e48aa5.png">


Fixes https://github.com/flutter/flutter/issues/99195

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
