### PR TITLE
[flutter_tools] Upgrade only from flutter update-packages

### DIFF
--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1333,7 +1333,6 @@ class PubspecDependency extends PubspecLine {
     } else {
       versionToUse = version;
     }
-    // final versionToUse = useAnyVersion || version.isEmpty ? 'any' : version;
     switch (kind) {
       case DependencyKind.unknown:
       case DependencyKind.overridden:

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1323,7 +1323,9 @@ class PubspecDependency extends PubspecLine {
   /// fake package that we'll use to get the version numbers figured out.
   void describeForFakePubspec(StringBuffer dependencies, StringBuffer overrides, { bool doUpgrade = true }) {
     final String versionToUse;
-    if (version.isEmpty) {
+    // This should only happen when manually adding new dependencies; otherwise
+    // versions should always be pinned exactly
+    if (version.isEmpty || version == 'any') {
       versionToUse = 'any';
     } else if (doUpgrade) {
       // Must wrap in quotes for Yaml parsing

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1321,6 +1321,10 @@ class PubspecDependency extends PubspecLine {
 
   /// This generates the entry for this dependency for the pubspec.yaml for the
   /// fake package that we'll use to get the version numbers figured out.
+  ///
+  /// When called with [doUpgrade] as [true], the version constrains will be set
+  /// to >= whatever the previous version was. If [doUpgrade] is [false], then
+  /// the previous version is used again as an exact pin.
   void describeForFakePubspec(StringBuffer dependencies, StringBuffer overrides, { bool doUpgrade = true }) {
     final String versionToUse;
     // This should only happen when manually adding new dependencies; otherwise

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -384,7 +384,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       fakePackage.writeAsStringSync(
         _generateFakePubspec(
           dependencies,
-          useAnyVersion: doUpgrade,
+          doUpgrade: doUpgrade,
         ),
       );
       // Create a synthetic flutter SDK so that transitive flutter SDK
@@ -1394,7 +1394,7 @@ String _generateFakePubspec(
 }) {
   final StringBuffer result = StringBuffer();
   final StringBuffer overrides = StringBuffer();
-  final bool verbose = useAnyVersion;
+  final bool verbose = doUpgrade;
   result.writeln('name: flutter_update_packages');
   result.writeln('environment:');
   result.writeln("  sdk: '>=2.10.0 <3.0.0'");
@@ -1424,7 +1424,7 @@ String _generateFakePubspec(
   }
   for (final PubspecDependency dependency in dependencies) {
     if (!dependency.pointsToSdk) {
-      dependency.describeForFakePubspec(result, overrides, useAnyVersion: useAnyVersion);
+      dependency.describeForFakePubspec(result, overrides, doUpgrade: doUpgrade);
     }
   }
   result.write(overrides.toString());

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -382,7 +382,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       final File fakePackage = _pubspecFor(tempDir);
       fakePackage.createSync();
       fakePackage.writeAsStringSync(
-        _generateFakePubspec(
+        generateFakePubspec(
           dependencies,
           doUpgrade: doUpgrade,
         ),
@@ -1371,6 +1371,7 @@ class PubspecDependency extends PubspecLine {
           dependencies.writeln('  $name:');
           dependencies.writeln(lockLine);
         }
+        break;
     }
   }
 
@@ -1388,9 +1389,10 @@ File _pubspecFor(Directory directory) {
 
 /// Generates the source of a fake pubspec.yaml file given a list of
 /// dependencies.
-String _generateFakePubspec(
+@visibleForTesting
+String generateFakePubspec(
   Iterable<PubspecDependency> dependencies, {
-  bool useAnyVersion = false
+  bool doUpgrade = false
 }) {
   final StringBuffer result = StringBuffer();
   final StringBuffer overrides = StringBuffer();

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -1321,8 +1321,17 @@ class PubspecDependency extends PubspecLine {
 
   /// This generates the entry for this dependency for the pubspec.yaml for the
   /// fake package that we'll use to get the version numbers figured out.
-  void describeForFakePubspec(StringBuffer dependencies, StringBuffer overrides, { bool useAnyVersion = true}) {
-    final String versionToUse = useAnyVersion || version.isEmpty ? 'any' : version;
+  void describeForFakePubspec(StringBuffer dependencies, StringBuffer overrides, { bool doUpgrade = true }) {
+    final String versionToUse;
+    if (version.isEmpty) {
+      versionToUse = 'any';
+    } else if (doUpgrade) {
+      // Must wrap in quotes for Yaml parsing
+      versionToUse = "'>= $version'";
+    } else {
+      versionToUse = version;
+    }
+    // final versionToUse = useAnyVersion || version.isEmpty ? 'any' : version;
     switch (kind) {
       case DependencyKind.unknown:
       case DependencyKind.overridden:

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -176,8 +176,8 @@ void main() {
   });
 
   group('generateFakePubspec', () {
+    const String prevVersion = '1.2.0';
     testUsingContext('constrains package versions to >= previous version if doUpgrade: true', () {
-      const String prevVersion = '1.2.0';
       final String pubspecSource = generateFakePubspec(
         <PubspecDependency>[
           PubspecDependency(
@@ -194,6 +194,25 @@ void main() {
       );
       final YamlMap pubspec = loadYaml(pubspecSource) as YamlMap;
       expect((pubspec['dependencies'] as YamlMap)['foo'], '>= $prevVersion');
+    });
+
+    testUsingContext('uses previous package versions doUpgrade: false', () {
+      final String pubspecSource = generateFakePubspec(
+        <PubspecDependency>[
+          PubspecDependency(
+            '  foo: $prevVersion',
+            'foo',
+            '',
+            version: prevVersion,
+            sourcePath: '/path/to/pubspec.yaml',
+            kind: DependencyKind.normal,
+            isTransitive: false,
+          ),
+        ],
+        doUpgrade: false,
+      );
+      final YamlMap pubspec = loadYaml(pubspecSource) as YamlMap;
+      expect((pubspec['dependencies'] as YamlMap)['foo'], prevVersion);
     });
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/update_packages_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/commands/update_packages.dart';
 import 'package:flutter_tools/src/dart/pub.dart';
 import 'package:meta/meta.dart';
 import 'package:test/fake.dart';
+import 'package:yaml/yaml.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
@@ -171,6 +172,28 @@ void main() {
       Cache: () => Cache.test(
         processManager: FakeProcessManager.any(),
       ),
+    });
+  });
+
+  group('generateFakePubspec', () {
+    testUsingContext('constrains package versions to >= previous version if doUpgrade: true', () {
+      const String prevVersion = '1.2.0';
+      final String pubspecSource = generateFakePubspec(
+        <PubspecDependency>[
+          PubspecDependency(
+            '  foo: $prevVersion',
+            'foo',
+            '',
+            version: prevVersion,
+            sourcePath: '/path/to/pubspec.yaml',
+            kind: DependencyKind.normal,
+            isTransitive: false,
+          ),
+        ],
+        doUpgrade: true,
+      );
+      final YamlMap pubspec = loadYaml(pubspecSource) as YamlMap;
+      expect((pubspec['dependencies'] as YamlMap)['foo'], '>= $prevVersion');
     });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/102781

Previously, `flutter update-packages --force-upgrade` command would:

1. Crawl the flutter/flutter repo, collecting the set of all pub packages depended on
2. Create a synthetic pub package, populated with all the packages from step 1
3. For manually pinned packages, the pinned version would be used; else, each package version would be set to `any`
4. Run `pub get` on the synthetic package, allowing pub to version solve and determine the "best" version solution
5. Backfill the exact versions resolved by pub get on the synthetic packages to the actual pubspec.yaml files in the repo.

The problem with this algorithm is that the "best version solution" algorithm from step 4 that `pub get` uses is a heuristic that can sometimes result in certain packages getting downgraded relative to the previous run (see https://github.com/flutter/flutter/issues/102781#issuecomment-1115850357 for more details).

This PR solves the problem by substituting `>= $prevVersion` for `any` in step 3. This will preclude `pub` from consideration a solution that would downgrade a package.