### PR TITLE
Add benchmark case for RasterCache

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1366,6 +1366,17 @@ targets:
       task_name: color_filter_cache_perf__e2e_summary
     scheduler: luci
 
+  - name: Linux_android raster_cache_use_memory_perf__e2e_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    bringup: true
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab","android","linux"]
+      task_name: raster_cache_use_memory_perf__e2e_summary
+    scheduler: luci
+
   - name: Linux_android shader_mask_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -67,6 +67,7 @@
 /dev/devicelab/bin/tasks/platform_views_scroll_perf__timeline_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/plugin_dependencies_test.dart @jmagman @flutter/tool
 /dev/devicelab/bin/tasks/routing_test.dart @zanderso @flutter/tool
+/dev/devicelab/bin/tasks/raster_cache_use_memory_perf__e2e_summary.dart @flar @flutter/engine
 /dev/devicelab/bin/tasks/textfield_perf__e2e_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/web_size__compile_test.dart @yjbanov @flutter/web
 /dev/devicelab/bin/tasks/opacity_peephole_col_of_rows_perf__e2e_summary.dart @flar @flutter/engine

--- a/dev/benchmarks/macrobenchmarks/lib/common.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/common.dart
@@ -21,6 +21,7 @@ const String kFadingChildAnimationRouteName = '/fading_child_animation';
 const String kImageFilteredTransformAnimationRouteName = '/imagefiltered_transform_animation';
 const String kMultiWidgetConstructionRouteName = '/multi_widget_construction';
 const String kHeavyGridViewRouteName = '/heavy_gridview';
+const String kRasterCacheUseMemory = '/raster_cache_use_memory';
 const String kShaderMaskCacheRouteName = '/shader_mask_cache';
 const String kSimpleScrollRouteName = '/simple_scroll';
 const String kStackSizeRouteName = '/stack_size';

--- a/dev/benchmarks/macrobenchmarks/lib/main.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/main.dart
@@ -27,6 +27,7 @@ import 'src/opacity_peephole.dart';
 import 'src/picture_cache.dart';
 import 'src/picture_cache_complexity_scoring.dart';
 import 'src/post_backdrop_filter.dart';
+import 'src/raster_cache_use_memory.dart';
 import 'src/shader_mask_cache.dart';
 import 'src/simple_animation.dart';
 import 'src/simple_scroll.dart';
@@ -66,6 +67,7 @@ class MacrobenchmarksApp extends StatelessWidget {
         kImageFilteredTransformAnimationRouteName: (BuildContext context) => const FilteredChildAnimationPage(FilterType.rotateFilter),
         kMultiWidgetConstructionRouteName: (BuildContext context) => const MultiWidgetConstructTable(10, 20),
         kHeavyGridViewRouteName: (BuildContext context) => const HeavyGridViewPage(),
+        kRasterCacheUseMemory: (BuildContext context) => const RasterCacheUseMemory(),
         kShaderMaskCacheRouteName: (BuildContext context) => const ShaderMaskCachePage(),
         kSimpleScrollRouteName: (BuildContext context) => const SimpleScroll(),
         kStackSizeRouteName: (BuildContext context) => const StackSizePage(),
@@ -189,6 +191,13 @@ class HomePage extends StatelessWidget {
             child: const Text('Color Filter Cache'),
             onPressed: () {
               Navigator.pushNamed(context, kColorFilterCacheRouteName);
+            },
+          ),
+          ElevatedButton(
+            key: const Key(kRasterCacheUseMemory),
+            child: const Text('RasterCache Use Memory'),
+            onPressed: () {
+              Navigator.pushNamed(context, kRasterCacheUseMemory);
             },
           ),
           ElevatedButton(

--- a/dev/benchmarks/macrobenchmarks/lib/src/raster_cache_use_memory.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/raster_cache_use_memory.dart
@@ -50,8 +50,8 @@ class _RasterCacheUseMemoryState extends State<RasterCacheUseMemory>
               ),
               child: RepaintBoundary(
                 child: Container(
-                  width: 100,
-                  height: 100,
+                  width: 50,
+                  height: 50,
                   color: Colors.red,
                 ),
               ),
@@ -96,7 +96,7 @@ class _RasterCacheUseMemoryState extends State<RasterCacheUseMemory>
                                 borderRadius: BorderRadius.circular(5.0),
                               ),
                               child: const FlutterLogo(
-                                size: 300,
+                                size: 50,
                               ),
                             ),
                           ),
@@ -109,13 +109,13 @@ class _RasterCacheUseMemoryState extends State<RasterCacheUseMemory>
             ),
           ),
           const RepaintBoundary(
-            child: SizedBox(
-              height: 800,
-              child: FlutterLogo(
-                size: 100,
-              ),
+            child: FlutterLogo(
+              size: 50,
             ),
-          )
+          ),
+          Container(
+            height: 800,
+          ),
         ],
       ),
     );

--- a/dev/benchmarks/macrobenchmarks/lib/src/raster_cache_use_memory.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/raster_cache_use_memory.dart
@@ -21,10 +21,10 @@ class _RasterCacheUseMemoryState extends State<RasterCacheUseMemory>
   void initState() {
     super.initState();
     _controller.addListener(() {
-      if (_controller.offset < 20) {
-        _controller.animateTo(150,
+      if (_controller.offset < 5) {
+        _controller.animateTo(20,
             duration: const Duration(milliseconds: 1000), curve: Curves.ease);
-      } else if (_controller.offset > 130) {
+      } else if (_controller.offset >= 19) {
         _controller.animateTo(0,
             duration: const Duration(milliseconds: 1000), curve: Curves.ease);
       }

--- a/dev/benchmarks/macrobenchmarks/lib/src/raster_cache_use_memory.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/raster_cache_use_memory.dart
@@ -1,0 +1,129 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:ui';
+import 'package:flutter/material.dart';
+
+class RasterCacheUseMemory extends StatefulWidget {
+  const RasterCacheUseMemory({super.key});
+
+  @override
+  State<RasterCacheUseMemory> createState() => _RasterCacheUseMemoryState();
+}
+
+class _RasterCacheUseMemoryState extends State<RasterCacheUseMemory>
+    with TickerProviderStateMixin {
+  final ScrollController _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(() {
+      if (_controller.offset < 20) {
+        _controller.animateTo(150,
+            duration: const Duration(milliseconds: 1000), curve: Curves.ease);
+      } else if (_controller.offset > 130) {
+        _controller.animateTo(0,
+            duration: const Duration(milliseconds: 1000), curve: Curves.ease);
+      }
+    });
+    Timer(const Duration(milliseconds: 1000), () {
+      _controller.animateTo(150,
+          duration: const Duration(milliseconds: 1000), curve: Curves.ease);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.lightBlue,
+      body: ListView(
+        controller: _controller,
+        children: <Widget>[
+          RepaintBoundary(
+            child: ImageFiltered(
+              imageFilter: ImageFilter.blur(
+                sigmaX: 4,
+                sigmaY: 4,
+              ),
+              child: RepaintBoundary(
+                child: Container(
+                  width: 100,
+                  height: 100,
+                  color: Colors.red,
+                ),
+              ),
+            ),
+          ),
+          ShaderMask(
+            shaderCallback: (Rect bounds) {
+              return const RadialGradient(
+                center: Alignment.topLeft,
+                radius: 1.0,
+                colors: <Color>[Colors.yellow, Colors.deepOrange],
+                tileMode: TileMode.mirror,
+              ).createShader(bounds);
+            },
+            blendMode: BlendMode.srcATop,
+            child: Opacity(
+              opacity: 0.5,
+              child: Column(
+                children: <Widget>[
+                  ImageFiltered(
+                    imageFilter: ImageFilter.blur(
+                      sigmaX: 4,
+                      sigmaY: 4,
+                    ),
+                    child: Row(
+                      children: <Widget>[
+                        ImageFiltered(
+                          imageFilter: ImageFilter.blur(
+                            sigmaX: 4,
+                            sigmaY: 4,
+                          ),
+                          child: RepaintBoundary(
+                            child: Container(
+                              margin: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+                              decoration: BoxDecoration(
+                                color: Colors.white70,
+                                boxShadow: const <BoxShadow>[
+                                  BoxShadow(
+                                    blurRadius: 5.0,
+                                  ),
+                                ],
+                                borderRadius: BorderRadius.circular(5.0),
+                              ),
+                              child: const FlutterLogo(
+                                size: 300,
+                              ),
+                            ),
+                          ),
+                        )
+                      ],
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+          const RepaintBoundary(
+            child: SizedBox(
+              height: 800,
+              child: FlutterLogo(
+                size: 100,
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/dev/benchmarks/macrobenchmarks/test/raster_cache_use_memory_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/raster_cache_use_memory_perf_e2e.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:macrobenchmarks/common.dart';
+
+import 'util.dart';
+
+void main() {
+  macroPerfTestE2E(
+    'raster_cache_use_memory_perf',
+    kRasterCacheUseMemory,
+    pageDelay: const Duration(seconds: 1),
+    duration: const Duration(seconds: 10),
+  );
+}

--- a/dev/devicelab/bin/tasks/raster_cache_use_memory_perf__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/raster_cache_use_memory_perf__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+  await task(createRasterCacheUseMemoryPerfE2ETest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -384,6 +384,13 @@ TaskFunction createColorFilterCachePerfE2ETest() {
   ).run;
 }
 
+TaskFunction createRasterCacheUseMemoryPerfE2ETest() {
+  return PerfTest.e2e(
+    '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',
+    'test/raster_cache_use_memory_perf_e2e.dart',
+  ).run;
+}
+
 TaskFunction createShaderMaskCachePerfE2ETest() {
   return PerfTest.e2e(
     '${flutterDirectory.path}/dev/benchmarks/macrobenchmarks',


### PR DESCRIPTION
Add a scenario for test raster cache memory use and render time
https://github.com/flutter/engine/pull/31892

In this benchmark test scenario, I build a ListView that will have 3 Children, the first LayerTree is an ImageFilterLayer and a DisplayListLayer, the second LayerTree is a ShaderMaskLayer subtree, and the third is a DisplayListLayer.

According to the existing RasterCache logic, the ImageFilterLayer will be cached many times because it is a bottom-up cache process.

However, this PR differentiates the RasterCache process and changes it to a top-down logic, so that once the parent ImageFilterLayer is cached, the child node will not have any extra cache.

The Layer tree is shown in the following figure
<img width="250" alt="image" src="https://user-images.githubusercontent.com/10297030/167977537-e913e12d-f576-4ff9-af4d-d46f40c8f09b.png">


cc @flar 


