### PR TITLE
remove unnecessary .toString()

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -160,11 +160,11 @@ class ProcessRunner {
       }
     } on ProcessException catch (e) {
       final String message = 'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
-          'failed with:\n${e.toString()}';
+          'failed with:\n$e';
       throw PreparePackageException(message);
     } on ArgumentError catch (e) {
       final String message = 'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
-          'failed with:\n${e.toString()}';
+          'failed with:\n$e';
       throw PreparePackageException(message);
     }
 

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1654,7 +1654,7 @@ Future<void> _dartRunTest(String workingDirectory, {
     if (coverage != null)
       '--coverage=$coverage',
     if (perTestTimeout != null)
-      '--timeout=${perTestTimeout.inMilliseconds.toString()}ms',
+      '--timeout=${perTestTimeout.inMilliseconds}ms',
     if (testPaths != null)
       for (final String testPath in testPaths)
         testPath,

--- a/dev/bots/unpublish_package.dart
+++ b/dev/bots/unpublish_package.dart
@@ -190,11 +190,11 @@ class ProcessRunner {
       }
     } on ProcessException catch (e) {
       final String message = 'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
-          'failed with:\n${e.toString()}';
+          'failed with:\n$e';
       throw UnpublishException(message);
     } on ArgumentError catch (e) {
       final String message = 'Running "${commandLine.join(' ')}" in ${workingDirectory.path} '
-          'failed with:\n${e.toString()}';
+          'failed with:\n$e';
       throw UnpublishException(message);
     }
 

--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -278,14 +278,14 @@ class Version {
     final String branchX = branchMatch.group(1)!;
     if (x != int.tryParse(branchX)) {
       throw ConductorException(
-        'Parsed version ${toString()} has a different x value than candidate '
+        'Parsed version $this has a different x value than candidate '
         'branch $candidateBranch',
       );
     }
     final String branchY = branchMatch.group(2)!;
     if (y != int.tryParse(branchY)) {
       throw ConductorException(
-        'Parsed version ${toString()} has a different y value than candidate '
+        'Parsed version $this has a different y value than candidate '
         'branch $candidateBranch',
       );
     }
@@ -295,7 +295,7 @@ class Version {
       final String branchM = branchMatch.group(3)!;
       if (m != int.tryParse(branchM)) {
         throw ConductorException(
-          'Parsed version ${toString()} has a different m value than candidate '
+          'Parsed version $this has a different m value than candidate '
           'branch $candidateBranch with type $type',
         );
       }

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -758,7 +758,7 @@ void checkDirectoryNotExists(String directory) {
 void checkCollectionContains<T>(Iterable<T> values, Iterable<T> collection) {
   for (final T value in values) {
     if (!collection.contains(value)) {
-      throw TaskResult.failure('Expected to find `$value` in `${collection.toString()}`.');
+      throw TaskResult.failure('Expected to find `$value` in `$collection`.');
     }
   }
 }

--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -189,7 +189,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
       if (!mounted) {
         return;
       }
-      showMessage(context, 'Failed saving ${e.toString()}');
+      showMessage(context, 'Failed saving $e');
     }
   }
 
@@ -309,6 +309,6 @@ class TouchEventDiff extends StatelessWidget {
     for (int i = 0; i < coords.length; i++) {
       buffer.write('p$i x: ${coords[i]['x']} y: ${coords[i]['y']}, pressure: ${coords[i]['pressure']} ');
     }
-    print(buffer.toString());
+    print(buffer);
   }
 }

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/icons_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/icons_demo.dart
@@ -101,7 +101,7 @@ class _IconsDemoCard extends StatelessWidget {
   TableRow _buildIconRow(double size) {
     return TableRow(
       children: <Widget> [
-        _centeredText('${size.floor().toString()} ${icon.toString()}'),
+        _centeredText('${size.floor()} $icon'),
         _buildIconButton(size, icon, true),
         _buildIconButton(size, icon, false),
       ],
@@ -122,9 +122,9 @@ class _IconsDemoCard extends StatelessWidget {
             children: <TableRow> [
               TableRow(
                 children: <Widget> [
-                  _centeredText('Size ${icon.toString()}'),
-                  _centeredText('Enabled ${icon.toString()}'),
-                  _centeredText('Disabled ${icon.toString()}'),
+                  _centeredText('Size $icon'),
+                  _centeredText('Enabled $icon'),
+                  _centeredText('Disabled $icon'),
                 ]
               ),
               _buildIconRow(18.0),

--- a/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
@@ -171,7 +171,7 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
       if (!mounted) {
         return;
       }
-      showMessage(context, 'Failed saving ${e.toString()}');
+      showMessage(context, 'Failed saving $e');
     }
   }
 
@@ -281,6 +281,6 @@ class TouchEventDiff extends StatelessWidget {
     for (int i = 0; i < coords.length; i++) {
       buffer.write('p$i x: ${coords[i]['x']} y: ${coords[i]['y']}, pressure: ${coords[i]['pressure']} ');
     }
-    print(buffer.toString());
+    print(buffer);
   }
 }

--- a/dev/tools/examples_smoke_test.dart
+++ b/dev/tools/examples_smoke_test.dart
@@ -228,12 +228,12 @@ Future<String> runCommand(
     );
   } on ProcessException catch (e) {
     stderr.writeln('Running "${cmd.join(' ')}" in ${workingDirectory.path} '
-        'failed with:\n${e.toString()}');
+        'failed with:\n$e');
     exitCode = 2;
     return utf8.decode(stdoutOutput);
   } on ArgumentError catch (e) {
     stderr.writeln('Running "${cmd.join(' ')}" in ${workingDirectory.path} '
-        'failed with:\n${e.toString()}');
+        'failed with:\n$e');
     exitCode = 3;
     return utf8.decode(stdoutOutput);
   }

--- a/dev/tools/gen_defaults/lib/template.dart
+++ b/dev/tools/gen_defaults/lib/template.dart
@@ -149,6 +149,6 @@ abstract class TokenTemplate {
 
   /// Generate a [TextTheme] text style name for the given component token.
   String textStyle(String componentToken) {
-    return '$textThemePrefix${tokens["$componentToken.text-style"]!.toString()}';
+    return '$textThemePrefix${tokens["$componentToken.text-style"]}';
   }
 }

--- a/dev/tools/update_icons.dart
+++ b/dev/tools/update_icons.dart
@@ -419,7 +419,7 @@ void _generateIconDemo(File demoFilePath, Map<String, String> tokenPairMap) {
           home: Scaffold(
             body: Wrap(
               children: const [
-                ${newIconUsages.toString()}
+                $newIconUsages
               ],
             ),
           ),

--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -619,7 +619,7 @@ class FlutterErrorDetails with Diagnosticable {
     } else if (exception is Error || exception is Exception) {
       longMessage = exception.toString();
     } else {
-      longMessage = '  ${exception.toString()}';
+      longMessage = '  $exception';
     }
     longMessage = longMessage.trimRight();
     if (longMessage.isEmpty)

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -403,7 +403,7 @@ class _IndicatorPainter extends CustomPainter {
     if (!(rect.size >= insets.collapsedSize)) {
       throw FlutterError(
           'indicatorPadding insets should be less than Tab Size\n'
-          'Rect Size : ${rect.size}, Insets: ${insets.toString()}',
+          'Rect Size : ${rect.size}, Insets: $insets',
       );
     }
     return insets.deflateRect(rect);

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -1975,7 +1975,7 @@ abstract class RenderBox extends RenderObject {
   /// of those functions, call [markNeedsLayout] instead to schedule a layout of
   /// the box.
   Size get size {
-    assert(hasSize, 'RenderBox was not laid out: ${toString()}');
+    assert(hasSize, 'RenderBox was not laid out: $this');
     assert(() {
       final Size? size = _size;
       if (size is _DebugSize) {

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -2829,8 +2829,8 @@ class BuildOwner {
                 ErrorSummary('Multiple widgets used the same GlobalKey.'),
                 ErrorDescription(
                   'The key $key was used by multiple widgets. The parents of those widgets were:\n'
-                  '- ${older.toString()}\n'
-                  '- ${newer.toString()}\n'
+                  '- $older\n'
+                  '- $newer\n'
                   'A GlobalKey can only be specified on one widget at a time in the widget tree.',
                 ),
               ]);
@@ -2840,7 +2840,7 @@ class BuildOwner {
                 ErrorDescription(
                   'The key $key was used by multiple widgets. The parents of those widgets were '
                   'different widgets that both had the following description:\n'
-                  '  ${parent.toString()}\n'
+                  '  $parent\n'
                   'A GlobalKey can only be specified on one widget at a time in the widget tree.',
                 ),
               ]);

--- a/packages/flutter/test/animation/curves_test.dart
+++ b/packages/flutter/test/animation/curves_test.dart
@@ -37,7 +37,7 @@ void main() {
     const double delta = 0.005;
     for (double x = 0.0; x < 1.0 - delta; x += delta) {
       final double deltaY = curve.transform(x) - curve.transform(x + delta);
-      assert(deltaY.abs() < delta * maximumSlope, '${curve.toString()} discontinuous at $x');
+      assert(deltaY.abs() < delta * maximumSlope, '$curve discontinuous at $x');
     }
   }
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1294,7 +1294,7 @@ void main() {
     Finder counterFinder = find.byType(Text);
     expect(counterFinder, findsOneWidget);
     final Text counterWidget = tester.widget(counterFinder);
-    expect(counterWidget.data, '0/${maxLength.toString()}');
+    expect(counterWidget.data, '0/$maxLength');
 
     // When counter, counterText, and buildCounter are set, shows the counter
     // widget.
@@ -1309,7 +1309,7 @@ void main() {
       required bool isFocused,
     }) {
       return Text(
-        '${currentLength.toString()} of ${maxLength.toString()}',
+        '$currentLength of $maxLength',
         key: buildCounterKey,
       );
     }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -4679,7 +4679,7 @@ void main() {
         child: Center(
             child: TextField(
               buildCounter: (BuildContext context, { required int currentLength, int? maxLength, required bool isFocused }) {
-                return Text('${currentLength.toString()} of ${maxLength.toString()}');
+                return Text('$currentLength of $maxLength');
               },
               maxLength: 10,
             ),

--- a/packages/flutter/test/material/text_form_field_test.dart
+++ b/packages/flutter/test/material/text_form_field_test.dart
@@ -645,7 +645,7 @@ void main() {
         child: Center(
             child: TextFormField(
               buildCounter: (BuildContext context, { int? currentLength, int? maxLength, bool? isFocused }) {
-                return Text('${currentLength.toString()} of ${maxLength.toString()}');
+                return Text('$currentLength of $maxLength');
               },
               maxLength: 10,
             ),

--- a/packages/flutter/test/material/tooltip_theme_test.dart
+++ b/packages/flutter/test/material/tooltip_theme_test.dart
@@ -97,8 +97,8 @@ void main() {
       'semantics: excluded',
       'decoration: BoxDecoration(color: Color(0xffffffff))',
       'textStyle: TextStyle(inherit: true, decoration: TextDecoration.underline)',
-      'wait duration: ${wait.toString()}',
-      'show duration: ${show.toString()}',
+      'wait duration: $wait',
+      'show duration: $show',
       'triggerMode: $triggerMode',
       'enableFeedback: true',
     ]);

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -413,7 +413,7 @@ mixin CommandHandlerFactory {
     }
 
     if (text == null) {
-      throw UnsupportedError('Type ${widget.runtimeType.toString()} is currently not supported by getText');
+      throw UnsupportedError('Type ${widget.runtimeType} is currently not supported by getText');
     }
 
     return GetTextResult(text);

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -148,7 +148,7 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
       }
       logger.printError('AndroidManifest.xml is not a valid XML document.');
       logger.printError('Please check $manifestLocation for errors.');
-      throwToolExit('XML Parser error message: ${exception.toString()}');
+      throwToolExit('XML Parser error message: $exception');
     }
 
     final Iterable<XmlElement> manifests = document.findElements('manifest');

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1265,7 +1265,7 @@ class LocalizationsGenerator {
     final List<String> sortedClassImports = supportedLocales
       .where((LocaleInfo locale) => isBaseClassLocale(locale, locale.languageCode))
       .map((LocaleInfo locale) {
-        final String library = '${fileName}_${locale.toString()}';
+        final String library = '${fileName}_$locale';
         if (useDeferredLoading) {
           return "import '$library.$fileExtension' deferred as $library;";
         } else {

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -442,7 +442,7 @@ class AppResourceBundle {
     } on FormatException catch (e) {
       throw L10nException(
         'The arb file ${file.path} has the following formatting issue: \n'
-        '${e.toString()}',
+        '$e',
       );
     }
 

--- a/packages/flutter_tools/lib/src/resident_devtools_handler.dart
+++ b/packages/flutter_tools/lib/src/resident_devtools_handler.dart
@@ -161,7 +161,7 @@ class FlutterResidentDevtoolsHandler implements ResidentDevtoolsHandler {
       );
     } on Exception catch (e) {
       _logger.printError(
-        'Failed to set DevTools server address: ${e.toString()}. Deep links to'
+        'Failed to set DevTools server address: $e. Deep links to'
         ' DevTools will not show in Flutter errors.',
       );
     }
@@ -215,7 +215,7 @@ class FlutterResidentDevtoolsHandler implements ResidentDevtoolsHandler {
     } on Exception catch (e) {
       _logger.printError(e.toString());
       _logger.printError(
-        'Failed to set vm service URI: ${e.toString()}. Deep links to DevTools'
+        'Failed to set vm service URI: $e. Deep links to DevTools'
         ' will not show in Flutter errors.',
       );
     }

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -245,7 +245,7 @@ flutter:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          'plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()}\n',
+          'plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri}\n',
           mode: FileMode.append,
         );
     }
@@ -275,7 +275,7 @@ flutter:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          'plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()}\n',
+          'plugin1:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri}\n',
           mode: FileMode.append,
         );
       return pluginUsingJavaAndNewEmbeddingDir;
@@ -305,7 +305,7 @@ flutter:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          'plugin2:${pluginUsingKotlinAndNewEmbeddingDir.childDirectory('lib').uri.toString()}\n',
+          'plugin2:${pluginUsingKotlinAndNewEmbeddingDir.childDirectory('lib').uri}\n',
           mode: FileMode.append,
         );
     }
@@ -333,7 +333,7 @@ flutter:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          '$pluginName:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri.toString()}\n',
+          '$pluginName:${pluginUsingOldEmbeddingDir.childDirectory('lib').uri}\n',
           mode: FileMode.append,
         );
     }
@@ -366,7 +366,7 @@ flutter:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          'plugin4:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri.toString()}',
+          'plugin4:${pluginUsingJavaAndNewEmbeddingDir.childDirectory('lib').uri}',
           mode: FileMode.append,
         );
     }
@@ -397,7 +397,7 @@ dependencies:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          '$name:${pluginDirectory.childDirectory('lib').uri.toString()}\n',
+          '$name:${pluginDirectory.childDirectory('lib').uri}\n',
           mode: FileMode.append,
         );
       return pluginDirectory;
@@ -435,7 +435,7 @@ dependencies:
       flutterProject.directory
         .childFile('.packages')
         .writeAsStringSync(
-          '$name:${pluginDirectory.childDirectory('lib').uri.toString()}\n',
+          '$name:${pluginDirectory.childDirectory('lib').uri}\n',
           mode: FileMode.append,
         );
       return pluginDirectory;
@@ -1076,7 +1076,7 @@ dependencies:
         flutterProject.directory
           .childFile('.packages')
           .writeAsStringSync('''
-web_plugin_with_nested:${webPluginWithNestedFile.childDirectory('lib').uri.toString()}
+web_plugin_with_nested:${webPluginWithNestedFile.childDirectory('lib').uri}
 ''');
 
         await injectPlugins(flutterProject, webPlatform: true);

--- a/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
+++ b/packages/flutter_tools/test/integration.shard/deferred_components_test.dart
@@ -39,8 +39,8 @@ void main() {
       '--target-platform=android-arm64',
     ], workingDirectory: tempDir.path);
 
-    printOnFailure('stdout:\n${result.stdout.toString()}');
-    printOnFailure('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout}');
+    printOnFailure('stderr:\n${result.stderr}');
     expect(result.exitCode, 0);
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
@@ -75,8 +75,8 @@ void main() {
       'appbundle',
     ], workingDirectory: tempDir.path);
 
-    printOnFailure('stdout:\n${result.stdout.toString()}');
-    printOnFailure('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout}');
+    printOnFailure('stderr:\n${result.stderr}');
     expect(result.stdout.toString(), contains('app-release.aab'));
     expect(result.stdout.toString(), contains('Deferred components prebuild validation passed.'));
     expect(result.stdout.toString(), contains('Deferred components gen_snapshot validation passed.'));
@@ -121,8 +121,8 @@ void main() {
       '--no-deferred-components',
     ], workingDirectory: tempDir.path);
 
-    printOnFailure('stdout:\n${result.stdout.toString()}');
-    printOnFailure('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout}');
+    printOnFailure('stderr:\n${result.stderr}');
     expect(result.stdout.toString().contains('app-release.aab'), true);
     expect(result.stdout.toString().contains('Deferred components prebuild validation passed.'), false);
     expect(result.stdout.toString().contains('Deferred components gen_snapshot validation passed.'), false);
@@ -169,8 +169,8 @@ void main() {
       '--no-validate-deferred-components',
     ], workingDirectory: tempDir.path);
 
-    printOnFailure('stdout:\n${result.stdout.toString()}');
-    printOnFailure('stderr:\n${result.stderr.toString()}');
+    printOnFailure('stdout:\n${result.stdout}');
+    printOnFailure('stderr:\n${result.stderr}');
     expect(result.stdout.toString().contains('app-release.aab'), true);
     expect(result.stdout.toString().contains('Deferred components prebuild validation passed.'), false);
     expect(result.stdout.toString().contains('Deferred components gen_snapshot validation passed.'), false);

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -753,7 +753,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
   }
 
   void _throwErrorResponse(String message) {
-    throw Exception('$message\n\n$_lastResponse\n\n${_errorBuffer.toString()}'.trim());
+    throw Exception('$message\n\n$_lastResponse\n\n$_errorBuffer'.trim());
   }
 
   final bool spawnDdsInstance;

--- a/packages/integration_test/lib/common.dart
+++ b/packages/integration_test/lib/common.dart
@@ -92,7 +92,7 @@ class Response {
     for (final Failure failure in failureDetails) {
       sb.writeln('Failure in method: ${failure.methodName}');
       sb.writeln(failure.details);
-      sb.writeln('end of failure ${failureCount.toString()}\n\n');
+      sb.writeln('end of failure $failureCount\n\n');
       failureCount++;
     }
     return sb.toString();


### PR DESCRIPTION
This will avoid new diagnostics after changes on `noop_primitive_operations` introduced by https://github.com/dart-lang/linter/pull/3379