### PR TITLE
[TimePicker] parameter to focus on minutes

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1969,7 +1969,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   late final _RestorableTimePickerEntryMode _entryMode = _RestorableTimePickerEntryMode(widget.initialEntryMode);
-  final _RestorableTimePickerMode _mode = _RestorableTimePickerMode(widget.focusOnMinutes ? _TimePickerMode.minute : _TimePickerMode.hour);
+  late final _RestorableTimePickerMode _mode = _RestorableTimePickerMode(widget.focusOnMinutes ? _TimePickerMode.minute : _TimePickerMode.hour);
   final _RestorableTimePickerModeN _lastModeAnnounced = _RestorableTimePickerModeN(null);
   final _RestorableAutovalidateMode _autovalidateMode = _RestorableAutovalidateMode(AutovalidateMode.disabled);
   final RestorableBoolN _autofocusHour = RestorableBoolN(null);

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1804,6 +1804,7 @@ class TimePickerDialog extends StatefulWidget {
     this.restorationId,
     this.initialEntryMode = TimePickerEntryMode.dial,
     this.onEntryModeChanged,
+    this.focusOnMinutes = false,
   }) : assert(initialTime != null);
 
   /// The time initially selected when the dialog is shown.
@@ -1833,6 +1834,9 @@ class TimePickerDialog extends StatefulWidget {
 
   /// Optionally provide your own minute label text.
   final String? minuteLabelText;
+  
+  /// If set minutes selection is active when the dialog is shown.
+  final bool focusOnMinutes;
 
   /// Restoration ID to save and restore the state of the [TimePickerDialog].
   ///
@@ -1965,7 +1969,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   late final _RestorableTimePickerEntryMode _entryMode = _RestorableTimePickerEntryMode(widget.initialEntryMode);
-  final _RestorableTimePickerMode _mode = _RestorableTimePickerMode(_TimePickerMode.hour);
+  final _RestorableTimePickerMode _mode = _RestorableTimePickerMode(widget.focusOnMinutes ? _TimePickerMode.minute : _TimePickerMode.hour);
   final _RestorableTimePickerModeN _lastModeAnnounced = _RestorableTimePickerModeN(null);
   final _RestorableAutovalidateMode _autovalidateMode = _RestorableAutovalidateMode(AutovalidateMode.disabled);
   final RestorableBoolN _autofocusHour = RestorableBoolN(null);
@@ -2354,6 +2358,9 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
 /// determine the initial time entry selection of the picker (either a clock
 /// dial or text input).
 ///
+/// The `focusOnMinutes` parameter can be set to focus on minutes selection
+/// instead of hours when the dialog is first shown. 
+///
 /// Optional strings for the [helpText], [cancelText], [errorInvalidText],
 /// [hourLabelText], [minuteLabelText] and [confirmText] can be provided to
 /// override the default values.
@@ -2421,6 +2428,7 @@ Future<TimeOfDay?> showTimePicker({
   RouteSettings? routeSettings,
   EntryModeChangeCallback? onEntryModeChanged,
   Offset? anchorPoint,
+  bool focusOnMinutes = false,
 }) async {
   assert(context != null);
   assert(initialTime != null);
@@ -2438,6 +2446,7 @@ Future<TimeOfDay?> showTimePicker({
     hourLabelText: hourLabelText,
     minuteLabelText: minuteLabelText,
     onEntryModeChanged: onEntryModeChanged,
+    focusOnMinutes: focusOnMinutes,
   );
   return showDialog<TimeOfDay>(
     context: context,

--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -1834,7 +1834,7 @@ class TimePickerDialog extends StatefulWidget {
 
   /// Optionally provide your own minute label text.
   final String? minuteLabelText;
-  
+
   /// If set minutes selection is active when the dialog is shown.
   final bool focusOnMinutes;
 
@@ -2359,7 +2359,7 @@ class _TimePickerDialogState extends State<TimePickerDialog> with RestorationMix
 /// dial or text input).
 ///
 /// The `focusOnMinutes` parameter can be set to focus on minutes selection
-/// instead of hours when the dialog is first shown. 
+/// instead of hours when the dialog is first shown.
 ///
 /// Optional strings for the [helpText], [cancelText], [errorInvalidText],
 /// [hourLabelText], [minuteLabelText] and [confirmText] can be provided to


### PR DESCRIPTION
I added an optional named parameter `focusOnMinutes` to the `showTimePicker()` function and to the `TimePickerDialog`. It is set to false by default. If set to true `mode` is set to `_TimePickerMode.minute` instead that `_TimePickerMode.hour` when the dialog is first shown.

I needed to create different `DateTimeField`s to select distinctly hours and minutes. This gives the end user a shortcut if he wants to change only the minute fields. This shortcuts saves 1 tap over 4 in total (75%) in this case scenario, that it is not so uncommon.

On the other side the cost of this changes is near to zero. Up to my knowledge what I have added cannot have bugs or affect the use of the library in any way with respect with the previous version.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

I hardly read the contibutor guide or followed any process but please just look.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
