### PR TITLE
remove assert on markNeedsCompositingBitsUpdate

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2295,12 +2295,6 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         return;
       }
     }
-    assert(() {
-      final AbstractNode? parent = this.parent;
-      if (parent is RenderObject)
-        return parent._needsCompositing;
-      return true;
-    }());
     // parent is fine (or there isn't one), but we are dirty
     if (owner != null)
       owner!._nodesNeedingCompositingBitsUpdate.add(this);


### PR DESCRIPTION
I don't believe this assert holds any longer, as you can end up toggling on/off repaint boundaries which can lead us to composite things we previously didn't need to
