### PR TITLE
Allows the body and header of NestedScrollView to scroll in sync

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -314,7 +314,10 @@ class NestedScrollView extends StatefulWidget {
       SliverFillRemaining(
         child: PrimaryScrollController(
           controller: innerController,
-          child: body,
+          child: ScrollConfiguration(
+            behavior: scrollBehavior ?? ScrollConfiguration.of(context).copyWith(scrollbars: false, underNestedScrollScope: true),
+            child: body
+          ),
         ),
       ),
     ];

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -99,6 +99,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
+    bool? underNestedScrollScope,
     Set<PointerDeviceKind>? dragDevices,
     ScrollPhysics? physics,
     TargetPlatform? platform,
@@ -112,6 +113,7 @@ class ScrollBehavior {
       delegate: this,
       scrollbars: scrollbars ?? true,
       overscroll: overscroll ?? true,
+      underNestedScrollScope: underNestedScrollScope ?? false,
       physics: physics,
       platform: platform,
       dragDevices: dragDevices,
@@ -131,6 +133,15 @@ class ScrollBehavior {
   /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
   /// impossible to select text in scrollable containers and is not recommended.
   Set<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
+
+  /// If set to true, the [ScrollView] in the subtree will use [PrimaryScrollController]
+  /// if the [ScrollController] is null.
+  ///
+  /// See also:
+  ///
+  ///  * [NestedScrollView], which depends on PrimaryScrollController to scroll
+  ///    its body.
+  bool get underNestedScrollScope => false;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -273,9 +284,11 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscroll = true,
     this.physics,
     this.platform,
+    bool? underNestedScrollScope,
     Set<PointerDeviceKind>? dragDevices,
     AndroidOverscrollIndicator? androidOverscrollIndicator,
-  }) : _androidOverscrollIndicator = androidOverscrollIndicator,
+  }) : _underNestedScrollScope = underNestedScrollScope,
+       _androidOverscrollIndicator = androidOverscrollIndicator,
        _dragDevices = dragDevices;
 
   final ScrollBehavior delegate;
@@ -283,6 +296,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final bool overscroll;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
+  final bool? _underNestedScrollScope;
   final Set<PointerDeviceKind>? _dragDevices;
   @override
   final AndroidOverscrollIndicator? _androidOverscrollIndicator;
@@ -292,6 +306,9 @@ class _WrappedScrollBehavior implements ScrollBehavior {
 
   @override
   AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator ?? delegate.androidOverscrollIndicator;
+
+  @override
+  bool get underNestedScrollScope => _underNestedScrollScope ?? delegate.underNestedScrollScope;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -316,6 +333,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
+    bool? underNestedScrollScope,
     ScrollPhysics? physics,
     TargetPlatform? platform,
     Set<PointerDeviceKind>? dragDevices,
@@ -324,6 +342,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     return delegate.copyWith(
       scrollbars: scrollbars ?? this.scrollbars,
       overscroll: overscroll ?? this.overscroll,
+      underNestedScrollScope: underNestedScrollScope ?? this.underNestedScrollScope,
       physics: physics ?? this.physics,
       platform: platform ?? this.platform,
       dragDevices: dragDevices ?? this.dragDevices,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -393,8 +393,14 @@ abstract class ScrollView extends StatelessWidget {
     final List<Widget> slivers = buildSlivers(context);
     final AxisDirection axisDirection = getDirection(context);
 
-    final ScrollController? scrollController =
-        primary ? PrimaryScrollController.of(context) : controller;
+    final ScrollBehavior ancestorBehavior = ScrollConfiguration.of(context);
+    ScrollController? scrollController;
+    // check if the scrollable is under a nested scroll scope
+    if (ancestorBehavior.underNestedScrollScope) {
+      scrollController = controller ?? PrimaryScrollController.of(context);
+    } else {
+      scrollController = primary ? PrimaryScrollController.of(context) : controller;
+    }
     final Scrollable scrollable = Scrollable(
       dragStartBehavior: dragStartBehavior,
       axisDirection: axisDirection,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -2552,6 +2552,38 @@ void main() {
     expect(scrollStarted, 2);
     expect(scrollEnded, 2);
   });
+
+  testWidgets('NestedScrollView.body will be connected if horizontal', (WidgetTester tester) async {
+    final GlobalKey<NestedScrollViewState> globalKey = GlobalKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: NestedScrollView(
+            key: globalKey,
+            scrollDirection: Axis.horizontal,
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+              return <Widget>[const SliverAppBar(title: Text('Demo'))];
+            },
+            body: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemBuilder: (BuildContext context, int index) => Text('Item $index'),
+            )),
+      ),
+    ));
+
+    expect(globalKey.currentState?.innerController, isNotNull);
+
+    // scroll to right
+    await tester.fling(find.text('Item 1'), const Offset(-50.0, 0.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(globalKey.currentState!.outerController.position.pixels, globalKey.currentState!.outerController.position.maxScrollExtent);
+    expect(globalKey.currentState!.innerController.position.pixels, greaterThan(0));
+
+    // scroll to left
+    await tester.fling(find.byType(ListView), const Offset(50.0, 0.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(globalKey.currentState!.outerController.position.pixels, 0);
+    expect(globalKey.currentState!.innerController.position.pixels, 0);
+  });
 }
 
 class TestHeader extends SliverPersistentHeaderDelegate {


### PR DESCRIPTION
This PR makes the body and header of NestedScrollView scrolling in sync by introducing a new property to ScrollConfiguration. It provides an efficient way for the scroll view to know whether it is a descendant of NestedScrollView. This also allow a potential fix to #40740

Fixes #102001

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
