### PR TITLE
TextStyle support different inherit lerp

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1068,7 +1068,6 @@ class TextStyle with Diagnosticable {
   /// based on the [backgroundColor] property).
   static TextStyle? lerp(TextStyle? a, TextStyle? b, double t) {
     assert(t != null);
-    assert(a == null || b == null || a.inherit == b.inherit);
     if (a == null && b == null) {
       return null;
     }

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -89,6 +89,15 @@ class _DartUiTextStyleToStringMatcher extends Matcher {
 Matcher matchesToStringOf(TextStyle textStyle) => _DartUiTextStyleToStringMatcher(textStyle);
 
 void main() {
+  // Regression test for https://github.com/flutter/flutter/issues/103864
+  test('TextStyle support different inherit lerp', () {
+    const TextStyle inheritStyle = TextStyle();
+    const TextStyle nonInheritStyle = TextStyle(inherit: false);
+
+    expect(TextStyle.lerp(inheritStyle, nonInheritStyle, 0.51)!.inherit, false);
+    expect(TextStyle.lerp(nonInheritStyle, inheritStyle, 0.51)!.inherit, true);
+  });
+
   test('TextStyle control test', () {
     expect(
       const TextStyle(inherit: false).toString(),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/103864
Fixes https://github.com/flutter/flutter/issues/89947 
Fixes https://github.com/flutter/flutter/issues/70281 
Fixes https://github.com/flutter/flutter/issues/43358 
Fixes https://github.com/flutter/flutter/issues/40514

I can not find why we do not support different `inherit` lerp, so try to support to see if this will break something.