### PR TITLE
Migrate abandon

### DIFF
--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -16,7 +16,7 @@ import 'migrate_abandon.dart';
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
   MigrateCommand({
-    bool verbose = false,
+    // bool verbose = false,
     required this.logger,
     required FileSystem fileSystem,
     required Terminal terminal,

--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -10,8 +10,8 @@ import '../base/platform.dart';
 import '../base/terminal.dart';
 import '../migrate/migrate_utils.dart';
 import '../runner/flutter_command.dart';
-import 'migrate_status.dart';
 import 'migrate_abandon.dart';
+import 'migrate_status.dart';
 
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {

--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -16,7 +16,6 @@ import 'migrate_abandon.dart';
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
   MigrateCommand({
-    // bool verbose = false,
     required this.logger,
     required FileSystem fileSystem,
     required Terminal terminal,
@@ -30,7 +29,13 @@ class MigrateCommand extends FlutterCommand {
       platform: platform,
       processManager: processManager
     ));
-    addSubcommand(MigrateAbandonCommand(logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
+    addSubcommand(MigrateAbandonCommand(
+      logger: logger,
+      fileSystem: fileSystem,
+      terminal: terminal,
+      platform: platform,
+      processManager: processManager
+    ));
   }
 
   final Logger logger;

--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -11,18 +11,18 @@ import '../base/terminal.dart';
 import '../migrate/migrate_utils.dart';
 import '../runner/flutter_command.dart';
 import 'migrate_status.dart';
+import 'migrate_abandon.dart';
 
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
   MigrateCommand({
     bool verbose = false,
     required this.logger,
-    // TODO(garyq): Add parameter in as they are needed for subcommands.
     required FileSystem fileSystem,
+    required Terminal terminal,
     required Platform platform,
     required ProcessManager processManager,
   }) {
-    // TODO(garyq): Add each subcommand back in as they land.
     addSubcommand(MigrateStatusCommand(
       verbose: verbose,
       logger: logger,
@@ -30,6 +30,7 @@ class MigrateCommand extends FlutterCommand {
       platform: platform,
       processManager: processManager
     ));
+    addSubcommand(MigrateAbandonCommand(logger: logger, fileSystem: fileSystem, terminal: terminal, platform: platform, processManager: processManager));
   }
 
   final Logger logger;

--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -16,6 +16,7 @@ import 'migrate_abandon.dart';
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
   MigrateCommand({
+    required bool verbose,
     required this.logger,
     required FileSystem fileSystem,
     required Terminal terminal,

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -31,7 +31,7 @@ class MigrateAbandonCommand extends FlutterCommand {
     argParser.addOption(
       'working-directory',
       help: 'Specifies the custom migration working directory used to stage and edit proposed changes. '
-            'This path can be absolute or relative to the flutter project root.',
+            'This path can be absolute or relative to the flutter project root. This defaults to `migrate_working_dir`',
       valueHelp: 'path',
     );
     argParser.addOption(
@@ -74,7 +74,7 @@ class MigrateAbandonCommand extends FlutterCommand {
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
     final String? customWorkingDirectoryPath = stringArg('working-directory');
     if (customWorkingDirectoryPath != null) {
-      if (customWorkingDirectoryPath.startsWith(fileSystem.path.separator) || customWorkingDirectoryPath.startsWith('/')) {
+      if (customWorkingDirectoryPath.startsWith(fileSystem.path.separator) || customWorkingDirectoryPath.startsWith(RegExp(r'[A-Z]:\\'))) {
         // Is an absolute path
         workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
       } else {
@@ -92,7 +92,7 @@ class MigrateAbandonCommand extends FlutterCommand {
     }
 
     logger.printStatus('\nAbandoning the existing migration will delete the migration working directory at ${workingDirectory.path}');
-    final bool force = boolArg('force');
+    final bool force = boolArg('force') ?? false;
     if (!force) {
       String selection = 'y';
       terminal.usesTerminalUi = true;

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -120,7 +120,12 @@ class MigrateAbandonCommand extends FlutterCommand {
       }
     }
 
-    stagingDirectory.deleteSync(recursive: true);
+    try {
+      stagingDirectory.deleteSync(recursive: true);
+    } on FileSystemException catch (e) {
+      logger.printError('Deletion failed with: $e');
+      logger.printError('Please manually delete the staging directory at `${stagingDirectory.path}`');
+    }
 
     logger.printStatus('\nAbandon complete. Start a new migration with:');
     printCommandText('flutter migrate start', logger);

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -33,7 +33,7 @@ class MigrateAbandonCommand extends FlutterCommand {
       help: 'Specifies the custom migration working directory used to stage '
             'and edit proposed changes. This path can be absolute or relative '
             'to the flutter project root. This defaults to '
-            '`$kDefaultMigrateWorkingDirectoryName`',
+            '`$kDefaultMigrateStagingDirectoryName`',
       valueHelp: 'path',
     );
     argParser.addOption(
@@ -76,28 +76,28 @@ class MigrateAbandonCommand extends FlutterCommand {
     final FlutterProject project = projectDirectory == null
       ? FlutterProject.current()
       : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
-    Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
-    final String? customWorkingDirectoryPath = stringArg('staging-directory');
-    if (customWorkingDirectoryPath != null) {
-      if (fileSystem.path.isAbsolute(customWorkingDirectoryPath)) {
-        workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
+    Directory stagingDirectory = project.directory.childDirectory(kDefaultMigrateStagingDirectoryName);
+    final String? customStagingDirectoryPath = stringArg('staging-directory');
+    if (customStagingDirectoryPath != null) {
+      if (fileSystem.path.isAbsolute(customStagingDirectoryPath)) {
+        stagingDirectory = fileSystem.directory(customStagingDirectoryPath);
       } else {
-        workingDirectory = project.directory.childDirectory(customWorkingDirectoryPath);
+        stagingDirectory = project.directory.childDirectory(customStagingDirectoryPath);
       }
-      if (!workingDirectory.existsSync()) {
-        logger.printError('Provided working directory `$customWorkingDirectoryPath` '
+      if (!stagingDirectory.existsSync()) {
+        logger.printError('Provided staging directory `$customStagingDirectoryPath` '
                           'does not exist or is not valid.');
         return const FlutterCommandResult(ExitStatus.fail);
       }
     }
-    if (!workingDirectory.existsSync()) {
+    if (!stagingDirectory.existsSync()) {
       logger.printStatus('No migration in progress. Start a new migration with:');
       printCommandText('flutter migrate start', logger);
       return const FlutterCommandResult(ExitStatus.fail);
     }
 
     logger.printStatus('\nAbandoning the existing migration will delete the '
-                       'migration working directory at ${workingDirectory.path}');
+                       'migration staging directory at ${stagingDirectory.path}');
     final bool force = boolArg('force') ?? false;
     if (!force) {
       String selection = 'y';
@@ -120,7 +120,7 @@ class MigrateAbandonCommand extends FlutterCommand {
       }
     }
 
-    workingDirectory.deleteSync(recursive: true);
+    stagingDirectory.deleteSync(recursive: true);
 
     logger.printStatus('\nAbandon complete. Start a new migration with:');
     printCommandText('flutter migrate start', logger);

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -29,14 +29,17 @@ class MigrateAbandonCommand extends FlutterCommand {
        ) {
     requiresPubspecYaml();
     argParser.addOption(
-      'working-directory',
-      help: 'Specifies the custom migration working directory used to stage and edit proposed changes. '
-            'This path can be absolute or relative to the flutter project root. This defaults to `migrate_working_dir`',
+      'staging-directory',
+      help: 'Specifies the custom migration working directory used to stage '
+            'and edit proposed changes. This path can be absolute or relative '
+            'to the flutter project root. This defaults to '
+            '`$kDefaultMigrateWorkingDirectoryName`',
       valueHelp: 'path',
     );
     argParser.addOption(
       'project-directory',
-      help: 'The root directory of the flutter project.',
+      help: 'The root directory of the flutter project. This defaults to the '
+            'current working directory if omitted.',
       valueHelp: 'path',
     );
     argParser.addFlag(
@@ -74,7 +77,7 @@ class MigrateAbandonCommand extends FlutterCommand {
       ? FlutterProject.current()
       : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
-    final String? customWorkingDirectoryPath = stringArg('working-directory');
+    final String? customWorkingDirectoryPath = stringArg('staging-directory');
     if (customWorkingDirectoryPath != null) {
       if (fileSystem.path.isAbsolute(customWorkingDirectoryPath)) {
         workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
@@ -82,7 +85,8 @@ class MigrateAbandonCommand extends FlutterCommand {
         workingDirectory = project.directory.childDirectory(customWorkingDirectoryPath);
       }
       if (!workingDirectory.existsSync()) {
-        logger.printError('Provided working directory `$customWorkingDirectoryPath` does not exist or is not valid.');
+        logger.printError('Provided working directory `$customWorkingDirectoryPath` '
+                          'does not exist or is not valid.');
         return const FlutterCommandResult(ExitStatus.fail);
       }
     }
@@ -92,7 +96,8 @@ class MigrateAbandonCommand extends FlutterCommand {
       return const FlutterCommandResult(ExitStatus.fail);
     }
 
-    logger.printStatus('\nAbandoning the existing migration will delete the migration working directory at ${workingDirectory.path}');
+    logger.printStatus('\nAbandoning the existing migration will delete the '
+                       'migration working directory at ${workingDirectory.path}');
     final bool force = boolArg('force') ?? false;
     if (!force) {
       String selection = 'y';

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -74,8 +74,7 @@ class MigrateAbandonCommand extends FlutterCommand {
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
     final String? customWorkingDirectoryPath = stringArg('working-directory');
     if (customWorkingDirectoryPath != null) {
-      if (customWorkingDirectoryPath.startsWith(fileSystem.path.separator) || customWorkingDirectoryPath.startsWith(RegExp(r'[A-Z]:\\'))) {
-        // Is an absolute path
+      if (fileSystem.path.isAbsolute(customWorkingDirectoryPath)) {
         workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
       } else {
         workingDirectory = project.directory.childDirectory(customWorkingDirectoryPath);

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -70,7 +70,9 @@ class MigrateAbandonCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     final String? projectDirectory = stringArg('project-directory');
     final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(logger: logger, fileSystem: fileSystem);
-    final FlutterProject project = projectDirectory == null ? FlutterProject.current() : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
+    final FlutterProject project = projectDirectory == null
+      ? FlutterProject.current()
+      : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
     final String? customWorkingDirectoryPath = stringArg('working-directory');
     if (customWorkingDirectoryPath != null) {

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -1,0 +1,109 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:process/process.dart';
+
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/platform.dart';
+import '../base/process.dart';
+import '../base/terminal.dart';
+import '../migrate/migrate_utils.dart';
+import '../project.dart';
+import '../runner/flutter_command.dart';
+import 'migrate.dart';
+
+/// Abandons the existing migration by deleting the migrate working directory.
+class MigrateAbandonCommand extends FlutterCommand {
+  MigrateAbandonCommand({
+    required this.logger,
+    required this.fileSystem,
+    required this.terminal,
+    required Platform platform,
+    required ProcessManager processManager,
+  }) : migrateUtils = MigrateUtils(
+         logger: logger,
+         fileSystem: fileSystem,
+         platform: platform,
+         processManager: processManager,
+       ) {
+    requiresPubspecYaml();
+    argParser.addOption(
+      'working-directory',
+      help: 'Specifies the custom migration working directory used to stage and edit proposed changes. '
+            'This path can be absolute or relative to the flutter project root.',
+      valueHelp: 'path',
+    );
+  }
+
+  final Logger logger;
+
+  final FileSystem fileSystem;
+
+  final Terminal terminal;
+
+  final MigrateUtils migrateUtils;
+
+  @override
+  final String name = 'abandon';
+
+  @override
+  final String description = 'Deletes the current active migration working directory.';
+
+  @override
+  String get category => FlutterCommandCategory.project;
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final FlutterProject flutterProject = FlutterProject.current();
+    Directory workingDirectory = flutterProject.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
+    final String? customWorkingDirectoryPath = stringArg('working-directory');
+    if (customWorkingDirectoryPath != null) {
+      if (customWorkingDirectoryPath.startsWith(fileSystem.path.separator) || customWorkingDirectoryPath.startsWith('/')) {
+        // Is an absolute path
+        workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
+      } else {
+        workingDirectory = flutterProject.directory.childDirectory(customWorkingDirectoryPath);
+      }
+      if (!workingDirectory.existsSync()) {
+        logger.printError('Provided working directory `$customWorkingDirectoryPath` does not exist or is not a valid.');
+        return const FlutterCommandResult(ExitStatus.fail);
+      }
+    }
+    if (!workingDirectory.existsSync()) {
+      logger.printStatus('No migration in progress. Start a new migration with:');
+      printCommandText('flutter migrate start', logger);
+      return const FlutterCommandResult(ExitStatus.fail);
+    }
+
+    logger.printStatus('\nAbandoning the existing migration will delete the migration working directory at ${workingDirectory.path}');
+    String selection = 'y';
+    terminal.usesTerminalUi = true;
+    try {
+      selection = await terminal.promptForCharInput(
+        <String>['y', 'n'],
+        logger: logger,
+        prompt: 'Are you sure you wish to continue with abandoning? (y)es, (N)o',
+        defaultChoiceIndex: 1,
+      );
+    } on StateError catch(e) {
+      logger.printError(
+        e.message,
+        indent: 0,
+      );
+    }
+    if (selection != 'y') {
+      return const FlutterCommandResult(ExitStatus.success);
+    }
+
+    workingDirectory.deleteSync(recursive: true);
+    
+    logger.printStatus('\nAbandon complete. Start a new migration with:');
+    printCommandText('flutter migrate start', logger);
+    return const FlutterCommandResult(ExitStatus.success);
+  }
+}

--- a/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_abandon.dart
@@ -115,7 +115,7 @@ class MigrateAbandonCommand extends FlutterCommand {
     }
 
     workingDirectory.deleteSync(recursive: true);
-    
+
     logger.printStatus('\nAbandon complete. Start a new migration with:');
     printCommandText('flutter migrate start', logger);
     return const FlutterCommandResult(ExitStatus.success);

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
@@ -44,7 +44,7 @@ void main() {
 
   testUsingContext('abandon deletes staging directory', () async {
     final MigrateCommand command = MigrateCommand(
-      // verbose: true,
+      verbose: true,
       logger: logger,
       fileSystem: fileSystem,
       terminal: terminal,

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
@@ -13,9 +13,9 @@ import 'package:flutter_tools/src/commands/migrate.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 
-import '../src/common.dart';
-import '../src/context.dart';
-import '../src/test_flutter_command_runner.dart';
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/test_flutter_command_runner.dart';
 
 void main() {
   FileSystem fileSystem;

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/migrate.dart';
+import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 
@@ -42,7 +43,7 @@ void main() {
     tryToDelete(appDir);
   });
 
-  testUsingContext('abandon deletes working directory', () async {
+  testUsingContext('abandon deletes staging directory', () async {
     final MigrateCommand command = MigrateCommand(
       // verbose: true,
       logger: logger,
@@ -51,7 +52,7 @@ void main() {
       platform: platform,
       processManager: processManager,
     );
-    final Directory workingDir = appDir.childDirectory('migrate_working_dir');
+    final Directory stagingDir = appDir.childDirectory(kDefaultMigrateStagingDirectoryName);
     appDir.childFile('lib/main.dart').createSync(recursive: true);
     final File pubspecOriginal = appDir.childFile('pubspec.yaml');
     pubspecOriginal.createSync();
@@ -70,17 +71,17 @@ dev_dependencies:
 flutter:
   uses-material-design: true''', flush: true);
 
-    expect(workingDir.existsSync(), false);
+    expect(stagingDir.existsSync(), false);
     await createTestCommandRunner(command).run(
       <String>[
         'migrate',
         'abandon',
-        '--staging-directory=${workingDir.path}',
+        '--staging-directory=${stagingDir.path}',
         '--project-directory=${appDir.path}',
       ]
     );
-    expect(logger.errorText, contains('Provided working directory'));
-    expect(logger.errorText, contains('migrate_working_dir` does not exist or is not valid.'));
+    expect(logger.errorText, contains('Provided staging directory'));
+    expect(logger.errorText, contains('migrate_staging_dir` does not exist or is not valid.'));
 
     logger.clear();
     await createTestCommandRunner(command).run(
@@ -92,7 +93,7 @@ flutter:
     );
     expect(logger.statusText, contains('No migration in progress. Start a new migration with:'));
 
-    final File pubspecModified = workingDir.childFile('pubspec.yaml');
+    final File pubspecModified = stagingDir.childFile('pubspec.yaml');
     pubspecModified.createSync(recursive: true);
     pubspecModified.writeAsStringSync('''
 name: newname
@@ -110,11 +111,11 @@ flutter:
   uses-material-design: false
   EXTRALINE''', flush: true);
 
-    final File addedFile = workingDir.childFile('added.file');
+    final File addedFile = stagingDir.childFile('added.file');
     addedFile.createSync(recursive: true);
     addedFile.writeAsStringSync('new file contents');
 
-    final File manifestFile = workingDir.childFile('.migrate_manifest');
+    final File manifestFile = stagingDir.childFile('.migrate_manifest');
     manifestFile.createSync(recursive: true);
     manifestFile.writeAsStringSync('''
 merged_files:
@@ -127,19 +128,19 @@ deleted_files:
 
     expect(appDir.childFile('lib/main.dart').existsSync(), true);
 
-    expect(workingDir.existsSync(), true);
+    expect(stagingDir.existsSync(), true);
     logger.clear();
     await createTestCommandRunner(command).run(
       <String>[
         'migrate',
         'abandon',
-        '--staging-directory=${workingDir.path}',
+        '--staging-directory=${stagingDir.path}',
         '--project-directory=${appDir.path}',
         '--force',
       ]
     );
     expect(logger.statusText, contains('Abandon complete. Start a new migration with:'));
-    expect(workingDir.existsSync(), false);
+    expect(stagingDir.existsSync(), false);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
@@ -75,7 +75,7 @@ flutter:
       <String>[
         'migrate',
         'abandon',
-        '--working-directory=${workingDir.path}',
+        '--staging-directory=${workingDir.path}',
         '--project-directory=${appDir.path}',
       ]
     );
@@ -133,7 +133,7 @@ deleted_files:
       <String>[
         'migrate',
         'abandon',
-        '--working-directory=${workingDir.path}',
+        '--staging-directory=${workingDir.path}',
         '--project-directory=${appDir.path}',
         '--force',
       ]

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
@@ -10,8 +10,8 @@ import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/migrate.dart';
-import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 
 
 import '../../src/common.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_abandon_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_tools/src/commands/migrate.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 
-
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/test_flutter_command_runner.dart';

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_status_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_status_test.dart
@@ -7,6 +7,7 @@
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/migrate.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -20,7 +21,7 @@ void main() {
   FileSystem fileSystem;
   BufferLogger logger;
   Platform platform;
-  // TODO(garyq): Add terminal back in when other subcommands land.
+  Terminal terminal;
   ProcessManager processManager;
   Directory appDir;
 
@@ -29,6 +30,7 @@ void main() {
     appDir = fileSystem.systemTempDirectory.createTempSync('apptestdir');
     logger = BufferLogger.test();
     platform = FakePlatform();
+    terminal = Terminal.test();
     processManager = globals.processManager;
   });
 
@@ -45,6 +47,7 @@ void main() {
       verbose: true,
       logger: logger,
       fileSystem: fileSystem,
+      terminal: terminal,
       platform: platform,
       processManager: processManager,
     );

--- a/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
@@ -1,0 +1,149 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/migrate.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+
+
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  FileSystem fileSystem;
+  BufferLogger logger;
+  Platform platform;
+  Terminal terminal;
+  ProcessManager processManager;
+  Directory appDir;
+
+  setUp(() {
+    fileSystem = globals.localFileSystem;
+    appDir = fileSystem.systemTempDirectory.createTempSync('apptestdir');
+    logger = BufferLogger.test();
+    platform = FakePlatform();
+    terminal = Terminal.test();
+    processManager = globals.processManager;
+  });
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  tearDown(() async {
+    tryToDelete(appDir);
+  });
+
+  testUsingContext('abandon deletes working directory', () async {
+    final MigrateCommand command = MigrateCommand(
+      verbose: true,
+      logger: logger,
+      fileSystem: fileSystem,
+      terminal: terminal,
+      platform: platform,
+      processManager: processManager,
+    );
+    Directory workingDir = appDir.childDirectory('migrate_working_dir');
+    appDir.childFile('lib/main.dart').createSync(recursive: true);
+    final File pubspecOriginal = appDir.childFile('pubspec.yaml');
+    pubspecOriginal.createSync();
+    pubspecOriginal.writeAsStringSync('''
+name: originalname
+description: A new Flutter project.
+version: 1.0.0+1
+environment:
+  sdk: '>=2.18.0-58.0.dev <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true''', flush: true);
+
+    expect(workingDir.existsSync(), false);
+    await createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'abandon',
+        '--working-directory=${workingDir.path}',
+        '--project-directory=${appDir.path}',
+      ]
+    );
+    expect(logger.errorText, contains('Provided working directory'));
+    expect(logger.errorText, contains('/migrate_working_dir` does not exist or is not valid.'));
+
+    logger.clear();
+    await createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'abandon',
+        '--project-directory=${appDir.path}',
+      ]
+    );
+    expect(logger.statusText, contains('No migration in progress. Start a new migration with:'));
+
+    final File pubspecModified = workingDir.childFile('pubspec.yaml');
+    pubspecModified.createSync(recursive: true);
+    pubspecModified.writeAsStringSync('''
+name: newname
+description: new description of the test project
+version: 1.0.0+1
+environment:
+  sdk: '>=2.18.0-58.0.dev <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: false
+  EXTRALINE''', flush: true);
+
+    final File addedFile = workingDir.childFile('added.file');
+    addedFile.createSync(recursive: true);
+    addedFile.writeAsStringSync('new file contents');
+
+    final File manifestFile = workingDir.childFile('.migrate_manifest');
+    manifestFile.createSync(recursive: true);
+    manifestFile.writeAsStringSync('''
+merged_files:
+  - pubspec.yaml
+conflict_files:
+added_files:
+  - added.file
+deleted_files:
+''');
+
+    expect(appDir.childFile('lib/main.dart').existsSync(), true);
+
+    expect(workingDir.existsSync(), true);
+    logger.clear();
+    await createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'abandon',
+        '--working-directory=${workingDir.path}',
+        '--project-directory=${appDir.path}',
+        '--force',
+      ]
+    );
+    expect(logger.statusText, contains('Abandon complete. Start a new migration with:'));
+    expect(workingDir.existsSync(), false);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Platform: () => platform,
+  });
+}

--- a/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
@@ -80,7 +80,7 @@ flutter:
       ]
     );
     expect(logger.errorText, contains('Provided working directory'));
-    expect(logger.errorText, contains('/migrate_working_dir` does not exist or is not valid.'));
+    expect(logger.errorText, contains('migrate_working_dir` does not exist or is not valid.'));
 
     logger.clear();
     await createTestCommandRunner(command).run(

--- a/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
@@ -44,14 +44,14 @@ void main() {
 
   testUsingContext('abandon deletes working directory', () async {
     final MigrateCommand command = MigrateCommand(
-      verbose: true,
+      // verbose: true,
       logger: logger,
       fileSystem: fileSystem,
       terminal: terminal,
       platform: platform,
       processManager: processManager,
     );
-    Directory workingDir = appDir.childDirectory('migrate_working_dir');
+    final Directory workingDir = appDir.childDirectory('migrate_working_dir');
     appDir.childFile('lib/main.dart').createSync(recursive: true);
     final File pubspecOriginal = appDir.childFile('pubspec.yaml');
     pubspecOriginal.createSync();

--- a/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_abandon_test.dart
@@ -4,7 +4,6 @@
 
 // @dart = 2.8
 
-import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';


### PR DESCRIPTION
`flutter migrate abandon` subcommand.

This command deletes the migrate_working_directory if it exists, thus abandoning any ongoing migration.

Depends on https://github.com/flutter/flutter/pull/101937