### PR TITLE
DefaultTextEditingShortcuts should use meta-based shortcut for iOS

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -323,7 +323,8 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Control + shift? + Z
   };
 
-  // There is not documented complete iOS shortcuts. Use mac shortcuts for now.
+  // There is no complete documentation of iOS shortcuts. Use mac shortcuts for
+  // now.
   static final Map<ShortcutActivator, Intent> _iOSShortcuts = _macShortcuts;
 
   // The following key combinations have no effect on text editing on this

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -231,25 +231,6 @@ class DefaultTextEditingShortcuts extends Shortcuts {
 
   static final Map<ShortcutActivator, Intent> _fuchsiaShortcuts = _androidShortcuts;
 
-  // The following key combinations have no effect on text editing on this
-  // platform:
-  //   * End
-  //   * Home
-  //   * Meta + X
-  //   * Meta + C
-  //   * Meta + V
-  //   * Meta + A
-  //   * Meta + shift? + Z
-  //   * Meta + shift? + arrow down
-  //   * Meta + shift? + arrow left
-  //   * Meta + shift? + arrow right
-  //   * Meta + shift? + arrow up
-  //   * Shift + end
-  //   * Shift + home
-  //   * Meta + shift? + delete
-  //   * Meta + shift? + backspace
-  static final Map<ShortcutActivator, Intent> _iOSShortcuts = _commonShortcuts;
-
   static final Map<ShortcutActivator, Intent> _linuxShortcuts = <ShortcutActivator, Intent>{
     ..._commonShortcuts,
     const SingleActivator(LogicalKeyboardKey.home): const ExtendSelectionToLineBreakIntent(forward: false, collapseSelection: true),
@@ -341,6 +322,9 @@ class DefaultTextEditingShortcuts extends Shortcuts {
     //   * Control + shift? + home
     //   * Control + shift? + Z
   };
+
+  // There is not documented complete iOS shortcuts. Use mac shortcuts for now.
+  static final Map<ShortcutActivator, Intent> _iOSShortcuts = _macShortcuts;
 
   // The following key combinations have no effect on text editing on this
   // platform:

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -644,7 +644,7 @@ void main() {
     expect(MediaQuery.of(capturedContext), isNotNull);
   });
 
-  testWidgets('WidgetsApp provide meta based shortcut for iOS', (WidgetTester tester) async {
+  testWidgets('WidgetsApp provides meta based shortcuts for iOS and macOS', (WidgetTester tester) async {
     final FocusNode focusNode = FocusNode();
     final SelectAllSpy selectAllSpy = SelectAllSpy();
     final CopySpy copySpy = CopySpy();
@@ -707,7 +707,10 @@ void main() {
     expect(selectAllSpy.invoked, isTrue);
     expect(copySpy.invoked, isTrue);
     expect(pasteSpy.invoked, isTrue);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
+  },
+  variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
+  skip: kIsWeb, // Web uses a different set of shortcuts.
+  );
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -707,7 +707,7 @@ void main() {
     expect(selectAllSpy.invoked, isTrue);
     expect(copySpy.invoked, isTrue);
     expect(pasteSpy.invoked, isTrue);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }), skip: kIsWeb); // Web uses a different set of shortcuts.
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }), skip: kIsWeb); // [intended] Web uses a different set of shortcuts.
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -707,10 +707,7 @@ void main() {
     expect(selectAllSpy.invoked, isTrue);
     expect(copySpy.invoked, isTrue);
     expect(pasteSpy.invoked, isTrue);
-  },
-  variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
-  skip: kIsWeb, // Web uses a different set of shortcuts.
-  );
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }), skip: kIsWeb); // Web uses a different set of shortcuts.
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -643,10 +643,99 @@ void main() {
     );
     expect(MediaQuery.of(capturedContext), isNotNull);
   });
+
+  testWidgets('WidgetsApp provide meta based shortcut for iOS', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    final SelectAllSpy selectAllSpy = SelectAllSpy();
+    final CopySpy copySpy = CopySpy();
+    final PasteSpy pasteSpy = PasteSpy();
+    final Map<Type, Action<Intent>> actions = <Type, Action<Intent>>{
+      // Copy Paste
+      SelectAllTextIntent: selectAllSpy,
+      CopySelectionTextIntent: copySpy,
+      PasteTextIntent: pasteSpy,
+    };
+    await tester.pumpWidget(
+      WidgetsApp(
+        builder: (BuildContext context, Widget? child) {
+          return Actions(
+            actions: actions,
+            child: Focus(
+              focusNode: focusNode,
+              child: const Placeholder(),
+            ),
+          );
+        },
+        color: const Color(0xFF123456),
+      ),
+    );
+    focusNode.requestFocus();
+    await tester.pump();
+    expect(selectAllSpy.invoked, isFalse);
+    expect(copySpy.invoked, isFalse);
+    expect(pasteSpy.invoked, isFalse);
+
+    // Select all.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyA);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyA);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+    await tester.pump();
+
+    expect(selectAllSpy.invoked, isTrue);
+    expect(copySpy.invoked, isFalse);
+    expect(pasteSpy.invoked, isFalse);
+
+    // Copy.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyC);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+    await tester.pump();
+
+    expect(selectAllSpy.invoked, isTrue);
+    expect(copySpy.invoked, isTrue);
+    expect(pasteSpy.invoked, isFalse);
+
+    // Paste.
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.metaLeft);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.keyV);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.keyV);
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.metaLeft);
+    await tester.pump();
+
+    expect(selectAllSpy.invoked, isTrue);
+    expect(copySpy.invoked, isTrue);
+    expect(pasteSpy.invoked, isTrue);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);
 typedef SimpleNavigatorRouterDelegatePopPage<T> = bool Function(Route<T> route, T result, SimpleNavigatorRouterDelegate delegate);
+
+class SelectAllSpy extends Action<SelectAllTextIntent> {
+  bool invoked = false;
+  @override
+  void invoke(SelectAllTextIntent intent) {
+    invoked = true;
+  }
+}
+
+class CopySpy extends Action<CopySelectionTextIntent> {
+  bool invoked = false;
+  @override
+  void invoke(CopySelectionTextIntent intent) {
+    invoked = true;
+  }
+}
+
+class PasteSpy extends Action<PasteTextIntent> {
+  bool invoked = false;
+  @override
+  void invoke(PasteTextIntent intent) {
+    invoked = true;
+  }
+}
 
 class SimpleRouteInformationParser extends RouteInformationParser<RouteInformation> {
   SimpleRouteInformationParser();

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -124,7 +124,7 @@ void main() {
 
   group('Common text editing shortcuts: ',
     () {
-      final TargetPlatformVariant allExceptMacOS = TargetPlatformVariant(TargetPlatform.values.toSet()..remove(TargetPlatform.macOS));
+      final TargetPlatformVariant allExceptApple = TargetPlatformVariant(TargetPlatform.values.toSet()..removeAll(<TargetPlatform>[TargetPlatform.macOS, TargetPlatform.iOS]));
 
       group('backspace', () {
         const LogicalKeyboardKey trigger = LogicalKeyboardKey.backspace;
@@ -491,8 +491,8 @@ void main() {
       group('word modifier + backspace', () {
         const LogicalKeyboardKey trigger = LogicalKeyboardKey.backspace;
         SingleActivator wordModifierBackspace() {
-          final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
-          return SingleActivator(trigger, control: !isMacOS, alt: isMacOS);
+          final bool isApple = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+          return SingleActivator(trigger, control: !isApple, alt: isApple);
         }
 
         testWidgets('WordModifier-backspace', (WidgetTester tester) async {
@@ -631,8 +631,8 @@ void main() {
       group('word modifier + delete', () {
         const LogicalKeyboardKey trigger = LogicalKeyboardKey.delete;
         SingleActivator wordModifierDelete() {
-          final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
-          return SingleActivator(trigger, control: !isMacOS, alt: isMacOS);
+          final bool isApple = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+          return SingleActivator(trigger, control: !isApple, alt: isApple);
         }
 
         testWidgets('WordModifier-delete', (WidgetTester tester) async {
@@ -764,8 +764,8 @@ void main() {
       group('line modifier + backspace', () {
         const LogicalKeyboardKey trigger = LogicalKeyboardKey.backspace;
         SingleActivator lineModifierBackspace() {
-          final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
-          return SingleActivator(trigger, meta: isMacOS, alt: !isMacOS);
+          final bool isApple = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+          return SingleActivator(trigger, meta: isApple, alt: !isApple);
         }
 
         testWidgets('alt-backspace', (WidgetTester tester) async {
@@ -945,8 +945,8 @@ void main() {
       group('line modifier + delete', () {
         const LogicalKeyboardKey trigger = LogicalKeyboardKey.delete;
         SingleActivator lineModifierDelete() {
-          final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
-          return SingleActivator(trigger, meta: isMacOS, alt: !isMacOS);
+          final bool isApple = defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS;
+          return SingleActivator(trigger, meta: isApple, alt: !isApple);
         }
 
         testWidgets('alt-delete', (WidgetTester tester) async {
@@ -1167,7 +1167,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 4,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptApple);
 
           testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1181,7 +1181,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 20,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptApple);
         });
 
         group('right', () {
@@ -1230,7 +1230,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 10,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptApple);
 
          testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1245,7 +1245,7 @@ void main() {
               offset: 35, // Before the newline character.
               affinity: TextAffinity.upstream,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptApple);
         });
 
         group('With initial non-collapsed selection', () {
@@ -1352,7 +1352,7 @@ void main() {
             expect(controller.selection, const TextSelection.collapsed(
               offset: 28, // After "good".
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptApple);
 
          testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
             controller.text = testText;
@@ -1406,7 +1406,7 @@ void main() {
               offset: 35, // After "people".
               affinity: TextAffinity.upstream,
             ));
-          }, variant: allExceptMacOS);
+          }, variant: allExceptApple);
         });
 
         group('vertical movement', () {

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5251,19 +5251,19 @@ void main() {
     }
     if (shortcutModifier) {
       await tester.sendKeyDownEvent(
-        platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.controlLeft,
+        platform == 'macos' || platform == 'ios' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.controlLeft,
         platform: platform,
       );
     }
     if (wordModifier) {
       await tester.sendKeyDownEvent(
-        platform == 'macos' ? LogicalKeyboardKey.altLeft : LogicalKeyboardKey.controlLeft,
+        platform == 'macos' || platform == 'ios' ? LogicalKeyboardKey.altLeft : LogicalKeyboardKey.controlLeft,
         platform: platform,
       );
     }
     if (lineModifier) {
       await tester.sendKeyDownEvent(
-        platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.altLeft,
+        platform == 'macos' || platform == 'ios' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.altLeft,
         platform: platform,
       );
     }
@@ -5273,19 +5273,19 @@ void main() {
     }
     if (lineModifier) {
       await tester.sendKeyUpEvent(
-        platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.altLeft,
+        platform == 'macos' || platform == 'ios' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.altLeft,
         platform: platform,
       );
     }
     if (wordModifier) {
       await tester.sendKeyUpEvent(
-        platform == 'macos' ? LogicalKeyboardKey.altLeft : LogicalKeyboardKey.controlLeft,
+        platform == 'macos' || platform == 'ios' ? LogicalKeyboardKey.altLeft : LogicalKeyboardKey.controlLeft,
         platform: platform,
       );
     }
     if (shortcutModifier) {
       await tester.sendKeyUpEvent(
-        platform == 'macos' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.controlLeft,
+        platform == 'macos' || platform == 'ios' ? LogicalKeyboardKey.metaLeft : LogicalKeyboardKey.controlLeft,
         platform: platform,
       );
     }
@@ -5594,7 +5594,6 @@ void main() {
 
     switch (defaultTargetPlatform) {
       // These platforms extend by line.
-      case TargetPlatform.iOS:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -5612,7 +5611,8 @@ void main() {
         );
         break;
 
-      // Mac expands by line.
+      // Mac and iOS expands by line.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
           selection,
@@ -6785,7 +6785,6 @@ void main() {
     switch (defaultTargetPlatform) {
       // These platforms don't handle shift + home/end at all.
       case TargetPlatform.android:
-      case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(
           selectionAfterHome,
@@ -6858,7 +6857,8 @@ void main() {
         );
         break;
 
-      // Mac goes to the start/end of the document.
+      // Mac and iOS goes to the start/end of the document.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
           selectionAfterHome,
@@ -7135,7 +7135,6 @@ void main() {
     switch (defaultTargetPlatform) {
       // These platforms don't move the selection with shift + home/end at all.
       case TargetPlatform.android:
-      case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(
           selection,
@@ -7148,7 +7147,8 @@ void main() {
         );
         break;
 
-      // Mac selects to the start of the document.
+      // Mac and iOS selects to the start of the document.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
           selection,
@@ -7192,7 +7192,6 @@ void main() {
     switch (defaultTargetPlatform) {
       // These platforms don't move the selection with home/end at all still.
       case TargetPlatform.android:
-      case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(
           selection,
@@ -7205,7 +7204,8 @@ void main() {
         );
         break;
 
-      // Mac selects to the start of the document.
+      // Mac and iOS selects to the start of the document.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
           selection,
@@ -7327,7 +7327,6 @@ void main() {
     switch (defaultTargetPlatform) {
       // These platforms don't move the selection with home/end at all.
       case TargetPlatform.android:
-      case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(
           selection,
@@ -7340,7 +7339,8 @@ void main() {
         );
         break;
 
-      // Mac selects to the end of the document.
+      // Mac and iOS selects to the end of the document.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
           selection,
@@ -7384,7 +7384,6 @@ void main() {
     switch (defaultTargetPlatform) {
       // These platforms don't move the selection with home/end at all still.
       case TargetPlatform.android:
-      case TargetPlatform.iOS:
       case TargetPlatform.fuchsia:
         expect(
           selection,
@@ -7397,7 +7396,8 @@ void main() {
         );
         break;
 
-      // Mac stays at the end of the document.
+      // Mac and iOS stays at the end of the document.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
           selection,
@@ -10260,7 +10260,7 @@ void main() {
       wordModifier: true,
       targetPlatform: defaultTargetPlatform,
     );
-    if (defaultTargetPlatform == TargetPlatform.macOS) {
+    if (defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS) {
       // word wo|rd word
       expect(controller.selection.isCollapsed, true);
       expect(controller.selection.baseOffset, 7);
@@ -10311,7 +10311,7 @@ void main() {
       wordModifier: true,
       targetPlatform: defaultTargetPlatform,
     );
-    if (defaultTargetPlatform == TargetPlatform.macOS) {
+    if (defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.iOS) {
       // word wo|rd word
       expect(controller.selection.isCollapsed, true);
       expect(controller.selection.baseOffset, 7);
@@ -10400,7 +10400,6 @@ void main() {
     expect(controller.selection.isCollapsed, false);
     switch (defaultTargetPlatform) {
       // These platforms extend by line.
-      case TargetPlatform.iOS:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -10409,7 +10408,8 @@ void main() {
         expect(controller.selection.extentOffset, 15);
         break;
 
-      // Mac expands by line.
+      // Mac and iOS expands by line.
+      case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 15);
         expect(controller.selection.extentOffset, 24);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -5611,7 +5611,7 @@ void main() {
         );
         break;
 
-      // Mac and iOS expands by line.
+      // Mac and iOS expand by line.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
@@ -6857,7 +6857,7 @@ void main() {
         );
         break;
 
-      // Mac and iOS goes to the start/end of the document.
+      // Mac and iOS go to the start/end of the document.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
@@ -7147,7 +7147,7 @@ void main() {
         );
         break;
 
-      // Mac and iOS selects to the start of the document.
+      // Mac and iOS select to the start of the document.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
@@ -7204,7 +7204,7 @@ void main() {
         );
         break;
 
-      // Mac and iOS selects to the start of the document.
+      // Mac and iOS select to the start of the document.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
@@ -7339,7 +7339,7 @@ void main() {
         );
         break;
 
-      // Mac and iOS selects to the end of the document.
+      // Mac and iOS select to the end of the document.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
@@ -7396,7 +7396,7 @@ void main() {
         );
         break;
 
-      // Mac and iOS stays at the end of the document.
+      // Mac and iOS stay at the end of the document.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(
@@ -10408,7 +10408,7 @@ void main() {
         expect(controller.selection.extentOffset, 15);
         break;
 
-      // Mac and iOS expands by line.
+      // Mac and iOS expand by line.
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
         expect(controller.selection.baseOffset, 15);


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/103073

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
