### PR TITLE
allow opting out of compositing

### DIFF
--- a/dev/bots/deprecated_features.dart
+++ b/dev/bots/deprecated_features.dart
@@ -1,0 +1,9 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The set of deprecated features that must be explicitly enabled with a bool dart define.
+/// See flutter/packages/flutter/test_deprecated/README.md
+const List<String> kDeprecatedFeatures = <String>[
+  'flutter.deprecated.physical_model_layer', // removal of physical model layer and forced compositing.
+];

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -14,6 +14,7 @@ import 'package:file/local.dart';
 import 'package:path/path.dart' as path;
 
 import 'browser.dart';
+import 'deprecated_features.dart';
 import 'flutter_compact_formatter.dart';
 import 'run_command.dart';
 import 'service_worker_test.dart';
@@ -718,6 +719,15 @@ Future<void> _runFrameworkTests() async {
       path.join(flutterRoot, 'packages', 'flutter'),
       options: <String>['--dart-define=dart.vm.product=false', '--dart-define=dart.vm.profile=true', ...soundNullSafetyOptions],
       tests: <String>['test_profile${path.separator}'],
+    );
+    // Run reprecated mode tests (see packages/flutter/test_deprecated/README.md)
+    await _runFlutterTest(
+      path.join(flutterRoot, 'packages', 'flutter'),
+      options: <String>[
+        ...<String>[for (String feature in kDeprecatedFeatures) '--dart-define=$feature=true'],
+        ...soundNullSafetyOptions,
+      ],
+      tests: <String>['test_deprecated${path.separator}'],
     );
   }
 

--- a/packages/flutter/test_deprecated/README.md
+++ b/packages/flutter/test_deprecated/README.md
@@ -1,0 +1,69 @@
+This folder contains unit tests that are intended to provide basic coverage of deprecated features while we
+are in the process of removing them. Due to the large number of pixel diff tests in google, it can be difficult
+to land features that change subpixel values even slightly. Because we'd like to keep improving the performance and
+fidelity of the framework, we must nevertheless soldier on.
+
+For one example, we'd like to remove the forced compositing from the Material widget. However, this leads to
+slight hairline differences in thousands of places. First, we add a private dart define in the library
+with the significant behavioral change. Note: by default bool.fromEnvironment is false.
+
+proxy_box.dart
+```dart
+// Allows opting into the old physical model behavior.
+// to use: `flutter run --dart-define=flutter.deprecated.physical_model_layer=true`.
+const bool _kForcePhysicalModeLayer = bool.fromEnvironment('flutter.deprecated.physical_model_layer');
+```
+
+Then, we leave the old functionality in the render object guarded by this const value:
+
+proxy_box.dart
+```dart
+ @override
+  void paint(PaintingContext context, Offset offset) {
+    if (child == null) {
+      layer = null;
+      return;
+    }
+
+    _updateClip();
+    final RRect offsetRRect = _clip!.shift(offset);
+    final Rect offsetBounds = offsetRRect.outerRect;
+    final Path offsetRRectAsPath = Path()..addRRect(offsetRRect);
+    bool paintShadows = true;
+    assert(() {
+      if (debugDisableShadows) {
+        if (elevation > 0.0) {
+          context.canvas.drawRRect(
+            offsetRRect,
+            Paint()
+              ..color = shadowColor
+              ..style = PaintingStyle.stroke
+              ..strokeWidth = elevation * 2.0,
+          );
+        }
+        paintShadows = false;
+      }
+      return true;
+    }());
+
+    if (_kForcePhysicalModeLayer) {
+      layer ??= PhysicalModelLayer();
+      (layer! as PhysicalModelLayer)
+        ..clipPath = offsetRRectAsPath
+        ..clipBehavior = clipBehavior
+        ..elevation = paintShadows ? elevation : 0.0
+        ..color = color
+        ..shadowColor = shadowColor;
+      context.pushLayer(layer!, super.paint, offset, childPaintBounds: offsetBounds);
+      assert(() {
+        layer?.debugCreator = debugCreator;
+        return true;
+      }());
+      return;
+    }
+
+    // Rest of the method...
+```
+
+Finally we update `dev/bots/deprecated_features.dart` to contain the value "flutter.deprecated.physical_model_layer" and then
+write a simple test in this folder that asserts the old behavior is still present.

--- a/packages/flutter/test_deprecated/physical_model_layer_test.dart
+++ b/packages/flutter/test_deprecated/physical_model_layer_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('RenderPhysicalModel creates a PhysicalModelLayer', (WidgetTester tester) async {
+    expect(const bool.fromEnvironment('flutter.deprecated.physical_model_layer'), true);
+
+    for (final MaterialType type in MaterialType.values) {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: Material(
+            type: type,
+            child: const Text('Hello, World'),
+          )),
+        ),
+      );
+    }
+
+    expect(tester.layers.whereType<PhysicalModelLayer>, hasLength(2));
+  });
+}

--- a/packages/flutter/test_deprecated/physical_model_layer_test.dart
+++ b/packages/flutter/test_deprecated/physical_model_layer_test.dart
@@ -21,6 +21,7 @@ void main() {
       );
     }
 
-    expect(tester.layers.whereType<PhysicalModelLayer>, hasLength(2));
+    // One for the Scaffold's material, one for the material itself
+    expect(tester.layers.whereType<PhysicalModelLayer>(), hasLength(2));
   });
 }


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
