### PR TITLE
Add onOpened callback to PopupMenuButton

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -999,6 +999,7 @@ class PopupMenuButton<T> extends StatefulWidget {
     super.key,
     required this.itemBuilder,
     this.initialValue,
+    this.onOpened,
     this.onSelected,
     this.onCanceled,
     this.tooltip,
@@ -1027,6 +1028,9 @@ class PopupMenuButton<T> extends StatefulWidget {
 
   /// The value of the menu item, if any, that should be highlighted when the menu opens.
   final T? initialValue;
+
+  /// Called when the popup menu is shown.
+  final VoidCallback? onOpened;
 
   /// Called when the user selects a value from the popup menu created by this button.
   ///
@@ -1186,6 +1190,7 @@ class PopupMenuButtonState<T> extends State<PopupMenuButton<T>> {
     final List<PopupMenuEntry<T>> items = widget.itemBuilder(context);
     // Only show the menu if there is something to show
     if (items.isNotEmpty) {
+      widget.onOpened?.call();
       showMenu<T?>(
         context: context,
         elevation: widget.elevation ?? popupMenuTheme.elevation,


### PR DESCRIPTION
This PR adds a new callback `onOpened` to `PopupMenuButton`, called when the menu appears (normally after tapping the button).

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes #21773 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
