### PR TITLE
Add Focus support for iOS platform view

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -231,7 +231,9 @@ class PlatformViewsService {
     }
     await SystemChannels.platform_views.invokeMethod<void>('create', args);
     final UiKitViewController controller = UiKitViewController._(id, layoutDirection);
-    _instance._focusCallbacks[id] = onFocus ?? () {};
+    if (onFocus != null) {
+      _instance._focusCallbacks[id] = onFocus;
+    }
     return controller;
   }
 }

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -230,11 +230,10 @@ class PlatformViewsService {
       );
     }
     await SystemChannels.platform_views.invokeMethod<void>('create', args);
-    final UiKitViewController controller = UiKitViewController._(id, layoutDirection);
     if (onFocus != null) {
       _instance._focusCallbacks[id] = onFocus;
     }
-    return controller;
+    return UiKitViewController._(id, layoutDirection);
   }
 }
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -199,6 +199,8 @@ class PlatformViewsService {
   /// factory for this view type must have been registered on the platform side.
   /// Platform view factories are typically registered by plugin code.
   ///
+  /// `onFocus` is a callback that will be invoked when the UIKit view asks to
+  /// get the input focus.
   /// The `id, `viewType, and `layoutDirection` parameters must not be null.
   /// If `creationParams` is non null then `creationParamsCodec` must not be null.
   static Future<UiKitViewController> initUiKitView({
@@ -207,6 +209,7 @@ class PlatformViewsService {
     required TextDirection layoutDirection,
     dynamic creationParams,
     MessageCodec<dynamic>? creationParamsCodec,
+    VoidCallback? onFocus,
   }) async {
     assert(id != null);
     assert(viewType != null);
@@ -227,7 +230,9 @@ class PlatformViewsService {
       );
     }
     await SystemChannels.platform_views.invokeMethod<void>('create', args);
-    return UiKitViewController._(id, layoutDirection);
+    final UiKitViewController controller = UiKitViewController._(id, layoutDirection);
+    _instance._focusCallbacks[id] = onFocus ?? () {};
+    return controller;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -562,7 +562,7 @@ class _UiKitViewState extends State<UiKitView> {
   UiKitViewController? _controller;
   TextDirection? _layoutDirection;
   bool _initialized = false;
-  FocusNode? _focusNode;
+  late FocusNode _focusNode;
 
   static final Set<Factory<OneSequenceGestureRecognizer>> _emptyRecognizersSet =
     <Factory<OneSequenceGestureRecognizer>>{};
@@ -645,7 +645,7 @@ class _UiKitViewState extends State<UiKitView> {
       creationParams: widget.creationParams,
       creationParamsCodec: widget.creationParamsCodec,
       onFocus: () {
-        _focusNode!.requestFocus();
+        _focusNode.requestFocus();
       }
     );
     if (!mounted) {
@@ -660,21 +660,7 @@ class _UiKitViewState extends State<UiKitView> {
   }
 
   void _onFocusChange(bool isFocused) {
-    if (!isFocused) {
-      // Unlike Android, we do not need to send "clearFocus" channel message
-      // to the engine, because focusing on another view will automatically
-      // cancel the focus on the previously focused platform view.
-    } else {
-      SystemChannels.textInput.invokeMethod<void>(
-        'TextInput.setPlatformViewClient',
-        <String, dynamic>{'platformViewId': _controller!.id},
-      ).catchError((dynamic e) {
-        // TODO(huan): remove this once "TextInput.setPlatformViewClient" is implemented on engine.
-        if (e is MissingPluginException) {
-          return;
-        }
-      });
-    }
+    // TODO(hellohuanlin): send 'TextInput.setPlatformViewClient' channel message to engine after the engine is updated to handle this message.
   }
 }
 

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -559,7 +559,6 @@ class _AndroidViewState extends State<AndroidView> {
 }
 
 class _UiKitViewState extends State<UiKitView> {
-  int? _id;
   UiKitViewController? _controller;
   TextDirection? _layoutDirection;
   bool _initialized = false;
@@ -590,7 +589,6 @@ class _UiKitViewState extends State<UiKitView> {
     }
     _initialized = true;
     _createNewUiKitView();
-    _focusNode = FocusNode(debugLabel: "UiKitView(id: $_id)");
   }
 
   @override
@@ -657,7 +655,7 @@ class _UiKitViewState extends State<UiKitView> {
     widget.onPlatformViewCreated?.call(id);
     setState(() {
       _controller = controller;
-      _id = id;
+      _focusNode = FocusNode(debugLabel: 'UiKitView(id: $id)');
     });
   }
 
@@ -669,7 +667,7 @@ class _UiKitViewState extends State<UiKitView> {
     } else {
       SystemChannels.textInput.invokeMethod<void>(
         'TextInput.setPlatformViewClient',
-        <String, dynamic>{'platformViewId': _id},
+        <String, dynamic>{'platformViewId': _controller!.id},
       ).catchError((dynamic e) {
         // TODO(huan): remove this once "TextInput.setPlatformViewClient" is implemented on engine.
         if (e is MissingPluginException) {

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -340,6 +340,13 @@ class FakeIosPlatformViewsController {
     _registeredViewTypes.add(viewType);
   }
 
+  void invokeViewFocused(int viewId) {
+    final MethodCodec codec = SystemChannels.platform_views.codec;
+    final ByteData data = codec.encodeMethodCall(MethodCall('viewFocused', viewId));
+    ServicesBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(SystemChannels.platform_views.name, data, (ByteData? data) {});
+  }
+
   Future<dynamic> _onMethodCall(MethodCall call) {
     switch(call.method) {
       case 'create':

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -1978,7 +1978,7 @@ void main() {
       },
     );
 
-    testWidgets('AndroidView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
+    testWidgets('UiKitView rebuilt with same gestureRecognizers', (WidgetTester tester) async {
       final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
       viewsController.registerViewType('webview');
 
@@ -2012,6 +2012,59 @@ void main() {
       expect(factoryInvocationCount, 1);
     });
 
+    testWidgets('UiKitView can take input focus', (WidgetTester tester) async {
+      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+      final FakeIosPlatformViewsController viewsController = FakeIosPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      final GlobalKey containerKey = GlobalKey();
+      await tester.pumpWidget(
+        Center(
+          child: Column(
+            children: <Widget>[
+              const SizedBox(
+                width: 200.0,
+                height: 100.0,
+                child: UiKitView(viewType: 'webview', layoutDirection: TextDirection.ltr),
+              ),
+              Focus(
+                debugLabel: 'container',
+                child: Container(key: containerKey),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      // First frame is before the platform view was created so the render object
+      // is not yet in the tree.
+      await tester.pump();
+
+      final Focus uiKitViewFocusWidget = tester.widget(
+        find.descendant(
+          of: find.byType(UiKitView),
+          matching: find.byType(Focus),
+        ),
+      );
+      final FocusNode uiKitViewFocusNode = uiKitViewFocusWidget.focusNode!;
+      final Element containerElement = tester.element(find.byKey(containerKey));
+      final FocusNode containerFocusNode = Focus.of(containerElement);
+
+      containerFocusNode.requestFocus();
+
+      await tester.pump();
+
+      expect(containerFocusNode.hasFocus, isTrue);
+      expect(uiKitViewFocusNode.hasFocus, isFalse);
+
+      viewsController.invokeViewFocused(currentViewId + 1);
+
+      await tester.pump();
+
+      expect(containerFocusNode.hasFocus, isFalse);
+      expect(uiKitViewFocusNode.hasFocus, isTrue);
+    });
+
     testWidgets('UiKitView has correct semantics', (WidgetTester tester) async {
       final SemanticsHandle handle = tester.ensureSemantics();
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
@@ -2039,7 +2092,14 @@ void main() {
       // is not yet in the tree.
       await tester.pump();
 
-      final SemanticsNode semantics = tester.getSemantics(find.byType(UiKitView));
+      final SemanticsNode semantics = tester.getSemantics(
+        find.descendant(
+          of: find.byType(UiKitView),
+          matching: find.byWidgetPredicate(
+              (Widget widget) => widget.runtimeType.toString() == "_UiKitPlatformView",
+          ),
+        ),
+      );
 
       expect(semantics.platformViewId, currentViewId + 1);
       expect(semantics.rect, const Rect.fromLTWH(0, 0, 200, 100));

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -2096,7 +2096,7 @@ void main() {
         find.descendant(
           of: find.byType(UiKitView),
           matching: find.byWidgetPredicate(
-              (Widget widget) => widget.runtimeType.toString() == "_UiKitPlatformView",
+              (Widget widget) => widget.runtimeType.toString() == '_UiKitPlatformView',
           ),
         ),
       );


### PR DESCRIPTION
This PR makes iOS platform view focusable. 

Since frameworks and engines are separate repos, I have to try-and-catch the non-existing "viewFocused" channel message for now. Will remove the try-catch after we landed and rolled the engine update. 

The main idea is that: 

1. In the framework, a platform view needs to be wrapped under FocusNode with a `onFocusChange` callback saved
2. In the engine, when a platform view is focused, it should send a channel message "viewFocused" to framework, which will invoke the `onFocusChange` saved in the previous step
3. The `onFocusChange` will then send a channel message "TextInput.setPlatformViewClient" to the engine, which should remove the focus on previously focused text inputs (e.g. EditableText)


I am going through the Flutter Style Guide now (will check the box once I am done). But I tried my best to following existing conventions.



## Related Issue

https://github.com/flutter/flutter/issues/34187

## Pre-launch Checklist


I am going through the Flutter Style Guide now (will check the box once I am done). But I tried my best to following existing conventions. 


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
