### PR TITLE
Clean up ci.yaml and add missing gradle caches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -14,12 +14,12 @@ platform_properties:
     properties:
       caches: >-
         [
-          {"name":"builder_linux_framework","path":"builder"},
-          {"name":"android_sdk","path":"android"},
-          {"name":"chrome_and_driver_96","path":"chrome"},
-          {"name":"flutter_sdk","path":"flutter sdk"},
-          {"name":"openjdk_11","path":"java"},
-          {"name":"pub_cache","path":".pub-cache"}
+          {"name": "builder_linux_framework", "path": "builder"},
+          {"name": "android_sdk", "path": "android"},
+          {"name": "chrome_and_driver_96", "path": "chrome"},
+          {"name": "flutter_sdk", "path": "flutter sdk"},
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "pub_cache", "path": ".pub-cache"}
         ]
       dependencies: >-
         [
@@ -31,13 +31,13 @@ platform_properties:
     properties:
       caches: >-
         [
-          {"name":"builder_linux_devicelab","path":"builder"},
-          {"name":"android_sdk","path":"android"},
-          {"name":"chrome_and_driver_96","path":"chrome"},
-          {"name":"flutter_sdk","path":"flutter sdk"},
-          {"name":"gradle","path":"gradle"},
-          {"name":"openjdk_11","path":"java"},
-          {"name":"pub_cache","path":".pub-cache"}
+          {"name": "builder_linux_devicelab", "path": "builder"},
+          {"name": "android_sdk", "path": "android"},
+          {"name": "chrome_and_driver_96", "path": "chrome"},
+          {"name": "flutter_sdk", "path": "flutter sdk"},
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "pub_cache", "path": ".pub-cache"}
         ]
       dependencies: >-
         [
@@ -51,13 +51,13 @@ platform_properties:
     properties:
       caches: >-
         [
-          {"name":"builder_linux_devicelab","path":"builder"},
-          {"name":"android_sdk","path":"android"},
-          {"name":"chrome_and_driver_96","path":"chrome"},
-          {"name":"flutter_sdk","path":"flutter sdk"},
-          {"name":"gradle","path":"gradle"},
-          {"name":"openjdk_11","path":"java"},
-          {"name":"pub_cache","path":".pub-cache"}
+          {"name": "builder_linux_devicelab", "path": "builder"},
+          {"name": "android_sdk", "path": "android"},
+          {"name": "chrome_and_driver_96", "path": "chrome"},
+          {"name": "flutter_sdk", "path": "flutter sdk"},
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "pub_cache", "path": ".pub-cache"}
         ]
       dependencies: >-
         [
@@ -71,14 +71,14 @@ platform_properties:
     properties:
       caches: >-
         [
-          {"name":"builder_mac_framework","path":"builder"},
-          {"name":"android_sdk","path":"android"},
-          {"name":"chrome_and_driver_96","path":"chrome"},
-          {"name":"flutter_sdk","path":"flutter sdk"},
-          {"name":"openjdk_11","path":"java"},
-          {"name":"osx_sdk_13a233","path":"osx_sdk"},
-          {"name":"pub_cache","path":".pub-cache"},
-          {"name":"xcode_binary","path":"xcode_binary"}
+          {"name": "builder_mac_framework", "path": "builder"},
+          {"name": "android_sdk", "path": "android"},
+          {"name": "chrome_and_driver_96", "path": "chrome"},
+          {"name": "flutter_sdk", "path": "flutter sdk"},
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "osx_sdk_13a233", "path": "osx_sdk"},
+          {"name": "pub_cache", "path": ".pub-cache"},
+          {"name": "xcode_binary", "path": "xcode_binary"}
         ]
       dependencies: >-
         []
@@ -90,13 +90,13 @@ platform_properties:
     properties:
       caches: >-
           [
-            {"name":"builder_mac_devicelab","path":"builder"},
-            {"name":"android_sdk","path":"android"},
-            {"name":"chrome_and_driver_96","path":"chrome"},
-            {"name":"flutter_sdk","path":"flutter sdk"},
-            {"name":"gradle","path":"gradle"},
-            {"name":"openjdk_11","path":"java"},
-            {"name":"pub_cache","path":".pub-cache"}
+            {"name": "builder_mac_devicelab", "path": "builder"},
+            {"name": "android_sdk", "path": "android"},
+            {"name": "chrome_and_driver_96", "path": "chrome"},
+            {"name": "flutter_sdk", "path": "flutter sdk"},
+            {"name": "gradle", "path": "gradle"},
+            {"name": "openjdk_11", "path": "java"},
+            {"name": "pub_cache", "path": ".pub-cache"}
           ]
       dependencies: >-
         [
@@ -111,12 +111,12 @@ platform_properties:
     properties:
       caches: >-
           [
-            {"name":"builder_mac_devicelab","path":"builder"},
-            {"name":"android_sdk","path":"android"},
-            {"name":"flutter_sdk","path":"flutter sdk"},
-            {"name":"gradle","path":"gradle"},
-            {"name":"openjdk_11","path":"java"},
-            {"name":"pub_cache","path":".pub-cache"}
+            {"name":"builder_mac_devicelab", "path":"builder"},
+            {"name": "android_sdk", "path": "android"},
+            {"name": "flutter_sdk", "path": "flutter sdk"},
+            {"name": "gradle", "path": "gradle"},
+            {"name": "openjdk_11", "path": "java"},
+            {"name": "pub_cache", "path": ".pub-cache"}
           ]
       dependencies: >-
         [
@@ -130,14 +130,14 @@ platform_properties:
     properties:
       caches: >-
           [
-            {"name":"builder_mac_devicelab","path":"builder"},
-            {"name":"chrome_and_driver_96","path":"chrome"},
-            {"name":"flutter_sdk","path":"flutter sdk"},
-            {"name":"gradle","path":"gradle"},
-            {"name":"openjdk_11","path":"java"},
-            {"name":"pub_cache","path":".pub-cache"},
-            {"name":"xcode_binary","path":"xcode_binary"},
-            {"name":"osx_sdk_13a233","path":"osx_sdk"}
+            {"name": "builder_mac_devicelab", "path": "builder"},
+            {"name": "chrome_and_driver_96", "path": "chrome"},
+            {"name": "flutter_sdk", "path": "flutter sdk"},
+            {"name": "gradle", "path": "gradle"},
+            {"name": "openjdk_11", "path": "java"},
+            {"name": "pub_cache", "path": ".pub-cache"},
+            {"name": "xcode_binary", "path": "xcode_binary"},
+            {"name": "osx_sdk_13a233", "path": "osx_sdk"}
           ]
       dependencies: >-
         [
@@ -153,14 +153,14 @@ platform_properties:
     properties:
       caches: >-
           [
-            {"name":"builder_mac_devicelab","path":"builder"},
-            {"name":"chrome_and_driver_96","path":"chrome"},
-            {"name":"flutter_sdk","path":"flutter sdk"},
-            {"name":"gradle","path":"gradle"},
-            {"name":"openjdk","path":"java11"},
-            {"name":"pub_cache","path":".pub-cache"},
-            {"name":"xcode_binary","path":"xcode_binary"},
-            {"name":"osx_sdk_13a233","path":"osx_sdk"}
+            {"name": "builder_mac_devicelab", "path": "builder"},
+            {"name": "chrome_and_driver_96", "path": "chrome"},
+            {"name": "flutter_sdk", "path": "flutter sdk"},
+            {"name": "gradle", "path": "gradle"},
+            {"name": "openjdk", "path": "java11"},
+            {"name": "pub_cache", "path": ".pub-cache"},
+            {"name": "xcode_binary", "path": "xcode_binary"},
+            {"name": "osx_sdk_13a233", "path": "osx_sdk"}
           ]
       dependencies: >-
         [
@@ -176,13 +176,13 @@ platform_properties:
     properties:
       caches: >-
           [
-            {"name":"builder_win_framework","path":"builder"},
-            {"name":"android_sdk","path":"android"},
-            {"name":"chrome_and_driver_96","path":"chrome"},
-            {"name":"flutter_sdk","path":"flutter sdk"},
-            {"name":"openjdk_11","path":"java"},
-            {"name":"pub_cache","path":".pub-cache"},
-            {"name":"vsbuild","path":"vsbuild"}
+            {"name": "builder_win_framework", "path": "builder"},
+            {"name": "android_sdk", "path": "android"},
+            {"name": "chrome_and_driver_96", "path": "chrome"},
+            {"name": "flutter_sdk", "path": "flutter sdk"},
+            {"name": "openjdk_11", "path": "java"},
+            {"name": "pub_cache", "path": ".pub-cache"},
+            {"name": "vsbuild", "path": "vsbuild"}
           ]
       dependencies: >-
           [
@@ -194,13 +194,13 @@ platform_properties:
     properties:
       caches: >-
           [
-            {"name":"builder_win_devicelab","path":"builder"},
-            {"name":"android_sdk","path":"android"},
-            {"name":"chrome_and_driver_96","path":"chrome"},
-            {"name":"flutter_sdk","path":"flutter sdk"},
-            {"name":"gradle","path":"gradle"},
-            {"name":"openjdk_11","path":"java"},
-            {"name":"pub_cache","path":".pub-cache"}
+            {"name": "builder_win_devicelab", "path": "builder"},
+            {"name": "android_sdk", "path": "android"},
+            {"name": "chrome_and_driver_96", "path": "chrome"},
+            {"name": "flutter_sdk", "path": "flutter sdk"},
+            {"name": "gradle", "path": "gradle"},
+            {"name": "openjdk_11", "path": "java"},
+            {"name": "pub_cache", "path": ".pub-cache"}
           ]
       dependencies: >-
           [
@@ -239,7 +239,7 @@ targets:
       shard: build_tests
       subshard: "1_2"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
 
   - name: Linux build_tests_2_2
     recipe: flutter/flutter_drone
@@ -258,14 +258,14 @@ targets:
       shard: build_tests
       subshard: "2_2"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
 
   - name: Linux ci_yaml flutter roller
     recipe: infra/ci_yaml
     timeout: 30
     properties:
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - .ci.yaml
 
@@ -274,7 +274,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["framework","hostonly"]
+        ["framework", "hostonly"]
       validation: customer_testing
       validation_name: Customer testing
 
@@ -292,7 +292,7 @@ targets:
           {"dependency": "firebase"}
         ]
       tags: >
-        ["framework","hostonly"]
+        ["framework", "hostonly"]
       validation: docs
       validation_name: Docs
       firebase_project: master-docs-flutter-dev
@@ -364,7 +364,7 @@ targets:
       shard: flutter_plugins
       subshard: analyze
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
 
   - name: Linux framework_tests_libraries
     recipe: flutter/flutter_drone
@@ -407,7 +407,7 @@ targets:
       shard: framework_tests
       subshard: misc
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/flutter/
@@ -453,7 +453,7 @@ targets:
       validation: fuchsia_precache
       validation_name: Fuchsia precache
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
 
   - name: Linux gradle_desugar_classes_test
     recipe: devicelab/devicelab_drone
@@ -461,7 +461,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -471,7 +471,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_desugar_classes_test
     runIf:
       - dev/**
@@ -494,7 +494,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_java8_compile_test
     runIf:
       - dev/**
@@ -507,7 +507,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -517,7 +517,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_plugin_bundle_test
     runIf:
       - dev/**
@@ -530,7 +530,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -540,7 +540,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_plugin_fat_apk_test
     runIf:
       - dev/**
@@ -553,7 +553,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -563,7 +563,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_plugin_light_apk_test
     runIf:
       - dev/**
@@ -576,7 +576,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -586,7 +586,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_custom_host_app_name_test
     runIf:
       - dev/**
@@ -600,7 +600,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -608,7 +609,7 @@ targets:
           {"dependency": "chrome_and_driver", "version": "version:96.2"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_host_with_custom_build_test
     runIf:
       - dev/**
@@ -622,7 +623,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle", "path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -632,7 +633,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_test
     runIf:
       - dev/**
@@ -646,7 +647,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -656,7 +657,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_dependencies_test
     runIf:
       - dev/**
@@ -670,7 +671,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle", "path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -680,7 +681,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_test
     runIf:
       - dev/**
@@ -698,7 +699,7 @@ targets:
       shard: skp_generator
       subshard: "0"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/flutter/
@@ -711,17 +712,13 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      caches: >-
-        [
-          {"name":"gradle","path":"gradle"}
-        ]
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
           {"dependency": "chrome_and_driver", "version": "version:96.2"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: technical_debt__cost
 
   - name: Linux test_ownership
@@ -731,7 +728,7 @@ targets:
       - master
     properties:
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - .ci.yaml
 
@@ -751,7 +748,7 @@ targets:
       shard: tool_integration_tests
       subshard: "1_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     runIf:
       - dev/
@@ -775,7 +772,7 @@ targets:
       shard: tool_integration_tests
       subshard: "2_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     runIf:
       - dev/
@@ -799,7 +796,7 @@ targets:
       shard: tool_integration_tests
       subshard: "3_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     runIf:
       - dev/
@@ -823,7 +820,7 @@ targets:
       shard: tool_integration_tests
       subshard: "4_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     runIf:
       - dev/
@@ -844,7 +841,7 @@ targets:
       shard: tool_tests
       subshard: commands
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/flutter_tools/
@@ -864,7 +861,7 @@ targets:
       shard: tool_tests
       subshard: general
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/flutter_tools/
@@ -878,7 +875,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -895,7 +893,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -923,7 +922,7 @@ targets:
       shard: web_long_running_tests
       subshard: "1_5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/
@@ -943,7 +942,7 @@ targets:
       shard: web_long_running_tests
       subshard: "2_5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/
@@ -963,7 +962,7 @@ targets:
       shard: web_long_running_tests
       subshard: "3_5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/
@@ -983,7 +982,7 @@ targets:
       shard: web_long_running_tests
       subshard: "4_5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/
@@ -1003,7 +1002,7 @@ targets:
       shard: web_long_running_tests
       subshard: "5_5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     runIf:
       - dev/
       - packages/
@@ -1023,7 +1022,7 @@ targets:
       shard: web_tests
       subshard: "0"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1044,7 +1043,7 @@ targets:
       shard: web_tests
       subshard: "1"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1065,7 +1064,7 @@ targets:
       shard: web_tests
       subshard: "2"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1086,7 +1085,7 @@ targets:
       shard: web_tests
       subshard: "3"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1107,7 +1106,7 @@ targets:
       shard: web_tests
       subshard: "4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1128,7 +1127,7 @@ targets:
       shard: web_tests
       subshard: "5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1149,7 +1148,7 @@ targets:
       shard: web_tests
       subshard: "6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1170,7 +1169,7 @@ targets:
       shard: web_tests
       subshard: "7_last"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1191,7 +1190,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "0"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1211,7 +1210,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "1"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1231,7 +1230,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "2"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1251,7 +1250,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "3"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1271,7 +1270,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1291,7 +1290,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "5"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1311,7 +1310,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1331,7 +1330,7 @@ targets:
       shard: web_canvaskit_tests
       subshard: "7_last"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1352,7 +1351,7 @@ targets:
       shard: web_tool_tests
       subshard: web
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -1366,7 +1365,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: analyzer_benchmark
     scheduler: luci
 
@@ -1376,7 +1375,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab" ,"android", "linux"]
       task_name: android_defines_test
     scheduler: luci
 
@@ -1386,7 +1385,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_obfuscate_test
     scheduler: luci
 
@@ -1396,7 +1395,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_semantics_integration_test
 
   - name: Linux_android android_stack_size_test
@@ -1405,7 +1404,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_stack_size_test
     scheduler: luci
 
@@ -1415,7 +1414,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_view_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -1425,7 +1424,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: animated_image_gc_perf
     scheduler: luci
 
@@ -1436,7 +1435,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: animated_complex_opacity_perf__e2e_summary
 
   - name: Linux_android animated_placeholder_perf__e2e_summary
@@ -1445,7 +1444,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: animated_placeholder_perf__e2e_summary
     scheduler: luci
 
@@ -1455,7 +1454,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: backdrop_filter_perf__e2e_summary
     scheduler: luci
 
@@ -1465,7 +1464,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: backdrop_filter_perf__timeline_summary
     scheduler: luci
 
@@ -1475,7 +1474,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: basic_material_app_android__compile
     scheduler: luci
 
@@ -1485,7 +1484,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: channels_integration_test
     scheduler: luci
 
@@ -1495,7 +1494,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: color_filter_and_fade_perf__e2e_summary
     scheduler: luci
 
@@ -1505,7 +1504,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: color_filter_cache_perf__e2e_summary
     scheduler: luci
 
@@ -1515,7 +1514,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: shader_mask_cache_perf__e2e_summary
     scheduler: luci
 
@@ -1525,7 +1524,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: complex_layout_android__compile
       dependencies: >-
         [
@@ -1533,7 +1532,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1543,7 +1543,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: complex_layout_android__scroll_smoothness
       dependencies: >-
         [
@@ -1551,7 +1551,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1569,7 +1570,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1587,7 +1589,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1605,7 +1608,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1615,7 +1619,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: complex_layout_scroll_perf__timeline_summary
       dependencies: >-
         [
@@ -1623,7 +1627,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1633,7 +1638,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: complex_layout_semantics_perf
       dependencies: >-
         [
@@ -1641,7 +1646,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1651,7 +1657,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: complex_layout__start_up
       dependencies: >-
         [
@@ -1659,7 +1665,8 @@ targets:
         ]
       caches: >-
         [
-          {"name": "openjdk_11", "path": "java"}
+          {"name": "openjdk_11", "path": "java"},
+          {"name": "gradle", "path": "gradle"}
         ]
     scheduler: luci
 
@@ -1669,7 +1676,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: cubic_bezier_perf__e2e_summary
     scheduler: luci
 
@@ -1679,7 +1686,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: cubic_bezier_perf_sksl_warmup__e2e_summary
     scheduler: luci
 
@@ -1689,7 +1696,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: cubic_bezier_perf__timeline_summary
     scheduler: luci
 
@@ -1699,7 +1706,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: cull_opacity_perf__e2e_summary
     scheduler: luci
 
@@ -1709,7 +1716,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: cull_opacity_perf__timeline_summary
     scheduler: luci
 
@@ -1719,7 +1726,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: devtools_profile_start_test
     scheduler: luci
 
@@ -1729,7 +1736,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: drive_perf_debug_warning
     scheduler: luci
 
@@ -1739,7 +1746,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: embedded_android_views_integration_test
     scheduler: luci
 
@@ -1749,7 +1756,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: external_ui_integration_test
     scheduler: luci
 
@@ -1759,7 +1766,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: fading_child_animation_perf__timeline_summary
     scheduler: luci
 
@@ -1769,7 +1776,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: fast_scroll_heavy_gridview__memory
     scheduler: luci
 
@@ -1779,7 +1786,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: fast_scroll_large_images__memory
     scheduler: luci
 
@@ -1789,7 +1796,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flavors_test
     scheduler: luci
 
@@ -1799,7 +1806,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_engine_group_performance
     scheduler: luci
 
@@ -1809,7 +1816,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery__back_button_memory
     scheduler: luci
 
@@ -1819,7 +1826,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery__image_cache_memory
     scheduler: luci
 
@@ -1829,7 +1836,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab" ,"android", "linux"]
       task_name: flutter_gallery__memory_nav
     scheduler: luci
 
@@ -1839,7 +1846,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery__start_up
     scheduler: luci
 
@@ -1849,7 +1856,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery__start_up_delayed
     scheduler: luci
 
@@ -1859,7 +1866,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery_android__compile
     scheduler: luci
 
@@ -1869,7 +1876,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery_v2_chrome_run_test
     scheduler: luci
 
@@ -1879,7 +1886,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_gallery_v2_web_compile_test
     scheduler: luci
 
@@ -1889,7 +1896,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_test_performance
     scheduler: luci
 
@@ -1899,7 +1906,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: flutter_view__start_up
     scheduler: luci
 
@@ -1909,7 +1916,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: frame_policy_delay_test_android
     scheduler: luci
 
@@ -1919,7 +1926,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: fullscreen_textfield_perf
     scheduler: luci
 
@@ -1929,7 +1936,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: fullscreen_textfield_perf__e2e_summary
     scheduler: luci
 
@@ -1939,7 +1946,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: hello_world__memory
     scheduler: luci
 
@@ -1949,7 +1956,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: home_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -1958,7 +1965,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: hot_mode_dev_cycle_linux__benchmark
     runIf:
       - dev/**
@@ -1970,7 +1977,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: hybrid_android_views_integration_test
     scheduler: luci
 
@@ -1980,7 +1987,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: image_list_jit_reported_duration
     scheduler: luci
 
@@ -1990,7 +1997,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: imagefiltered_transform_animation_perf__timeline_summary
     scheduler: luci
 
@@ -2000,7 +2007,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: imagefiltered_transform_animation_perf__timeline_summary
     scheduler: luci
 
@@ -2010,7 +2017,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: image_list_reported_duration
     scheduler: luci
 
@@ -2020,7 +2027,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab" ,"android", "linux"]
       task_name: integration_ui_driver
     scheduler: luci
 
@@ -2030,7 +2037,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: integration_ui_keyboard_resize
     scheduler: luci
 
@@ -2040,7 +2047,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: integration_ui_screenshot
     scheduler: luci
 
@@ -2050,7 +2057,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: integration_ui_textfield
     scheduler: luci
 
@@ -2060,7 +2067,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: large_image_changer_perf_android
     scheduler: luci
 
@@ -2070,7 +2077,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: linux_chrome_dev_mode
     scheduler: luci
 
@@ -2080,7 +2087,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: multi_widget_construction_perf__e2e_summary
     scheduler: luci
 
@@ -2091,7 +2098,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: new_gallery__crane_perf
 
   - name: Linux_android new_gallery__transition_perf
@@ -2100,7 +2107,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: new_gallery__transition_perf
     scheduler: luci
 
@@ -2110,7 +2117,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: new_gallery__transition_perf
     scheduler: luci
 
@@ -2120,7 +2127,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: picture_cache_perf__e2e_summary
     scheduler: luci
 
@@ -2130,7 +2137,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: picture_cache_perf__timeline_summary
     scheduler: luci
 
@@ -2140,7 +2147,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_picture_cache_complexity_scoring_perf__timeline_summary
     scheduler: luci
 
@@ -2150,7 +2157,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: platform_channels_benchmarks
     scheduler: luci
 
@@ -2160,7 +2167,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: platform_channel_sample_test
     scheduler: luci
 
@@ -2170,7 +2177,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: platform_interaction_test
     scheduler: luci
 
@@ -2180,7 +2187,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: platform_views_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -2190,7 +2197,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: platform_views_scroll_perf__timeline_summary
     scheduler: luci
 
@@ -2200,7 +2207,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: platform_view__start_up
     scheduler: luci
 
@@ -2210,7 +2217,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: routing_test
     scheduler: luci
 
@@ -2220,7 +2227,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: service_extensions_test
     scheduler: luci
 
@@ -2230,7 +2237,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: textfield_perf__e2e_summary
     scheduler: luci
 
@@ -2240,7 +2247,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux","samsung","s10"]
+        ["devicelab", "android", "linux", "samsung", "s10"]
       task_name: textfield_perf__timeline_summary
     scheduler: luci
 
@@ -2258,6 +2265,7 @@ targets:
         ]
       caches: >-
         [
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
     scheduler: luci
@@ -2268,7 +2276,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: web_size__compile_test
     scheduler: luci
 
@@ -2278,7 +2286,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_one_rect_perf__e2e_summary
     scheduler: luci
 
@@ -2288,7 +2296,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_col_of_rows_perf__e2e_summary
     scheduler: luci
 
@@ -2298,7 +2306,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_opacity_of_grid_perf__e2e_summary
     scheduler: luci
 
@@ -2308,7 +2316,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_grid_of_opacity_perf__e2e_summary
     scheduler: luci
 
@@ -2318,7 +2326,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_fade_transition_text_perf__e2e_summary
     scheduler: luci
 
@@ -2328,7 +2336,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_grid_of_alpha_savelayers_perf__e2e_summary
     scheduler: luci
 
@@ -2338,7 +2346,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: opacity_peephole_col_of_alpha_savelayer_rows_perf__e2e_summary
     scheduler: luci
 
@@ -2348,7 +2356,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: gradient_dynamic_perf__e2e_summary
 
   - name: Linux_android gradient_consistent_perf__e2e_summary
@@ -2358,7 +2366,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: gradient_consistent_perf__e2e_summary
 
   - name: Linux_android gradient_static_perf__e2e_summary
@@ -2368,7 +2376,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: gradient_static_perf__e2e_summary
 
   - name: Linux_android android_choreographer_do_frame_test
@@ -2377,7 +2385,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_choreographer_do_frame_test
     scheduler: luci
 
@@ -2388,7 +2396,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","linux"]
+        ["devicelab", "android", "linux"]
       task_name: android_lifecycles_test
 
   - name: Mac build_ios_framework_module_test
@@ -2397,7 +2405,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -2407,7 +2416,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: build_ios_framework_module_test
     scheduler: luci
     runIf:
@@ -2422,7 +2431,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: build_ios_framework_module_test
     runIf:
       - dev/**
@@ -2448,7 +2457,7 @@ targets:
       shard: build_tests
       subshard: "1_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Mac build_tests_2_4
@@ -2468,7 +2477,7 @@ targets:
       shard: build_tests
       subshard: "2_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Mac build_tests_3_4
@@ -2488,7 +2497,7 @@ targets:
       shard: build_tests
       subshard: "3_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Mac build_tests_4_4
@@ -2508,7 +2517,7 @@ targets:
       shard: build_tests
       subshard: "4_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Mac customer_testing
@@ -2519,7 +2528,7 @@ targets:
       validation: customer_testing
       validation_name: Customer testing
       tags: >
-        ["framework","hostonly"]
+        ["framework", "hostonly"]
     scheduler: luci
 
   - name: Mac dart_plugin_registry_test
@@ -2528,7 +2537,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -2536,7 +2546,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: dart_plugin_registry_test
     scheduler: luci
     runIf:
@@ -2556,7 +2566,7 @@ targets:
       shard: framework_tests
       subshard: libraries
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -2586,7 +2596,7 @@ targets:
       shard: framework_tests
       subshard: misc
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -2612,7 +2622,7 @@ targets:
       shard: framework_tests
       subshard: widgets
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -2633,7 +2643,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -2641,7 +2652,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_plugin_bundle_test
     scheduler: luci
     runIf:
@@ -2655,7 +2666,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -2664,7 +2675,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_custom_host_app_name_test
     scheduler: luci
     runIf:
@@ -2679,7 +2690,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -2687,7 +2699,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_host_with_custom_build_test
     scheduler: luci
     runIf:
@@ -2702,7 +2714,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -2711,7 +2723,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_test
     scheduler: luci
     runIf:
@@ -2724,11 +2736,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      caches: >-
-        [
-          {"name":"gradle","path":"gradle"},
-          {"name": "openjdk_11", "path": "java"}
-        ]
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
@@ -2737,7 +2744,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_test_ios
     scheduler: luci
     runIf:
@@ -2763,7 +2770,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_dependencies_test
     scheduler: luci
     runIf:
@@ -2776,10 +2783,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      caches: >-
-        [
-          {"name":"gradle","path":"gradle"}
-        ]
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:31v8"},
@@ -2788,7 +2791,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_lint_mac
     scheduler: luci
     runIf:
@@ -2804,7 +2807,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -2812,7 +2816,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_test
     scheduler: luci
     runIf:
@@ -2827,7 +2831,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name": "gradle", "path": "gradle"}
         ]
       dependencies: >-
         [
@@ -2837,7 +2841,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_test_ios
     scheduler: luci
     runIf:
@@ -2858,7 +2862,7 @@ targets:
         ]
       shard: tool_host_cross_arch_tests
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     runIf:
       - dev/**
@@ -2883,7 +2887,7 @@ targets:
       shard: tool_integration_tests
       subshard: "1_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -2909,7 +2913,7 @@ targets:
       shard: tool_integration_tests
       subshard: "2_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -2935,7 +2939,7 @@ targets:
       shard: tool_integration_tests
       subshard: "3_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -2961,7 +2965,7 @@ targets:
       shard: tool_integration_tests
       subshard: "4_4"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -2983,7 +2987,7 @@ targets:
       shard: tool_tests
       subshard: commands
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Mac tool_tests_general
@@ -2999,7 +3003,7 @@ targets:
       shard: tool_tests
       subshard: general
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -3020,7 +3024,7 @@ targets:
           {"dependency": "xcode"}
         ]
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       validation: verify_binaries_codesigned
       validation_name: Verify binaries codesigned
     scheduler: luci
@@ -3039,7 +3043,7 @@ targets:
       shard: web_tool_tests
       subshard: web
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -3052,7 +3056,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: entrypoint_dart_registrant
     runIf:
       - dev/**
@@ -3066,7 +3070,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: hello_world_android__compile
     scheduler: luci
 
@@ -3077,7 +3081,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac","arm64"]
+        ["devicelab", "android", "mac", "arm64"]
       task_name: hello_world_android__compile
 
   - name: Mac_android hot_mode_dev_cycle__benchmark
@@ -3086,7 +3090,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: hot_mode_dev_cycle__benchmark
     scheduler: luci
 
@@ -3096,7 +3100,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: integration_test_test
     scheduler: luci
 
@@ -3107,7 +3111,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac","arm64"]
+        ["devicelab", "android", "mac", "arm64"]
       task_name: integration_test_test
 
   - name: Mac_android integration_ui_frame_number
@@ -3116,7 +3120,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: integration_ui_frame_number
     scheduler: luci
 
@@ -3126,7 +3130,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: microbenchmarks
     scheduler: luci
 
@@ -3137,7 +3141,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: run_release_test
     scheduler: luci
 
@@ -3150,7 +3154,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac","arm64"]
+        ["devicelab", "android", "mac", "arm64"]
       task_name: run_release_test
 
   - name: Mac_android flutter_gallery_mac__start_up
@@ -3159,7 +3163,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","mac"]
+        ["devicelab", "android", "mac"]
       task_name: flutter_gallery_mac__start_up
     scheduler: luci
 
@@ -3169,7 +3173,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3179,7 +3183,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: backdrop_filter_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3189,7 +3193,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: basic_material_app_ios__compile
     scheduler: luci
 
@@ -3199,7 +3203,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: channels_integration_test_ios
     scheduler: luci
 
@@ -3209,7 +3213,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: complex_layout_ios__compile
       dependencies: >-
         [
@@ -3227,7 +3231,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: complex_layout_ios__start_up
       dependencies: >-
         [
@@ -3245,7 +3249,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: complex_layout_scroll_perf_ios__timeline_summary
       dependencies: >-
         [
@@ -3264,7 +3268,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: cubic_bezier_perf_ios_sksl_warmup__timeline_summary
 
   - name: Mac_ios external_ui_integration_test_ios
@@ -3273,7 +3277,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: external_ui_integration_test_ios
     scheduler: luci
 
@@ -3283,7 +3287,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: route_test_ios
     scheduler: luci
 
@@ -3293,7 +3297,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: flavors_test_ios
     scheduler: luci
 
@@ -3303,7 +3307,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__compile
     scheduler: luci
 
@@ -3313,7 +3317,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: flutter_gallery_ios__compile
     scheduler: luci
 
@@ -3323,7 +3327,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__start_up
     scheduler: luci
 
@@ -3333,7 +3337,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: flutter_view_ios__start_up
 
   - name: Mac_ios hello_world_ios__compile
@@ -3342,7 +3346,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: hello_world_ios__compile
     scheduler: luci
 
@@ -3352,7 +3356,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: hello_world_ios__compile
     scheduler: luci
 
@@ -3361,7 +3365,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - dev/**
@@ -3374,7 +3378,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - dev/**
@@ -3386,7 +3390,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: integration_test_test_ios
     scheduler: luci
 
@@ -3396,7 +3400,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_driver
     scheduler: luci
 
@@ -3406,7 +3410,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_frame_number
     scheduler: luci
 
@@ -3416,7 +3420,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_keyboard_resize
     scheduler: luci
 
@@ -3426,7 +3430,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_screenshot
     scheduler: luci
 
@@ -3436,7 +3440,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_textfield
     scheduler: luci
 
@@ -3446,7 +3450,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: ios_app_with_extensions_test
     scheduler: luci
 
@@ -3456,7 +3460,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: ios_app_with_extensions_test
     scheduler: luci
 
@@ -3466,7 +3470,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: ios_content_validation_test
     scheduler: luci
 
@@ -3476,7 +3480,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: ios_content_validation_test
     scheduler: luci
 
@@ -3486,7 +3490,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: ios_defines_test
     scheduler: luci
 
@@ -3496,7 +3500,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: ios_platform_view_tests
     scheduler: luci
 
@@ -3507,7 +3511,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: large_image_changer_perf_ios
 
   - name: Mac_ios macos_chrome_dev_mode
@@ -3516,7 +3520,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: macos_chrome_dev_mode
     scheduler: luci
 
@@ -3526,7 +3530,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: macos_chrome_dev_mode
     scheduler: luci
 
@@ -3536,7 +3540,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios
     scheduler: luci
 
@@ -3547,7 +3551,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: new_gallery_ios__transition_perf
 
   - name: Mac_ios new_gallery_impeller_ios__transition_perf
@@ -3557,7 +3561,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: new_gallery_impeller_ios__transition_perf
 
   - name: Mac_ios ios_picture_cache_complexity_scoring_perf__timeline_summary
@@ -3566,7 +3570,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: ios_picture_cache_complexity_scoring_perf__timeline_summary
     scheduler: luci
 
@@ -3576,7 +3580,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: platform_channel_sample_test_ios
     scheduler: luci
 
@@ -3586,7 +3590,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: platform_channel_sample_test_swift
     scheduler: luci
 
@@ -3596,7 +3600,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: platform_channels_benchmarks_ios
     scheduler: luci
 
@@ -3606,7 +3610,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: platform_interaction_test_ios
     scheduler: luci
 
@@ -3616,7 +3620,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: platform_view_ios__start_up
     scheduler: luci
 
@@ -3626,7 +3630,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: platform_views_scroll_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3636,7 +3640,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: post_backdrop_filter_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3646,7 +3650,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: simple_animation_perf_ios
     scheduler: luci
 
@@ -3657,7 +3661,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
 
   - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
@@ -3666,7 +3670,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
     scheduler: luci
 
@@ -3676,7 +3680,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac"]
+        ["devicelab", "ios", "mac"]
       task_name: native_ui_tests_ios
 
   - name: Mac_arm64_ios native_ui_tests_ios
@@ -3685,7 +3689,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: native_ui_tests_ios
     scheduler: luci
 
@@ -3699,7 +3703,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: native_ui_tests_macos
     scheduler: luci
     runIf:
@@ -3718,7 +3722,7 @@ targets:
           {"dependency": "gems"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: run_release_test_macos
     runIf:
       - dev/**
@@ -3733,7 +3737,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","ios","mac","arm64"]
+        ["devicelab", "ios", "mac", "arm64"]
       task_name: run_release_test_macos
     runIf:
       - dev/**
@@ -3758,7 +3762,7 @@ targets:
       shard: build_tests
       subshard: "1_3"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Windows build_tests_2_3
@@ -3777,7 +3781,7 @@ targets:
       shard: build_tests
       subshard: "2_3"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Windows build_tests_3_3
@@ -3796,7 +3800,7 @@ targets:
       shard: build_tests
       subshard: "3_3"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
 
   - name: Windows customer_testing
@@ -3807,7 +3811,7 @@ targets:
       validation: customer_testing
       validation_name: Customer testing
       tags: >
-        ["framework","hostonly"]
+        ["framework", "hostonly"]
     scheduler: luci
 
   - name: Windows framework_tests_libraries
@@ -3821,7 +3825,7 @@ targets:
       shard: framework_tests
       subshard: libraries
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -3850,7 +3854,7 @@ targets:
       shard: framework_tests
       subshard: misc
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -3876,7 +3880,7 @@ targets:
       shard: framework_tests
       subshard: widgets
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/
@@ -3897,7 +3901,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name":"gradle", "path":"gradle"}
         ]
       dependencies: >-
         [
@@ -3906,7 +3910,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: gradle_plugin_bundle_test
     scheduler: luci
     runIf:
@@ -3921,14 +3925,14 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name":"gradle", "path":"gradle"}
         ]
       dependencies: >-
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: hot_mode_dev_cycle_win_target__benchmark
     scheduler: luci
 
@@ -3944,10 +3948,11 @@ targets:
         ]
       caches: >-
         [
+          {"name":"gradle", "path":"gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: module_custom_host_app_name_test
     scheduler: luci
     runIf:
@@ -3957,30 +3962,6 @@ targets:
       - .ci.yaml
 
   - name: Windows module_host_with_custom_build_test
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      caches: >-
-        [
-          {"name":"gradle","path":"gradle"}
-        ]
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:31v8"},
-          {"dependency": "chrome_and_driver", "version": "version:96.2"},
-          {"dependency": "open_jdk", "version": "11"}
-        ]
-      tags: >
-        ["devicelab","hostonly"]
-      task_name: module_host_with_custom_build_test
-    scheduler: luci
-    runIf:
-      - dev/**
-      - packages/flutter_tools/**
-      - bin/**
-      - .ci.yaml
-
-  - name: Windows module_test
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -3996,7 +3977,32 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
+      task_name: module_host_with_custom_build_test
+    scheduler: luci
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
+
+  - name: Windows module_test
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      caches: >-
+        [
+          {"name": "gradle", "path": "gradle"},
+          {"name": "openjdk_11", "path": "java"}
+        ]
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:31v8"},
+          {"dependency": "chrome_and_driver", "version": "version:96.2"},
+          {"dependency": "open_jdk", "version": "11"}
+        ]
+      tags: >
+        ["devicelab", "hostonly"]
       task_name: module_test
     scheduler: luci
     runIf:
@@ -4011,7 +4017,7 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"},
+          {"name": "gradle", "path": "gradle"},
           {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
@@ -4021,7 +4027,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_dependencies_test
     scheduler: luci
     runIf:
@@ -4036,7 +4042,8 @@ targets:
     properties:
       caches: >-
         [
-          {"name":"gradle","path":"gradle"}
+          {"name":"gradle", "path":"gradle"},
+          {"name": "openjdk_11", "path": "java"}
         ]
       dependencies: >-
         [
@@ -4045,7 +4052,7 @@ targets:
           {"dependency": "open_jdk", "version": "11"}
         ]
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       task_name: plugin_test
     scheduler: luci
     runIf:
@@ -4070,7 +4077,7 @@ targets:
       shard: tool_integration_tests
       subshard: "1_6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -4095,7 +4102,7 @@ targets:
       shard: tool_integration_tests
       subshard: "2_6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -4120,7 +4127,7 @@ targets:
       shard: tool_integration_tests
       subshard: "3_6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -4145,7 +4152,7 @@ targets:
       shard: tool_integration_tests
       subshard: "4_6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -4170,7 +4177,7 @@ targets:
       shard: tool_integration_tests
       subshard: "5_6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -4195,7 +4202,7 @@ targets:
       shard: tool_integration_tests
       subshard: "6_6"
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
       test_timeout_secs: "2700"
     scheduler: luci
     runIf:
@@ -4217,7 +4224,7 @@ targets:
       shard: tool_tests
       subshard: commands
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -4238,7 +4245,7 @@ targets:
       shard: tool_tests
       subshard: general
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -4260,7 +4267,7 @@ targets:
       shard: web_tool_tests
       subshard: web
       tags: >
-        ["framework","hostonly","shard"]
+        ["framework", "hostonly", "shard"]
     scheduler: luci
     runIf:
       - dev/**
@@ -4273,7 +4280,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","hostonly"]
+        ["devicelab", "hostonly"]
       dependencies: >-
         [
           {"dependency": "vs_build", "version": "version:vs2019"}
@@ -4287,7 +4294,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: basic_material_app_win__compile
     scheduler: luci
 
@@ -4297,7 +4304,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: channels_integration_test_win
     scheduler: luci
 
@@ -4307,7 +4314,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: complex_layout_win__compile
       dependencies: >-
         [
@@ -4325,7 +4332,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: flavors_test_win
     scheduler: luci
 
@@ -4335,7 +4342,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: flutter_gallery_win__compile
     scheduler: luci
 
@@ -4345,7 +4352,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: hot_mode_dev_cycle_win__benchmark
     scheduler: luci
 
@@ -4355,7 +4362,7 @@ targets:
     timeout: 60
     properties:
       tags: >
-        ["devicelab","android","windows"]
+        ["devicelab", "android", "windows"]
       task_name: windows_chrome_dev_mode
     scheduler: luci
 
@@ -4365,4 +4372,4 @@ targets:
     scheduler: google_internal
     properties:
       tags: >
-          ["framework","hostonly","shard"]
+          ["framework", "hostonly", "shard"]


### PR DESCRIPTION
* Mechanical transformation of the JSON objects, so spacing is consistent across all instances
* Add missing Gradle caches to tasks that use the Gradle build system (Should reduce network failures seen in https://github.com/flutter/flutter/issues/102661)
* Remove Gradle and openjdk caches from tasks that don't need those. e.g. ios-only tasks