### PR TITLE
Fix empty Stack with infinite constraints throws

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -520,8 +520,7 @@ class RenderStack extends RenderBox
     assert(_resolvedAlignment != null);
     bool hasNonPositionedChildren = false;
     if (childCount == 0) {
-      assert(constraints.biggest.isFinite);
-      return constraints.biggest;
+      return (constraints.biggest.isFinite) ? constraints.biggest : constraints.smallest;
     }
 
     double width = constraints.minWidth;

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -148,5 +148,30 @@ void main() {
     });
   });
 
+  test('Stack in Flex can layout with no children', () {
+    // Render an empty Stack in a Flex
+    final RenderFlex flex = RenderFlex(
+      textDirection: TextDirection.ltr,
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: <RenderBox>[
+        RenderStack(
+          textDirection: TextDirection.ltr,
+          children: <RenderBox>[],
+        ),
+      ]
+    );
+
+    bool stackFlutterErrorThrown = false;
+    layout(
+      flex,
+      constraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      onErrors: () {
+        stackFlutterErrorThrown = true;
+      }
+    );
+
+    expect(stackFlutterErrorThrown, false);
+  });
+
   // More tests in ../widgets/stack_test.dart
 }


### PR DESCRIPTION
## Description

Before this PR, when a `Stack` is empty and is given infinite constraints, an assertion error was thrown.
The previous assertion was added by the following PR : https://github.com/flutter/flutter/pull/16250

This PR update `RenderStack` to return the smallest valid `Size` instead of an assertion error. 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/102640
Fixes https://github.com/flutter/flutter/issues/88575


## Tests

Add one test in `rendering/slack_test.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.