### PR TITLE
Make RenderSliverGrid more accurately report overflow

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -670,7 +670,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       paintExtent: paintExtent,
       maxPaintExtent: estimatedTotalExtent,
       cacheExtent: cacheExtent,
-      hasVisualOverflow: estimatedTotalExtent > paintExtent || constraints.scrollOffset > 0.0 || constraints.overlap < 0.0,
+      hasVisualOverflow: estimatedTotalExtent > paintExtent || constraints.scrollOffset > 0.0 || constraints.overlap != 0.0,
     );
 
     // We may have started the layout while scrolled to the end, which

--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -654,7 +654,6 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       leadingScrollOffset: leadingScrollOffset,
       trailingScrollOffset: trailingScrollOffset,
     );
-
     final double paintExtent = calculatePaintOffset(
       constraints,
       from: math.min(constraints.scrollOffset, leadingScrollOffset),
@@ -671,8 +670,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       paintExtent: paintExtent,
       maxPaintExtent: estimatedTotalExtent,
       cacheExtent: cacheExtent,
-      // Conservative to avoid complexity.
-      hasVisualOverflow: true,
+      hasVisualOverflow: estimatedTotalExtent > paintExtent || constraints.scrollOffset > 0.0 || constraints.overlap < 0.0,
     );
 
     // We may have started the layout while scrolled to the end, which

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -644,13 +644,50 @@ void main() {
     expect(counters[4], 2);
   });
 
+  testWidgets('GridView does not report visual overflow unnecessarily', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: GridView(
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
+          children: <Widget>[
+            Container(height: 200.0),
+          ],
+        ),
+      ),
+    );
+
+    // 1st, check that the render object has received the default clip behavior.
+    final RenderViewport renderObject = tester.allRenderObjects.whereType<RenderViewport>().first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    // The context will get Clip.none because there is no actual visual overflow.
+    final TestClipPaintingContext context = TestClipPaintingContext();
+    renderObject.paint(context, Offset.zero);
+    expect(context.clipBehavior, equals(Clip.none));
+  });
+
   testWidgets('GridView respects clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: GridView(
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
-          children: <Widget>[Container(height: 2000.0)],
+          children: <Widget>[
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+          ],
         ),
       ),
     );
@@ -671,7 +708,21 @@ void main() {
         child: GridView(
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
           clipBehavior: Clip.antiAlias,
-          children: <Widget>[Container(height: 2000.0)],
+          children: <Widget>[
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+            Container(height: 2000.0),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/104046

Existing test needed to be updated because it does not actually cause overflow - even though the container height is 2000, it's getting clipped by the individual grid square - _not_ by the whole grid itself. Adding more squares to the grid causes overflow to happen.