### PR TITLE
[flutter_tools] throw error when argResults is null

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1524,20 +1524,20 @@ abstract class FlutterCommand extends Command<void> {
 
   /// Gets the parsed command-line option named [name] as a `bool?`.
   bool? boolArg(String name) {
-    if (argResults == null || !argParser.options.containsKey(name)) {
+    if (!argParser.options.containsKey(name)) {
       return null;
     }
-    return argResults?[name] as bool?;
+    return argResults![name] as bool;
   }
 
   /// Gets the parsed command-line option named [name] as a `String`.
   String? stringArgDeprecated(String name) => argResults?[name] as String?;
 
   String? stringArg(String name) {
-    if (argResults == null || !argParser.options.containsKey(name)) {
+    if (!argParser.options.containsKey(name)) {
       return null;
     }
-    return argResults?[name] as String?;
+    return argResults![name] as String;
   }
 
   /// Gets the parsed command-line option named [name] as an `int`.

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -34,6 +34,9 @@ void main() {
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addFlag('key');
     command.argParser.addFlag('key-false');
+    // argResults will be null at this point, if attempt to read them is made,
+    // exception `Null check operator used on a null value` would be thrown.
+    expect(()=>command.boolArg('key'), throwsA( const TypeMatcher<TypeError>()));
 
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key']);
@@ -56,8 +59,12 @@ void main() {
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addOption('key');
+    // argResults will be null at this point, if attempt to read them is made,
+    // exception `Null check operator used on a null value` would be thrown
+    expect(()=>command.stringArg('key'), throwsA( const TypeMatcher<TypeError>()));
+
     runner.addCommand(command);
-    await runner.run(<String>['test', '--key=value']);
+    await runner.run(<String>['dummy', '--key=value']);
 
     expect(command.stringArg('key'), 'value');
     expect(command.stringArg('empty'), null);

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -36,7 +36,7 @@ void main() {
     command.argParser.addFlag('key-false');
     // argResults will be null at this point, if attempt to read them is made,
     // exception `Null check operator used on a null value` would be thrown.
-    expect(() => command.boolArg('key'), throwsA( const TypeMatcher<TypeError>()));
+    expect(() => command.boolArg('key'), throwsA(const TypeMatcher<TypeError>()));
 
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key']);

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -61,7 +61,7 @@ void main() {
     command.argParser.addOption('key');
     // argResults will be null at this point, if attempt to read them is made,
     // exception `Null check operator used on a null value` would be thrown
-    expect(() => command.stringArg('key'), throwsA( const TypeMatcher<TypeError>()));
+    expect(() => command.stringArg('key'), throwsA(const TypeMatcher<TypeError>()));
 
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key=value']);

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -36,7 +36,7 @@ void main() {
     command.argParser.addFlag('key-false');
     // argResults will be null at this point, if attempt to read them is made,
     // exception `Null check operator used on a null value` would be thrown.
-    expect(()=>command.boolArg('key'), throwsA( const TypeMatcher<TypeError>()));
+    expect(() => command.boolArg('key'), throwsA( const TypeMatcher<TypeError>()));
 
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key']);
@@ -61,7 +61,7 @@ void main() {
     command.argParser.addOption('key');
     // argResults will be null at this point, if attempt to read them is made,
     // exception `Null check operator used on a null value` would be thrown
-    expect(()=>command.stringArg('key'), throwsA( const TypeMatcher<TypeError>()));
+    expect(() => command.stringArg('key'), throwsA( const TypeMatcher<TypeError>()));
 
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key=value']);

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -15,19 +15,6 @@ import '../src/context.dart';
 import '../src/testbed.dart';
 import 'runner/utils.dart';
 
-class CommandDummy extends FlutterCommand{
-  @override
-  String get description => 'description';
-
-  @override
-  String get name => 'test';
-
-  @override
-  Future<FlutterCommandResult> runCommand() async {
-    return FlutterCommandResult.success();
-  }
-}
-
 void main() {
   test('Help for command line arguments is consistently styled and complete', () => Testbed().run(() {
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
@@ -62,7 +49,11 @@ void main() {
   });
 
   testUsingContext('String? safe argResults', () async {
-    final CommandDummy command = CommandDummy();
+    final DummyFlutterCommand command = DummyFlutterCommand(
+        commandFunction: () async {
+          return const FlutterCommandResult(ExitStatus.success);
+        }
+    );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
     command.argParser.addOption('key');
     runner.addCommand(command);


### PR DESCRIPTION
- Replaces CommandDummy with the DummyFlutterCommand
- throw an error when argResults is null

*List which issues are fixed by this PR. You must list at least one issue.*
part of #101595

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
