### PR TITLE
Update open sdk version to be version `version:11`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -122,7 +122,7 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "open_jdk", "version": "11"}
+          {"dependency": "open_jdk", "version": "version:11"}
         ]
       os: Mac-12
       cpu: arm64


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/102589, which used same tag of `11` as `mac_android` platform (which works because there is a version `11` created).

However for the arm64, there is only a tag `version:11`, without a version `11`. And this caused the build failing to find the deps: https://ci.chromium.org/ui/p/flutter/builders/staging/Mac_arm64_android%20hello_world_android__compile/5/overview.

This PR updates the version to be `version:11` from `11`.
One success build: https://luci-milo.appspot.com/raw/build/logs.chromium.org/flutter/led/keyonghan_google.com/aa9bcd6c65ad20f1e74bfd80ed8a870fad761cca2081209c994b9a804813320b/+/build.proto