### PR TITLE
[framework] switch to default Map from HashMap

### DIFF
--- a/packages/flutter/lib/src/rendering/table.dart
+++ b/packages/flutter/lib/src/rendering/table.dart
@@ -386,7 +386,7 @@ class RenderTable extends RenderBox {
        _textDirection = textDirection,
        _columns = columns ?? (children != null && children.isNotEmpty ? children.first.length : 0),
        _rows = rows ?? 0,
-       _columnWidths = columnWidths ?? HashMap<int, TableColumnWidth>(),
+       _columnWidths = columnWidths ?? <int, TableColumnWidth>{},
        _defaultColumnWidth = defaultColumnWidth,
        _border = border,
        _textBaseline = textBaseline,
@@ -478,7 +478,7 @@ class RenderTable extends RenderBox {
       return;
     if (_columnWidths.isEmpty && value == null)
       return;
-    _columnWidths = value ?? HashMap<int, TableColumnWidth>();
+    _columnWidths = value ?? <int, TableColumnWidth>{};
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection' show HashMap;
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -130,11 +128,11 @@ Locale basicLocaleListResolution(List<Locale>? preferredLocales, Iterable<Locale
   }
   // Hash the supported locales because apps can support many locales and would
   // be expensive to search through them many times.
-  final Map<String, Locale> allSupportedLocales = HashMap<String, Locale>();
-  final Map<String, Locale> languageAndCountryLocales = HashMap<String, Locale>();
-  final Map<String, Locale> languageAndScriptLocales = HashMap<String, Locale>();
-  final Map<String, Locale> languageLocales = HashMap<String, Locale>();
-  final Map<String?, Locale> countryLocales = HashMap<String?, Locale>();
+  final Map<String, Locale> allSupportedLocales = <String, Locale>{};
+  final Map<String, Locale> languageAndCountryLocales = <String, Locale>{};
+  final Map<String, Locale> languageAndScriptLocales = <String, Locale>{};
+  final Map<String, Locale> languageLocales = <String, Locale>{};
+  final Map<String?, Locale> countryLocales = <String?, Locale>{};
   for (final Locale locale in supportedLocales) {
     allSupportedLocales['${locale.languageCode}_${locale.scriptCode}_${locale.countryCode}'] ??= locale;
     languageAndScriptLocales['${locale.languageCode}_${locale.scriptCode}'] ??= locale;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2723,7 +2723,7 @@ class BuildOwner {
   Map<Element, Set<GlobalKey>>? _debugElementsThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans;
 
   void _debugTrackElementThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans(Element node, GlobalKey key) {
-    _debugElementsThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans ??= HashMap<Element, Set<GlobalKey>>();
+    _debugElementsThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans ??= <Element, Set<GlobalKey>>{};
     final Set<GlobalKey> keys = _debugElementsThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans!
       .putIfAbsent(node, () => HashSet<GlobalKey>());
     keys.add(key);
@@ -2938,7 +2938,7 @@ class BuildOwner {
                 keys.addAll(_debugElementsThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans![element]!);
             }
             if (keys.isNotEmpty) {
-              final Map<String, int> keyStringCount = HashMap<String, int>();
+              final Map<String, int> keyStringCount = <String, int>{};
               for (final String key in keys.map<String>((GlobalKey key) => key.toString())) {
                 if (keyStringCount.containsKey(key)) {
                   keyStringCount.update(key, (int value) => value + 1);
@@ -2955,7 +2955,7 @@ class BuildOwner {
                 }
               });
               final Iterable<Element> elements = _debugElementsThatWillNeedToBeRebuiltDueToGlobalKeyShenanigans!.keys;
-              final Map<String, int> elementStringCount = HashMap<String, int>();
+              final Map<String, int> elementStringCount = <String, int>{};
               for (final String element in elements.map<String>((Element element) => element.toString())) {
                 if (elementStringCount.containsKey(element)) {
                   elementStringCount.update(element, (int value) => value + 1);
@@ -5237,16 +5237,16 @@ class InheritedElement extends ProxyElement {
   /// Creates an element that uses the given widget as its configuration.
   InheritedElement(InheritedWidget super.widget);
 
-  final Map<Element, Object?> _dependents = HashMap<Element, Object?>();
+  final Map<Element, Object?> _dependents = <Element, Object?>{};
 
   @override
   void _updateInheritance() {
     assert(_lifecycleState == _ElementLifecycle.active);
     final Map<Type, InheritedElement>? incomingWidgets = _parent?._inheritedWidgets;
     if (incomingWidgets != null)
-      _inheritedWidgets = HashMap<Type, InheritedElement>.of(incomingWidgets);
+      _inheritedWidgets = Map<Type, InheritedElement>.of(incomingWidgets);
     else
-      _inheritedWidgets = HashMap<Type, InheritedElement>();
+      _inheritedWidgets = <Type, InheritedElement>{};
     _inheritedWidgets![widget.runtimeType] = this;
   }
 

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -804,7 +804,7 @@ class ListWheelElement extends RenderObjectElement implements ListWheelChildMana
   // Any time we do case 1, though, we reset the cache.
 
   /// A cache of widgets so that we don't have to rebuild every time.
-  final Map<int, Widget?> _childWidgets = HashMap<int, Widget?>();
+  final Map<int, Widget?> _childWidgets = <int, Widget?>{};
 
   /// The map containing all active child elements. SplayTreeMap is used so that
   /// we have all elements ordered and iterable by their keys.

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection' show SplayTreeMap, HashMap;
+import 'dart:collection' show SplayTreeMap;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
@@ -1155,7 +1155,7 @@ class SliverMultiBoxAdaptorElement extends RenderObjectElement implements Render
     assert(_currentlyUpdatingChildIndex == null);
     try {
       final SplayTreeMap<int, Element?> newChildren = SplayTreeMap<int, Element?>();
-      final Map<int, double> indexToLayoutOffset = HashMap<int, double>();
+      final Map<int, double> indexToLayoutOffset = <int, double>{};
       final SliverMultiBoxAdaptorWidget adaptorWidget = widget as SliverMultiBoxAdaptorWidget;
       void processElement(int index) {
         _currentlyUpdatingChildIndex = index;

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:collection' show HashMap;
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:math' as math;
@@ -744,7 +743,7 @@ mixin WidgetInspectorService {
 
   List<String>? _pubRootDirectories;
   /// Memoization for [_isLocalCreationLocation].
-  final HashMap<String, bool> _isLocalCreationCache = HashMap<String, bool>();
+  final Map<String, bool> _isLocalCreationCache = <String, bool>{};
 
   bool _trackRebuildDirtyWidgets = false;
   bool _trackRepaintWidgets = false;


### PR DESCRIPTION
We've seen several instances where the default hash map (LinkedHashMap) has better performance than HashMap.

* LinkedHashMap.of has a fast path for copying objects that HashMap.of does not. because of the different internal representations it would be difficult to port this to HashMap. https://github.com/dart-lang/sdk/issues/47856
* On the web, LinkedHashMap can use a JS object if the keys are primitive types. This can be signifiicantly faster in some cases.

Beyond those reasons, the LinkedHashMap is the default, and generally we should try and stick with defautls unless we have a good reason too. While we don't need the ordering property of the linked map, the documented reason of using hashmap for better performance is also not proven or observable. Therefore, I believe it is a reasonable choice to revert back to the default.
