### PR TITLE
Made Directionality forego dependency tracking for better performance.

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -95,7 +95,7 @@ export 'package:flutter/services.dart' show
 /// [Widget]s.
 class _UbiquitousInheritedElement extends InheritedElement {
   /// Creates an element that uses the given widget as its configuration.
-  _UbiquitousInheritedElement(InheritedWidget widget) : super(widget);
+  _UbiquitousInheritedElement(super.widget);
 
   @override
   void setDependencies(Element dependent, Object? value) {
@@ -131,8 +131,7 @@ class _UbiquitousInheritedElement extends InheritedElement {
 ///
 ///  * [_UbiquitousInheritedElement], the [Element] for [_UbiquitousInheritedWidget].
 abstract class _UbiquitousInheritedWidget extends InheritedWidget {
-  const _UbiquitousInheritedWidget({ Key? key, required Widget child })
-    : super(key: key, child: child);
+  const _UbiquitousInheritedWidget({super.key, required super.child});
 
   @override
   InheritedElement createElement() => _UbiquitousInheritedElement(this);

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -83,15 +83,26 @@ export 'package:flutter/services.dart' show
 /// An [InheritedElement] that has hundreds of dependencies but will
 /// infrequently change.  This provides a performance tradeoff where building
 /// the [Widget]s is faster but performing updates is slower.
+///
+/// |                     | _UbiquitiousInheritedElement | InheritedElement |
+/// |---------------------|------------------------------|------------------|
+/// | insert (best case)  | O(1)                         | O(1)             |
+/// | insert (worst case) | O(1)                         | O(n)             |
+/// | search (best case)  | O(n)                         | O(1)             |
+/// | search (worst case) | O(n)                         | O(n)             |
+///
+/// Insert happens when building the [Widget] tree, search happens when updating
+/// [Widget]s.
 class _UbiquitousInheritedElement extends InheritedElement {
   /// Creates an element that uses the given widget as its configuration.
   _UbiquitousInheritedElement(InheritedWidget widget) : super(widget);
 
   @override
   void setDependencies(Element dependent, Object? value) {
-    if (value != null) {
-      throw Exception('Setting aspects on _UbiquitousInheritedElement is not supported.');
-    }
+    // This is where the cost of [InheritedElement] is incurred during build
+    // time of the widget tree.  Omitting this bookkeeping is where the
+    // performance savings come from.
+    assert(value != null);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -102,7 +102,7 @@ class _UbiquitousInheritedElement extends InheritedElement {
     // This is where the cost of [InheritedElement] is incurred during build
     // time of the widget tree.  Omitting this bookkeeping is where the
     // performance savings come from.
-    assert(value != null);
+    assert(value == null);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4197,6 +4197,11 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     return true;
   }
 
+  /// Returns `true` if [dependOnInheritedElement] was previously called with [ancestor].
+  @protected
+  bool doesDependOnInheritedElement(InheritedElement ancestor) =>
+      _dependencies != null && _dependencies!.contains(ancestor);
+
   @override
   InheritedWidget dependOnInheritedElement(InheritedElement ancestor, { Object? aspect }) {
     assert(ancestor != null);

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1713,7 +1713,7 @@ The findRenderObject() method was called for the following element:
 }
 
 class _TestInheritedElement extends InheritedElement {
-  _TestInheritedElement(InheritedWidget widget) : super(widget);
+  _TestInheritedElement(super.widget);
   @override
   bool doesDependOnInheritedElement(InheritedElement element) {
     return super.doesDependOnInheritedElement(element);

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1696,12 +1696,16 @@ The findRenderObject() method was called for the following element:
   });
 
   testWidgets('doesDependOnInheritedElement', (WidgetTester tester) async {
-    final _TestInheritedElement ancestor = _TestInheritedElement(
-        const Directionality(
-            textDirection: TextDirection.ltr, child: Placeholder()));
-    final _TestInheritedElement child = _TestInheritedElement(
-        const Directionality(
-            textDirection: TextDirection.ltr, child: Placeholder()));
+    final _TestInheritedElement ancestor =
+        _TestInheritedElement(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: Placeholder(),
+    ));
+    final _TestInheritedElement child =
+        _TestInheritedElement(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: Placeholder(),
+    ));
     expect(child.doesDependOnInheritedElement(ancestor), isFalse);
     child.dependOnInheritedElement(ancestor);
     expect(child.doesDependOnInheritedElement(ancestor), isTrue);

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1694,6 +1694,26 @@ The findRenderObject() method was called for the following element:
 
     expect(inheritedElement.hashCode, identityHashCode(inheritedElement));
   });
+
+  testWidgets('doesDependOnInheritedElement', (WidgetTester tester) async {
+    final _TestInheritedElement ancestor = _TestInheritedElement(
+        const Directionality(
+            textDirection: TextDirection.ltr, child: Placeholder()));
+    final _TestInheritedElement child = _TestInheritedElement(
+        const Directionality(
+            textDirection: TextDirection.ltr, child: Placeholder()));
+    expect(child.doesDependOnInheritedElement(ancestor), isFalse);
+    child.dependOnInheritedElement(ancestor);
+    expect(child.doesDependOnInheritedElement(ancestor), isTrue);
+  });
+}
+
+class _TestInheritedElement extends InheritedElement {
+  _TestInheritedElement(InheritedWidget widget) : super(widget);
+  @override
+  bool doesDependOnInheritedElement(InheritedElement element) {
+    return super.doesDependOnInheritedElement(element);
+  }
 }
 
 class _WidgetWithNoVisitChildren extends StatelessWidget {


### PR DESCRIPTION
Customer money is spending 20ms of startup time doing bookkeeping for `Directionality`  This gets rid of that bookkeeping which makes updates faster, but Directionality should be changed infrequently.  On some platforms change in text direction actually forces reloading the process anyways (iOS).

Local testing of this change to the increase `stock_build_iteration` 2.5% (21ms).

I tried to make this solution more general but there was apprehension to change the public API and it seemed like other Widgets didn't have the same draw as Directionality.

Examples of widgets using Directionality.of:
- Semantics.getTextDirection
- createLocalImageConfiguration
- Transform.updateRenderObject
- FittedBox.createRenderObject

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
