### PR TITLE
Deprecating `Shorcuts.of` and `Shortctus.maybeOf`

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -808,11 +808,12 @@ class ShortcutManager extends ChangeNotifier with Diagnosticable {
 ///  * [Action], a class for defining an invocation of a user action.
 ///  * [CallbackAction], a class for creating an action from a callback.
 class Shortcuts extends StatefulWidget {
-  /// Creates a const [Shortcuts] widget that creates its own manager.
+  /// Creates a const [Shortcuts] widget that owns the map of shortcuts and
+  /// creates its own manager.
   ///
   /// The `manager` argument is deprecated. Use the [Shortcuts.manager]
   /// constructor instead. Once the deprecated argument is removed, [manager]
-  /// will always be null when this constructor is used.
+  /// will always return null when this constructor is used.
   ///
   /// The [child] and [shortcuts] arguments are required.
   const Shortcuts({
@@ -830,11 +831,13 @@ class Shortcuts extends StatefulWidget {
        assert(shortcuts != null),
        assert(child != null);
 
-  /// Constructs a const [Shortcuts] widget that allows the [manager] to
-  /// determine by itself what the map of shortcuts is.
+  /// Constructs a const [Shortcuts] widget that uses the [manager] to
+  /// own the map of shortcuts.
   ///
-  /// If this constructor is used, [shortcuts] will be empty and ignored, and
-  /// the [manager] will determine which shortcuts are in effect.
+  /// If this constructor is used, [shortcuts] will return the contents of
+  /// [ShortcutManager.shortcuts].
+  ///
+  /// The [child] and [manager] arguments are required.
   const Shortcuts.manager({
     super.key,
     required ShortcutManager this.manager,

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -637,10 +637,12 @@ class _ActivatorIntentPair with Diagnosticable {
   }
 }
 
-/// A manager of keyboard shortcut bindings.
+/// A manager of keyboard shortcut bindings used by [Shortcuts] to handle key
+/// events.
 ///
-/// A [ShortcutManager] is obtained by calling [Shortcuts.of] on the context of
-/// the widget that you want to find a manager for.
+/// Typically, a [Shortcuts] widget supplies its own manager, but in uncommon
+/// cases where overriding the usual shortcut manager behavior is desired, a
+/// subclassed [ShortcutManager] may be supplied.
 class ShortcutManager extends ChangeNotifier with Diagnosticable {
   /// Constructs a [ShortcutManager].
   ShortcutManager({
@@ -853,6 +855,10 @@ class Shortcuts extends StatefulWidget {
   /// Returns the [ShortcutManager] that most tightly encloses the given
   /// [BuildContext].
   ///
+  /// This is deprecated, since modifying the state of a [ShortcutManager]
+  /// outside of a [Shortcuts] implementation could be overwritten by the
+  /// [Shortcuts] widget at any time, and isn't especially useful.
+  ///
   /// If no [Shortcuts] widget encloses the context given, will assert in debug
   /// mode and throw an exception in release mode.
   ///
@@ -860,6 +866,11 @@ class Shortcuts extends StatefulWidget {
   ///
   ///  * [maybeOf], which is similar to this function, but will return null if
   ///    it doesn't find a [Shortcuts] ancestor.
+  @Deprecated(
+    'Finding a ShortcutsManager in this way will no longer be supported. '
+    'This feature was deprecated after v3.1.0-0.0.pre.',
+  )
+  // When this is finally removed, _ShortcutsMarker can also be removed.
   static ShortcutManager of(BuildContext context) {
     assert(context != null);
     final _ShortcutsMarker? inherited = context.dependOnInheritedWidgetOfExactType<_ShortcutsMarker>();
@@ -883,6 +894,10 @@ class Shortcuts extends StatefulWidget {
   /// Returns the [ShortcutManager] that most tightly encloses the given
   /// [BuildContext].
   ///
+  /// This is deprecated, since modifying the state of a [ShortcutManager]
+  /// outside of a [Shortcuts] implementation could be overwritten by the
+  /// [Shortcuts] widget at any time, and isn't especially useful.
+  ///
   /// If no [Shortcuts] widget encloses the context given, will return null.
   ///
   /// See also:
@@ -890,6 +905,11 @@ class Shortcuts extends StatefulWidget {
   ///  * [of], which is similar to this function, but returns a non-nullable
   ///    result, and will throw an exception if it doesn't find a [Shortcuts]
   ///    ancestor.
+  @Deprecated(
+    'Finding a ShortcutsManager in this way will no longer be supported. '
+    'This feature was deprecated after v3.1.0-0.0.pre.',
+  )
+  // When this is finally removed, _ShortcutsMarker can also be removed.
   static ShortcutManager? maybeOf(BuildContext context) {
     assert(context != null);
     final _ShortcutsMarker? inherited = context.dependOnInheritedWidgetOfExactType<_ShortcutsMarker>();

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -817,7 +817,7 @@ class Shortcuts extends StatefulWidget {
   /// The [child] and [shortcuts] arguments are required.
   const Shortcuts({
     super.key,
-    required this.shortcuts,
+    required Map<ShortcutActivator, Intent> shortcuts,
     required this.child,
     this.debugLabel,
     @Deprecated(
@@ -826,11 +826,12 @@ class Shortcuts extends StatefulWidget {
     )
     this.manager,
   }) : _forceShortcutsOnManager = true,
+       _shortcuts = shortcuts,
        assert(shortcuts != null),
        assert(child != null);
 
-  /// Constructs a [Shortcuts] widget that allows the [manager] to determine by
-  /// itself what the map of shortcuts is.
+  /// Constructs a const [Shortcuts] widget that allows the [manager] to
+  /// determine by itself what the map of shortcuts is.
   ///
   /// If this constructor is used, [shortcuts] will be empty and ignored, and
   /// the [manager] will determine which shortcuts are in effect.
@@ -840,13 +841,16 @@ class Shortcuts extends StatefulWidget {
     required this.child,
     this.debugLabel,
   }) : _forceShortcutsOnManager = false,
-       shortcuts = const <ShortcutActivator, Intent>{};
+       _shortcuts = const <ShortcutActivator, Intent>{},
+       assert(manager != null),
+       assert(child != null);
 
   // Whether or not this instance should force the shortcuts property into the
   // manager, or let it manage them itself.
   // TODO(gspencergoog): Once the manager constructor parameter is removed, then
-  // we can use whether or not the manager property is null to determine how to
-  // treat it, and this bool can go away.
+  //                     we can use whether or not the manager property is null
+  //                     to determine how to treat it, and this bool can go
+  //                     away. https://github.com/flutter/flutter/issues/104129
   final bool _forceShortcutsOnManager;
 
   /// The [ShortcutManager] that will manage the mapping between key
@@ -866,7 +870,8 @@ class Shortcuts extends StatefulWidget {
   /// in here (e.g. a final variable from your widget class) instead of defining
   /// it inline in the build function.
   /// {@endtemplate}
-  final Map<ShortcutActivator, Intent> shortcuts;
+  Map<ShortcutActivator, Intent> get shortcuts => _forceShortcutsOnManager ? _shortcuts : manager!.shortcuts;
+  final Map<ShortcutActivator, Intent> _shortcuts;
 
   /// The child widget for this [Shortcuts] widget.
   ///
@@ -901,7 +906,7 @@ class Shortcuts extends StatefulWidget {
     'This feature was deprecated after v3.1.0-0.0.pre.',
   )
   // TODO(gspencergoog): When this is finally removed, _ShortcutsMarker can also
-  // be removed.
+  //                     be removed. https://github.com/flutter/flutter/issues/104129
   static ShortcutManager of(BuildContext context) {
     assert(context != null);
     final _ShortcutsMarker? inherited = context.dependOnInheritedWidgetOfExactType<_ShortcutsMarker>();
@@ -941,7 +946,7 @@ class Shortcuts extends StatefulWidget {
     'This feature was deprecated after v3.1.0-0.0.pre.',
   )
   // TODO(gspencergoog): When this is finally removed, _ShortcutsMarker can also
-  // be removed.
+  //                     be removed. https://github.com/flutter/flutter/issues/104129
   static ShortcutManager? maybeOf(BuildContext context) {
     assert(context != null);
     final _ShortcutsMarker? inherited = context.dependOnInheritedWidgetOfExactType<_ShortcutsMarker>();

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -532,13 +532,31 @@ void main() {
 
   group(Shortcuts, () {
     testWidgets('Default constructed Shortcuts has empty shortcuts', (WidgetTester tester) async {
-      final ShortcutManager manager = ShortcutManager();
-      expect(manager.shortcuts, isNotNull);
-      expect(manager.shortcuts, isEmpty);
       const Shortcuts shortcuts = Shortcuts(shortcuts: <LogicalKeySet, Intent>{}, child: SizedBox());
       await tester.pumpWidget(shortcuts);
       expect(shortcuts.shortcuts, isNotNull);
       expect(shortcuts.shortcuts, isEmpty);
+    });
+    testWidgets('Default constructed Shortcuts.manager has empty shortcuts', (WidgetTester tester) async {
+      final ShortcutManager manager = ShortcutManager();
+      expect(manager.shortcuts, isNotNull);
+      expect(manager.shortcuts, isEmpty);
+      final Shortcuts shortcuts = Shortcuts.manager(manager: manager, child: const SizedBox());
+      await tester.pumpWidget(shortcuts);
+      expect(shortcuts.shortcuts, isNotNull);
+      expect(shortcuts.shortcuts, isEmpty);
+    });
+    testWidgets('Shortcuts.manager passes on shortcuts', (WidgetTester tester) async {
+      final Map<LogicalKeySet, Intent> testShortcuts = <LogicalKeySet, Intent>{
+      LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
+      };
+      final ShortcutManager manager = ShortcutManager(shortcuts: testShortcuts);
+      expect(manager.shortcuts, isNotNull);
+      expect(manager.shortcuts, equals(testShortcuts));
+      final Shortcuts shortcuts = Shortcuts.manager(manager: manager, child: const SizedBox());
+      await tester.pumpWidget(shortcuts);
+      expect(shortcuts.shortcuts, isNotNull);
+      expect(shortcuts.shortcuts, equals(testShortcuts));
     });
     testWidgets('Shortcuts.of and maybeOf find shortcuts', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();


### PR DESCRIPTION
## Description

This deprecates `Shorcuts.of` and `Shortctus.maybeOf` because they're not especially useful, since the only thing you can really set on a `ShortcutManager` is the shortcuts, and the `Shortcuts` widget that you give it to manages those, so if it rebuilds, it overwrites what you set.

Once this is finally removed, it will also eliminate an `InheritedWidget` for each `Shortcuts` widget.

## Tests
- Added tests for Shortcuts.manager