### PR TITLE
Make NestedScrollView support PageStorageKey

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -99,6 +99,7 @@ class ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
+    bool? underNestedScrollScope,
     Set<PointerDeviceKind>? dragDevices,
     ScrollPhysics? physics,
     TargetPlatform? platform,
@@ -112,6 +113,7 @@ class ScrollBehavior {
       delegate: this,
       scrollbars: scrollbars ?? true,
       overscroll: overscroll ?? true,
+      underNestedScrollScope: underNestedScrollScope ?? false,
       physics: physics,
       platform: platform,
       dragDevices: dragDevices,
@@ -131,6 +133,15 @@ class ScrollBehavior {
   /// Enabling this for [PointerDeviceKind.mouse] will make it difficult or
   /// impossible to select text in scrollable containers and is not recommended.
   Set<PointerDeviceKind> get dragDevices => _kTouchLikeDeviceTypes;
+
+  /// If set to true, the [ScrollView] in the subtree will use [PrimaryScrollController]
+  /// if the [ScrollController] is null.
+  ///
+  /// See also:
+  ///
+  ///  * [NestedScrollView], which depends on PrimaryScrollController to scroll
+  ///    its body.
+  bool get underNestedScrollScope => false;
 
   /// Wraps the given widget, which scrolls in the given [AxisDirection].
   ///
@@ -273,9 +284,11 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     this.overscroll = true,
     this.physics,
     this.platform,
+    bool? underNestedScrollScope,
     Set<PointerDeviceKind>? dragDevices,
     AndroidOverscrollIndicator? androidOverscrollIndicator,
-  }) : _androidOverscrollIndicator = androidOverscrollIndicator,
+  }) : _underNestedScrollScope = underNestedScrollScope,
+       _androidOverscrollIndicator = androidOverscrollIndicator,
        _dragDevices = dragDevices;
 
   final ScrollBehavior delegate;
@@ -283,6 +296,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   final bool overscroll;
   final ScrollPhysics? physics;
   final TargetPlatform? platform;
+  final bool? _underNestedScrollScope;
   final Set<PointerDeviceKind>? _dragDevices;
   @override
   final AndroidOverscrollIndicator? _androidOverscrollIndicator;
@@ -292,6 +306,9 @@ class _WrappedScrollBehavior implements ScrollBehavior {
 
   @override
   AndroidOverscrollIndicator get androidOverscrollIndicator => _androidOverscrollIndicator ?? delegate.androidOverscrollIndicator;
+
+  @override
+  bool get underNestedScrollScope => _underNestedScrollScope ?? delegate.underNestedScrollScope;
 
   @override
   Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
@@ -316,6 +333,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
   ScrollBehavior copyWith({
     bool? scrollbars,
     bool? overscroll,
+    bool? underNestedScrollScope,
     ScrollPhysics? physics,
     TargetPlatform? platform,
     Set<PointerDeviceKind>? dragDevices,
@@ -324,6 +342,7 @@ class _WrappedScrollBehavior implements ScrollBehavior {
     return delegate.copyWith(
       scrollbars: scrollbars ?? this.scrollbars,
       overscroll: overscroll ?? this.overscroll,
+      underNestedScrollScope: underNestedScrollScope ?? this.underNestedScrollScope,
       physics: physics ?? this.physics,
       platform: platform ?? this.platform,
       dragDevices: dragDevices ?? this.dragDevices,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -407,7 +407,7 @@ abstract class ScrollView extends StatelessWidget {
     } else {
       scrollController = primary ? PrimaryScrollController.of(context) : controller;
     }
-    
+
     final Scrollable scrollable = Scrollable(
       dragStartBehavior: dragStartBehavior,
       axisDirection: axisDirection,

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -13,7 +13,9 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
 import 'media_query.dart';
+import 'nested_scroll_view.dart';
 import 'notification_listener.dart';
+import 'page_storage.dart';
 import 'primary_scroll_controller.dart';
 import 'scroll_configuration.dart';
 import 'scroll_controller.dart';
@@ -393,8 +395,19 @@ abstract class ScrollView extends StatelessWidget {
     final List<Widget> slivers = buildSlivers(context);
     final AxisDirection axisDirection = getDirection(context);
 
-    final ScrollController? scrollController =
-        primary ? PrimaryScrollController.of(context) : controller;
+    final ScrollBehavior ancestorBehavior = ScrollConfiguration.of(context);
+    ScrollController? scrollController;
+    // check if the scrollable is under a nested scroll scope
+    if (ancestorBehavior.underNestedScrollScope) {
+      scrollController = controller ?? PrimaryScrollController.of(context);
+      if (key is PageStorageKey) {
+        final NestedScrollViewState nestedScrollViewState = NestedScrollView.of(context);
+        nestedScrollViewState.preserveScrollPosition();
+      }
+    } else {
+      scrollController = primary ? PrimaryScrollController.of(context) : controller;
+    }
+    
     final Scrollable scrollable = Scrollable(
       dragStartBehavior: dragStartBehavior,
       axisDirection: axisDirection,

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -735,19 +735,121 @@ void main() {
     );
     await gesture5.moveBy(const Offset(400.0, 0.0));
     await tester.pump(); // bring the left page into view
-    await tester.pump(); // shadow would come back starting here, but there's no shadow to show
+    await tester.pump(); // shadow comes back starting here because the scroll position is preserved by pageStorage key
+    expectedBuildCount += 1;
     expect(buildCount, expectedBuildCount);
-    expect(find.text('Item 18'), findsNothing);
-    expect(find.text('Item 2'), findsNWidgets(2));
+    expect(find.text('Item 18'), findsOneWidget); // item 18 should be found because of preserved scroll position
+    expect(find.text('Item 2'), findsOneWidget);
     checkPhysicalLayer(elevation: 0);
     await tester.pump(const Duration(seconds: 1)); // shadow would be finished coming back
-    checkPhysicalLayer(elevation: 0);
+    checkPhysicalLayer(elevation: 4);
     await gesture5.up();
     await tester.pump(); // right tab view goes away
-    await tester.pumpAndSettle();
     expect(buildCount, expectedBuildCount);
-    checkPhysicalLayer(elevation: 0);
     debugDisableShadows = true;
+  });
+
+  testWidgets('NestedScrollView supports PageStorageKey', (WidgetTester tester) async {
+    final List<String> tabs = <String>['Tab 1', 'Tab 2'];
+    await tester.pumpWidget(
+      MaterialApp(
+        home: DefaultTabController(
+          length: tabs.length,
+          child: Scaffold(
+            body: NestedScrollView(
+              headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) {
+                return <Widget>[
+                  SliverOverlapAbsorber(
+                    handle: NestedScrollView.sliverOverlapAbsorberHandleFor(context),
+                    sliver: SliverAppBar(
+                      title: const Text('Books'),
+                      pinned: true,
+                      expandedHeight: 150.0,
+                      forceElevated: innerBoxIsScrolled,
+                      bottom: TabBar(
+                        tabs: tabs.map((String name) => Tab(text: name)).toList(),
+                      ),
+                    ),
+                  ),
+                ];
+              },
+              body: TabBarView(
+                children: tabs.map((String name) {
+                  return SafeArea(
+                    top: false,
+                    bottom: false,
+                    child: Builder(
+                      builder: (BuildContext context) {
+                        return CustomScrollView(
+                          key: PageStorageKey<String>(name),
+                          slivers: <Widget>[
+                            SliverOverlapInjector(
+                              handle:
+                                  NestedScrollView.sliverOverlapAbsorberHandleFor(
+                                      context),
+                            ),
+                            SliverPadding(
+                              padding: const EdgeInsets.all(8.0),
+                              sliver: SliverFixedExtentList(
+                                itemExtent: 48.0,
+                                delegate: SliverChildBuilderDelegate(
+                                  (BuildContext context, int index) {
+                                    return ListTile(
+                                      title: Text('Item $index'),
+                                    );
+                                  },
+                                  childCount: 30,
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                  );
+                }).toList(),
+              ),
+            ),
+          ),
+        ),
+      )
+    );
+
+    // Scroll to bottom of tab1
+    await tester.fling(find.text('Item 2'), const Offset(0.0, -250.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 29'), findsOneWidget);
+
+    // Bring tab2 into view
+    await tester.fling(find.text('Item 29'), const Offset(-400, 0.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(find.text('Item 2'), findsOneWidget);
+    expect(find.text('Item 29'), findsNothing);
+
+    // Scroll to bottom of tab2
+    await tester.fling(find.text('Item 2'), const Offset(0.0, -250.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 29'), findsOneWidget);
+
+    // Bring tab1 into view, the scroll position of tab1 should remain unchanged
+    await tester.fling(find.text('Item 29'), const Offset(400, 0.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 29'), findsOneWidget);
+
+    // Scroll to top of tab1
+    await tester.fling(find.text('Item 29'), const Offset(0.0, 250.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(find.text('Item 2'), findsOneWidget);
+    expect(find.text('Item 29'), findsNothing);
+
+    // Bring tab2 into view, the scroll position of tab2 should remain unchanged
+    await tester.fling(find.text('Item 2'), const Offset(-400, 0.0), 10000.0);
+    await tester.pumpAndSettle();
+    expect(find.text('Item 2'), findsNothing);
+    expect(find.text('Item 29'), findsOneWidget);
   });
 
   testWidgets('NestedScrollView and bouncing', (WidgetTester tester) async {


### PR DESCRIPTION
This PR allows NestedScrollView to preserve its scroll position using PageStorageKey. This is based on #103253.

Fixes #40740

I changed the `NestedScrollView and internal scrolling` test, as the original expectation was wrong. PageStorageKey should preserve the scroll position.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
