### PR TITLE
Migrate FakeProcess stdout/err to List<int>

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 
@@ -25,8 +23,8 @@ void main() {
       // the FakeCommands below expect an exitCode of 0.
       const FakeCommand(
         command: <String>['iproxy', '12345:456', '--udid', '1234'],
-        stdout: null, // no stdout indicates failure.
         environment: kDyLdLibEntry,
+        // Empty stdout indicates failure.
       ),
       const FakeCommand(
         command: <String>['iproxy', '12346:456', '--udid', '1234'],

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -141,24 +141,24 @@ class _FakeProcess implements io.Process {
       }),
       stdin = stdin ?? IOSink(StreamController<List<int>>().sink)
   {
-    if (_stderr == null) {
+    if (_stderr.isEmpty) {
       stderr = const Stream<List<int>>.empty();
     } else if (outputFollowsExit) {
       stderr = Stream<List<int>>.fromFuture(exitCode.then((_) {
-        return Future<List<int>>(() => utf8.encode(_stderr));
+        return Future<List<int>>(() => _stderr);
       }));
     } else {
-      stderr = Stream<List<int>>.value(utf8.encode(_stderr));
+      stderr = Stream<List<int>>.value(_stderr);
     }
 
-    if (_stdout == null) {
+    if (_stdout.isEmpty) {
       stdout = const Stream<List<int>>.empty();
     } else if (outputFollowsExit) {
       stdout = Stream<List<int>>.fromFuture(exitCode.then((_) {
-        return Future<List<int>>(() => utf8.encode(_stdout));
+        return Future<List<int>>(() => _stdout);
       }));
     } else {
-      stdout = Stream<List<int>>.value(utf8.encode(_stdout));
+      stdout = Stream<List<int>>.value(_stdout);
     }
   }
 
@@ -171,7 +171,7 @@ class _FakeProcess implements io.Process {
   @override
   final int pid;
 
-  final String _stderr;
+  final List<int> _stderr;
 
   @override
   late final Stream<List<int>> stderr;
@@ -182,7 +182,7 @@ class _FakeProcess implements io.Process {
   @override
   late final Stream<List<int>> stdout;
 
-  final String _stdout;
+  final List<int> _stdout;
 
   @override
   bool kill([io.ProcessSignal signal = io.ProcessSignal.sigterm]) {
@@ -268,9 +268,9 @@ abstract class FakeProcessManager implements ProcessManager {
       fakeCommand.exitCode,
       fakeCommand.duration,
       _pid,
-      fakeCommand.stderr,
+      encoding?.encode(fakeCommand.stderr) ?? fakeCommand.stderr.codeUnits,
       fakeCommand.stdin,
-      fakeCommand.stdout,
+      encoding?.encode(fakeCommand.stdout) ?? fakeCommand.stdout.codeUnits,
       fakeCommand.completer,
       fakeCommand.outputFollowsExit,
     );
@@ -322,15 +322,15 @@ abstract class FakeProcessManager implements ProcessManager {
     Map<String, String>? environment,
     bool includeParentEnvironment = true, // ignored
     bool runInShell = false, // ignored
-    Encoding? stdoutEncoding = io.systemEncoding, // actual encoder is ignored
-    Encoding? stderrEncoding = io.systemEncoding, // actual encoder is ignored
+    Encoding? stdoutEncoding = io.systemEncoding,
+    Encoding? stderrEncoding = io.systemEncoding,
   }) {
     final _FakeProcess process = _runCommand(command.cast<String>(), workingDirectory, environment, stdoutEncoding);
     return io.ProcessResult(
       process.pid,
       process._exitCode,
-      stdoutEncoding == null ? utf8.encode(process._stdout) : process._stdout,
-      stderrEncoding == null ? utf8.encode(process._stderr) : process._stderr,
+      stdoutEncoding == null ? process._stdout : stdoutEncoding.decode(process._stdout),
+      stderrEncoding == null ? process._stderr : stderrEncoding.decode(process._stderr),
     );
   }
 


### PR DESCRIPTION
And don't do weird bypassing the encoder crap in runSync, but bizarrely
not in run (async).

Before committing this, remember to delete the commented out code.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
