### PR TITLE
Add `minLines` option to text widgets

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -351,7 +351,7 @@ class TextPainter {
   /// After this is set, you must call [layout] before the next call to [paint].
   int? get minLines => _minLines;
   int? _minLines;
-  /// The value may be null. If it is not null, then it must be greater than or 
+  /// The value may be null. If it is not null, then it must be greater than or
   /// equal to zero.
   set minLines(int? value) {
     assert(value == null || value >= 0);
@@ -648,8 +648,8 @@ class TextPainter {
       if (newWidth != _applyFloatingPointHack(_paragraph!.width)) {
         _paragraph!.layout(ui.ParagraphConstraints(width: newWidth));
       }
-    }   
-    
+    }
+
     _layoutMinLines();
   }
 
@@ -666,11 +666,11 @@ class TextPainter {
 
     if (lines.isEmpty) {
       // No lines are present, but the paragraph still takes up one line of space.
-      // That's why we need to subtract this line from the calculation for the 
+      // That's why we need to subtract this line from the calculation for the
       // minLines height.
       _additionalMinLinesHeight = preferredLineHeight * (minLines! - 1);
       return;
-    } 
+    }
 
     if (lines.isNotEmpty) {
       final int fillerLineCount = minLines! - lines.length;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -72,7 +72,7 @@ class RenderParagraph extends RenderBox
   ///
   /// The [maxLines] property may be null (and indeed defaults to null), but if
   /// it is not null, it must be greater than zero.
-  /// 
+  ///
   /// The [minLines] property may be null (and indeed defaults to null), but if
   /// it is not null, it must be greater than or equal to zero.
   RenderParagraph(InlineSpan text, {
@@ -240,11 +240,11 @@ class RenderParagraph extends RenderBox
     markNeedsLayout();
   }
 
-  /// An optional minimum number of lines for the text to span. If the text 
-  /// falls short of the given number of lines, lines will be added below until 
+  /// An optional minimum number of lines for the text to span. If the text
+  /// falls short of the given number of lines, lines will be added below until
   /// there are the given number of lines.
   int? get minLines => _textPainter.minLines;
-  /// The value may be null. If it is not null, then it must be greater than or 
+  /// The value may be null. If it is not null, then it must be greater than or
   /// equal to zero.
   set minLines(int? value) {
     assert(value == null || value >= 0);

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -72,12 +72,16 @@ class RenderParagraph extends RenderBox
   ///
   /// The [maxLines] property may be null (and indeed defaults to null), but if
   /// it is not null, it must be greater than zero.
+  /// 
+  /// The [minLines] property may be null (and indeed defaults to null), but if
+  /// it is not null, it must be greater than or equal to zero.
   RenderParagraph(InlineSpan text, {
     TextAlign textAlign = TextAlign.start,
     required TextDirection textDirection,
     bool softWrap = true,
     TextOverflow overflow = TextOverflow.clip,
     double textScaleFactor = 1.0,
+    int? minLines,
     int? maxLines,
     Locale? locale,
     StrutStyle? strutStyle,
@@ -91,6 +95,7 @@ class RenderParagraph extends RenderBox
        assert(softWrap != null),
        assert(overflow != null),
        assert(textScaleFactor != null),
+       assert(minLines == null || minLines >= 0),
        assert(maxLines == null || maxLines > 0),
        assert(textWidthBasis != null),
        _softWrap = softWrap,
@@ -100,6 +105,7 @@ class RenderParagraph extends RenderBox
          textAlign: textAlign,
          textDirection: textDirection,
          textScaleFactor: textScaleFactor,
+         minLines: minLines,
          maxLines: maxLines,
          ellipsis: overflow == TextOverflow.ellipsis ? _kEllipsis : null,
          locale: locale,
@@ -231,6 +237,20 @@ class RenderParagraph extends RenderBox
       return;
     _textPainter.textScaleFactor = value;
     _overflowShader = null;
+    markNeedsLayout();
+  }
+
+  /// An optional minimum number of lines for the text to span. If the text 
+  /// falls short of the given number of lines, lines will be added below until 
+  /// there are the given number of lines.
+  int? get minLines => _textPainter.minLines;
+  /// The value may be null. If it is not null, then it must be greater than or 
+  /// equal to zero.
+  set minLines(int? value) {
+    assert(value == null || value >= 0);
+    if (_textPainter.minLines == value)
+      return;
+    _textPainter.minLines = value;
     markNeedsLayout();
   }
 
@@ -1085,6 +1105,7 @@ class RenderParagraph extends RenderBox
         defaultValue: null,
       ),
     );
+    properties.add(IntProperty('minLines', minLines, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, ifNull: 'unlimited'));
   }
 }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5480,6 +5480,7 @@ class RichText extends MultiChildRenderObjectWidget {
     this.softWrap = true,
     this.overflow = TextOverflow.clip,
     this.textScaleFactor = 1.0,
+    this.minLines,
     this.maxLines,
     this.locale,
     this.strutStyle,
@@ -5490,6 +5491,7 @@ class RichText extends MultiChildRenderObjectWidget {
        assert(softWrap != null),
        assert(overflow != null),
        assert(textScaleFactor != null),
+       assert(minLines == null || minLines >= 0),
        assert(maxLines == null || maxLines > 0),
        assert(textWidthBasis != null),
        super(children: _extractChildren(text));
@@ -5547,6 +5549,12 @@ class RichText extends MultiChildRenderObjectWidget {
   /// the specified font size.
   final double textScaleFactor;
 
+  /// An optional minimum number of lines for the text to span.
+  ///
+  /// If the text falls short of the given number of lines, lines will be added
+  /// below until there are the given number of lines.
+  final int? minLines;
+
   /// An optional maximum number of lines for the text to span, wrapping if necessary.
   /// If the text exceeds the given number of lines, it will be truncated according
   /// to [overflow].
@@ -5582,6 +5590,7 @@ class RichText extends MultiChildRenderObjectWidget {
       softWrap: softWrap,
       overflow: overflow,
       textScaleFactor: textScaleFactor,
+      minLines: minLines,
       maxLines: maxLines,
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis,
@@ -5600,6 +5609,7 @@ class RichText extends MultiChildRenderObjectWidget {
       ..softWrap = softWrap
       ..overflow = overflow
       ..textScaleFactor = textScaleFactor
+      ..minLines = minLines
       ..maxLines = maxLines
       ..strutStyle = strutStyle
       ..textWidthBasis = textWidthBasis
@@ -5615,6 +5625,7 @@ class RichText extends MultiChildRenderObjectWidget {
     properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
     properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: TextOverflow.clip));
     properties.add(DoubleProperty('textScaleFactor', textScaleFactor, defaultValue: 1.0));
+    properties.add(IntProperty('minLines', minLines, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, ifNull: 'unlimited'));
     properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: TextWidthBasis.parent));
     properties.add(StringProperty('text', text.toPlainText()));

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -42,6 +42,7 @@ class DefaultTextStyle extends InheritedTheme {
     this.textAlign,
     this.softWrap = true,
     this.overflow = TextOverflow.clip,
+    this.minLines,
     this.maxLines,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
@@ -49,6 +50,7 @@ class DefaultTextStyle extends InheritedTheme {
   }) : assert(style != null),
        assert(softWrap != null),
        assert(overflow != null),
+       assert(minLines == null || minLines >= 0),
        assert(maxLines == null || maxLines > 0),
        assert(child != null),
        assert(textWidthBasis != null);
@@ -63,6 +65,7 @@ class DefaultTextStyle extends InheritedTheme {
     : style = const TextStyle(),
       textAlign = null,
       softWrap = true,
+      minLines = null,
       maxLines = null,
       overflow = TextOverflow.clip,
       textWidthBasis = TextWidthBasis.parent,
@@ -91,6 +94,7 @@ class DefaultTextStyle extends InheritedTheme {
     TextAlign? textAlign,
     bool? softWrap,
     TextOverflow? overflow,
+    int? minLines,
     int? maxLines,
     TextWidthBasis? textWidthBasis,
     required Widget child,
@@ -105,6 +109,7 @@ class DefaultTextStyle extends InheritedTheme {
           textAlign: textAlign ?? parent.textAlign,
           softWrap: softWrap ?? parent.softWrap,
           overflow: overflow ?? parent.overflow,
+          minLines: minLines ?? parent.minLines,
           maxLines: maxLines ?? parent.maxLines,
           textWidthBasis: textWidthBasis ?? parent.textWidthBasis,
           child: child,
@@ -132,6 +137,12 @@ class DefaultTextStyle extends InheritedTheme {
   /// If [softWrap] is true or null, the glyph causing overflow, and those that follow,
   /// will not be rendered. Otherwise, it will be shown with the given overflow option.
   final TextOverflow overflow;
+
+  /// An optional minimum number of lines for the text to span.
+  ///
+  /// If the text falls short of the given number of lines, lines will be added
+  /// below until there are the given number of lines.
+  final int? minLines;
 
   /// An optional maximum number of lines for the text to span, wrapping if necessary.
   /// If the text exceeds the given number of lines, it will be truncated according
@@ -172,6 +183,7 @@ class DefaultTextStyle extends InheritedTheme {
         textAlign != oldWidget.textAlign ||
         softWrap != oldWidget.softWrap ||
         overflow != oldWidget.overflow ||
+        minLines != oldWidget.minLines ||
         maxLines != oldWidget.maxLines ||
         textWidthBasis != oldWidget.textWidthBasis ||
         textHeightBehavior != oldWidget.textHeightBehavior;
@@ -184,6 +196,7 @@ class DefaultTextStyle extends InheritedTheme {
       textAlign: textAlign,
       softWrap: softWrap,
       overflow: overflow,
+      minLines: minLines,
       maxLines: maxLines,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
@@ -368,6 +381,7 @@ class Text extends StatelessWidget {
     this.softWrap,
     this.overflow,
     this.textScaleFactor,
+    this.minLines,
     this.maxLines,
     this.semanticsLabel,
     this.textWidthBasis,
@@ -399,6 +413,7 @@ class Text extends StatelessWidget {
     this.softWrap,
     this.overflow,
     this.textScaleFactor,
+    this.minLines,
     this.maxLines,
     this.semanticsLabel,
     this.textWidthBasis,
@@ -477,6 +492,8 @@ class Text extends StatelessWidget {
   /// [MediaQuery], or 1.0 if there is no [MediaQuery] in scope.
   final double? textScaleFactor;
 
+  final int? minLines;
+
   /// An optional maximum number of lines for the text to span, wrapping if necessary.
   /// If the text exceeds the given number of lines, it will be truncated according
   /// to [overflow].
@@ -527,6 +544,7 @@ class Text extends StatelessWidget {
       softWrap: softWrap ?? defaultTextStyle.softWrap,
       overflow: overflow ?? effectiveTextStyle?.overflow ?? defaultTextStyle.overflow,
       textScaleFactor: textScaleFactor ?? MediaQuery.textScaleFactorOf(context),
+      minLines: minLines ?? defaultTextStyle.minLines,
       maxLines: maxLines ?? defaultTextStyle.maxLines,
       strutStyle: strutStyle,
       textWidthBasis: textWidthBasis ?? defaultTextStyle.textWidthBasis,
@@ -563,6 +581,7 @@ class Text extends StatelessWidget {
     properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
     properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
     properties.add(DoubleProperty('textScaleFactor', textScaleFactor, defaultValue: null));
+    properties.add(IntProperty('minLines', minLines, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, defaultValue: null));
     properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: null));
     properties.add(DiagnosticsProperty<ui.TextHeightBehavior>('textHeightBehavior', textHeightBehavior, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -492,6 +492,10 @@ class Text extends StatelessWidget {
   /// [MediaQuery], or 1.0 if there is no [MediaQuery] in scope.
   final double? textScaleFactor;
 
+  /// An optional minimum number of lines for the text to span.
+  ///
+  /// If the text falls short of the given number of lines, lines will be added
+  /// below until there are the given number of lines.
   final int? minLines;
 
   /// An optional maximum number of lines for the text to span, wrapping if necessary.

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -355,6 +355,111 @@ void main() {
     expect(paragraph.size.height, 30.0);
   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61018
 
+  test('minLines on empty text', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(
+        text: '',
+        style: TextStyle(fontFamily: 'Ahem', fontSize: 20.0),
+      ),
+      textDirection: TextDirection.ltr,
+    );
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: 100.0));
+    void layoutAt(int? minLines) {
+      paragraph.minLines = minLines;
+      pumpFrame();
+    }
+
+    layoutAt(null);
+    expect(paragraph.size.height, 20.0);
+
+    layoutAt(0);
+    expect(paragraph.size.height, 20.0);
+
+    layoutAt(1);
+    expect(paragraph.size.height, 20.0);
+
+    layoutAt(2);
+    expect(paragraph.size.height, 40.0);
+
+    layoutAt(3);
+    expect(paragraph.size.height, 60.0);
+  }, skip: isBrowser);
+
+  test('minLines', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(
+        text: "How do you write like you're running out of time? Write day and night like you're running out of time?",
+            // 0123456789 0123456789 012 345 0123456 012345 01234 012345678 012345678 0123 012 345 0123456 012345 01234
+            // 0          1          2       3       4      5     6         7         8    9       10      11     12
+        style: TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+      ),
+      textDirection: TextDirection.ltr,
+    );
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: 100.0));
+    void layoutAt(int? minLines) {
+      paragraph.minLines = minLines;
+      pumpFrame();
+    }
+
+    layoutAt(null);
+    expect(paragraph.size.height, 130.0);
+
+    layoutAt(0);
+    expect(paragraph.size.height, 130.0);
+
+    layoutAt(1);
+    expect(paragraph.size.height, 130.0);
+
+    layoutAt(14);
+    expect(paragraph.size.height, 140.0);
+
+    layoutAt(15);
+    expect(paragraph.size.height, 150.0);
+
+    layoutAt(20);
+    expect(paragraph.size.height, 200.0);
+  }, skip: isBrowser);
+
+  test('minLines and maxLines', () {
+    final RenderParagraph paragraph = RenderParagraph(
+      const TextSpan(
+        text: "How do you write like you're running out of time? Write day and night like you're running out of time?",
+            // 0123456789 0123456789 012 345 0123456 012345 01234 012345678 012345678 0123 012 345 0123456 012345 01234
+            // 0          1          2       3       4      5     6         7         8    9       10      11     12
+        style: TextStyle(fontFamily: 'Ahem', fontSize: 10.0),
+      ),
+      textDirection: TextDirection.ltr,
+    );
+    layout(paragraph, constraints: const BoxConstraints(maxWidth: 100.0));
+    void layoutAt(int? minLines, int? maxLines) {
+      paragraph.minLines = minLines;
+      paragraph.maxLines = maxLines;
+      pumpFrame();
+    }
+
+    layoutAt(null, null);
+    expect(paragraph.size.height, 130.0);
+
+    layoutAt(1, 1);
+    expect(paragraph.size.height, 10.0);
+
+    layoutAt(1, 2);
+    expect(paragraph.size.height, 20.0);
+
+    layoutAt(3, 2);
+    expect(paragraph.size.height, 30.0);
+
+    layoutAt(15, 5);
+    expect(paragraph.size.height, 150.0);
+
+    layoutAt(15, 15);
+    expect(paragraph.size.height, 150.0);
+
+    layoutAt(20, 25);
+    expect(paragraph.size.height, 200.0);
+  }, skip: isBrowser);
+
+
   test('changing color does not do layout', () {
     final RenderParagraph paragraph = RenderParagraph(
       const TextSpan(

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -383,7 +383,7 @@ void main() {
 
     layoutAt(3);
     expect(paragraph.size.height, 60.0);
-  }, skip: isBrowser);
+  });
 
   test('minLines', () {
     final RenderParagraph paragraph = RenderParagraph(
@@ -418,7 +418,7 @@ void main() {
 
     layoutAt(20);
     expect(paragraph.size.height, 200.0);
-  }, skip: isBrowser);
+  });
 
   test('minLines and maxLines', () {
     final RenderParagraph paragraph = RenderParagraph(
@@ -457,7 +457,7 @@ void main() {
 
     layoutAt(20, 25);
     expect(paragraph.size.height, 200.0);
-  }, skip: isBrowser);
+  }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61018
 
 
   test('changing color does not do layout', () {

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -1504,7 +1504,7 @@ void main() {
                 child: RichText(
                   textDirection: TextDirection.ltr,
                   minLines: 5,
-                  text: const TextSpan(children: [
+                  text: const TextSpan(children: <TextSpan>[
                     TextSpan(text: 'Pppp ', style: TextStyle(color: Colors.red, fontSize: 24)),
                     TextSpan(text: 'Pppp ', style: TextStyle(color: Colors.black, fontSize: 16)),
                     TextSpan(text: 'Ppppp ', style: TextStyle(color: Colors.yellow, fontSize: 8))

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -1362,4 +1362,164 @@ void main() {
       matchesGoldenFile('text_golden.TextHeightBehavior.1.png'),
     );
   });
+
+  testWidgets('Text minLines', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(
+            width: 200.0,
+            height: 200.0,
+            color: Colors.green,
+            child: Center(
+              child: Container(
+                width: 100.0,
+                color: Colors.blue,
+                child: const Text(
+                  'Ppppp pppp',
+                  style: TextStyle(color: Colors.black),
+                  minLines: 5,
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byType(Container).first,
+      matchesGoldenFile('text_golden.MinLines.1.png'),
+    );
+  });
+
+  testWidgets('Text minLines and maxLines', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(
+            width: 200.0,
+            height: 200.0,
+            color: Colors.green,
+            child: Center(
+              child: Container(
+                width: 100.0,
+                color: Colors.blue,
+                child: const Text(
+                  'Ppppp pppp Ppppp pppp Ppppp pppp',
+                  style: TextStyle(color: Colors.black),
+                  minLines: 5,
+                  maxLines: 2,
+                  textDirection: TextDirection.ltr,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byType(Container).first,
+      matchesGoldenFile('text_golden.MinLines.2.png'),
+    );
+  });
+
+  testWidgets('Text minLines empty text', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(
+            width: 200.0,
+            height: 200.0,
+            color: Colors.green,
+            child: Center(
+              child: Container(
+                width: 100.0,
+                color: Colors.blue,
+                child: const Text(
+                  '',
+                  style: TextStyle(color: Colors.black),
+                  minLines: 5,
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ),
+          ),
+        ),
+      )
+    );
+
+    await expectLater(
+      find.byType(Container).first,
+      matchesGoldenFile('text_golden.MinLines.3.png'),
+    );
+  });
+
+  testWidgets('Text minLines line height', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(
+            width: 200.0,
+            height: 200.0,
+            color: Colors.green,
+            child: Center(
+              child: Container(
+                width: 100.0,
+                color: Colors.blue,
+                child: const Text(
+                  'Ppppp',
+                  style: TextStyle(color: Colors.black, height: 2),
+                  minLines: 5,
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ),
+          ),
+        ),
+      )
+    );
+
+    await expectLater(
+      find.byType(Container).first,
+      matchesGoldenFile('text_golden.MinLines.4.png'),
+    );
+  });
+
+  testWidgets('Text minLines rich text', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(
+            width: 200.0,
+            height: 200.0,
+            color: Colors.green,
+            child: Center(
+              child: Container(
+                width: 100.0,
+                color: Colors.blue,
+                child: RichText(
+                  textDirection: TextDirection.ltr,
+                  minLines: 5,
+                  text: const TextSpan(children: [
+                    TextSpan(text: 'Pppp ', style: TextStyle(color: Colors.red, fontSize: 24)),
+                    TextSpan(text: 'Pppp ', style: TextStyle(color: Colors.black, fontSize: 16)),
+                    TextSpan(text: 'Ppppp ', style: TextStyle(color: Colors.yellow, fontSize: 8))
+                  ]),
+                ),
+              ),
+            ),
+          ),
+        ),
+      )
+    );
+
+    await expectLater(
+      find.byType(Container).first,
+      matchesGoldenFile('text_golden.MinLines.5.png'),
+    );
+  });
 }


### PR DESCRIPTION
This PR adds the ability to specify `minLines` to text related widgets and classes (`Text`, `RichText`, `Paragraph`, `TextPainter`).
This is useful when we want a text to span a specified number of lines, no matter the actual content of the text. 

Right now, this is possible with some workarounds (see https://github.com/flutter/flutter/issues/31134#issuecomment-560089409), which don't work well when `maxLines` with ellipsis is involved. 

This PR closes #31134

This video shows the implemented feature. All texts have `minLines: 5`.

https://user-images.githubusercontent.com/1659532/167919018-44d1fca2-ea67-42f1-91f1-a643ecef1db1.mov

# Behaviour:
- When no `minLines` is provided, or `minLines` is 0, the feature is disabled
- When `minLines` is provided with a value larger than 0, the text bounds will span the specified amount of `minLines` (using `preferredLineHeight` as the height of a line for reference)
- When `minLines` is used in combination with `maxLines`, the text will stop at the specified `maxLines`. The `minLines` still defines the total height of the text.

# Open questions:

## 1. `minLines` & `maxLines` in combination

Does the behaviour of `minLines` in combination with `maxLines` make sense, when `minLines` is larger than `maxLines`? 

The text will stop at the specified `maxLines`, but the total height of the text will go beyond to have `minLines` of lines.

## 2. Line Height of "filler" lines (when used in `RichText` with mixed font sizes)

Is there a better way to determine the line height for filler lines than `preferredLineHeight` of `TextPainter`? 

The `preferredLineHeight` works great for texts with a uniform font size, but in combination with `RichText` with **mixed font sizes**, this solution doesn't seem optimal. The `preferredLineHeight` for mixed font sizes in the text would change based on the count of lines, which causes the total height of the text to change when a line is added or removed.

In theory, since we are computing the line metrics, we could use the minimum line height or the maximum line height for the text as well - or even make this configurable by the user.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
