### PR TITLE
Refactor web text editing shortcuts

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -432,11 +432,12 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget result = child;
     if (kIsWeb) {
-      // On web platform, this shortcuts makes sure the following:
+      // On web platform, these shortcuts makes sure the following:
       //
-      // 1. Shortcuts fired in TextField are swallowed.
-      // 2. Shortcuts fired above TextField will still trigger corresponding
-      //    intents.
+      // 1. Shortcuts fired when a TextField is focused are ignored and
+      //    forwarded to the browser.
+      // 2. Shortcuts fired when no TextField is focused will still trigger
+      //    default text editing Shortcuts
       //
       // In (2), the disabling shortcuts will still fire; however, the
       // [DoNothingAndStopPropagationTextIntent] will not be handled because the

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -10,8 +10,7 @@ import 'framework.dart';
 import 'shortcuts.dart';
 import 'text_editing_intents.dart';
 
-/// A [Shortcuts] widget with the shortcuts used for the default text editing
-/// behavior.
+/// A widget with the shortcuts used for the default text editing behavior.
 ///
 /// This default behavior can be overridden by placing a [Shortcuts] widget
 /// lower in the widget tree than this. See the [Action] class for an example
@@ -147,16 +146,12 @@ import 'text_editing_intents.dart';
 ///
 ///   * [WidgetsApp], which creates a DefaultTextEditingShortcuts.
 class DefaultTextEditingShortcuts extends StatelessWidget {
-  /// Creates a [Shortcuts] widget that provides the default text editing
+  /// Creates a [DefaultTextEditingShortcuts] widget that provides the default text editing
   /// shortcuts on the current platform.
   const DefaultTextEditingShortcuts({
     super.key,
     required this.child,
   });
-  //     : super(
-  //   debugLabel: '<Default Text Editing Shortcuts>',
-  //   shortcuts: _shortcuts,
-  // )
 
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -437,16 +437,16 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget result = child;
     if (kIsWeb) {
-      // This shortcuts makes sure the following:
+      // On web platform, this shortcuts makes sure the following:
       //
-      // 1. Shortcuts fired in TextField is swallowed.
+      // 1. Shortcuts fired in TextField are swallowed.
       // 2. Shortcuts fired above TextField will still trigger corresponding
       //    intents.
       //
-      // In (2), the disabling shortcuts will still fire. The
+      // In (2), the disabling shortcuts will still fire; however, the
       // [DoNothingAndStopPropagationTextIntent] will not be handled because the
       // context is above the TextField. The key event will then trigger the
-      // default Text Editing Shortcuts
+      // default Text Editing Shortcuts.
       result = Shortcuts(
         debugLabel: '<Web disabling text shortcuts>',
         shortcuts: _webDisablingTextShortcuts,

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -432,19 +432,16 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
   Widget build(BuildContext context) {
     Widget result = child;
     if (kIsWeb) {
-      // On web platform, these shortcuts makes sure the following:
+      // On the web, these shortcuts make sure of the following:
       //
-      // 1. Shortcuts fired when a TextField is focused are ignored and
-      //    forwarded to the browser.
-      // 2. Shortcuts fired when no TextField is focused will still trigger
-      //    default text editing Shortcuts
-      //
-      // In (2), the disabling shortcuts will still fire; however, the
-      // [DoNothingAndStopPropagationTextIntent] will not be handled because the
-      // context is above the TextField. The key event will then trigger the
-      // default Text Editing Shortcuts.
+      // 1. Shortcuts fired when an EditableText is focused are ignored and
+      //    forwarded to the browser by the EditableText's Actions, because it
+      //    maps DoNothingAndStopPropagationTextIntent to DoNothingAction.
+      // 2. Shortcuts fired when no EditableText is focused will still trigger
+      //    _shortcuts assuming DoNothingAndStopPropagationTextIntent is
+      //    unhandled elsewhere.
       result = Shortcuts(
-        debugLabel: '<Web disabling text shortcuts>',
+        debugLabel: '<Web Disabling Text Editing Shortcuts>',
         shortcuts: _webDisablingTextShortcuts,
         child: result
       );

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -196,6 +196,7 @@ void main() {
       '     Semantics\n'
       '     _FocusMarker\n'
       '     Focus\n'
+      '     Shortcuts\n'
       '     DefaultTextEditingShortcuts\n'
       '     _ShortcutsMarker\n'
       '     Semantics\n'

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -192,6 +192,13 @@ void main() {
       '     FocusTraversalGroup\n'
       '     _ActionsMarker\n'
       '     Actions\n'
+      '${kIsWeb
+          ? '     _ShortcutsMarker\n'
+            '     Semantics\n'
+            '     _FocusMarker\n'
+            '     Focus\n'
+            '     Shortcuts\n'
+           : ''}'
       '     _ShortcutsMarker\n'
       '     Semantics\n'
       '     _FocusMarker\n'

--- a/packages/flutter/test/widgets/app_test.dart
+++ b/packages/flutter/test/widgets/app_test.dart
@@ -707,7 +707,7 @@ void main() {
     expect(selectAllSpy.invoked, isTrue);
     expect(copySpy.invoked, isTrue);
     expect(pasteSpy.invoked, isTrue);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }), skip: kIsWeb); // [intended] Web uses a different set of shortcuts.
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 }
 
 typedef SimpleRouterDelegateBuilder = Widget Function(BuildContext, RouteInformation);

--- a/packages/flutter/test/widgets/clipboard_utils.dart
+++ b/packages/flutter/test/widgets/clipboard_utils.dart
@@ -11,22 +11,22 @@ class MockClipboard {
 
   final bool hasStringsThrows;
 
-  dynamic _clipboardData = <String, dynamic>{
+  dynamic clipboardData = <String, dynamic>{
     'text': null,
   };
 
   Future<Object?> handleMethodCall(MethodCall methodCall) async {
     switch (methodCall.method) {
       case 'Clipboard.getData':
-        return _clipboardData;
+        return clipboardData;
       case 'Clipboard.hasStrings':
         if (hasStringsThrows)
           throw Exception();
-        final Map<String, dynamic>? clipboardDataMap = _clipboardData as Map<String, dynamic>?;
+        final Map<String, dynamic>? clipboardDataMap = clipboardData as Map<String, dynamic>?;
         final String? text = clipboardDataMap?['text'] as String?;
         return <String, bool>{'value': text != null && text.isNotEmpty};
       case 'Clipboard.setData':
-        _clipboardData = methodCall.arguments;
+        clipboardData = methodCall.arguments;
         break;
     }
     return null;

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -1812,7 +1812,7 @@ void main() {
     }, variant: macOSOnly);
   }, skip: kIsWeb); // [intended] on web these keys are handled by the browser.
 
-  group('Web does accept', () {
+  group('Web does not accept', () {
     final TargetPlatformVariant allExceptApple = TargetPlatformVariant(TargetPlatform.values.toSet()..removeAll(<TargetPlatform>[TargetPlatform.macOS, TargetPlatform.iOS]));
     const TargetPlatformVariant appleOnly = TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS, TargetPlatform.iOS });
     group('macOS shortcuts', () {

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'clipboard_utils.dart';
+
 Future<void> sendKeyCombination(
   WidgetTester tester,
   SingleActivator activator,
@@ -40,6 +42,18 @@ Iterable<SingleActivator> allModifierVariants(LogicalKeyboardKey trigger) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final MockClipboard mockClipboard = MockClipboard();
+
+  setUp(() async {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, mockClipboard.handleMethodCall);
+    await Clipboard.setData(const ClipboardData(text: 'empty'));
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
   const String testText =
       'Now is the time for\n' // 20
       'all good people\n'     // 20 + 16 => 36
@@ -1797,4 +1811,328 @@ void main() {
       ));
     }, variant: macOSOnly);
   }, skip: kIsWeb); // [intended] on web these keys are handled by the browser.
+
+  group('Web does accept', () {
+    final TargetPlatformVariant allExceptApple = TargetPlatformVariant(TargetPlatform.values.toSet()..removeAll(<TargetPlatform>[TargetPlatform.macOS, TargetPlatform.iOS]));
+    const TargetPlatformVariant appleOnly = TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS, TargetPlatform.iOS });
+    group('macOS shortcuts', () {
+
+      testWidgets('word modifier + arrowLeft', (WidgetTester tester) async {
+        controller.text = testText;
+        controller.selection = const TextSelection.collapsed(
+          offset: 7,   // Before the first "the"
+        );
+        await tester.pumpWidget(buildEditableText());
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true));
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection.collapsed(offset: 7));
+      }, variant: appleOnly);
+
+      testWidgets('word modifier + arrowRight', (WidgetTester tester) async {
+        controller.text = testText;
+        controller.selection = const TextSelection.collapsed(
+          offset: 7,   // Before the first "the"
+        );
+        await tester.pumpWidget(buildEditableText());
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true));
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection.collapsed(offset: 7));
+      }, variant: appleOnly);
+
+      testWidgets('line modifier + arrowLeft', (WidgetTester tester) async {
+        controller.text = testText;
+        controller.selection = const TextSelection.collapsed(
+          offset: 24,   // Before the "good".
+        );
+        await tester.pumpWidget(buildEditableText());
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true));
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection.collapsed(offset: 24,));
+      }, variant: appleOnly);
+
+      testWidgets('line modifier + arrowRight', (WidgetTester tester) async {
+        controller.text = testText;
+        controller.selection = const TextSelection.collapsed(
+          offset: 24,   // Before the "good".
+        );
+        await tester.pumpWidget(buildEditableText());
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true));
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection.collapsed(
+          offset: 24, // Before the newline character.
+        ));
+      }, variant: appleOnly);
+
+      testWidgets('word modifier + arrow key movement', (WidgetTester tester) async {
+        controller.text = testText;
+        controller.selection = const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        );
+        await tester.pumpWidget(buildEditableText());
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true));
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        ));
+
+        controller.selection = const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        );
+        await tester.pump();
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true));
+        await tester.pump();
+        expect(controller.selection, const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        ));
+
+        controller.selection = const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        );
+        await tester.pump();
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true));
+        await tester.pump();
+        expect(controller.selection, const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        ));
+
+        // "good" to "come" is selected.
+        controller.selection = const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        );
+        await tester.pump();
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowRight, alt: true));
+        await tester.pump();
+        expect(controller.selection, const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        ));
+      }, variant: appleOnly);
+
+      testWidgets('line modifier + arrow key movement', (WidgetTester tester) async {
+        controller.text = testText;
+        // "good" to "come" is selected.
+        controller.selection = const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        );
+        await tester.pumpWidget(buildEditableText());
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true));
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        ));
+
+        // "good" to "come" is selected.
+        controller.selection = const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        );
+        await tester.pump();
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true));
+        await tester.pump();
+        expect(controller.selection, const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        ));
+
+        // "good" to "come" is selected.
+        controller.selection = const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        );
+        await tester.pump();
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true));
+        await tester.pump();
+        expect(controller.selection, const TextSelection(
+          baseOffset: 24,
+          extentOffset: 43,
+        ));
+
+        // "good" to "come" is selected.
+        controller.selection = const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        );
+        await tester.pump();
+        await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.arrowRight, meta: true));
+        await tester.pump();
+        expect(controller.selection, const TextSelection(
+          baseOffset: 43,
+          extentOffset: 24,
+        ));
+      }, variant: appleOnly);
+    });
+
+    testWidgets('vertical movement', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(
+        offset: 0,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+
+      for (final SingleActivator activator in allModifierVariants(LogicalKeyboardKey.arrowDown)) {
+        await sendKeyCombination(tester, activator);
+        await tester.pump();
+
+        expect(controller.text, testText);
+        expect(
+          controller.selection,
+          const TextSelection.collapsed(offset: 0),
+          reason: activator.toString(),
+        );
+      }
+    }, variant: TargetPlatformVariant.all());
+
+    testWidgets('horizontal movement', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(
+        offset: 0,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+
+      for (final SingleActivator activator in allModifierVariants(LogicalKeyboardKey.arrowRight)) {
+        await sendKeyCombination(tester, activator);
+        await tester.pump();
+
+        expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      }
+    }, variant: TargetPlatformVariant.all());
+
+    testWidgets('select all non apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(
+        offset: 0,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, control: true));
+      await tester.pump();
+
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+    }, variant: allExceptApple);
+
+    testWidgets('select all apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(
+        offset: 0,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyA, meta: true));
+      await tester.pump();
+
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+    }, variant: appleOnly);
+
+    testWidgets('copy non apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyC, control: true));
+      await tester.pump();
+
+      final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
+      expect(clipboardData['text'], 'empty');
+    }, variant: allExceptApple);
+
+    testWidgets('copy apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyC, meta: true));
+      await tester.pump();
+
+      final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
+      expect(clipboardData['text'], 'empty');
+    }, variant: appleOnly);
+
+    testWidgets('cut non apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyX, control: true));
+      await tester.pump();
+
+      final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
+      expect(clipboardData['text'], 'empty');
+      expect(controller.selection, const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      ));
+    }, variant: allExceptApple);
+
+    testWidgets('cut apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyX, meta: true));
+      await tester.pump();
+
+      final Map<String, dynamic> clipboardData = mockClipboard.clipboardData as Map<String, dynamic>;
+      expect(clipboardData['text'], 'empty');
+      expect(controller.selection, const TextSelection(
+        baseOffset: 0,
+        extentOffset: 4,
+      ));
+    }, variant: appleOnly);
+
+    testWidgets('paste non apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(offset: 0);
+      mockClipboard.clipboardData = <String, dynamic>{
+        'text': 'some text',
+      };
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyV, control: true));
+      await tester.pump();
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      expect(controller.text, testText);
+    }, variant: allExceptApple);
+
+    testWidgets('paste apple', (WidgetTester tester) async {
+      controller.text = testText;
+      controller.selection = const TextSelection.collapsed(offset: 0);
+      mockClipboard.clipboardData = <String, dynamic>{
+        'text': 'some text',
+      };
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, const SingleActivator(LogicalKeyboardKey.keyV, meta: true));
+      await tester.pump();
+      expect(controller.selection, const TextSelection.collapsed(offset: 0));
+      expect(controller.text, testText);
+    }, variant: appleOnly);
+
+  }, skip: !kIsWeb);// [intended] specific tests target web.
 }


### PR DESCRIPTION
Previously the text editing shortcuts were disabled on web because shortcuts are handled on the platform side for text fields.

This pr changes it that the is update disabled if the focus node is under the Editable Text so that other widgets who want to handle the shortcuts if it is fired above the EditableText 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
