### PR TITLE
Fix crash from alt-tab'ing just after startup

### DIFF
--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -319,7 +319,8 @@ class MouseTracker extends ChangeNotifier {
         // so that [mouseIsConnected], which is decided by `_mouseStates`, is
         // correct during the callbacks.
         if (existingState == null) {
-          assert(event is! PointerRemovedEvent);
+          if (event is PointerRemovedEvent)
+            return;
           _mouseStates[device] = _MouseState(initialEvent: event);
         } else {
           assert(event is! PointerAddedEvent);

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -133,6 +133,15 @@ void main() {
     listenerLogs.clear();
   });
 
+  test('should not crash if the first event is a Removed event', () {
+    final List<PointerEvent> events = <PointerEvent>[];
+    _setUpWithOneAnnotation(logEvents: events);
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      _pointerData(PointerChange.remove, Offset.zero),
+    ]));
+    events.clear();
+  });
+
   test('should correctly handle multiple devices', () {
     final List<PointerEvent> events = <PointerEvent>[];
     _setUpWithOneAnnotation(logEvents: events);

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -133,6 +133,7 @@ void main() {
     listenerLogs.clear();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/90838
   test('should not crash if the first event is a Removed event', () {
     final List<PointerEvent> events = <PointerEvent>[];
     _setUpWithOneAnnotation(logEvents: events);


### PR DESCRIPTION
There is a common failure on desktop platforms that I and other developers have experienced. If you do the following sequence of actions, your app will start logging endless "assertion failed" messages and stop responding to mouse events:

    - start the app with 'flutter run'
    - position your mouse above where the app window will load
    - when the app loads, alt-tab away from it, then alt-tab back

This is a sequence I have done unintentionally many times, and -- judging by these issue reports -- so have others:

  - Fixes #76325
  - Fixes #80867
  - Fixes #90838
  - Fixes #98262
  - Fixes #99761
  - Fixes #100659
  - https://github.com/flutter/flutter/issues/70375#issuecomment-829325236
  - Possibly #70375 ?
  - Possibly #93233 ?
  - Possibly #96364 ?

It looks like the problem is that when you do that series of actions, the first mouse event that the app sees is a Removed event. The author(s) of mouse_tracker.dart assumed that such a thing could not happen, and even (helpfully) put in an assertion to that effect.

I don't have a deep understanding of the mouse tracker, but it appears that a reasonable response to receiving an initial Removed event is to simply ignore the event and wait for the next one. Doing this fixes the
crash, and the mouse continues to work afterward.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
