### PR TITLE
Fixes documentation inconsistencies around 'material' and 'material design'

### DIFF
--- a/dev/benchmarks/test_apps/stocks/README.md
+++ b/dev/benchmarks/test_apps/stocks/README.md
@@ -1,6 +1,6 @@
 # Stocks
 
-Demo app for the material design widgets and other features provided by Flutter.
+Demo app for the Material Design widgets and other features provided by Flutter.
 
 ## Building
 

--- a/dev/integration_tests/flutter_gallery/web/index.html
+++ b/dev/integration_tests/flutter_gallery/web/index.html
@@ -6,7 +6,7 @@ found in the LICENSE file. -->
 <head>
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A demo app for Flutter's Material Design and cupertino widgets, as well as many other features of the Flutter SDK.">
+  <meta name="description" content="A demo app for Flutter's material and cupertino widgets, as well as many other features of the Flutter SDK.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/dev/integration_tests/flutter_gallery/web/index.html
+++ b/dev/integration_tests/flutter_gallery/web/index.html
@@ -6,7 +6,7 @@ found in the LICENSE file. -->
 <head>
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A demo app for Flutter's material design and cupertino widgets, as well as many other features of the Flutter SDK.">
+  <meta name="description" content="A demo app for Flutter's Material Design and cupertino widgets, as well as many other features of the Flutter SDK.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -46,7 +46,7 @@ class CupertinoColors {
   ///
   /// See also:
   ///
-  ///  * [material.Colors.white], the same color, in the material design palette.
+  ///  * [material.Colors.white], the same color, in the Material Design palette.
   ///  * [black], opaque black in the [CupertinoColors] palette.
   static const Color white = Color(0xFFFFFFFF);
 
@@ -56,7 +56,7 @@ class CupertinoColors {
   ///
   /// See also:
   ///
-  ///  * [material.Colors.black], the same color, in the material design palette.
+  ///  * [material.Colors.black], the same color, in the Material Design palette.
   ///  * [white], opaque white in the [CupertinoColors] palette.
   static const Color black = Color(0xFF000000);
 

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -48,7 +48,7 @@ import 'thumb_painter.dart';
 ///
 /// See also:
 ///
-///  * [Switch], the material design equivalent.
+///  * [Switch], the Material Design equivalent.
 ///  * <https://developer.apple.com/ios/human-interface-guidelines/controls/switches/>
 class CupertinoSwitch extends StatefulWidget {
   /// Creates an iOS-style switch.

--- a/packages/flutter/lib/src/material/animated_icons/animated_icons_data.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons_data.dart
@@ -10,51 +10,51 @@
 
 part of material_animated_icons;
 
-/// Identifier for the supported material design animated icons.
+/// Identifier for the supported Material Design animated icons.
 ///
 /// Use with [AnimatedIcon] class to show specific animated icons.
 abstract class AnimatedIcons {
 
-  /// The material design add to event icon animation.
+  /// The Material Design add to event icon animation.
   static const AnimatedIconData add_event = _$add_event;
 
-  /// The material design arrow to menu icon animation.
+  /// The Material Design arrow to menu icon animation.
   static const AnimatedIconData arrow_menu = _$arrow_menu;
 
-  /// The material design close to menu icon animation.
+  /// The Material Design close to menu icon animation.
   static const AnimatedIconData close_menu = _$close_menu;
 
-  /// The material design ellipsis to search icon animation.
+  /// The Material Design ellipsis to search icon animation.
   static const AnimatedIconData ellipsis_search = _$ellipsis_search;
 
-  /// The material design event to add icon animation.
+  /// The Material Design event to add icon animation.
   static const AnimatedIconData event_add = _$event_add;
 
-  /// The material design home to menu icon animation.
+  /// The Material Design home to menu icon animation.
   static const AnimatedIconData home_menu = _$home_menu;
 
-  /// The material design list to view icon animation.
+  /// The Material Design list to view icon animation.
   static const AnimatedIconData list_view = _$list_view;
 
-  /// The material design menu to arrow icon animation.
+  /// The Material Design menu to arrow icon animation.
   static const AnimatedIconData menu_arrow = _$menu_arrow;
 
-  /// The material design menu to close icon animation.
+  /// The Material Design menu to close icon animation.
   static const AnimatedIconData menu_close = _$menu_close;
 
-  /// The material design menu to home icon animation.
+  /// The Material Design menu to home icon animation.
   static const AnimatedIconData menu_home = _$menu_home;
 
-  /// The material design pause to play icon animation.
+  /// The Material Design pause to play icon animation.
   static const AnimatedIconData pause_play = _$pause_play;
 
-  /// The material design play to pause icon animation.
+  /// The Material Design play to pause icon animation.
   static const AnimatedIconData play_pause = _$play_pause;
 
-  /// The material design search to ellipsis icon animation.
+  /// The Material Design search to ellipsis icon animation.
   static const AnimatedIconData search_ellipsis = _$search_ellipsis;
 
-  /// The material design view to list icon animation.
+  /// The Material Design view to list icon animation.
   static const AnimatedIconData view_list = _$view_list;
 }
 

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -50,10 +50,10 @@ enum ThemeMode {
   dark,
 }
 
-/// An application that uses material design.
+/// An application that uses Material Design.
 ///
 /// A convenience widget that wraps a number of widgets that are commonly
-/// required for material design applications. It builds upon a [WidgetsApp] by
+/// required for Material Design applications. It builds upon a [WidgetsApp] by
 /// adding material-design specific functionality, such as [AnimatedTheme] and
 /// [GridPaper].
 ///

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -62,7 +62,7 @@ class _PreferredAppBarSize extends Size {
   final double? bottomHeight;
 }
 
-/// A material design app bar.
+/// A Material Design app bar.
 ///
 /// An app bar consists of a toolbar and potentially other widgets, such as a
 /// [TabBar] and a [FlexibleSpaceBar]. App bars typically expose one or more
@@ -144,7 +144,7 @@ class _PreferredAppBarSize extends Size {
 ///  * <https://material.io/design/components/app-bars-top.html>
 ///  * Cookbook: [Place a floating app bar above a list](https://flutter.dev/docs/cookbook/lists/floating-app-bar)
 class AppBar extends StatefulWidget implements PreferredSizeWidget {
-  /// Creates a material design app bar.
+  /// Creates a Material Design app bar.
   ///
   /// The arguments [primary], [toolbarOpacity], [bottomOpacity],
   /// [backwardsCompatibility], and [automaticallyImplyLeading] must
@@ -1269,7 +1269,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
   }
 }
 
-/// A material design app bar that integrates with a [CustomScrollView].
+/// A Material Design app bar that integrates with a [CustomScrollView].
 ///
 /// An app bar consists of a toolbar and potentially other widgets, such as a
 /// [TabBar] and a [FlexibleSpaceBar]. App bars typically expose one or more
@@ -1355,7 +1355,7 @@ class _SliverAppBarDelegate extends SliverPersistentHeaderDelegate {
 ///    can expand and collapse.
 ///  * <https://material.io/design/components/app-bars-top.html>
 class SliverAppBar extends StatefulWidget {
-  /// Creates a material design app bar that can be placed in a [CustomScrollView].
+  /// Creates a Material Design app bar that can be placed in a [CustomScrollView].
   ///
   /// The arguments [forceElevated], [primary], [floating], [pinned], [snap]
   /// and [automaticallyImplyLeading] must not be null.

--- a/packages/flutter/lib/src/material/arc.dart
+++ b/packages/flutter/lib/src/material/arc.dart
@@ -17,7 +17,7 @@ const double _kOnAxisDelta = 2.0;
 ///
 /// This class specializes the interpolation of [Tween<Offset>] so that instead
 /// of a straight line, the intermediate points follow the arc of a circle in a
-/// manner consistent with material design principles.
+/// manner consistent with Material Design principles.
 ///
 /// The arc's radius is related to the bounding box that contains the [begin]
 /// and [end] points. If the bounding box is taller than it is wide, then the
@@ -218,7 +218,7 @@ T _maxBy<T>(Iterable<T> input, _KeyFunc<T> keyFunc) {
 ///
 /// This class specializes the interpolation of [Tween<Rect>] so that instead of
 /// growing or shrinking linearly, opposite corners of the rectangle follow arcs
-/// in a manner consistent with material design principles.
+/// in a manner consistent with Material Design principles.
 ///
 /// Specifically, the rectangle corners whose diagonals are closest to the overall
 /// direction of the animation follow arcs defined with [MaterialPointArcTween].

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -20,7 +20,7 @@ import 'theme.dart';
 ///    [Navigator.maybePop] to return to the previous route.
 ///  * [IconButton], which is a more general widget for creating buttons
 ///    with icons.
-///  * [Icon], a material design icon.
+///  * [Icon], a Material Design icon.
 ///  * [ThemeData.platform], which specifies the current platform.
 class BackButtonIcon extends StatelessWidget {
   /// Creates an icon that shows the appropriate "back" image for
@@ -45,7 +45,7 @@ class BackButtonIcon extends StatelessWidget {
   Widget build(BuildContext context) => Icon(_getIconData(Theme.of(context).platform));
 }
 
-/// A material design back button.
+/// A Material Design back button.
 ///
 /// A [BackButton] is an [IconButton] with a "back" icon appropriate for the
 /// current [TargetPlatform]. When pressed, the back button calls
@@ -110,7 +110,7 @@ class BackButton extends StatelessWidget {
   }
 }
 
-/// A material design close button.
+/// A Material Design close button.
 ///
 /// A [CloseButton] is an [IconButton] with a "close" icon. When pressed, the
 /// close button calls [Navigator.maybePop] to return to the previous route.
@@ -125,7 +125,7 @@ class BackButton extends StatelessWidget {
 ///  * [BackButton], which is more appropriate for middle nodes in the
 ///    navigation tree or where pages can be popped instantaneously with
 ///    no user data consequence.
-///  * [IconButton], to create other material design icon buttons.
+///  * [IconButton], to create other Material Design icon buttons.
 class CloseButton extends StatelessWidget {
   /// Creates a Material Design close button.
   const CloseButton({ super.key, this.color, this.onPressed });

--- a/packages/flutter/lib/src/material/banner.dart
+++ b/packages/flutter/lib/src/material/banner.dart
@@ -18,7 +18,7 @@ const Curve _materialBannerHeightCurve = Curves.fastOutSlowIn;
 /// The [ScaffoldMessengerState.showMaterialBanner] function returns a
 /// [ScaffoldFeatureController]. The value of the controller's closed property
 /// is a Future that resolves to a MaterialBannerClosedReason. Applications that need
-/// to know how a material banner was closed can use this value.
+/// to know how a [MaterialBanner] was closed can use this value.
 ///
 /// Example:
 ///
@@ -183,7 +183,7 @@ class MaterialBanner extends StatefulWidget {
 
   // API for ScaffoldMessengerState.showMaterialBanner():
 
-  /// Creates an animation controller useful for driving a material banner's entrance and exit animation.
+  /// Creates an animation controller useful for driving a [MaterialBanner]'s entrance and exit animation.
   static AnimationController createAnimationController({ required TickerProvider vsync }) {
     return AnimationController(
       duration: _materialBannerTransitionDuration,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -35,9 +35,9 @@ typedef BottomSheetDragEndHandler = void Function(
   required bool isClosing,
 });
 
-/// A material design bottom sheet.
+/// A Material Design bottom sheet.
 ///
-/// There are two kinds of bottom sheets in material design:
+/// There are two kinds of bottom sheets in Material Design:
 ///
 ///  * _Persistent_. A persistent bottom sheet shows information that
 ///    supplements the primary content of the app. A persistent bottom sheet
@@ -600,7 +600,7 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
   }
 }
 
-/// Shows a modal material design bottom sheet.
+/// Shows a modal Material Design bottom sheet.
 ///
 /// A modal bottom sheet is an alternative to a menu or a dialog and prevents
 /// the user from interacting with the rest of the app.
@@ -718,7 +718,7 @@ Future<T?> showModalBottomSheet<T>({
   ));
 }
 
-/// Shows a material design bottom sheet in the nearest [Scaffold] ancestor. If
+/// Shows a Material Design bottom sheet in the nearest [Scaffold] ancestor. If
 /// you wish to show a persistent bottom sheet, use [Scaffold.bottomSheet].
 ///
 /// Returns a controller that can be used to close and otherwise manipulate the

--- a/packages/flutter/lib/src/material/button_theme.dart
+++ b/packages/flutter/lib/src/material/button_theme.dart
@@ -33,7 +33,7 @@ enum ButtonBarLayoutBehavior {
   /// Button bars will be constrained to a minimum height of 52.
   ///
   /// This setting is require to create button bars which conform to the
-  /// material specification.
+  /// Material Design specification.
   constrained,
 
   /// Button bars will calculate their padding from the button theme padding.

--- a/packages/flutter/lib/src/material/calendar_date_picker.dart
+++ b/packages/flutter/lib/src/material/calendar_date_picker.dart
@@ -52,7 +52,7 @@ const double _monthNavButtonsWidth = 108.0;
 ///  * [showDatePicker], which creates a Dialog that contains a
 ///    [CalendarDatePicker] and provides an optional compact view where the
 ///    user can enter a date as a line of text.
-///  * [showTimePicker], which shows a dialog that contains a material design
+///  * [showTimePicker], which shows a dialog that contains a Material Design
 ///    time picker.
 ///
 class CalendarDatePicker extends StatefulWidget {

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -8,7 +8,7 @@ import 'card_theme.dart';
 import 'material.dart';
 import 'theme.dart';
 
-/// A material design card: a panel with slightly rounded corners and an
+/// A Material Design card: a panel with slightly rounded corners and an
 /// elevation shadow.
 ///
 /// A card is a sheet of [Material] used to represent some related information,
@@ -54,7 +54,7 @@ import 'theme.dart';
 ///  * [showDialog], to display a modal card.
 ///  * <https://material.io/design/components/cards.html>
 class Card extends StatelessWidget {
-  /// Creates a material design card.
+  /// Creates a Material Design card.
   ///
   /// The [elevation] must be null or non-negative. The [borderOnForeground]
   /// must not be null.

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -12,7 +12,7 @@ import 'theme.dart';
 import 'theme_data.dart';
 import 'toggleable.dart';
 
-/// A material design checkbox.
+/// A Material Design checkbox.
 ///
 /// The checkbox itself does not maintain any state. Instead, when the state of
 /// the checkbox changes, the widget calls the [onChanged] callback. Most
@@ -46,7 +46,7 @@ import 'toggleable.dart';
 ///  * <https://material.io/design/components/selection-controls.html#checkboxes>
 ///  * <https://material.io/design/components/lists.html#types>
 class Checkbox extends StatefulWidget {
-  /// Creates a material design checkbox.
+  /// Creates a Material Design checkbox.
   ///
   /// The checkbox itself does not maintain any state. Instead, when the state of
   /// the checkbox changes, the widget calls the [onChanged] callback. Most

--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -39,7 +39,7 @@ const Duration _kDisableDuration = Duration(milliseconds: 75);
 const Color _kSelectScrimColor = Color(0x60191919);
 const Icon _kDefaultDeleteIcon = Icon(Icons.cancel, size: _kDeleteIconSize);
 
-/// An interface defining the base attributes for a material design chip.
+/// An interface defining the base attributes for a Material Design chip.
 ///
 /// Chips are compact elements that represent an attribute, text, entity, or
 /// action.
@@ -187,7 +187,7 @@ abstract class ChipAttributes {
   Color? get shadowColor;
 }
 
-/// An interface for material design chips that can be deleted.
+/// An interface for Material Design chips that can be deleted.
 ///
 /// The defaults mentioned in the documentation for each attribute are what
 /// the implementing classes typically use for defaults (but this class doesn't
@@ -257,7 +257,7 @@ abstract class DeletableChipAttributes {
   bool get useDeleteButtonTooltip;
 }
 
-/// An interface for material design chips that can have check marks.
+/// An interface for Material Design chips that can have check marks.
 ///
 /// The defaults mentioned in the documentation for each attribute are what
 /// the implementing classes typically use for defaults (but this class doesn't
@@ -290,7 +290,7 @@ abstract class CheckmarkableChipAttributes {
   Color? get checkmarkColor;
 }
 
-/// An interface for material design chips that can be selected.
+/// An interface for Material Design chips that can be selected.
 ///
 /// The defaults mentioned in the documentation for each attribute are what
 /// the implementing classes typically use for defaults (but this class doesn't
@@ -400,7 +400,7 @@ abstract class SelectableChipAttributes {
   ShapeBorder get avatarBorder;
 }
 
-/// An interface for material design chips that can be enabled and disabled.
+/// An interface for Material Design chips that can be enabled and disabled.
 ///
 /// The defaults mentioned in the documentation for each attribute are what
 /// the implementing classes typically use for defaults (but this class doesn't
@@ -447,7 +447,7 @@ abstract class DisabledChipAttributes {
   Color? get disabledColor;
 }
 
-/// An interface for material design chips that can be tapped.
+/// An interface for Material Design chips that can be tapped.
 ///
 /// The defaults mentioned in the documentation for each attribute are what
 /// the implementing classes typically use for defaults (but this class doesn't
@@ -509,7 +509,7 @@ abstract class TappableChipAttributes {
   String? get tooltip;
 }
 
-/// A material design chip.
+/// A Material Design chip.
 ///
 /// Chips are compact elements that represent an attribute, text, entity, or
 /// action.
@@ -549,7 +549,7 @@ abstract class TappableChipAttributes {
 ///    vertical runs.
 ///  * <https://material.io/design/components/chips.html>
 class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttributes {
-  /// Creates a material design chip.
+  /// Creates a Material Design chip.
   ///
   /// The [label], [autofocus], and [clipBehavior] arguments must not be null.
   /// The [elevation] must be null or non-negative.
@@ -658,7 +658,7 @@ class Chip extends StatelessWidget implements ChipAttributes, DeletableChipAttri
   }
 }
 
-/// A raw material design chip.
+/// A raw Material Design chip.
 ///
 /// This serves as the basis for all of the chip widget types to aggregate.
 /// It is typically not created directly, one of the other chip types

--- a/packages/flutter/lib/src/material/chip_action.dart
+++ b/packages/flutter/lib/src/material/chip_action.dart
@@ -8,7 +8,7 @@ import 'chip.dart';
 import 'debug.dart';
 import 'theme_data.dart';
 
-/// A material design action chip.
+/// A Material Design action chip.
 ///
 /// Action chips are a set of options which trigger an action related to primary
 /// content. Action chips should appear dynamically and contextually in a UI.

--- a/packages/flutter/lib/src/material/chip_choice.dart
+++ b/packages/flutter/lib/src/material/chip_choice.dart
@@ -9,7 +9,7 @@ import 'chip_theme.dart';
 import 'debug.dart';
 import 'theme_data.dart';
 
-/// A material design choice chip.
+/// A Material Design choice chip.
 ///
 /// [ChoiceChip]s represent a single choice from a set. Choice chips contain
 /// related descriptive text or categories.

--- a/packages/flutter/lib/src/material/chip_filter.dart
+++ b/packages/flutter/lib/src/material/chip_filter.dart
@@ -8,7 +8,7 @@ import 'chip.dart';
 import 'debug.dart';
 import 'theme_data.dart';
 
-/// A material design filter chip.
+/// A Material Design filter chip.
 ///
 /// Filter chips use tags or descriptive words as a way to filter content.
 ///

--- a/packages/flutter/lib/src/material/chip_input.dart
+++ b/packages/flutter/lib/src/material/chip_input.dart
@@ -8,7 +8,7 @@ import 'chip.dart';
 import 'debug.dart';
 import 'theme_data.dart';
 
-/// A material design input chip.
+/// A Material Design input chip.
 ///
 /// Input chips represent a complex piece of information, such as an entity
 /// (person, place, or thing) or conversational text, in a compact form.

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -98,7 +98,7 @@ class ChipTheme extends InheritedTheme {
   bool updateShouldNotify(ChipTheme oldWidget) => data != oldWidget.data;
 }
 
-/// Holds the color, shape, and text styles for a material design chip theme.
+/// Holds the color, shape, and text styles for a Material Design chip theme.
 ///
 /// Use this class to configure a [ChipTheme] widget, or to set the
 /// [ThemeData.chipTheme] for a [Theme] widget.

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -1885,7 +1885,7 @@ class Colors {
   );
   static const int _blueGreyPrimaryValue = 0xFF607D8B;
 
-  /// The material design primary color swatches, excluding grey.
+  /// The Material Design primary color swatches, excluding grey.
   static const List<MaterialColor> primaries = <MaterialColor>[
     red,
     pink,
@@ -1910,7 +1910,7 @@ class Colors {
     blueGrey,
   ];
 
-  /// The material design accent color swatches.
+  /// The Material Design accent color swatches.
   static const List<MaterialAccentColor> accents = <MaterialAccentColor>[
     redAccent,
     pinkAccent,

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -304,7 +304,7 @@ class DataCell {
       onTapCancel != null;
 }
 
-/// A material design data table.
+/// A Material Design data table.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ktTajqbhIcY}
 ///

--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -182,9 +182,9 @@ enum DatePickerEntryMode {
 ///
 /// See also:
 ///
-///  * [showDatePicker], which shows a dialog that contains a material design
+///  * [showDatePicker], which shows a dialog that contains a Material Design
 ///    date picker.
-///  * [CalendarDatePicker], widget which implements the material design date picker.
+///  * [CalendarDatePicker], widget which implements the Material Design date picker.
 enum DatePickerMode {
   /// Choosing a month and day.
   day,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -126,13 +126,13 @@ const double _inputFormLandscapeHeight = 108.0;
 ///
 /// See also:
 ///
-///  * [showDateRangePicker], which shows a material design date range picker
+///  * [showDateRangePicker], which shows a Material Design date range picker
 ///    used to select a range of dates.
 ///  * [CalendarDatePicker], which provides the calendar grid used by the date picker dialog.
 ///  * [InputDatePickerFormField], which provides a text input field for entering dates.
 ///  * [DisplayFeatureSubScreen], which documents the specifics of how
 ///    [DisplayFeature]s can split the screen into sub-screens.
-///  * [showTimePicker], which shows a dialog that contains a material design time picker.
+///  * [showTimePicker], which shows a dialog that contains a Material Design time picker.
 ///
 Future<DateTime?> showDatePicker({
   required BuildContext context,
@@ -925,7 +925,7 @@ class _DatePickerHeader extends StatelessWidget {
 ///
 /// See also:
 ///
-///  * [showDatePicker], which shows a material design date picker used to
+///  * [showDatePicker], which shows a Material Design date picker used to
 ///    select a single date.
 ///  * [DateTimeRange], which is used to describe a date range.
 ///  * [DisplayFeatureSubScreen], which documents the specifics of how

--- a/packages/flutter/lib/src/material/debug.dart
+++ b/packages/flutter/lib/src/material/debug.dart
@@ -10,7 +10,7 @@ import 'scaffold.dart' show Scaffold, ScaffoldMessenger;
 
 /// Asserts that the given context has a [Material] ancestor.
 ///
-/// Used by many material design widgets to make sure that they are
+/// Used by many Material Design widgets to make sure that they are
 /// only used in contexts where they can print ink onto some material.
 ///
 /// To call this function, use the following pattern, typically in the
@@ -31,7 +31,7 @@ bool debugCheckHasMaterial(BuildContext context) {
         ErrorDescription(
           '${context.widget.runtimeType} widgets require a Material '
           'widget ancestor.\n'
-          'In material design, most widgets are conceptually "printed" on '
+          'In Material Design, most widgets are conceptually "printed" on '
           "a sheet of material. In Flutter's material library, that "
           'material is represented by the Material widget. It is the '
           'Material widget that renders ink splashes, for instance. '
@@ -54,7 +54,7 @@ bool debugCheckHasMaterial(BuildContext context) {
 /// Asserts that the given context has a [Localizations] ancestor that contains
 /// a [MaterialLocalizations] delegate.
 ///
-/// Used by many material design widgets to make sure that they are
+/// Used by many Material Design widgets to make sure that they are
 /// only used in contexts where they have access to localizations.
 ///
 /// To call this function, use the following pattern, typically in the

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -24,11 +24,11 @@ import 'theme_data.dart';
 
 const EdgeInsets _defaultInsetPadding = EdgeInsets.symmetric(horizontal: 40.0, vertical: 24.0);
 
-/// A material design dialog.
+/// A Material Design dialog.
 ///
 /// This dialog widget does not have any opinion about the contents of the
 /// dialog. Rather than using this widget directly, consider using [AlertDialog]
-/// or [SimpleDialog], which implement specific kinds of material design
+/// or [SimpleDialog], which implement specific kinds of Material Design
 /// dialogs.
 ///
 /// See also:
@@ -166,7 +166,7 @@ class Dialog extends StatelessWidget {
   }
 }
 
-/// A material design alert dialog.
+/// A Material Design alert dialog.
 ///
 /// An alert dialog informs the user about situations that require
 /// acknowledgement. An alert dialog has an optional title and an optional list
@@ -700,7 +700,7 @@ class SimpleDialogOption extends StatelessWidget {
   }
 }
 
-/// A simple material design dialog.
+/// A simple Material Design dialog.
 ///
 /// A simple dialog offers the user a choice between several options. A simple
 /// dialog has an optional title that is displayed above the choices.

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -24,7 +24,7 @@ import 'theme.dart';
 ///
 /// See also:
 ///
-///  * [Dialog], a material dialog that can be customized using this [DialogTheme].
+///  * [Dialog], a Material Design dialog that can be customized using this [DialogTheme].
 ///  * [ThemeData], which describes the overall theme information for the
 ///    application.
 @immutable

--- a/packages/flutter/lib/src/material/divider.dart
+++ b/packages/flutter/lib/src/material/divider.dart
@@ -12,7 +12,7 @@ import 'theme.dart';
 
 /// A thin horizontal line, with padding on either side.
 ///
-/// In the material design language, this represents a divider. Dividers can be
+/// In the Material Design language, this represents a divider. Dividers can be
 /// used in lists, [Drawer]s, and elsewhere to separate content.
 ///
 /// To create a divider between [ListTile] items, consider using
@@ -41,7 +41,7 @@ import 'theme.dart';
 ///  * [VerticalDivider], which is the vertical analog of this widget.
 ///  * <https://material.io/design/components/dividers.html>
 class Divider extends StatelessWidget {
-  /// Creates a material design divider.
+  /// Creates a Material Design divider.
   ///
   /// The [height], [thickness], [indent], and [endIndent] must be null or
   /// non-negative.
@@ -179,7 +179,7 @@ class Divider extends StatelessWidget {
 
 /// A thin vertical line, with padding on either side.
 ///
-/// In the material design language, this represents a divider. Vertical
+/// In the Material Design language, this represents a divider. Vertical
 /// dividers can be used in horizontally scrolling lists, such as a
 /// [ListView] with [ListView.scrollDirection] set to [Axis.horizontal].
 ///
@@ -201,7 +201,7 @@ class Divider extends StatelessWidget {
 ///  * [Divider], which is the horizontal analog of this widget.
 ///  * <https://material.io/design/components/dividers.html>
 class VerticalDivider extends StatelessWidget {
-  /// Creates a material design vertical divider.
+  /// Creates a Material Design vertical divider.
   ///
   /// The [width], [thickness], [indent], and [endIndent] must be null or
   /// non-negative.

--- a/packages/flutter/lib/src/material/drawer.dart
+++ b/packages/flutter/lib/src/material/drawer.dart
@@ -47,7 +47,7 @@ const double _kEdgeDragWidth = 20.0;
 const double _kMinFlingVelocity = 365.0;
 const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 
-/// A material design panel that slides in horizontally from the edge of a
+/// A Material Design panel that slides in horizontally from the edge of a
 /// [Scaffold] to show navigation links in an application.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=WRj86iHihgY}
@@ -134,7 +134,7 @@ const Duration _kBaseSettleDuration = Duration(milliseconds: 246);
 ///  * [ScaffoldState.openDrawer], which displays its [Drawer], if any.
 ///  * <https://material.io/design/components/navigation-drawer.html>
 class Drawer extends StatelessWidget {
-  /// Creates a material design drawer.
+  /// Creates a Material Design drawer.
   ///
   /// Typically used in the [Scaffold.drawer] property.
   ///

--- a/packages/flutter/lib/src/material/drawer_header.dart
+++ b/packages/flutter/lib/src/material/drawer_header.dart
@@ -10,11 +10,11 @@ import 'theme.dart';
 
 const double _kDrawerHeaderHeight = 160.0 + 1.0; // bottom edge
 
-/// The top-most region of a material design drawer. The header's [child]
+/// The top-most region of a Material Design drawer. The header's [child]
 /// widget, if any, is placed inside a [Container] whose [decoration] can be
 /// passed as an argument, inset by the given [padding].
 ///
-/// Part of the material design [Drawer].
+/// Part of the Material Design [Drawer].
 ///
 /// Requires one of its ancestors to be a [Material] widget. This condition is
 /// satisfied by putting the [DrawerHeader] in a [Drawer].
@@ -25,7 +25,7 @@ const double _kDrawerHeaderHeight = 160.0 + 1.0; // bottom edge
 ///    specialized for showing user accounts.
 ///  * <https://material.io/design/components/navigation-drawer.html>
 class DrawerHeader extends StatelessWidget {
-  /// Creates a material design drawer header.
+  /// Creates a Material Design drawer header.
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   const DrawerHeader({

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -759,7 +759,7 @@ class DropdownMenuItem<T> extends _DropdownMenuItemContainer {
 ///
 /// This is used by [DataTable] to remove the underline from any
 /// [DropdownButton] widgets placed within material data tables, as
-/// required by the material design specification.
+/// required by the Material Design specification.
 class DropdownButtonHideUnderline extends InheritedWidget {
   /// Creates a [DropdownButtonHideUnderline]. A non-null [child] must
   /// be given.
@@ -778,7 +778,7 @@ class DropdownButtonHideUnderline extends InheritedWidget {
   bool updateShouldNotify(DropdownButtonHideUnderline oldWidget) => false;
 }
 
-/// A material design button for selecting from a list of items.
+/// A Material Design button for selecting from a list of items.
 ///
 /// A dropdown button lets the user select from a number of items. The button
 /// shows the currently selected item as well as an arrow that opens a menu for

--- a/packages/flutter/lib/src/material/flexible_space_bar.dart
+++ b/packages/flutter/lib/src/material/flexible_space_bar.dart
@@ -35,7 +35,7 @@ enum StretchMode {
   fadeTitle,
 }
 
-/// The part of a material design [AppBar] that expands, collapses, and
+/// The part of a Material Design [AppBar] that expands, collapses, and
 /// stretches.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=mSc7qFzxHDw}

--- a/packages/flutter/lib/src/material/floating_action_button.dart
+++ b/packages/flutter/lib/src/material/floating_action_button.dart
@@ -30,7 +30,7 @@ enum _FloatingActionButtonType {
   extended,
 }
 
-/// A material design floating action button.
+/// A Material Design floating action button.
 ///
 /// A floating action button is a circular icon button that hovers over content
 /// to promote a primary action in the application. Floating action buttons are
@@ -331,7 +331,7 @@ class FloatingActionButton extends StatelessWidget {
   /// If this is not explicitly set, then there can only be one
   /// [FloatingActionButton] per route (that is, per screen), since otherwise
   /// there would be a tag conflict (multiple heroes on one route can't have the
-  /// same tag). The material design specification recommends only using one
+  /// same tag). The Material Design specification recommends only using one
   /// floating action button per screen.
   final Object? heroTag;
 

--- a/packages/flutter/lib/src/material/grid_tile.dart
+++ b/packages/flutter/lib/src/material/grid_tile.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/widgets.dart';
 
-/// A tile in a material design grid list.
+/// A tile in a Material Design grid list.
 ///
 /// A grid list is a [GridView] of tiles in a vertical and horizontal
 /// array. Each tile typically contains some visually rich content (e.g., an

--- a/packages/flutter/lib/src/material/grid_tile_bar.dart
+++ b/packages/flutter/lib/src/material/grid_tile_bar.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 import 'colors.dart';
 import 'theme.dart';
 
-/// A header used in a material design [GridTile].
+/// A header used in a Material Design [GridTile].
 ///
 /// Typically used to add a one or two line header or footer on a [GridTile].
 ///

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -21,7 +21,7 @@ import 'tooltip.dart';
 // See: <https://material.io/design/usability/accessibility.html#layout-typography>.
 const double _kMinButtonSize = kMinInteractiveDimension;
 
-/// A material design icon button.
+/// A Material Design icon button.
 ///
 /// An icon button is a picture printed on a [Material] widget that reacts to
 /// touches by filling with color (ink).

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -94,7 +94,7 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 ///
 /// See also:
 ///
-///  * [Icons], a library of predefined icons.
+///  * [Icons], the library of Material Icons.
 ///  * [BackButton], an icon button for a "back" affordance which adapts to the
 ///    current platform's conventions.
 ///  * [CloseButton], an icon button for closing pages.

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -7,7 +7,7 @@ import 'package:flutter/widgets.dart';
 
 // ignore_for_file: non_constant_identifier_names
 
-/// A set of platform-adaptive material design icons.
+/// A set of platform-adaptive Material Design icons.
 ///
 /// Use [Icons.adaptive] to access a static instance of this class.
 class PlatformAdaptiveIcons implements Icons {
@@ -93,7 +93,7 @@ class PlatformAdaptiveIcons implements Icons {
   // END GENERATED PLATFORM ADAPTIVE ICONS
 }
 
-/// Identifiers for the supported material design icons.
+/// Identifiers for the supported Material Design icons.
 ///
 /// Use with the [Icon] class to show specific icons.
 ///
@@ -152,7 +152,7 @@ class Icons {
   // prevents instantiation and extension.
   Icons._();
 
-  /// A set of platform-adaptive material design icons.
+  /// A set of platform-adaptive Material Design icons.
   ///
   /// Provides a convenient way to show a certain set of platform-appropriate
   /// icons on Apple platforms.

--- a/packages/flutter/lib/src/material/ink_well.dart
+++ b/packages/flutter/lib/src/material/ink_well.dart
@@ -247,7 +247,7 @@ typedef _CheckContext = bool Function(BuildContext context);
 ///
 /// The [InkResponse] widget must have a [Material] widget as an ancestor. The
 /// [Material] widget is where the ink reactions are actually painted. This
-/// matches the material design premise wherein the [Material] is what is
+/// matches the Material Design premise wherein the [Material] is what is
 /// actually reacting to touches by spreading ink.
 ///
 /// If a Widget uses this class directly, it should include the following line
@@ -280,7 +280,7 @@ typedef _CheckContext = bool Function(BuildContext context);
 /// See also:
 ///
 ///  * [GestureDetector], for listening for gestures without ink splashes.
-///  * [ElevatedButton] and [TextButton], two kinds of buttons in material design.
+///  * [ElevatedButton] and [TextButton], two kinds of buttons in Material Design.
 ///  * [IconButton], which combines [InkResponse] with an [Icon].
 class InkResponse extends StatelessWidget {
   /// Creates an area of a [Material] that responds to touch.
@@ -1147,7 +1147,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 ///
 /// The [InkWell] widget must have a [Material] widget as an ancestor. The
 /// [Material] widget is where the ink reactions are actually painted. This
-/// matches the material design premise wherein the [Material] is what is
+/// matches the Material Design premise wherein the [Material] is what is
 /// actually reacting to touches by spreading ink.
 ///
 /// If a Widget uses this class directly, it should include the following line
@@ -1211,7 +1211,7 @@ class _InkResponseState extends State<_InkResponseStateWidget>
 /// See also:
 ///
 ///  * [GestureDetector], for listening for gestures without ink splashes.
-///  * [ElevatedButton] and [TextButton], two kinds of buttons in material design.
+///  * [ElevatedButton] and [TextButton], two kinds of buttons in Material Design.
 ///  * [InkResponse], a variant of [InkWell] that doesn't force a rectangular
 ///    shape on the ink reaction.
 class InkWell extends InkResponse {

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -25,7 +25,7 @@ import 'theme.dart';
 ///
 /// See also:
 ///
-///  * [showDatePicker], which shows a dialog that contains a material design
+///  * [showDatePicker], which shows a dialog that contains a Material Design
 ///    date picker which includes support for text entry of dates.
 ///  * [MaterialLocalizations.parseCompactDate], which is used to parse the text
 ///    input into a [DateTime].

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2844,10 +2844,10 @@ class InputDecoration {
   ///
   /// The prefix icon is constrained with a minimum size of 48px by 48px, but
   /// can be expanded beyond that. Anything larger than 24px will require
-  /// additional padding to ensure it matches the material spec of 12px padding
-  /// between the left edge of the input and leading edge of the prefix icon.
-  /// The following snippet shows how to pad the leading edge of the prefix
-  /// icon:
+  /// additional padding to ensure it matches the Material Design spec of 12px
+  /// padding between the left edge of the input and leading edge of the prefix
+  /// icon. The following snippet shows how to pad the leading edge of the
+  /// prefix icon:
   ///
   /// ```dart
   /// prefixIcon: Padding(
@@ -2966,10 +2966,10 @@ class InputDecoration {
   ///
   /// The suffix icon is constrained with a minimum size of 48px by 48px, but
   /// can be expanded beyond that. Anything larger than 24px will require
-  /// additional padding to ensure it matches the material spec of 12px padding
-  /// between the right edge of the input and trailing edge of the prefix icon.
-  /// The following snippet shows how to pad the trailing edge of the suffix
-  /// icon:
+  /// additional padding to ensure it matches the Material Design spec of 12px
+  /// padding between the right edge of the input and trailing edge of the
+  /// prefix icon. The following snippet shows how to pad the trailing edge of
+  /// the suffix icon:
   ///
   /// ```dart
   /// suffixIcon: Padding(

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -95,7 +95,7 @@ enum ListTileControlAffinity {
 /// widget, like `Container(color: Colors.white)`, is included in
 /// between the [ListTile] and its [Material] ancestor, then the
 /// opaque widget will obscure the material widget and its background
-/// [tileColor], etc. If this a problem, one can wrap a material
+/// [tileColor], etc. If this a problem, one can wrap a [Material]
 /// widget around the list tile, e.g.:
 ///
 /// ```dart

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -15,7 +15,7 @@ import 'theme.dart';
 /// Used by [InkHighlight] and [InkSplash], for example.
 typedef RectCallback = Rect Function();
 
-/// The various kinds of material in material design. Used to
+/// The various kinds of material in Material Design. Used to
 /// configure the default behavior of [Material] widgets.
 ///
 /// See also:
@@ -48,7 +48,7 @@ enum MaterialType {
   transparency
 }
 
-/// The border radii used by the various kinds of material in material design.
+/// The border radii used by the various kinds of material in Material Design.
 ///
 /// See also:
 ///
@@ -62,7 +62,7 @@ const Map<MaterialType, BorderRadius?> kMaterialEdges = <MaterialType, BorderRad
   MaterialType.transparency: null,
 };
 
-/// An interface for creating [InkSplash]s and [InkHighlight]s on a material.
+/// An interface for creating [InkSplash]s and [InkHighlight]s on a [Material].
 ///
 /// Typically obtained via [Material.of].
 abstract class MaterialInkController {
@@ -99,7 +99,7 @@ abstract class MaterialInkController {
 ///
 /// ## The Material Metaphor
 ///
-/// Material is the central metaphor in material design. Each piece of material
+/// Material is the central metaphor in Material Design. Each piece of material
 /// exists at a given elevation, which influences how that piece of material
 /// visually relates to other pieces of material and how that material casts
 /// shadows.

--- a/packages/flutter/lib/src/material/material_button.dart
+++ b/packages/flutter/lib/src/material/material_button.dart
@@ -40,7 +40,7 @@ import 'theme_data.dart';
 ///
 ///  * [IconButton], to create buttons that contain icons rather than text.
 class MaterialButton extends StatelessWidget {
-  /// Creates a material button.
+  /// Creates a Material Design button.
   ///
   /// To create a custom Material button consider using [TextButton],
   /// [ElevatedButton], or [OutlinedButton].

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -63,7 +63,7 @@ import 'theme.dart';
 ///     out horizontally.
 ///  * https://material.io/components/navigation-rail/
 class NavigationRail extends StatefulWidget {
-  /// Creates a material design navigation rail.
+  /// Creates a Material Design navigation rail.
   ///
   /// The value of [destinations] must be a list of one or more
   /// [NavigationRailDestination] values.

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -59,8 +59,8 @@ import 'theme_data.dart';
 ///
 /// See also:
 ///
-///  * [ElevatedButton], a filled material design button with a shadow.
-///  * [TextButton], a material design button without a shadow.
+///  * [ElevatedButton], a filled Material Design button with a shadow.
+///  * [TextButton], a Material Design button without a shadow.
 ///  * <https://material.io/design/components/buttons.html>
 class OutlinedButton extends ButtonStyleButton {
   /// Create an OutlinedButton.

--- a/packages/flutter/lib/src/material/paginated_data_table.dart
+++ b/packages/flutter/lib/src/material/paginated_data_table.dart
@@ -20,7 +20,7 @@ import 'material_localizations.dart';
 import 'progress_indicator.dart';
 import 'theme.dart';
 
-/// A material design data table that shows data using multiple pages.
+/// A Material Design data table that shows data using multiple pages.
 ///
 /// A paginated data table shows [rowsPerPage] rows of data per page and
 /// provides controls for showing other pages.

--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -47,7 +47,7 @@ enum PopupMenuPosition {
   under,
 }
 
-/// A base class for entries in a material design popup menu.
+/// A base class for entries in a Material Design popup menu.
 ///
 /// The popup menu widget uses this interface to interact with the menu items.
 /// To show a popup menu, use the [showMenu] function. To create a button that
@@ -96,7 +96,7 @@ abstract class PopupMenuEntry<T> extends StatefulWidget {
   bool represents(T? value);
 }
 
-/// A horizontal divider in a material design popup menu.
+/// A horizontal divider in a Material Design popup menu.
 ///
 /// This widget adapts the [Divider] for use in popup menus.
 ///
@@ -180,7 +180,7 @@ class _RenderMenuItem extends RenderShiftedBox {
   }
 }
 
-/// An item in a material design popup menu.
+/// An item in a Material Design popup menu.
 ///
 /// To show a popup menu, use the [showMenu] function. To create a button that
 /// shows a popup menu, consider using [PopupMenuButton].
@@ -384,7 +384,7 @@ class PopupMenuItemState<T, W extends PopupMenuItem<T>> extends State<W> {
   }
 }
 
-/// An item with a checkmark in a material design popup menu.
+/// An item with a checkmark in a Material Design popup menu.
 ///
 /// To show a popup menu, use the [showMenu] function. To create a button that
 /// shows a popup menu, consider using [PopupMenuButton].
@@ -1123,7 +1123,7 @@ class PopupMenuButton<T> extends StatefulWidget {
   /// ```
   ///
   /// The default constraints ensure that the menu width matches maximum width
-  /// recommended by the material design guidelines.
+  /// recommended by the Material Design guidelines.
   /// Specifying this parameter enables creation of menu wider than
   /// the default maximum width.
   final BoxConstraints? constraints;

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -18,7 +18,7 @@ const int _kIndeterminateCircularDuration = 1333 * 2222;
 
 enum _ActivityIndicatorType { material, adaptive }
 
-/// A base class for material design progress indicators.
+/// A base class for Material Design progress indicators.
 ///
 /// This widget cannot be instantiated directly. For a linear progress
 /// indicator, see [LinearProgressIndicator]. For a circular progress indicator,
@@ -225,7 +225,7 @@ class _LinearProgressIndicatorPainter extends CustomPainter {
   }
 }
 
-/// A material design linear progress indicator, also known as a progress bar.
+/// A Material Design linear progress indicator, also known as a progress bar.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}
 ///
@@ -438,7 +438,7 @@ class _CircularProgressIndicatorPainter extends CustomPainter {
   }
 }
 
-/// A material design circular progress indicator, which spins to indicate that
+/// A Material Design circular progress indicator, which spins to indicate that
 /// the application is busy.
 ///
 /// {@youtube 560 315 https://www.youtube.com/watch?v=O-rhXZLtpv0}

--- a/packages/flutter/lib/src/material/radio.dart
+++ b/packages/flutter/lib/src/material/radio.dart
@@ -15,7 +15,7 @@ import 'toggleable.dart';
 const double _kOuterRadius = 8.0;
 const double _kInnerRadius = 4.5;
 
-/// A material design radio button.
+/// A Material Design radio button.
 ///
 /// Used to select between a number of mutually exclusive values. When one radio
 /// button in a group is selected, the other radio buttons in the group cease to
@@ -55,7 +55,7 @@ const double _kInnerRadius = 4.5;
 ///  * [Checkbox] and [Switch], for toggling a particular value on or off.
 ///  * <https://material.io/design/components/selection-controls.html#radio-buttons>
 class Radio<T> extends StatefulWidget {
-  /// Creates a material design radio button.
+  /// Creates a Material Design radio button.
   ///
   /// The radio button itself does not maintain any state. Instead, when the
   /// radio button is selected, the widget calls the [onChanged] callback. Most

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -474,8 +474,8 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
     }
   }
 
-  /// Removes all the materialBanners currently in queue by clearing the queue
-  /// and running normal exit animation on the current materialBanner.
+  /// Removes all the [MaterialBanner]s currently in queue by clearing the queue
+  /// and running normal exit animation on the current [MaterialBanner].
   void clearMaterialBanners() {
     if (_materialBanners.isEmpty || _materialBannerController!.status == AnimationStatus.dismissed)
       return;
@@ -1333,7 +1333,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
   }
 }
 
-/// Implements the basic material design visual layout structure.
+/// Implements the basic Material Design visual layout structure.
 ///
 /// This class provides APIs for showing drawers and bottom sheets.
 ///
@@ -1454,7 +1454,7 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
 ///  * <https://material.io/design/layout/responsive-layout-grid.html>
 ///  * Cookbook: [Add a Drawer to a screen](https://flutter.dev/docs/cookbook/design/drawer)
 class Scaffold extends StatefulWidget {
-  /// Creates a visual scaffold for material design widgets.
+  /// Creates a visual scaffold for Material Design widgets.
   const Scaffold({
     super.key,
     this.appBar,
@@ -2250,7 +2250,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     );
   }
 
-  /// Shows a material design bottom sheet in the nearest [Scaffold]. To show
+  /// Shows a Material Design bottom sheet in the nearest [Scaffold]. To show
   /// a persistent bottom sheet, use the [Scaffold.bottomSheet].
   ///
   /// Returns a controller that can be used to close and otherwise manipulate the

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -70,7 +70,7 @@ const Duration _kScrollbarTimeToFade = Duration(milliseconds: 600);
 ///  * [ListView], which displays a linear, scrollable list of children.
 ///  * [GridView], which displays a 2 dimensional, scrollable array of children.
 class Scrollbar extends StatelessWidget {
-  /// Creates a material design scrollbar that by default will connect to the
+  /// Creates a Material Design scrollbar that by default will connect to the
   /// closest Scrollable descendant of [child].
   ///
   /// The [child] should be a source of [ScrollNotification] notifications,

--- a/packages/flutter/lib/src/material/shadows.dart
+++ b/packages/flutter/lib/src/material/shadows.dart
@@ -8,7 +8,7 @@ import 'package:flutter/painting.dart';
 // Currently, only the elevation values that are bound to one or more widgets are
 // defined here.
 
-/// Map of elevation offsets used by material design to [BoxShadow] definitions.
+/// Map of elevation offsets used by Material Design to [BoxShadow] definitions.
 ///
 /// The following elevations have defined shadows: 1, 2, 3, 4, 6, 8, 9, 12, 16, 24.
 ///

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -150,7 +150,7 @@ enum Thumb {
   end,
 }
 
-/// Holds the color, shape, and typography values for a material design slider
+/// Holds the color, shape, and typography values for a Material Design slider
 /// theme.
 ///
 /// Use this class to configure a [SliderTheme] widget, or to set the
@@ -2286,7 +2286,7 @@ class RoundSliderThumbShape extends SliderComponentShape {
 
   /// The preferred radius of the round thumb shape when the slider is enabled.
   ///
-  /// If it is not provided, then the material default of 10 is used.
+  /// If it is not provided, then the Material Design default of 10 is used.
   final double enabledThumbRadius;
 
   /// The preferred radius of the round thumb shape when the slider is disabled.
@@ -2394,7 +2394,7 @@ class RoundRangeSliderThumbShape extends RangeSliderThumbShape {
 
   /// The preferred radius of the round thumb shape when the slider is enabled.
   ///
-  /// If it is not provided, then the material default of 10 is used.
+  /// If it is not provided, then the Material Design default of 10 is used.
   final double enabledThumbRadius;
 
   /// The preferred radius of the round thumb shape when the slider is disabled.

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -28,7 +28,7 @@ const double _kSwitchHeightCollapsed = _kSwitchMinSize;
 
 enum _SwitchType { material, adaptive }
 
-/// A material design switch.
+/// A Material Design switch.
 ///
 /// Used to toggle the on/off state of a single setting.
 ///
@@ -53,7 +53,7 @@ enum _SwitchType { material, adaptive }
 ///  * [Slider], for selecting a value in a range.
 ///  * <https://material.io/design/components/selection-controls.html#switches>
 class Switch extends StatelessWidget {
-  /// Creates a material design switch.
+  /// Creates a Material Design switch.
   ///
   /// The switch itself does not maintain any state. Instead, when the state of
   /// the switch changes, the widget calls the [onChanged] callback. Most widgets

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -47,7 +47,7 @@ enum TabBarIndicatorSize {
   label,
 }
 
-/// A material design [TabBar] tab.
+/// A Material Design [TabBar] tab.
 ///
 /// If both [icon] and [text] are provided, the text is displayed below
 /// the icon.
@@ -59,7 +59,7 @@ enum TabBarIndicatorSize {
 ///  * [TabController], which coordinates tab selection between a [TabBar] and a [TabBarView].
 ///  * <https://material.io/design/components/tabs.html>
 class Tab extends StatelessWidget implements PreferredSizeWidget {
-  /// Creates a material design [TabBar] tab.
+  /// Creates a Material Design [TabBar] tab.
   ///
   /// At least one of [text], [icon], and [child] must be non-null. The [text]
   /// and [child] arguments must not be used at the same time. The
@@ -552,7 +552,7 @@ class _TabBarScrollController extends ScrollController {
   }
 }
 
-/// A material design widget that displays a horizontal row of tabs.
+/// A Material Design widget that displays a horizontal row of tabs.
 ///
 /// Typically created as the [AppBar.bottom] part of an [AppBar] and in
 /// conjunction with a [TabBarView].
@@ -588,7 +588,7 @@ class _TabBarScrollController extends ScrollController {
 ///  * [TabBarView], which displays page views that correspond to each tab.
 ///  * [TabBar], which is used to display the [Tab] that corresponds to each page of the [TabBarView].
 class TabBar extends StatefulWidget implements PreferredSizeWidget {
-  /// Creates a material design tab bar.
+  /// Creates a Material Design tab bar.
   ///
   /// The [tabs] argument must not be null and its length must match the [controller]'s
   /// [TabController.length].

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -113,7 +113,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
   }
 }
 
-/// A material design text field.
+/// A Material Design text field.
 ///
 /// A text field lets the user enter text, either with hardware keyboard or with
 /// an onscreen keyboard.

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -66,7 +66,7 @@ import 'typography.dart';
 /// See also:
 ///
 ///  * [Typography], the class that generates [TextTheme]s appropriate for a platform.
-///  * [Theme], for other aspects of a material design application that can be
+///  * [Theme], for other aspects of a Material Design application that can be
 ///    globally adjusted, such as the color scheme.
 ///  * <https://material.io/design/typography/>
 @immutable
@@ -75,7 +75,7 @@ class TextTheme with Diagnosticable {
   ///
   /// Rather than creating a new text theme, consider using [Typography.black]
   /// or [Typography.white], which implement the typography styles in the
-  /// material design specification:
+  /// Material Design specification:
   ///
   /// <https://material.io/design/typography/#type-scale>
   ///
@@ -280,7 +280,7 @@ class TextTheme with Diagnosticable {
   /// the new values.
   ///
   /// Consider using [Typography.black] or [Typography.white], which implement
-  /// the typography styles in the material design specification, as a starting
+  /// the typography styles in the Material Design specification, as a starting
   /// point.
   ///
   /// {@tool snippet}
@@ -455,7 +455,7 @@ class TextTheme with Diagnosticable {
   /// `bodyColor` is applied to the remaining text styles.
   ///
   /// Consider using [Typography.black] or [Typography.white], which implement
-  /// the typography styles in the material design specification, as a starting
+  /// the typography styles in the Material Design specification, as a starting
   /// point.
   TextTheme apply({
     String? fontFamily,

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -994,7 +994,7 @@ class ThemeData with Diagnosticable {
   ///
   /// See also:
   ///
-  ///   * [StretchingOverscrollIndicator], a material design edge effect
+  ///   * [StretchingOverscrollIndicator], a Material Design edge effect
   ///     that transforms the contents of a scrollable when overscrolled.
   ///   * [GlowingOverscrollIndicator], an edge effect that paints a glow
   ///     over the contents of a scrollable when overscrolled.
@@ -1867,7 +1867,7 @@ class ThemeData with Diagnosticable {
   /// [Brightness.dark].
   ///
   /// This compares the luminosity of the given color to a threshold value that
-  /// matches the material design specification.
+  /// matches the Material Design specification.
   static Brightness estimateBrightnessForColor(Color color) {
     final double relativeLuminance = color.computeLuminance();
 
@@ -2624,7 +2624,7 @@ class VisualDensity with Diagnosticable {
   /// The base adjustment in logical pixels of the visual density of UI components.
   ///
   /// The input density values are multiplied by a constant to arrive at a base
-  /// size adjustment that fits material design guidelines.
+  /// size adjustment that fits Material Design guidelines.
   ///
   /// Individual components may adjust this value based upon their own
   /// individual interpretation of density.

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1782,14 +1782,14 @@ class _HourMinuteTextFieldState extends State<_HourMinuteTextField> with Restora
 /// Signature for when the time picker entry mode is changed.
 typedef EntryModeChangeCallback = void Function(TimePickerEntryMode);
 
-/// A material design time picker designed to appear inside a popup dialog.
+/// A Material Design time picker designed to appear inside a popup dialog.
 ///
 /// Pass this widget to [showDialog]. The value returned by [showDialog] is the
 /// selected [TimeOfDay] if the user taps the "OK" button, or null if the user
 /// taps the "CANCEL" button. The selected time is reported by calling
 /// [Navigator.pop].
 class TimePickerDialog extends StatefulWidget {
-  /// Creates a material time picker.
+  /// Creates a Material Design time picker.
   ///
   /// [initialTime] must not be null.
   const TimePickerDialog({
@@ -2327,7 +2327,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
   }
 }
 
-/// Shows a dialog containing a material design time picker.
+/// Shows a dialog containing a Material Design time picker.
 ///
 /// The returned Future resolves to the time selected by the user when the user
 /// closes the dialog. If the user cancels the dialog, null is returned.
@@ -2400,7 +2400,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
 ///
 /// See also:
 ///
-///  * [showDatePicker], which shows a dialog that contains a material design
+///  * [showDatePicker], which shows a dialog that contains a Material Design
 ///    date picker.
 ///  * [TimePickerThemeData], which allows you to customize the colors,
 ///    typography, and shape of the time picker.

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -16,7 +16,7 @@ import 'theme.dart';
 import 'tooltip_theme.dart';
 import 'tooltip_visibility.dart';
 
-/// A material design tooltip.
+/// A Material Design tooltip.
 ///
 /// Tooltips provide text labels which help explain the function of a button or
 /// other user interface action. Wrap the button in a [Tooltip] widget and provide

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -91,7 +91,7 @@ class Typography with Diagnosticable {
     TextTheme? tall,
   }) = Typography.material2018;
 
-  /// Creates a typography instance using material design's 2014 defaults.
+  /// Creates a typography instance using Material Design's 2014 defaults.
   ///
   /// If [platform] is [TargetPlatform.iOS] or [TargetPlatform.macOS], the
   /// default values for [black] and [white] are [blackCupertino] and
@@ -119,7 +119,7 @@ class Typography with Diagnosticable {
     );
   }
 
-  /// Creates a typography instance using material design's 2018 defaults.
+  /// Creates a typography instance using Material Design's 2018 defaults.
   ///
   /// If [platform] is [TargetPlatform.iOS] or [TargetPlatform.macOS], the
   /// default values for [black] and [white] are [blackCupertino] and
@@ -222,7 +222,7 @@ class Typography with Diagnosticable {
       assert(dense != null),
       assert(tall != null);
 
-  /// A material design text theme with dark glyphs.
+  /// A Material Design text theme with dark glyphs.
   ///
   /// This [TextTheme] should provide color but not geometry (font size,
   /// weight, etc). A text theme's geometry depends on the locale. To look
@@ -233,7 +233,7 @@ class Typography with Diagnosticable {
   /// geometry.
   final TextTheme black;
 
-  /// A material design text theme with light glyphs.
+  /// A Material Design text theme with light glyphs.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   /// A text theme's geometry depends on the locale. To look up a localized
@@ -354,7 +354,7 @@ class Typography with Diagnosticable {
     properties.add(DiagnosticsProperty<TextTheme>('tall', tall, defaultValue: defaultTypography.tall));
   }
 
-  /// A material design text theme with dark glyphs based on Roboto.
+  /// A Material Design text theme with dark glyphs based on Roboto.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   static const TextTheme blackMountainView = TextTheme(
@@ -375,7 +375,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'blackMountainView labelSmall', fontFamily: 'Roboto', color: Colors.black, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with light glyphs based on Roboto.
+  /// A Material Design text theme with light glyphs based on Roboto.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   static const TextTheme whiteMountainView = TextTheme(
@@ -396,7 +396,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'whiteMountainView labelSmall', fontFamily: 'Roboto', color: Colors.white, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with dark glyphs based on Segoe UI.
+  /// A Material Design text theme with dark glyphs based on Segoe UI.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   static const TextTheme blackRedmond = TextTheme(
@@ -417,7 +417,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'blackRedmond labelSmall', fontFamily: 'Segoe UI', color: Colors.black, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with light glyphs based on Segoe UI.
+  /// A Material Design text theme with light glyphs based on Segoe UI.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   static const TextTheme whiteRedmond = TextTheme(
@@ -439,7 +439,7 @@ class Typography with Diagnosticable {
   );
 
   static const List<String> _helsinkiFontFallbacks = <String>['Ubuntu', 'Cantarell', 'DejaVu Sans', 'Liberation Sans', 'Arial'];
-  /// A material design text theme with dark glyphs based on Roboto, with
+  /// A Material Design text theme with dark glyphs based on Roboto, with
   /// fallback fonts that are likely (but not guaranteed) to be installed on
   /// Linux.
   ///
@@ -462,7 +462,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'blackHelsinki labelSmall', fontFamily: 'Roboto', fontFamilyFallback: _helsinkiFontFallbacks, color: Colors.black, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with light glyphs based on Roboto, with fallbacks of DejaVu Sans, Liberation Sans and Arial.
+  /// A Material Design text theme with light glyphs based on Roboto, with fallbacks of DejaVu Sans, Liberation Sans and Arial.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   static const TextTheme whiteHelsinki = TextTheme(
@@ -483,7 +483,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'whiteHelsinki labelSmall', fontFamily: 'Roboto', fontFamilyFallback: _helsinkiFontFallbacks, color: Colors.white, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with dark glyphs based on San Francisco.
+  /// A Material Design text theme with dark glyphs based on San Francisco.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   ///
@@ -506,7 +506,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'blackCupertino labelSmall', fontFamily: '.SF UI Text', color: Colors.black, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with light glyphs based on San Francisco.
+  /// A Material Design text theme with light glyphs based on San Francisco.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   ///
@@ -529,7 +529,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'whiteCupertino labelSmall', fontFamily: '.SF UI Text', color: Colors.white, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with dark glyphs based on San Francisco.
+  /// A Material Design text theme with dark glyphs based on San Francisco.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   ///
@@ -552,7 +552,7 @@ class Typography with Diagnosticable {
     labelSmall: TextStyle(debugLabel: 'blackRedwoodCity labelSmall', fontFamily: '.AppleSystemUIFont', color: Colors.black, decoration: TextDecoration.none),
   );
 
-  /// A material design text theme with light glyphs based on San Francisco.
+  /// A Material Design text theme with light glyphs based on San Francisco.
   ///
   /// This [TextTheme] provides color but not geometry (font size, weight, etc).
   ///

--- a/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
+++ b/packages/flutter/lib/src/material/user_accounts_drawer_header.dart
@@ -282,7 +282,7 @@ class _AccountDetailsLayout extends MultiChildLayoutDelegate {
   }
 }
 
-/// A material design [Drawer] header that identifies the app's user.
+/// A Material Design [Drawer] header that identifies the app's user.
 ///
 /// Requires one of its ancestors to be a [Material] widget.
 ///
@@ -291,7 +291,7 @@ class _AccountDetailsLayout extends MultiChildLayoutDelegate {
 ///  * [DrawerHeader], for a drawer header that doesn't show user accounts.
 ///  * <https://material.io/design/components/navigation-drawer.html#anatomy>
 class UserAccountsDrawerHeader extends StatefulWidget {
-  /// Creates a material design drawer header.
+  /// Creates a Material Design drawer header.
   ///
   /// Requires one of its ancestors to be a [Material] widget.
   const UserAccountsDrawerHeader({

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -253,7 +253,7 @@ abstract class BoxBorder extends ShapeBorder {
 /// {@end-tool}
 /// {@tool snippet}
 ///
-/// The border for a material design divider:
+/// The border for a Material Design divider:
 ///
 /// ```dart
 /// Border(bottom: BorderSide(color: Theme.of(context).dividerColor))
@@ -299,7 +299,7 @@ abstract class BoxBorder extends ShapeBorder {
 ///  * [BoxDecoration], which uses this class to describe its edge decoration.
 ///  * [BorderSide], which is used to describe each side of the box.
 ///  * [Theme], from the material layer, which can be queried to obtain appropriate colors
-///    to use for borders in a material app, as shown in the "divider" sample above.
+///    to use for borders in a [MaterialApp], as shown in the "divider" sample above.
 class Border extends BoxBorder {
   /// Creates a border.
   ///
@@ -594,7 +594,7 @@ class Border extends BoxBorder {
 ///  * [BoxDecoration], which uses this class to describe its edge decoration.
 ///  * [BorderSide], which is used to describe each side of the box.
 ///  * [Theme], from the material layer, which can be queried to obtain appropriate colors
-///    to use for borders in a material app, as shown in the "divider" sample above.
+///    to use for borders in a [MaterialApp], as shown in the "divider" sample above.
 class BorderDirectional extends BoxBorder {
   /// Creates a border.
   ///

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -421,9 +421,9 @@ class HSLColor {
 ///
 /// See also:
 ///
-///  * [MaterialColor] and [MaterialAccentColor], which define material design
+///  * [MaterialColor] and [MaterialAccentColor], which define Material Design
 ///    primary and accent color swatches.
-///  * [material.Colors], which defines all of the standard material design
+///  * [material.Colors], which defines all of the standard Material Design
 ///    colors.
 @immutable
 class ColorSwatch<T> extends Color {

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -973,8 +973,8 @@ class WidgetsApp extends StatefulWidget {
   /// Builds the widget the [WidgetInspector] uses to switch between view and
   /// inspect modes.
   ///
-  /// This lets [MaterialApp] to use a material button to toggle the inspector
-  /// select mode without requiring [WidgetInspector] to depend on the
+  /// This lets [MaterialApp] to use a Material Design button to toggle the
+  /// inspector select mode without requiring [WidgetInspector] to depend on the
   /// material package.
   final InspectorSelectButtonBuilder? inspectorSelectButtonBuilder;
 

--- a/packages/flutter/lib/src/widgets/icon.dart
+++ b/packages/flutter/lib/src/widgets/icon.dart
@@ -61,7 +61,7 @@ import 'icon_theme_data.dart';
 /// See also:
 ///
 ///  * [IconButton], for interactive icons.
-///  * [Icons], for the list of available icons for use with this class.
+///  * [Icons], the library of Material Icons available for use with this class.
 ///  * [IconTheme], which provides ambient configuration for icons.
 ///  * [ImageIcon], for showing icons from [AssetImage]s or other [ImageProvider]s.
 class Icon extends StatelessWidget {

--- a/packages/flutter/lib/src/widgets/image_icon.dart
+++ b/packages/flutter/lib/src/widgets/image_icon.dart
@@ -18,7 +18,7 @@ import 'image.dart';
 ///  * [IconButton], for interactive icons.
 ///  * [IconTheme], which provides ambient configuration for icons.
 ///  * [Icon], for icons based on glyphs from fonts instead of images.
-///  * [Icons], a predefined font based set of icons from the material design library.
+///  * [Icons], a predefined font based set of icons from the Material Design library.
 class ImageIcon extends StatelessWidget {
   /// Creates an image icon.
   ///

--- a/packages/flutter/lib/src/widgets/image_icon.dart
+++ b/packages/flutter/lib/src/widgets/image_icon.dart
@@ -18,7 +18,7 @@ import 'image.dart';
 ///  * [IconButton], for interactive icons.
 ///  * [IconTheme], which provides ambient configuration for icons.
 ///  * [Icon], for icons based on glyphs from fonts instead of images.
-///  * [Icons], a predefined font based set of icons from the Material Design library.
+///  * [Icons], the library of Material Icons.
 class ImageIcon extends StatelessWidget {
   /// Creates an image icon.
   ///

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -60,7 +60,7 @@ import 'transitions.dart';
 ///    its items.
 ///  * [SliverReorderableList], a sliver list that allows the user to reorder
 ///    its items.
-///  * [ReorderableListView], a material design list that allows the user to
+///  * [ReorderableListView], a Material Design list that allows the user to
 ///    reorder its items.
 typedef ReorderCallback = void Function(int oldIndex, int newIndex);
 
@@ -102,7 +102,7 @@ typedef ReorderItemProxyDecorator = Widget Function(Widget child, int index, Ani
 ///
 ///  * [SliverReorderableList], a sliver list that allows the user to reorder
 ///    its items.
-///  * [ReorderableListView], a material design list that allows the user to
+///  * [ReorderableListView], a Material Design list that allows the user to
 ///    reorder its items.
 class ReorderableList extends StatefulWidget {
   /// Creates a scrolling container that allows the user to interactively
@@ -419,7 +419,7 @@ class ReorderableListState extends State<ReorderableList> {
 ///
 ///  * [ReorderableList], a regular widget list that allows the user to reorder
 ///    its items.
-///  * [ReorderableListView], a material design list that allows the user to
+///  * [ReorderableListView], a Material Design list that allows the user to
 ///    reorder its items.
 class SliverReorderableList extends StatefulWidget {
   /// Creates a sliver list that allows the user to interactively reorder its
@@ -1223,7 +1223,7 @@ class _ReorderableItemState extends State<_ReorderableItem> {
 ///    its items.
 ///  * [SliverReorderableList], a sliver list that allows the user to reorder
 ///    its items.
-///  * [ReorderableListView], a material design list that allows the user to
+///  * [ReorderableListView], a Material Design list that allows the user to
 ///    reorder its items.
 class ReorderableDragStartListener extends StatelessWidget {
   /// Creates a listener for a drag immediately following a pointer down
@@ -1291,7 +1291,7 @@ class ReorderableDragStartListener extends StatelessWidget {
 ///    its items.
 ///  * [SliverReorderableList], a sliver list that allows the user to reorder
 ///    its items.
-///  * [ReorderableListView], a material design list that allows the user to
+///  * [ReorderableListView], a Material Design list that allows the user to
 ///    reorder its items.
 class ReorderableDelayedDragStartListener extends ReorderableDragStartListener {
   /// Creates a listener for an drag following a long press event over the

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -334,7 +334,7 @@ class DefaultTextHeightBehavior extends InheritedTheme {
 /// To make [Text] react to touch events, wrap it in a [GestureDetector] widget
 /// with a [GestureDetector.onTap] handler.
 ///
-/// In a material design application, consider using a [TextButton] instead, or
+/// In a Material Design application, consider using a [TextButton] instead, or
 /// if that isn't appropriate, at least using an [InkWell] instead of
 /// [GestureDetector].
 ///

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -29,7 +29,7 @@ void main() {
       'FlutterError\n'
       '   No Material widget found.\n'
       '   Chip widgets require a Material widget ancestor.\n'
-      '   In material design, most widgets are conceptually "printed" on a\n'
+      '   In Material Design, most widgets are conceptually "printed" on a\n'
       "   sheet of material. In Flutter's material library, that material\n"
       '   is represented by the Material widget. It is the Material widget\n'
       '   that renders ink splashes, for instance. Because of this, many\n'

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -521,7 +521,7 @@ flutter:
     Platform: () => FakePlatform(),
   });
 
-  testUsingContext('does not include material design assets if uses-material-design: true is '
+  testUsingContext('does not include Material Design assets if uses-material-design: true is '
     'specified only by a dependency', () async {
     globals.fs.file('.packages').writeAsStringSync(r'''
 example:lib/

--- a/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_manifest_test.dart
@@ -65,7 +65,7 @@ dependencies:
     expect(flutterManifest.assets, isEmpty);
   });
 
-  testWithoutContext('FlutterManifest knows if material design is used', () async {
+  testWithoutContext('FlutterManifest knows if Material Design is used', () async {
     const String manifest = '''
 name: test
 dependencies:


### PR DESCRIPTION
- 'material design' ⇒ 'Material Design'
- links to Widgets where applicable
- keeps usages of 'material' where it makes sense
  - e.g. material library or material in `material.dart`

Fixes #102631

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
