### PR TITLE
Select all text on single line EditableText on web when focused by anything other than clicking

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1615,6 +1615,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   final LayerLink _endHandleLayerLink = LayerLink();
 
   bool _didAutoFocus = false;
+  bool _focusedDirectly = false;
 
   AutofillGroupState? _currentAutofillScope;
   @override
@@ -2656,6 +2657,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                           || (!_value.composing.isCollapsed && value.composing.isCollapsed);
     final bool selectionChanged = _value.selection != value.selection;
 
+    _focusedDirectly = cause != null;
+
     if (textChanged) {
       try {
         value = widget.inputFormatters?.fold<TextEditingValue>(
@@ -2826,6 +2829,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       if (!widget.readOnly) {
         _scheduleShowCaretOnScreen(withAnimation: true);
       }
+      if (kIsWeb && widget._userSelectionEnabled && widget.maxLines == 1 && !_focusedDirectly) {
+        // Select all text in a single line input on web if it wasn't focused directly.
+        _handleSelectionChanged(TextSelection(baseOffset: 0, extentOffset: _value.text.length), null);
+      }
       if (!_value.selection.isValid) {
         // Place cursor at the end if the selection is invalid when we receive focus.
         _handleSelectionChanged(TextSelection.collapsed(offset: _value.text.length), null);
@@ -2839,6 +2846,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       WidgetsBinding.instance.removeObserver(this);
       setState(() { _currentPromptRectRange = null; });
     }
+    _focusedDirectly = false;
     updateKeepAlive();
   }
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -5915,7 +5915,7 @@ void main() {
 
       expect(focusNode1.hasFocus, isTrue);
       expect(focusNode2.hasFocus, isFalse);
-      expect(controller.selection.baseOffset, 6);
+      expect(controller.selection.baseOffset, kIsWeb ? 0 : 6);
       expect(controller.selection.extentOffset, 12);
 
       // Select everything.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1655,7 +1655,7 @@ void main() {
     expect(tester.testTextInput.hasAnyClients, isBrowser ? isTrue : isFalse);
     await skipPastScrollingAnimation(tester);
 
-    expect(controller.selection.isCollapsed, true);
+    expect(controller.selection.isCollapsed, isBrowser ? isFalse : isTrue);
 
     await tester.tap(find.byType(TextField));
     await tester.pump();
@@ -6393,6 +6393,15 @@ void main() {
     semanticsOwner.performAction(inputFieldId, SemanticsAction.tap);
     await tester.pump();
 
+    const TextSelection endSelection = TextSelection(
+      baseOffset: textInTextField.length,
+      extentOffset: textInTextField.length,
+    );
+    const TextSelection allSelection = TextSelection(
+      baseOffset: 0,
+      extentOffset: textInTextField.length,
+    );
+
     expect(semantics, hasSemantics(
       TestSemantics.root(
         children: <TestSemantics>[
@@ -6409,13 +6418,12 @@ void main() {
               SemanticsAction.setSelection,
               SemanticsAction.setText,
               SemanticsAction.paste,
+              if (kIsWeb) SemanticsAction.cut,
+              if (kIsWeb) SemanticsAction.copy,
             ],
             value: textInTextField,
             textDirection: TextDirection.ltr,
-            textSelection: const TextSelection(
-              baseOffset: textInTextField.length,
-              extentOffset: textInTextField.length,
-            ),
+            textSelection: isBrowser ? allSelection : endSelection,
           ),
         ],
       ),

--- a/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
+++ b/packages/flutter/test/widgets/editable_text_show_on_screen_test.dart
@@ -553,7 +553,7 @@ void main() {
         focusNode.requestFocus();
         await tester.pumpAndSettle();
 
-        expect(isCaretOnScreen(tester), !readOnly);
+        expect(isCaretOnScreen(tester), isBrowser ? isFalse : !readOnly);
         expect(scrollController.offset, readOnly ? 0.0 : greaterThan(0.0));
         expect(editableScrollController.offset, readOnly ? 0.0 : greaterThan(0.0));
       });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -635,6 +635,7 @@ void main() {
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: EditableText(
+            maxLines: kIsWeb ? 2 : 1,
             controller: controller,
             backgroundCursorColor: Colors.grey,
             focusNode: focusNode,
@@ -661,6 +662,47 @@ void main() {
     expect(controller.value, value);
     expect(focusNode.hasFocus, isFalse);
   });
+
+  testWidgets('selects all on focus change on web', (WidgetTester tester) async {
+    const String testText = 'test test';
+    const TextSelection allSelection = TextSelection(
+        baseOffset: 0,
+        extentOffset: testText.length
+    );
+    const TextEditingValue value = TextEditingValue(
+      text: testText,
+      selection: TextSelection(affinity: TextAffinity.upstream, baseOffset: 5, extentOffset: 7),
+    );
+    controller.value = value;
+    await tester.pumpWidget(
+      MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: EditableText(
+            controller: controller,
+            backgroundCursorColor: Colors.grey,
+            focusNode: focusNode,
+            keyboardType: TextInputType.multiline,
+            style: textStyle,
+            cursorColor: cursorColor,
+          ),
+        ),
+      ),
+    );
+
+    expect(controller.value, value);
+    expect(focusNode.hasFocus, isFalse);
+
+    focusNode.requestFocus();
+    await tester.pump();
+
+    // On web this should select all of the text to match <input> behavior
+    expect(controller.value.selection, allSelection);
+    expect(focusNode.hasFocus, isTrue);
+  },
+    skip: !kIsWeb // [intended] should only select all on web
+  );
 
   testWidgets('EditableText does not derive selection color from DefaultSelectionStyle', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/103341.
@@ -888,6 +930,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: EditableText(
+            maxLines: kIsWeb ? 2 : 1,
             backgroundCursorColor: Colors.grey,
             controller: controller,
             focusNode: focusNode,
@@ -3846,6 +3889,8 @@ void main() {
     ));
 
     expect((findRenderEditable(tester).text! as TextSpan).text, expectedValue);
+    const TextSelection lastSelection =TextSelection.collapsed(offset: 24);
+    const TextSelection allSelection = TextSelection(baseOffset: 0, extentOffset: 24);
 
     expect(
       semantics,
@@ -3873,7 +3918,7 @@ void main() {
                           ],
                           value: expectedValue,
                           textDirection: TextDirection.ltr,
-                          textSelection: const TextSelection.collapsed(offset: 24),
+                          textSelection: kIsWeb ? allSelection : lastSelection,
                         ),
                       ],
                     ),
@@ -4743,6 +4788,7 @@ void main() {
             child: Center(
               child: Material(
                 child: EditableText(
+                  maxLines: kIsWeb ? 2 : 1,
                   backgroundCursorColor: Colors.grey,
                   controller: controller,
                   focusNode: FocusNode(),
@@ -4979,6 +5025,7 @@ void main() {
 
     await tester.pumpWidget(MaterialApp( // So we can show overlays.
       home: EditableText(
+        maxLines: kIsWeb ? 2 : 1,
         autofocus: true,
         backgroundCursorColor: Colors.grey,
         controller: controller,
@@ -11190,6 +11237,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: EditableText(
+          maxLines: kIsWeb ? 2 : 1,
           autofocus: true,
           controller: TextEditingController(text: 'A'),
           focusNode: focusNode,

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -962,6 +962,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: TextField(
+            maxLines: isBrowser ? 2 : 1,
             autofocus: true,
             controller: controller,
           ),


### PR DESCRIPTION
Selects all text in `EditableText` with `maxLines == 1` on web when focused without a `SelectionChangedCause`. Emulates native behavior with `<input>`.

Fixes https://github.com/flutter/flutter/issues/78895

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
