### PR TITLE
Stop recommending "shrinkWrap"

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -1385,9 +1385,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
                   'If this widget is always nested in a scrollable widget there '
                   'is no need to use a viewport because there will always be enough '
                   'vertical space for the children. In this case, consider using a '
-                  'Column instead. Otherwise, consider using the "shrinkWrap" property '
-                  '(or a ShrinkWrappingViewport) to size the height of the viewport '
-                  'to the sum of the heights of its children.',
+                  'Column or Wrap instead. Otherwise, consider using a '
+                  'CustomScrollView to concatenate arbitrary slivers into a '
+                  'single scrollable.',
                 ),
               ]);
             }
@@ -1415,9 +1415,9 @@ class RenderViewport extends RenderViewportBase<SliverPhysicalContainerParentDat
                   'If this widget is always nested in a scrollable widget there '
                   'is no need to use a viewport because there will always be enough '
                   'horizontal space for the children. In this case, consider using a '
-                  'Row instead. Otherwise, consider using the "shrinkWrap" property '
-                  '(or a ShrinkWrappingViewport) to size the width of the viewport '
-                  'to the sum of the widths of its children.',
+                  'Row or Wrap instead. Otherwise, consider using a '
+                  'CustomScrollView to concatenate arbitrary slivers into a '
+                  'single scrollable.',
                 ),
               ]);
             }

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -1708,9 +1708,8 @@ void main() {
           '   If this widget is always nested in a scrollable widget there is\n'
           '   no need to use a viewport because there will always be enough\n'
           '   horizontal space for the children. In this case, consider using a\n'
-          '   Row instead. Otherwise, consider using the "shrinkWrap" property\n'
-          '   (or a ShrinkWrappingViewport) to size the width of the viewport\n'
-          '   to the sum of the widths of its children.\n',
+          '   Row or Wrap instead. Otherwise, consider using a CustomScrollView\n'
+          '   to concatenate arbitrary slivers into a single scrollable.\n',
       );
     });
 
@@ -1743,9 +1742,9 @@ void main() {
           '   If this widget is always nested in a scrollable widget there is\n'
           '   no need to use a viewport because there will always be enough\n'
           '   vertical space for the children. In this case, consider using a\n'
-          '   Column instead. Otherwise, consider using the "shrinkWrap"\n'
-          '   property (or a ShrinkWrappingViewport) to size the height of the\n'
-          '   viewport to the sum of the heights of its children.\n',
+          '   Column or Wrap instead. Otherwise, consider using a\n'
+          '   CustomScrollView to concatenate arbitrary slivers into a single\n'
+          '   scrollable.\n',
       );
     });
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/103085

Using a ShrinkWrapping viewport is pretty much never the right thing to do in the case of this error. It introduces a much more expensive widget to the tree than a `Column`, `Row`, or `Wrap` would be, and the real solution if you can't use those is to use a `CustomScrollView` instead to arrange your slivers.

One of the main problems introduced by this pattern is that it breaks up a scrollable into many more repaint boundaries than necessary, which makes painting/compositing/rasterization less efficient later in most cases.