### PR TITLE
Reduce Gradle log level in verbose output

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -269,7 +269,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
     ];
     if (_logger.isVerbose) {
       command.add('--full-stacktrace');
-      command.add('--debug');
+      command.add('--info');
       command.add('-Pverbose=true');
     } else {
       command.add('-q');
@@ -593,7 +593,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
     ];
     if (_logger.isVerbose) {
       command.add('--full-stacktrace');
-      command.add('--debug');
+      command.add('--info');
       command.add('-Pverbose=true');
     } else {
       command.add('-q');

--- a/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_gradle_builder_test.dart
@@ -142,7 +142,7 @@ void main() {
         command: <String>[
          'gradlew',
           '--full-stacktrace',
-          '--debug',
+          '--info',
           '-Pverbose=true',
           '-Ptarget-platform=android-arm,android-arm64,android-x64',
           '-Ptarget=lib/main.dart',
@@ -782,7 +782,7 @@ void main() {
           '-Pis-plugin=false',
           '-PbuildNumber=1.0',
           '--full-stacktrace',
-          '--debug',
+          '--info',
           '-Pverbose=true',
           '-Pdart-obfuscation=false',
           '-Ptrack-widget-creation=false',


### PR DESCRIPTION
Since adding the `--info` level in https://github.com/flutter/flutter/pull/101734, the logs have become huge. 
Almost all the debug logs seem irrelevant.

Helps with b/230071477

