### PR TITLE
Add debug logging to deferred components test for deflaking

### DIFF
--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: avoid_print
-
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
@@ -41,8 +39,8 @@ void main() {
       '--target-platform=android-arm64',
     ], workingDirectory: tempDir.path);
 
-    print('stdout:\n${result.stdout.toString()}');
-    print('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout.toString()}');
+    printOnFailure('stderr:\n${result.stderr.toString()}');
     expect(result.exitCode, 0);
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
@@ -77,8 +75,8 @@ void main() {
       'appbundle',
     ], workingDirectory: tempDir.path);
 
-    print('stdout:\n${result.stdout.toString()}');
-    print('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout.toString()}');
+    printOnFailure('stderr:\n${result.stderr.toString()}');
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
     expect(result.stdout.toString(), contains('Deferred components gen_snapshot validation passed.'));
@@ -123,8 +121,8 @@ void main() {
       '--no-deferred-components',
     ], workingDirectory: tempDir.path);
 
-    print('stdout:\n${result.stdout.toString()}');
-    print('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout.toString()}');
+    printOnFailure('stderr:\n${result.stderr.toString()}');
     expect(result.stdout.toString().contains('app-release.aab'), true);
     expect(result.stdout.toString().contains('Deferred components prebuild validation passed.'), false);
     expect(result.stdout.toString().contains('Deferred components gen_snapshot validation passed.'), false);

--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -38,6 +38,8 @@ void main() {
       '--target-platform=android-arm64',
     ], workingDirectory: tempDir.path);
 
+    print('stdout:\n${result.stdout.toString()}');
+    print('stderr:\n${result.stderr.toString()}');
     expect(result.exitCode, 0);
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
@@ -72,7 +74,8 @@ void main() {
       'appbundle',
     ], workingDirectory: tempDir.path);
 
-    print(result.stderr.toString());
+    print('stdout:\n${result.stdout.toString()}');
+    print('stderr:\n${result.stderr.toString()}');
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
     expect(result.stdout.toString(), contains('Deferred components gen_snapshot validation passed.'));
@@ -117,6 +120,8 @@ void main() {
       '--no-deferred-components',
     ], workingDirectory: tempDir.path);
 
+    print('stdout:\n${result.stdout.toString()}');
+    print('stderr:\n${result.stderr.toString()}');
     expect(result.stdout.toString().contains('app-release.aab'), true);
     expect(result.stdout.toString().contains('Deferred components prebuild validation passed.'), false);
     expect(result.stdout.toString().contains('Deferred components gen_snapshot validation passed.'), false);
@@ -163,6 +168,8 @@ void main() {
       '--no-validate-deferred-components',
     ], workingDirectory: tempDir.path);
 
+    print('stdout:\n${result.stdout.toString()}');
+    print('stderr:\n${result.stderr.toString()}');
     expect(result.stdout.toString().contains('app-release.aab'), true);
     expect(result.stdout.toString().contains('Deferred components prebuild validation passed.'), false);
     expect(result.stdout.toString().contains('Deferred components gen_snapshot validation passed.'), false);

--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -169,8 +169,8 @@ void main() {
       '--no-validate-deferred-components',
     ], workingDirectory: tempDir.path);
 
-    print('stdout:\n${result.stdout.toString()}');
-    print('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout.toString()}');
+    printOnFailure('stderr:\n${result.stderr.toString()}');
     expect(result.stdout.toString().contains('app-release.aab'), true);
     expect(result.stdout.toString().contains('Deferred components prebuild validation passed.'), false);
     expect(result.stdout.toString().contains('Deferred components gen_snapshot validation passed.'), false);

--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: avoid_print
+
 import 'package:archive/archive.dart';
 import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
@@ -11,6 +13,7 @@ import '../src/common.dart';
 import 'test_data/deferred_components_project.dart';
 import 'test_driver.dart';
 import 'test_utils.dart';
+
 
 void main() {
   late Directory tempDir;

--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -72,6 +72,7 @@ void main() {
       'appbundle',
     ], workingDirectory: tempDir.path);
 
+    print(result.stderr.toString());
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
     expect(result.stdout.toString(), contains('Deferred components gen_snapshot validation passed.'));


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/101609 Tracks flakes in deferred components build tests.

This adds logging to obtain better information on what is happening.