### PR TITLE
Fix Tooltip obscured by keyboard

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -841,6 +841,7 @@ class _TooltipOverlay extends StatelessWidget {
       );
     }
     return Positioned.fill(
+      bottom: MediaQuery.maybeOf(context)?.viewInsets.bottom ?? 0.0,
       child: CustomSingleChildLayout(
         delegate: _TooltipPositionDelegate(
           target: target,


### PR DESCRIPTION
## Description

This PR updates Tooltip positionning to avoid that tooltips are obscured by the keyboard.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/23666


## Tests

Add one test in `material/tooltip_test.dart`


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.