### PR TITLE
[flutter_tools] fix RangeError in flutter channel command

### DIFF
--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -79,6 +79,10 @@ class ChannelCommand extends FlutterCommand {
 
     for (final String line in rawOutput) {
       final List<String> split = line.split('/');
+      if (split.length != 2) {
+        // We don't know how to parse this line, skip it.
+        continue;
+      }
       final String branch = split[1];
       if (split.length > 1) {
         final int index = officialChannels.indexOf(branch);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/103763

I'm not sure why, multiple users are getting tool crashes from trying to parse output from `git branch -r` with lines that do not have a single `/`. Skip trying to parse these lines, since we don't know how to anyway.