### PR TITLE
Revert "Add assertion that snackbars have a place to go"

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -265,11 +265,6 @@ class ScaffoldMessengerState extends State<ScaffoldMessenger> with TickerProvide
   /// ** See code in examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.0.dart **
   /// {@end-tool}
   ScaffoldFeatureController<SnackBar, SnackBarClosedReason> showSnackBar(SnackBar snackBar) {
-    assert(
-      _scaffolds.isNotEmpty,
-      'ScaffoldMessenger.showSnackBar was called, but there are currently no '
-      'descendant Scaffolds to present to.',
-    );
     _snackBarController ??= SnackBar.createAnimationController(vsync: this)
       ..addStatusListener(_handleSnackBarStatusChanged);
     if (_snackBars.isEmpty) {

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2090,34 +2090,6 @@ void main() {
     await tester.pump(const Duration(milliseconds: 750));
     await expectLater(find.byType(MaterialApp), matchesGoldenFile('snack_bar.goldenTest.backdropFilter.png'));
   });
-
-  testWidgets('ScaffoldMessenger will alert for snackbars that cannot be presented', (WidgetTester tester) async {
-    // Regression test for https://github.com/flutter/flutter/issues/103004
-    await tester.pumpWidget(const MaterialApp(
-      home: Center(),
-    ));
-
-    final ScaffoldMessengerState scaffoldMessengerState = tester.state<ScaffoldMessengerState>(
-      find.byType(ScaffoldMessenger),
-    );
-    expect(
-      () {
-        scaffoldMessengerState.showSnackBar(const SnackBar(
-          content: Text('I am a snack bar.'),
-        ));
-      },
-      throwsA(
-        isA<AssertionError>().having(
-          (AssertionError error) => error.toString(),
-          'description',
-          contains(
-            'ScaffoldMessenger.showSnackBar was called, but there are currently '
-            'no descendant Scaffolds to present to.'
-          )
-        ),
-      ),
-    );
-  });
 }
 
 /// Start test for "SnackBar dismiss test".


### PR DESCRIPTION
Reverts flutter/flutter#103006

This breaks customer tests, which are actually bugs! Will resolve with the affected customers before re-landing.