### PR TITLE
Add padding for Navigation Bar to account for safe area

### DIFF
--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -148,6 +148,8 @@ class NavigationBar extends StatelessWidget {
       ?? navigationBarTheme.labelBehavior
       ?? defaults.labelBehavior!;
     final double additionalBottomPadding = MediaQuery.of(context).padding.bottom;
+    final double additionalLeftPadding = MediaQuery.of(context).padding.left;
+    final double additionalRightPadding = MediaQuery.of(context).padding.right;
 
     return Material(
       color: backgroundColor
@@ -155,7 +157,8 @@ class NavigationBar extends StatelessWidget {
         ?? defaults.backgroundColor!,
       elevation: elevation ?? navigationBarTheme.elevation ?? defaults.elevation!,
       child: Padding(
-        padding: EdgeInsets.only(bottom: additionalBottomPadding),
+        padding: EdgeInsets.fromLTRB(additionalLeftPadding, 0,
+          additionalRightPadding, additionalBottomPadding),
         child: MediaQuery.removePadding(
           context: context,
           removeBottom: true,

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -147,44 +147,35 @@ class NavigationBar extends StatelessWidget {
     final NavigationDestinationLabelBehavior effectiveLabelBehavior = labelBehavior
       ?? navigationBarTheme.labelBehavior
       ?? defaults.labelBehavior!;
-    final double additionalBottomPadding = MediaQuery.of(context).padding.bottom;
-    final double additionalLeftPadding = MediaQuery.of(context).padding.left;
-    final double additionalRightPadding = MediaQuery.of(context).padding.right;
 
     return Material(
       color: backgroundColor
         ?? navigationBarTheme.backgroundColor
         ?? defaults.backgroundColor!,
       elevation: elevation ?? navigationBarTheme.elevation ?? defaults.elevation!,
-      child: Padding(
-        padding: EdgeInsets.fromLTRB(additionalLeftPadding, 0,
-          additionalRightPadding, additionalBottomPadding),
-        child: MediaQuery.removePadding(
-          context: context,
-          removeBottom: true,
-          child: SizedBox(
-            height: effectiveHeight,
-            child: Row(
-              children: <Widget>[
-                for (int i = 0; i < destinations.length; i++)
-                  Expanded(
-                    child: _SelectableAnimatedBuilder(
-                      duration: animationDuration ?? const Duration(milliseconds: 500),
-                      isSelected: i == selectedIndex,
-                      builder: (BuildContext context, Animation<double> animation) {
-                        return _NavigationDestinationInfo(
-                          index: i,
-                          totalNumberOfDestinations: destinations.length,
-                          selectedAnimation: animation,
-                          labelBehavior: effectiveLabelBehavior,
-                          onTap: _handleTap(i),
-                          child: destinations[i],
-                        );
-                      },
-                    ),
+      child: SafeArea(
+        child: SizedBox(
+          height: effectiveHeight,
+          child: Row(
+            children: <Widget>[
+              for (int i = 0; i < destinations.length; i++)
+                Expanded(
+                  child: _SelectableAnimatedBuilder(
+                    duration: animationDuration ?? const Duration(milliseconds: 500),
+                    isSelected: i == selectedIndex,
+                    builder: (BuildContext context, Animation<double> animation) {
+                      return _NavigationDestinationInfo(
+                        index: i,
+                        totalNumberOfDestinations: destinations.length,
+                        selectedAnimation: animation,
+                        labelBehavior: effectiveLabelBehavior,
+                        onTap: _handleTap(i),
+                        child: destinations[i],
+                      );
+                    },
                   ),
-              ],
-            ),
+                ),
+            ],
           ),
         ),
       ),

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -140,31 +140,28 @@ void main() {
 
   testWidgets('NavigationBar respects the notch/system navigation bar in landscape mode', (WidgetTester tester) async {
     const double safeAreaPadding = 40.0;
-    final NavigationBar navigationBar = NavigationBar(
-      destinations: const <Widget>[
-        NavigationDestination(
-          icon: Icon(Icons.ac_unit),
-          label: 'AC',
-        ),
-        NavigationDestination(
-          key: Key('Center'),
-          icon: Icon(Icons.center_focus_strong),
-          label: 'Center',
-        ),
-        NavigationDestination(
-          icon: Icon(Icons.access_alarm),
-          label: 'Alarm',
-        ),
-      ],
-      onDestinationSelected: (int i) {},
-    );
+    Widget _navigationBar() {
+      return NavigationBar(
+        destinations: const <Widget>[
+          NavigationDestination(
+            icon: Icon(Icons.ac_unit),
+            label: 'AC',
+          ),
+          NavigationDestination(
+            key: Key('Center'),
+            icon: Icon(Icons.center_focus_strong),
+            label: 'Center',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.access_alarm),
+            label: 'Alarm',
+          ),
+        ],
+        onDestinationSelected: (int i) {},
+      );
+    }
 
-    await tester.pumpWidget(
-      _buildWidget(
-        navigationBar,
-      ),
-    );
-
+    await tester.pumpWidget(_buildWidget(_navigationBar(),));
     final double defaultWidth = tester.getSize(find.byType(NavigationBar)).width;
     final Finder defaultCenterItem = find.byKey(const Key('Center'));
     final Offset center = tester.getCenter(defaultCenterItem);
@@ -174,13 +171,13 @@ void main() {
       _buildWidget(
         MediaQuery(
           data: const MediaQueryData(padding: EdgeInsets.only(left: safeAreaPadding)),
-          child: navigationBar,
+          child: _navigationBar(),
         ),
       ),
     );
 
     // The position of center item of navigation bar should indicate whether
-    // the safe area is sufficiently respected, if safe area is on the left side.
+    // the safe area is sufficiently respected, when safe area is on the left side.
     // e.g. Android device with system navigation bar in landscape mode.
     final Finder leftPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset leftPaddedCenter = tester.getCenter(leftPaddedCenterItem);
@@ -190,13 +187,13 @@ void main() {
       _buildWidget(
         MediaQuery(
           data: const MediaQueryData(padding: EdgeInsets.only(right: safeAreaPadding)),
-          child: navigationBar,
+          child: _navigationBar(),
         ),
       ),
     );
 
     // The position of center item of navigation bar should indicate whether
-    // the safe area is sufficiently respected, if safe area is on the right side.
+    // the safe area is sufficiently respected, when safe area is on the right side.
     // e.g. Android device with system navigation bar in landscape mode.
     final Finder rightPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset rightPaddedCenter = tester.getCenter(rightPaddedCenterItem);
@@ -208,13 +205,13 @@ void main() {
         MediaQuery(
           data: const MediaQueryData(padding: EdgeInsets.fromLTRB(
               safeAreaPadding, 0, safeAreaPadding, safeAreaPadding)),
-          child: navigationBar,
+          child: _navigationBar(),
         ),
       ),
     );
 
     // The position of center item of navigation bar should indicate whether
-    // the safe area is sufficiently respected, if safe area is on both sides.
+    // the safe area is sufficiently respected, when safe areas are on both sides.
     // e.g. iOS device with both sides of round corner.
     final Finder paddedCenterItem = find.byKey(const Key('Center'));
     final Offset paddedCenter = tester.getCenter(paddedCenterItem);

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -161,7 +161,7 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(_buildWidget(navigationBar(),));
+    await tester.pumpWidget(_buildWidget(navigationBar()));
     final double defaultWidth = tester.getSize(find.byType(NavigationBar)).width;
     final Finder defaultCenterItem = find.byKey(const Key('Center'));
     final Offset center = tester.getCenter(defaultCenterItem);
@@ -184,11 +184,8 @@ void main() {
     final Finder leftPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset leftPaddedCenter = tester.getCenter(leftPaddedCenterItem);
     expect(
-        leftPaddedCenter.dx,
-        closeTo(
-            (defaultWidth + safeAreaPadding) / 2.0,
-            precisionErrorTolerance
-        ),
+      leftPaddedCenter.dx,
+      closeTo((defaultWidth + safeAreaPadding) / 2.0, precisionErrorTolerance),
     );
 
     await tester.pumpWidget(
@@ -208,20 +205,20 @@ void main() {
     final Finder rightPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset rightPaddedCenter = tester.getCenter(rightPaddedCenterItem);
     expect(
-        rightPaddedCenter.dx,
-        closeTo((defaultWidth - safeAreaPadding) / 2, precisionErrorTolerance),
+      rightPaddedCenter.dx,
+      closeTo((defaultWidth - safeAreaPadding) / 2, precisionErrorTolerance),
     );
 
     await tester.pumpWidget(
       _buildWidget(
         MediaQuery(
           data: const MediaQueryData(
-              padding: EdgeInsets.fromLTRB(
-                  safeAreaPadding,
-                  0,
-                  safeAreaPadding,
-                  safeAreaPadding
-              ),
+            padding: EdgeInsets.fromLTRB(
+                safeAreaPadding,
+                0,
+                safeAreaPadding,
+                safeAreaPadding
+            ),
           ),
           child: navigationBar(),
         ),
@@ -234,8 +231,8 @@ void main() {
     final Finder paddedCenterItem = find.byKey(const Key('Center'));
     final Offset paddedCenter = tester.getCenter(paddedCenterItem);
     expect(
-        paddedCenter.dx,
-        closeTo(defaultWidth / 2, precisionErrorTolerance),
+      paddedCenter.dx,
+      closeTo(defaultWidth / 2, precisionErrorTolerance),
     );
   });
 

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -140,7 +140,7 @@ void main() {
 
   testWidgets('NavigationBar respects the notch/system navigation bar in landscape mode', (WidgetTester tester) async {
     const double safeAreaPadding = 40.0;
-    Widget _navigationBar() {
+    Widget navigationBar() {
       return NavigationBar(
         destinations: const <Widget>[
           NavigationDestination(
@@ -161,7 +161,7 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(_buildWidget(_navigationBar(),));
+    await tester.pumpWidget(_buildWidget(navigationBar(),));
     final double defaultWidth = tester.getSize(find.byType(NavigationBar)).width;
     final Finder defaultCenterItem = find.byKey(const Key('Center'));
     final Offset center = tester.getCenter(defaultCenterItem);
@@ -170,8 +170,10 @@ void main() {
     await tester.pumpWidget(
       _buildWidget(
         MediaQuery(
-          data: const MediaQueryData(padding: EdgeInsets.only(left: safeAreaPadding)),
-          child: _navigationBar(),
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(left: safeAreaPadding),
+          ),
+          child: navigationBar(),
         ),
       ),
     );
@@ -181,13 +183,21 @@ void main() {
     // e.g. Android device with system navigation bar in landscape mode.
     final Finder leftPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset leftPaddedCenter = tester.getCenter(leftPaddedCenterItem);
-    expect(leftPaddedCenter.dx, closeTo((defaultWidth + safeAreaPadding) / 2.0, precisionErrorTolerance));
+    expect(
+        leftPaddedCenter.dx,
+        closeTo(
+            (defaultWidth + safeAreaPadding) / 2.0,
+            precisionErrorTolerance
+        ),
+    );
 
     await tester.pumpWidget(
       _buildWidget(
         MediaQuery(
-          data: const MediaQueryData(padding: EdgeInsets.only(right: safeAreaPadding)),
-          child: _navigationBar(),
+          data: const MediaQueryData(
+              padding: EdgeInsets.only(right: safeAreaPadding)
+          ),
+          child: navigationBar(),
         ),
       ),
     );
@@ -197,15 +207,23 @@ void main() {
     // e.g. Android device with system navigation bar in landscape mode.
     final Finder rightPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset rightPaddedCenter = tester.getCenter(rightPaddedCenterItem);
-    expect(rightPaddedCenter.dx, closeTo((defaultWidth - safeAreaPadding) / 2,
-        precisionErrorTolerance));
+    expect(
+        rightPaddedCenter.dx,
+        closeTo((defaultWidth - safeAreaPadding) / 2, precisionErrorTolerance),
+    );
 
     await tester.pumpWidget(
       _buildWidget(
         MediaQuery(
-          data: const MediaQueryData(padding: EdgeInsets.fromLTRB(
-              safeAreaPadding, 0, safeAreaPadding, safeAreaPadding)),
-          child: _navigationBar(),
+          data: const MediaQueryData(
+              padding: EdgeInsets.fromLTRB(
+                  safeAreaPadding,
+                  0,
+                  safeAreaPadding,
+                  safeAreaPadding
+              ),
+          ),
+          child: navigationBar(),
         ),
       ),
     );
@@ -215,7 +233,10 @@ void main() {
     // e.g. iOS device with both sides of round corner.
     final Finder paddedCenterItem = find.byKey(const Key('Center'));
     final Offset paddedCenter = tester.getCenter(paddedCenterItem);
-    expect(paddedCenter.dx, closeTo(defaultWidth / 2, precisionErrorTolerance));
+    expect(
+        paddedCenter.dx,
+        closeTo(defaultWidth / 2, precisionErrorTolerance),
+    );
   });
 
   testWidgets('NavigationBar uses proper defaults when no parameters are given', (WidgetTester tester) async {

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/physics.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -141,33 +140,32 @@ void main() {
 
   testWidgets('NavigationBar respects the notch/system navigation bar in landscape mode', (WidgetTester tester) async {
     const double safeAreaPadding = 40.0;
+    final NavigationBar navigationBar = NavigationBar(
+      destinations: const <Widget>[
+        NavigationDestination(
+          icon: Icon(Icons.ac_unit),
+          label: 'AC',
+        ),
+        NavigationDestination(
+          key: Key('Center'),
+          icon: Icon(Icons.center_focus_strong),
+          label: 'Center',
+        ),
+        NavigationDestination(
+          icon: Icon(Icons.access_alarm),
+          label: 'Alarm',
+        ),
+      ],
+      onDestinationSelected: (int i) {},
+    );
 
     await tester.pumpWidget(
       _buildWidget(
-        NavigationBar(
-          destinations: const <Widget>[
-            NavigationDestination(
-              icon: Icon(Icons.ac_unit),
-              label: 'AC',
-            ),
-            NavigationDestination(
-              key: Key('Center'),
-              icon: Icon(Icons.center_focus_strong),
-              label: 'Center',
-            ),
-            NavigationDestination(
-              icon: Icon(Icons.access_alarm),
-              label: 'Alarm',
-            ),
-          ],
-          onDestinationSelected: (int i) {},
-        ),
+        navigationBar,
       ),
     );
 
-    final Finder defaultNavigationBar = find.byType(NavigationBar);
-    final double defaultWidth = tester.getSize(defaultNavigationBar).width;
-    expect(defaultWidth, 800.0);
+    final double defaultWidth = tester.getSize(find.byType(NavigationBar)).width;
     final Finder defaultCenterItem = find.byKey(const Key('Center'));
     final Offset center = tester.getCenter(defaultCenterItem);
     expect(center.dx, defaultWidth / 2);
@@ -176,24 +174,7 @@ void main() {
       _buildWidget(
         MediaQuery(
           data: const MediaQueryData(padding: EdgeInsets.only(left: safeAreaPadding)),
-          child: NavigationBar(
-            destinations: const <Widget>[
-              NavigationDestination(
-                icon: Icon(Icons.ac_unit),
-                label: 'AC',
-              ),
-              NavigationDestination(
-                key: Key('Center'),
-                icon: Icon(Icons.center_focus_strong),
-                label: 'Center',
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.access_alarm),
-                label: 'Alarm',
-              ),
-            ],
-            onDestinationSelected: (int i) {},
-          ),
+          child: navigationBar,
         ),
       ),
     );
@@ -203,31 +184,13 @@ void main() {
     // e.g. Android device with system navigation bar in landscape mode.
     final Finder leftPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset leftPaddedCenter = tester.getCenter(leftPaddedCenterItem);
-    expect(nearEqual(leftPaddedCenter.dx, (defaultWidth + safeAreaPadding) / 2.0,
-        precisionErrorTolerance), true);
+    expect(leftPaddedCenter.dx, closeTo((defaultWidth + safeAreaPadding) / 2.0, precisionErrorTolerance));
 
     await tester.pumpWidget(
       _buildWidget(
         MediaQuery(
           data: const MediaQueryData(padding: EdgeInsets.only(right: safeAreaPadding)),
-          child: NavigationBar(
-            destinations: const <Widget>[
-              NavigationDestination(
-                icon: Icon(Icons.ac_unit),
-                label: 'AC',
-              ),
-              NavigationDestination(
-                key: Key('Center'),
-                icon: Icon(Icons.center_focus_strong),
-                label: 'Center',
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.access_alarm),
-                label: 'Alarm',
-              ),
-            ],
-            onDestinationSelected: (int i) {},
-          ),
+          child: navigationBar,
         ),
       ),
     );
@@ -237,32 +200,15 @@ void main() {
     // e.g. Android device with system navigation bar in landscape mode.
     final Finder rightPaddedCenterItem = find.byKey(const Key('Center'));
     final Offset rightPaddedCenter = tester.getCenter(rightPaddedCenterItem);
-    expect(nearEqual(rightPaddedCenter.dx, (defaultWidth - safeAreaPadding) / 2,
-        precisionErrorTolerance), true);
+    expect(rightPaddedCenter.dx, closeTo((defaultWidth - safeAreaPadding) / 2,
+        precisionErrorTolerance));
 
     await tester.pumpWidget(
       _buildWidget(
         MediaQuery(
           data: const MediaQueryData(padding: EdgeInsets.fromLTRB(
               safeAreaPadding, 0, safeAreaPadding, safeAreaPadding)),
-          child: NavigationBar(
-            destinations: const <Widget>[
-              NavigationDestination(
-                icon: Icon(Icons.ac_unit),
-                label: 'AC',
-              ),
-              NavigationDestination(
-                key: Key('Center'),
-                icon: Icon(Icons.center_focus_strong),
-                label: 'Center',
-              ),
-              NavigationDestination(
-                icon: Icon(Icons.access_alarm),
-                label: 'Alarm',
-              ),
-            ],
-            onDestinationSelected: (int i) {},
-          ),
+          child: navigationBar,
         ),
       ),
     );
@@ -272,7 +218,7 @@ void main() {
     // e.g. iOS device with both sides of round corner.
     final Finder paddedCenterItem = find.byKey(const Key('Center'));
     final Offset paddedCenter = tester.getCenter(paddedCenterItem);
-    expect(nearEqual(paddedCenter.dx, defaultWidth / 2, precisionErrorTolerance), true);
+    expect(paddedCenter.dx, closeTo(defaultWidth / 2, precisionErrorTolerance));
   });
 
 

--- a/packages/flutter/test/material/navigation_bar_test.dart
+++ b/packages/flutter/test/material/navigation_bar_test.dart
@@ -218,7 +218,6 @@ void main() {
     expect(paddedCenter.dx, closeTo(defaultWidth / 2, precisionErrorTolerance));
   });
 
-
   testWidgets('NavigationBar uses proper defaults when no parameters are given', (WidgetTester tester) async {
     // Pre-M3 settings that were hand coded.
     await tester.pumpWidget(


### PR DESCRIPTION
This PR adds paddings for Navigation Bar so that when a Android/iOS device is in landscape mode, the Navigation Bar will respect SafeAreas by default. 

Fixes #101605.
<img width="726" alt="Screen Shot 2022-04-22 at 5 53 48 PM" src="https://user-images.githubusercontent.com/36861262/164844272-8925e445-3368-4f1b-9356-94ad01945cfc.png">
<img width="719" alt="Screen Shot 2022-04-22 at 5 55 24 PM" src="https://user-images.githubusercontent.com/36861262/164844324-c528f900-ad6d-4ada-a36e-1e4f79b08c1e.png">
<img width="588" alt="Screen Shot 2022-04-22 at 5 56 15 PM" src="https://user-images.githubusercontent.com/36861262/164844391-2deeb472-f3c3-492e-9215-cd0a487bce8f.png">


## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
