### PR TITLE
Improve `Hero` examples

### DIFF
--- a/examples/api/lib/widgets/heroes/hero.0.dart
+++ b/examples/api/lib/widgets/heroes/hero.0.dart
@@ -13,13 +13,8 @@ class HeroApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('Hero Sample')),
-        body: const Center(
-          child: HeroExample(),
-        ),
-      ),
+    return const MaterialApp(
+      home: HeroExample(),
     );
   }
 }
@@ -29,31 +24,24 @@ class HeroExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: <Widget>[
-        const SizedBox(
-          height: 20.0,
-        ),
-        ListTile(
-          leading: Hero(
-            tag: 'hero-rectangle',
-            child: _box(const Size(50, 50)),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Hero Sample')),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const SizedBox(height: 20.0),
+          ListTile(
+            leading: const Hero(
+              tag: 'hero-rectangle',
+              child: BoxWidget(size: Size(50.0, 50.0)),
+            ),
+            onTap: () => _gotoDetailsPage(context),
+            title: const Text(
+              'Tap on the icon to view hero animation transition.',
+            ),
           ),
-          onTap: () => _gotoDetailsPage(context),
-          title: const Text(
-            'Tap on the icon to view hero animation transition.',
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _box(Size size) {
-    return Container(
-      width: size.width,
-      height: size.height,
-      color: Colors.blue,
+        ],
+      ),
     );
   }
 
@@ -63,18 +51,28 @@ class HeroExample extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Second Page'),
         ),
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Hero(
-                tag: 'hero-rectangle',
-                child: _box(const Size(200, 200)),
-              ),
-            ],
+        body: const Center(
+          child: Hero(
+            tag: 'hero-rectangle',
+            child: BoxWidget(size: Size(200.0, 200.0)),
           ),
         ),
       ),
     ));
+  }
+}
+
+class BoxWidget extends StatelessWidget {
+  const BoxWidget({Key? key, required this.size}) : super(key: key);
+
+  final Size size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size.width,
+      height: size.height,
+      color: Colors.blue,
+    );
   }
 }

--- a/examples/api/lib/widgets/heroes/hero.1.dart
+++ b/examples/api/lib/widgets/heroes/hero.1.dart
@@ -18,13 +18,8 @@ class HeroApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      home: Scaffold(
-        appBar: AppBar(title: const Text('Hero Sample')),
-        body: const Center(
-          child: HeroExample(),
-        ),
-      ),
+    return const MaterialApp(
+      home: HeroExample(),
     );
   }
 }
@@ -34,43 +29,45 @@ class HeroExample extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: <Widget>[
-        ListTile(
-          leading: Hero(
-            tag: 'hero-default-tween',
-            child: _box(size: 50.0, color: Colors.red[700]!.withOpacity(0.5)),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Hero Sample')),
+      body: Column(
+        children: <Widget>[
+          ListTile(
+            leading: Hero(
+              tag: 'hero-default-tween',
+              child: BoxWidget(
+                size: const Size(50.0, 50.0),
+                color:Colors.red[700]!.withOpacity(0.5),
+              ),
+            ),
+            title: const Text(
+              'This red icon will use a default rect tween during the hero flight.',
+            ),
           ),
-          title: const Text(
-            'This red icon will use a default rect tween during the hero flight.',
+          const SizedBox(height: 10.0),
+          ListTile(
+            leading: Hero(
+              tag: 'hero-custom-tween',
+              createRectTween: (Rect? begin, Rect? end) {
+                return MaterialRectCenterArcTween(begin: begin, end: end);
+              },
+              child: BoxWidget(
+                size: const Size(50.0, 50.0),
+                color:Colors.blue[700]!.withOpacity(0.5),
+              ),
+            ),
+            title: const Text(
+              'This blue icon will use a custom rect tween during the hero flight.',
+            ),
           ),
-        ),
-        const SizedBox(height: 10.0),
-        ListTile(
-          leading: Hero(
-            tag: 'hero-custom-tween',
-            createRectTween: (Rect? begin, Rect? end) {
-              return MaterialRectCenterArcTween(begin: begin, end: end);
-            },
-            child: _box(size: 50.0, color: Colors.blue[700]!.withOpacity(0.5)),
+          const SizedBox(height: 10),
+          ElevatedButton(
+            onPressed: () => _gotoDetailsPage(context),
+            child: const Text('Tap to trigger hero flight'),
           ),
-          title: const Text(
-            'This blue icon will use a custom rect tween during the hero flight.',
-          ),
-        ),
-        const SizedBox(height: 10),
-        ElevatedButton(
-          onPressed: () => _gotoDetailsPage(context),
-          child: const Text('Tap to trigger hero flight'),
-        ),
-      ],
-    );
-  }
-
-  Widget _box({double? size, Color? color}) {
-    return Container(
-      color: color,
-      child: FlutterLogo(size: size),
+        ],
+      ),
     );
   }
 
@@ -89,15 +86,15 @@ class HeroExample extends StatelessWidget {
                 createRectTween: (Rect? begin, Rect? end) {
                   return MaterialRectCenterArcTween(begin: begin, end: end);
                 },
-                child: _box(
-                  size: 400.0,
+                child: BoxWidget(
+                  size: const Size(400.0, 400.0),
                   color: Colors.blue[700]!.withOpacity(0.5),
                 ),
               ),
               Hero(
                 tag: 'hero-default-tween',
-                child: _box(
-                  size: 400.0,
+                child: BoxWidget(
+                  size: const Size(400.0, 400.0),
                   color: Colors.red[700]!.withOpacity(0.5),
                 ),
               ),
@@ -106,5 +103,25 @@ class HeroExample extends StatelessWidget {
         ),
       ),
     ));
+  }
+}
+
+class BoxWidget extends StatelessWidget {
+  const BoxWidget({
+    Key? key,
+    required this.size,
+    required this.color,
+  }) : super(key: key);
+
+  final Size size;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: size.width,
+      height: size.height,
+      color: color,
+    );
   }
 }


### PR DESCRIPTION
> I think it would be a good example for the audience if this were a separate stateless widget. It's more efficient that way, and helps with segmentation of the code.

Context: https://github.com/flutter/flutter/pull/102650#discussion_r865046798

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
