### PR TITLE
Enable Mac/android arm64 tests as `bringup: true`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -114,7 +114,6 @@ platform_properties:
           [
             {"name":"builder_mac_devicelab","path":"builder"},
             {"name":"android_sdk","path":"android"},
-            {"name":"chrome_and_driver_96","path":"chrome"},
             {"name":"flutter_sdk","path":"flutter sdk"},
             {"name":"gradle","path":"gradle"},
             {"name":"openjdk_11","path":"java"},
@@ -123,7 +122,6 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "chrome_and_driver", "version": "version:98.1"},
           {"dependency": "open_jdk", "version": "11"}
         ]
       os: Mac-12

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -108,7 +108,7 @@ platform_properties:
       os: Mac-12
       cpu: x86
       device_os: N
-  mac_android:
+  mac_arm64_android:
     properties:
       caches: >-
           [

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -108,6 +108,27 @@ platform_properties:
       os: Mac-12
       cpu: x86
       device_os: N
+  mac_android:
+    properties:
+      caches: >-
+          [
+            {"name":"builder_mac_devicelab","path":"builder"},
+            {"name":"android_sdk","path":"android"},
+            {"name":"chrome_and_driver_96","path":"chrome"},
+            {"name":"flutter_sdk","path":"flutter sdk"},
+            {"name":"gradle","path":"gradle"},
+            {"name":"openjdk_11","path":"java"},
+            {"name":"pub_cache","path":".pub-cache"}
+          ]
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:31v8"},
+          {"dependency": "chrome_and_driver", "version": "version:98.1"},
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      os: Mac-12
+      cpu: arm64
+      device_os: N
   mac_ios:
     properties:
       caches: >-
@@ -1451,17 +1472,6 @@ targets:
       tags: >
         ["devicelab","android","linux"]
       task_name: animated_image_gc_perf
-    scheduler: luci
-
-  - name: Linux_android animated_complex_opacity_perf__e2e_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    bringup: true
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab","android","linux"]
-      task_name: animated_complex_opacity_perf__e2e_summary
     scheduler: luci
 
   - name: Linux_android animated_placeholder_perf__e2e_summary
@@ -3110,6 +3120,17 @@ targets:
       task_name: hello_world_android__compile
     scheduler: luci
 
+  - name: Mac_arm64_android hello_world_android__compile
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true # Flaky: https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","mac","arm64"]
+      task_name: hello_world_android__compile
+    scheduler: luci
+
   - name: Mac_android hot_mode_dev_cycle__benchmark
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3127,6 +3148,17 @@ targets:
     properties:
       tags: >
         ["devicelab","android","mac"]
+      task_name: integration_test_test
+    scheduler: luci
+
+  - name: Mac_arm64_android integration_test_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true # Flaky: https://github.com/flutter/flutter/issues/87508
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","mac","arm64"]
       task_name: integration_test_test
     scheduler: luci
 
@@ -3158,6 +3190,19 @@ targets:
     properties:
       tags: >
         ["devicelab","android","mac"]
+      task_name: run_release_test
+    scheduler: luci
+
+  - name: Mac_arm64_android run_release_test
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true # Flaky: https://github.com/flutter/flutter/issues/87508
+    runIf:
+      - dev/**
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","mac","arm64"]
       task_name: run_release_test
     scheduler: luci
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1474,6 +1474,17 @@ targets:
       task_name: animated_image_gc_perf
     scheduler: luci
 
+  - name: Linux_android animated_complex_opacity_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: animated_complex_opacity_perf__e2e_summary
+    scheduler: luci
+
   - name: Linux_android animated_placeholder_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
These three Mac arm64 android tests have been passing consistently.

https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_android_staging%20integration_test_test?limit=50
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_android_staging%20hello_world_android__compile?limit=50
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_android_staging%20run_release_test?limit=50

Issue: https://github.com/flutter/flutter/issues/87508