### PR TITLE
[flutter_conductor] Fix codesign test

### DIFF
--- a/dev/conductor/core/lib/src/repository.dart
+++ b/dev/conductor/core/lib/src/repository.dart
@@ -647,6 +647,11 @@ class FrameworkRepository extends Repository {
     return true;
   }
 
+  Future<File> get engineVersionFile async => (await checkoutDirectory)
+        .childDirectory('bin')
+        .childDirectory('internal')
+        .childFile('engine.version');
+
   /// Update this framework's engine version file.
   ///
   /// Returns [true] if the version file was updated and a commit is needed.
@@ -655,10 +660,7 @@ class FrameworkRepository extends Repository {
     @visibleForTesting File? engineVersionFile,
   }) async {
     assert(newEngine.isNotEmpty);
-    engineVersionFile ??= (await checkoutDirectory)
-        .childDirectory('bin')
-        .childDirectory('internal')
-        .childFile('engine.version');
+    engineVersionFile ??= await this.engineVersionFile;
     assert(engineVersionFile.existsSync());
     final String oldEngine = engineVersionFile.readAsStringSync();
     if (oldEngine.trim() == newEngine.trim()) {

--- a/dev/conductor/core/test/codesign_integration_test.dart
+++ b/dev/conductor/core/test/codesign_integration_test.dart
@@ -4,7 +4,7 @@
 
 // This test clones the framework and downloads pre-built binaries; it sometimes
 // times out with the default 5 minutes: https://github.com/flutter/flutter/issues/100937
-@Timeout(Duration(minutes: 10))
+@Timeout(Duration(minutes: 20))
 
 import 'dart:io' as io;
 


### PR DESCRIPTION
Partial fix to https://github.com/flutter/flutter/issues/95297

Whereas the `Mac $BRANCH verify_binaries_codesigned` builder only runs on post-submit release branches, this would add a check that the binaries are codesigned pre-submit.

From looking at https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20stable%20firebase_release_smoke_test/38/overview, it looks like relying on `platform.environment['LUCI_BRANCH']` will only work pre-submit. However, it's probably better to catch unsigned binaries in pre-submit than post-submit?

WDYT @CaseyHillers and @XilaiZhang?