### PR TITLE
[web] do not swallow WebDriver errors

### DIFF
--- a/packages/flutter_driver/lib/src/driver/web_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/web_driver.dart
@@ -294,34 +294,30 @@ class FlutterWebConnection {
 
   /// Sends command via WebDriver to Flutter web application.
   Future<dynamic> sendCommand(String script, Duration? duration) async {
-    dynamic result;
+    String phase = 'executing';
     try {
+      // Execute the script, which should leave the result in the `$flutterDriverResult` global variable.
       await _driver.execute(script, <void>[]);
-    } catch (error) {
-      // We should not just arbitrarily throw all exceptions on the ground.
-      // This is probably hiding real errors.
-      // TODO(ianh): Determine what exceptions are expected here and handle those specifically.
-    }
 
-    try {
-      result = await waitFor<dynamic>(
+      // Read the result.
+      phase = 'reading';
+      final dynamic result = await waitFor<dynamic>(
         () => _driver.execute(r'return $flutterDriverResult', <String>[]),
         matcher: isNotNull,
         timeout: duration ?? const Duration(days: 30),
       );
-    } catch (error) {
-      // We should not just arbitrarily throw all exceptions on the ground.
-      // This is probably hiding real errors.
-      // TODO(ianh): Determine what exceptions are expected here and handle those specifically.
-      // Returns null if exception thrown.
-      return null;
-    } finally {
-      // Resets the result.
-      await _driver.execute(r'''
-        $flutterDriverResult = null
-      ''', <void>[]);
+
+      // Reset the result to null to avoid polluting the results of future commands.
+      phase = 'resetting';
+      await _driver.execute(r'$flutterDriverResult = null', <void>[]);
+      return result;
+    } catch (error, stackTrace) {
+      throw DriverError(
+        'Error while $phase FlutterDriver result for command: $script',
+        error,
+        stackTrace,
+      );
     }
-    return result;
   }
 
   /// Gets performance log from WebDriver.


### PR DESCRIPTION
The details of the error causing https://github.com/flutter/flutter/issues/102660 seem to be obscured by catching the error and returning `null`. This PR rethrows all errors that happen in the WebDriver as `DriverError`.