### PR TITLE
Enforce minimum plugin version iOS 11

### DIFF
--- a/dev/devicelab/lib/tasks/plugin_tests.dart
+++ b/dev/devicelab/lib/tasks/plugin_tests.dart
@@ -204,7 +204,7 @@ class $dartPluginClass {
     podspecContent = podspecContent.replaceFirst(
       versionString,
       target == 'ios'
-          ? "s.platform = :ios, '7.0'"
+          ? "s.platform = :ios, '10.0'"
           : "s.platform = :osx, '10.8'"
     );
     podspec.writeAsStringSync(podspecContent, flush: true);
@@ -240,8 +240,8 @@ class $dartPluginClass {
           if (target == 'ios') {
             // Plugins with versions lower than the app version should not have IPHONEOS_DEPLOYMENT_TARGET set.
             // The plugintest plugin target should not have IPHONEOS_DEPLOYMENT_TARGET set since it has been lowered
-            // in _reduceDarwinPluginMinimumVersion to 7, which is below the target version of 9.
-            if (podsProjectContent.contains('IPHONEOS_DEPLOYMENT_TARGET = 7')) {
+            // in _reduceDarwinPluginMinimumVersion to 10, which is below the target version of 11.
+            if (podsProjectContent.contains('IPHONEOS_DEPLOYMENT_TARGET = 10')) {
               throw TaskResult.failure('Plugin build setting IPHONEOS_DEPLOYMENT_TARGET not removed');
             }
             if (!podsProjectContent.contains(r'"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "$(inherited) i386";')) {

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -34,7 +34,7 @@ def flutter_additional_ios_build_settings(target)
   return unless target.platform_name == :ios
 
   # [target.deployment_target] is a [String] formatted as "8.0".
-  inherit_deployment_target = target.deployment_target[/\d+/].to_i < 9
+  inherit_deployment_target = target.deployment_target[/\d+/].to_i < 11
 
   # This podhelper script is at $FLUTTER_ROOT/packages/flutter_tools/bin.
   # Add search paths from $FLUTTER_ROOT/bin/cache/artifacts/engine.


### PR DESCRIPTION
App-side, enforce that plugins should only be built for iOS 11 and higher.

Part of https://github.com/flutter/flutter/issues/101959.  Will allow the engine framework to increase the minimum to iOS 11 since apps will no longer try to build plugins for iOS 9 linking against Flutter.framework.

Will unblock https://github.com/flutter/flutter/issues/101964

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
