### PR TITLE
Enable users to scroll the nestedScrollView using ScrollController

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -799,10 +799,7 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
 
   double unnestOffset(double value, _NestedScrollPosition source) {
     if (source == _outerPosition)
-      return value.clamp(
-        _outerPosition!.minScrollExtent,
-        _outerPosition!.maxScrollExtent,
-      );
+      return value;
     if (value < source.minScrollExtent)
       return value - source.minScrollExtent + _outerPosition!.minScrollExtent;
     return value - source.minScrollExtent + _outerPosition!.maxScrollExtent;

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -2559,6 +2559,37 @@ void main() {
     expect(scrollStarted, 2);
     expect(scrollEnded, 2);
   });
+
+  // Regression test of https://github.com/flutter/flutter/issues/93818
+  group('NestedScrollView scroll normally when using', (){
+    testWidgets('ScrollController.jumpTo', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+
+      await tester.pumpWidget(buildTest(controller: controller, key: globalKey));
+      // Jump to the end of the list
+      controller.jumpTo(100000);
+      await tester.pumpAndSettle();
+      expect(globalKey.currentState!.outerController.position.pixels, globalKey.currentState!.outerController.position.maxScrollExtent);
+      expect(globalKey.currentState!.innerController.position.pixels, globalKey.currentState!.innerController.position.maxScrollExtent);
+    });
+
+    testWidgets('ScrollController.animateTo', (WidgetTester tester) async {
+      final ScrollController controller = ScrollController();
+      final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+
+      await tester.pumpWidget(buildTest(controller: controller, key: globalKey));
+      // Animate to the end of the list
+      controller.animateTo(
+        100000,
+        duration: const Duration(milliseconds: 100),
+        curve: Curves.linear,
+      );
+      await tester.pumpAndSettle();
+      expect(globalKey.currentState!.outerController.position.pixels, globalKey.currentState!.outerController.position.maxScrollExtent);
+      expect(globalKey.currentState!.innerController.position.pixels, globalKey.currentState!.innerController.position.maxScrollExtent);
+    });
+  });
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {


### PR DESCRIPTION
This PR changes the method _NestedScrollCoordinator.unnestOffset. This is because this method clamps the value that passes to the outter position when using ScrollController.animateTo and ScrollController.jumpTo, which prevents users from being able to use the ScrollController to scroll the NestedScrollView.

Fixes #93818

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
