### PR TITLE
Provide flutter sdk kernel files to dwds launcher instead of dart ones

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -301,7 +301,7 @@ class WebAssetServer implements AssetReader {
       ).strategy,
       expressionCompiler: expressionCompiler,
       spawnDds: enableDds,
-      sdkConfigurationProvider: SdkWebConfigurationProvider(),
+      sdkConfigurationProvider: SdkWebConfigurationProvider(globals.artifacts),
     );
     shelf.Pipeline pipeline = const shelf.Pipeline();
     if (enableDwds) {

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -43,6 +43,7 @@ import '../web/chrome.dart';
 import '../web/compile.dart';
 import '../web/flutter_js.dart' as flutter_js;
 import '../web/memory_fs.dart';
+import 'sdk_web_configuration.dart';
 
 typedef DwdsLauncher = Future<Dwds> Function({
   @required AssetReader assetReader,
@@ -300,6 +301,7 @@ class WebAssetServer implements AssetReader {
       ).strategy,
       expressionCompiler: expressionCompiler,
       spawnDds: enableDds,
+      sdkConfigurationProvider: SdkWebConfigurationProvider(),
     );
     shelf.Pipeline pipeline = const shelf.Pipeline();
     if (enableDwds) {
@@ -1011,16 +1013,6 @@ void log(logging.LogRecord event) {
   if (event.level >= logging.Level.SEVERE) {
     globals.printError('${event.loggerName}: ${event.message}$error', stackTrace: event.stackTrace);
   } else if (event.level == logging.Level.WARNING) {
-    // TODO(elliette): Remove the following message suppressions after DWDS is
-    // >13.1.0, https://github.com/flutter/flutter/issues/101639
-    const String dartUri = 'DartUri';
-    if (event.loggerName == dartUri) {
-      const String webSqlWarning = 'Unresolved uri: dart:web_sql';
-      const String uiWarning = 'Unresolved uri: dart:ui';
-      if (event.message == webSqlWarning || event.message == uiWarning) {
-        return;
-      }
-    }
     globals.printWarning('${event.loggerName}: ${event.message}$error');
   } else  {
     globals.printTrace('${event.loggerName}: ${event.message}$error');

--- a/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
+++ b/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
+++ b/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
@@ -1,0 +1,46 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:async';
+
+import 'package:dwds/dwds.dart';
+
+import '../artifacts.dart';
+import '../base/file_system.dart';
+import '../globals.dart' as globals;
+
+/// Provides paths to SDK files for dart SDK used in flutter.
+class SdkWebConfigurationProvider extends SdkConfigurationProvider {
+  SdkWebConfigurationProvider();
+  SdkConfiguration _configuration;
+
+  /// Create and validate configuration matching the default SDK layout.
+  /// Create configuration matching the default SDK layout.
+  @override
+  Future<SdkConfiguration> get configuration async {
+    if (_configuration == null) {
+      final String sdkDir = globals.artifacts.getHostArtifact(HostArtifact.flutterWebSdk).path;
+      final String unsoundSdkSummaryPath = globals.artifacts.getHostArtifact(HostArtifact.webPlatformKernelDill).path;
+      final String soundSdkSummaryPath = globals.artifacts.getHostArtifact(HostArtifact.webPlatformSoundKernelDill).path;
+      final String librariesPath = globals.artifacts.getHostArtifact(HostArtifact.flutterWebLibrariesJson).path;
+
+      _configuration = SdkConfiguration(
+        sdkDirectory: sdkDir,
+        unsoundSdkSummaryPath: unsoundSdkSummaryPath,
+        soundSdkSummaryPath: soundSdkSummaryPath,
+        librariesPath: librariesPath,
+      );
+    }
+    return _configuration;
+  }
+
+  /// Validate that SDK configuration exists on disk.
+  static void validate(SdkConfiguration configuration, { FileSystem fileSystem }) {
+    configuration.validateSdkDir(fileSystem: fileSystem);
+    configuration.validateSummaries(fileSystem: fileSystem);
+    configuration.validateLibrariesSpec(fileSystem: fileSystem);
+  }
+}

--- a/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
+++ b/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
@@ -10,11 +10,13 @@ import 'package:dwds/dwds.dart';
 
 import '../artifacts.dart';
 import '../base/file_system.dart';
-import '../globals.dart' as globals;
 
 /// Provides paths to SDK files for dart SDK used in flutter.
 class SdkWebConfigurationProvider extends SdkConfigurationProvider {
-  SdkWebConfigurationProvider();
+
+  SdkWebConfigurationProvider(this._artifacts);
+
+  final Artifacts _artifacts;
   SdkConfiguration _configuration;
 
   /// Create and validate configuration matching the default SDK layout.
@@ -22,10 +24,10 @@ class SdkWebConfigurationProvider extends SdkConfigurationProvider {
   @override
   Future<SdkConfiguration> get configuration async {
     if (_configuration == null) {
-      final String sdkDir = globals.artifacts.getHostArtifact(HostArtifact.flutterWebSdk).path;
-      final String unsoundSdkSummaryPath = globals.artifacts.getHostArtifact(HostArtifact.webPlatformKernelDill).path;
-      final String soundSdkSummaryPath = globals.artifacts.getHostArtifact(HostArtifact.webPlatformSoundKernelDill).path;
-      final String librariesPath = globals.artifacts.getHostArtifact(HostArtifact.flutterWebLibrariesJson).path;
+      final String sdkDir = _artifacts.getHostArtifact(HostArtifact.flutterWebSdk).path;
+      final String unsoundSdkSummaryPath = _artifacts.getHostArtifact(HostArtifact.webPlatformKernelDill).path;
+      final String soundSdkSummaryPath = _artifacts.getHostArtifact(HostArtifact.webPlatformSoundKernelDill).path;
+      final String librariesPath = _artifacts.getHostArtifact(HostArtifact.flutterWebLibrariesJson).path;
 
       _configuration = SdkConfiguration(
         sdkDirectory: sdkDir,

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -76,28 +76,26 @@ void main() {
     });
   });
 
-  test('.log() filters events', () => testbed.run(() {
-    // harmless warning that should be filtered out
-    const String harmlessMessage = 'Unresolved uri: dart:ui';
-    // serious warning
-    const String seriousMessage = 'Something bad happened';
+  test('.log() reports warnings', () => testbed.run(() {
+    const String unresolvedUriMessage = 'Unresolved uri:';
+    const String otherMessage = 'Something bad happened';
 
     final List<logging.LogRecord> events = <logging.LogRecord>[
       logging.LogRecord(
         logging.Level.WARNING,
-        harmlessMessage,
+        unresolvedUriMessage,
         'DartUri',
       ),
       logging.LogRecord(
         logging.Level.WARNING,
-        seriousMessage,
+        otherMessage,
         'DartUri',
       ),
     ];
 
     events.forEach(log);
-    expect(logger.warningText, contains(seriousMessage));
-    expect(logger.warningText, isNot(contains(harmlessMessage)));
+    expect(logger.warningText, contains(unresolvedUriMessage));
+    expect(logger.warningText, contains(otherMessage));
   }));
 
   test('Handles against malformed manifest', () => testbed.run(() async {

--- a/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/expression_evaluation_web_test.dart
@@ -23,6 +23,9 @@ void main() {
       tempDir = createResolvedTempDirectorySync('run_expression_eval_test.');
       await project.setUpIn(tempDir);
       flutter = FlutterRunTestDriver(tempDir);
+      flutter.stdout.listen((String line) {
+        expect(line, isNot(contains('Unresolved uri:')));
+      });
     });
 
     tearDown(() async {

--- a/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
+++ b/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
+++ b/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
@@ -1,0 +1,56 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'package:dwds/dwds.dart';
+import 'package:file/file.dart';
+import 'package:file/memory.dart';
+import 'package:flutter_tools/src/artifacts.dart';
+import 'package:flutter_tools/src/base/context.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/isolated/sdk_web_configuration.dart';
+
+import '../src/common.dart';
+
+void main() {
+  FileSystem fileSystem;
+
+  group('Flutter SDK configuration for web', () {
+    final SdkConfigurationProvider provider = SdkWebConfigurationProvider();
+    SdkConfiguration configuration;
+
+    setUp(() async {
+      fileSystem = MemoryFileSystem.test();
+      fileSystem.directory('HostArtifact.flutterWebSdk').createSync();
+      fileSystem.file('HostArtifact.webPlatformKernelDill').createSync();
+      fileSystem.file('HostArtifact.webPlatformSoundKernelDill').createSync();
+      fileSystem.file('HostArtifact.flutterWebLibrariesJson').createSync();
+
+      await context.run<void>(
+        overrides: <Type, Generator>{
+          Logger: () => globals.logger,
+          Artifacts: () =>  Artifacts.test(fileSystem: fileSystem),
+          FileSystem: () => fileSystem,
+        },
+        body: () async {
+          configuration = await provider.configuration;
+        }
+      );
+    });
+
+    testWithoutContext('can be validated', () {
+      SdkWebConfigurationProvider.validate(configuration, fileSystem: fileSystem);
+    });
+
+    testWithoutContext('is correct', () {
+      expect(configuration.sdkDirectory, 'HostArtifact.flutterWebSdk');
+      expect(configuration.unsoundSdkSummaryPath, 'HostArtifact.webPlatformKernelDill');
+      expect(configuration.soundSdkSummaryPath, 'HostArtifact.webPlatformSoundKernelDill');
+      expect(configuration.librariesPath, 'HostArtifact.flutterWebLibrariesJson');
+      expect(configuration.compilerWorkerPath, isNull);
+    });
+  });
+}

--- a/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
+++ b/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
@@ -8,9 +8,6 @@ import 'package:dwds/dwds.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/context.dart';
-import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/sdk_web_configuration.dart';
 
 import '../src/common.dart';
@@ -19,7 +16,7 @@ void main() {
   FileSystem fileSystem;
 
   group('Flutter SDK configuration for web', () {
-    final SdkConfigurationProvider provider = SdkWebConfigurationProvider();
+    final SdkConfigurationProvider provider = SdkWebConfigurationProvider(Artifacts.test(fileSystem: fileSystem));
     SdkConfiguration configuration;
 
     setUp(() async {
@@ -29,16 +26,7 @@ void main() {
       fileSystem.file('HostArtifact.webPlatformSoundKernelDill').createSync();
       fileSystem.file('HostArtifact.flutterWebLibrariesJson').createSync();
 
-      await context.run<void>(
-        overrides: <Type, Generator>{
-          Logger: () => globals.logger,
-          Artifacts: () =>  Artifacts.test(fileSystem: fileSystem),
-          FileSystem: () => fileSystem,
-        },
-        body: () async {
-          configuration = await provider.configuration;
-        }
-      );
+      configuration = await provider.configuration;
     });
 
     testWithoutContext('can be validated', () {

--- a/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
+++ b/packages/flutter_tools/test/web.shard/sdk_web_configuration_test.dart
@@ -16,7 +16,6 @@ void main() {
   FileSystem fileSystem;
 
   group('Flutter SDK configuration for web', () {
-    final SdkConfigurationProvider provider = SdkWebConfigurationProvider(Artifacts.test(fileSystem: fileSystem));
     SdkConfiguration configuration;
 
     setUp(() async {
@@ -26,6 +25,8 @@ void main() {
       fileSystem.file('HostArtifact.webPlatformSoundKernelDill').createSync();
       fileSystem.file('HostArtifact.flutterWebLibrariesJson').createSync();
 
+      final SdkWebConfigurationProvider provider =
+        SdkWebConfigurationProvider(Artifacts.test(fileSystem: fileSystem));
       configuration = await provider.configuration;
     });
 


### PR DESCRIPTION
Provide flutter SDK kernel files to dwds launcher instead of dart ones.

Flutter SDK adds libraries to the dart SDK kernel files. Passing flutter SDK will make those additional libraries available for expression compilation.

Closes: https://github.com/flutter/flutter/issues/101639

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
