### PR TITLE
Fix timepicker size change when input incorrect time

### DIFF
--- a/packages/flutter/lib/src/material/time_picker.dart
+++ b/packages/flutter/lib/src/material/time_picker.dart
@@ -26,7 +26,6 @@ import 'material_localizations.dart';
 import 'material_state.dart';
 import 'text_button.dart';
 import 'text_field.dart';
-import 'text_form_field.dart';
 import 'text_theme.dart';
 import 'theme.dart';
 import 'theme_data.dart';
@@ -2452,10 +2451,8 @@ void _announceToAccessibility(BuildContext context, String message) {
 // TODO(rami-a): Remove this logic once https://github.com/flutter/flutter/issues/54104 is fixed.
 
 class _TimePickerTextFormField extends FormField<String> {
-  final TextEditingController controller;
 
   _TimePickerTextFormField({
-    super.key,
     required this.controller,
     super.restorationId,
     bool autofocus = false,
@@ -2493,6 +2490,7 @@ class _TimePickerTextFormField extends FormField<String> {
       );
     },
   );
+  final TextEditingController controller;
 
   @override
   FormFieldState<String> createState() => _TextFormFieldState();


### PR DESCRIPTION
Fix #103353

<img width="545" alt="time picker screenshot" src="https://user-images.githubusercontent.com/9416042/168115965-3bb29a98-ed00-4c64-bb47-77e0616c6d4f.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
