### PR TITLE
Create `takeExceptionDetails` which is similar to `takeException` but allows the user to know details (e.g. stack trace)

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -596,7 +596,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// that one except it provides more details such as stack traces.
   FlutterErrorDetails? takeExceptionDetails() {
     assert(inTest);
-    final result = _pendingExceptionDetails;
+    final FlutterErrorDetails? result = _pendingExceptionDetails;
     _pendingExceptionDetails = null;
     return result;
   }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -588,6 +588,18 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     _pendingExceptionDetails = null;
     return result;
   }
+
+  /// Returns the details of the exception most recently caught by the 
+  /// Flutter framework.
+  ///
+  /// See [takeException] for more description. This method is similar to
+  /// that one except it provides more details such as stack traces.
+  FlutterErrorDetails? takeExceptionDetails() {
+    assert(inTest);
+    final result = _pendingExceptionDetails;
+    _pendingExceptionDetails = null;
+    return result;
+  }
   FlutterExceptionHandler? _oldExceptionHandler;
   late StackTraceDemangler _oldStackTraceDemangler;
   FlutterErrorDetails? _pendingExceptionDetails;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -589,7 +589,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     return result;
   }
 
-  /// Returns the details of the exception most recently caught by the 
+  /// Returns the details of the exception most recently caught by the
   /// Flutter framework.
   ///
   /// See [takeException] for more description. This method is similar to

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -932,7 +932,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// Returns the exception details most recently caught by the Flutter framework.
   ///
   /// See [TestWidgetsFlutterBinding.takeExceptionDetails] for details.
-  dynamic takeExceptionDetails() {
+  FlutterErrorDetails? takeExceptionDetails() {
     return binding.takeExceptionDetails();
   }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -929,6 +929,13 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     return binding.takeException();
   }
 
+  /// Returns the exception details most recently caught by the Flutter framework.
+  ///
+  /// See [TestWidgetsFlutterBinding.takeExceptionDetails] for details.
+  dynamic takeExceptionDetails() {
+    return binding.takeExceptionDetails();
+  }
+
   /// Acts as if the application went idle.
   ///
   /// Runs all remaining microtasks, including those scheduled as a result of

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -588,6 +588,14 @@ void main() {
       expect(tester.takeException(), isArgumentError);
     });
 
+    testWidgets('reports errors via framework with details', (WidgetTester tester) async {
+      final String? value = await tester.runAsync<String>(() async {
+        throw ArgumentError();
+      });
+      expect(value, isNull);
+      expect(tester.takeExceptionDetails()?.exception, isArgumentError);
+    });
+
     testWidgets('disallows re-entry', (WidgetTester tester) async {
       final Completer<void> completer = Completer<void>();
       tester.runAsync<void>(() => completer.future);


### PR DESCRIPTION
Please see https://github.com/flutter/flutter/issues/103487

Close #103487

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
