### PR TITLE
Revert "Fix position of CupertinoContextMenu within Transform.scale"

### DIFF
--- a/packages/flutter/lib/src/cupertino/context_menu.dart
+++ b/packages/flutter/lib/src/cupertino/context_menu.dart
@@ -47,11 +47,10 @@ typedef _ContextMenuPreviewBuilderChildless = Widget Function(
 Rect _getRect(GlobalKey globalKey) {
   assert(globalKey.currentContext != null);
   final RenderBox renderBoxContainer = globalKey.currentContext!.findRenderObject()! as RenderBox;
-  return Rect.fromPoints(renderBoxContainer.localToGlobal(
+  final Offset containerOffset = renderBoxContainer.localToGlobal(
     renderBoxContainer.paintBounds.topLeft,
-  ), renderBoxContainer.localToGlobal(
-    renderBoxContainer.paintBounds.bottomRight
-  ));
+  );
+  return containerOffset & renderBoxContainer.paintBounds.size;
 }
 
 // The context menu arranges itself slightly differently based on the location

--- a/packages/flutter/test/cupertino/context_menu_test.dart
+++ b/packages/flutter/test/cupertino/context_menu_test.dart
@@ -228,62 +228,6 @@ void main() {
         kIsWeb ? SystemMouseCursors.click : SystemMouseCursors.basic,
       );
     });
-
-    testWidgets('CupertinoContextMenu is in the correct position when within a Transform.scale', (WidgetTester tester) async {
-      final Widget child = _getChild();
-      await tester.pumpWidget(CupertinoApp(
-        home: CupertinoPageScaffold(
-          child: MediaQuery(
-            data: const MediaQueryData(size: Size(800, 600)),
-            child: Transform.scale(
-              scale: 0.5,
-              child: Align(
-                //alignment: Alignment.bottomRight,
-                child: CupertinoContextMenu(
-                  actions: const <CupertinoContextMenuAction>[
-                    CupertinoContextMenuAction(
-                      child: Text('CupertinoContextMenuAction'),
-                    ),
-                  ],
-                  child: child
-                ),
-              )
-            )
-          )
-        )
-      ));
-      expect(find.byWidget(child), findsOneWidget);
-      final Rect childRect = tester.getRect(find.byWidget(child));
-      expect(find.byType(ShaderMask), findsNothing);
-
-      // Start a press on the child.
-      final TestGesture gesture = await tester.startGesture(childRect.center);
-      await tester.pump();
-
-      // The _DecoyChild is showing directly on top of the child.
-      expect(_findDecoyChild(child), findsOneWidget);
-      Rect decoyChildRect = tester.getRect(_findDecoyChild(child));
-      expect(childRect, equals(decoyChildRect));
-
-      expect(find.byType(ShaderMask), findsOneWidget);
-
-      // After a small delay, the _DecoyChild has begun to animate.
-      await tester.pump(const Duration(milliseconds: 100));
-      decoyChildRect = tester.getRect(_findDecoyChild(child));
-      expect(childRect, isNot(equals(decoyChildRect)));
-
-      // Eventually the decoy fully scales by _kOpenSize.
-      await tester.pump(const Duration(milliseconds: 500));
-      decoyChildRect = tester.getRect(_findDecoyChild(child));
-      expect(childRect, isNot(equals(decoyChildRect)));
-      expect(decoyChildRect.width, childRect.width * kOpenScale);
-
-      // Then the CupertinoContextMenu opens.
-      await tester.pumpAndSettle();
-      await gesture.up();
-      await tester.pumpAndSettle();
-      expect(_findStatic(), findsOneWidget);
-    });
   });
 
   group('CupertinoContextMenu when open', () {

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -473,8 +473,8 @@ void main() {
       Rect.fromLTRB(
         0,
         height - titleFontSize - 10,
-        (width / 1.5).floorToDouble() * 1.5,
-        height,
+        (width / 1.5).floorToDouble(),
+        height - 10,
       ),
     );
   });
@@ -545,8 +545,8 @@ void main() {
       Rect.fromLTRB(
         0,
         height - titleFontSize - bottomMargin,
-        (collapsedWidth / 3).floorToDouble() * 3,
-        height,
+        (collapsedWidth / 3).floorToDouble(),
+        height - bottomMargin,
       ),
     );
   });

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -4321,17 +4321,17 @@ void main() {
     await pumpDecorator(focused: false, empty: false);
     await tester.pumpAndSettle();
     expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
-    expect(getLabelRect(tester).size, equals(const Size(80, 16) * 0.75));
+    expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     await pumpDecorator(focused: true);
     await tester.pumpAndSettle();
     expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
-    expect(getLabelRect(tester).size, equals(const Size(80, 16) * 0.75));
+    expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     await pumpDecorator(focused: true, empty: false);
     await tester.pumpAndSettle();
     expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
-    expect(getLabelRect(tester).size, equals(const Size(80, 16) * 0.75));
+    expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     await pumpDecorator(focused: false, enabled: false);
     await tester.pumpAndSettle();
@@ -4341,7 +4341,7 @@ void main() {
     await pumpDecorator(focused: false, empty: false, enabled: false);
     await tester.pumpAndSettle();
     expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
-    expect(getLabelRect(tester).size, equals(const Size(80, 16) * 0.75));
+    expect(getLabelRect(tester).size, equals(const Size(80, 16)));
 
     // Focused and disabled happens with NavigationMode.directional.
     await pumpDecorator(focused: true, enabled: false);
@@ -4352,7 +4352,7 @@ void main() {
     await pumpDecorator(focused: true, empty: false, enabled: false);
     await tester.pumpAndSettle();
     expect(getLabelRect(tester).topLeft, equals(const Offset(12, -5.5)));
-    expect(getLabelRect(tester).size, equals(const Size(80, 16) * 0.75));
+    expect(getLabelRect(tester).size, equals(const Size(80, 16)));
   });
 
   testWidgets('InputDecorationTheme.toString()', (WidgetTester tester) async {

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1138,7 +1138,7 @@ abstract class WidgetController {
 
   /// Returns the rect of the given widget. This is only valid once
   /// the widget's render object has been laid out at least once.
-  Rect getRect(Finder finder) => Rect.fromPoints(getTopLeft(finder), getBottomRight(finder));
+  Rect getRect(Finder finder) => getTopLeft(finder) & getSize(finder);
 
   /// Attempts to find the [SemanticsNode] of first result from `finder`.
   ///


### PR DESCRIPTION
Reverts flutter/flutter#97896

This appears to have broken the build: 

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8815246629840523313/+/u/run_test.dart_for_web_tests_shard_and_subshard_3/test_stdout

Reverting for now to get the tree green again.
