### PR TITLE
Fix DraggableScrollableController.animateTo leaks Ticker

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -52,7 +52,7 @@ typedef ScrollableWidgetBuilder = Widget Function(
 /// constraints provided to an attached sheet change.
 class DraggableScrollableController extends ChangeNotifier {
   _DraggableScrollableSheetScrollController? _attachedController;
-  Set<AnimationController> _animationControllers = <AnimationController>{};
+  final Set<AnimationController> _animationControllers = <AnimationController>{};
 
   /// Get the current size (as a fraction of the parent height) of the attached sheet.
   double get size {
@@ -201,7 +201,7 @@ class DraggableScrollableController extends ChangeNotifier {
     for (final AnimationController animationController in _animationControllers) {
       animationController.dispose();
     }
-    _animationControllers = <AnimationController>{};
+    _animationControllers.clear();
   }
 }
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -52,6 +52,7 @@ typedef ScrollableWidgetBuilder = Widget Function(
 /// constraints provided to an attached sheet change.
 class DraggableScrollableController extends ChangeNotifier {
   _DraggableScrollableSheetScrollController? _attachedController;
+  Set<AnimationController> _animationControllers = <AnimationController>{};
 
   /// Get the current size (as a fraction of the parent height) of the attached sheet.
   double get size {
@@ -115,6 +116,7 @@ class DraggableScrollableController extends ChangeNotifier {
       vsync: _attachedController!.position.context.vsync,
       value: _attachedController!.extent.currentSize,
     );
+    _animationControllers.add(animationController);
     _attachedController!.position.goIdle();
     // This disables any snapping until the next user interaction with the sheet.
     _attachedController!.extent.hasDragged = false;
@@ -175,6 +177,7 @@ class DraggableScrollableController extends ChangeNotifier {
     assert(_attachedController == null, 'Draggable scrollable controller is already attached to a sheet.');
     _attachedController = scrollController;
     _attachedController!.extent._currentSize.addListener(notifyListeners);
+    _attachedController!.onPositionDetached = _disposeAnimationControllers;
   }
 
   void _onExtentReplaced(_DraggableSheetExtent previousExtent) {
@@ -192,6 +195,13 @@ class DraggableScrollableController extends ChangeNotifier {
   void _detach() {
     _attachedController?.extent._currentSize.removeListener(notifyListeners);
     _attachedController = null;
+  }
+
+  void _disposeAnimationControllers() {
+    for (final AnimationController animationController in _animationControllers) {
+      animationController.dispose();
+    }
+    _animationControllers = <AnimationController>{};
   }
 }
 
@@ -724,6 +734,7 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
   }) : assert(extent != null);
 
   _DraggableSheetExtent extent;
+  VoidCallback? onPositionDetached;
 
   @override
   _DraggableScrollableSheetScrollPosition createScrollPosition(
@@ -763,6 +774,12 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
       );
     }
     extent.updateSize(extent.initialSize, position.context.notificationContext!);
+  }
+
+  @override
+  void detach(ScrollPosition position) {
+    onPositionDetached?.call();
+    super.detach(position);
   }
 }
 

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1211,6 +1211,7 @@ void main() {
     });
 
     testWidgets('DraggableScrollableController.animateTo should not leak Ticker', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/102483
       final DraggableScrollableController controller = DraggableScrollableController();
       await tester.pumpWidget(_boilerplate(() {}, controller: controller));
 

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1209,4 +1209,18 @@ void main() {
     expect(controller.isAttached, true);
     expect(controller.size, isNotNull);
     });
+
+    testWidgets('DraggableScrollableController.animateTo should not leak Ticker', (WidgetTester tester) async {
+      final DraggableScrollableController controller = DraggableScrollableController();
+      await tester.pumpWidget(_boilerplate(() {}, controller: controller));
+
+      controller.animateTo(0.0, curve: Curves.linear, duration: const Duration(milliseconds: 200));
+      await tester.pump();
+
+      // Dispose the DraggableScrollableSheet
+      await tester.pumpWidget(const SizedBox.shrink());
+      // Controller should be detached and no exception should be thrown
+      expect(controller.isAttached, false);
+      expect(tester.takeException(), isNull);
+    });
 }


### PR DESCRIPTION
## Description

`DraggableScrollableController.animateTo` creates new AnimationControllers but don’t dispose them. It creates new AnimationControllers using a `vsync` it gets from the following call `vsync: _attachedController!.position.context.vsync,` doing so the AnimationController is attached to a ScrollableState widget.

This PR allows `DraggableScrollableController` to manage the AnimationControllers it created and to register a callback called when the ScollableState is disposed (more precisely when the Position object is detached from the ScrollableState).

## Related Issue

Fixes https://github.com/flutter/flutter/issues/102483


## Tests

Add one test in `draggable_scrollable_sheet_test.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.