### PR TITLE
[flutter_tools] ensure linux doctor validator finishes when pkg-config is not installed

### DIFF
--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -127,7 +127,7 @@ class LinuxDoctorValidator extends DoctorValidator {
       final _VersionInfo? version = installedVersions[kPkgConfigBinary];
       if (version == null || version.number == null) {
         messages.add(ValidationMessage.error(_userMessages.pkgConfigMissing));
-        // exit early because we cannot validate libraries without pkg-config
+        // Exit early because we cannot validate libraries without pkg-config.
         return ValidationResult(validationType, messages);
       } else {
         assert(_requiredBinaryVersions.containsKey(kPkgConfigBinary));

--- a/packages/flutter_tools/lib/src/linux/linux_doctor.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_doctor.dart
@@ -127,6 +127,8 @@ class LinuxDoctorValidator extends DoctorValidator {
       final _VersionInfo? version = installedVersions[kPkgConfigBinary];
       if (version == null || version.number == null) {
         messages.add(ValidationMessage.error(_userMessages.pkgConfigMissing));
+        // exit early because we cannot validate libraries without pkg-config
+        return ValidationResult(validationType, messages);
       } else {
         assert(_requiredBinaryVersions.containsKey(kPkgConfigBinary));
         // The full version description is just the number, so add context.

--- a/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
+++ b/packages/flutter_tools/test/general.shard/linux/linux_doctor_test.dart
@@ -219,6 +219,30 @@ void main() {
     ]);
   });
 
+  testWithoutContext('Missing validation when pkg-config is missing', () async {
+    final UserMessages userMessages = UserMessages();
+    final ProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+      _clangPresentCommand('4.0.1'),
+      _cmakePresentCommand('3.16.3'),
+      _ninjaPresentCommand('1.10.0'),
+      _missingBinaryException('pkg-config'),
+      // We never check libraries because pkg-config is not present
+    ]);
+    final DoctorValidator linuxDoctorValidator = LinuxDoctorValidator(
+      processManager: processManager,
+      userMessages: userMessages,
+    );
+    final ValidationResult result = await linuxDoctorValidator.validate();
+
+    expect(result.type, ValidationType.missing);
+    expect(result.messages, <ValidationMessage>[
+      const ValidationMessage('clang version 4.0.1-6+build1'),
+      const ValidationMessage('cmake version 3.16.3'),
+      const ValidationMessage('ninja version 1.10.0'),
+      ValidationMessage.error(userMessages.pkgConfigMissing),
+    ]);
+  });
+
   testWithoutContext('Missing validation when CMake is not available', () async {
     final ProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
       _clangPresentCommand('4.0.1'),


### PR DESCRIPTION
A follow-up fix to https://github.com/flutter/flutter/pull/100159

Even though we were catching the initial exception when we called `pkg-config --version`, we then followed to call `pkg-config` again to look up gtk libraries, so the exception bubbled up again into the doctor. Instead, only validate the gtk libraries if we know pkg-config is installed.

Fixes https://github.com/flutter/flutter/issues/103744