### PR TITLE
Add ShortcutsRegistry

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -119,7 +119,15 @@ class ChangeNotifier implements Listenable {
   int _reentrantlyRemovedListeners = 0;
   bool _debugDisposed = false;
 
-  bool _debugAssertNotDisposed() {
+  /// Used by subclasses to assert that the [ChangeNotifier] has not yet been disposed.
+  ///
+  /// Should only be called inside of an assert, as in:
+  ///
+  /// ```dart
+  /// assert(debugAssertNotDisposed());
+  /// ```
+  @protected
+  bool debugAssertNotDisposed() {
     assert(() {
       if (_debugDisposed) {
         throw FlutterError(
@@ -149,7 +157,7 @@ class ChangeNotifier implements Listenable {
   /// so, stopping that same work.
   @protected
   bool get hasListeners {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     return _count > 0;
   }
 
@@ -181,7 +189,7 @@ class ChangeNotifier implements Listenable {
   ///    the list of closures that are notified when the object changes.
   @override
   void addListener(VoidCallback listener) {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     if (_count == _listeners.length) {
       if (_count == 0) {
         _listeners = List<VoidCallback?>.filled(1, null);
@@ -273,7 +281,7 @@ class ChangeNotifier implements Listenable {
   /// This method should only be called by the object's owner.
   @mustCallSuper
   void dispose() {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     assert(() {
       _debugDisposed = true;
       return true;
@@ -301,7 +309,7 @@ class ChangeNotifier implements Listenable {
   @visibleForTesting
   @pragma('vm:notify-debugger-on-exception')
   void notifyListeners() {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     if (_count == 0)
       return;
 

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -119,13 +119,22 @@ class ChangeNotifier implements Listenable {
   int _reentrantlyRemovedListeners = 0;
   bool _debugDisposed = false;
 
-  /// Used by subclasses to assert that the [ChangeNotifier] has not yet been disposed.
+  /// Used by subclasses to assert that the [ChangeNotifier] has not yet been
+  /// disposed.
   ///
-  /// Should only be called inside of an assert, as in:
+  /// {@tool snippet}
+  /// The `debugAssertNotDisposed` function should only be called inside of an
+  /// assert, as in this example.
   ///
   /// ```dart
-  /// assert(debugAssertNotDisposed());
+  /// class MyNotifier with ChangeNotifier {
+  ///   void doUpdate() {
+  ///     assert(debugAssertNotDisposed());
+  ///     // ...
+  ///   }
+  /// }
   /// ```
+  /// {@end-tool}
   @protected
   bool debugAssertNotDisposed() {
     assert(() {

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -533,29 +533,6 @@ class CallbackAction<T extends Intent> extends Action<T> {
   Object? invoke(T intent) => onInvoke(intent);
 }
 
-/// An intent that encapsulates a [VoidCallback] to be invoked by a
-/// [VoidCallbackAction] when it receives this intent.
-class VoidCallbackIntent extends Intent {
-  /// Creates a [VoidCallbackIntent].
-  ///
-  /// The [callback] argument is required.
-  const VoidCallbackIntent(this.callback);
-
-  /// The callback that is to be called by the [VoidCallbackAction] that
-  /// receives this intent.
-  final VoidCallback callback;
-}
-
-/// An action that invokes the [VoidCallback] given to it by the
-/// [VoidCallbackIntent] that configures it when invoked.
-class VoidCallbackAction extends Action<VoidCallbackIntent> {
-  @override
-  Object? invoke(VoidCallbackIntent intent) {
-    intent.callback();
-    return null;
-  }
-}
-
 /// An action dispatcher that simply invokes the actions given to it.
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -533,6 +533,29 @@ class CallbackAction<T extends Intent> extends Action<T> {
   Object? invoke(T intent) => onInvoke(intent);
 }
 
+/// An intent that encapsulates a [VoidCallback] to be invoked by a
+/// [VoidCallbackAction] when it receives this intent.
+class VoidCallbackIntent extends Intent {
+  /// Creates a [VoidCallbackIntent].
+  ///
+  /// The [callback] argument is required.
+  const VoidCallbackIntent(this.callback);
+
+  /// The callback that is to be called by the [VoidCallbackAction] that
+  /// receives this intent.
+  final VoidCallback callback;
+}
+
+/// An action that invokes the [VoidCallback] given to it by the
+/// [VoidCallbackIntent] that configures it when invoked.
+class VoidCallbackAction extends Action<VoidCallbackIntent> {
+  @override
+  Object? invoke(VoidCallbackIntent intent) {
+    intent.callback();
+    return null;
+  }
+}
+
 /// An action dispatcher that simply invokes the actions given to it.
 ///
 /// See also:

--- a/packages/flutter/lib/src/widgets/restoration.dart
+++ b/packages/flutter/lib/src/widgets/restoration.dart
@@ -473,7 +473,7 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
 
   @override
   void dispose() {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed()); // FYI, This uses ChangeNotifier's _debugDisposed, not _disposed.
     _owner?._unregister(this);
     super.dispose();
     _disposed = true;
@@ -483,14 +483,14 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
   String? _restorationId;
   RestorationMixin? _owner;
   void _register(String restorationId, RestorationMixin owner) {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     assert(restorationId != null);
     assert(owner != null);
     _restorationId = restorationId;
     _owner = owner;
   }
   void _unregister() {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     assert(_restorationId != null);
     assert(_owner != null);
     _restorationId = null;
@@ -503,28 +503,15 @@ abstract class RestorableProperty<T> extends ChangeNotifier {
   @protected
   State get state {
     assert(isRegistered);
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     return _owner!;
   }
 
   /// Whether this property is currently registered with a [RestorationMixin].
   @protected
   bool get isRegistered {
-    assert(_debugAssertNotDisposed());
+    assert(debugAssertNotDisposed());
     return _restorationId != null;
-  }
-
-  bool _debugAssertNotDisposed() {
-    assert(() {
-      if (_disposed) {
-        throw FlutterError(
-          'A $runtimeType was used after being disposed.\n'
-          'Once you have called dispose() on a $runtimeType, it can no longer be used.',
-        );
-      }
-      return true;
-    }());
-    return true;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1179,7 +1179,7 @@ class ShortcutRegistry extends ShortcutManager {
   ///
   /// There is a default [ShortcutRegistrar] instance in [WidgetsApp], so if you
   /// are using [WidgetsApp], [MaterialApp] or [CupertinoApp], you don't need to
-  /// create your own [ShortcutsRegistrar].
+  /// create your own [ShortcutRegistrar].
   ///
   /// See also:
   ///
@@ -1217,7 +1217,7 @@ class ShortcutRegistry extends ShortcutManager {
   ///
   /// There is a default [ShortcutRegistrar] instance in [WidgetsApp], so if you
   /// are using [WidgetsApp], [MaterialApp] or [CupertinoApp], you don't need to
-  /// create your own [ShortcutsRegistrar].
+  /// create your own [ShortcutRegistrar].
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1287,7 +1287,7 @@ class ShortcutRegistry with ChangeNotifier {
 /// shortcuts are no longer needed.
 ///
 /// To replace or update the shortcuts in the registry, call
-/// [ShortcutRegistry.replaceAll] and supply the token returned by
+/// [ShortcutRegistryToken.replaceAll] and supply the token returned by
 /// [ShortcutRegistry.addAll].
 ///
 /// To remove previously added shortcuts from the registry, call

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -1062,19 +1062,19 @@ class CallbackShortcuts extends StatelessWidget {
   }
 }
 
-/// A class used by [ShortcutsRegistrar] that allows adding or removing shortcut
+/// A class used by [ShortcutRegistrar] that allows adding or removing shortcut
 /// bindings.
 ///
-/// Objects of this type are returned from [ShortcutsRegistrar.of] and
-/// [ShortcutsRegistrar.maybeOf].
+/// Objects of this type are returned from [ShortcutRegistrar.of] and
+/// [ShortcutRegistrar.maybeOf].
 ///
 /// The registry may be listened to (with [addListener]/[removeListener]) for
 /// change notifications when the registered shortcuts change. When shortcuts
 /// are added or removed, change notifications will be dispatched after the
 /// current frame is finished.
-class ShortcutsRegistry extends ChangeNotifier {
+class ShortcutRegistry extends ChangeNotifier {
   /// Gets the combined shortcut bindings from all contexts that are registered
-  /// with this [ShortcutsRegistry].
+  /// with this [ShortcutRegistry].
   ///
   /// Returns a copy: modifying the returned map will have no effect.
   Map<ShortcutActivator, Intent> get shortcuts {
@@ -1085,7 +1085,7 @@ class ShortcutsRegistry extends ChangeNotifier {
   final Map<BuildContext, Map<ShortcutActivator, Intent>> _contextShortcuts = <BuildContext, Map<ShortcutActivator, Intent>>{};
 
   /// Adds the given shortcut bindings associated with the given `context`
-  /// in this [ShortcutsRegistry].
+  /// in this [ShortcutRegistry].
   ///
   /// Will assert in debug mode if another context has already defined a given
   /// shortcut.
@@ -1115,7 +1115,7 @@ class ShortcutsRegistry extends ChangeNotifier {
         for (final ShortcutActivator shortcut in contextEntry.value.keys) {
           if (previous.containsKey(shortcut)) {
             throw FlutterError(
-                '$ShortcutsRegistry: Received a duplicate registration for the '
+                '$ShortcutRegistry: Received a duplicate registration for the '
                 'shortcut activator $shortcut in ${contextEntry.key} and ${previous[shortcut]}.');
           }
           previous[shortcut] = contextEntry.key;
@@ -1132,49 +1132,49 @@ class ShortcutsRegistry extends ChangeNotifier {
 /// The registered shortcuts are valid whenever a widget below this one in the
 /// hierarchy has focus.
 ///
-/// To add shortcuts to the registry, call [ShortcutsRegistrar.of] or
-/// [ShortcutsRegistrar.maybeOf] to get the [ShortcutsRegistry], and then add
-/// them using [ShortcutsRegistry.addAll].
+/// To add shortcuts to the registry, call [ShortcutRegistrar.of] or
+/// [ShortcutRegistrar.maybeOf] to get the [ShortcutRegistry], and then add
+/// them using [ShortcutRegistry.addAll].
 ///
-/// To remove shortcuts to the registry, call [ShortcutsRegistrar.of] or
-/// [ShortcutsRegistrar.maybeOf] to get the [ShortcutsRegistry], and then remove
-/// them using [ShortcutsRegistry.removeAll].
-class ShortcutsRegistrar extends StatefulWidget {
-  /// Creates a const [ShortcutsRegistrar].
+/// To remove shortcuts to the registry, call [ShortcutRegistrar.of] or
+/// [ShortcutRegistrar.maybeOf] to get the [ShortcutRegistry], and then remove
+/// them using [ShortcutRegistry.removeAll].
+class ShortcutRegistrar extends StatefulWidget {
+  /// Creates a const [ShortcutRegistrar].
   ///
   /// The [child] parameter is required.
-  const ShortcutsRegistrar({super.key, required this.child});
+  const ShortcutRegistrar({super.key, required this.child});
 
   /// The widget below this widget in the tree.
   ///
   /// {@macro flutter.widgets.ProxyWidget.child}
   final Widget child;
 
-  /// Returns the [ShortcutsRegistry] that belongs to the [ShortcutsRegistrar]
+  /// Returns the [ShortcutRegistry] that belongs to the [ShortcutRegistrar]
   /// which most tightly encloses the given [BuildContext].
   ///
-  /// If no [ShortcutsRegistrar] widget encloses the context given, `of` will
+  /// If no [ShortcutRegistrar] widget encloses the context given, `of` will
   /// throw an exception in debug mode.
   ///
-  /// The dependencies of [ShortcutsRegistrar] will have their
+  /// The dependencies of [ShortcutRegistrar] will have their
   /// [State.didChangeDependencies] called whenever the shortcuts have changed.
   ///
   /// See also:
   ///
   ///  * [maybeOf], which is similar to this function, but will return null if
-  ///    it doesn't find a [ShortcutsRegistrar] ancestor.
-  static ShortcutsRegistry of(BuildContext context) {
+  ///    it doesn't find a [ShortcutRegistrar] ancestor.
+  static ShortcutRegistry of(BuildContext context) {
     assert(context != null);
-    final _ShortcutsRegistrarMarker? inherited =
-        context.dependOnInheritedWidgetOfExactType<_ShortcutsRegistrarMarker>();
+    final _ShortcutRegistrarMarker? inherited =
+        context.dependOnInheritedWidgetOfExactType<_ShortcutRegistrarMarker>();
     assert(() {
       if (inherited == null) {
         throw FlutterError(
-          'Unable to find a $ShortcutsRegistrar widget in the context.\n'
-          '$ShortcutsRegistrar.of() was called with a context that does not contain a '
-          '$ShortcutsRegistrar widget.\n'
-          'No $ShortcutsRegistrar ancestor could be found starting from the context that was '
-          'passed to $ShortcutsRegistrar.of().\n'
+          'Unable to find a $ShortcutRegistrar widget in the context.\n'
+          '$ShortcutRegistrar.of() was called with a context that does not contain a '
+          '$ShortcutRegistrar widget.\n'
+          'No $ShortcutRegistrar ancestor could be found starting from the context that was '
+          'passed to $ShortcutRegistrar.of().\n'
           'The context used was:\n'
           '  $context',
         );
@@ -1184,39 +1184,39 @@ class ShortcutsRegistrar extends StatefulWidget {
     return inherited!.registry;
   }
 
-  /// Returns [ShortcutsRegistry] of the [ShortcutsRegistrar] that
+  /// Returns [ShortcutRegistry] of the [ShortcutRegistrar] that
   /// most tightly encloses the given [BuildContext].
   ///
-  /// If no [ShortcutsRegistrar] widget encloses the given context,
+  /// If no [ShortcutRegistrar] widget encloses the given context,
   /// `maybeOf` will return null.
   ///
-  /// The dependencies of [ShortcutsRegistrar] will have their
+  /// The dependencies of [ShortcutRegistrar] will have their
   /// [State.didChangeDependencies] called whenever the shortcuts have changed.
   ///
   /// See also:
   ///
   ///  * [of], which is similar to this function, but returns a non-nullable
   ///    result, and will throw an exception if it doesn't find a
-  ///    [ShortcutsRegistrar] ancestor.
-  static ShortcutsRegistry? maybeOf(BuildContext context) {
+  ///    [ShortcutRegistrar] ancestor.
+  static ShortcutRegistry? maybeOf(BuildContext context) {
     assert(context != null);
-    final _ShortcutsRegistrarMarker? inherited =
-        context.dependOnInheritedWidgetOfExactType<_ShortcutsRegistrarMarker>();
+    final _ShortcutRegistrarMarker? inherited =
+        context.dependOnInheritedWidgetOfExactType<_ShortcutRegistrarMarker>();
     return inherited?.registry;
   }
 
   @override
-  State<ShortcutsRegistrar> createState() => _ShortcutsRegistrarState();
+  State<ShortcutRegistrar> createState() => _ShortcutRegistrarState();
 }
 
-class _ShortcutsRegistrarState extends State<ShortcutsRegistrar> {
-  late ShortcutsRegistry registry;
+class _ShortcutRegistrarState extends State<ShortcutRegistrar> {
+  late ShortcutRegistry registry;
   bool updateScheduled = false;
 
   @override
   void initState() {
     super.initState();
-    registry = ShortcutsRegistry();
+    registry = ShortcutRegistry();
     registry.addListener(handleRegistryChange);
   }
 
@@ -1243,7 +1243,7 @@ class _ShortcutsRegistrarState extends State<ShortcutsRegistrar> {
   Widget build(BuildContext context) {
     return Shortcuts(
       shortcuts: registry.shortcuts,
-      child: _ShortcutsRegistrarMarker(
+      child: _ShortcutRegistrarMarker(
         registry: registry,
         child: widget.child,
       ),
@@ -1251,16 +1251,16 @@ class _ShortcutsRegistrarState extends State<ShortcutsRegistrar> {
   }
 }
 
-class _ShortcutsRegistrarMarker extends InheritedWidget {
-  const _ShortcutsRegistrarMarker({
+class _ShortcutRegistrarMarker extends InheritedWidget {
+  const _ShortcutRegistrarMarker({
     required this.registry,
     required super.child,
   });
 
-  final ShortcutsRegistry registry;
+  final ShortcutRegistry registry;
 
   @override
-  bool updateShouldNotify(covariant _ShortcutsRegistrarMarker oldWidget) {
+  bool updateShouldNotify(covariant _ShortcutRegistrarMarker oldWidget) {
     return registry != oldWidget.registry;
   }
 }

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1624,18 +1624,13 @@ void main() {
       }));
     });
 
-    testWidgets('using a disposed or foreign token asserts', (WidgetTester tester) async {
+    testWidgets('using a disposed token asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
       final ShortcutRegistryToken token = registry.addAll(<ShortcutActivator, Intent>{
         const SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
       });
       token.dispose();
-      final ShortcutRegistry registry2 = ShortcutRegistry();
-      final ShortcutRegistryToken token2 = registry2.addAll(<ShortcutActivator, Intent>{
-        const SingleActivator(LogicalKeyboardKey.keyB): DoNothingIntent(),
-      });
-      expect(() {registry.replaceAll(token, <ShortcutActivator, Intent>{}); }, throwsAssertionError);
-      expect(() {registry.replaceAll(token2, <ShortcutActivator, Intent>{}); }, throwsAssertionError);
+      expect(() {token.replaceAll(<ShortcutActivator, Intent>{}); }, throwsFlutterError);
     });
 
     testWidgets('setting duplicate bindings asserts', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1671,7 +1671,8 @@ class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _registryToken = ShortcutRegistrar.of(context).addAll(widget.shortcuts);
+    _registryToken?.dispose();
+    _registryToken = ShortcutRegistry.of(context).addAll(widget.shortcuts);
   }
 
   @override
@@ -1679,9 +1680,9 @@ class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
     super.didUpdateWidget(oldWidget);
     if (widget.shortcuts != oldWidget.shortcuts || _registryToken == null) {
       _registryToken?.dispose();
-      _registryToken = ShortcutRegistrar.of(context).addAll(widget.shortcuts);
+      _registryToken = ShortcutRegistry.of(context).addAll(widget.shortcuts);
     }
-    widget.onDependencyUpdate?.call(ShortcutRegistrar.of(context).shortcuts);
+    widget.onDependencyUpdate?.call(ShortcutRegistry.of(context).shortcuts);
   }
 
   @override

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1626,7 +1626,7 @@ void main() {
 
     testWidgets('using a disposed token asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
-      final ShortcutRegistryToken token = registry.addAll(<ShortcutActivator, Intent>{
+      final ShortcutRegistryEntry token = registry.addAll(<ShortcutActivator, Intent>{
         const SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
       });
       token.dispose();
@@ -1635,11 +1635,11 @@ void main() {
 
     testWidgets('setting duplicate bindings asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
-      final ShortcutRegistryToken token = registry.addAll(<ShortcutActivator, Intent>{
+      final ShortcutRegistryEntry token = registry.addAll(<ShortcutActivator, Intent>{
         const SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
       });
       expect(() {
-        final ShortcutRegistryToken token2 = registry.addAll(const <ShortcutActivator, Intent>{
+        final ShortcutRegistryEntry token2 = registry.addAll(const <ShortcutActivator, Intent>{
           SingleActivator(LogicalKeyboardKey.keyA): ActivateIntent(),
         });
         token2.dispose();
@@ -1661,7 +1661,7 @@ class TestCallbackRegistration extends StatefulWidget {
 }
 
 class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
-  ShortcutRegistryToken? _registryToken;
+  ShortcutRegistryEntry? _registryToken;
 
   @override
   void didChangeDependencies() {

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1316,16 +1316,16 @@ void main() {
         ShortcutRegistrar(
           child: TestCallbackRegistration(
             shortcuts: <ShortcutActivator, Intent>{
-              const SingleActivator(LogicalKeyboardKey.keyA): _VoidCallbackIntent(() {
+              const SingleActivator(LogicalKeyboardKey.keyA): VoidCallbackIntent(() {
                 invokedA += 1;
               }),
-              const SingleActivator(LogicalKeyboardKey.keyB): _VoidCallbackIntent(() {
+              const SingleActivator(LogicalKeyboardKey.keyB): VoidCallbackIntent(() {
                 invokedB += 1;
               }),
             },
             child: Actions(
               actions: <Type, Action<Intent>>{
-                _VoidCallbackIntent: _VoidCallbackAction(),
+                VoidCallbackIntent: VoidCallbackAction(),
               },
               child: const Focus(
                 autofocus: true,
@@ -1393,20 +1393,20 @@ void main() {
         ShortcutRegistrar(
           child: TestCallbackRegistration(
             shortcuts: <ShortcutActivator, Intent>{
-              const SingleActivator(LogicalKeyboardKey.keyA): _VoidCallbackIntent(() {
+              const SingleActivator(LogicalKeyboardKey.keyA): VoidCallbackIntent(() {
                 invokedOuter += 1;
               }),
             },
             child: ShortcutRegistrar(
               child: TestCallbackRegistration(
                 shortcuts: <ShortcutActivator, Intent>{
-                  const SingleActivator(LogicalKeyboardKey.keyA): _VoidCallbackIntent(() {
+                  const SingleActivator(LogicalKeyboardKey.keyA): VoidCallbackIntent(() {
                     invokedInner += 1;
                   }),
                 },
                 child: Actions(
                   actions: <Type, Action<Intent>>{
-                    _VoidCallbackIntent: _VoidCallbackAction(),
+                    VoidCallbackIntent: VoidCallbackAction(),
                   },
                 child: const Focus(
                   autofocus: true,
@@ -1434,20 +1434,20 @@ void main() {
         ShortcutRegistrar(
           child: TestCallbackRegistration(
             shortcuts: <ShortcutActivator, Intent>{
-              const CharacterActivator('b'): _VoidCallbackIntent(() {
+              const CharacterActivator('b'): VoidCallbackIntent(() {
                 invokedOuter += 1;
               }),
             },
             child: ShortcutRegistrar(
               child: TestCallbackRegistration(
                 shortcuts: <ShortcutActivator, Intent>{
-                  const CharacterActivator('a'): _VoidCallbackIntent(() {
+                  const CharacterActivator('a'): VoidCallbackIntent(() {
                     invokedInner += 1;
                   }),
                 },
                 child: Actions(
                   actions: <Type, Action<Intent>>{
-                    _VoidCallbackIntent: _VoidCallbackAction(),
+                    VoidCallbackIntent: VoidCallbackAction(),
                   },
                   child: const Focus(
                     autofocus: true,
@@ -1501,12 +1501,12 @@ void main() {
                 return true;
               },
             ),
-            _VoidCallbackIntent: _VoidCallbackAction(),
+            VoidCallbackIntent: VoidCallbackAction(),
           },
           child: ShortcutRegistrar(
             child: TestCallbackRegistration(
               shortcuts: <ShortcutActivator, Intent>{
-                const CharacterActivator('b'): _VoidCallbackIntent(() {
+                const CharacterActivator('b'): VoidCallbackIntent(() {
                   invokedCallbackB += 1;
                 }),
               },
@@ -1518,7 +1518,7 @@ void main() {
                 child: ShortcutRegistrar(
                   child: TestCallbackRegistration(
                     shortcuts: <ShortcutActivator, Intent>{
-                      const CharacterActivator('a'): _VoidCallbackIntent(() {
+                      const CharacterActivator('a'): VoidCallbackIntent(() {
                         invokedCallbackA += 1;
                       }),
                     },
@@ -1565,7 +1565,7 @@ void main() {
             },
             child: Actions(
               actions: <Type, Action<Intent>>{
-                _VoidCallbackIntent: _VoidCallbackAction(),
+                VoidCallbackIntent: VoidCallbackAction(),
               },
               child: const Focus(
                 autofocus: true,
@@ -1585,7 +1585,7 @@ void main() {
             },
             child: Actions(
               actions: <Type, Action<Intent>>{
-                _VoidCallbackIntent: _VoidCallbackAction(),
+                VoidCallbackIntent: VoidCallbackAction(),
               },
               child: const Focus(
                 autofocus: true,
@@ -1606,7 +1606,7 @@ void main() {
             },
             child: Actions(
               actions: <Type, Action<Intent>>{
-                _VoidCallbackIntent: _VoidCallbackAction(),
+                VoidCallbackIntent: VoidCallbackAction(),
               },
               child: const Focus(
                 autofocus: true,
@@ -1694,29 +1694,6 @@ class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
   @override
   Widget build(BuildContext context) {
     return widget.child;
-  }
-}
-
-/// An intent that encapsulates a [VoidCallback] to be invoked by a
-/// [_VoidCallbackAction] when it receives this intent.
-class _VoidCallbackIntent extends Intent {
-  /// Creates a [_VoidCallbackIntent].
-  ///
-  /// The [callback] argument is required.
-  const _VoidCallbackIntent(this.callback);
-
-  /// The callback that is to be called by the [_VoidCallbackAction] that
-  /// receives this intent.
-  final VoidCallback callback;
-}
-
-/// An action that invokes the [VoidCallback] given to it by the
-/// [_VoidCallbackIntent] that configures it when invoked.
-class _VoidCallbackAction extends Action<_VoidCallbackIntent> {
-  @override
-  Object? invoke(_VoidCallbackIntent intent) {
-    intent.callback();
-    return null;
   }
 }
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1643,22 +1643,22 @@ class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _cachedRegistry ??= ShortcutsRegistrar.of(context)..setShortcuts(context, widget.shortcuts);
+    _cachedRegistry ??= ShortcutsRegistrar.of(context)..addAll(context, widget.shortcuts);
   }
 
   @override
   void didUpdateWidget(TestCallbackRegistration oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.shortcuts != oldWidget.shortcuts || _cachedRegistry == null) {
-      _cachedRegistry?.clearShortcuts(context);
-      _cachedRegistry = ShortcutsRegistrar.of(context)..setShortcuts(context, widget.shortcuts);
+      _cachedRegistry?.removeAll(context);
+      _cachedRegistry = ShortcutsRegistrar.of(context)..addAll(context, widget.shortcuts);
     }
     widget.onDependencyUpdate?.call(ShortcutsRegistrar.of(context).shortcuts);
   }
 
   @override
   void dispose() {
-    _cachedRegistry?.clearShortcuts(context);
+    _cachedRegistry?.removeAll(context);
     super.dispose();
   }
 

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1308,12 +1308,12 @@ void main() {
     });
   });
 
-  group('ShortcutsRegistrar', () {
-    testWidgets('trigger ShortcutsRegistrar on key events', (WidgetTester tester) async {
+  group('ShortcutRegistrar', () {
+    testWidgets('trigger ShortcutRegistrar on key events', (WidgetTester tester) async {
       int invokedA = 0;
       int invokedB = 0;
       await tester.pumpWidget(
-        ShortcutsRegistrar(
+        ShortcutRegistrar(
           child: TestCallbackRegistration(
             shortcuts: <ShortcutActivator, Intent>{
               const SingleActivator(LogicalKeyboardKey.keyA): _VoidCallbackIntent(() {
@@ -1359,7 +1359,7 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: ShortcutsRegistrar(
+            body: ShortcutRegistrar(
               child: TestCallbackRegistration(
                 shortcuts: const <ShortcutActivator, Intent>{
                   SingleActivator(LogicalKeyboardKey.keyA, control: true): SelectAllTextIntent(SelectionChangedCause.keyboard),
@@ -1386,18 +1386,18 @@ void main() {
       expect(controller.selection.extentOffset, equals(7));
     });
 
-    testWidgets('nested ShortcutsRegistrars stop propagation', (WidgetTester tester) async {
+    testWidgets('nested ShortcutRegistrars stop propagation', (WidgetTester tester) async {
       int invokedOuter = 0;
       int invokedInner = 0;
       await tester.pumpWidget(
-        ShortcutsRegistrar(
+        ShortcutRegistrar(
           child: TestCallbackRegistration(
             shortcuts: <ShortcutActivator, Intent>{
               const SingleActivator(LogicalKeyboardKey.keyA): _VoidCallbackIntent(() {
                 invokedOuter += 1;
               }),
             },
-            child: ShortcutsRegistrar(
+            child: ShortcutRegistrar(
               child: TestCallbackRegistration(
                 shortcuts: <ShortcutActivator, Intent>{
                   const SingleActivator(LogicalKeyboardKey.keyA): _VoidCallbackIntent(() {
@@ -1427,18 +1427,18 @@ void main() {
       expect(invokedInner, equals(1));
     });
 
-    testWidgets('non-overlapping nested ShortcutsRegistrars fire appropriately', (WidgetTester tester) async {
+    testWidgets('non-overlapping nested ShortcutRegistrars fire appropriately', (WidgetTester tester) async {
       int invokedOuter = 0;
       int invokedInner = 0;
       await tester.pumpWidget(
-        ShortcutsRegistrar(
+        ShortcutRegistrar(
           child: TestCallbackRegistration(
             shortcuts: <ShortcutActivator, Intent>{
               const CharacterActivator('b'): _VoidCallbackIntent(() {
                 invokedOuter += 1;
               }),
             },
-            child: ShortcutsRegistrar(
+            child: ShortcutRegistrar(
               child: TestCallbackRegistration(
                 shortcuts: <ShortcutActivator, Intent>{
                   const CharacterActivator('a'): _VoidCallbackIntent(() {
@@ -1503,7 +1503,7 @@ void main() {
             ),
             _VoidCallbackIntent: _VoidCallbackAction(),
           },
-          child: ShortcutsRegistrar(
+          child: ShortcutRegistrar(
             child: TestCallbackRegistration(
               shortcuts: <ShortcutActivator, Intent>{
                 const CharacterActivator('b'): _VoidCallbackIntent(() {
@@ -1515,7 +1515,7 @@ void main() {
                   SingleActivator(LogicalKeyboardKey.keyA): TestIntent(),
                   SingleActivator(LogicalKeyboardKey.keyB): TestIntent2(),
                 },
-                child: ShortcutsRegistrar(
+                child: ShortcutRegistrar(
                   child: TestCallbackRegistration(
                     shortcuts: <ShortcutActivator, Intent>{
                       const CharacterActivator('a'): _VoidCallbackIntent(() {
@@ -1556,7 +1556,7 @@ void main() {
         shortcutsChanged.add(shortcuts);
       }
       await tester.pumpWidget(
-        ShortcutsRegistrar(
+        ShortcutRegistrar(
           child: TestCallbackRegistration(
             onDependencyUpdate: dependenciesUpdated,
             shortcuts: const <ShortcutActivator, Intent>{
@@ -1577,7 +1577,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        ShortcutsRegistrar(
+        ShortcutRegistrar(
           child: TestCallbackRegistration(
             onDependencyUpdate: dependenciesUpdated,
             shortcuts: const <ShortcutActivator, Intent>{
@@ -1597,7 +1597,7 @@ void main() {
       );
 
       await tester.pumpWidget(
-        ShortcutsRegistrar(
+        ShortcutRegistrar(
           child: TestCallbackRegistration(
             onDependencyUpdate: dependenciesUpdated,
             shortcuts: const <ShortcutActivator, Intent>{
@@ -1638,12 +1638,12 @@ class TestCallbackRegistration extends StatefulWidget {
 }
 
 class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
-  ShortcutsRegistry? _cachedRegistry;
+  ShortcutRegistry? _cachedRegistry;
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _cachedRegistry ??= ShortcutsRegistrar.of(context)..addAll(context, widget.shortcuts);
+    _cachedRegistry ??= ShortcutRegistrar.of(context)..addAll(context, widget.shortcuts);
   }
 
   @override
@@ -1651,9 +1651,9 @@ class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
     super.didUpdateWidget(oldWidget);
     if (widget.shortcuts != oldWidget.shortcuts || _cachedRegistry == null) {
       _cachedRegistry?.removeAll(context);
-      _cachedRegistry = ShortcutsRegistrar.of(context)..addAll(context, widget.shortcuts);
+      _cachedRegistry = ShortcutRegistrar.of(context)..addAll(context, widget.shortcuts);
     }
-    widget.onDependencyUpdate?.call(ShortcutsRegistrar.of(context).shortcuts);
+    widget.onDependencyUpdate?.call(ShortcutRegistrar.of(context).shortcuts);
   }
 
   @override


### PR DESCRIPTION
## Description

This adds a `ShortcutsRegistry` for `ShortcutActivator` to `Intent` mappings that can be modified from its descendants.  

This is so that descendants can make shortcuts dynamically available to a larger portion of the app than just their descendants. This is a precursor needed by the new `MenuBar`, for instance, so that the menu bar itself can be placed where it likes, but the shortcuts it defines can be in effect for most, if not all, of the UI surface in the app. For example, the "Ctrl-Q" quit binding would need to work even if the focused widget wasn't a child of the `MenuBar`.

This just provides the shortcut to intent mapping, the actions activated by the intent are described in the context where they make sense. For example, defining a "Ctrl-C" shortcut mapped to a "CopyIntent" should perform different functions if it happens while a `TextField` has focus vs when a drawing has focus, so those different areas would need to define different actions mapped to "CopyIntent". A hypothetical "QuitIntent" would probably be active for the entire app, so would be mapped in an `Actions` widget near the top of the hierarchy.

## Tests
 - Added tests for the new widget and registry.