### PR TITLE
Remove build_aar_module_test from devicelab tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -205,32 +205,6 @@ targets:
       validation_name: Analyze
     scheduler: luci
 
-  - name: Linux build_aar_module_test
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      caches: >-
-        [
-          {"name":"gradle","path":"gradle"},
-          {"name": "openjdk_11", "path": "java"}
-        ]
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "chrome_and_driver", "version": "version:96.2"},
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      tags: >
-        ["devicelab","hostonly"]
-      task_name: build_aar_module_test
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
   - name: Linux build_tests_1_2
     recipe: flutter/flutter_drone
     timeout: 60
@@ -2445,31 +2419,6 @@ targets:
         ["devicelab","android","linux"]
       task_name: android_lifecycles_test
 
-  - name: Mac build_aar_module_test
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      caches: >-
-        [
-          {"name":"gradle", "path":"gradle"},
-          {"name": "openjdk_11", "path": "java"}
-        ]
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      tags: >
-        ["devicelab","hostonly"]
-      task_name: build_aar_module_test
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-    scheduler: luci
-
   - name: Mac build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -3799,33 +3748,6 @@ targets:
       - bin/**
       - .ci.yaml
     scheduler: luci
-
-  - name: Windows build_aar_module_test
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/102226
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      add_recipes_cq: "true"
-      caches: >-
-        [
-          {"name":"gradle","path":"gradle"},
-          {"name": "openjdk_11", "path": "java"}
-        ]
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "chrome_and_driver", "version": "version:96.2"},
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      tags: >
-        ["devicelab","hostonly"]
-      task_name: build_aar_module_test
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
 
   - name: Windows build_tests_1_3
     recipe: flutter/flutter_drone


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/102318

These tests don't need a device. 
I plan to move this test to the tool's integration shard.