### PR TITLE
remove all usage of dart:io exit from tool/framework

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -426,12 +426,6 @@ abstract class BindingBase {
     }());
 
     if (!kReleaseMode) {
-      if (!kIsWeb) {
-        registerSignalServiceExtension(
-          name: 'exit',
-          callback: _exitApplication,
-        );
-      }
       // These service extensions are used in profile mode applications.
       registerStringServiceExtension(
         name: 'connectedVmServiceUri',

--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -4,7 +4,6 @@
 
 import 'dart:convert' show json;
 import 'dart:developer' as developer;
-import 'dart:io' show exit;
 import 'dart:ui' as ui show SingletonFlutterWindow, Brightness, PlatformDispatcher, window;
 // Before adding any more dart:ui imports, please read the README.
 
@@ -866,11 +865,6 @@ abstract class BindingBase {
 
   @override
   String toString() => '<${objectRuntimeType(this, 'BindingBase')}>';
-}
-
-/// Terminate the Flutter application.
-Future<void> _exitApplication() async {
-  exit(0);
 }
 
 /// Additional configuration used for hot reload reassemble optimizations.

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -176,7 +176,7 @@ void main() {
     // framework, excluding any that are for the widget inspector
     // (see widget_inspector_test.dart for tests of the ext.flutter.inspector
     // service extensions).
-    const int serviceExtensionCount = 36;
+    const int serviceExtensionCount = 35;
 
     expect(binding.extensions.length, serviceExtensionCount + widgetInspectorExtensionCount - disabledExtensions);
 
@@ -567,12 +567,6 @@ void main() {
     expect(data, isFalse);
     expect(completed, isTrue);
     TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', null);
-  });
-
-  test('Service extensions - exit', () async {
-    // no test for _calling_ 'exit', because that should terminate the process!
-    // Not expecting extension to be available for web platform.
-    expect(binding.extensions.containsKey('exit'), !isBrowser);
   });
 
   test('Service extensions - platformOverride', () async {

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -168,9 +168,8 @@ void main() {
     }
 
     // The following service extensions are disabled in web:
-    // 1. exit
-    // 2. showPerformanceOverlay
-    const int disabledExtensions = kIsWeb ? 2 : 0;
+    // 1. showPerformanceOverlay
+    const int disabledExtensions = kIsWeb ? 1 : 0;
 
     // The expected number of registered service extensions in the Flutter
     // framework, excluding any that are for the widget inspector

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -303,14 +303,6 @@ class FlutterDriverService extends DriverService {
       if (!await _device.uninstallApp(_applicationPackage, userIdentifier: userIdentifier)) {
         _logger.printError('Failed to uninstall app');
       }
-    } else if (_device.supportsFlutterExit) {
-      // Otherwise use the VM Service URI to stop the app as a best effort approach.
-      final vm_service.VM vm = await _vmService.service.getVM();
-      final vm_service.IsolateRef isolateRef = vm.isolates
-        .firstWhere((vm_service.IsolateRef element) {
-          return !element.isSystemIsolate;
-        }, orElse: () => null);
-      unawaited(_vmService.flutterExit(isolateId: isolateRef.id));
     } else {
       _logger.printTrace('No application package for $_device, leaving app running');
     }

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -717,32 +717,6 @@ class FlutterVmService {
     );
   }
 
-  /// Exit the application by calling [exit] from `dart:io`.
-  ///
-  /// This method is only supported by certain embedders. This is
-  /// described by [Device.supportsFlutterExit].
-  Future<bool> flutterExit({
-    required String isolateId,
-  }) async {
-    try {
-      final Map<String, Object?>? result = await invokeFlutterExtensionRpcRaw(
-        'ext.flutter.exit',
-        isolateId: isolateId,
-      );
-      // A response of `null` indicates that `invokeFlutterExtensionRpcRaw` caught an RPCError
-      // with a missing method code. This can happen when attempting to quit a Flutter app
-      // that never registered the methods in the bindings.
-      if (result == null) {
-        return false;
-      }
-    } on vm_service.SentinelException {
-      // Do nothing on sentinel, the isolate already exited.
-    } on vm_service.RPCError {
-      // Do nothing on RPCError, the isolate already exited.
-    }
-    return true;
-  }
-
   /// Return the current platform override for the flutter view running with
   /// the main isolate [isolateId].
   ///


### PR DESCRIPTION
Currently exit is only used as a fallback on certain platforms and if there is no application package (i.e. we did an after-the-fact attach). We'd like to consider disabling io.exit to prevent users from easily crashing their applications, so this needs to be removed
