### PR TITLE
add noSuchMethod to _MulticastCanvas to unblock smoke testing against forthcoming new getTransform/Clip methods

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -103,6 +103,10 @@ class _MulticastCanvas implements Canvas {
     _screenshot.clipRect(rect, clipOp: clipOp, doAntiAlias: doAntiAlias);
   }
 
+  Rect getCurrentClipBounds() {
+    return Rect.zero;
+  }
+
   @override
   void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
     _main.drawArc(rect, startAngle, sweepAngle, useCenter, paint);
@@ -284,6 +288,10 @@ class _MulticastCanvas implements Canvas {
   void translate(double dx, double dy) {
     _main.translate(dx, dy);
     _screenshot.translate(dx, dy);
+  }
+
+  Float64List getCurrentTransform() {
+    return Matrix4.identity().storage;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -103,10 +103,6 @@ class _MulticastCanvas implements Canvas {
     _screenshot.clipRect(rect, clipOp: clipOp, doAntiAlias: doAntiAlias);
   }
 
-  Rect getCurrentClipBounds() {
-    return Rect.zero;
-  }
-
   @override
   void drawArc(Rect rect, double startAngle, double sweepAngle, bool useCenter, Paint paint) {
     _main.drawArc(rect, startAngle, sweepAngle, useCenter, paint);
@@ -290,9 +286,8 @@ class _MulticastCanvas implements Canvas {
     _screenshot.translate(dx, dy);
   }
 
-  Float64List getCurrentTransform() {
-    return Matrix4.identity().storage;
-  }
+  @override
+  dynamic noSuchMethod(Invocation invocation) {}
 }
 
 Rect _calculateSubtreeBoundsHelper(RenderObject object, Matrix4 transform) {

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -287,7 +287,9 @@ class _MulticastCanvas implements Canvas {
   }
 
   @override
-  dynamic noSuchMethod(Invocation invocation) {}
+  dynamic noSuchMethod(Invocation invocation) {
+    super.noSuchMethod(invocation);
+  }
 }
 
 Rect _calculateSubtreeBoundsHelper(RenderObject object, Matrix4 transform) {


### PR DESCRIPTION
The noSuchMethod override prevents the compiler from complaining while we roll the new methods over from the engine.