### PR TITLE
Avoid scheduling a forced frame when there is no child to the renderView

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -235,10 +235,13 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   ///
   /// See [dart:ui.PlatformDispatcher.onMetricsChanged].
   @protected
+  @visibleForTesting
   void handleMetricsChanged() {
     assert(renderView != null);
     renderView.configuration = createViewConfiguration();
-    scheduleForcedFrame();
+    if (renderView.child != null) {
+      scheduleForcedFrame();
+    }
   }
 
   /// Called when the platform text scale factor changes.

--- a/packages/flutter/test/rendering/binding_test.dart
+++ b/packages/flutter/test/rendering/binding_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  test('handleMetricsChanged does not scheduleForcedFrame unless there is a child to the renderView', () async {
+    expect(SchedulerBinding.instance.hasScheduledFrame, false);
+    RendererBinding.instance.handleMetricsChanged();
+    expect(SchedulerBinding.instance.hasScheduledFrame, false);
+
+    RendererBinding.instance.renderView.child = RenderLimitedBox();
+    RendererBinding.instance.handleMetricsChanged();
+    expect(SchedulerBinding.instance.hasScheduledFrame, true);
+  });
+}


### PR DESCRIPTION
xref b/230429702

See https://github.com/flutter/flutter/pull/101544

We can get multiple calls to `handleMetricsChanged` during application startup. These calls may happen at any point, sometimes before `runApp` is called. Before a render object is attached to the root `RenderView`, we should avoid forcing a frame to be scheduled, as it may cause a black flickering and dismissal of the splash screen too early on Android.

Depending on what branch 101544 landed in, we may need to look at cherry picking this change in.

/cc @jiahaog fyi