### PR TITLE
Enable M1 mac/ios tests in prod as bringup: false

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2447,7 +2447,6 @@ targets:
   - name: Mac_arm64_ios build_ios_framework_module_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3309,7 +3308,6 @@ targets:
   - name: Mac_arm64_ios flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3349,7 +3347,6 @@ targets:
   - name: Mac_arm64_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3372,7 +3369,6 @@ targets:
   - name: Mac_arm64_ios hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3455,7 +3451,6 @@ targets:
   - name: Mac_arm64_ios ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3476,7 +3471,6 @@ targets:
   - name: Mac_arm64_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3527,7 +3521,6 @@ targets:
   - name: Mac_arm64_ios macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3687,7 +3680,6 @@ targets:
   - name: Mac_arm64_ios native_ui_tests_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3736,7 +3728,6 @@ targets:
   - name: Mac_arm64_ios run_release_test_macos
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/102089.
This PR marks these tests as `bringup: false` to block trees if failing.

Issue: https://github.com/flutter/flutter/issues/87508