### PR TITLE
Add option to CupertinoSliverRefreshControl.buildRefreshIndicator

### DIFF
--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -374,6 +374,11 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     double pulledExtent,
     double refreshTriggerPullDistance,
     double refreshIndicatorExtent,
+{
+  double? marginTop,
+  double? radius,
+  Color? color,
+}
   ) {
     final double percentageComplete = (pulledExtent / refreshTriggerPullDistance).clamp(0.0, 1.0);
 
@@ -389,17 +394,18 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         clipBehavior: Clip.none,
         children: <Widget>[
           Positioned(
-            top: _kActivityIndicatorMargin,
+          top: marginTop ?? _kActivityIndicatorMargin,
             left: 0.0,
             right: 0.0,
-            child: _buildIndicatorForRefreshState(refreshState, _kActivityIndicatorRadius, percentageComplete),
+            child: _buildIndicatorForRefreshState(refreshState, radius ?? _kActivityIndicatorRadius, percentageComplete,color,),
           ),
         ],
       ),
     );
   }
 
-  static Widget _buildIndicatorForRefreshState(RefreshIndicatorMode refreshState, double radius, double percentageComplete) {
+  static Widget _buildIndicatorForRefreshState(RefreshIndicatorMode refreshState, double radius, double percentageComplete,  Color? color,
+) {
     switch (refreshState) {
       case RefreshIndicatorMode.drag:
         // While we're dragging, we draw individual ticks of the spinner while simultaneously
@@ -408,15 +414,15 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         const Curve opacityCurve = Interval(0.0, 0.35, curve: Curves.easeInOut);
         return Opacity(
           opacity: opacityCurve.transform(percentageComplete),
-          child: CupertinoActivityIndicator.partiallyRevealed(radius: radius, progress: percentageComplete),
+          child: CupertinoActivityIndicator.partiallyRevealed(radius: radius, progress: percentageComplete,color: color,),
         );
       case RefreshIndicatorMode.armed:
       case RefreshIndicatorMode.refresh:
         // Once we're armed or performing the refresh, we just show the normal spinner.
-        return CupertinoActivityIndicator(radius: radius);
+        return CupertinoActivityIndicator(radius: radius,color: color);
       case RefreshIndicatorMode.done:
         // When the user lets go, the standard transition is to shrink the spinner.
-        return CupertinoActivityIndicator(radius: radius * percentageComplete);
+        return CupertinoActivityIndicator(radius: radius * percentageComplete,color:color);
       case RefreshIndicatorMode.inactive:
         // Anything else doesn't show anything.
         return Container();

--- a/packages/flutter/lib/src/cupertino/refresh.dart
+++ b/packages/flutter/lib/src/cupertino/refresh.dart
@@ -373,14 +373,13 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
     RefreshIndicatorMode refreshState,
     double pulledExtent,
     double refreshTriggerPullDistance,
-    double refreshIndicatorExtent,
-{
-  double? marginTop,
-  double? radius,
-  Color? color,
-}
-  ) {
-    final double percentageComplete = (pulledExtent / refreshTriggerPullDistance).clamp(0.0, 1.0);
+    double refreshIndicatorExtent, {
+    double? marginTop,
+    double? radius,
+    Color? color,
+  }) {
+    final double percentageComplete =
+        (pulledExtent / refreshTriggerPullDistance).clamp(0.0, 1.0);
 
     // Place the indicator at the top of the sliver that opens up. Note that we're using
     // a Stack/Positioned widget because the CupertinoActivityIndicator does some internal
@@ -394,18 +393,27 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         clipBehavior: Clip.none,
         children: <Widget>[
           Positioned(
-          top: marginTop ?? _kActivityIndicatorMargin,
+            top: marginTop ?? _kActivityIndicatorMargin,
             left: 0.0,
             right: 0.0,
-            child: _buildIndicatorForRefreshState(refreshState, radius ?? _kActivityIndicatorRadius, percentageComplete,color,),
+            child: _buildIndicatorForRefreshState(
+              refreshState,
+              radius ?? _kActivityIndicatorRadius,
+              percentageComplete,
+              color,
+            ),
           ),
         ],
       ),
     );
   }
 
-  static Widget _buildIndicatorForRefreshState(RefreshIndicatorMode refreshState, double radius, double percentageComplete,  Color? color,
-) {
+  static Widget _buildIndicatorForRefreshState(
+    RefreshIndicatorMode refreshState,
+    double radius,
+    double percentageComplete,
+    Color? color,
+  ) {
     switch (refreshState) {
       case RefreshIndicatorMode.drag:
         // While we're dragging, we draw individual ticks of the spinner while simultaneously
@@ -414,15 +422,20 @@ class CupertinoSliverRefreshControl extends StatefulWidget {
         const Curve opacityCurve = Interval(0.0, 0.35, curve: Curves.easeInOut);
         return Opacity(
           opacity: opacityCurve.transform(percentageComplete),
-          child: CupertinoActivityIndicator.partiallyRevealed(radius: radius, progress: percentageComplete,color: color,),
+          child: CupertinoActivityIndicator.partiallyRevealed(
+            radius: radius,
+            progress: percentageComplete,
+            color: color,
+          ),
         );
       case RefreshIndicatorMode.armed:
       case RefreshIndicatorMode.refresh:
         // Once we're armed or performing the refresh, we just show the normal spinner.
-        return CupertinoActivityIndicator(radius: radius,color: color);
+        return CupertinoActivityIndicator(radius: radius, color: color);
       case RefreshIndicatorMode.done:
         // When the user lets go, the standard transition is to shrink the spinner.
-        return CupertinoActivityIndicator(radius: radius * percentageComplete,color:color);
+        return CupertinoActivityIndicator(
+            radius: radius * percentageComplete, color: color);
       case RefreshIndicatorMode.inactive:
         // Anything else doesn't show anything.
         return Container();


### PR DESCRIPTION
I was developing an application and needed to change the colors, etc. of the Indicator.
The buildRefreshIndicator is defined publicly, but I could not customize it because there are no options available.
So I added the option.

To use the option, implement as follows

```dart
CupertinoSliverRefreshControl(
  onRefresh: onRefresh,
  builder: (
    context,
    refreshState,
    pulledExtent,
    refreshTriggerPullDistance,
    refreshIndicatorExtent,
  ) =>
      CupertinoSliverRefreshControl.buildRefreshIndicator(
        context,
        refreshState,
        pulledExtent,
        refreshTriggerPullDistance,
        refreshIndicatorExtent,
        color: Colors.white,
      ),
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
