### PR TITLE
[tool] Consistent FakeProcessManager.run/runSync

### DIFF
--- a/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_port_forwarder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/ios/devices.dart';
 
@@ -25,8 +23,8 @@ void main() {
       // the FakeCommands below expect an exitCode of 0.
       const FakeCommand(
         command: <String>['iproxy', '12345:456', '--udid', '1234'],
-        stdout: null, // no stdout indicates failure.
         environment: kDyLdLibEntry,
+        // Empty stdout indicates failure.
       ),
       const FakeCommand(
         command: <String>['iproxy', '12346:456', '--udid', '1234'],


### PR DESCRIPTION
`FakeProcessManager` is a test-oriented implementation of `ProcessManager`
that simulates launching processes and returning `ProcessResult` objects
whose `exitCode`, `stdout`, `stderr` can be used to write platform-portable,
hermetic tests that don't rely on actually launching processes from
executables on disk. Its `run` and `runSync` methods provide asynchronous and
synchronous variants of this functionality.

Previously, the behaviour of `run` and `runSync` were inconsistent with
regards to the treatment of the `stdoutEncoding` (similarly,
`stderrEncoding`) parameters:

`run`:
* if the encoding was null, `ProcessResult.stdout` was returned as a
  String in UTF-8 encoding. This was incorrect. The behaviour as
  specified in `ProcessResult.stdout` is that in this case, a raw
  `List<int>` should be returned.
* If the encoding was unspecified, `ProcessResult.stdout` was returned as
  a `String` in the `io.systemEncoding` encoding. This was correct.
* If the encoding was non-null, `ProcessResult.stdout` was returned as a
  `String` in the specified encoding. This was correct.

`runSync`:
* if the encoding was null, `ProcessResult.stdout` was returned as a
  `List<int>` in UTF-8 encoding. This was incorrect. The behaviour as
  specified in `ProcessResult.stdout` is that in this case, a raw
  `List<int>` should be returned.
* If the encoding was unspecified, `ProcessResult.stdout` was returned as
  `List<int>` in UTF-8 encoding. This was incorrect. The behaviour as
  specified in `ProcessResult.stdout` is that in this case, a String a
  `String` in the `io.systemEncoding` encoding should be returned.
* if the encoding was non-null, `ProcessResult.stdout` was returned as a
  `String` in unknown (but probably UTF-8) encoding. This was incorrect.
  The behaviour as specified in `ProcessResult.stdout` is that in this
  case, a `String` in the specified encoding should be returned.

`_FakeProcess`, from which we obtain the fake stdout and stderr values now
holds these fields as raw `List<int>` of bytes rather than as `String`s. It
is up to the user to supply values that can be decoded with the encoding
passed to `run`/`runAsync`.

`run` and `runAsync` have been updated to set stdout (likewise, stderr) as
specified in the `ProcessResult` documentation.

This is pre-factoring for #102451, in which the tool throws an exception
when processing the JSON output from stdout of the `vswhere.exe` tool,
whose output was found to include the `U+FFFD` Unicode replacement
character during UTF-8 decoding, which triggers a `toolExit` exception
when decoded using our [Utf8Decoder][decoder] configured with `reportErrors` =
true. Because `FakeProcessManager.runAsync` did not previously invoke
`utf8.decode` on its output (behaviour which differs from the non-fake
implementation), it was impossible to write tests to verify the fix.

Ref: https://api.flutter.dev/flutter/dart-io/ProcessResult/stdout.html

Issue: https://github.com/flutter/flutter/issues/102451

[decoder]: https://github.com/flutter/flutter/blob/fd312f1ccff909fde28d2247a489bf210bbc6c48/packages/flutter_tools/lib/src/convert.dart#L51-L60

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
