### PR TITLE
Migrate resolve-conflicts

### DIFF
--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -12,8 +12,8 @@ import '../migrate/migrate_utils.dart';
 import '../runner/flutter_command.dart';
 import 'migrate_abandon.dart';
 import 'migrate_apply.dart';
-import 'migrate_status.dart';
 import 'migrate_resolve_conflicts.dart';
+import 'migrate_status.dart';
 
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
@@ -47,7 +47,11 @@ class MigrateCommand extends FlutterCommand {
       platform: platform,
       processManager: processManager
     ));
-    addSubcommand(MigrateResolveConflictsCommand(logger: logger, fileSystem: fileSystem, terminal: terminal));
+    addSubcommand(MigrateResolveConflictsCommand(
+      logger: logger,
+      fileSystem: fileSystem,
+      terminal: terminal
+    ));
   }
 
   final Logger logger;

--- a/packages/flutter_tools/lib/src/commands/migrate.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate.dart
@@ -13,6 +13,7 @@ import '../runner/flutter_command.dart';
 import 'migrate_abandon.dart';
 import 'migrate_apply.dart';
 import 'migrate_status.dart';
+import 'migrate_resolve_conflicts.dart';
 
 /// Base command for the migration tool.
 class MigrateCommand extends FlutterCommand {
@@ -46,6 +47,7 @@ class MigrateCommand extends FlutterCommand {
       platform: platform,
       processManager: processManager
     ));
+    addSubcommand(MigrateResolveConflictsCommand(logger: logger, fileSystem: fileSystem, terminal: terminal));
   }
 
   final Logger logger;

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -78,7 +78,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
     final String? customWorkingDirectoryPath = stringArg('staging-directory');
     if (customWorkingDirectoryPath != null) {
-      if (Context().isAbsolute(customWorkingDirectoryPath)) {
+      if (fileSystem.path.isAbsolute(customWorkingDirectoryPath)) {
         workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
       } else {
         workingDirectory = project.directory.childDirectory(customWorkingDirectoryPath);

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -180,19 +180,12 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       logger.printStatus('\nConflict in $localPath.');
       // Select action
       String selection = 's';
-      try {
-        selection = await terminal.promptForCharInput(
-          <String>['o', 'n', 's'],
-          logger: logger,
-          prompt: 'Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually?',
-          defaultChoiceIndex: 2,
-        );
-      } on StateError catch(e) {
-        logger.printError(
-          e.message,
-          indent: 0,
-        );
-      }
+      selection = await terminal.promptForCharInput(
+        <String>['o', 'n', 's'],
+        logger: logger,
+        prompt: 'Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually?',
+        defaultChoiceIndex: 2,
+      );
 
       switch(selection) {
         case 'o': {
@@ -266,19 +259,12 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       logger.printStatus('Conflicts in $localPath complete.\n');
       logger.printStatus('You chose to:\n  Skip $skipCount conflicts\n  Acccept the original lines for $originalCount conflicts\n  Accept the new lines for $newCount conflicts\n');
       String selection = 'n';
-      try {
-        selection = await terminal.promptForCharInput(
-          <String>['y', 'n', 'r'],
-          logger: logger,
-          prompt: 'Commit the changes to the working directory? (y)es, (n)o, (r)etry this file',
-          defaultChoiceIndex: 1,
-        );
-      } on StateError catch(e) {
-        logger.printError(
-          e.message,
-          indent: 0,
-        );
-      }
+      selection = await terminal.promptForCharInput(
+        <String>['y', 'n', 'r'],
+        logger: logger,
+        prompt: 'Commit the changes to the working directory? (y)es, (n)o, (r)etry this file',
+        defaultChoiceIndex: 1,
+      );
       switch(selection) {
         case 'y': {
           if (hasChanges) {

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -122,6 +122,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
     return const FlutterCommandResult(ExitStatus.success);
   }
 
+  /// Parses the lines of a file and extracts a list of Conflicts.
   List<Conflict> findConflicts(List<String> lines) {
     // Find all conflicts
     final List<Conflict> conflicts = <Conflict>[];
@@ -145,6 +146,8 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
     return conflicts;
   }
 
+  /// Display a detected conflict and prompt the developer on whether to accept the original lines, new lines,
+  /// or skip handling the conflict.
   Future<void> promptDeveloperSelectAction(List<Conflict> conflicts, List<String> lines, String localPath) async {
     final int contextLineCount = int.parse(stringArg('context-lines')!);
     for (final Conflict conflict in conflicts) {
@@ -210,7 +213,10 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
     }
   }
 
-  // Returns true if changes were accepted or rejected. Returns false if user indicated to retry.
+  /// Prints a summary of the changes selected and prompts the developer to commit, abandon, or retry
+  /// the changes.
+  ///
+  /// Returns true if changes were accepted or rejected. Returns false if user indicated to retry.
   Future<bool> verifyAndCommit(List<Conflict> conflicts, List<String> lines, File file, String localPath) async {
     int originalCount = 0;
     int newCount = 0;
@@ -295,6 +301,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
     return true;
   }
 
+  /// Prints the line of a file with a prefix that indicates the line count.
   void printConflictLine(String text, int lineNumber, {TerminalColor? color}) {
     final String padding = ' ' * (5 - lineNumber.toString().length); // This pads line numbers up to 99,999
     logger.printStatus('$lineNumber$padding', color: TerminalColor.grey, newline: false, indent: 2);
@@ -302,7 +309,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
   }
 }
 
-/// Represents a conflict in a file and tracks what the developer chose to do with it.
+/// Simple data class that represents a conflict in a file and tracks what the developer chose to do with it.
 class Conflict {
   Conflict(this.startLine, this.dividerLine, this.endLine);
 

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:path/path.dart';
+
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/terminal.dart';
@@ -21,9 +23,9 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
   }) {
     requiresPubspecYaml();
     argParser.addOption(
-      'working-directory',
-      help: 'Specifies the custom migration working directory used to stage and edit proposed changes. '
-            'This path can be absolute or relative to the flutter project root.',
+      'staging-directory',
+      help: 'Specifies the custom migration staging directory used to stage and edit proposed changes. '
+            'This path can be absolute or relative to the flutter project root. This defaults to `$kDefaultMigrateWorkingDirectoryName`',
       valueHelp: 'path',
     );
     argParser.addOption(
@@ -74,10 +76,9 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
 
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
-    final String? customWorkingDirectoryPath = stringArg('working-directory');
+    final String? customWorkingDirectoryPath = stringArg('staging-directory');
     if (customWorkingDirectoryPath != null) {
-      if (customWorkingDirectoryPath.startsWith(fileSystem.path.separator) || customWorkingDirectoryPath.startsWith('/')) {
-        // Is an absolute path
+      if (Context().isAbsolute(customWorkingDirectoryPath)) {
         workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
       } else {
         workingDirectory = project.directory.childDirectory(customWorkingDirectoryPath);
@@ -113,7 +114,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       // Prompt developer
       await promptDeveloperSelectAction(conflicts, lines, localPath);
 
-      bool result = await verifyAndCommit(conflicts, lines, file, localPath);
+      final bool result = await verifyAndCommit(conflicts, lines, file, localPath);
       if (!result) {
         i--;
       }

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -302,8 +302,9 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
   }
 
   /// Prints the line of a file with a prefix that indicates the line count.
-  void printConflictLine(String text, int lineNumber, {TerminalColor? color}) {
-    final String padding = ' ' * (5 - lineNumber.toString().length); // This pads line numbers up to 99,999
+  void printConflictLine(String text, int lineNumber, {TerminalColor? color, int paddingLength = 5}) {
+    // Default padding of 5 pads line numbers up to 99,999
+    final String padding = ' ' * (paddingLength - lineNumber.toString().length);
     logger.printStatus('$lineNumber$padding', color: TerminalColor.grey, newline: false, indent: 2);
     logger.printStatus(text, color: color);
   }

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -1,0 +1,294 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:process/process.dart';
+
+import '../base/file_system.dart';
+import '../base/logger.dart';
+import '../base/platform.dart';
+import '../base/process.dart';
+import '../base/terminal.dart';
+import '../base/terminal.dart';
+import '../migrate/migrate_manifest.dart';
+import '../migrate/migrate_utils.dart';
+import '../project.dart';
+import '../runner/flutter_command.dart';
+import 'migrate.dart';
+
+/// Flutter migrate subcommand that guides the developer through conflicts,
+/// allowing them to accept the original, the new lines, or skip and resolve manually.
+class MigrateResolveConflictsCommand extends FlutterCommand {
+  MigrateResolveConflictsCommand({
+    required this.logger,
+    required this.fileSystem,
+    required this.terminal,
+  }) {
+    requiresPubspecYaml();
+    argParser.addOption(
+      'working-directory',
+      help: 'Specifies the custom migration working directory used to stage and edit proposed changes. '
+            'This path can be absolute or relative to the flutter project root.',
+      valueHelp: 'path',
+    );
+    argParser.addOption(
+      'context-lines',
+      defaultsTo: '5',
+      help: 'The number of lines of context to show around the each conflict. Defaults to 5.',
+    );
+    argParser.addFlag(
+      'confirm-commit',
+      defaultsTo: true,
+      help: 'Indicates if proposed changes require user verification before writing to disk.',
+    );
+  }
+
+  final Logger logger;
+
+  final FileSystem fileSystem;
+
+  final Terminal terminal;
+
+  @override
+  final String name = 'resolve-conflicts';
+
+  @override
+  final String description = 'Prints the current status of the in progress migration.';
+
+  @override
+  String get category => FlutterCommandCategory.project;
+
+  @override
+  Future<Set<DevelopmentArtifact>> get requiredArtifacts async => const <DevelopmentArtifact>{};
+
+  static const String _conflictStartMarker = '<<<<<<<';
+  static const String _conflictDividerMarker = '=======';
+  static const String _conflictEndMarker = '>>>>>>>';
+
+  @override
+  Future<FlutterCommandResult> runCommand() async {
+    final FlutterProject project = FlutterProject.current();
+    Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
+    final String? customWorkingDirectoryPath = stringArg('working-directory');
+    if (customWorkingDirectoryPath != null) {
+      if (customWorkingDirectoryPath.startsWith(fileSystem.path.separator) || customWorkingDirectoryPath.startsWith('/')) {
+        // Is an absolute path
+        workingDirectory = fileSystem.directory(customWorkingDirectoryPath);
+      } else {
+        workingDirectory = project.directory.childDirectory(customWorkingDirectoryPath);
+      }
+    }
+    if (!workingDirectory.existsSync()) {
+      logger.printStatus('No migration in progress. Start a new migration with:');
+      printCommandText('flutter migrate start', logger);
+      return const FlutterCommandResult(ExitStatus.fail);
+    }
+
+    final File manifestFile = MigrateManifest.getManifestFileFromDirectory(workingDirectory);
+    final MigrateManifest manifest = MigrateManifest.fromFile(manifestFile);
+
+    final int contextLineCount = int.parse(stringArg('context-lines')!);
+
+    checkAndPrintMigrateStatus(manifest, workingDirectory, logger: logger);
+
+    final List<String> conflictFiles = manifest.remainingConflictFiles(workingDirectory);
+
+    terminal.usesTerminalUi = true;
+
+    for (int i = 0; i < conflictFiles.length; i++) {
+      final String localPath = conflictFiles[i];
+      final File file = workingDirectory.childFile(localPath);
+      final List<String> lines = file.readAsStringSync().split('\n');
+      // We write a newline in the output, this counteracts it.
+      if (lines.last == '') {
+        lines.removeLast();
+      }
+
+      // Find all conflicts
+      final List<Conflict> conflicts = <Conflict>[];
+      Conflict currentConflict = Conflict.empty();
+      for (int lineNumber = 0; lineNumber < lines.length; lineNumber++) {
+        final String line = lines[lineNumber];
+        if (line.contains(_conflictStartMarker)) {
+          currentConflict.startLine = lineNumber;
+        } else if (line.contains(_conflictDividerMarker)) {
+          currentConflict.dividerLine = lineNumber;
+        } else if (line.contains(_conflictEndMarker)) {
+          currentConflict.endLine = lineNumber;
+          assert(currentConflict.startLine! < currentConflict.dividerLine! && currentConflict.dividerLine! < currentConflict.endLine!);
+          conflicts.add(currentConflict);
+          currentConflict = Conflict.empty();
+        }
+      }
+
+      // Prompt developer
+      int originalCount = 0;
+      int newCount = 0;
+      int skipCount = 0;
+      for (final Conflict conflict in conflicts) {
+        assert(conflict.startLine != null && conflict.dividerLine != null && conflict.endLine != null);
+        // Print the conflict for reference
+        logger.printStatus(terminal.clearScreen(), newline: false);
+        logger.printStatus('Cyan', color: TerminalColor.cyan, newline: false);
+        logger.printStatus(' = Original lines.  ', newline: false);
+        logger.printStatus('Green', color: TerminalColor.green, newline: false);
+        logger.printStatus(' = New lines.\n', newline: true);
+
+        // Print the conflict for reference
+        for (int lineNumber = (conflict.startLine! - contextLineCount).abs(); lineNumber < conflict.startLine!; lineNumber++) {
+          printConflictLine(lines[lineNumber], lineNumber, color: TerminalColor.grey);
+        }
+        printConflictLine(lines[conflict.startLine!], conflict.startLine!);
+        for (int lineNumber = conflict.startLine! + 1; lineNumber < conflict.dividerLine!; lineNumber++) {
+          printConflictLine(lines[lineNumber], lineNumber, color: TerminalColor.cyan);
+        }
+        printConflictLine(lines[conflict.dividerLine!], conflict.dividerLine!);
+        for (int lineNumber = conflict.dividerLine! + 1; lineNumber < conflict.endLine!; lineNumber++) {
+          printConflictLine(lines[lineNumber], lineNumber, color: TerminalColor.green);
+        }
+        printConflictLine(lines[conflict.endLine!], conflict.endLine!);
+        for (int lineNumber = conflict.endLine! + 1; lineNumber <= (conflict.endLine! + contextLineCount).clamp(0, lines.length - 1); lineNumber++) {
+          printConflictLine(lines[lineNumber], lineNumber, color: TerminalColor.grey);
+        }
+
+        logger.printStatus('\nConflict in $localPath.');
+        // Select action
+        String selection = 's';
+        try {
+          selection = await terminal.promptForCharInput(
+            <String>['o', 'n', 's'],
+            logger: logger,
+            prompt: 'Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually?',
+            defaultChoiceIndex: 2,
+          );
+        } on StateError catch(e) {
+          logger.printError(
+            e.message,
+            indent: 0,
+          );
+        }
+
+        switch(selection) {
+          case 'o': {
+            conflict.chooseOriginal();
+            break;
+          }
+          case 'n': {
+            conflict.chooseNew();
+            break;
+          }
+          case 's': {
+            conflict.skip();
+            break;
+          }
+        }
+      }
+
+      int lastPrintedLine = 0;
+      String result = '';
+      bool hasChanges = false;
+      for (final Conflict conflict in conflicts) {
+        if (conflict.keepOriginal != null) {
+          hasChanges = true; // don't unecessarily write file if no changes were made.
+        }
+        for (int lineNumber = lastPrintedLine; lineNumber < conflict.startLine!; lineNumber++) {
+          result += '${lines[lineNumber]}\n';
+        }
+        if (conflict.keepOriginal == null) {
+          // Skipped this conflict. Add all lines.
+          for (int lineNumber = conflict.startLine!; lineNumber <= conflict.endLine!; lineNumber++) {
+            result += '${lines[lineNumber]}\n';
+          }
+          skipCount++;
+        } else if (conflict.keepOriginal!) {
+          // Keeping original lines
+          for (int lineNumber = conflict.startLine! + 1; lineNumber < conflict.dividerLine!; lineNumber++) {
+            result += '${lines[lineNumber]}\n';
+          }
+          originalCount++;
+        } else {
+          // Keeping new lines
+          for (int lineNumber = conflict.dividerLine! + 1; lineNumber < conflict.endLine!; lineNumber++) {
+            result += '${lines[lineNumber]}\n';
+          }
+          newCount++;
+        }
+        lastPrintedLine = (conflict.endLine! + 1).clamp(0, lines.length);
+      }
+      for (int lineNumber = lastPrintedLine; lineNumber < lines.length; lineNumber++) {
+        result += '${lines[lineNumber]}\n';
+      }
+      result.trim();
+
+      // Display conflict summary for this file and confirm with user if the changes should be commited.
+      if (boolArg('confirm-commit') && skipCount != conflicts.length) {
+        logger.printStatus(terminal.clearScreen(), newline: false);
+        logger.printStatus('Conflicts in $localPath complete.\n');
+        logger.printStatus('You chose to:\n  Skip $skipCount conflicts\n  Acccept the original lines for $originalCount conflicts\n  Accept the new lines for $newCount conflicts\n');
+        String selection = 'n';
+        try {
+          selection = await terminal.promptForCharInput(
+            <String>['y', 'n', 'r'],
+            logger: logger,
+            prompt: 'Commit the changes to the working directory? (y)es, (n)o, (r)etry this file',
+            defaultChoiceIndex: 1,
+          );
+        } on StateError catch(e) {
+          logger.printError(
+            e.message,
+            indent: 0,
+          );
+        }
+        switch(selection) {
+          case 'y': {
+            if (hasChanges) {
+              file.writeAsStringSync(result, flush: true);
+            }
+            break;
+          }
+          case 'n': {
+            break;
+          }
+          case 'r': {
+            i--;
+            break;
+          }
+        }
+      } else {
+        file.writeAsStringSync(result, flush: true);
+      }
+    }
+    return const FlutterCommandResult(ExitStatus.success);
+  }
+
+  void printConflictLine(String text, int lineNumber, {TerminalColor? color}) {
+    final String padding = ' ' * (5 - lineNumber.toString().length); // This pads line numbers up to 99,999
+    logger.printStatus('$lineNumber$padding', color: TerminalColor.grey, newline: false, indent: 2);
+    logger.printStatus(text, color: color);
+  }
+}
+
+/// Represents a conflict in a file and tracks what the developer chose to do with it.
+class Conflict {
+  Conflict(this.startLine, this.dividerLine, this.endLine);
+
+  Conflict.empty();
+
+  int? startLine;
+  int? dividerLine;
+  int? endLine;
+
+  bool? keepOriginal;
+
+  void chooseOriginal() {
+    keepOriginal = true;
+  }
+
+  void skip() {
+    keepOriginal = null;
+  }
+
+  void chooseNew() {
+    keepOriginal = false;
+  }
+}

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -69,7 +69,9 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
   Future<FlutterCommandResult> runCommand() async {
     final String? projectDirectory = stringArg('project-directory');
     final FlutterProjectFactory flutterProjectFactory = FlutterProjectFactory(logger: logger, fileSystem: fileSystem);
-    final FlutterProject project = projectDirectory == null ? FlutterProject.current() : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
+    final FlutterProject project = projectDirectory == null
+      ? FlutterProject.current()
+      : flutterProjectFactory.fromDirectory(fileSystem.directory(projectDirectory));
 
     Directory workingDirectory = project.directory.childDirectory(kDefaultMigrateWorkingDirectoryName);
     final String? customWorkingDirectoryPath = stringArg('working-directory');

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -2,13 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:process/process.dart';
-
 import '../base/file_system.dart';
 import '../base/logger.dart';
-import '../base/platform.dart';
-import '../base/process.dart';
-import '../base/terminal.dart';
 import '../base/terminal.dart';
 import '../migrate/migrate_manifest.dart';
 import '../migrate/migrate_utils.dart';
@@ -221,7 +216,8 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       result.trim();
 
       // Display conflict summary for this file and confirm with user if the changes should be commited.
-      if (boolArg('confirm-commit') && skipCount != conflicts.length) {
+      final bool confirm = boolArg('confirm-commit') ?? true;
+      if (confirm && skipCount != conflicts.length) {
         logger.printStatus(terminal.clearScreen(), newline: false);
         logger.printStatus('Conflicts in $localPath complete.\n');
         logger.printStatus('You chose to:\n  Skip $skipCount conflicts\n  Acccept the original lines for $originalCount conflicts\n  Accept the new lines for $newCount conflicts\n');

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -112,7 +112,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       final List<Conflict> conflicts = findConflicts(lines, localPath);
 
       // Prompt developer
-      FlutterCommandResult? promptResult = await promptDeveloperSelectAction(conflicts, lines, localPath);
+      final FlutterCommandResult? promptResult = await promptDeveloperSelectAction(conflicts, lines, localPath);
       if (promptResult != null) {
         return promptResult;
       }

--- a/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
+++ b/packages/flutter_tools/lib/src/commands/migrate_resolve_conflicts.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import '../base/file_system.dart';
 import '../base/logger.dart';
 import '../base/terminal.dart';
@@ -164,7 +166,7 @@ class MigrateResolveConflictsCommand extends FlutterCommand {
       logger.printStatus(' = New lines.\n', newline: true);
 
       // Print the conflict for reference
-      for (int lineNumber = (conflict.startLine! - contextLineCount).abs(); lineNumber < conflict.startLine!; lineNumber++) {
+      for (int lineNumber = max(conflict.startLine! - contextLineCount, 0); lineNumber < conflict.startLine!; lineNumber++) {
         printConflictLine(lines[lineNumber], lineNumber, color: TerminalColor.grey);
       }
       printConflictLine(lines[conflict.startLine!], conflict.startLine!);

--- a/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
+++ b/packages/flutter_tools/lib/src/migrate/migrate_manifest.dart
@@ -163,7 +163,7 @@ class MigrateManifest {
 
     final StringBuffer newFileManifestContents = StringBuffer();
     for (final String localPath in addedFiles) {
-      newFileManifestContents.write('  - $localPath\n)');
+      newFileManifestContents.write('  - $localPath\n');
     }
 
     final StringBuffer deletedFileManifestContents = StringBuffer();

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_resolve_conflicts_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_resolve_conflicts_test.dart
@@ -17,10 +17,10 @@ import 'package:flutter_tools/src/migrate/migrate_utils.dart';
 import 'package:test/fake.dart';
 
 
-import '../src/common.dart';
-import '../src/context.dart';
-import '../src/fakes.dart';
-import '../src/test_flutter_command_runner.dart';
+import '../../src/common.dart';
+import '../../src/context.dart';
+import '../../src/fakes.dart';
+import '../../src/test_flutter_command_runner.dart';
 
 void main() {
   FileSystem fileSystem;

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_resolve_conflicts_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_resolve_conflicts_test.dart
@@ -133,7 +133,7 @@ Cyan = Original lines.  Green = New lines.
   7    hi'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: n
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: n
 
 
 Conflicts in conflict_file complete.
@@ -206,7 +206,7 @@ Cyan = Original lines.  Green = New lines.
   7    hi'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: n
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: n
 
 
 Conflicts in conflict_file complete.
@@ -279,7 +279,7 @@ Cyan = Original lines.  Green = New lines.
   7    hi'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: o
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: o
 
 
 Conflicts in conflict_file complete.
@@ -412,7 +412,7 @@ Cyan = Original lines.  Green = New lines.
   7    hi'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: o
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: o
 
 
 Conflicts in conflict_file complete.
@@ -496,7 +496,7 @@ Cyan = Original lines.  Green = New lines.
   7    hi'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: n
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: n
 
 
 Conflicts in conflict_file complete.
@@ -520,7 +520,7 @@ Cyan = Original lines.  Green = New lines.
   8    hi'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file2.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: o
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: o
 
 
 Conflicts in conflict_file2 complete.
@@ -604,7 +604,7 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
 Cyan = Original lines.  Green = New lines.'''));
     expect(logger.statusText, contains('''
 Conflict in conflict_file.
-Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: n
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? Or to exit the wizard, (q)uit. [o|n|s|q]: n
 
 
 Conflicts in conflict_file complete.

--- a/packages/flutter_tools/test/commands.shard/permeable/migrate_resolve_conflicts_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/migrate_resolve_conflicts_test.dart
@@ -125,6 +125,8 @@ flutter:
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======
@@ -198,6 +200,8 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======
@@ -271,6 +275,8 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======
@@ -344,6 +350,8 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======
@@ -404,6 +412,8 @@ Cyan = Original lines.  Green = New lines.
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======
@@ -488,6 +498,8 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======
@@ -510,6 +522,7 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
         expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    MoreConflicts
   1    <<<<<<<
   2    original
   3    multiple
@@ -591,6 +604,8 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
     expect(logger.statusText, contains('''
 Cyan = Original lines.  Green = New lines.
 
+  0    hello
+  1    wow a bunch of lines
   2    <<<<<<<
   3    original
   4    =======

--- a/packages/flutter_tools/test/integration.shard/migrate_resolve_conflicts_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_resolve_conflicts_test.dart
@@ -7,17 +7,19 @@
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/migrate.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/migrate/migrate_manifest.dart';
 import 'package:flutter_tools/src/migrate/migrate_result.dart';
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
+import 'package:test/fake.dart';
 
 
-import '../commands.shard/hermetic/custom_devices_test.dart';
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fakes.dart';
 import '../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -616,4 +618,53 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
     ProcessManager: () => processManager,
     Platform: () => platform,
   });
+}
+
+class FakeTerminal extends Fake implements Terminal {
+  factory FakeTerminal({Platform platform}) {
+    return FakeTerminal._private(
+        stdio: FakeStdio(),
+        platform: platform
+    );
+  }
+
+  FakeTerminal._private({
+    this.stdio,
+    Platform platform
+  }) :
+    terminal = AnsiTerminal(
+      stdio: stdio,
+      platform: platform
+    );
+
+  final FakeStdio stdio;
+  final AnsiTerminal terminal;
+
+  void simulateStdin(String line) {
+    stdio.simulateStdin(line);
+  }
+
+  @override
+  set usesTerminalUi(bool value) => terminal.usesTerminalUi = value;
+
+  @override
+  bool get usesTerminalUi => terminal.usesTerminalUi;
+
+  @override
+  String clearScreen() => terminal.clearScreen();
+
+  @override
+  Future<String> promptForCharInput(
+    List<String> acceptedCharacters, {
+    Logger logger,
+    String prompt,
+    int defaultChoiceIndex,
+    bool displayAcceptedCharacters = true
+  }) => terminal.promptForCharInput(
+      acceptedCharacters,
+      logger: logger,
+      prompt: prompt,
+      defaultChoiceIndex: defaultChoiceIndex,
+      displayAcceptedCharacters: displayAcceptedCharacters
+    );
 }

--- a/packages/flutter_tools/test/integration.shard/migrate_resolve_conflicts_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_resolve_conflicts_test.dart
@@ -4,17 +4,15 @@
 
 // @dart = 2.8
 
-import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/migrate.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/migrate/migrate_manifest.dart';
 import 'package:flutter_tools/src/migrate/migrate_result.dart';
 import 'package:flutter_tools/src/migrate/migrate_utils.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 
 
 import '../commands.shard/hermetic/custom_devices_test.dart';
@@ -104,8 +102,6 @@ flutter:
       sdkDirs: <String, Directory>{},
     ));
     manifest.writeFile();
-    File manifestFile = workingDir.childFile('.migrate_manifest');
-    print((terminal as FakeTerminal).terminal);
 
     expect(workingDir.existsSync(), true);
     final Future<void> commandFuture = createTestCommandRunner(command).run(
@@ -179,8 +175,6 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
       sdkDirs: <String, Directory>{},
     ));
     manifest.writeFile();
-    File manifestFile = workingDir.childFile('.migrate_manifest');
-    print((terminal as FakeTerminal).terminal);
 
     expect(workingDir.existsSync(), true);
     final Future<void> commandFuture = createTestCommandRunner(command).run(
@@ -254,8 +248,6 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
       sdkDirs: <String, Directory>{},
     ));
     manifest.writeFile();
-    File manifestFile = workingDir.childFile('.migrate_manifest');
-    print((terminal as FakeTerminal).terminal);
 
     expect(workingDir.existsSync(), true);
     final Future<void> commandFuture = createTestCommandRunner(command).run(
@@ -329,8 +321,6 @@ Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n
       sdkDirs: <String, Directory>{},
     ));
     manifest.writeFile();
-    File manifestFile = workingDir.childFile('.migrate_manifest');
-    print((terminal as FakeTerminal).terminal);
 
     expect(workingDir.existsSync(), true);
     final Future<void> commandFuture = createTestCommandRunner(command).run(
@@ -391,8 +381,6 @@ Cyan = Original lines.  Green = New lines.
       sdkDirs: <String, Directory>{},
     ));
     manifest.writeFile();
-    File manifestFile = workingDir.childFile('.migrate_manifest');
-    print((terminal as FakeTerminal).terminal);
 
     expect(workingDir.existsSync(), true);
     final Future<void> commandFuture = createTestCommandRunner(command).run(

--- a/packages/flutter_tools/test/integration.shard/migrate_resolve_conflicts_test.dart
+++ b/packages/flutter_tools/test/integration.shard/migrate_resolve_conflicts_test.dart
@@ -1,0 +1,364 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/migrate.dart';
+import 'package:flutter_tools/src/migrate/migrate_manifest.dart';
+import 'package:flutter_tools/src/migrate/migrate_result.dart';
+import 'package:flutter_tools/src/migrate/migrate_utils.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+
+
+import '../commands.shard/hermetic/custom_devices_test.dart';
+import '../src/common.dart';
+import '../src/context.dart';
+import '../src/test_flutter_command_runner.dart';
+
+void main() {
+  FileSystem fileSystem;
+  BufferLogger logger;
+  Platform platform;
+  FakeTerminal terminal;
+  ProcessManager processManager;
+  Directory appDir;
+  Directory workingDir;
+  MigrateCommand command;
+
+  setUp(() {
+    fileSystem = globals.localFileSystem;
+    appDir = fileSystem.systemTempDirectory.createTempSync('apptestdir');
+    appDir.createSync(recursive: true);
+    appDir.childFile('lib/main.dart').createSync(recursive: true);
+    workingDir = appDir.childDirectory('migrate_working_dir');
+    workingDir.createSync(recursive: true);
+    logger = BufferLogger.test();
+    platform = FakePlatform();
+    terminal = FakeTerminal(platform: platform);
+    processManager = globals.processManager;
+
+    final File pubspecOriginal = appDir.childFile('pubspec.yaml');
+    pubspecOriginal.createSync(recursive: true);
+    pubspecOriginal.writeAsStringSync('''
+name: originalname
+description: A new Flutter project.
+version: 1.0.0+1
+environment:
+  sdk: '>=2.18.0-58.0.dev <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true''', flush: true);
+    command = MigrateCommand(
+      logger: logger,
+      fileSystem: fileSystem,
+      terminal: terminal,
+    );
+  });
+
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  tearDown(() async {
+    tryToDelete(appDir);
+  });
+
+  testUsingContext('commits new simple conflict', () async {
+    final File conflictFile = workingDir.childFile('conflict_file');
+    conflictFile.createSync(recursive: true);
+    conflictFile.writeAsStringSync('hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n', flush: true);
+
+    final MigrateManifest manifest = MigrateManifest(migrateRootDir: workingDir, migrateResult: MigrateResult(
+      mergeResults: <MergeResult>[
+        StringMergeResult.explicit(
+          localPath: 'merged_file',
+          mergedString: 'str',
+          hasConflict: false,
+          exitCode: 0,
+        ),
+        StringMergeResult.explicit(
+          localPath: 'conflict_file',
+          mergedString: 'hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n',
+          hasConflict: true,
+          exitCode: 1,
+        ),
+      ],
+      addedFiles: <FilePendingMigration>[FilePendingMigration('added_file', fileSystem.file('added_file'))],
+      deletedFiles: <FilePendingMigration>[FilePendingMigration('deleted_file', fileSystem.file('deleted_file'))],
+      // The following are ignored by the manifest.
+      mergeTypeMap: <String, MergeType>{'test': MergeType.threeWay},
+      diffMap: <String, DiffResult>{},
+      tempDirectories: <Directory>[],
+      sdkDirs: <String, Directory>{},
+    ));
+    manifest.writeFile();
+    File manifestFile = workingDir.childFile('.migrate_manifest');
+    print((terminal as FakeTerminal).terminal);
+
+    expect(workingDir.existsSync(), true);
+    final Future<void> commandFuture = createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'resolve-conflicts',
+        '--working-directory=${workingDir.path}',
+        '--project-directory=${appDir.path}',
+      ]
+    );
+
+    terminal.simulateStdin('n');
+    terminal.simulateStdin('y');
+
+    await commandFuture;
+    expect(logger.statusText, contains('''
+Cyan = Original lines.  Green = New lines.
+
+  2    <<<<<<<
+  3    original
+  4    =======
+  5    new
+  6    >>>>>>>
+  7    hi'''));
+    expect(logger.statusText, contains('''
+Conflict in conflict_file.
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: n
+
+
+Conflicts in conflict_file complete.
+
+You chose to:
+  Skip 0 conflicts
+  Acccept the original lines for 0 conflicts
+  Accept the new lines for 1 conflicts
+
+Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n|r]:'''));
+    expect(conflictFile.readAsStringSync(), equals('hello\nwow a bunch of lines\nnew\nhi\n'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Platform: () => platform,
+  });
+
+  testUsingContext('skip commit simple conflict leaves intact', () async {
+    final File conflictFile = workingDir.childFile('conflict_file');
+    conflictFile.createSync(recursive: true);
+    conflictFile.writeAsStringSync('hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n', flush: true);
+
+    final MigrateManifest manifest = MigrateManifest(migrateRootDir: workingDir, migrateResult: MigrateResult(
+      mergeResults: <MergeResult>[
+        StringMergeResult.explicit(
+          localPath: 'merged_file',
+          mergedString: 'str',
+          hasConflict: false,
+          exitCode: 0,
+        ),
+        StringMergeResult.explicit(
+          localPath: 'conflict_file',
+          mergedString: 'hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n',
+          hasConflict: true,
+          exitCode: 1,
+        ),
+      ],
+      addedFiles: <FilePendingMigration>[FilePendingMigration('added_file', fileSystem.file('added_file'))],
+      deletedFiles: <FilePendingMigration>[FilePendingMigration('deleted_file', fileSystem.file('deleted_file'))],
+      // The following are ignored by the manifest.
+      mergeTypeMap: <String, MergeType>{'test': MergeType.threeWay},
+      diffMap: <String, DiffResult>{},
+      tempDirectories: <Directory>[],
+      sdkDirs: <String, Directory>{},
+    ));
+    manifest.writeFile();
+    File manifestFile = workingDir.childFile('.migrate_manifest');
+    print((terminal as FakeTerminal).terminal);
+
+    expect(workingDir.existsSync(), true);
+    final Future<void> commandFuture = createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'resolve-conflicts',
+        '--working-directory=${workingDir.path}',
+        '--project-directory=${appDir.path}',
+      ]
+    );
+
+    terminal.simulateStdin('n');
+    terminal.simulateStdin('n');
+
+    await commandFuture;
+    expect(logger.statusText, contains('''
+Cyan = Original lines.  Green = New lines.
+
+  2    <<<<<<<
+  3    original
+  4    =======
+  5    new
+  6    >>>>>>>
+  7    hi'''));
+    expect(logger.statusText, contains('''
+Conflict in conflict_file.
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: n
+
+
+Conflicts in conflict_file complete.
+
+You chose to:
+  Skip 0 conflicts
+  Acccept the original lines for 0 conflicts
+  Accept the new lines for 1 conflicts
+
+Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n|r]:'''));
+    expect(conflictFile.readAsStringSync(), equals('hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Platform: () => platform,
+  });
+
+  testUsingContext('commits original simple conflict', () async {
+    final File conflictFile = workingDir.childFile('conflict_file');
+    conflictFile.createSync(recursive: true);
+    conflictFile.writeAsStringSync('hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n', flush: true);
+
+    final MigrateManifest manifest = MigrateManifest(migrateRootDir: workingDir, migrateResult: MigrateResult(
+      mergeResults: <MergeResult>[
+        StringMergeResult.explicit(
+          localPath: 'merged_file',
+          mergedString: 'str',
+          hasConflict: false,
+          exitCode: 0,
+        ),
+        StringMergeResult.explicit(
+          localPath: 'conflict_file',
+          mergedString: 'hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n',
+          hasConflict: true,
+          exitCode: 1,
+        ),
+      ],
+      addedFiles: <FilePendingMigration>[FilePendingMigration('added_file', fileSystem.file('added_file'))],
+      deletedFiles: <FilePendingMigration>[FilePendingMigration('deleted_file', fileSystem.file('deleted_file'))],
+      // The following are ignored by the manifest.
+      mergeTypeMap: <String, MergeType>{'test': MergeType.threeWay},
+      diffMap: <String, DiffResult>{},
+      tempDirectories: <Directory>[],
+      sdkDirs: <String, Directory>{},
+    ));
+    manifest.writeFile();
+    File manifestFile = workingDir.childFile('.migrate_manifest');
+    print((terminal as FakeTerminal).terminal);
+
+    expect(workingDir.existsSync(), true);
+    final Future<void> commandFuture = createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'resolve-conflicts',
+        '--working-directory=${workingDir.path}',
+        '--project-directory=${appDir.path}',
+      ]
+    );
+
+    terminal.simulateStdin('o');
+    terminal.simulateStdin('y');
+
+    await commandFuture;
+    expect(logger.statusText, contains('''
+Cyan = Original lines.  Green = New lines.
+
+  2    <<<<<<<
+  3    original
+  4    =======
+  5    new
+  6    >>>>>>>
+  7    hi'''));
+    expect(logger.statusText, contains('''
+Conflict in conflict_file.
+Accept the (o)riginal lines, (n)ew lines, or (s)kip and resolve the conflict manually? [o|n|s]: o
+
+
+Conflicts in conflict_file complete.
+
+You chose to:
+  Skip 0 conflicts
+  Acccept the original lines for 1 conflicts
+  Accept the new lines for 0 conflicts
+
+Commit the changes to the working directory? (y)es, (n)o, (r)etry this file [y|n|r]:'''));
+    expect(conflictFile.readAsStringSync(), equals('hello\nwow a bunch of lines\noriginal\nhi\n'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Platform: () => platform,
+  });
+
+  testUsingContext('skip conflict leaves file unchanged', () async {
+    final File conflictFile = workingDir.childFile('conflict_file');
+    conflictFile.createSync(recursive: true);
+    conflictFile.writeAsStringSync('hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n', flush: true);
+
+    final MigrateManifest manifest = MigrateManifest(migrateRootDir: workingDir, migrateResult: MigrateResult(
+      mergeResults: <MergeResult>[
+        StringMergeResult.explicit(
+          localPath: 'merged_file',
+          mergedString: 'str',
+          hasConflict: false,
+          exitCode: 0,
+        ),
+        StringMergeResult.explicit(
+          localPath: 'conflict_file',
+          mergedString: 'hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n',
+          hasConflict: true,
+          exitCode: 1,
+        ),
+      ],
+      addedFiles: <FilePendingMigration>[FilePendingMigration('added_file', fileSystem.file('added_file'))],
+      deletedFiles: <FilePendingMigration>[FilePendingMigration('deleted_file', fileSystem.file('deleted_file'))],
+      // The following are ignored by the manifest.
+      mergeTypeMap: <String, MergeType>{'test': MergeType.threeWay},
+      diffMap: <String, DiffResult>{},
+      tempDirectories: <Directory>[],
+      sdkDirs: <String, Directory>{},
+    ));
+    manifest.writeFile();
+    File manifestFile = workingDir.childFile('.migrate_manifest');
+    print((terminal as FakeTerminal).terminal);
+
+    expect(workingDir.existsSync(), true);
+    final Future<void> commandFuture = createTestCommandRunner(command).run(
+      <String>[
+        'migrate',
+        'resolve-conflicts',
+        '--working-directory=${workingDir.path}',
+        '--project-directory=${appDir.path}',
+      ]
+    );
+
+    terminal.simulateStdin('s');
+    terminal.simulateStdin('y');
+
+    await commandFuture;
+    expect(logger.statusText, contains('''
+Cyan = Original lines.  Green = New lines.
+
+  2    <<<<<<<
+  3    original
+  4    =======
+  5    new
+  6    >>>>>>>
+  7    hi'''));
+    expect(conflictFile.readAsStringSync(), equals('hello\nwow a bunch of lines\n<<<<<<<\noriginal\n=======\nnew\n>>>>>>>\nhi\n'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    ProcessManager: () => processManager,
+    Platform: () => platform,
+  });
+}


### PR DESCRIPTION
flutter migrate resolve-conflicts subcommand.

This guided conflict resolution wizard prompts the developer if they with to accept the original lines, the new lines, or skip and manually resolve the conflict. This command allows rapid resolution of mundane conflicts that are common with the migrate command.
