### PR TITLE
Fix `DropdownButtonFormField` edge alignment

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -512,7 +512,10 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
       computedMaxHeight = math.min(computedMaxHeight, menuMaxHeight!);
     }
     final double buttonTop = buttonRect.top;
-    final double buttonBottom = math.min(buttonRect.bottom, availableHeight);
+    double buttonBottom = math.min(buttonRect.bottom, availableHeight);
+    if (buttonRect.height < _kMenuItemHeight) {
+      buttonBottom = buttonRect.bottom - kMaterialListPadding.vertical;
+    }
     final double selectedItemOffset = getItemOffset(index);
 
     // If the button is placed on the bottom or top of the screen, its top or

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -1095,4 +1095,57 @@ void main() {
       selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)),
     );
   });
+
+  testWidgets(
+    'DropdownButtonFormField is aligned properly when button is positioned on edge',
+    (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/101575
+      final Widget dropdownFormField = DropdownButtonFormField<String>(
+        onChanged: onChanged,
+        value: menuItems.first,
+        decoration: const InputDecoration(
+          isDense: true,
+          contentPadding: EdgeInsets.zero,
+          border: InputBorder.none,
+        ),
+        items: menuItems.map<DropdownMenuItem<String>>((String item) {
+          return DropdownMenuItem<String>(
+            value: item,
+            child: Text(item, key: ValueKey<String>('${item}Text')),
+          );
+        }).toList(),
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView(
+              children: <Widget>[
+                Container(
+                  height: 600,
+                  color: const Color(0xff00ff00),
+                ),
+                Center(
+                  child: SizedBox(
+                    width: 120.0,
+                    child: dropdownFormField,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      await tester.drag(find.byType(ListView), const Offset(0.0, -50.0), touchSlopY: 0, warnIfMissed: false);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('one'));
+      await tester.pumpAndSettle();
+
+      final RenderBox firstItem = tester.renderObjectList<RenderBox>(find.text('one')).toList()[1];
+      expect(tester.takeException(), null);
+      expect(firstItem.localToGlobal(Offset.zero).dx, equals(340.0));
+      expect(firstItem.localToGlobal(Offset.zero).dy, equals(412.0));
+  });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/101575

Currently, there is an assertion to avoid the menu being cut off at the edge as a result menu shifted to Offset.zero, which is way off.
So my fix is keeping the menu in the position but overriding y position so that menu doesn't get cut off.

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const MyApp());
}

class MyApp extends StatefulWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  _MyAppState createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: SafeArea(
          child: SingleChildScrollView(
            padding: const EdgeInsets.all(20.0),
            child: Column(
              crossAxisAlignment: CrossAxisAlignment.start,
              children: [
                const SizedBox(height: 20),
                Column(
                    crossAxisAlignment: CrossAxisAlignment.start,
                    children: const [
                      Text("Title",
                          style: TextStyle(
                              fontSize: 20,
                              fontWeight: FontWeight.bold,
                              color: Colors.blue)),
                    ]),
                const SizedBox(height: 20),
                Center(
                  child: Container(
                    padding: const EdgeInsets.only(top: 20),
                    decoration: BoxDecoration(
                        border: Border.all(color: Colors.grey),
                        borderRadius:
                            const BorderRadius.all(Radius.circular(10))),
                    child: Column(
                      children: [
                        Container(
                            width: double.infinity,
                            height: 80,
                            color: Colors.green),
                        Container(
                            width: double.infinity,
                            height: 1000,
                            color: Colors.yellow),
                        tablePaging(),
                      ],
                    ),
                  ),
                ),
              ],
            ),
          ),
        ),
      ),
    );
  }
}

Widget tablePaging() {
  double fs = 12;
  Color color = Colors.blueAccent;
  FontWeight fw = FontWeight.bold;

  List<String> list = [for (int i = 1; i <= 10; i++) (i * 10).toString()];
  List<DropdownMenuItem<String>> items = [
    for (String i in list) DropdownMenuItem(child: Text(i), value: i)
  ];

  return Container(
    padding: const EdgeInsets.all(10.0),
    height: 40,
    decoration: const BoxDecoration(
        color: Colors.blue,
        borderRadius: BorderRadius.vertical(bottom: Radius.circular(10))),
    child: Row(
      mainAxisAlignment: MainAxisAlignment.end,
      children: [
        Container(
          width: 100,
          color: Colors.white.withOpacity(0.5),
          child: DropdownButtonFormField<String>(
            value: int.parse(list.first).toString(),
            items: items,
            onChanged: (String? value) {},
            icon: Icon(Icons.arrow_drop_down_outlined, color: color, size: 18),
            style: TextStyle(color: color, fontSize: fs, fontWeight: fw),
            decoration: const InputDecoration(
                isDense: true,
                contentPadding: EdgeInsets.all(0),
                border: InputBorder.none),
          ),
        ),
      ],
    ),
  );
}
``` 
	
</details>

### Bug

https://user-images.githubusercontent.com/48603081/166472100-87628366-e574-4a2f-9d81-298d28295d01.mov



### Fixed

https://user-images.githubusercontent.com/48603081/166472135-348df5bb-693a-4d20-a360-000cfaf84279.mov




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
