### PR TITLE
use super parameters in framework

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -920,10 +920,9 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
 class _CupertinoEdgeShadowPainter extends BoxPainter {
   _CupertinoEdgeShadowPainter(
     this._decoration,
-    VoidCallback? onChange,
+    super.onChange,
   ) : assert(_decoration != null),
-      assert(_decoration._colors == null || _decoration._colors!.length > 1),
-      super(onChange);
+      assert(_decoration._colors == null || _decoration._colors!.length > 1);
 
   final _CupertinoEdgeShadowDecoration _decoration;
 

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -187,8 +187,8 @@ class _RenderCupertinoTextSelectionToolbarShape extends RenderShiftedBox {
   _RenderCupertinoTextSelectionToolbarShape(
     this._anchor,
     this._isAbove,
-    RenderBox? child,
-  ) : super(child);
+    super.child,
+  ) ;
 
 
   @override

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -188,7 +188,7 @@ class _RenderCupertinoTextSelectionToolbarShape extends RenderShiftedBox {
     this._anchor,
     this._isAbove,
     super.child,
-  ) ;
+  );
 
 
   @override

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -509,7 +509,7 @@ class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
 
 class _DelayedPointerState extends MultiDragPointerState {
   _DelayedPointerState(super.initialPosition, Duration delay, super.kind, super. deviceGestureSettings)
-      : assert(delay != null){
+      : assert(delay != null) {
     _timer = Timer(delay, _delayPassed);
   }
 

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -508,7 +508,7 @@ class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
 }
 
 class _DelayedPointerState extends MultiDragPointerState {
-  _DelayedPointerState(super.initialPosition, Duration delay, super.kind, super. deviceGestureSettings)
+  _DelayedPointerState(super.initialPosition, Duration delay, super.kind, super.deviceGestureSettings)
       : assert(delay != null) {
     _timer = Timer(delay, _delayPassed);
   }

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -508,9 +508,8 @@ class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
 }
 
 class _DelayedPointerState extends MultiDragPointerState {
-  _DelayedPointerState(Offset initialPosition, Duration delay, PointerDeviceKind kind, DeviceGestureSettings? deviceGestureSettings)
-      : assert(delay != null),
-        super(initialPosition, kind, deviceGestureSettings) {
+  _DelayedPointerState(super.initialPosition, Duration delay, super.kind, super. deviceGestureSettings)
+      : assert(delay != null){
     _timer = Timer(delay, _delayPassed);
   }
 

--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -334,12 +334,11 @@ class InkDecoration extends InkFeature {
   InkDecoration({
     required Decoration? decoration,
     required ImageConfiguration configuration,
-    required MaterialInkController controller,
+    required super.controller,
     required super.referenceBox,
     super.onRemoved,
   }) : assert(configuration != null),
-       _configuration = configuration,
-       super(controller: controller) {
+       _configuration = configuration {
     this.decoration = decoration;
     controller.addInkFeature(this);
   }

--- a/packages/flutter/lib/src/material/ink_highlight.dart
+++ b/packages/flutter/lib/src/material/ink_highlight.dart
@@ -37,9 +37,9 @@ class InkHighlight extends InteractiveInkFeature {
   ///
   /// When the highlight is removed, `onRemoved` will be called.
   InkHighlight({
-    required MaterialInkController controller,
+    required super.controller,
     required super.referenceBox,
-    required Color color,
+    required super.color,
     required TextDirection textDirection,
     BoxShape shape = BoxShape.rectangle,
     double? radius,
@@ -57,8 +57,7 @@ class InkHighlight extends InteractiveInkFeature {
        _borderRadius = borderRadius ?? BorderRadius.zero,
        _customBorder = customBorder,
        _textDirection = textDirection,
-       _rectCallback = rectCallback,
-       super(controller: controller, color: color) {
+       _rectCallback = rectCallback {
     _alphaController = AnimationController(duration: fadeDuration, vsync: controller.vsync)
       ..addListener(controller.markNeedsPaint)
       ..addStatusListener(_handleAlphaStatusChanged)

--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -99,8 +99,8 @@ class InkSparkle extends InteractiveInkFeature {
   /// identified in the shader as "noise", and the sparkles are derived from
   /// pseudorandom triangular noise.
   InkSparkle({
-    required MaterialInkController controller,
-    required RenderBox referenceBox,
+    required super.controller,
+    required super.referenceBox,
     required super.color,
     required Offset position,
     required TextDirection textDirection,
@@ -118,8 +118,7 @@ class InkSparkle extends InteractiveInkFeature {
        _customBorder = customBorder,
        _textDirection = textDirection,
        _targetRadius = (radius ?? _getTargetRadius(referenceBox, containedInkWell, rectCallback, position)) * _targetRadiusMultiplier,
-       _clipCallback = _getClipCallback(referenceBox, containedInkWell, rectCallback),
-       super(controller: controller, referenceBox: referenceBox) {
+       _clipCallback = _getClipCallback(referenceBox, containedInkWell, rectCallback) {
     // InkSparkle will not be painted until the async compilation completes.
     _InkSparkleFactory.compileShaderIfNeccessary();
     controller.addInkFeature(this);

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -82,9 +82,8 @@ class UnderlineTabIndicator extends Decoration {
 }
 
 class _UnderlinePainter extends BoxPainter {
-  _UnderlinePainter(this.decoration, VoidCallback? onChanged)
-    : assert(decoration != null),
-      super(onChanged);
+  _UnderlinePainter(this.decoration, super.onChanged)
+    : assert(decoration != null);
 
   final UnderlineTabIndicator decoration;
 

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -391,9 +391,8 @@ class BoxDecoration extends Decoration {
 
 /// An object that paints a [BoxDecoration] into a canvas.
 class _BoxDecorationPainter extends BoxPainter {
-  _BoxDecorationPainter(this._decoration, VoidCallback? onChanged)
-    : assert(_decoration != null),
-      super(onChanged);
+  _BoxDecorationPainter(this._decoration, super.onChanged)
+    : assert(_decoration != null);
 
   final BoxDecoration _decoration;
 


### PR DESCRIPTION
New language feature in Dart 2.17: https://github.com/dart-lang/language/issues/1855

used super parameters in 
 - packages/flutter/lib/src/cupertino
 - packages/flutter/lib/src/gestures
 - packages/flutter/lib/src/material
 - packages/flutter/lib/src/painting

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
