### PR TITLE
rename local functions with `_`s

### DIFF
--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1518,7 +1518,7 @@ void main() {
   });
 
   testWidgets('DatePicker adapts to MaterialApp dark mode', (WidgetTester tester) async {
-    Widget _buildDatePicker(Brightness brightness) {
+    Widget buildDatePicker(Brightness brightness) {
       return MaterialApp(
         theme: ThemeData(brightness: brightness),
         home: CupertinoDatePicker(
@@ -1530,14 +1530,14 @@ void main() {
     }
 
     // CupertinoDatePicker with light theme.
-    await tester.pumpWidget(_buildDatePicker(Brightness.light));
+    await tester.pumpWidget(buildDatePicker(Brightness.light));
     RenderParagraph paragraph = tester.renderObject(find.text('October').first);
     expect(paragraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.
     expect(paragraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
 
     // CupertinoDatePicker with dark theme.
-    await tester.pumpWidget(_buildDatePicker(Brightness.dark));
+    await tester.pumpWidget(buildDatePicker(Brightness.dark));
     paragraph = tester.renderObject(find.text('October').first);
     expect(paragraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.
@@ -1545,7 +1545,7 @@ void main() {
   });
 
   testWidgets('TimerPicker adapts to MaterialApp dark mode', (WidgetTester tester) async {
-    Widget _buildTimerPicker(Brightness brightness) {
+    Widget buildTimerPicker(Brightness brightness) {
       return MaterialApp(
         theme: ThemeData(brightness: brightness),
         home: CupertinoTimerPicker(
@@ -1557,14 +1557,14 @@ void main() {
     }
 
     // CupertinoTimerPicker with light theme.
-    await tester.pumpWidget(_buildTimerPicker(Brightness.light));
+    await tester.pumpWidget(buildTimerPicker(Brightness.light));
     RenderParagraph paragraph = tester.renderObject(find.text('hours'));
     expect(paragraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.
     expect(paragraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
 
     // CupertinoTimerPicker with light theme.
-    await tester.pumpWidget(_buildTimerPicker(Brightness.dark));
+    await tester.pumpWidget(buildTimerPicker(Brightness.dark));
     paragraph = tester.renderObject(find.text('hours'));
     expect(paragraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.

--- a/packages/flutter/test/cupertino/form_row_test.dart
+++ b/packages/flutter/test/cupertino/form_row_test.dart
@@ -170,7 +170,7 @@ void main() {
     const Widget prefix = Text('Prefix');
     const Widget helper = Text('Helper');
 
-    Widget _buildFormRow(Brightness brightness) {
+    Widget buildFormRow(Brightness brightness) {
       return MaterialApp(
         theme: ThemeData(brightness: brightness),
         home: const Center(
@@ -184,7 +184,7 @@ void main() {
     }
 
     // CupertinoFormRow with light theme.
-    await tester.pumpWidget(_buildFormRow(Brightness.light));
+    await tester.pumpWidget(buildFormRow(Brightness.light));
     RenderParagraph helperParagraph = tester.renderObject(find.text('Helper'));
     expect(helperParagraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.
@@ -195,7 +195,7 @@ void main() {
     expect(prefixParagraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
 
     // CupertinoFormRow with light theme.
-    await tester.pumpWidget(_buildFormRow(Brightness.dark));
+    await tester.pumpWidget(buildFormRow(Brightness.dark));
     helperParagraph = tester.renderObject(find.text('Helper'));
     expect(helperParagraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -425,7 +425,7 @@ void main() {
   });
 
   testWidgets('Picker adapts to MaterialApp dark mode', (WidgetTester tester) async {
-    Widget _buildCupertinoPicker(Brightness brightness) {
+    Widget buildCupertinoPicker(Brightness brightness) {
       return MaterialApp(
         theme: ThemeData(brightness: brightness),
         home: Align(
@@ -450,14 +450,14 @@ void main() {
     }
 
     // CupertinoPicker with light theme.
-    await tester.pumpWidget(_buildCupertinoPicker(Brightness.light));
+    await tester.pumpWidget(buildCupertinoPicker(Brightness.light));
     RenderParagraph paragraph = tester.renderObject(find.text('1'));
     expect(paragraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.
     expect(paragraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
 
     // CupertinoPicker with dark theme.
-    await tester.pumpWidget(_buildCupertinoPicker(Brightness.dark));
+    await tester.pumpWidget(buildCupertinoPicker(Brightness.dark));
     paragraph = tester.renderObject(find.text('1'));
     expect(paragraph.text.style!.color, CupertinoColors.label);
     // Text style should not return unresolved color.


### PR DESCRIPTION
rename local functions with `_`s

These will be flagged by the next linter release which updates `non_constant_identifier_names` to flag local functions.

See also: #102615.  (This has crept in since then.)

And:

* https://github.com/flutter/flutter/pull/102615
* https://dart-review.googlesource.com/c/sdk/+/242391
* dart-lang/sdk#58715

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
