### PR TITLE
Enable jank metric collection in profile mode

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -682,7 +682,7 @@ abstract class ResidentHandlers {
   /// use case is to look at the various layers in proportion to see what
   /// contributes the most towards raster performance.
   Future<bool> debugFrameJankMetrics() async {
-    if (!supportsServiceProtocol || !isRunningDebug) {
+    if (!supportsServiceProtocol) {
       return false;
     }
     for (final FlutterDevice device in flutterDevices) {


### PR DESCRIPTION
This was always meant to be enabled in profile.