### PR TITLE
Deflake arm64 android tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3073,7 +3073,6 @@ targets:
   - name: Mac_arm64_android hello_world_android__compile
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # Flaky: https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3103,7 +3102,6 @@ targets:
   - name: Mac_arm64_android integration_test_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # Flaky: https://github.com/flutter/flutter/issues/87508
     timeout: 60
     properties:
       tags: >
@@ -3144,7 +3142,6 @@ targets:
   - name: Mac_arm64_android run_release_test
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true # Flaky: https://github.com/flutter/flutter/issues/87508
     runIf:
       - dev/**
     timeout: 60


### PR DESCRIPTION
Follow up of https://github.com/flutter/flutter/pull/102589 to mark tests as unflaky. 
Tests have been passing consistently:
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_android%20integration_test_test?limit=50
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_android%20hello_world_android__compile?limit=50
https://ci.chromium.org/p/flutter/builders/staging/Mac_arm64_android%20run_release_test?limit=50

Issue: https://github.com/flutter/flutter/issues/87508