### PR TITLE
[DropdownButton]: Fix `alignment` parameter doesn't work for `hint` when `isExpanded: true`

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1386,7 +1386,7 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     if (widget.hint != null || (!_enabled && widget.disabledHint != null)) {
       Widget displayedHint = _enabled ? widget.hint! : widget.disabledHint ?? widget.hint!;
       if (widget.selectedItemBuilder == null)
-        displayedHint = _DropdownMenuItemContainer(child: displayedHint);
+        displayedHint = _DropdownMenuItemContainer(alignment: widget.alignment, child: displayedHint);
 
       hintIndex = items.length;
       items.add(DefaultTextStyle(

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -58,7 +58,7 @@ Widget buildDropdown({
     List<String>? items = menuItems,
     List<Widget> Function(BuildContext)? selectedItemBuilder,
     double? itemHeight = kMinInteractiveDimension,
-    Alignment alignment = Alignment.center,
+    AlignmentDirectional alignment = AlignmentDirectional.centerStart,
     TextDirection textDirection = TextDirection.ltr,
     Size? mediaSize,
     FocusNode? focusNode,
@@ -98,6 +98,7 @@ Widget buildDropdown({
         items: listItems,
         selectedItemBuilder: selectedItemBuilder,
         itemHeight: itemHeight,
+        alignment: alignment,
         menuMaxHeight: menuMaxHeight,
       ),
     );
@@ -123,6 +124,7 @@ Widget buildDropdown({
     items: listItems,
     selectedItemBuilder: selectedItemBuilder,
     itemHeight: itemHeight,
+    alignment: alignment,
     menuMaxHeight: menuMaxHeight,
   );
 }
@@ -144,7 +146,7 @@ Widget buildFrame({
   List<String>? items = menuItems,
   List<Widget> Function(BuildContext)? selectedItemBuilder,
   double? itemHeight = kMinInteractiveDimension,
-  Alignment alignment = Alignment.center,
+  AlignmentDirectional alignment = AlignmentDirectional.centerStart,
   TextDirection textDirection = TextDirection.ltr,
   Size? mediaSize,
   FocusNode? focusNode,
@@ -153,13 +155,14 @@ Widget buildFrame({
   Color? dropdownColor,
   bool isFormField = false,
   double? menuMaxHeight,
+  Alignment dropdownAlignment = Alignment.center,
 }) {
   return TestApp(
     textDirection: textDirection,
     mediaSize: mediaSize,
     child: Material(
       child: Align(
-        alignment: alignment,
+        alignment: dropdownAlignment,
         child: RepaintBoundary(
           child: buildDropdown(
             isFormField: isFormField,
@@ -183,6 +186,7 @@ Widget buildFrame({
             items: items,
             selectedItemBuilder: selectedItemBuilder,
             itemHeight: itemHeight,
+            alignment: alignment,
             menuMaxHeight: menuMaxHeight,
           ),
         ),
@@ -1180,19 +1184,19 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.topLeft, value: menuItems.last, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.topLeft, value: menuItems.last, onChanged: onChanged),
     );
     expect(menuRect.topLeft, Offset.zero);
     expect(menuRect.topRight, Offset(menuRect.width, 0.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.topCenter, value: menuItems.last, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.topCenter, value: menuItems.last, onChanged: onChanged),
     );
     expect(menuRect.topLeft, Offset(buttonRect.left, 0.0));
     expect(menuRect.topRight, Offset(buttonRect.right, 0.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.topRight, value: menuItems.last, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.topRight, value: menuItems.last, onChanged: onChanged),
     );
     expect(menuRect.topLeft, Offset(800.0 - menuRect.width, 0.0));
     expect(menuRect.topRight, const Offset(800.0, 0.0));
@@ -1202,7 +1206,7 @@ void main() {
     // is selected) and shifted horizontally so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.centerLeft, value: menuItems.first, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.centerLeft, value: menuItems.first, onChanged: onChanged),
     );
     expect(menuRect.topLeft, Offset(0.0, buttonRect.top));
     expect(menuRect.topRight, Offset(menuRect.width, buttonRect.top));
@@ -1214,7 +1218,7 @@ void main() {
     expect(menuRect.topRight, buttonRect.topRight);
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.centerRight, value: menuItems.first, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.centerRight, value: menuItems.first, onChanged: onChanged),
     );
     expect(menuRect.topLeft, Offset(800.0 - menuRect.width, buttonRect.top));
     expect(menuRect.topRight, Offset(800.0, buttonRect.top));
@@ -1224,19 +1228,19 @@ void main() {
     // so that it fits within the frame.
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.bottomLeft, value: menuItems.first, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.bottomLeft, value: menuItems.first, onChanged: onChanged),
     );
     expect(menuRect.bottomLeft, const Offset(0.0, 600.0));
     expect(menuRect.bottomRight, Offset(menuRect.width, 600.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.bottomCenter, value: menuItems.first, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.bottomCenter, value: menuItems.first, onChanged: onChanged),
     );
     expect(menuRect.bottomLeft, Offset(buttonRect.left, 600.0));
     expect(menuRect.bottomRight, Offset(buttonRect.right, 600.0));
 
     await popUpAndDown(
-      buildFrame(alignment: Alignment.bottomRight, value: menuItems.first, onChanged: onChanged),
+      buildFrame(dropdownAlignment: Alignment.bottomRight, value: menuItems.first, onChanged: onChanged),
     );
     expect(menuRect.bottomLeft, Offset(800.0 - menuRect.width, 600.0));
     expect(menuRect.bottomRight, const Offset(800.0, 600.0));
@@ -3680,5 +3684,59 @@ void main() {
         ..rrect()
         ..rrect(rrect: const RRect.fromLTRBXY(0.0, 0.0, 800.0, 208.0, radius, radius)),
     );
+  });
+
+  testWidgets('DropdownButton hint alignment', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    const String hintText = 'hint';
+
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 348.0);
+
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      alignment: AlignmentDirectional.center,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 356.0);
+
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      alignment: AlignmentDirectional.centerEnd,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 364.0);
+
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      isExpanded: true,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 0.0);
+
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      isExpanded: true,
+      alignment: AlignmentDirectional.center,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 356.0);
+
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      isExpanded: true,
+      alignment: AlignmentDirectional.centerEnd,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 712.0);
   });
 }

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -3690,53 +3690,153 @@ void main() {
     final Key buttonKey = UniqueKey();
     const String hintText = 'hint';
 
+    // DropdownButton with `isExpanded: false` (default)
+    // AlignmentDirectional.centerStart (default)
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
       hint: const Text(hintText)),
     );
     expect(tester.getTopLeft(find.text(hintText)).dx, 348.0);
-
+    expect(tester.getTopLeft(find.text(hintText)).dy, 292.0);
+    // AlignmentDirectional.topStart
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      alignment: AlignmentDirectional.topStart,
+      itemHeight: 100.0,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 348.0);
+    expect(tester.getTopLeft(find.text(hintText)).dy, 250.0);
+    // AlignmentDirectional.bottomStart
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      alignment: AlignmentDirectional.bottomStart,
+      itemHeight: 100.0,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getBottomLeft(find.text(hintText)).dx, 348.0);
+    expect(tester.getBottomLeft(find.text(hintText)).dy, 350.0);
+    // AlignmentDirectional.center
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       mediaSize: const Size(800, 600),
       alignment: AlignmentDirectional.center,
+      itemHeight: 100.0,
       hint: const Text(hintText)),
     );
-    expect(tester.getTopLeft(find.text(hintText)).dx, 356.0);
-
+    expect(tester.getCenter(find.text(hintText)).dx, 388.0);
+    expect(tester.getCenter(find.text(hintText)).dy, 300.0);
+    // AlignmentDirectional.topEnd
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      alignment: AlignmentDirectional.topEnd,
+      itemHeight: 100.0,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopRight(find.text(hintText)).dx, 428.0);
+    expect(tester.getTopRight(find.text(hintText)).dy, 250.0);
+    // AlignmentDirectional.centerEnd
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       mediaSize: const Size(800, 600),
       alignment: AlignmentDirectional.centerEnd,
+      itemHeight: 100.0,
       hint: const Text(hintText)),
     );
-    expect(tester.getTopLeft(find.text(hintText)).dx, 364.0);
-
+    expect(tester.getTopRight(find.text(hintText)).dx, 428.0);
+    expect(tester.getTopRight(find.text(hintText)).dy, 292.0);
+    // AlignmentDirectional.topEnd
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       mediaSize: const Size(800, 600),
+      alignment: AlignmentDirectional.bottomEnd,
+      itemHeight: 100.0,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopRight(find.text(hintText)).dx, 428.0);
+    expect(tester.getTopRight(find.text(hintText)).dy, 334.0);
+
+    // DropdownButton with `isExpanded: true`
+    // AlignmentDirectional.centerStart (default)
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
       isExpanded: true,
       hint: const Text(hintText)),
     );
     expect(tester.getTopLeft(find.text(hintText)).dx, 0.0);
-
+    expect(tester.getTopLeft(find.text(hintText)).dy, 292.0);
+    // AlignmentDirectional.topStart
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
+      isExpanded: true,
+      alignment: AlignmentDirectional.topStart,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopLeft(find.text(hintText)).dx, 0.0);
+    expect(tester.getTopLeft(find.text(hintText)).dy, 250.0);
+    // AlignmentDirectional.bottomStart
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
+      isExpanded: true,
+      alignment: AlignmentDirectional.bottomStart,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getBottomLeft(find.text(hintText)).dx, 0.0);
+    expect(tester.getBottomLeft(find.text(hintText)).dy, 350.0);
+    // AlignmentDirectional.center
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
       isExpanded: true,
       alignment: AlignmentDirectional.center,
       hint: const Text(hintText)),
     );
-    expect(tester.getTopLeft(find.text(hintText)).dx, 356.0);
-
+    expect(tester.getCenter(find.text(hintText)).dx, 388.0);
+    expect(tester.getCenter(find.text(hintText)).dy, 300.0);
+    // AlignmentDirectional.topEnd
     await tester.pumpWidget(buildFrame(
       buttonKey: buttonKey,
       mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
+      isExpanded: true,
+      alignment: AlignmentDirectional.topEnd,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getTopRight(find.text(hintText)).dx, 776.0);
+    expect(tester.getTopRight(find.text(hintText)).dy, 250.0);
+    // AlignmentDirectional.centerEnd
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
       isExpanded: true,
       alignment: AlignmentDirectional.centerEnd,
       hint: const Text(hintText)),
     );
-    expect(tester.getTopLeft(find.text(hintText)).dx, 712.0);
+    expect(tester.getTopRight(find.text(hintText)).dx, 776.0);
+    expect(tester.getTopRight(find.text(hintText)).dy, 292.0);
+    // AlignmentDirectional.bottomEnd
+    await tester.pumpWidget(buildFrame(
+      buttonKey: buttonKey,
+      mediaSize: const Size(800, 600),
+      itemHeight: 100.0,
+      isExpanded: true,
+      alignment: AlignmentDirectional.bottomEnd,
+      hint: const Text(hintText)),
+    );
+    expect(tester.getBottomRight(find.text(hintText)).dx, 776.0);
+    expect(tester.getBottomRight(find.text(hintText)).dy, 350.0);
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/102751

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
