### PR TITLE
[flutter_tools] switch to tester with fractional translation and no raster cache

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -1837,6 +1837,9 @@ abstract class _RenderPhysicalModelBase<T> extends _RenderCustomClip<T> {
   }
 
   @override
+  bool get alwaysNeedsCompositing => true;
+
+  @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
     config.elevation = elevation;

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -62,17 +62,17 @@ void main() {
   test('RenderPhysicalModel compositing', () {
     final RenderPhysicalModel root = RenderPhysicalModel(color: const Color(0xffff00ff));
     layout(root, phase: EnginePhase.composite);
-    expect(root.needsCompositing, isFalse);
+    expect(root.needsCompositing, isTrue);
 
     // On Fuchsia, the system compositor is responsible for drawing shadows
     // for physical model layers with non-zero elevation.
     root.elevation = 1.0;
     pumpFrame(phase: EnginePhase.composite);
-    expect(root.needsCompositing, isFalse);
+    expect(root.needsCompositing, isTrue);
 
     root.elevation = 0.0;
     pumpFrame(phase: EnginePhase.composite);
-    expect(root.needsCompositing, isFalse);
+    expect(root.needsCompositing, isTrue);
   });
 
   test('RenderSemanticsGestureHandler adds/removes correct semantic actions', () {
@@ -127,16 +127,16 @@ void main() {
           clipper: const ShapeBorderClipper(shape: CircleBorder()),
         );
         layout(root, phase: EnginePhase.composite);
-        expect(root.needsCompositing, isFalse);
+        expect(root.needsCompositing, isTrue);
 
         // On non-Fuchsia platforms, we composite physical shape layers
         root.elevation = 1.0;
         pumpFrame(phase: EnginePhase.composite);
-        expect(root.needsCompositing, isFalse);
+        expect(root.needsCompositing, isTrue);
 
         root.elevation = 0.0;
         pumpFrame(phase: EnginePhase.composite);
-        expect(root.needsCompositing, isFalse);
+        expect(root.needsCompositing, isTrue);
       }
       debugDefaultTargetPlatformOverride = null;
     });

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -19,6 +19,8 @@ enum Artifact {
   genSnapshot,
   /// The flutter tester binary.
   flutterTester,
+  /// A flutter tester binary without raster cache or fractional translation.
+  flutterTesterFractionalTranslation,
   flutterFramework,
   flutterXcframework,
   /// The framework directory of the macOS desktop.
@@ -159,6 +161,8 @@ String? _artifactToFileName(Artifact artifact, [ TargetPlatform? platform, Build
     case Artifact.genSnapshot:
       return 'gen_snapshot';
     case Artifact.flutterTester:
+      return 'flutter_Tester$exe';
+    case Artifact.flutterTesterFractionalTranslation:
       return 'flutter_tester_fractional_translation$exe';
     case Artifact.flutterFramework:
       return 'Flutter.framework';
@@ -475,6 +479,7 @@ class CachedArtifacts implements Artifacts {
       case Artifact.flutterMacOSFramework:
       case Artifact.flutterPatchedSdkPath:
       case Artifact.flutterTester:
+      case Artifact.flutterTesterFractionalTranslation:
       case Artifact.flutterXcframework:
       case Artifact.fontSubset:
       case Artifact.fuchsiaFlutterRunner:
@@ -508,6 +513,7 @@ class CachedArtifacts implements Artifacts {
       case Artifact.flutterMacOSFramework:
       case Artifact.flutterPatchedSdkPath:
       case Artifact.flutterTester:
+      case Artifact.flutterTesterFractionalTranslation:
       case Artifact.fontSubset:
       case Artifact.fuchsiaFlutterRunner:
       case Artifact.fuchsiaKernelCompiler:
@@ -553,6 +559,7 @@ class CachedArtifacts implements Artifacts {
       case Artifact.flutterFramework:
       case Artifact.flutterMacOSFramework:
       case Artifact.flutterTester:
+      case Artifact.flutterTesterFractionalTranslation:
       case Artifact.flutterXcframework:
       case Artifact.fontSubset:
       case Artifact.frontendServerSnapshotForEngineDartSdk:
@@ -592,6 +599,7 @@ class CachedArtifacts implements Artifacts {
           _artifactToFileName(artifact),
         );
       case Artifact.flutterTester:
+      case Artifact.flutterTesterFractionalTranslation:
       case Artifact.vmSnapshotData:
       case Artifact.isolateSnapshotData:
       case Artifact.icuData:
@@ -854,6 +862,8 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
         return _genSnapshotPath();
       case Artifact.flutterTester:
         return _flutterTesterPath(platform!);
+      case Artifact.flutterTesterFractionalTranslation:
+        return _flutterTesterFractionalPath(platform!);
       case Artifact.isolateSnapshotData:
       case Artifact.vmSnapshotData:
         return _fileSystem.path.join(engineOutPath, 'gen', 'flutter', 'lib', 'snapshot', artifactFileName);
@@ -934,6 +944,17 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
   }
 
   String _flutterTesterPath(TargetPlatform platform) {
+    if (_platform.isLinux) {
+      return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
+    } else if (_platform.isMacOS) {
+      return _fileSystem.path.join(engineOutPath, 'flutter_tester');
+    } else if (_platform.isWindows) {
+      return _fileSystem.path.join(engineOutPath, 'flutter_tester.exe');
+    }
+    throw Exception('Unsupported platform $platform.');
+  }
+
+  String _flutterTesterFractionalPath(TargetPlatform platform) {
     if (_platform.isLinux) {
       return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
     } else if (_platform.isMacOS) {

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -861,9 +861,8 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
       case Artifact.genSnapshot:
         return _genSnapshotPath();
       case Artifact.flutterTester:
-        return _flutterTesterPath(platform!);
       case Artifact.flutterTesterFractionalTranslation:
-        return _flutterTesterFractionalPath(platform!);
+        return _fileSystem.path.join(engineOutPath, _artifactToFileName(artifact, platform));
       case Artifact.isolateSnapshotData:
       case Artifact.vmSnapshotData:
         return _fileSystem.path.join(engineOutPath, 'gen', 'flutter', 'lib', 'snapshot', artifactFileName);
@@ -941,28 +940,6 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
       }
     }
     throw Exception('Unable to find $genSnapshotName');
-  }
-
-  String _flutterTesterPath(TargetPlatform platform) {
-    if (_platform.isLinux) {
-      return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
-    } else if (_platform.isMacOS) {
-      return _fileSystem.path.join(engineOutPath, 'flutter_tester');
-    } else if (_platform.isWindows) {
-      return _fileSystem.path.join(engineOutPath, 'flutter_tester.exe');
-    }
-    throw Exception('Unsupported platform $platform.');
-  }
-
-  String _flutterTesterFractionalPath(TargetPlatform platform) {
-    if (_platform.isLinux) {
-      return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
-    } else if (_platform.isMacOS) {
-      return _fileSystem.path.join(engineOutPath, 'flutter_tester_fractional_translation');
-    } else if (_platform.isWindows) {
-      return _fileSystem.path.join(engineOutPath, 'flutter_tester_fractional_translation.exe');
-    }
-    throw Exception('Unsupported platform $platform.');
   }
 
   @override

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -161,7 +161,7 @@ String? _artifactToFileName(Artifact artifact, [ TargetPlatform? platform, Build
     case Artifact.genSnapshot:
       return 'gen_snapshot';
     case Artifact.flutterTester:
-      return 'flutter_Tester$exe';
+      return 'flutter_tester$exe';
     case Artifact.flutterTesterFractionalTranslation:
       return 'flutter_tester_fractional_translation$exe';
     case Artifact.flutterFramework:

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -159,7 +159,7 @@ String? _artifactToFileName(Artifact artifact, [ TargetPlatform? platform, Build
     case Artifact.genSnapshot:
       return 'gen_snapshot';
     case Artifact.flutterTester:
-      return 'flutter_tester$exe';
+      return 'flutter_tester_fractional_translation$exe';
     case Artifact.flutterFramework:
       return 'Flutter.framework';
     case Artifact.flutterXcframework:
@@ -937,9 +937,9 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
     if (_platform.isLinux) {
       return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
     } else if (_platform.isMacOS) {
-      return _fileSystem.path.join(engineOutPath, 'flutter_tester');
+      return _fileSystem.path.join(engineOutPath, 'flutter_tester_fractional_translation');
     } else if (_platform.isWindows) {
-      return _fileSystem.path.join(engineOutPath, 'flutter_tester.exe');
+      return _fileSystem.path.join(engineOutPath, 'flutter_tester_fractional_translation.exe');
     }
     throw Exception('Unsupported platform $platform.');
   }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -216,6 +216,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
               'as a multiplier of the default timeout (e.g. "2x"), '
               'or as the string "none" to disable the timeout entirely.',
         defaultsTo: '30s',
+      )
+      ..addOption('enable-fractional-translation',
+        help: 'Enables fraction translation of engine composited layers in '
+              'the software renderer backend for flutter tester. Also disables '
+              'the raster cache.',
       );
     addDdsOptions(verboseHelp: verboseHelp);
     usesFatalWarningsOption(verboseHelp: verboseHelp);
@@ -308,6 +313,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     final String tags = stringArgDeprecated('tags');
     final String excludeTags = stringArgDeprecated('exclude-tags');
     final BuildInfo buildInfo = await getBuildInfo(forcedBuildMode: BuildMode.debug);
+    final bool enableFractionalTranslation = boolArg('enable-fractional-translation');
 
     if (buildInfo.packageConfig['test_api'] == null) {
       throwToolExit(
@@ -455,6 +461,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       totalShards: totalShards,
       integrationTestDevice: integrationTestDevice,
       integrationTestUserIdentifier: stringArgDeprecated(FlutterOptions.kDeviceUser),
+      enableFractionalTranslation: enableFractionalTranslation,
     );
 
     if (collector != null) {

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -217,10 +217,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
               'or as the string "none" to disable the timeout entirely.',
         defaultsTo: '30s',
       )
-      ..addOption('enable-fractional-translation',
+      ..addFlag('enable-fractional-translation',
         help: 'Enables fraction translation of engine composited layers in '
               'the software renderer backend for flutter tester. Also disables '
               'the raster cache.',
+        defaultsTo: true,
       );
     addDdsOptions(verboseHelp: verboseHelp);
     usesFatalWarningsOption(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -222,6 +222,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
               'the software renderer backend for flutter tester. Also disables '
               'the raster cache.',
         defaultsTo: true,
+        hide: !verboseHelp,
       );
     addDdsOptions(verboseHelp: verboseHelp);
     usesFatalWarningsOption(verboseHelp: verboseHelp);

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -55,6 +55,7 @@ abstract class FlutterTestRunner {
     int totalShards,
     Device integrationTestDevice,
     String integrationTestUserIdentifier,
+    bool enableFractionalTranslation = false,
   });
 }
 
@@ -91,9 +92,12 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     int totalShards,
     Device integrationTestDevice,
     String integrationTestUserIdentifier,
+    bool enableFractionalTranslation = false,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
-    final String shellPath = globals.artifacts.getArtifactPath(Artifact.flutterTester);
+    final String shellPath = enableFractionalTranslation
+      ? globals.artifacts.getArtifactPath(Artifact.flutterTesterFractionalTranslation)
+      : globals.artifacts.getArtifactPath(Artifact.flutterTester);
 
     // Compute the command-line arguments for package:test.
     final List<String> testArgs = <String>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -605,6 +605,53 @@ dev_dependencies:
     ]),
   });
 
+  testUsingContext('Opts into fractional translation', () async {
+    final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+    final TestCommand testCommand = TestCommand(testRunner: testRunner);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+    await commandRunner.run(const <String>[
+      'test',
+      '--no-pub',
+    ]);
+
+    expect(
+      testRunner.lastEnableFractionalTranslation,
+      true,
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fs,
+    ProcessManager: () => FakeProcessManager.any(),
+    DeviceManager: () => _FakeDeviceManager(<Device>[
+      FakeDevice('ephemeral', 'ephemeral', type: PlatformType.android),
+    ]),
+  });
+
+  testUsingContext('Can opt out of fractional translation', () async {
+    final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+    final TestCommand testCommand = TestCommand(testRunner: testRunner);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+    await commandRunner.run(const <String>[
+      'test',
+      '--no-enable-fractional-translation',
+      '--no-pub',
+    ]);
+
+    expect(
+      testRunner.lastEnableFractionalTranslation,
+      false,
+    );
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fs,
+    ProcessManager: () => FakeProcessManager.any(),
+    DeviceManager: () => _FakeDeviceManager(<Device>[
+      FakeDevice('ephemeral', 'ephemeral', type: PlatformType.android),
+    ]),
+  });
+
   testUsingContext('Integration tests given flavor', () async {
     final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
 
@@ -733,6 +780,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
   int exitCode;
   bool lastEnableObservatoryValue;
   DebuggingOptions lastDebuggingOptionsValue;
+  bool lastEnableFractionalTranslation;
 
   @override
   Future<int> runTests(
@@ -768,9 +816,11 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     int totalShards,
     Device integrationTestDevice,
     String integrationTestUserIdentifier,
+    bool enableFractionalTranslation = false,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     lastDebuggingOptionsValue = debuggingOptions;
+    lastEnableFractionalTranslation = enableFractionalTranslation;
     return exitCode;
   }
 }

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -135,11 +135,11 @@ void main() {
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester),
-        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester'),
+        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester_fractional_translation'),
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester, platform: TargetPlatform.linux_arm64),
-        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-arm64', 'flutter_tester'),
+        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-arm64', 'flutter_tester_fractional_translation'),
       );
       expect(
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
@@ -304,7 +304,7 @@ void main() {
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester),
-        fileSystem.path.join('/out', 'android_debug_unopt', 'flutter_tester'),
+        fileSystem.path.join('/out', 'android_debug_unopt', 'flutter_tester_fractional_translation'),
       );
       expect(
         artifacts.getHostArtifact(HostArtifact.engineDartSdkPath).path,

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -135,10 +135,18 @@ void main() {
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester),
+        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester'),
+      );
+      expect(
+        artifacts.getArtifactPath(Artifact.flutterTesterFractionalTranslation),
         fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-x64', 'flutter_tester_fractional_translation'),
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester, platform: TargetPlatform.linux_arm64),
+        fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-arm64', 'flutter_tester'),
+      );
+      expect(
+        artifacts.getArtifactPath(Artifact.flutterTesterFractionalTranslation, platform: TargetPlatform.linux_arm64),
         fileSystem.path.join('root', 'bin', 'cache', 'artifacts', 'engine', 'linux-arm64', 'flutter_tester_fractional_translation'),
       );
       expect(
@@ -304,6 +312,10 @@ void main() {
       );
       expect(
         artifacts.getArtifactPath(Artifact.flutterTester),
+        fileSystem.path.join('/out', 'android_debug_unopt', 'flutter_tester'),
+      );
+      expect(
+        artifacts.getArtifactPath(Artifact.flutterTesterFractionalTranslation),
         fileSystem.path.join('/out', 'android_debug_unopt', 'flutter_tester_fractional_translation'),
       );
       expect(


### PR DESCRIPTION
Allow an opt out for the open source framework that requires an opt in for the google3 tooling. Still need to confirm this renders the right things, of course. Either the current golden infra will detect a diff or I'll have to update this PR with a synthetic change to trigger some pixel snapping