### PR TITLE
[flutter_tools] remove assertion for deprecation .packages

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -675,7 +675,7 @@ void main() {
       '.android/settings.gradle',
       '.gitignore',
       '.metadata',
-      '.packages',
+      '.dart_tool/package_config.json',
       'analysis_options.yaml',
       'lib/main.dart',
       'pubspec.lock',


### PR DESCRIPTION
.packages is deprecated and not used by the tool. Unblocks the pub roll.