### PR TITLE
[framework] remove animated opacity layers at fully opaque

### DIFF
--- a/packages/flutter/test/rendering/proxy_sliver_test.dart
+++ b/packages/flutter/test/rendering/proxy_sliver_test.dart
@@ -98,10 +98,33 @@ void main() {
     expect(renderSliverAnimatedOpacity.needsCompositing, false);
   });
 
-  test('RenderSliverAnimatedOpacity does composite if it is opaque', () {
+  test('RenderSliverAnimatedOpacity does not composite if it is fully opaque', () {
     final Animation<double> opacityAnimation = AnimationController(
       vsync: FakeTickerProvider(),
     )..value = 1.0;
+
+    final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
+      opacity: opacityAnimation,
+      sliver: RenderSliverToBoxAdapter(
+        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      ),
+    );
+
+    final RenderViewport root = RenderViewport(
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      cacheExtent: 250.0,
+      children: <RenderSliver>[renderSliverAnimatedOpacity],
+    );
+
+    layout(root, phase: EnginePhase.composite);
+    expect(renderSliverAnimatedOpacity.needsCompositing, false);
+  });
+
+  test('RenderSliverAnimatedOpacity does composite if it is partially opaque', () {
+    final Animation<double> opacityAnimation = AnimationController(
+      vsync: FakeTickerProvider(),
+    )..value = 0.5;
 
     final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
       opacity: opacityAnimation,

--- a/packages/flutter/test/widgets/animated_opacity_repaint_test.dart
+++ b/packages/flutter/test/widgets/animated_opacity_repaint_test.dart
@@ -32,12 +32,12 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(RenderTestObject.paintCount, 1);
+    expect(RenderTestObject.paintCount, 2);
 
     controller.stop();
     await tester.pump();
 
-    expect(RenderTestObject.paintCount, 1);
+    expect(RenderTestObject.paintCount, 2);
   });
 
   testWidgets('RenderAnimatedOpacityMixin allows opacity layer to be disposed when animating to 0 opacity', (WidgetTester tester) async {
@@ -55,13 +55,18 @@ void main() {
     );
 
     expect(RenderTestObject.paintCount, 1);
-    expect(tester.layers, contains(isA<OpacityLayer>()));
+    expect(tester.layers, isNot(contains(isA<OpacityLayer>())));
     controller.forward();
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    expect(tester.layers, contains(isA<OpacityLayer>()));
 
     await tester.pump();
     await tester.pump(const Duration(seconds: 2));
 
-    expect(RenderTestObject.paintCount, 1);
+    expect(RenderTestObject.paintCount, 2);
 
     controller.stop();
     await tester.pump();


### PR DESCRIPTION
When fade transitions finish we currently leave them in the tree to avoid an obvious pixel snap on low DPR devices. Experiment with removing the opacity layers and instead doing a pixel snap in the render object.