### PR TITLE
Make NestedScrollView.body to be connected if horizontal

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -427,9 +427,10 @@ class NestedScrollViewState extends State<NestedScrollView> {
     super.dispose();
   }
 
-  /// allow the body of NesetedScrollView to restore its scroll position;
-  void preserveInnerScrollPosition() {
-    _coordinator!.preserveInnerScrollPosition = true;
+  /// This allows NesetedScrollView to restore its scroll position
+  /// using PageStorageKey.
+  void preserveScrollPosition() {
+    _coordinator!.preserveScrollPosition = true;
   }
 
   bool? _lastHasScrolledBody;
@@ -632,12 +633,12 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     return false;
   }
 
-  /// 
-  bool get preserveInnerScrollPosition => _preserveInnerScrollPosition;
-  bool _preserveInnerScrollPosition = false;
-  set preserveInnerScrollPosition(bool value) {
+  /// If set to true, the scroll position will be preserved
+  bool get preserveScrollPosition => _preserveScrollPosition;
+  bool _preserveScrollPosition = false;
+  set preserveScrollPosition(bool value) {
     assert(value != null);
-    _preserveInnerScrollPosition = value;
+    _preserveScrollPosition = value;
   }
 
   void updateShadow() { _onHasScrolledBodyChanged(); }
@@ -1207,7 +1208,7 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
 
   @override
   void restoreScrollOffset() {
-    if (coordinator.canScrollBody || coordinator.preserveInnerScrollPosition)
+    if (coordinator.canScrollBody || coordinator.preserveScrollPosition)
       super.restoreScrollOffset();
   }
 

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -308,13 +308,7 @@ class NestedScrollView extends StatefulWidget {
     return target!.state._absorberHandle;
   }
 
-  /// Returns the [NestedScrollViewState] of the nearest ancestor
-  /// [NestedScrollView].
-  ///
-  /// Must to be called under a NestedScrollScope
-  /// See also:
-  ///
-  ///  * [ScrollConfiguration.underNestedScrollScope], which establish a NestedScrollScope
+  /// Returns the [NestedScrollViewState] of the nearest ancestor [NestedScrollView].
   static NestedScrollViewState of(BuildContext context) {
     final _InheritedNestedScrollView? target = context.dependOnInheritedWidgetOfExactType<_InheritedNestedScrollView>();
     assert(
@@ -427,8 +421,7 @@ class NestedScrollViewState extends State<NestedScrollView> {
     super.dispose();
   }
 
-  /// This allows NesetedScrollView to restore its scroll position
-  /// using PageStorageKey.
+  /// This allows NesetedScrollView to restore its scroll position using PageStorageKey.
   void preserveScrollPosition() {
     _coordinator!.preserveScrollPosition = true;
   }
@@ -633,7 +626,6 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     return false;
   }
 
-  /// If set to true, the scroll position will be preserved
   bool get preserveScrollPosition => _preserveScrollPosition;
   bool _preserveScrollPosition = false;
   set preserveScrollPosition(bool value) {

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -314,7 +314,10 @@ class NestedScrollView extends StatefulWidget {
       SliverFillRemaining(
         child: PrimaryScrollController(
           controller: innerController,
-          child: body,
+          child: ScrollConfiguration(
+            behavior: scrollBehavior ?? ScrollConfiguration.of(context).copyWith(scrollbars: false, usePrimaryScrollController: true),
+            child: body
+          ),
         ),
       ),
     ];

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -99,7 +99,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
-    bool? usePrimaryScrollController,
+    bool? underNestedScrollScope,
     Set<PointerDeviceKind>? dragDevices,
     ScrollPhysics? physics,
     TargetPlatform? platform,
@@ -113,7 +113,7 @@ class ScrollBehavior {
       delegate: this,
       scrollbars: scrollbars ?? true,
       overscroll: overscroll ?? true,
-      usePrimaryScrollController: usePrimaryScrollController ?? false,
+      underNestedScrollScope: underNestedScrollScope ?? false,
       physics: physics,
       platform: platform,
       dragDevices: dragDevices,
@@ -141,7 +141,7 @@ class ScrollBehavior {
   ///
   ///  * [NestedScrollView], which depends on PrimaryScrollController to scroll
   ///    its body.
-  bool get usePrimaryScrollController => false;
+  bool get underNestedScrollScope => false;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -284,10 +284,10 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscroll = true,
     this.physics,
     this.platform,
-    bool? usePrimaryScrollController,
+    bool? underNestedScrollScope,
     Set<PointerDeviceKind>? dragDevices,
     AndroidOverscrollIndicator? androidOverscrollIndicator,
-  }) : _usePrimaryScrollController = usePrimaryScrollController,
+  }) : _underNestedScrollScope = underNestedScrollScope,
        _androidOverscrollIndicator = androidOverscrollIndicator,
        _dragDevices = dragDevices;
 
@@ -296,7 +296,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final bool overscroll;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
-  final bool? _usePrimaryScrollController;
+  final bool? _underNestedScrollScope;
   final Set<PointerDeviceKind>? _dragDevices;
   @override
   final AndroidOverscrollIndicator? _androidOverscrollIndicator;
@@ -308,7 +308,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator ?? delegate.androidOverscrollIndicator;
 
   @override
-  bool get usePrimaryScrollController => _usePrimaryScrollController ?? delegate.usePrimaryScrollController;
+  bool get underNestedScrollScope => _underNestedScrollScope ?? delegate.underNestedScrollScope;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -333,7 +333,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
-    bool? usePrimaryScrollController,
+    bool? underNestedScrollScope,
     ScrollPhysics? physics,
     TargetPlatform? platform,
     Set<PointerDeviceKind>? dragDevices,
@@ -342,7 +342,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     return delegate.copyWith(
       scrollbars: scrollbars ?? this.scrollbars,
       overscroll: overscroll ?? this.overscroll,
-      usePrimaryScrollController: usePrimaryScrollController ?? this.usePrimaryScrollController,
+      underNestedScrollScope: underNestedScrollScope ?? this.underNestedScrollScope,
       physics: physics ?? this.physics,
       platform: platform ?? this.platform,
       dragDevices: dragDevices ?? this.dragDevices,

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -306,7 +306,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
 
   @override
   AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator ?? delegate.androidOverscrollIndicator;
-  
+
   @override
   bool get usePrimaryScrollController => _usePrimaryScrollController ?? delegate.usePrimaryScrollController;
 

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -99,6 +99,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
+    bool? usePrimaryScrollController,
     Set<PointerDeviceKind>? dragDevices,
     ScrollPhysics? physics,
     TargetPlatform? platform,
@@ -112,6 +113,7 @@ class ScrollBehavior {
       delegate: this,
       scrollbars: scrollbars ?? true,
       overscroll: overscroll ?? true,
+      usePrimaryScrollController: usePrimaryScrollController ?? false,
       physics: physics,
       platform: platform,
       dragDevices: dragDevices,
@@ -131,6 +133,15 @@ class ScrollBehavior {
   /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
   /// impossible to select text in scrollable containers and is not recommended.
   Set<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
+
+  /// If set to true, the [ScrollView] in the subtree will use [PrimaryScrollController]
+  /// if the [ScrollController] is null.
+  ///
+  /// See also:
+  ///
+  ///  * [NestedScrollView], which depends on PrimaryScrollController to scroll
+  ///    its body.
+  bool get usePrimaryScrollController => false;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -273,9 +284,11 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscroll = true,
     this.physics,
     this.platform,
+    bool? usePrimaryScrollController,
     Set<PointerDeviceKind>? dragDevices,
     AndroidOverscrollIndicator? androidOverscrollIndicator,
-  }) : _androidOverscrollIndicator = androidOverscrollIndicator,
+  }) : _usePrimaryScrollController = usePrimaryScrollController,
+       _androidOverscrollIndicator = androidOverscrollIndicator,
        _dragDevices = dragDevices;
 
   final ScrollBehavior delegate;
@@ -283,6 +296,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final bool overscroll;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
+  final bool? _usePrimaryScrollController;
   final Set<PointerDeviceKind>? _dragDevices;
   @override
   final AndroidOverscrollIndicator? _androidOverscrollIndicator;
@@ -292,6 +306,9 @@ class _WrappedScrollBehavior implements ScrollBehavior {
 
   @override
   AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator ?? delegate.androidOverscrollIndicator;
+  
+  @override
+  bool get usePrimaryScrollController => _usePrimaryScrollController ?? delegate.usePrimaryScrollController;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -316,6 +333,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
+    bool? usePrimaryScrollController,
     ScrollPhysics? physics,
     TargetPlatform? platform,
     Set<PointerDeviceKind>? dragDevices,
@@ -324,6 +342,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     return delegate.copyWith(
       scrollbars: scrollbars ?? this.scrollbars,
       overscroll: overscroll ?? this.overscroll,
+      usePrimaryScrollController: usePrimaryScrollController ?? this.usePrimaryScrollController,
       physics: physics ?? this.physics,
       platform: platform ?? this.platform,
       dragDevices: dragDevices ?? this.dragDevices,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -402,7 +402,7 @@ abstract class ScrollView extends StatelessWidget {
       scrollController = controller ?? PrimaryScrollController.of(context);
       if (key is PageStorageKey) {
         final NestedScrollViewState nestedScrollViewState = NestedScrollView.of(context);
-        nestedScrollViewState.preserveInnerScrollPosition();
+        nestedScrollViewState.preserveScrollPosition();
       }
     } else {
       scrollController = primary ? PrimaryScrollController.of(context) : controller;

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -13,7 +13,9 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
 import 'media_query.dart';
+import 'nested_scroll_view.dart';
 import 'notification_listener.dart';
+import 'page_storage.dart';
 import 'primary_scroll_controller.dart';
 import 'scroll_configuration.dart';
 import 'scroll_controller.dart';
@@ -395,11 +397,17 @@ abstract class ScrollView extends StatelessWidget {
 
     final ScrollBehavior ancestorBehavior = ScrollConfiguration.of(context);
     ScrollController? scrollController;
-    if (ancestorBehavior.usePrimaryScrollController) {
+    // check if the scrollable is under a nested scroll scope
+    if (ancestorBehavior.underNestedScrollScope) {
       scrollController = controller ?? PrimaryScrollController.of(context);
+      if (key is PageStorageKey) {
+        final NestedScrollViewState nestedScrollViewState = NestedScrollView.of(context);
+        nestedScrollViewState.preserveInnerScrollPosition();
+      }
     } else {
       scrollController = primary ? PrimaryScrollController.of(context) : controller;
     }
+
     final Scrollable scrollable = Scrollable(
       dragStartBehavior: dragStartBehavior,
       axisDirection: axisDirection,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -393,8 +393,13 @@ abstract class ScrollView extends StatelessWidget {
     final List<Widget> slivers = buildSlivers(context);
     final AxisDirection axisDirection = getDirection(context);
 
-    final ScrollController? scrollController =
-        primary ? PrimaryScrollController.of(context) : controller;
+    final ScrollBehavior ancestorBehavior = ScrollConfiguration.of(context);
+    ScrollController? scrollController;
+    if (ancestorBehavior.usePrimaryScrollController) {
+      scrollController = controller ?? PrimaryScrollController.of(context);
+    } else {
+      scrollController = primary ? PrimaryScrollController.of(context) : controller;
+    }
     final Scrollable scrollable = Scrollable(
       dragStartBehavior: dragStartBehavior,
       axisDirection: axisDirection,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -762,8 +762,7 @@ void main() {
               headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
                 return <Widget>[
                   SliverOverlapAbsorber(
-                    handle:
-                        NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                    handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     sliver: SliverAppBar(
                       title: const Text('Books'), 
                       pinned: true,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -766,7 +766,7 @@ void main() {
                         NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     sliver: SliverAppBar(
                       title:
-                          const Text('Books'), 
+                        const Text('Books'), 
                       pinned: true,
                       expandedHeight: 150.0,
                       forceElevated: innerBoxIsScrolled,
@@ -824,7 +824,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Item 2'), findsNothing);
     expect(find.text('Item 29'), findsOneWidget);
-    
+
     // Bring tab2 into view
     await tester.fling(find.text('Item 29'), const Offset(-400, 0.0), 10000.0);
     await tester.pumpAndSettle();
@@ -842,7 +842,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text('Item 2'), findsNothing);
     expect(find.text('Item 29'), findsOneWidget);
-    
+
     // Scroll to top of tab1
     await tester.fling(find.text('Item 29'), const Offset(0.0, 250.0), 10000.0);
     await tester.pumpAndSettle();

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -765,8 +765,7 @@ void main() {
                     handle:
                         NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     sliver: SliverAppBar(
-                      title:
-                        const Text('Books'), 
+                      title: const Text('Books'), 
                       pinned: true,
                       expandedHeight: 150.0,
                       forceElevated: innerBoxIsScrolled,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -764,7 +764,7 @@ void main() {
                   SliverOverlapAbsorber(
                     handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
                     sliver: SliverAppBar(
-                      title: const Text('Books'), 
+                      title: const Text('Books'),
                       pinned: true,
                       expandedHeight: 150.0,
                       forceElevated: innerBoxIsScrolled,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -2552,6 +2552,32 @@ void main() {
     expect(scrollStarted, 2);
     expect(scrollEnded, 2);
   });
+
+  testWidgets('NestedScrollView.body will be connected if horizontal', (WidgetTester tester) async {
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: NestedScrollView(
+            key: globalKey,
+            scrollDirection: Axis.horizontal,
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+              return <Widget>[const SliverAppBar(title: Text('Demo'))];
+            },
+            body: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+            )),
+      ),
+    ));
+
+    expect(globalKey.currentState?.innerController, isNotNull);
+
+    // scroll to right
+    await tester.fling(find.text('Item 1'), const Offset(-50.0, 0.0), 10000.0);
+    await tester.pumpAndSettle();
+
+    expect(globalKey.currentState!.outerController.position.pixels, globalKey.currentState!.outerController.position.maxScrollExtent);
+  });
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {


### PR DESCRIPTION
This PR fixes the following issues
Fixes #102001 
Fixes #40740

I change the `NestedScrollView and internal scrolling` test, as the original expectation was wrong. NestedScrollView supports PageStorageKey now.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
