### PR TITLE
Remove Linux android views

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2273,19 +2273,6 @@ targets:
       task_name: web_size__compile_test
     scheduler: luci
 
-  - name: Linux android views
-    bringup: true # Flaky https://github.com/flutter/flutter/issues/99001
-    recipe: flutter/android_views
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "android_virtual_device", "version": "31"}
-        ]
-      tags: >
-        ["framework","hostonly"]
-    timeout: 60
-
   - name: Linux_android opacity_peephole_one_rect_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false


### PR DESCRIPTION
This test has deteriorated in stability: https://github.com/flutter/flutter/issues/99001

We plan on reworking the avd system, so until then, let's remove this test as it is not giving us a useful signal.