### PR TITLE
[web] Adjust expectation of dialog_test for Dart HHH bot

### DIFF
--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -329,8 +329,11 @@ void main() {
 
     // TODO(yjbanov): https://github.com/flutter/flutter/issues/99933
     //                A bug in the HTML renderer and/or Chrome 96+ causes a
-    //                discrepancy in the paragraph height.
-    const bool hasIssue99933 = kIsWeb && !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA');
+    //                discrepancy in the paragraph height. However, Dart HHH
+    //                uses an older version of Chrome at this time.
+    const bool hasIssue99933 = kIsWeb &&
+        !bool.fromEnvironment('FLUTTER_WEB_USE_SKIA') &&
+        !bool.fromEnvironment('DART_HHH_BOT');
     expect(tester.getSize(find.text('The Title')), equals(const Size(270.0, hasIssue99933 ? 133 : 132.0)));
     expect(tester.getTopLeft(find.text('The Title')), equals(const Offset(265.0, 80.0 + 24.0)));
     expect(tester.getSize(find.widgetWithText(CupertinoDialogAction, 'Cancel')), equals(const Size(310.0, 148.0)));


### PR DESCRIPTION
dialog_test started failing in the Dart HHH bot since https://github.com/flutter/flutter/commit/c2409797ff19c81fed208706ccb760ca2b30f28e landed. When Chrome was rolled in flutter, the expectation of the test was updated, however, the Dart HHH still use an older version of Chrome (Chrome 84 I believe). Once that Chrome gets updated, we should revert this change.

/cc @nshahan 