### PR TITLE
[flutter_tools] Have FlutterValidator fail on non-ideal git config

### DIFF
--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -16,8 +16,8 @@ class UserMessages {
   // Messages used in FlutterValidator
   String flutterStatusInfo(String? channel, String? version, String os, String locale) =>
       'Channel ${channel ?? 'unknown'}, ${version ?? 'Unknown'}, on $os, locale $locale';
-  String flutterVersion(String version, String? channel, String flutterRoot) =>
-      'Flutter version $version on ${channel ?? 'unknown'} at $flutterRoot';
+  String flutterVersion(String version, String channel, String flutterRoot) =>
+      'Flutter version $version on channel $channel at $flutterRoot';
   String flutterRevision(String revision, String age, String date) =>
       'Framework revision $revision ($age), $date';
   String flutterUpstreamRepositoryUrl(String url) => 'Upstream repository $url';

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -16,11 +16,13 @@ class UserMessages {
   // Messages used in FlutterValidator
   String flutterStatusInfo(String? channel, String? version, String os, String locale) =>
       'Channel ${channel ?? 'unknown'}, ${version ?? 'Unknown'}, on $os, locale $locale';
-  String flutterVersion(String version, String flutterRoot) =>
-      'Flutter version $version at $flutterRoot';
+  String flutterVersion(String version, String? channel, String flutterRoot) =>
+      'Flutter version $version on ${channel ?? 'unknown'} at $flutterRoot';
   String flutterRevision(String revision, String age, String date) =>
       'Framework revision $revision ($age), $date';
   String flutterUpstreamRepositoryUrl(String url) => 'Upstream repository $url';
+  String flutterUpstreamRepositoryUrlEnvMismatch(String url) => 'Upstream repository $url is not the same as FLUTTER_GIT_URL';
+  String flutterUpstreamRepositoryUrlNonStandard(String url) => 'Upstream repository $url is not a standard remote';
   String flutterGitUrl(String url) => 'FLUTTER_GIT_URL = $url';
   String engineRevision(String revision) => 'Engine revision $revision';
   String dartRevision(String revision) => 'Dart version $revision';

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -481,11 +481,11 @@ class FlutterValidator extends DoctorValidator {
       upstreamValidationError = VersionUpstreamValidator(version: version, platform: _platform).run();
 
       final String flutterVersionMessage = _userMessages.flutterVersion(frameworkVersion, versionChannel, _flutterRoot());
-      messages.add(
-        versionChannel == 'unknown' || frameworkVersion == '0.0.0-unknown'
-          ? ValidationMessage.hint(flutterVersionMessage)
-          : ValidationMessage(flutterVersionMessage)
-      );
+      if (versionChannel == 'unknown' || frameworkVersion == '0.0.0-unknown') {
+        messages.add(ValidationMessage.hint(flutterVersionMessage));
+      } else {
+        messages.add(ValidationMessage(flutterVersionMessage));
+      }
       if (repositoryUrl == null) {
         messages.add(ValidationMessage.hint(_userMessages.flutterUpstreamRepositoryUrl('unknown')));
       } else if (upstreamValidationError != null) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -534,8 +534,9 @@ class FlutterValidator extends DoctorValidator {
     final String flutterVersionMessage = _userMessages.flutterVersion(frameworkVersion, versionChannel, _flutterRoot());
 
     // The tool sets the channel as "unknown", if the tracking branch isn't a
-    // git remote, and sets the frameworkVersion as  "0.0.0-unknown" if "git
-    // describe" on HEAD doesn't produce an expected format to be parsed.
+    // git remote, and sets the frameworkVersion as "0.0.0-unknown" if "git
+    // describe" on HEAD doesn't produce an expected format to be parsed for the
+    // frameworkVersion.
     if (versionChannel == 'unknown' || frameworkVersion == '0.0.0-unknown') {
       return ValidationMessage.hint(flutterVersionMessage);
     }
@@ -546,12 +547,13 @@ class FlutterValidator extends DoctorValidator {
     final String? repositoryUrl = version.repositoryUrl;
     final VersionCheckError? upstreamValidationError = VersionUpstreamValidator(version: version, platform: _platform).run();
 
+    // VersionUpstreamValidator can produce an error if repositoryUrl is null
     if (upstreamValidationError != null) {
       final String errorMessage = upstreamValidationError.message;
       if(errorMessage.contains('could not determine the remote upstream which is being tracked')) {
-        // This will be true only if repositoryUrl is null
         return ValidationMessage.hint(_userMessages.flutterUpstreamRepositoryUrl('unknown'));
       }
+      // At this point, repositoryUrl must not be null
       if (errorMessage.contains('Flutter SDK is tracking a non-standard remote')) {
         return ValidationMessage.hint(_userMessages.flutterUpstreamRepositoryUrlNonStandard(repositoryUrl!));
       }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -533,10 +533,10 @@ class FlutterValidator extends DoctorValidator {
   ValidationMessage _getFlutterVersionMessage(String frameworkVersion, String versionChannel) {
     final String flutterVersionMessage = _userMessages.flutterVersion(frameworkVersion, versionChannel, _flutterRoot());
 
-    // The tool sets the channel as "unknown", if the tracking branch isn't a
-    // git remote, and sets the frameworkVersion as "0.0.0-unknown" if "git
-    // describe" on HEAD doesn't produce an expected format to be parsed for the
-    // frameworkVersion.
+    // The tool sets the channel as "unknown", if the current branch is on a
+    // "detached HEAD" state or doesn't have an upstream, and sets the
+    // frameworkVersion as "0.0.0-unknown" if  "git describe" on HEAD doesn't
+    // produce an expected format to be parsed for the frameworkVersion.
     if (versionChannel == 'unknown' || frameworkVersion == '0.0.0-unknown') {
       return ValidationMessage.hint(flutterVersionMessage);
     }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -550,7 +550,7 @@ class FlutterValidator extends DoctorValidator {
     // VersionUpstreamValidator can produce an error if repositoryUrl is null
     if (upstreamValidationError != null) {
       final String errorMessage = upstreamValidationError.message;
-      if(errorMessage.contains('could not determine the remote upstream which is being tracked')) {
+      if (errorMessage.contains('could not determine the remote upstream which is being tracked')) {
         return ValidationMessage.hint(_userMessages.flutterUpstreamRepositoryUrl('unknown'));
       }
       // At this point, repositoryUrl must not be null

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -533,6 +533,9 @@ class FlutterValidator extends DoctorValidator {
   ValidationMessage _getFlutterVersionMessage(String frameworkVersion, String versionChannel) {
     final String flutterVersionMessage = _userMessages.flutterVersion(frameworkVersion, versionChannel, _flutterRoot());
 
+    // The tool sets the channel as "unknown", if the tracking branch isn't a
+    // git remote, and sets the frameworkVersion as  "0.0.0-unknown" if "git
+    // describe" on HEAD doesn't produce an expected format to be parsed.
     if (versionChannel == 'unknown' || frameworkVersion == '0.0.0-unknown') {
       return ValidationMessage.hint(flutterVersionMessage);
     }

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -252,6 +252,8 @@ class ValidationMessage {
 
   bool get isHint => type == ValidationMessageType.hint;
 
+  bool get isInformation => type == ValidationMessageType.information;
+
   String get indicator {
     switch (type) {
       case ValidationMessageType.error:

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -191,13 +191,13 @@ void main() {
       expect(logContents, contains('flutter crash'));
       expect(logContents, contains('Exception: an exception % --'));
       expect(logContents, contains('CrashingFlutterCommand.runCommand'));
-      expect(logContents, contains('[✓] Flutter'));
+      expect(logContents, contains('[!] Flutter'));
 
       final CrashDetails sentDetails = (globals.crashReporter as WaitingCrashReporter)._details;
       expect(sentDetails.command, 'flutter crash');
       expect(sentDetails.error.toString(), 'Exception: an exception % --');
       expect(sentDetails.stackTrace.toString(), contains('CrashingFlutterCommand.runCommand'));
-      expect(await sentDetails.doctorText.text, contains('[✓] Flutter'));
+      expect(await sentDetails.doctorText.text, contains('[!] Flutter'));
     }, overrides: <Type, Generator>{
       Platform: () => FakePlatform(
         environment: <String, String>{


### PR DESCRIPTION
Fixes #102035.

Makes the version and the upstream repository message display an issue in cases where `flutter upgrade` is not supported.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
