### PR TITLE
Replace ListView with ListView.builder for LicensesPage

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -607,31 +607,29 @@ class _PackagesViewState extends State<_PackagesView> {
     final _LicenseData data,
     final bool drawSelection,
   ) {
-    return ListView(
-      children: <Widget>[
-        widget.about,
-        ...data.packages
-            .asMap()
-            .entries
-            .map<Widget>((MapEntry<int, String> entry) {
-              final String packageName = entry.value;
-              final int index = entry.key;
-              final List<int> bindings = data.packageLicenseBindings[packageName]!;
-              return _PackageListTile(
-                packageName: packageName,
-                index: index,
-                isSelected: drawSelection && entry.key == (selectedId ?? 0),
-                numberLicenses: bindings.length,
-                onTap: () {
-                  widget.selectedId.value = index;
-                  _MasterDetailFlow.of(context)!.openDetailPage(_DetailArguments(
-                    packageName,
-                    bindings.map((int i) => data.licenses[i]).toList(growable: false),
-                  ));
-                },
-              );
-            }),
-      ],
+    return ListView.builder(
+      itemCount: data.packages.length + 1,
+      itemBuilder: (BuildContext context, int index) {
+        if (index == 0) {
+          return widget.about;
+        }
+        final int packageIndex = index - 1;
+        final String packageName = data.packages[packageIndex];
+        final List<int> bindings = data.packageLicenseBindings[packageName]!;
+        return _PackageListTile(
+          packageName: packageName,
+          index: packageIndex,
+          isSelected: drawSelection && packageIndex == (selectedId ?? 0),
+          numberLicenses: bindings.length,
+          onTap: () {
+            widget.selectedId.value = packageIndex;
+            _MasterDetailFlow.of(context)!.openDetailPage(_DetailArguments(
+              packageName,
+              bindings.map((int i) => data.licenses[i]).toList(growable: false),
+            ));
+          },
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
For apps with a large amount of dependencies, LicensesPage can become slow on some older devices. Using ListView.builder() instead of ListView() reduces the likelihood of that.
