### PR TITLE
Add bidding on GestureArena victory

### DIFF
--- a/packages/flutter/lib/src/gestures/arena.dart
+++ b/packages/flutter/lib/src/gestures/arena.dart
@@ -49,8 +49,11 @@ class GestureArenaEntry {
   ///
   /// It's fine to attempt to resolve a gesture recognizer for an arena that is
   /// already resolved.
-  void resolve(GestureDisposition disposition) {
-    _arena._resolve(_pointer, _member, disposition);
+  ///
+  /// If a [bid] is provided, the highest bid over 1.0 will be awarded victory upon
+  /// calling [GestureArenaManager.gavel].
+  void resolve(GestureDisposition disposition, {double? bid}) {
+    _arena._resolve(_pointer, _member, disposition, bid: bid);
   }
 }
 
@@ -59,6 +62,7 @@ class _GestureArena {
   bool isOpen = true;
   bool isHeld = false;
   bool hasPendingSweep = false;
+  final Map<GestureArenaMember, double> bids = <GestureArenaMember, double>{};
 
   /// If a member attempts to win while the arena is still open, it becomes the
   /// "eager winner". We look for an eager winner when closing the arena to new
@@ -129,6 +133,20 @@ class GestureArenaManager {
     state.isOpen = false;
     assert(_debugLogDiagnostic(pointer, 'Closing', state));
     _tryToResolveArena(pointer, state);
+  }
+
+  /// Resolves any bidding wars between members.
+  ///
+  /// Called after the framework has finished dispatching events.
+  void gavel(int pointer) {
+    final _GestureArena? state = _arenas[pointer];
+    if (state == null) {
+      return;
+    }
+    assert(_debugLogDiagnostic(pointer, 'Ending Routing', state));
+    if (!state.isOpen && state.bids.isNotEmpty) {
+      _tryToResolveArena(pointer, state);
+    }
   }
 
   /// Forces resolution of the arena, giving the win to the first member.
@@ -213,7 +231,7 @@ class GestureArenaManager {
   /// Reject or accept a gesture recognizer.
   ///
   /// This is called by calling [GestureArenaEntry.resolve] on the object returned from [add].
-  void _resolve(int pointer, GestureArenaMember member, GestureDisposition disposition) {
+  void _resolve(int pointer, GestureArenaMember member, GestureDisposition disposition, {double? bid}) {
     final _GestureArena? state = _arenas[pointer];
     if (state == null) {
       return; // This arena has already resolved.
@@ -228,9 +246,13 @@ class GestureArenaManager {
       }
     } else {
       assert(disposition == GestureDisposition.accepted);
-      if (state.isOpen) {
+      if (bid != null) {
+        state.bids[member] = bid;
+      }
+      else if (state.isOpen) {
         state.eagerWinner ??= member;
-      } else {
+      }
+      else {
         assert(_debugLogDiagnostic(pointer, 'Self-declared winner: $member'));
         _resolveInFavorOf(pointer, state, member);
       }
@@ -248,6 +270,19 @@ class GestureArenaManager {
     } else if (state.eagerWinner != null) {
       assert(_debugLogDiagnostic(pointer, 'Eager winner: ${state.eagerWinner}'));
       _resolveInFavorOf(pointer, state, state.eagerWinner!);
+    } else if (!state.isHeld) {
+      double bestBid = 0.0;
+      GestureArenaMember? winner;
+      for (final MapEntry<GestureArenaMember, double> bid in state.bids.entries) {
+        // Need to use > so that tie is broken by later map insertion (deeper inside element tree)
+        if (bid.value > bestBid) {
+          bestBid = bid.value;
+          winner = bid.key;
+        }
+      }
+      if (winner != null && bestBid >= 1) {
+        _resolveInFavorOf(pointer, state, winner);
+      }
     }
   }
 

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -458,6 +458,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   @override // from HitTestTarget
   void handleEvent(PointerEvent event, HitTestEntry entry) {
     pointerRouter.route(event);
+    gestureArena.gavel(event.pointer);
     if (event is PointerDownEvent || event is PointerPanZoomStartEvent) {
       gestureArena.close(event.pointer);
     } else if (event is PointerUpEvent || event is PointerPanZoomEndEvent) {

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -832,7 +832,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   }
 
   @override
-  void resolve(GestureDisposition disposition) {
+  void resolve(GestureDisposition disposition, {double? bid}) {
     if (disposition == GestureDisposition.rejected) {
       if (_longPressAccepted) {
         // This can happen if the gesture has been canceled. For example when
@@ -842,7 +842,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         _checkLongPressCancel();
       }
     }
-    super.resolve(disposition);
+    super.resolve(disposition, bid: bid);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -236,7 +236,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
 
   Offset _getDeltaForDetails(Offset delta);
   double? _getPrimaryValueFromOffset(Offset value);
-  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop);
+  double _calculateAcceptFactor(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop);
 
   final Map<int, VelocityTracker> _velocityTrackers = <int, VelocityTracker>{};
 
@@ -345,9 +345,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
           untransformedDelta: movedLocally,
           untransformedEndPosition: localPosition
         ).distance * (_getPrimaryValueFromOffset(movedLocally) ?? 1).sign;
-        if (_hasSufficientGlobalDistanceToAccept(event.kind, gestureSettings?.touchSlop)) {
-          resolve(GestureDisposition.accepted);
-        }
+        resolve(GestureDisposition.accepted, bid: _calculateAcceptFactor(event.kind, gestureSettings?.touchSlop));
       }
     }
     if (event is PointerUpEvent || event is PointerCancelEvent || event is PointerPanZoomEndEvent) {
@@ -572,8 +570,8 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
   }
 
   @override
-  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop) {
-    return _globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
+  double _calculateAcceptFactor(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop) {
+    return _globalDistanceMoved.abs() / computeHitSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
@@ -618,8 +616,8 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
   }
 
   @override
-  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop) {
-    return _globalDistanceMoved.abs() > computeHitSlop(pointerDeviceKind, gestureSettings);
+  double _calculateAcceptFactor(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop) {
+    return _globalDistanceMoved.abs() / computeHitSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override
@@ -657,8 +655,8 @@ class PanGestureRecognizer extends DragGestureRecognizer {
   }
 
   @override
-  bool _hasSufficientGlobalDistanceToAccept(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop) {
-    return _globalDistanceMoved.abs() > computePanSlop(pointerDeviceKind, gestureSettings);
+  double _calculateAcceptFactor(PointerDeviceKind pointerDeviceKind, double? deviceTouchSlop) {
+    return _globalDistanceMoved.abs() / computePanSlop(pointerDeviceKind, gestureSettings);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -75,11 +75,12 @@ abstract class MultiDragPointerState {
     _arenaEntry = entry;
   }
 
-  /// Resolve this pointer's entry in the [GestureArenaManager] with the given disposition.
+  /// Resolve this pointer's entry in the [GestureArenaManager] with the given disposition
+  /// and bid.
   @protected
   @mustCallSuper
-  void resolve(GestureDisposition disposition) {
-    _arenaEntry!.resolve(disposition);
+  void resolve(GestureDisposition disposition, {double? bid}) {
+    _arenaEntry!.resolve(disposition, bid: bid);
   }
 
   void _move(PointerMoveEvent event) {
@@ -343,9 +344,7 @@ class _ImmediatePointerState extends MultiDragPointerState {
   @override
   void checkForResolutionAfterMove() {
     assert(pendingDelta != null);
-    if (pendingDelta!.distance > computeHitSlop(kind, gestureSettings)) {
-      resolve(GestureDisposition.accepted);
-    }
+    resolve(GestureDisposition.accepted, bid: pendingDelta!.distance / computeHitSlop(kind, gestureSettings));
   }
 
   @override
@@ -400,9 +399,7 @@ class _HorizontalPointerState extends MultiDragPointerState {
   @override
   void checkForResolutionAfterMove() {
     assert(pendingDelta != null);
-    if (pendingDelta!.dx.abs() > computeHitSlop(kind, gestureSettings)) {
-      resolve(GestureDisposition.accepted);
-    }
+    resolve(GestureDisposition.accepted, bid: pendingDelta!.dx.abs() / computeHitSlop(kind, gestureSettings));
   }
 
   @override
@@ -457,9 +454,7 @@ class _VerticalPointerState extends MultiDragPointerState {
   @override
   void checkForResolutionAfterMove() {
     assert(pendingDelta != null);
-    if (pendingDelta!.dy.abs() > computeHitSlop(kind, gestureSettings)) {
-      resolve(GestureDisposition.accepted);
-    }
+    resolve(GestureDisposition.accepted, bid: pendingDelta!.dy.abs() / computeHitSlop(kind, gestureSettings));
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -347,14 +347,16 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   void didStopTrackingLastPointer(int pointer);
 
   /// Resolves this recognizer's participation in each gesture arena with the
-  /// given disposition.
+  /// given disposition and bid.
   @protected
   @mustCallSuper
-  void resolve(GestureDisposition disposition) {
+  void resolve(GestureDisposition disposition, {double? bid}) {
     final List<GestureArenaEntry> localEntries = List<GestureArenaEntry>.of(_entries.values);
-    _entries.clear();
+    if (bid == null) {
+      _entries.clear();
+    }
     for (final GestureArenaEntry entry in localEntries) {
-      entry.resolve(disposition);
+      entry.resolve(disposition, bid: bid);
     }
   }
 
@@ -362,11 +364,11 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
   /// the given disposition.
   @protected
   @mustCallSuper
-  void resolvePointer(int pointer, GestureDisposition disposition) {
+  void resolvePointer(int pointer, GestureDisposition disposition, {double? bid}) {
     final GestureArenaEntry? entry = _entries[pointer];
     if (entry != null) {
       _entries.remove(pointer);
-      entry.resolve(disposition);
+      entry.resolve(disposition, bid: bid);
     }
   }
 
@@ -377,7 +379,6 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
       GestureBinding.instance.pointerRouter.removeRoute(pointer, handleEvent);
     }
     _trackedPointers.clear();
-    assert(_entries.isEmpty);
     super.dispose();
   }
 

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -250,7 +250,7 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
   }
 
   @override
-  void resolve(GestureDisposition disposition) {
+  void resolve(GestureDisposition disposition, {double? bid}) {
     if (_wonArenaForPrimaryPointer && disposition == GestureDisposition.rejected) {
       // This can happen if the gesture has been canceled. For example, when
       // the pointer has exceeded the touch slop, the buttons have been changed,
@@ -259,7 +259,7 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
       _checkCancel(null, 'spontaneous');
       _reset();
     }
-    super.resolve(disposition);
+    super.resolve(disposition, bid: bid);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/team.dart
+++ b/packages/flutter/lib/src/gestures/team.dart
@@ -15,8 +15,8 @@ class _CombiningGestureArenaEntry implements GestureArenaEntry {
   final GestureArenaMember _member;
 
   @override
-  void resolve(GestureDisposition disposition) {
-    _combiner._resolve(_member, disposition);
+  void resolve(GestureDisposition disposition, {double? bid}) {
+    _combiner._resolve(_member, disposition, bid: bid);
   }
 }
 
@@ -69,7 +69,7 @@ class _CombiningGestureArenaMember extends GestureArenaMember {
     return _CombiningGestureArenaEntry(this, member);
   }
 
-  void _resolve(GestureArenaMember member, GestureDisposition disposition) {
+  void _resolve(GestureArenaMember member, GestureDisposition disposition, {double? bid}) {
     if (_resolved) {
       return;
     }
@@ -77,12 +77,12 @@ class _CombiningGestureArenaMember extends GestureArenaMember {
       _members.remove(member);
       member.rejectGesture(_pointer);
       if (_members.isEmpty) {
-        _entry!.resolve(disposition);
+        _entry!.resolve(disposition, bid: bid);
       }
     } else {
       assert(disposition == GestureDisposition.accepted);
       _winner ??= _owner.captain ?? member;
-      _entry!.resolve(disposition);
+      _entry!.resolve(disposition, bid: bid);
     }
   }
 }

--- a/packages/flutter/test/gestures/arena_test.dart
+++ b/packages/flutter/test/gestures/arena_test.dart
@@ -166,4 +166,30 @@ void main() {
     tester.arena.close(primaryKey);
     tester.expectSecondWin();
   });
+
+  test('Highest bid over 1.0 wins', () {
+    final GestureTester tester = GestureTester();
+    tester.addFirst();
+    tester.addSecond();
+    tester.arena.close(primaryKey);
+    tester.expectNothing();
+    tester.firstEntry.resolve(GestureDisposition.accepted, bid: 1.1);
+    tester.secondEntry.resolve(GestureDisposition.accepted, bid: 1.2);
+    tester.expectNothing();
+    tester.arena.gavel(primaryKey);
+    tester.expectSecondWin();
+  });
+
+  test('Synchronous resolve wins over bidder', () {
+    final GestureTester tester = GestureTester();
+    tester.addFirst();
+    tester.addSecond();
+    tester.arena.close(primaryKey);
+    tester.expectNothing();
+    tester.firstEntry.resolve(GestureDisposition.accepted, bid: 1.1);
+    tester.secondEntry.resolve(GestureDisposition.accepted);
+    tester.expectSecondWin();
+    tester.arena.gavel(primaryKey);
+    tester.expectSecondWin();
+  });
 }

--- a/packages/flutter/test/gestures/gesture_tester.dart
+++ b/packages/flutter/test/gestures/gesture_tester.dart
@@ -18,6 +18,7 @@ class GestureTester {
 
   void route(PointerEvent event) {
     GestureBinding.instance.pointerRouter.route(event);
+    GestureBinding.instance.gestureArena.gavel(event.pointer);
     async.flushMicrotasks();
   }
 }

--- a/packages/flutter/test/gestures/team_test.dart
+++ b/packages/flutter/test/gestures/team_test.dart
@@ -47,7 +47,7 @@ void main() {
     log.clear();
 
     test(const Offset(0.0, 30.0));
-    expect(log, <String>['vertical-drag-start']);
+    expect(log, <String>['horizontal-drag-start']); // The team won, and horizontal drag is the first member of the team
     log.clear();
 
     horizontalDrag.dispose();

--- a/packages/flutter/test/gestures/transformed_scale_test.dart
+++ b/packages/flutter/test/gestures/transformed_scale_test.dart
@@ -34,8 +34,8 @@ void main() {
     final TestGesture pointer2 = await tester.startGesture(tester.getCenter(find.byKey(redContainer)) + const Offset(30, 30));
     await pointer2.moveTo(tester.getCenter(find.byKey(redContainer)) + const Offset(20, 20));
 
-    expect(updateDetails.single.localFocalPoint, const Offset(50, 50));
-    expect(updateDetails.single.focalPoint, const Offset(400, 300));
+    expect(updateDetails[1].localFocalPoint, const Offset(50, 50));
+    expect(updateDetails[1].focalPoint, const Offset(400, 300));
 
     expect(startDetails, hasLength(2));
     expect(startDetails.first.localFocalPoint, const Offset(30, 30));

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -1116,8 +1116,8 @@ void main() {
       await gesture2.up();
       await tester.pumpAndSettle();
       expect(transformationController.value, equals(Matrix4.identity()));
-      expect(initialScale, null);
-      expect(scale, null);
+      expect(initialScale, 1.0);
+      expect(scale, 1.0);
 
       // Pinch to zoom for a larger amount is detected. It starts smoothly at
       // 1.0 despite the fact that the gesture has already moved a bit.


### PR DESCRIPTION
`ScaleGestureRecognizer` and `DragGestureRecognizer` (and its children) now provide a scalar `bid` when requesting to win the gesture arena. This will fix the race condition of gesture disambiguation depending on device touch sampling rate. 

As a side effect, those recognizers won't always win the arena synchronously (all bids need to be received before awarding the winner), so timing specifics of gesture update events will not be the same as before this change. 

Fixes #11384

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
