### PR TITLE
[tool] Add tests for FakeProcess

### DIFF
--- a/packages/flutter_tools/test/general.shard/fake_process_manager_test.dart
+++ b/packages/flutter_tools/test/general.shard/fake_process_manager_test.dart
@@ -1,0 +1,175 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'package:fake_async/fake_async.dart';
+
+import '../src/common.dart';
+import '../src/fake_process_manager.dart';
+
+void main() {
+  group(FakeProcess, () {
+    testWithoutContext('exits with specified exit code', () async {
+      final FakeProcess process = FakeProcess(exitCode: 42);
+      expect(await process.exitCode, 42);
+    });
+
+    testWithoutContext('exits with specified stderr, stdout', () async {
+      final FakeProcess process = FakeProcess(
+        stderr: 'stderr\u{FFFD}'.codeUnits,
+        stdout: 'stdout\u{FFFD}'.codeUnits,
+      );
+      await process.exitCode;
+
+      // Verify that no encoding changes have been applied to output.
+      //
+      // In the past, we had hardcoded UTF-8 encoding for these streams in
+      // FakeProcess. When a specific encoding is desired, it can be specified
+      // on FakeCommand or in the encoding parameter of FakeProcessManager.run
+      // or FakeProcessManager.runAsync.
+      expect((await process.stderr.toList()).expand((List<int> x) => x), 'stderr\u{FFFD}'.codeUnits);
+      expect((await process.stdout.toList()).expand((List<int> x) => x), 'stdout\u{FFFD}'.codeUnits);
+    });
+
+    testWithoutContext('exits after specified delay (if no completer specified)', () {
+      final bool done = FakeAsync().run<bool>((FakeAsync time) {
+        final FakeProcess process = FakeProcess(
+          duration: const Duration(seconds: 30),
+        );
+
+        bool hasExited = false;
+        unawaited(process.exitCode.then((int _) { hasExited = true; }));
+
+        // Verify process hasn't exited before specified delay.
+        time.elapse(const Duration(seconds: 15));
+        expect(hasExited, isFalse);
+
+        // Verify process has exited after specified delay.
+        time.elapse(const Duration(seconds: 20));
+        expect(hasExited, isTrue);
+
+        return true;
+      });
+      expect(done, isTrue);
+    });
+
+    testWithoutContext('exits when completer completes (if no duration specified)', () {
+      final bool done = FakeAsync().run<bool>((FakeAsync time) {
+        final Completer<void> completer = Completer<void>();
+        final FakeProcess process = FakeProcess(
+          completer: completer,
+        );
+
+        bool hasExited = false;
+        unawaited(process.exitCode.then((int _) { hasExited = true; }));
+
+        // Verify process hasn't exited when all async tasks flushed.
+        time.elapse(Duration.zero);
+        expect(hasExited, isFalse);
+
+        // Verify process has exited after completer completes.
+        completer.complete();
+        time.flushMicrotasks();
+        expect(hasExited, isTrue);
+
+        return true;
+      });
+      expect(done, isTrue);
+    });
+
+    testWithoutContext('when completer and duration are specified, does not exit until completer is completed', () {
+      final bool done = FakeAsync().run<bool>((FakeAsync time) {
+        final Completer<void> completer = Completer<void>();
+        final FakeProcess process = FakeProcess(
+          duration: const Duration(seconds: 30),
+          completer: completer,
+        );
+
+        bool hasExited = false;
+        unawaited(process.exitCode.then((int _) { hasExited = true; }));
+
+        // Verify process hasn't exited before specified delay.
+        time.elapse(const Duration(seconds: 15));
+        expect(hasExited, isFalse);
+
+        // Verify process hasn't exited until the completer completes.
+        time.elapse(const Duration(seconds: 20));
+        expect(hasExited, isFalse);
+
+        // Verify process exits after the completer completes.
+        completer.complete();
+        time.flushMicrotasks();
+        expect(hasExited, isTrue);
+
+        return true;
+      });
+      expect(done, isTrue);
+    });
+
+    testWithoutContext('when completer and duration are specified, does not exit until duration has elapsed', () {
+      final bool done = FakeAsync().run<bool>((FakeAsync time) {
+        final Completer<void> completer = Completer<void>();
+        final FakeProcess process = FakeProcess(
+          duration: const Duration(seconds: 30),
+          completer: completer,
+        );
+
+        bool hasExited = false;
+        unawaited(process.exitCode.then((int _) { hasExited = true; }));
+
+        // Verify process hasn't exited before specified delay.
+        time.elapse(const Duration(seconds: 15));
+        expect(hasExited, isFalse);
+
+        // Verify process does not exit until duration has elapsed.
+        completer.complete();
+        expect(hasExited, isFalse);
+
+        // Verify process exits after the duration elapses.
+        time.elapse(const Duration(seconds: 20));
+        expect(hasExited, isTrue);
+
+        return true;
+      });
+      expect(done, isTrue);
+    });
+
+    testWithoutContext('process exit is asynchronous', () async {
+      final FakeProcess process = FakeProcess();
+
+      bool hasExited = false;
+      unawaited(process.exitCode.then((int _) { hasExited = true; }));
+
+      // Verify process hasn't completed.
+      expect(hasExited, isFalse);
+
+      // Flush async tasks. Verify process completes.
+      await Future<void>.delayed(Duration.zero);
+      expect(hasExited, isTrue);
+    });
+
+    testWithoutContext('stderr, stdout stream data after exit when outputFollowsExit is true', () async {
+      final FakeProcess process = FakeProcess(
+        stderr: 'stderr'.codeUnits,
+        stdout: 'stdout'.codeUnits,
+        outputFollowsExit: true,
+      );
+
+      final List<int> stderr = <int>[];
+      final List<int> stdout = <int>[];
+      process.stderr.listen(stderr.addAll);
+      process.stdout.listen(stdout.addAll);
+
+      // Ensure that no bytes have been received at process exit.
+      await process.exitCode;
+      expect(stderr, isEmpty);
+      expect(stdout, isEmpty);
+
+      // Flush all remaining async work. Ensure stderr, stdout is received.
+      await Future<void>.delayed(Duration.zero);
+      expect(stderr, 'stderr'.codeUnits);
+      expect(stdout, 'stdout'.codeUnits);
+    });
+  });
+}


### PR DESCRIPTION
Because this class has some subtle behaviour with regards to control of
exit timing and when and how it streams data to stderr and stdout, it's
worth adding unit tests for this class directly, as well as (in a
followup patch) for FakeProcessManager.

This is additional testing relating to refactoring landed in:
https://github.com/flutter/flutter/pull/103947

Issue: https://github.com/flutter/flutter/issues/102451


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
