### PR TITLE
fix AnimatedSwitcher in Flex and with null child crashes

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -240,6 +240,7 @@ class AnimatedSwitcher extends StatefulWidget {
       children: <Widget>[
         ...previousChildren,
         if (currentChild != null) currentChild,
+        if (previousChildren.isEmpty && currentChild == null) const SizedBox.shrink(),
       ],
     );
   }

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -166,6 +166,21 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('AnimatedSwitcher in Flex handles null children.', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/88575
+    await tester.pumpWidget(
+      Column(
+        children: const <Widget>[
+          AnimatedSwitcher(
+            duration: Duration(milliseconds: 100),
+          ),
+        ],
+      ),
+    );
+
+    expect(tester.takeException(), null);
+  });
+
   testWidgets("AnimatedSwitcher doesn't start any animations after dispose.", (WidgetTester tester) async {
     await tester.pumpWidget(AnimatedSwitcher(
       duration: const Duration(milliseconds: 100),


### PR DESCRIPTION
## Description

Fix a non obvious crash when rendering a `Flex` that contains an `AnimatedSwitcher` without children.
This PR updates `AnimatedSwitcher.defaultLayoutBuilder` to avoid returning an empty `Stack`.


## Related Issue

Fixes https://github.com/flutter/flutter/issues/88575


## Tests

Add one test in `test/widgets/animated_switcher_test.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.