### PR TITLE
[flutter_tools] Add support for android bundle builds with multiple f…

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -894,6 +894,12 @@ File findBundleFile(FlutterProject project, BuildInfo buildInfo, Logger logger, 
     fileCandidates.add(getBundleDirectory(project)
         .childDirectory('${buildInfo.uncapitalizedFlavor}${camelCase('_${buildInfo.modeName}')}')
         .childFile('app-${buildInfo.uncapitalizedFlavor}-${buildInfo.modeName}.aab'));
+
+    // The Android Gradle plugin 4.1.0 uses hyphens for multi-dimensional flavor names.
+    // For example: flavor `fooBar` becomes `app-foo-bar-release.aab
+    fileCandidates.add(getBundleDirectory(project)
+        .childDirectory('${buildInfo.uncapitalizedFlavor}${camelCase('_${buildInfo.modeName}')}')
+        .childFile('app-${buildInfo.paramCaseFlavor}-${buildInfo.modeName}.aab'));
   }
   for (final File bundleFile in fileCandidates) {
     if (bundleFile.existsSync()) {

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -26,6 +26,17 @@ String camelCase(String str) {
   return str;
 }
 
+/// Converts `FooBar` to `fooBar`
+String uncapitalize(String str) {
+  if (str.isEmpty) {
+    return str;
+  }
+  else if (str.length < 2) {
+    return str.toLowerCase();
+  }
+  return str.substring(0, 1).toLowerCase() + str.substring(1);
+}
+
 final RegExp _upperRegex = RegExp(r'[A-Z]');
 
 /// Convert `fooBar` to `foo_bar`.

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -204,7 +204,11 @@ class BuildInfo {
 
   /// the flavor name in the output bundle files has the first character lower-cased,
   /// so the uncapitalized flavor name is used to compute the output file name
-  String? get uncapitalizedFlavor => _uncapitalize(flavor);
+  String get uncapitalizedFlavor => uncapitalize(flavor ?? '');
+
+  /// the flavor name in the output bundle files is lower-cased but uses hyphens
+  /// to separate multiple dimensions in the flavor name in the output file name
+  String get paramCaseFlavor => snakeCase(flavor ?? '', '-');
 
   /// Convert to a structured string encoded structure appropriate for usage
   /// in build system [Environment.defines].
@@ -1048,11 +1052,4 @@ String getNameForHostPlatformArch(HostPlatform platform) {
     case HostPlatform.windows_x64:
       return 'x64';
   }
-}
-
-String? _uncapitalize(String? s) {
-  if (s == null || s.isEmpty) {
-    return s;
-  }
-  return s.substring(0, 1).toLowerCase() + s.substring(1);
 }

--- a/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
@@ -333,6 +333,34 @@ void main() {
     expect(bundle.path, '/build/app/outputs/bundle/foo_BarDebug/app-foo_Bar-debug.aab');
   });
 
+  testWithoutContext(
+      'Finds app bundle when flavor contains multiple dimensions in release mode - Gradle 4.1', () {
+    final FlutterProject project = generateFakeAppBundle('fooBarRelease', 'app-foo-bar-release.aab', fileSystem);
+    final File bundle = findBundleFile(
+      project,
+      const BuildInfo(BuildMode.release, 'fooBar', treeShakeIcons: false),
+      BufferLogger.test(),
+      TestUsage(),
+    );
+
+    expect(bundle, isNotNull);
+    expect(bundle.path, '/build/app/outputs/bundle/fooBarRelease/app-foo-bar-release.aab');
+  });
+
+  testWithoutContext(
+      'Finds app bundle when flavor contains multiple dimensions in debug mode - Gradle 4.1', () {
+    final FlutterProject project = generateFakeAppBundle('fooBarDebug', 'app-foo-bar-debug.aab', fileSystem);
+    final File bundle = findBundleFile(
+      project,
+      const BuildInfo(BuildMode.debug, 'fooBar', treeShakeIcons: false),
+      BufferLogger.test(),
+      TestUsage(),
+    );
+
+    expect(bundle, isNotNull);
+    expect(bundle.path, '/build/app/outputs/bundle/fooBarDebug/app-foo-bar-debug.aab');
+  });
+
   testWithoutContext('AAB not found', () {
     final FlutterProject project = FlutterProject.fromDirectoryTest(fileSystem.currentDirectory);
     final TestUsage testUsage = TestUsage();


### PR DESCRIPTION
When building Android App Bundles with multi-dimensions the current flutter tools looks for files with the other names used by older android gradle plugin versions < v4.1

This PR fixes this by: adding to the current list of files the flutter tool searches to find the correctly named file for output.

For example when build with dimension `foo` and `bar` you execute the tool with `--flavor fooBar`.
Now the additional file added is named `app-foo-bar-release.aab`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
