### PR TITLE
Bump dartdoc to 5.1.2

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 5.0.1
+    "$DART" pub global activate dartdoc 5.1.2
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
See https://pub.dev/packages/dartdoc/changelog#510 for changes, most notably:

> Fixed the `{@youtube}` directive to respect the provided width and height. (https://github.com/flutter/flutter/issues/3030)

Fixes https://github.com/flutter/flutter/issues/90302.

Supersedes https://github.com/flutter/flutter/pull/104010 and https://github.com/flutter/flutter/pull/104094.