### PR TITLE
Make macos_chrome_dev_mode run host-only without device

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3324,13 +3324,13 @@ targets:
       task_name: large_image_changer_perf_ios
     scheduler: luci
 
-  - name: Mac_ios macos_chrome_dev_mode
+  - name: Mac macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
       tags: >
-        ["devicelab", "ios", "mac"]
+        ["devicelab", "hostonly"]
       task_name: macos_chrome_dev_mode
     scheduler: luci
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3327,7 +3327,6 @@ targets:
   - name: Mac macos_chrome_dev_mode
     bringup: true
     recipe: devicelab/devicelab_drone
-    presubmit: false
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3327,6 +3327,7 @@ targets:
   - name: Mac macos_chrome_dev_mode
     bringup: true
     recipe: devicelab/devicelab_drone
+    presubmit: false
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3325,6 +3325,7 @@ targets:
     scheduler: luci
 
   - name: Mac macos_chrome_dev_mode
+    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Remove tethered iOS requirement to allow this test to run on any idle Mac.

Filed https://github.com/flutter/flutter/issues/104034 to also allow `Mac_arm64_ios macos_chrome_dev_mode` to become host-only as well.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
