### PR TITLE
Text selection located wrong position when selecting multiple lines over max lines

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1036,6 +1036,7 @@ class _SelectionToolbarOverlay extends StatefulWidget {
 class _SelectionToolbarOverlayState extends State<_SelectionToolbarOverlay> with SingleTickerProviderStateMixin {
   late AnimationController _controller;
   Animation<double> get _opacity => _controller.view;
+  double get hiddenAmountInEditingRegion => widget.preferredLineHeight-widget.selectionEndpoints.first.point.dy;
 
   @override
   void initState() {
@@ -1080,7 +1081,7 @@ class _SelectionToolbarOverlayState extends State<_SelectionToolbarOverlay> with
       child: CompositedTransformFollower(
         link: widget.layerLink,
         showWhenUnlinked: false,
-        offset: -widget.editingRegion.topLeft,
+        offset:-widget.editingRegion.translate(0,hiddenAmountInEditingRegion>0?-hiddenAmountInEditingRegion:0).topLeft,
         child: Builder(
           builder: (BuildContext context) {
             return widget.selectionControls!.buildToolbar(

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -547,6 +547,79 @@ void main() {
       skip: isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
     );
+
+    testWidgets(
+      'When select multiple lines over max lines',
+      (WidgetTester tester) async {
+        final TextEditingController controller =
+            TextEditingController(text: 'abc\ndef\nghi\njkl\nmno\npqr');
+        await tester.pumpWidget(MaterialApp(
+          theme: ThemeData(platform: TargetPlatform.android),
+          home: Directionality(
+            textDirection: TextDirection.ltr,
+            child: MediaQuery(
+              data: const MediaQueryData(size: Size(800.0, 600.0)),
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: Material(
+                  child: TextField(
+                    style: const TextStyle(fontSize: 32, height: 1),
+                    maxLines: 2,
+                    controller: controller,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ));
+
+        // Initially, the menu isn't shown at all.
+        expect(find.text('Cut'), findsNothing);
+        expect(find.text('Copy'), findsNothing);
+        expect(find.text('Paste'), findsNothing);
+        expect(find.text('Select all'), findsNothing);
+        expect(find.byType(IconButton), findsNothing);
+
+        // Tap to place the cursor in the field, then tap the handle to show the
+        // selection menu.
+        await tester.tap(find.byType(TextField));
+        await tester.pumpAndSettle();
+        final RenderEditable renderEditable = findRenderEditable(tester);
+        final List<TextSelectionPoint> endpoints = globalize(
+          renderEditable.getEndpointsForSelection(controller.selection),
+          renderEditable,
+        );
+        expect(endpoints.length, 1);
+        final Offset handlePos = endpoints[0].point + const Offset(0.0, 1.0);
+        await tester.tapAt(handlePos, pointer: 7);
+        await tester.pumpAndSettle();
+        expect(find.text('Cut'), findsNothing);
+        expect(find.text('Copy'), findsNothing);
+        expect(find.text('Paste'), findsOneWidget);
+        expect(find.text('Select all'), findsOneWidget);
+        expect(find.byType(IconButton), findsNothing);
+
+        // Tap to select all.
+        await tester.tap(find.text('Select all'));
+        await tester.pumpAndSettle();
+
+        // Only Cut, Copy, and Paste are shown.
+        expect(find.text('Cut'), findsOneWidget);
+        expect(find.text('Copy'), findsOneWidget);
+        expect(find.text('Paste'), findsOneWidget);
+        expect(find.text('Select all'), findsNothing);
+        expect(find.byType(IconButton), findsNothing);
+
+        final Offset cutOffset = tester.getTopLeft(find.text('Cut'));
+        final Offset textFieldOffset =
+            tester.getTopLeft(find.byType(TextField));
+        expect(cutOffset.dy + 25, equals(textFieldOffset.dy));
+      },
+      skip:
+          isBrowser, // [intended] We do not use Flutter-rendered context menu on the Web.
+      variant: const TargetPlatformVariant(
+          <TargetPlatform>{TargetPlatform.android, TargetPlatform.iOS}),
+    );
   });
 
   group('material handles', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/96453

This PR fixes bugs that text selection located wrong position when selecting multiple lines over max lines.

related closed pr https://github.com/flutter/flutter/pull/96471

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

![Screen Shot 2022-04-28 at 3 35 07 PM](https://user-images.githubusercontent.com/52235899/165691789-05d0facd-3245-4f7a-91d3-84cacdf85bd2.png)


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat


