### PR TITLE
Fix `BottomSheet` to dismiss when tap

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -298,6 +298,13 @@ class _BottomSheetState extends State<BottomSheet> {
       );
     }
 
+    bottomSheet = ModalRoute.of(context)?.barrierDismissible != true
+        ? bottomSheet
+        : GestureDetector(
+            onTap: () => Navigator.maybePop(context),
+            child: bottomSheet,
+          );
+
     return !widget.enableDrag ? bottomSheet : GestureDetector(
       onVerticalDragStart: _handleDragStart,
       onVerticalDragUpdate: _handleDragUpdate,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -181,7 +181,7 @@ class BottomSheet extends StatefulWidget {
   final BoxConstraints? constraints;
 
   /// If true, the bottom sheet will be dismissed when user taps on the scrim.
-  /// 
+  ///
   /// Default is false.
   final bool? barrierDismissible;
 

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -209,7 +209,7 @@ class _BottomSheetState extends State<BottomSheet> {
 
   bool get _dismissUnderway => widget.animationController!.status == AnimationStatus.reverse;
 
-  double _contentExtent = 1.0;
+  double _contentRelativeExtent = 1.0;
 
   void _handleDragStart(DragStartDetails details) {
     widget.onDragStart?.call(details);
@@ -266,7 +266,7 @@ class _BottomSheetState extends State<BottomSheet> {
       widget.onClosing();
     }
 
-    _contentExtent = notification.extent;
+    _contentRelativeExtent = notification.extent / notification.maxExtent;
 
     return false;
   }
@@ -308,7 +308,7 @@ class _BottomSheetState extends State<BottomSheet> {
         : GestureDetector(
             onTapUp: (TapUpDetails detail) {
               final double relativePosition = 1 - detail.localPosition.dy / _childHeight;
-              if (relativePosition > _contentExtent) {
+              if (relativePosition > _contentRelativeExtent) {
                 Navigator.maybePop(context);
               }
             },

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -209,6 +209,8 @@ class _BottomSheetState extends State<BottomSheet> {
 
   bool get _dismissUnderway => widget.animationController!.status == AnimationStatus.reverse;
 
+  double _contentExtent = 1.0;
+
   void _handleDragStart(DragStartDetails details) {
     widget.onDragStart?.call(details);
   }
@@ -263,6 +265,9 @@ class _BottomSheetState extends State<BottomSheet> {
     if (notification.extent == notification.minExtent) {
       widget.onClosing();
     }
+
+    _contentExtent = notification.extent;
+
     return false;
   }
 
@@ -301,7 +306,12 @@ class _BottomSheetState extends State<BottomSheet> {
     bottomSheet = ModalRoute.of(context)?.barrierDismissible != true
         ? bottomSheet
         : GestureDetector(
-            onTap: () => Navigator.maybePop(context),
+            onTapUp: (TapUpDetails detail) {
+              final double relativePosition = 1 - detail.localPosition.dy / _childHeight;
+              if (relativePosition > _contentExtent) {
+                Navigator.maybePop(context);
+              }
+            },
             child: bottomSheet,
           );
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -586,7 +586,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
     super.initState();
     _extent = _DraggableSheetExtent(
       minSize: widget.minChildSize,
-      maxSize: widget.maxChildSize,
+      maxSize: widget.expand ? widget.maxChildSize : widget.initialChildSize,
       snap: widget.snap,
       snapSizes: _impliedSnapSizes(),
       initialSize: widget.initialChildSize,
@@ -666,7 +666,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
     _extent.dispose();
     _extent = _extent.copyWith(
       minSize: widget.minChildSize,
-      maxSize: widget.maxChildSize,
+      maxSize: widget.expand ? widget.maxChildSize : widget.initialChildSize,
       snap: widget.snap,
       snapSizes: _impliedSnapSizes(),
       initialSize: widget.initialChildSize,

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -591,7 +591,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       snapSizes: _impliedSnapSizes(),
       initialSize: widget.initialChildSize,
       onSizeChanged: _setExtent,
-    );
+    )..updateSize(widget.initialChildSize, context);
     _scrollController = _DraggableScrollableSheetScrollController(extent: _extent);
     widget.controller?._attach(_scrollController);
   }

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -270,6 +270,50 @@ void main() {
     expect(showBottomSheetThenCalled, isFalse);
   });
 
+  testWidgets('Tapping on a DraggableScrollableSheet in a modal BottomSheet should not dismiss it when expand=false', (WidgetTester tester) async {
+    late BuildContext savedContext;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            savedContext = context;
+            return Container();
+          },
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.text('BottomSheet'), findsNothing);
+
+    bool showBottomSheetThenCalled = false;
+    showModalBottomSheet<void>(
+      context: savedContext,
+      builder: (BuildContext context) => DraggableScrollableSheet(
+        expand: false,
+        builder: (_, ScrollController controller) {
+          return SingleChildScrollView(
+            controller: controller,
+            child: const Text('BottomSheet'),
+          );
+        },
+      ),
+    ).then<void>((void value) {
+      showBottomSheetThenCalled = true;
+    });
+
+    await tester.pumpAndSettle();
+    expect(find.text('BottomSheet'), findsOneWidget);
+    expect(showBottomSheetThenCalled, isFalse);
+
+    // Tap on the bottom sheet itself, it should not be dismissed
+    await tester.tap(find.text('BottomSheet'));
+    await tester.pumpAndSettle();
+    expect(find.text('BottomSheet'), findsOneWidget);
+    expect(showBottomSheetThenCalled, isFalse);
+  });
+
   testWidgets('Tapping outside a modal BottomSheet should dismiss it by default', (WidgetTester tester) async {
     late BuildContext savedContext;
 

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -373,7 +373,7 @@ testWidgets('Tapping inside a modal BottomSheet and outside a DraggableScrollabl
     final RenderBox renderBox = draggableScrollableSheetKey.currentContext!.findRenderObject()! as RenderBox;
     final Offset position = renderBox.localToGlobal(Offset.zero);
 
-    // Tap above the bottom sheet to dismiss it.
+    // Tap above the draggable scrollable sheet to dismiss it.
     await tester.tapAt(Offset(20.0, position.dy - 10.0));
     await tester.pumpAndSettle(); // Bottom sheet dismiss animation.
     expect(showBottomSheetThenCalled, isTrue);

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -414,8 +414,7 @@ testWidgets('Tapping inside a modal BottomSheet and outside a DraggableScrollabl
     expect(find.text('BottomSheet'), findsOneWidget);
     expect(showBottomSheetThenCalled, isFalse);
 
-    final RenderBox renderBox = draggableScrollableSheetKey.currentContext!.findRenderObject()! as RenderBox;
-    final Offset position = renderBox.localToGlobal(Offset.zero);
+    final Offset position = tester.getTopLeft(find.byKey(draggableScrollableSheetKey));
 
     // Tap above the draggable scrollable sheet to dismiss it.
     await tester.tapAt(Offset(20.0, position.dy - 10.0));
@@ -423,7 +422,7 @@ testWidgets('Tapping inside a modal BottomSheet and outside a DraggableScrollabl
     expect(showBottomSheetThenCalled, isTrue);
     expect(find.text('BottomSheet'), findsNothing);
   });
-  
+
   testWidgets('Verify that the BottomSheet animates non-linearly', (WidgetTester tester) async {
     late BuildContext savedContext;
 
@@ -805,6 +804,7 @@ testWidgets('Tapping inside a modal BottomSheet and outside a DraggableScrollabl
                   children: <TestSemantics>[
                     TestSemantics(
                       label: 'BottomSheet',
+                      actions: <SemanticsAction>[SemanticsAction.tap],
                       textDirection: TextDirection.ltr,
                     ),
                   ],
@@ -904,12 +904,17 @@ testWidgets('Tapping inside a modal BottomSheet and outside a DraggableScrollabl
                   ],
                   children: <TestSemantics>[
                     TestSemantics(
-                      flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
-                      actions: <SemanticsAction>[SemanticsAction.scrollDown, SemanticsAction.scrollUp],
-                      children: <TestSemantics>[
+                      actions: <SemanticsAction>[SemanticsAction.tap],
+                      children:<TestSemantics>[
                         TestSemantics(
-                          label: 'BottomSheet',
-                          textDirection: TextDirection.ltr,
+                          flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                          actions: <SemanticsAction>[SemanticsAction.scrollDown, SemanticsAction.scrollUp],
+                          children: <TestSemantics>[
+                            TestSemantics(
+                              label: 'BottomSheet',
+                              textDirection: TextDirection.ltr,
+                            ),
+                          ],
                         ),
                       ],
                     ),


### PR DESCRIPTION
## description

Hi, thank you for reviewing this PR!

I've noticed a very minor issue about `showModalBottomSheet` with `DraggableScrollableSheet`.
It doesn't dismiss even though it has `isDismissible=true` when we tap the red area (please see before/after video).
To solve this issue, I added `onTapUp` to `_BottomSheetState`

**before**

https://user-images.githubusercontent.com/52235899/164883091-86f08b5f-451d-4682-9432-0bb95677bdfa.mov

**after**

https://user-images.githubusercontent.com/52235899/164883077-e4b29a7c-5b7c-4f48-9955-5053fa10d82f.mov

*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/102432


*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
