### PR TITLE
Add thumb color customization to CupertinoSwitch using Switch.adaptive

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -437,11 +437,12 @@ class Switch extends StatelessWidget {
         height: size.height,
         alignment: Alignment.center,
         child: CupertinoSwitch(
-            dragStartBehavior: dragStartBehavior,
-            value: value,
-            onChanged: onChanged,
-            activeColor: activeColor,
-            trackColor: inactiveTrackColor,
+          dragStartBehavior: dragStartBehavior,
+          value: value,
+          onChanged: onChanged,
+          activeColor: activeColor,
+          trackColor: inactiveTrackColor,
+          thumbColor: inactiveThumbColor,
         ),
       ),
     );

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -725,6 +725,7 @@ void main() {
   testWidgets('Switch.adaptive', (WidgetTester tester) async {
     bool value = false;
     const Color inactiveTrackColor = Colors.pink;
+    const Color inactiveThumbColor = Colors.green;
 
     Widget buildFrame(TargetPlatform platform) {
       return MaterialApp(
@@ -736,6 +737,7 @@ void main() {
                 child: Switch.adaptive(
                   value: value,
                   inactiveTrackColor: inactiveTrackColor,
+                  inactiveThumbColor: inactiveThumbColor,
                   onChanged: (bool newValue) {
                     setState(() {
                       value = newValue;
@@ -756,6 +758,7 @@ void main() {
 
       final CupertinoSwitch adaptiveSwitch = tester.widget(find.byType(CupertinoSwitch));
       expect(adaptiveSwitch.trackColor, inactiveTrackColor, reason: 'on ${platform.name}');
+      expect(adaptiveSwitch.thumbColor, inactiveThumbColor, reason: 'on ${platform.name}');
 
       expect(value, isFalse, reason: 'on ${platform.name}');
       await tester.tap(find.byType(Switch));


### PR DESCRIPTION
### Description

When using Switch.adaptive allow to set the thumbColor

This PR fixes issue #103485

### Tests

I edited the "Switch.adaptive" testWidget to add a thumbColor check.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
