### PR TITLE
Add Tooltip default vertical padding

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -134,7 +134,8 @@ class Tooltip extends StatefulWidget {
 
   /// The amount of space by which to inset the tooltip's [child].
   ///
-  /// Defaults to 16.0 logical pixels in each direction.
+  /// On mobile, defaults to 16.0 logical pixels horizontally and 4.0 vertically.
+  /// On desktop, defaults to 8.0 logical pixels horizontally and 4.0 vertically.
   final EdgeInsetsGeometry? padding;
 
   /// The empty space that surrounds the tooltip.
@@ -403,11 +404,11 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
       case TargetPlatform.macOS:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        return const EdgeInsets.symmetric(horizontal: 8.0);
+        return const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0);
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.iOS:
-        return const EdgeInsets.symmetric(horizontal: 16.0);
+        return const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0);
     }
   }
 

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -801,15 +801,16 @@ void main() {
     tooltipKey.currentState?.ensureTooltipVisible();
     await tester.pump(const Duration(seconds: 2)); // faded in, show timer started (and at 0.0)
 
-    final RenderBox tip = tester.renderObject(
-      _findTooltipContainer(tooltipText),
-    );
+    final RenderBox tip = tester.renderObject(_findTooltipContainer(tooltipText));
     expect(tip.size.height, equals(32.0));
     expect(tip.size.width, equals(74.0));
     expect(tip, paints..rrect(
       rrect: RRect.fromRectAndRadius(tip.paintBounds, const Radius.circular(4.0)),
       color: const Color(0xe6616161),
     ));
+
+    final Container tooltipContainer = tester.firstWidget<Container>(_findTooltipContainer(tooltipText));
+    expect(tooltipContainer.padding, const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0));
   });
 
   testWidgets('Tooltip default size, shape, and color test for Desktop', (WidgetTester tester) async {
@@ -830,14 +831,15 @@ void main() {
     final RenderParagraph tooltipRenderParagraph = tester.renderObject<RenderParagraph>(find.text(tooltipText));
     expect(tooltipRenderParagraph.textSize.height, equals(12.0));
 
-    final RenderBox tooltipContainer = tester.renderObject(
-      _findTooltipContainer(tooltipText),
-    );
-    expect(tooltipContainer.size.height, equals(24.0));
-    expect(tooltipContainer, paints..rrect(
-      rrect: RRect.fromRectAndRadius(tooltipContainer.paintBounds, const Radius.circular(4.0)),
+    final RenderBox tooltipRenderBox = tester.renderObject(_findTooltipContainer(tooltipText));
+    expect(tooltipRenderBox.size.height, equals(24.0));
+    expect(tooltipRenderBox, paints..rrect(
+      rrect: RRect.fromRectAndRadius(tooltipRenderBox.paintBounds, const Radius.circular(4.0)),
       color: const Color(0xe6616161),
     ));
+
+    final Container tooltipContainer = tester.firstWidget<Container>(_findTooltipContainer(tooltipText));
+    expect(tooltipContainer.padding, const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.macOS, TargetPlatform.linux, TargetPlatform.windows}));
 
   testWidgets('Can tooltip decoration be customized', (WidgetTester tester) async {
@@ -1437,7 +1439,7 @@ void main() {
     tip = tester.renderObject(
       _findTooltipContainer(tooltipText),
     );
-    expect(tip.size.height, equals(56.0));
+    expect(tip.size.height, equals(64.0));
   });
 
   testWidgets('Tooltip text displays with richMessage', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR add a Tooltip default vertical padding for developper convenience.
see https://github.com/flutter/flutter/issues/86170#issuecomment-1118227966

@guidezpl
After investigating various solutions to not rely on vertical padding, I reached the conclusion that setting a default vertical padding is the best candidate :
- Users can easily override the default value as there is already a padding property on Tooltip (without relying on vertical padding we should add a new property and manage edge cases where the user already set the padding property).
- Before rendering, there is no simple way to know when a Text widget will wrap, so adding layout logic to increase Tooltip container height when the Text wraps will be complex and error-prone.


## Related Issue

Fixes https://github.com/flutter/flutter/issues/86170

## Tests

Update 3 tests.