### PR TITLE
Added clipBehavior on TabBarView

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1310,6 +1310,7 @@ class TabBarView extends StatefulWidget {
     this.physics,
     this.dragStartBehavior = DragStartBehavior.start,
     this.viewportFraction = 1.0,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(children != null),
        assert(dragStartBehavior != null);
 
@@ -1341,6 +1342,11 @@ class TabBarView extends StatefulWidget {
 
   /// {@macro flutter.widgets.pageview.viewportFraction}
   final double viewportFraction;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
 
   @override
   State<TabBarView> createState() => _TabBarViewState();
@@ -1531,6 +1537,7 @@ class _TabBarViewState extends State<TabBarView> {
       onNotification: _handleScrollNotification,
       child: PageView(
         dragStartBehavior: widget.dragStartBehavior,
+        clipBehavior: widget.clipBehavior,
         controller: _pageController,
         physics: widget.physics == null
           ? const PageScrollPhysics().applyTo(const ClampingScrollPhysics())

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1104,6 +1104,49 @@ void main() {
     expect(pageController.viewportFraction, 1);
   });
 
+  testWidgets('TabBarView has clipBehavior Clip.hardEdge by default', (WidgetTester tester) async {
+    final List<String> tabs = <String>['First', 'Second'];
+
+    Widget builder() {
+      return boilerplate(
+        child: DefaultTabController(
+          length: tabs.length,
+          child: TabBarView(
+            children: tabs.map<Widget>((String name) {
+              return Text(name);
+            }).toList(),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+    final TabBarView tabBarView = tester.widget(find.byType(TabBarView));
+    expect(tabBarView.clipBehavior, Clip.hardEdge);
+  });
+
+  testWidgets('TabBarView sets clipBehavior correctly', (WidgetTester tester) async {
+    final List<String> tabs = <String>['First', 'Second'];
+
+    Widget builder() {
+      return boilerplate(
+        child: DefaultTabController(
+          length: tabs.length,
+          child: TabBarView(
+            clipBehavior: Clip.none,
+            children: tabs.map<Widget>((String name) {
+              return Text(name);
+            }).toList(),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(builder());
+    final PageView pageView = tester.widget(find.byType(PageView));
+    expect(pageView.clipBehavior, Clip.none);
+  });
+
   testWidgets('TabBar tap skips indicator animation when disabled in controller', (WidgetTester tester) async {
     final List<String> tabs = <String>['A', 'B'];
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -1105,16 +1105,14 @@ void main() {
   });
 
   testWidgets('TabBarView has clipBehavior Clip.hardEdge by default', (WidgetTester tester) async {
-    final List<String> tabs = <String>['First', 'Second'];
+    final List<Widget> tabs = <Widget>[const Text('First'), const Text('Second')];
 
     Widget builder() {
       return boilerplate(
         child: DefaultTabController(
           length: tabs.length,
           child: TabBarView(
-            children: tabs.map<Widget>((String name) {
-              return Text(name);
-            }).toList(),
+            children: tabs,
           ),
         ),
       );
@@ -1126,7 +1124,7 @@ void main() {
   });
 
   testWidgets('TabBarView sets clipBehavior correctly', (WidgetTester tester) async {
-    final List<String> tabs = <String>['First', 'Second'];
+    final List<Widget> tabs = <Widget>[const Text('First'), const Text('Second')];
 
     Widget builder() {
       return boilerplate(
@@ -1134,9 +1132,7 @@ void main() {
           length: tabs.length,
           child: TabBarView(
             clipBehavior: Clip.none,
-            children: tabs.map<Widget>((String name) {
-              return Text(name);
-            }).toList(),
+            children: tabs,
           ),
         ),
       );


### PR DESCRIPTION
Fixes #102156

This PR added clipBehavior in TabBarView class so that when users set the `clipBehavior` to `Clip.none`, the shadow in the TabBarView will not be clipped. 

With default clipBehavior in TabBarView class.

<img width="551" alt="Screen Shot 2022-05-05 at 5 23 44 PM" src="https://user-images.githubusercontent.com/36861262/167047296-d50be6a6-c72d-48ef-be18-e8547de1fdc5.png">

Set `clipBehavior: Clip.none` on TabBarView.

<img width="551" alt="Screen Shot 2022-05-05 at 5 27 20 PM" src="https://user-images.githubusercontent.com/36861262/167047564-4f0eaadb-7154-4250-bd5d-081fca68f271.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
