### PR TITLE
`ReorderableListView`: fix broken dartpad example & update examples, add tests 

### DIFF
--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
@@ -6,33 +6,30 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const ReorderableApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
-  static const String _title = 'Flutter Code Sample';
+class ReorderableApp extends StatelessWidget {
+  const ReorderableApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const MyStatefulWidget(),
+        appBar: AppBar(title: const Text('ReorderableListView Sample')),
+        body: const ReorderableExample(),
       ),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({Key? key}) : super(key: key);
+class ReorderableExample extends StatefulWidget {
+  const ReorderableExample({Key? key}) : super(key: key);
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<ReorderableExample> createState() => _MyStatefulWidgetState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _MyStatefulWidgetState extends State<ReorderableExample> {
   final List<int> _items = List<int>.generate(50, (int index) => index);
 
   @override

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -7,33 +7,30 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const ReorderableApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
-  static const String _title = 'Flutter Code Sample';
+class ReorderableApp extends StatelessWidget {
+  const ReorderableApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const MyStatefulWidget(),
+        appBar: AppBar(title: const Text('ReorderableListView Sample')),
+        body: const ReorderableExample(),
       ),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({Key? key}) : super(key: key);
+class ReorderableExample extends StatefulWidget {
+  const ReorderableExample({Key? key}) : super(key: key);
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<ReorderableExample> createState() => _ReorderableExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _ReorderableExampleState extends State<ReorderableExample> {
   final List<int> _items = List<int>.generate(50, (int index) => index);
 
   @override

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart
@@ -6,33 +6,30 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const ReorderableApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
-  static const String _title = 'Flutter Code Sample';
+class ReorderableApp extends StatelessWidget {
+  const ReorderableApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const MyStatefulWidget(),
+        appBar: AppBar(title: const Text('ReorderableListView Sample')),
+        body: const ReorderableExample(),
       ),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({Key? key}) : super(key: key);
+class ReorderableExample extends StatefulWidget {
+  const ReorderableExample({Key? key}) : super(key: key);
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<ReorderableExample> createState() => _ReorderableExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _ReorderableExampleState extends State<ReorderableExample> {
   final List<int> _items = List<int>.generate(50, (int index) => index);
 
   @override

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart
@@ -6,35 +6,32 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const ReorderableApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
-
-  static const String _title = 'Flutter Code Sample';
+class ReorderableApp extends StatelessWidget {
+  const ReorderableApp({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
+        appBar: AppBar(title: const Text('ReorderableListView Sample')),
         body: const Center(
-          child: MyStatefulWidget(),
+          child: ReorderableExample(),
         ),
       ),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({Key? key}) : super(key: key);
+class ReorderableExample extends StatefulWidget {
+  const ReorderableExample({Key? key}) : super(key: key);
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<ReorderableExample> createState() => _ReorderableExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _ReorderableExampleState extends State<ReorderableExample> {
   final List<int> _items = List<int>.generate(50, (int index) => index);
 
   @override

--- a/examples/api/test/reorderable_list/reorderable_list_view.0_test.dart
+++ b/examples/api/test/reorderable_list/reorderable_list_view.0_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/reorderable_list/reorderable_list_view.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> longPressDrag(WidgetTester tester, Offset start, Offset end) async {
+    final TestGesture drag = await tester.startGesture(start);
+    await tester.pump(kLongPressTimeout + kPressTimeout);
+    await drag.moveTo(end);
+    await tester.pump(kPressTimeout);
+    await drag.up();
+  }
+
+  testWidgets('Reorder list item', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: example.ReorderableApp(),
+      ),
+    );
+
+    expect(tester.getCenter(find.text('Item 3')).dy, 252.0);
+    await longPressDrag(
+      tester,
+      tester.getCenter(find.text('Item 3')),
+      tester.getCenter(find.text('Item 2')),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getCenter(find.text('Item 3')).dy, 196.0);
+  });
+}

--- a/examples/api/test/reorderable_list/reorderable_list_view.1_test.dart
+++ b/examples/api/test/reorderable_list/reorderable_list_view.1_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/reorderable_list/reorderable_list_view.1.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> longPressDrag(WidgetTester tester, Offset start, Offset end) async {
+    final TestGesture drag = await tester.startGesture(start);
+    await tester.pump(kLongPressTimeout + kPressTimeout);
+    await drag.moveTo(end);
+    await tester.pump(kPressTimeout);
+    await drag.up();
+  }
+
+  testWidgets('Reorder list item', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: example.ReorderableApp(),
+      ),
+    );
+
+    expect(tester.getCenter(find.text('Item 3')).dy, 252.0);
+    await longPressDrag(
+      tester,
+      tester.getCenter(find.text('Item 3')),
+      tester.getCenter(find.text('Item 2')),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getCenter(find.text('Item 3')).dy, 196.0);
+  });
+}

--- a/examples/api/test/reorderable_list/reorderable_list_view.build_default_drag_handles.0_test.dart
+++ b/examples/api/test/reorderable_list/reorderable_list_view.build_default_drag_handles.0_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> longPressDrag(WidgetTester tester, Offset start, Offset end) async {
+    final TestGesture drag = await tester.startGesture(start);
+    await tester.pump(kLongPressTimeout + kPressTimeout);
+    await drag.moveTo(end);
+    await tester.pump(kPressTimeout);
+    await drag.up();
+  }
+
+  testWidgets('Reorder list item', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: example.ReorderableApp(),
+      ),
+    );
+
+    expect(tester.getCenter(find.text('Item 3')).dy, 280.0);
+    await longPressDrag(
+      tester,
+      tester.getCenter(find.text('Item 3')),
+      tester.getCenter(find.text('Item 2')),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getCenter(find.text('Item 3')).dy, 216.0);
+  });
+}

--- a/examples/api/test/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0_test.dart
+++ b/examples/api/test/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0_test.dart
@@ -1,0 +1,36 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Future<void> longPressDrag(WidgetTester tester, Offset start, Offset end) async {
+    final TestGesture drag = await tester.startGesture(start);
+    await tester.pump(kLongPressTimeout + kPressTimeout);
+    await drag.moveTo(end);
+    await tester.pump(kPressTimeout);
+    await drag.up();
+  }
+
+  testWidgets('Reorder list item', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: example.ReorderableApp(),
+      ),
+    );
+
+    expect(tester.getCenter(find.text('Item 3')).dy, 252.0);
+    await longPressDrag(
+      tester,
+      tester.getCenter(find.text('Item 3')),
+      tester.getCenter(find.text('Item 2')),
+    );
+    await tester.pumpAndSettle();
+    expect(tester.getCenter(find.text('Item 3')).dy, 196.0);
+  });
+}

--- a/packages/flutter/lib/src/material/reorderable_list.dart
+++ b/packages/flutter/lib/src/material/reorderable_list.dart
@@ -38,7 +38,7 @@ import 'theme.dart';
 ///
 /// This example demonstrates using the [proxyDecorator] callback to customize
 /// the appearance of a list item while it's being dragged.
-/// {@tool snippet}
+/// {@tool dartpad}
 ///
 /// While a drag is underway, the widget returned by the [proxyDecorator]
 /// serves as a "proxy" (a substitute) for the item in the list. The proxy is


### PR DESCRIPTION
API: https://master-api.flutter.dev/flutter/material/ReorderableListView-class.html

fixes https://github.com/flutter/flutter/issues/102724

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
