### PR TITLE
Fix ThemeData extension throws when the ThemeExtension not found

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1077,7 +1077,7 @@ class ThemeData with Diagnosticable {
   /// Obtain with `Theme.of(context).extension<MyThemeExtension>()`.
   ///
   /// See [extensions] for an interactive example.
-  T? extension<T>() => extensions[T] as T;
+  T? extension<T>() => extensions[T] as T?;
 
   /// The default [InputDecoration] values for [InputDecorator], [TextField],
   /// and [TextFormField] are based on this theme.

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -561,6 +561,14 @@ void main() {
       expect(lerped.extension<MyThemeExtensionA>()!.color2, const Color(0xff90ab7d));
       expect(lerped.extension<MyThemeExtensionB>()!.textStyle, const TextStyle(fontSize: 100)); // Not lerped
     });
+
+    testWidgets('should return null on extension not found', (WidgetTester tester) async {
+      final ThemeData theme = ThemeData(
+        extensions: const <ThemeExtension<dynamic>>{},
+      );
+
+      expect(theme.extension<MyThemeExtensionA>(), isNull);
+    });
   });
 
   test('copyWith, ==, hashCode basics', () {


### PR DESCRIPTION
The cast https://github.com/flutter/flutter/blob/0656a5c0333e690eac26211a022dcfa4a8144d25/packages/flutter/lib/src/material/theme_data.dart#L1080 causing error when the `T` extension is not in extensions
The PR change the cast to `as T?`

Fixes https://github.com/flutter/flutter/issues/103313

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
