### PR TITLE
Defer the OverlayEntry listenable disposal until its widget is unmounted

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -45,7 +45,7 @@ import 'ticker_provider.dart';
 /// if widgets in an overlay entry with [maintainState] set to true repeatedly
 /// call [State.setState], the user's battery will be drained unnecessarily.
 ///
-/// [OverlayEntry] is a [ChangeNotifier] that notifies when the widget built by
+/// [OverlayEntry] is a [Listenable] that notifies when the widget built by
 /// [builder] is mounted or unmounted, whose exact state can be queried by
 /// [mounted]. After the owner of the [OverlayEntry] calls [remove] and then
 /// [dispose], the widget may not be immediately removed from the widget tree.
@@ -58,7 +58,7 @@ import 'ticker_provider.dart';
 ///  * [OverlayState]
 ///  * [WidgetsApp]
 ///  * [MaterialApp]
-class OverlayEntry extends ChangeNotifier {
+class OverlayEntry implements Listenable {
   /// Creates an overlay entry.
   ///
   /// To insert the entry into an [Overlay], first find the overlay using
@@ -182,8 +182,9 @@ class OverlayEntry extends ChangeNotifier {
   }
 
   void _didUnmount() {
-    if (_disposedByOwner && !mounted) {
-      super.dispose();
+    assert(!mounted);
+    if (_disposedByOwner) {
+      _overlayStateMounted.dispose();
     }
   }
 
@@ -201,13 +202,12 @@ class OverlayEntry extends ChangeNotifier {
   /// tree.
   ///
   /// This method should only be called by the object's owner.
-  @override
   void dispose() {
     assert(!_disposedByOwner);
     assert(_overlay == null, 'An OverlayEntry must first be removed from the Overlay before dispose is called.');
     _disposedByOwner = true;
     if (!mounted) {
-      super.dispose();
+      _overlayStateMounted.dispose();
     }
   }
 

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -47,7 +47,10 @@ import 'ticker_provider.dart';
 ///
 /// [OverlayEntry] is a [ChangeNotifier] that notifies when the widget built by
 /// [builder] is mounted or unmounted, whose exact state can be queried by
-/// [mounted].
+/// [mounted]. After the owner of the [OverlayEntry] calls [remove] and then
+/// [dispose], the widget may not be immediately removed from the widget tree.
+/// As a result listeners of the [OverlayEntry] can get notified for one last
+/// time after the [dispose] call, when the widget is eventually unmounted.
 ///
 /// See also:
 ///
@@ -86,6 +89,7 @@ class OverlayEntry extends ChangeNotifier {
   bool get opaque => _opaque;
   bool _opaque;
   set opaque(bool value) {
+    assert(!_disposedByOwner);
     if (_opaque == value)
       return;
     _opaque = value;
@@ -109,6 +113,7 @@ class OverlayEntry extends ChangeNotifier {
   bool get maintainState => _maintainState;
   bool _maintainState;
   set maintainState(bool value) {
+    assert(!_disposedByOwner);
     assert(_maintainState != null);
     if (_maintainState == value)
       return;
@@ -120,14 +125,21 @@ class OverlayEntry extends ChangeNotifier {
   /// Whether the [OverlayEntry] is currently mounted in the widget tree.
   ///
   /// The [OverlayEntry] notifies its listeners when this value changes.
-  bool get mounted => _mounted;
-  bool _mounted = false;
-  void _updateMounted(bool value) {
-    if (value == _mounted) {
-      return;
-    }
-    _mounted = value;
-    notifyListeners();
+  bool get mounted => _overlayStateMounted.value;
+
+  /// Whether the `_OverlayState`s built using this [OverlayEntry] is currently
+  /// mounted.
+  final ValueNotifier<bool> _overlayStateMounted = ValueNotifier<bool>(false);
+
+  @override
+  void addListener(VoidCallback listener) {
+    assert(!_disposedByOwner);
+    _overlayStateMounted.addListener(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    _overlayStateMounted.removeListener(listener);
   }
 
   OverlayState? _overlay;
@@ -145,6 +157,7 @@ class OverlayEntry extends ChangeNotifier {
   /// until	the next frame (i.e. many milliseconds later).
   void remove() {
     assert(_overlay != null);
+    assert(!_disposedByOwner);
     final OverlayState overlay = _overlay!;
     _overlay = null;
     if (!overlay.mounted)
@@ -164,7 +177,38 @@ class OverlayEntry extends ChangeNotifier {
   ///
   /// You need to call this function if the output of [builder] has changed.
   void markNeedsBuild() {
+    assert(!_disposedByOwner);
     _key.currentState?._markNeedsBuild();
+  }
+
+  void _didUnmount() {
+    if (_disposedByOwner && !mounted) {
+      super.dispose();
+    }
+  }
+
+  bool _disposedByOwner = false;
+
+  /// Discards any resources used by this [OverlayEntry].
+  ///
+  /// This method must be called after [remove] if the [OverlayEntry] is
+  /// inserted into an [Overlay].
+  ///
+  /// After this is called, the object is not in a usable state and should be
+  /// discarded (calls to [addListener] will throw after the object is disposed).
+  /// However, the listeners registered may not be immediately released until
+  /// the widget built using this [OverlayEntry] is unmounted from the widget
+  /// tree.
+  ///
+  /// This method should only be called by the object's owner.
+  @override
+  void dispose() {
+    assert(!_disposedByOwner);
+    assert(_overlay == null, 'An OverlayEntry must first be removed from the Overlay before dispose is called.');
+    _disposedByOwner = true;
+    if (!mounted) {
+      super.dispose();
+    }
   }
 
   @override
@@ -192,12 +236,13 @@ class _OverlayEntryWidgetState extends State<_OverlayEntryWidget> {
   @override
   void initState() {
     super.initState();
-    widget.entry._updateMounted(true);
+    widget.entry._overlayStateMounted.value = true;
   }
 
   @override
   void dispose() {
-    widget.entry._updateMounted(false);
+    widget.entry._overlayStateMounted.value = false;
+    widget.entry._didUnmount();
     super.dispose();
   }
 


### PR DESCRIPTION
There're customers using `OverlayEntry.addListener` (and leaking listeners unfortunately).
Alternatively we can let `_OverlayEntryWidgetState` own the value notifier (so it doesn't leak since it will always be disposed by the state object). Old listeners won't be notified when the entry is reused to build new widgets but our internal customer and route entry are only interested in the mounted state of the current widget.
Fixes https://github.com/flutter/flutter/issues/102718


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
