### PR TITLE
add benchmark for animated complex opacity

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1453,6 +1453,17 @@ targets:
       task_name: animated_image_gc_perf
     scheduler: luci
 
+  - name: Linux_android animated_complex_opacity_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: animated_complex_opacity_perf__e2e_summary
+    scheduler: luci
+
   - name: Linux_android animated_placeholder_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -78,6 +78,7 @@
 /dev/devicelab/bin/tasks/gradient_consistent_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/gradient_dynamic_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/gradient_static_perf__e2e_summary.dart @flar @flutter/engine
+/dev/devicelab/bin/tasks/animated_complex_opacity_perf__e2e_summary @jonahwilliams @flutter/engine
 
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @zanderso @flutter/tool

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -78,7 +78,7 @@
 /dev/devicelab/bin/tasks/gradient_consistent_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/gradient_dynamic_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/gradient_static_perf__e2e_summary.dart @flar @flutter/engine
-/dev/devicelab/bin/tasks/animated_complex_opacity_perf__e2e_summary @jonahwilliams @flutter/engine
+/dev/devicelab/bin/tasks/animated_complex_opacity_perf__e2e_summary.dart @jonahwilliams @flutter/engine
 
 ## Windows Android DeviceLab tests
 /dev/devicelab/bin/tasks/basic_material_app_win__compile.dart @zanderso @flutter/tool

--- a/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
+++ b/dev/benchmarks/macrobenchmarks/android/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@ found in the LICENSE file. -->
         android:label="macrobenchmarks"
         android:icon="@mipmap/ic_launcher">
         <activity
+            android:exported="true"
             android:name=".MainActivity"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -27,6 +27,7 @@ const String kAnimationWithMicrotasksRouteName = '/animation_with_microtasks';
 const String kAnimatedImageRouteName = '/animated_image';
 const String kOpacityPeepholeRouteName = '/opacity_peephole';
 const String kGradientPerfRouteName = '/gradient_perf';
+const String kAnimatedComplexOpacityPerfRouteName = '/animated_complex_opacity';
 
 const String kOpacityPeepholeOneRectRouteName = '$kOpacityPeepholeRouteName/one_big_rect';
 const String kOpacityPeepholeColumnOfOpacityRouteName = '$kOpacityPeepholeRouteName/column_of_opacity';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import 'common.dart';
 
+import 'src/animated_complex_opacity.dart';
 import 'src/animated_image.dart';
 import 'src/animated_placeholder.dart';
 import 'src/animation_with_microtasks.dart';
@@ -72,6 +73,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         ...opacityPeepholeRoutes,
         kGradientPerfRouteName: (BuildContext context) => const GradientPerfHomePage(),
         ...gradientPerfRoutes,
+        kAnimatedComplexOpacityPerfRouteName: (BuildContext context) => const AnimatedComplexOpacity(),
       },
     );
   }
@@ -255,6 +257,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Gradient performance tests'),
             onPressed: () {
               Navigator.pushNamed(context, kGradientPerfRouteName);
+            },
+          ),
+          ElevatedButton(
+            key: const Key(kAnimatedComplexOpacityPerfRouteName),
+            child: const Text('Animated complex opacity perf'),
+            onPressed: () {
+              Navigator.pushNamed(context, kAnimatedComplexOpacityPerfRouteName);
             },
           ),
         ],

--- a/dev/benchmarks/macrobenchmarks/lib/src/animated_complex_opacity.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/animated_complex_opacity.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
 // Various tests to verify that Aniamted opacity layers (i.e. FadeTransition) do not

--- a/dev/benchmarks/macrobenchmarks/lib/src/animated_complex_opacity.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/animated_complex_opacity.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+// Various tests to verify that Aniamted opacity layers (i.e. FadeTransition) do not
+// dirty children even without explicit repaint boundaries. These intentionally use
+// text to ensure we don't measure the opacity peephole case.
+class AnimatedComplexOpacity extends StatefulWidget {
+  const AnimatedComplexOpacity({ super.key });
+
+  @override
+  State<AnimatedComplexOpacity> createState() => _AnimatedComplexOpacityState();
+}
+
+class _AnimatedComplexOpacityState extends State<AnimatedComplexOpacity> with SingleTickerProviderStateMixin {
+  late final AnimationController controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 5000));
+  late final Animation<double> animation = controller.drive(Tween<double>(begin: 0.0, end: 1.0));
+
+  @override
+  void initState() {
+    super.initState();
+    controller.forward(from: 0.0);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ListView(
+          children: <Widget>[
+            for (int i = 0; i < 20; i++)
+            FadeTransition(opacity: animation, child: Center(
+              child: Transform.scale(scale: 1.01, child: const ModeratelyComplexWidget()),
+            ))
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class ModeratelyComplexWidget extends StatelessWidget {
+  const ModeratelyComplexWidget({ super.key });
+
+  @override
+  Widget build(BuildContext context) {
+    return const Material(
+      elevation: 10,
+      clipBehavior: Clip.hardEdge,
+      child: ListTile(
+        leading: Icon(Icons.abc, size: 24),
+        title: DecoratedBox(decoration: BoxDecoration(color: Colors.red), child: Text('Hello World')),
+        trailing: FlutterLogo(),
+      ),
+    );
+  }
+}

--- a/dev/devicelab/bin/tasks/animated_complex_opacity_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/animated_complex_opacity_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createAnimatedComplexOpacityPerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -577,6 +577,13 @@ TaskFunction createGradientStaticPerfE2ETest() {
   ).run;
 }
 
+TaskFunction createAnimatedComplexOpacityPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/animated_complex_opacity_perf_e2e.dart',
+  ).run;
+}
+
 Map<String, dynamic> _average(List<Map<String, dynamic>> results, int iterations) {
   final Map<String, dynamic> tally = <String, dynamic>{};
   for (final Map<String, dynamic> item in results) {


### PR DESCRIPTION
benchmark to show improvement in https://github.com/flutter/flutter/pull/101952 towards addressing https://github.com/flutter/flutter/issues/101597 . Running locally shows about a 50% raster time improvement