### PR TITLE
Reland "Fix crash from alt-tab'ing just after startup" 

### DIFF
--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -319,7 +319,8 @@ class MouseTracker extends ChangeNotifier {
         // so that [mouseIsConnected], which is decided by `_mouseStates`, is
         // correct during the callbacks.
         if (existingState == null) {
-          assert(event is! PointerRemovedEvent);
+          if (event is PointerRemovedEvent)
+            return;
           _mouseStates[device] = _MouseState(initialEvent: event);
         } else {
           assert(event is! PointerAddedEvent);

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -133,6 +133,16 @@ void main() {
     listenerLogs.clear();
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/90838
+  test('should not crash if the first event is a Removed event', () {
+    final List<PointerEvent> events = <PointerEvent>[];
+    _setUpWithOneAnnotation(logEvents: events);
+    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+      _pointerData(PointerChange.remove, Offset.zero),
+    ]));
+    events.clear();
+  });
+
   test('should correctly handle multiple devices', () {
     final List<PointerEvent> events = <PointerEvent>[];
     setUpWithOneAnnotation(logEvents: events);

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -136,7 +136,7 @@ void main() {
   // Regression test for https://github.com/flutter/flutter/issues/90838
   test('should not crash if the first event is a Removed event', () {
     final List<PointerEvent> events = <PointerEvent>[];
-    _setUpWithOneAnnotation(logEvents: events);
+    setUpWithOneAnnotation(logEvents: events);
     ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero),
     ]));


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/102453.

The original PR was reverted because of a build failure due to a conflicting change https://github.com/flutter/flutter/pull/102615 that renamed the function.