### PR TITLE
Use consistent date instead of DateTime.now() in evaluation tests to avoid flakes

### DIFF
--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
@@ -157,19 +157,16 @@ Future<void> evaluateTrivialExpressions(FlutterTestDriver flutter) async {
 }
 
 Future<void> evaluateComplexExpressions(FlutterTestDriver flutter) async {
-  final ObjRef res = await flutter.evaluateInFrame('new DateTime.now().year');
-  expectValueOfType(res, InstanceKind.kInt, DateTime.now().year.toString());
+  final ObjRef res = await flutter.evaluateInFrame('new DateTime(2000).year');
+  expectValueOfType(res, InstanceKind.kInt, '2000');
 }
 
 Future<void> evaluateComplexReturningExpressions(FlutterTestDriver flutter) async {
-  final DateTime now = DateTime.now();
-  final ObjRef resp = await flutter.evaluateInFrame('new DateTime.now()');
+  final DateTime date = DateTime(2000);
+  final ObjRef resp = await flutter.evaluateInFrame('new DateTime(2000)');
   expectInstanceOfClass(resp, 'DateTime');
-  // Ensure we got a reasonable approximation. The more accurate we try to
-  // make this, the more likely it'll fail due to differences in the time
-  // in the remote VM and the local VM at the time the code runs.
   final ObjRef res = await flutter.evaluate(resp.id, r'"$year-$month-$day"');
-  expectValue(res, '${now.year}-${now.month}-${now.day}');
+  expectValue(res, '${date.year}-${date.month}-${date.day}');
 }
 
 void expectInstanceOfClass(ObjRef result, String name) {


### PR DESCRIPTION
Fixes a test flake where the test could call `DateTime.now()` and the VM being tested could call `DateTime.now()` and both get different dates because the test just happened to straddle midnight (although unlikely, has happened - see #103215)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
