### PR TITLE
[flutter_tools] fix missing cmake

### DIFF
--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -127,32 +127,30 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
   if (!globals.processManager.canRun('cmake')) {
     throwToolExit(globals.userMessages.cmakeMissing);
   }
-  try {
-    result = await globals.processUtils.stream(
-      <String>[
-        'cmake',
-        '-G',
-        'Ninja',
-        '-DCMAKE_BUILD_TYPE=$buildFlag',
-        '-DFLUTTER_TARGET_PLATFORM=${getNameForTargetPlatform(targetPlatform)}',
-        // Support cross-building for arm64 targets on x64 hosts.
-        // (Cross-building for x64 on arm64 hosts isn't supported now.)
-        if (needCrossBuild)
-          '-DFLUTTER_TARGET_PLATFORM_SYSROOT=$targetSysroot',
-        if (needCrossBuildOptionsForArm64)
-          '-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu',
-        if (needCrossBuildOptionsForArm64)
-          '-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu',
-        sourceDir.path,
-      ],
-      workingDirectory: buildDir.path,
-      environment: <String, String>{
-        'CC': 'clang',
-        'CXX': 'clang++',
-      },
-      trace: true,
-    );
-  }
+  result = await globals.processUtils.stream(
+    <String>[
+      'cmake',
+      '-G',
+      'Ninja',
+      '-DCMAKE_BUILD_TYPE=$buildFlag',
+      '-DFLUTTER_TARGET_PLATFORM=${getNameForTargetPlatform(targetPlatform)}',
+      // Support cross-building for arm64 targets on x64 hosts.
+      // (Cross-building for x64 on arm64 hosts isn't supported now.)
+      if (needCrossBuild)
+        '-DFLUTTER_TARGET_PLATFORM_SYSROOT=$targetSysroot',
+      if (needCrossBuildOptionsForArm64)
+        '-DCMAKE_C_COMPILER_TARGET=aarch64-linux-gnu',
+      if (needCrossBuildOptionsForArm64)
+        '-DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-gnu',
+      sourceDir.path,
+    ],
+    workingDirectory: buildDir.path,
+    environment: <String, String>{
+      'CC': 'clang',
+      'CXX': 'clang++',
+    },
+    trace: true,
+  );
   if (result != 0) {
     throwToolExit('Unable to generate build files');
   }

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -152,8 +152,6 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
       },
       trace: true,
     );
-  } on ArgumentError {
-    throwToolExit("cmake not found. Run 'flutter doctor' for more information.");
   }
   if (result != 0) {
     throwToolExit('Unable to generate build files');

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -124,6 +124,9 @@ Future<void> _runCmake(String buildModeName, Directory sourceDir, Directory buil
   final bool needCrossBuildOptionsForArm64 = needCrossBuild
       && targetPlatform == TargetPlatform.linux_arm64;
   int result;
+  if (!globals.processManager.canRun('cmake')) {
+    throwToolExit(globals.userMessages.cmakeMissing);
+  }
   try {
     result = await globals.processUtils.stream(
       <String>[

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_linux_test.dart
@@ -172,18 +172,15 @@ void main() {
     OperatingSystemUtils: () => FakeOperatingSystemUtils(),
   });
 
-  testUsingContext('Handles argument error from missing cmake', () async {
+  testUsingContext('Handles missing cmake', () async {
     final BuildCommand command = BuildCommand();
     setUpMockProjectFilesForBuild();
-    processManager = FakeProcessManager.list(<FakeCommand>[
-      cmakeCommand('release', onRun: () {
-        throw ArgumentError();
-      }),
-    ]);
+    processManager = FakeProcessManager.empty()
+        ..excludedExecutables.add('cmake');
 
     expect(createTestCommandRunner(command).run(
       const <String>['build', 'linux', '--no-pub']
-    ), throwsToolExit(message: "cmake not found. Run 'flutter doctor' for more information."));
+    ), throwsToolExit(message: 'CMake is required for Linux development.'));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/88897

Previously we were calling cmake and catching `ArgumentError` for the case where cmake was not installed. However, per #88897, it was actually throwing a `ProcessException`. Instead, explicitly check `processManager.canRun('cmake')` (rather than catching all `ProcessException`s), and if it is not runnable give the user the same `UserMessage` the doctor validator would.