### PR TITLE
Add VoidCallbackAction and VoidCallbackIntent

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -524,8 +524,6 @@ class CallbackAction<T extends Intent> extends Action<T> {
   CallbackAction({required this.onInvoke}) : assert(onInvoke != null);
 
   /// The callback to be called when invoked.
-  ///
-  /// Must not be null.
   @protected
   final OnInvokeCallback<T> onInvoke;
 
@@ -1296,7 +1294,34 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
   }
 }
 
-/// An [Intent], that is bound to a [DoNothingAction].
+/// An [Intent] that keeps a [VoidCallback] to be invoked by a
+/// [VoidCallbackAction] when it receives this intent.
+class VoidCallbackIntent extends Intent {
+  /// Creates a [VoidCallbackIntent].
+  const VoidCallbackIntent(this.callback);
+
+  /// The callback that is to be called by the [VoidCallbackAction] that
+  /// receives this intent.
+  final VoidCallback callback;
+}
+
+/// An [Action] that invokes the [VoidCallback] given to it in the
+/// [VoidCallbackIntent] passed to it when invoked.
+///
+/// See also:
+///
+///  * [CallbackAction], which is an action that will invoke a callback with the
+///    intent passed to the action's invoke method. The callback is configured
+///    on the action, not the intent, like this class.
+class VoidCallbackAction extends Action<VoidCallbackIntent> {
+  @override
+  Object? invoke(VoidCallbackIntent intent) {
+    intent.callback();
+    return null;
+  }
+}
+
+/// An [Intent] that is bound to a [DoNothingAction].
 ///
 /// Attaching a [DoNothingIntent] to a [Shortcuts] mapping is one way to disable
 /// a keyboard shortcut defined by a widget higher in the widget hierarchy and
@@ -1317,7 +1342,7 @@ class DoNothingIntent extends Intent {
   const DoNothingIntent._();
 }
 
-/// An [Intent], that is bound to a [DoNothingAction], but, in addition to not
+/// An [Intent] that is bound to a [DoNothingAction], but, in addition to not
 /// performing an action, also stops the propagation of the key event bound to
 /// this intent to other key event handlers in the focus chain.
 ///
@@ -1342,7 +1367,7 @@ class DoNothingAndStopPropagationIntent extends Intent {
   const DoNothingAndStopPropagationIntent._();
 }
 
-/// An [Action], that doesn't perform any action when invoked.
+/// An [Action] that doesn't perform any action when invoked.
 ///
 /// Attaching a [DoNothingAction] to an [Actions.actions] mapping is a way to
 /// disable an action defined by a widget higher in the widget hierarchy.
@@ -1411,7 +1436,7 @@ class ButtonActivateIntent extends Intent {
   const ButtonActivateIntent();
 }
 
-/// An action that activates the currently focused control.
+/// An [Action] that activates the currently focused control.
 ///
 /// This is an abstract class that serves as a base class for actions that
 /// activate a control. By default, is bound to [LogicalKeyboardKey.enter],
@@ -1419,7 +1444,7 @@ class ButtonActivateIntent extends Intent {
 /// default keyboard map in [WidgetsApp].
 abstract class ActivateAction extends Action<ActivateIntent> { }
 
-/// An intent that selects the currently focused control.
+/// An [Intent] that selects the currently focused control.
 class SelectIntent extends Intent { }
 
 /// An action that selects the currently focused control.
@@ -1441,7 +1466,7 @@ class DismissIntent extends Intent {
   const DismissIntent();
 }
 
-/// An action that dismisses the focused widget.
+/// An [Action] that dismisses the focused widget.
 ///
 /// This is an abstract class that serves as a base class for dismiss actions.
 abstract class DismissAction extends Action<DismissIntent> { }

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -524,6 +524,8 @@ class CallbackAction<T extends Intent> extends Action<T> {
   CallbackAction({required this.onInvoke}) : assert(onInvoke != null);
 
   /// The callback to be called when invoked.
+  ///
+  /// Must not be null.
   @protected
   final OnInvokeCallback<T> onInvoke;
 

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -1289,6 +1289,7 @@ class WidgetsApp extends StatefulWidget {
     DirectionalFocusIntent: DirectionalFocusAction(),
     ScrollIntent: ScrollAction(),
     PrioritizedIntents: PrioritizedAction(),
+    VoidCallbackIntent: VoidCallbackAction(),
   };
 
   @override


### PR DESCRIPTION
## Description

This adds a simple `VoidCallbackAction` and `VoidCallbackIntent` that allows configuring an intent that will invoke a void callback when the intent is sent to the action subsystem. This allows binding a shortcut directly to a void callback in a `Shortcuts` widget.

I also added an instance of `VoidCallbackAction` to the default actions so that simply binding a shortcut to a `VoidCallbackIntent` works anywhere in the app, and you don't need to add a `VoidCallbackAction` at the top of your app to make it work.

## Tests
 - Added a test for the new action and intent, cleaned up the test file a bit.