### PR TITLE
Fix `TabBar` label color for Material 3

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -188,12 +188,16 @@ class _TabStyle extends AnimatedWidget {
     // the same value of inherit. Force that to be inherit=true here.
     final TextStyle defaultStyle = (labelStyle
       ?? tabBarTheme.labelStyle
-      ?? themeData.primaryTextTheme.bodyText1!
+      ?? (themeData.useMaterial3
+          ? themeData.textTheme.bodyMedium!
+          : themeData.primaryTextTheme.bodyText1!)
     ).copyWith(inherit: true);
     final TextStyle defaultUnselectedStyle = (unselectedLabelStyle
       ?? tabBarTheme.unselectedLabelStyle
       ?? labelStyle
-      ?? themeData.primaryTextTheme.bodyText1!
+      ?? (themeData.useMaterial3
+          ? themeData.textTheme.bodyMedium!
+          : themeData.primaryTextTheme.bodyText1!)
     ).copyWith(inherit: true);
     final TextStyle textStyle = selected
       ? TextStyle.lerp(defaultStyle, defaultUnselectedStyle, animation.value)!
@@ -201,7 +205,9 @@ class _TabStyle extends AnimatedWidget {
 
     final Color selectedColor = labelColor
        ?? tabBarTheme.labelColor
-       ?? themeData.primaryTextTheme.bodyText1!.color!;
+       ?? (themeData.useMaterial3
+          ? themeData.colorScheme.onSurface
+          : themeData.primaryTextTheme.bodyText1!.color!);
     final Color unselectedColor = unselectedLabelColor
       ?? tabBarTheme.unselectedLabelColor
       ?? selectedColor.withAlpha(0xB2); // 70% alpha

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -73,16 +73,29 @@ void main() {
 
   testWidgets('Tab bar defaults - label style and selected/unselected label colors', (WidgetTester tester) async {
     // tests for the default label color and label styles when tabBarTheme and tabBar do not provide any
-    await tester.pumpWidget(_withTheme(null));
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    await tester.pumpWidget(MaterialApp(
+      theme: theme,
+        home: Scaffold(
+          body: RepaintBoundary(
+            key: _painterKey,
+            child: TabBar(
+              tabs: _tabs,
+              controller: TabController(length: _tabs.length, vsync: const TestVSync()),
+            ),
+          ),
+        ),
+      ),
+    );
 
     final RenderParagraph selectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab1Text));
     expect(selectedRenderObject.text.style!.fontFamily, equals('Roboto'));
     expect(selectedRenderObject.text.style!.fontSize, equals(14.0));
-    expect(selectedRenderObject.text.style!.color, equals(Colors.white));
+    expect(selectedRenderObject.text.style!.color, equals(theme.colorScheme.onSurface));
     final RenderParagraph unselectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab2Text));
     expect(unselectedRenderObject.text.style!.fontFamily, equals('Roboto'));
     expect(unselectedRenderObject.text.style!.fontSize, equals(14.0));
-    expect(unselectedRenderObject.text.style!.color, equals(Colors.white.withAlpha(0xB2)));
+    expect(unselectedRenderObject.text.style!.color, equals(theme.colorScheme.onSurface.withAlpha(0xB2)));
 
     // tests for the default value of labelPadding when tabBarTheme and tabBar do not provide one
     await tester.pumpWidget(_withTheme(null, tabs: _sizedTabs, isScrollable: true));
@@ -105,6 +118,7 @@ void main() {
     // verify tabOne and tabTwo is separated by right padding of tabOne and left padding of tabTwo
     expect(tabOneRect.right, equals(tabTwoRect.left - kTabLabelPadding.left - kTabLabelPadding.right));
   });
+
   testWidgets('Tab bar theme overrides label color (selected)', (WidgetTester tester) async {
     const Color labelColor = Colors.black;
     const TabBarTheme tabBarTheme = TabBarTheme(labelColor: labelColor);
@@ -349,5 +363,45 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.beveled_rect_indicator.png'),
     );
+  });
+
+  group('Material 2', () {
+    // Tests that are only relevant for Material 2. Once ThemeData.useMaterial3
+    // is turned on by default, these tests can be removed.
+
+    testWidgets('Tab bar defaults - label style and selected/unselected label colors', (WidgetTester tester) async {
+      // tests for the default label color and label styles when tabBarTheme and tabBar do not provide any
+      await tester.pumpWidget(_withTheme(null));
+
+      final RenderParagraph selectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab1Text));
+      expect(selectedRenderObject.text.style!.fontFamily, equals('Roboto'));
+      expect(selectedRenderObject.text.style!.fontSize, equals(14.0));
+      expect(selectedRenderObject.text.style!.color, equals(Colors.white));
+      final RenderParagraph unselectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab2Text));
+      expect(unselectedRenderObject.text.style!.fontFamily, equals('Roboto'));
+      expect(unselectedRenderObject.text.style!.fontSize, equals(14.0));
+      expect(unselectedRenderObject.text.style!.color, equals(Colors.white.withAlpha(0xB2)));
+
+      // tests for the default value of labelPadding when tabBarTheme and tabBar do not provide one
+      await tester.pumpWidget(_withTheme(null, tabs: _sizedTabs, isScrollable: true));
+
+      const double indicatorWeight = 2.0;
+      final Rect tabBar = tester.getRect(find.byType(TabBar));
+      final Rect tabOneRect = tester.getRect(find.byKey(_sizedTabs[0].key!));
+      final Rect tabTwoRect = tester.getRect(find.byKey(_sizedTabs[1].key!));
+
+      // verify coordinates of tabOne
+      expect(tabOneRect.left, equals(kTabLabelPadding.left));
+      expect(tabOneRect.top, equals(kTabLabelPadding.top));
+      expect(tabOneRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
+
+      // verify coordinates of tabTwo
+      expect(tabTwoRect.right, equals(tabBar.width - kTabLabelPadding.right));
+      expect(tabTwoRect.top, equals(kTabLabelPadding.top));
+      expect(tabTwoRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
+
+      // verify tabOne and tabTwo is separated by right padding of tabOne and left padding of tabTwo
+      expect(tabOneRect.right, equals(tabTwoRect.left - kTabLabelPadding.left - kTabLabelPadding.right));
+    });
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/103642

`TabBar` label colors using `ColorScheme.onSurface` for Material 3.
| Bug | Fix |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/168282543-6149a6be-89f9-47a1-b21f-a42f063258a5.png" height="450" /> | <img src="https://user-images.githubusercontent.com/48603081/168282549-8ba0cf1c-97bf-42c7-a83d-b3bb1b21fd7f.png" height="450" /> |


Using `bodyMedium` text style for Material 3. 
As when using Material 3, `bodyText1` points to `bodyLarge` which is a bigger font, as explained here in a test 
https://github.com/flutter/flutter/issues/102121#issuecomment-1103036850

![Screenshot 2022-05-13 at 14 46 42](https://user-images.githubusercontent.com/48603081/168282437-11c5a5fc-bf8a-48e5-935e-64b69d01c3d2.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
