### PR TITLE
fix a _DraggableScrollableSheetScrollPosition update bug

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -799,14 +799,9 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
   _DraggableScrollableSheetScrollPosition({
     required super.physics,
     required super.context,
-    ScrollPosition? oldPosition,
+    super.oldPosition,
     required this.getExtent,
-  }) : super(oldPosition: oldPosition) {
-    if (oldPosition is _DraggableScrollableSheetScrollPosition
-        && oldPosition._dragCancelCallback != null) {
-      _dragCancelCallback = oldPosition._dragCancelCallback;
-    }
-  }
+  });
 
   VoidCallback? _dragCancelCallback;
   final _DraggableSheetExtent Function() getExtent;
@@ -814,6 +809,21 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
   bool get listShouldScroll => pixels > 0.0;
 
   _DraggableSheetExtent get extent => getExtent();
+
+  @override
+  void absorb(ScrollPosition other) {
+    super.absorb(other);
+    assert(_dragCancelCallback = null);
+
+    if (other is! _DraggableScrollableSheetScrollPosition) {
+      return;
+    }
+
+    if (other._dragCancelCallback != null) {
+      _dragCancelCallback = other._dragCancelCallback;
+      other._dragCancelCallback = null;
+    }
+  }
 
   @override
   void beginActivity(ScrollActivity? newActivity) {

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -799,9 +799,15 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
   _DraggableScrollableSheetScrollPosition({
     required super.physics,
     required super.context,
-    super.oldPosition,
+    ScrollPosition? oldPosition,
     required this.getExtent,
-  });
+  }) : assert(oldPosition is _DraggableScrollableSheetScrollPosition?),
+       super(oldPosition: oldPosition) {
+    if (oldPosition is _DraggableScrollableSheetScrollPosition
+        && oldPosition._dragCancelCallback != null) {
+      _dragCancelCallback = oldPosition._dragCancelCallback;
+    }
+  }
 
   VoidCallback? _dragCancelCallback;
   final _DraggableSheetExtent Function() getExtent;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -813,7 +813,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
   @override
   void absorb(ScrollPosition other) {
     super.absorb(other);
-    assert(_dragCancelCallback = null);
+    assert(_dragCancelCallback == null);
 
     if (other is! _DraggableScrollableSheetScrollPosition) {
       return;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -801,8 +801,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
     required super.context,
     ScrollPosition? oldPosition,
     required this.getExtent,
-  }) : assert(oldPosition is _DraggableScrollableSheetScrollPosition?),
-       super(oldPosition: oldPosition) {
+  }) : super(oldPosition: oldPosition) {
     if (oldPosition is _DraggableScrollableSheetScrollPosition
         && oldPosition._dragCancelCallback != null) {
       _dragCancelCallback = oldPosition._dragCancelCallback;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/89681

If update the `_DraggableScrollableSheetScrollPosition` during drag will lose `_dragCancelCallback`, and will trigger an assertion.