### PR TITLE
[flutter_tools] add --uninstall-first flag and pipe it through to ios-deploy

### DIFF
--- a/dev/devicelab/lib/tasks/hot_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/hot_mode_tests.dart
@@ -33,7 +33,15 @@ TaskFunction createHotModeTest({String? deviceIdOverride, Map<String, String>? e
     final File benchmarkFile = file(path.join(_editedFlutterGalleryDir.path, 'hot_benchmark.json'));
     rm(benchmarkFile);
     final List<String> options = <String>[
-      '--hot', '-d', deviceIdOverride!, '--benchmark', '--resident',  '--no-android-gradle-daemon', '--no-publish-port', '--verbose',
+      '--hot',
+      '-d',
+      deviceIdOverride!,
+      '--benchmark',
+      '--resident',
+      '--no-android-gradle-daemon',
+      '--no-publish-port',
+      '--verbose',
+      '--uninstall-first',
     ];
     int hotReloadCount = 0;
     late Map<String, dynamic> smallReloadData;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -140,6 +140,12 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
               'this option multiple times each with one argument to pass '
               'multiple arguments to the Dart entrypoint. Currently this is '
               'only supported on desktop platforms.',
+      )
+      ..addFlag('uninstall-first',
+        hide: !verboseHelp,
+        help: 'Attempt to uninstall a previously installed app from the device '
+              'first before installing. This is normally not required and will '
+              'take longer. Currently only supported on iOS.',
     );
     usesWebOptions(verboseHelp: verboseHelp);
     usesTargetOption();
@@ -166,6 +172,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   bool get runningWithPrebuiltApplication => argResults[FlutterOptions.kUseApplicationBinary] != null;
   bool get trackWidgetCreation => boolArg('track-widget-creation');
   bool get enableImpeller => boolArg('enable-impeller');
+  bool get uninstallFirst => boolArg('uninstall-first');
 
   @override
   bool get reportNullSafety => true;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -143,9 +143,8 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
       )
       ..addFlag('uninstall-first',
         hide: !verboseHelp,
-        help: 'Attempt to uninstall a previously installed app from the device '
-              'first before installing. This is normally not required and will '
-              'take longer. Currently only supported on iOS.',
+        help: 'Uninstall previous versions of the app on the device '
+              'before reinstalling. Currently only supported on iOS.',
     );
     usesWebOptions(verboseHelp: verboseHelp);
     usesTargetOption();

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -203,6 +203,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webRunHeadless: featureFlags.isWebEnabled && boolArg('web-run-headless'),
         webBrowserDebugPort: browserDebugPort,
         enableImpeller: enableImpeller,
+        uninstallFirst: uninstallFirst,
       );
     } else {
       return DebuggingOptions.enabled(
@@ -247,6 +248,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         nullAssertions: boolArg('null-assertions'),
         nativeNullAssertions: boolArg('native-null-assertions'),
         enableImpeller: enableImpeller,
+        uninstallFirst: uninstallFirst,
       );
     }
   }

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -792,6 +792,7 @@ class DebuggingOptions {
     this.nullAssertions = false,
     this.nativeNullAssertions = false,
     this.enableImpeller = false,
+    this.uninstallFirst = false,
    }) : debuggingEnabled = true;
 
   DebuggingOptions.disabled(this.buildInfo, {
@@ -808,6 +809,7 @@ class DebuggingOptions {
       this.cacheSkSL = false,
       this.traceAllowlist,
       this.enableImpeller = false,
+      this.uninstallFirst = false,
     }) : debuggingEnabled = false,
       useTestFonts = false,
       startPaused = false,
@@ -876,6 +878,7 @@ class DebuggingOptions {
     required this.nullAssertions,
     required this.nativeNullAssertions,
     required this.enableImpeller,
+    required this.uninstallFirst,
   });
 
   final bool debuggingEnabled;
@@ -911,6 +914,11 @@ class DebuggingOptions {
   final bool webUseSseForDebugBackend;
   final bool webUseSseForInjectedClient;
   final bool enableImpeller;
+
+  /// Whether the tool should try to uninstall a previously installed version of the app.
+  ///
+  /// This is not implemented for every platform.
+  final bool uninstallFirst;
 
   /// Whether to run the browser in headless mode.
   ///
@@ -1026,6 +1034,7 @@ class DebuggingOptions {
       nullAssertions: (json['nullAssertions'] as bool?)!,
       nativeNullAssertions: (json['nativeNullAssertions'] as bool?)!,
       enableImpeller: (json['enableImpeller'] as bool?) ?? false,
+      uninstallFirst: (json['uninstallFirst'] as bool?) ?? false,
     );
 }
 

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -395,6 +395,7 @@ class IOSDevice extends Device {
             appDeltaDirectory: package.appDeltaDirectory,
             launchArguments: launchArguments,
             interfaceType: interfaceType,
+            uninstallFirst: debuggingOptions.uninstallFirst,
           );
           if (deviceLogReader is IOSDeviceLogReader) {
             deviceLogReader.debuggerStream = iosDeployDebugger;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -316,6 +316,7 @@ class IOSDevice extends Device {
     bool ipv6 = false,
     String? userIdentifier,
     @visibleForTesting Duration? discoveryTimeout,
+    bool uninstallFirst = false,
   }) async {
     String? packageId;
 
@@ -416,6 +417,7 @@ class IOSDevice extends Device {
           appDeltaDirectory: package.appDeltaDirectory,
           launchArguments: launchArguments,
           interfaceType: interfaceType,
+          uninstallFirst: uninstallFirst,
         );
       } else {
         installationResult = await iosDeployDebugger!.launchAndAttach() ? 0 : 1;

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -316,7 +316,6 @@ class IOSDevice extends Device {
     bool ipv6 = false,
     String? userIdentifier,
     @visibleForTesting Duration? discoveryTimeout,
-    bool uninstallFirst = false,
   }) async {
     String? packageId;
 
@@ -417,7 +416,7 @@ class IOSDevice extends Device {
           appDeltaDirectory: package.appDeltaDirectory,
           launchArguments: launchArguments,
           interfaceType: interfaceType,
-          uninstallFirst: uninstallFirst,
+          uninstallFirst: debuggingOptions.uninstallFirst,
         );
       } else {
         installationResult = await iosDeployDebugger!.launchAndAttach() ? 0 : 1;

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -16,6 +16,7 @@ import '../base/platform.dart';
 import '../base/process.dart';
 import '../cache.dart';
 import '../convert.dart';
+import '../device.dart';
 import 'code_signing.dart';
 import 'iproxy.dart';
 
@@ -128,6 +129,7 @@ class IOSDeploy {
     required List<String> launchArguments,
     required IOSDeviceConnectionInterface interfaceType,
     Directory? appDeltaDirectory,
+    required bool uninstallFirst,
   }) {
     appDeltaDirectory?.createSync(recursive: true);
     // Interactive debug session to support sending the lldb detach command.
@@ -145,6 +147,8 @@ class IOSDeploy {
         '--app_deltas',
         appDeltaDirectory.path,
       ],
+      if (uninstallFirst)
+        '--uninstall',
       '--debug',
       if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -16,7 +16,6 @@ import '../base/platform.dart';
 import '../base/process.dart';
 import '../cache.dart';
 import '../convert.dart';
-import '../device.dart';
 import 'code_signing.dart';
 import 'iproxy.dart';
 

--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -169,6 +169,7 @@ class IOSDeploy {
     required String bundlePath,
     required List<String> launchArguments,
     required IOSDeviceConnectionInterface interfaceType,
+    required bool uninstallFirst,
     Directory? appDeltaDirectory,
   }) async {
     appDeltaDirectory?.createSync(recursive: true);
@@ -184,6 +185,8 @@ class IOSDeploy {
       ],
       if (interfaceType != IOSDeviceConnectionInterface.network)
         '--no-wifi',
+      if (uninstallFirst)
+        '--uninstall',
       '--justlaunch',
       if (launchArguments.isNotEmpty) ...<String>[
         '--args',

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -369,7 +369,7 @@ void main() {
         Cache: () => Cache.test(processManager: FakeProcessManager.any()),
       });
 
-      testUsingContext('forwards --uninstall-only to ios-deploy --uninstall', () async {
+      testUsingContext('forwards --uninstall-only to DebuggingOptions', () async {
         final RunCommand command = RunCommand();
         final FakeDevice mockDevice = FakeDevice(
           sdkNameAndVersion: 'iOS 13',

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -369,6 +369,41 @@ void main() {
         Cache: () => Cache.test(processManager: FakeProcessManager.any()),
       });
 
+      testUsingContext('forwards --uninstall-only to ios-deploy --uninstall', () async {
+        final RunCommand command = RunCommand();
+        final FakeDevice mockDevice = FakeDevice(
+          sdkNameAndVersion: 'iOS 13',
+        )..startAppSuccess = false;
+
+        mockDeviceManager
+          ..devices = <Device>[
+            mockDevice,
+          ]
+          ..targetDevices = <Device>[
+            mockDevice,
+          ];
+
+        // Causes swift to be detected in the analytics.
+        fs.currentDirectory.childDirectory('ios').childFile('AppDelegate.swift').createSync(recursive: true);
+
+        await expectToolExitLater(createTestCommandRunner(command).run(<String>[
+          'run',
+          '--no-pub',
+          '--no-hot',
+          '--uninstall-first',
+        ]), isNull);
+
+        throw Exception('how to assert on passed flags?');
+      }, overrides: <Type, Generator>{
+        Artifacts: () => artifacts,
+        Cache: () => Cache.test(processManager: FakeProcessManager.any()),
+        DeviceManager: () => mockDeviceManager,
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        Usage: () => usage,
+      });
+
+
       testUsingContext('passes device target platform to usage', () async {
         final RunCommand command = RunCommand();
         final FakeDevice mockDevice = FakeDevice(sdkNameAndVersion: 'iOS 13')
@@ -407,7 +442,7 @@ void main() {
         Usage: () => usage,
       });
 
-       group('--machine', () {
+      group('--machine', () {
         testUsingContext('enables multidex by default', () async {
           final DaemonCapturingRunCommand command = DaemonCapturingRunCommand();
           final FakeDevice device = FakeDevice();

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -393,7 +393,8 @@ void main() {
           '--uninstall-first',
         ]), isNull);
 
-        throw Exception('how to assert on passed flags?');
+        final DebuggingOptions options = await command.createDebuggingOptions(false);
+        expect(options.uninstallFirst, isTrue);
       }, overrides: <Type, Generator>{
         Artifacts: () => artifacts,
         Cache: () => Cache.test(processManager: FakeProcessManager.any()),

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -53,6 +53,7 @@ void main () {
             '/',
             '--app_deltas',
             'app-delta',
+            '--uninstall',
             '--debug',
             '--args',
             <String>[
@@ -73,6 +74,7 @@ void main () {
         appDeltaDirectory: appDeltaDirectory,
         launchArguments: <String>['--enable-dart-profiling'],
         interfaceType: IOSDeviceConnectionInterface.network,
+        uninstallFirst: true,
       );
 
       expect(iosDeployDebugger.logLines, emits('Did finish launching.'));


### PR DESCRIPTION
Hopefully address https://github.com/flutter/flutter/issues/95582.

I ran the devicelab test locally and it removed the gallery app from my phone before installing it again.