### PR TITLE
Fix selection not deselected when TextField loses focus

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -20,7 +20,6 @@ import 'material_state.dart';
 import 'selectable_text.dart' show iOSHorizontalOffset;
 import 'text_selection.dart';
 import 'theme.dart';
-import 'colors.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -20,6 +20,7 @@ import 'material_state.dart';
 import 'selectable_text.dart' show iOSHorizontalOffset;
 import 'text_selection.dart';
 import 'theme.dart';
+import 'colors.dart';
 
 export 'package:flutter/services.dart' show TextInputType, TextInputAction, TextCapitalization, SmartQuotesType, SmartDashesType;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3253,7 +3253,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     assert(debugCheckHasMediaQuery(context));
     super.build(context); // See AutomaticKeepAliveClientMixin.
 
-    final Color? effectiveSelectionColor = widget.selectionColor ?? DefaultSelectionStyle.of(context).selectionColor;
+    final Color? effectiveSelectionColor = widget.selectionColor;
 
     final TextSelectionControls? controls = widget.selectionControls;
     return MouseRegion(

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3253,8 +3253,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     assert(debugCheckHasMediaQuery(context));
     super.build(context); // See AutomaticKeepAliveClientMixin.
 
-    final Color? effectiveSelectionColor = widget.selectionColor;
-
     final TextSelectionControls? controls = widget.selectionControls;
     return MouseRegion(
       cursor: widget.mouseCursor ?? SystemMouseCursors.text,
@@ -3316,7 +3314,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                         minLines: widget.minLines,
                         expands: widget.expands,
                         strutStyle: widget.strutStyle,
-                        selectionColor: effectiveSelectionColor,
+                        selectionColor: widget.selectionColor,
                         textScaleFactor: widget.textScaleFactor ?? MediaQuery.textScaleFactorOf(context),
                         textAlign: widget.textAlign,
                         textDirection: _textDirection,

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -434,6 +434,7 @@ void main() {
   );
 
   testWidgets('Text field drops selection color when losing focus', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/103341.
     final Key key1 = UniqueKey();
     final Key key2 = UniqueKey();
     final TextEditingController controller1 = TextEditingController();
@@ -460,7 +461,7 @@ void main() {
       ),
     );
 
-    final TextSelection selection = const TextSelection(baseOffset: 0, extentOffset: 4);
+    const TextSelection selection = TextSelection(baseOffset: 0, extentOffset: 4);
     final EditableTextState state1 = tester.state<EditableTextState>(find.byType(EditableText).first);
     final EditableTextState state2 = tester.state<EditableTextState>(find.byType(EditableText).last);
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -433,6 +433,62 @@ void main() {
     },
   );
 
+  testWidgets('Text field drops selection color when losing focus', (WidgetTester tester) async {
+    final Key key1 = UniqueKey();
+    final Key key2 = UniqueKey();
+    final TextEditingController controller1 = TextEditingController();
+    const Color selectionColor = Colors.orange;
+    const Color cursorColor = Colors.red;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: DefaultSelectionStyle(
+            selectionColor: selectionColor,
+            cursorColor: cursorColor,
+            child: Column(
+              children: <Widget>[
+                CupertinoTextField(
+                  key: key1,
+                  controller: controller1,
+                ),
+                CupertinoTextField(key: key2),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final TextSelection selection = const TextSelection(baseOffset: 0, extentOffset: 4);
+    final EditableTextState state1 = tester.state<EditableTextState>(find.byType(EditableText).first);
+    final EditableTextState state2 = tester.state<EditableTextState>(find.byType(EditableText).last);
+
+    await tester.tap(find.byKey(key1));
+    await tester.enterText(find.byKey(key1), 'abcd');
+    await tester.pump();
+
+    await tester.tap(find.byKey(key2));
+    await tester.enterText(find.byKey(key2), 'dcba');
+    await tester.pump();
+
+    // Focus and selection is active on first TextField, so the second TextFields
+    // selectionColor should be dropped.
+    await tester.tap(find.byKey(key1));
+    controller1.selection = const TextSelection(baseOffset: 0, extentOffset: 4);
+    await tester.pump();
+    expect(controller1.selection, selection);
+    expect(state1.widget.selectionColor, selectionColor);
+    expect(state2.widget.selectionColor, null);
+
+    // Focus and selection is active on second TextField, so the first TextFields
+    // selectionColor should be dropped.
+    await tester.tap(find.byKey(key2));
+    await tester.pump();
+    expect(state1.widget.selectionColor, null);
+    expect(state2.widget.selectionColor, selectionColor);
+  });
+
   testWidgets(
     'multi-lined text fields are intrinsically taller no-strut',
     (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -4199,6 +4199,7 @@ void main() {
   });
 
   testWidgets('Text field drops selection color when losing focus', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/103341.
     final Key key1 = UniqueKey();
     final Key key2 = UniqueKey();
     final TextEditingController controller1 = TextEditingController();
@@ -4223,7 +4224,7 @@ void main() {
       ),
     );
 
-    final TextSelection selection = const TextSelection(baseOffset: 0, extentOffset: 4);
+    const TextSelection selection = TextSelection(baseOffset: 0, extentOffset: 4);
     final EditableTextState state1 = tester.state<EditableTextState>(find.byType(EditableText).first);
     final EditableTextState state2 = tester.state<EditableTextState>(find.byType(EditableText).last);
 

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -48,6 +48,7 @@ void main() {
   });
 
   testWidgets('Theme overrides selection style', (WidgetTester tester) async {
+    final Key key = UniqueKey();
     const Color defaultSelectionColor = Color(0x11111111);
     const Color defaultCursorColor = Color(0x22222222);
     const Color themeSelectionColor = Color(0x33333333);
@@ -66,7 +67,9 @@ void main() {
                   cursorColor: themeCursorColor,
                 ),
               ),
-              child: const TextField(),
+              child: TextField(
+                key: key,
+              ),
             )
           ),
         ),
@@ -83,6 +86,12 @@ void main() {
       child.visitChildren(recursiveFinder);
     }
     root.visitChildren(recursiveFinder);
+
+    // Focus text field so it has a selection color. The selection color is null
+    // on an unfocused text field.
+    await tester.tap(find.byKey(key));
+    await tester.pump();
+
     expect(renderEditable.selectionColor, themeSelectionColor);
     expect(tester.widget<EditableText>(find.byType(EditableText)).cursorColor, themeCursorColor);
   });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -660,7 +660,7 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
-  testWidgets('selection color can be null with DefaultSelectionStyle as parent', (WidgetTester tester) async {
+  testWidgets('EditableText does not derive selection color from DefaultSelectionStyle', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/103341.
     const TextEditingValue value = TextEditingValue(
       text: 'test test',
@@ -682,7 +682,6 @@ void main() {
               keyboardType: TextInputType.multiline,
               style: textStyle,
               cursorColor: cursorColor,
-              selectionColor: null,
             ),
           ),
         )

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -660,6 +660,38 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
+  testWidgets('selection color can be null with DefaultSelectionStyle as parent', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/103341.
+    const TextEditingValue value = TextEditingValue(
+      text: 'test test',
+      selection: TextSelection(affinity: TextAffinity.upstream, baseOffset: 5, extentOffset: 7),
+    );
+    const Color selectionColor = Colors.orange;
+    controller.value = value;
+    await tester.pumpWidget(
+      DefaultSelectionStyle(
+        selectionColor: selectionColor,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: Directionality(
+            textDirection: TextDirection.ltr,
+            child: EditableText(
+              controller: controller,
+              backgroundCursorColor: Colors.grey,
+              focusNode: focusNode,
+              keyboardType: TextInputType.multiline,
+              style: textStyle,
+              cursorColor: cursorColor,
+              selectionColor: null,
+            ),
+          ),
+        )
+      ),
+    );
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    expect(state.renderEditable.selectionColor, null);
+  });
+
   testWidgets('visiblePassword keyboard is requested when set explicitly', (WidgetTester tester) async {
     await tester.pumpWidget(
       MediaQuery(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -660,36 +660,6 @@ void main() {
     expect(focusNode.hasFocus, isFalse);
   });
 
-  testWidgets('use DefaultSelectionStyle for selection color', (WidgetTester tester) async {
-    const TextEditingValue value = TextEditingValue(
-      text: 'test test',
-      selection: TextSelection(affinity: TextAffinity.upstream, baseOffset: 5, extentOffset: 7),
-    );
-    const Color selectionColor = Colors.orange;
-    controller.value = value;
-    await tester.pumpWidget(
-      DefaultSelectionStyle(
-        selectionColor: selectionColor,
-        child: MediaQuery(
-          data: const MediaQueryData(),
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: EditableText(
-              controller: controller,
-              backgroundCursorColor: Colors.grey,
-              focusNode: focusNode,
-              keyboardType: TextInputType.multiline,
-              style: textStyle,
-              cursorColor: cursorColor,
-            ),
-          ),
-        )
-      ),
-    );
-    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
-    expect(state.renderEditable.selectionColor, selectionColor);
-  });
-
   testWidgets('visiblePassword keyboard is requested when set explicitly', (WidgetTester tester) async {
     await tester.pumpWidget(
       MediaQuery(


### PR DESCRIPTION
## Description
The original issue was introduced by #101954 because the `selectionColor` on `EditableText` was never null. Previously null was passed to `EditableText` to paint no selection when it did not have focus. https://github.com/flutter/flutter/blob/5464c5bac742001448fe4fc0597be939379f88ea/packages/flutter/lib/src/material/text_field.dart#L1244 This change allows the selectionColor on `EditableText` to be null again by only taking `widget.selectionColor` and not inheriting `DefaultSelectionStyle.of(context)`.

## Related Issues
Fixes #103341

## Tests
Added tests to ensure selectionColor is dropped when focus is lost on TextField, and add regression test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
