### PR TITLE
Show custom error message when Kotlin or Gradle bump is required

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -470,7 +470,7 @@ class FlutterPlugin implements Plugin<Project> {
                 pluginProject.afterEvaluate {
                     int pluginCompileSdkVersion = pluginProject.android.compileSdkVersion.substring(8) as int
                     maxPluginCompileSdkVersion = Math.max(pluginCompileSdkVersion, maxPluginCompileSdkVersion)
-                    String pluginNdkVersion = pluginProject.android.ndkVersion ?: ndkVersionIfUnspecified
+                    String pluginNdkVersion = pluginProject.android.hasProperty('ndkVersion') ? pluginProject.android.ndkVersion : ndkVersionIfUnspecified
                     maxPluginNdkVersion = mostRecentSemanticVersion(pluginNdkVersion, maxPluginNdkVersion)
 
                     numProcessedPlugins--

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -461,7 +461,7 @@ class FlutterPlugin implements Plugin<Project> {
             int projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
-            String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified
+            String projectNdkVersion = project.android.hasProperty('ndkVersion') ? project.android.ndkVersion : ndkVersionIfUnspecified
             String maxPluginNdkVersion = projectNdkVersion
             int numProcessedPlugins = getPluginList().size()
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -461,7 +461,7 @@ class FlutterPlugin implements Plugin<Project> {
             int projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
-            String projectNdkVersion = project.android.hasProperty('ndkVersion') ? project.android.ndkVersion : ndkVersionIfUnspecified
+            String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified
             String maxPluginNdkVersion = projectNdkVersion
             int numProcessedPlugins = getPluginList().size()
 
@@ -470,7 +470,7 @@ class FlutterPlugin implements Plugin<Project> {
                 pluginProject.afterEvaluate {
                     int pluginCompileSdkVersion = pluginProject.android.compileSdkVersion.substring(8) as int
                     maxPluginCompileSdkVersion = Math.max(pluginCompileSdkVersion, maxPluginCompileSdkVersion)
-                    String pluginNdkVersion = pluginProject.android.hasProperty('ndkVersion') ? pluginProject.android.ndkVersion : ndkVersionIfUnspecified
+                    String pluginNdkVersion = pluginProject.android.ndkVersion ?: ndkVersionIfUnspecified
                     maxPluginNdkVersion = mostRecentSemanticVersion(pluginNdkVersion, maxPluginNdkVersion)
 
                     numProcessedPlugins--

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -12,6 +12,7 @@ import '../globals.dart' as globals;
 import '../project.dart';
 import '../reporting/reporting.dart';
 import 'android_studio.dart';
+import 'gradle_utils.dart';
 import 'multidex.dart';
 
 typedef GradleErrorTest = bool Function(String);
@@ -78,6 +79,7 @@ final List<GradleHandledError> gradleErrors = <GradleHandledError>[
   incompatibleKotlinVersionHandler,
   minCompileSdkVersionHandler,
   jvm11RequiredHandler,
+  outdatedGradleHandler,
 ];
 
 const String _boxTitle = 'Flutter Fix';
@@ -487,7 +489,7 @@ final GradleHandledError lockFileDepMissingHandler = GradleHandledError(
 @visibleForTesting
 final GradleHandledError incompatibleKotlinVersionHandler = GradleHandledError(
   test: _lineMatcher(const <String>[
-    'Module was compiled with an incompatible version of Kotlin',
+    'was compiled with an incompatible version of Kotlin',
   ]),
   handler: ({
     required String line,
@@ -507,6 +509,41 @@ final GradleHandledError incompatibleKotlinVersionHandler = GradleHandledError(
     return GradleBuildStatus.exit;
   },
   eventLabel: 'incompatible-kotlin-version',
+);
+
+final RegExp _outdatedGradlePattern = RegExp(r'The current Gradle version (.+) is not compatible with the Kotlin Gradle plugin');
+
+@visibleForTesting
+final GradleHandledError outdatedGradleHandler = GradleHandledError(
+  test: _outdatedGradlePattern.hasMatch,
+  handler: ({
+    required String line,
+    required FlutterProject project,
+    required bool usesAndroidX,
+    required bool multidexEnabled,
+  }) async {
+    final File gradleFile = project.directory
+        .childDirectory('android')
+        .childFile('build.gradle');
+    final File gradlePropertiesFile = project.directory
+        .childDirectory('android')
+        .childDirectory('gradle')
+        .childDirectory('wrapper')
+        .childFile('gradle-wrapper.properties');
+    globals.printBox(
+      '${globals.logger.terminal.warningMark} Your project needs to upgrade Gradle and the Android Gradle plugin.\n\n'
+      'To fix this issue, replace the following content:\n'
+      '${gradleFile.path}:\n'
+      '    ${globals.terminal.color("- classpath 'com.android.tools.build:gradle:<current-version>'", TerminalColor.red)}\n'
+      '    ${globals.terminal.color("+ classpath 'com.android.tools.build:gradle:$templateAndroidGradlePluginVersion'", TerminalColor.green)}\n'
+      '${gradlePropertiesFile.path}:\n'
+      '    ${globals.terminal.color('- https://services.gradle.org/distributions/gradle-<current-version>-all.zip', TerminalColor.red)}\n'
+      '    ${globals.terminal.color('+ https://services.gradle.org/distributions/gradle-$templateDefaultGradleVersion-all.zip', TerminalColor.green)}\n',
+      title: _boxTitle,
+    );
+    return GradleBuildStatus.exit;
+  },
+  eventLabel: 'outdated-gradle-version',
 );
 
 final RegExp _minCompileSdkVersionPattern = RegExp(r'The minCompileSdk \(([0-9]+)\) specified in a');

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -538,7 +538,7 @@ final GradleHandledError outdatedGradleHandler = GradleHandledError(
       '    ${globals.terminal.color("+ classpath 'com.android.tools.build:gradle:$templateAndroidGradlePluginVersion'", TerminalColor.green)}\n'
       '${gradlePropertiesFile.path}:\n'
       '    ${globals.terminal.color('- https://services.gradle.org/distributions/gradle-<current-version>-all.zip', TerminalColor.red)}\n'
-      '    ${globals.terminal.color('+ https://services.gradle.org/distributions/gradle-$templateDefaultGradleVersion-all.zip', TerminalColor.green)}\n',
+      '    ${globals.terminal.color('+ https://services.gradle.org/distributions/gradle-$templateDefaultGradleVersion-all.zip', TerminalColor.green)}',
       title: _boxTitle,
     );
     return GradleBuildStatus.exit;

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -943,7 +943,6 @@ A problem occurred evaluating project ':app'.
           '│ /android/gradle/wrapper/gradle-wrapper.properties:                               │\n'
           '│     - https://services.gradle.org/distributions/gradle-<current-version>-all.zip │\n'
           '│     + https://services.gradle.org/distributions/gradle-7.4-all.zip               │\n'
-          '│                                                                                  │\n'
           '└──────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -36,6 +36,7 @@ void main() {
           incompatibleKotlinVersionHandler,
           minCompileSdkVersionHandler,
           jvm11RequiredHandler,
+          outdatedGradleHandler,
         ])
       );
     });
@@ -877,6 +878,10 @@ Execution failed for task ':app:generateDebugFeatureTransitiveDeps'.
         incompatibleKotlinVersionHandler.test('Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 1.5.1, expected version is 1.1.15.'),
         isTrue,
       );
+      expect(
+        incompatibleKotlinVersionHandler.test("class 'kotlin.Unit' was compiled with an incompatible version of Kotlin."),
+        isTrue,
+      );
     });
 
     testUsingContext('suggestion', () async {
@@ -894,6 +899,52 @@ Execution failed for task ':app:generateDebugFeatureTransitiveDeps'.
           '│ update /android/build.gradle:                                                                │\n'
           "│ ext.kotlin_version = '<latest-version>'                                                      │\n"
           '└──────────────────────────────────────────────────────────────────────────────────────────────┘\n'
+        )
+      );
+    }, overrides: <Type, Generator>{
+      GradleUtils: () => FakeGradleUtils(),
+      Platform: () => fakePlatform('android'),
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.empty(),
+    });
+  });
+
+  group('Bump Gradle', () {
+    const String errorMessage = '''
+A problem occurred evaluating project ':app'.
+> Failed to apply plugin [id 'kotlin-android']
+   > The current Gradle version 4.10.2 is not compatible with the Kotlin Gradle plugin. Please use Gradle 6.1.1 or newer, or the previous version of the Kotlin plugin.
+''';
+
+    testWithoutContext('pattern', () {
+      expect(
+        outdatedGradleHandler.test(errorMessage),
+        isTrue,
+      );
+    });
+
+    testUsingContext('suggestion', () async {
+      await outdatedGradleHandler.handler(
+        line: errorMessage,
+        project: FlutterProject.fromDirectoryTest(globals.fs.currentDirectory),
+      );
+
+      expect(
+        testLogger.statusText,
+        contains(
+          '\n'
+          '┌─ Flutter Fix ────────────────────────────────────────────────────────────────────┐\n'
+          '│ [!] Your project needs to upgrade Gradle and the Android Gradle plugin.          │\n'
+          '│                                                                                  │\n'
+          '│ To fix this issue, replace the following content:                                │\n'
+          '│ /android/build.gradle:                                                           │\n'
+          "│     - classpath 'com.android.tools.build:gradle:<current-version>'               │\n"
+          "│     + classpath 'com.android.tools.build:gradle:7.1.2'                           │\n"
+          '│ /android/gradle/wrapper/gradle-wrapper.properties:                               │\n'
+          '│     - https://services.gradle.org/distributions/gradle-<current-version>-all.zip │\n'
+          '│     + https://services.gradle.org/distributions/gradle-7.4-all.zip               │\n'
+          '│                                                                                  │\n'
+          '└──────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );
     }, overrides: <Type, Generator>{


### PR DESCRIPTION
Shows custom error messages when a bump of Kotlin or Gradle is required.
Once the migration tool is available, we can tell folks to run it to find more mismatches.

![Screen Shot 2022-04-22 at 6 01 56 PM](https://user-images.githubusercontent.com/1410613/164845914-133ca2f9-bbc3-488a-90cc-70dfa0658a5f.png)

