### PR TITLE
Use libraryFilters flag to speed up coverage collection

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -114,14 +114,7 @@ Future<void> run(List<String> args) async {
     if (argResults['coverage'] as bool) {
       collector = CoverageCollector(
         packagesPath: globals.fs.path.normalize(globals.fs.path.absolute(argResults[_kOptionPackages] as String)),
-        libraryPredicate: (String libraryName) {
-          // If we have a specified coverage directory then accept all libraries.
-          if (coverageDirectory != null) {
-            return true;
-          }
-          final String projectName = FlutterProject.current().manifest.appName;
-          return libraryName.contains(projectName);
-        });
+        libraryNames: {FlutterProject.current().manifest.appName});
       if (!argResults.options.contains(_kOptionTestDirectory)) {
         throwToolExit('Use of --coverage requires setting --test-directory');
       }

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -114,8 +114,8 @@ Future<void> run(List<String> args) async {
     if (argResults['coverage'] as bool) {
       // If we have a specified coverage directory then accept all libraries by
       // setting libraryNames to null.
-      final libraryNames = coverageDirectory != null ? null :
-          {FlutterProject.current().manifest.appName};
+      final Set<String> libraryNames = coverageDirectory != null ? null :
+          <String>{FlutterProject.current().manifest.appName};
       collector = CoverageCollector(
         packagesPath: globals.fs.path.normalize(globals.fs.path.absolute(argResults[_kOptionPackages] as String)),
         libraryNames: libraryNames);

--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -112,9 +112,13 @@ Future<void> run(List<String> args) async {
     Directory testDirectory;
     CoverageCollector collector;
     if (argResults['coverage'] as bool) {
+      // If we have a specified coverage directory then accept all libraries by
+      // setting libraryNames to null.
+      final libraryNames = coverageDirectory != null ? null :
+          {FlutterProject.current().manifest.appName};
       collector = CoverageCollector(
         packagesPath: globals.fs.path.normalize(globals.fs.path.absolute(argResults[_kOptionPackages] as String)),
-        libraryNames: {FlutterProject.current().manifest.appName});
+        libraryNames: libraryNames);
       if (!argResults.options.contains(_kOptionTestDirectory)) {
         throwToolExit('Use of --coverage requires setting --test-directory');
       }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -380,7 +380,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       final String projectName = flutterProject.manifest.appName;
       collector = CoverageCollector(
         verbose: !machine,
-        libraryPredicate: (String libraryName) => libraryName.contains(projectName),
+        libraryNames: {projectName},
         packagesPath: buildInfo.packagesPath
       );
     }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -380,7 +380,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       final String projectName = flutterProject.manifest.appName;
       collector = CoverageCollector(
         verbose: !machine,
-        libraryNames: {projectName},
+        libraryNames: <String>{projectName},
         packagesPath: buildInfo.packagesPath
       );
     }

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -259,12 +259,16 @@ Future<Map<String, dynamic>> _getAllCoverage(
   final vm_service.VM vm = await service.getVM();
   final List<Map<String, dynamic>> coverage = <Map<String, dynamic>>[];
   bool libraryPredicate(String libraryName) {
-    if (libraryNames == null) return true;
-    final uri = Uri.parse(libraryName);
-    if (uri.scheme != 'package') return false;
-    final scope = uri.path.split('/').first;
+    if (libraryNames == null) {
+      return true;
+    }
+    final Uri uri = Uri.parse(libraryName);
+    if (uri.scheme != 'package') {
+      return false;
+    }
+    final String scope = uri.path.split('/').first;
     return libraryNames.contains(scope);
-  };
+  }
   for (final vm_service.IsolateRef isolateRef in vm.isolates) {
     if (isolateRef.isSystemIsolate) {
       continue;
@@ -276,9 +280,13 @@ Future<Map<String, dynamic>> _getAllCoverage(
           forceCompile: true,
           reportLines: true,
           libraryFilters: libraryNames == null ? null : List<String>.from(
-              libraryNames.map((name) => 'package:$name/')),
+              libraryNames.map((String name) => 'package:$name/')),
         );
-      _buildCoverageMap({}, [sourceReport], coverage);
+      _buildCoverageMap(
+          <String, vm_service.Script>{},
+          <vm_service.SourceReport>[sourceReport],
+          coverage,
+        );
     } else {
       vm_service.ScriptList scriptList;
       try {

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -249,18 +249,13 @@ Future<Map<String, dynamic>> collect(Uri serviceUri, Set<String> libraryNames, {
   return result;
 }
 
-bool _versionCheck(vm_service.Version version, int minMajor, int minMinor) {
-  return version.major > minMajor || (version.major == minMajor && version.minor >= minMinor);
-}
-
 Future<Map<String, dynamic>> _getAllCoverage(
   vm_service.VmService service,
   Set<String> libraryNames,
   bool forceSequential,
 ) async {
   final vm_service.Version version = await service.getVersion();
-  final reportLines = _versionCheck(version, 3, 51);
-  final libraryFilters = _versionCheck(version, 3, 57);
+  final bool libraryFilters = (version.major == 3 && version.minor >= 57) || version.major > 3;
   final vm_service.VM vm = await service.getVM();
   final List<Map<String, dynamic>> coverage = <Map<String, dynamic>>[];
   bool libraryPredicate(String libraryName) {
@@ -275,7 +270,6 @@ Future<Map<String, dynamic>> _getAllCoverage(
       continue;
     }
     if (libraryFilters) {
-      assert(reportLines);
       final vm_service.SourceReport sourceReport = await service.getSourceReport(
           isolateRef.id,
           <String>['Coverage'],
@@ -284,7 +278,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
           libraryFilters: libraryNames == null ? null : List<String>.from(
               libraryNames.map((name) => 'package:$name/')),
         );
-      _buildCoverageMap({}, [sourceReport], coverage, true);
+      _buildCoverageMap({}, [sourceReport], coverage);
     } else {
       vm_service.ScriptList scriptList;
       try {
@@ -310,7 +304,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
           <String>['Coverage'],
           scriptId: scriptId,
           forceCompile: true,
-          reportLines: reportLines ? true : null,
+          reportLines: true,
         )
         .then((vm_service.SourceReport report) {
           sourceReports.add(report);
@@ -319,19 +313,9 @@ Future<Map<String, dynamic>> _getAllCoverage(
           await null;
         }
         futures.add(getSourceReport);
-        if (reportLines) {
-          continue;
-        }
-        final Future<void> getObject = service
-          .getObject(isolateRef.id, scriptId)
-          .then((vm_service.Obj response) {
-            final vm_service.Script script = response as vm_service.Script;
-            scripts[scriptId] = script;
-          });
-        futures.add(getObject);
       }
       await Future.wait(futures);
-      _buildCoverageMap(scripts, sourceReports, coverage, reportLines);
+      _buildCoverageMap(scripts, sourceReports, coverage);
     }
   }
   return <String, dynamic>{'type': 'CodeCoverage', 'coverage': coverage};
@@ -342,7 +326,6 @@ void _buildCoverageMap(
   Map<String, vm_service.Script> scripts,
   List<vm_service.SourceReport> sourceReports,
   List<Map<String, dynamic>> coverage,
-  bool reportLines,
 ) {
   final Map<String, Map<int, int>> hitMaps = <String, Map<int, int>>{};
   for (final vm_service.SourceReport sourceReport  in sourceReports) {
@@ -359,24 +342,14 @@ void _buildCoverageMap(
       final Map<int, int> hitMap = hitMaps[uri];
       final List<int> hits = coverage.hits;
       final List<int> misses = coverage.misses;
-      final List<dynamic> tokenPositions = scripts[scriptRef.id]?.tokenPosTable;
-      // The token positions can be null if the script has no lines that may be
-      // covered. It will also be null if reportLines is true.
-      if (tokenPositions == null && !reportLines) {
-        continue;
-      }
       if (hits != null) {
-        for (final int hit in hits) {
-          final int line =
-              reportLines ? hit : _lineAndColumn(hit, tokenPositions)[0];
+        for (final int line in hits) {
           final int current = hitMap[line] ?? 0;
           hitMap[line] = current + 1;
         }
       }
       if (misses != null) {
-        for (final int miss in misses) {
-          final int line =
-              reportLines ? miss : _lineAndColumn(miss, tokenPositions)[0];
+        for (final int line in misses) {
           hitMap[line] ??= 0;
         }
       }
@@ -385,29 +358,6 @@ void _buildCoverageMap(
   hitMaps.forEach((String uri, Map<int, int> hitMap) {
     coverage.add(_toScriptCoverageJson(uri, hitMap));
   });
-}
-
-// Binary search the token position table for the line and column which
-// corresponds to each token position.
-// The format of this table is described in https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service.md#script
-List<int> _lineAndColumn(int position, List<dynamic> tokenPositions) {
-  int min = 0;
-  int max = tokenPositions.length;
-  while (min < max) {
-    final int mid = min + ((max - min) >> 1);
-    final List<int> row = (tokenPositions[mid] as List<dynamic>).cast<int>();
-    if (row[1] > position) {
-      max = mid;
-    } else {
-      for (int i = 1; i < row.length; i += 2) {
-        if (row[i] == position) {
-          return <int>[row.first, row[i + 1]];
-        }
-      }
-      min = mid + 1;
-    }
-  }
-  throw StateError('Unreachable');
 }
 
 // Returns a JSON hit map backward-compatible with pre-1.16.0 SDKs.

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -31,7 +31,8 @@ class CoverageCollector extends TestWatcher {
   /// Map of file path to coverage hit map for that file.
   Map<String, coverage.HitMap> _globalHitmap;
 
-  /// The names of the libraries to gather coverage for.
+  /// The names of the libraries to gather coverage for. If null, all libraries
+  /// will be accepted.
   Set<String> libraryNames;
 
   @override
@@ -263,6 +264,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
   final vm_service.VM vm = await service.getVM();
   final List<Map<String, dynamic>> coverage = <Map<String, dynamic>>[];
   bool libraryPredicate(String libraryName) {
+    if (libraryNames == null) return true;
     final uri = Uri.parse(libraryName);
     if (uri.scheme != 'package') return false;
     final scope = uri.path.split('/').first;
@@ -279,7 +281,7 @@ Future<Map<String, dynamic>> _getAllCoverage(
           <String>['Coverage'],
           forceCompile: true,
           reportLines: true,
-          libraryFilters: List<String>.from(
+          libraryFilters: libraryNames == null ? null : List<String>.from(
               libraryNames.map((name) => 'package:$name/')),
         );
       _buildCoverageMap({}, [sourceReport], coverage, true);

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -151,6 +151,158 @@ void main() {
     expect(fakeVmServiceHost.hasRemainingExpectations, false);
   });
 
+  testWithoutContext('Coverage collector with null libraryNames accepts all libraries', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        FakeVmServiceRequest(
+          method: 'getVersion',
+          jsonResponse: Version(major: 3, minor: 50).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getVM',
+          jsonResponse: (VM.parse(<String, Object>{})
+            ..isolates = <IsolateRef>[
+              IsolateRef.parse(<String, Object>{
+                'id': '1',
+              }),
+            ]
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getScripts',
+          args: <String, Object>{
+            'isolateId': '1',
+          },
+          jsonResponse: ScriptList(scripts: <ScriptRef>[
+            ScriptRef(uri: 'package:foo/foo.dart', id: '1'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: '2'),
+          ]).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'scriptId': '1',
+            'forceCompile': true,
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[],
+                  misses: <int>[],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'package:foo/foo.dart',
+                id: '1',
+              ),
+            ],
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getObject',
+          args: <String, Object>{
+            'isolateId': '1',
+            'objectId': '1',
+          },
+          jsonResponse: Script(
+            uri: 'package:foo/foo.dart',
+            id: '1',
+            library: LibraryRef(name: '', id: '1111', uri: 'foo.dart'),
+            tokenPosTable: <List<int>>[],
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'scriptId': '2',
+            'forceCompile': true,
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[],
+                  misses: <int>[],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'package:bar/bar.dart',
+                id: '2',
+              ),
+            ],
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getObject',
+          args: <String, Object>{
+            'isolateId': '1',
+            'objectId': '2',
+          },
+          jsonResponse: Script(
+            uri: 'package:bar/bar.dart',
+            id: '2',
+            library: LibraryRef(name: '', id: '1111', uri: 'bar.dart'),
+            tokenPosTable: <List<int>>[],
+          ).toJson(),
+        ),
+      ],
+    );
+
+    final Map<String, Object> result = await collect(
+      null,
+      null,
+      connector: (Uri uri) async {
+        return fakeVmServiceHost.vmService;
+      },
+    );
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Object>[
+        <String, Object>{
+          'source': 'package:foo/foo.dart',
+          'script': <String, Object>{
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
+            'uri': 'package:foo/foo.dart',
+            '_kind': 'library',
+          },
+          'hits': <Object>[],
+        },
+        <String, Object>{
+          'source': 'package:bar/bar.dart',
+          'script': <String, Object>{
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/package%3Abar%2Fbar.dart',
+            'uri': 'package:bar/bar.dart',
+            '_kind': 'library',
+          },
+          'hits': <Object>[],
+        },
+      ],
+    });
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
+
   testWithoutContext('Coverage collector skips loading Script objects when reportLines is available', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
@@ -291,6 +443,82 @@ void main() {
     final Map<String, Object> result = await collect(
       null,
       {'foo'},
+      connector: (Uri uri) async {
+        return fakeVmServiceHost.vmService;
+      },
+    );
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Object>[
+        <String, Object>{
+          'source': 'package:foo/foo.dart',
+          'script': <String, Object>{
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
+            'uri': 'package:foo/foo.dart',
+            '_kind': 'library',
+          },
+          'hits': <Object>[1, 1, 3, 1, 2, 0],
+        },
+      ],
+    });
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
+
+  testWithoutContext('Coverage collector with libraryFilters and null libraryNames', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        FakeVmServiceRequest(
+          method: 'getVersion',
+          jsonResponse: Version(major: 3, minor: 57).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getVM',
+          jsonResponse: (VM.parse(<String, Object>{})
+            ..isolates = <IsolateRef>[
+              IsolateRef.parse(<String, Object>{
+                'id': '1',
+              }),
+            ]
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'forceCompile': true,
+            'reportLines': true,
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[1, 3],
+                  misses: <int>[2],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'package:foo/foo.dart',
+                id: '1',
+              ),
+            ],
+          ).toJson(),
+        ),
+      ],
+    );
+
+    final Map<String, Object> result = await collect(
+      null,
+      null,
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     final Map<String, Object> result = await collect(
       null,
-      {'foo'},
+      <String>{'foo'},
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
@@ -114,7 +114,7 @@ void main() {
 
     final Map<String, Object> result = await collect(
       null,
-      {'foo'},
+      <String>{'foo'},
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
@@ -319,7 +319,7 @@ void main() {
 
     final Map<String, Object> result = await collect(
       null,
-      {'foo'},
+      <String>{'foo'},
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -16,7 +16,7 @@ void main() {
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
           method: 'getVersion',
-          jsonResponse: Version(major: 3, minor: 50).toJson(),
+          jsonResponse: Version(major: 3, minor: 51).toJson(),
         ),
         FakeVmServiceRequest(
           method: 'getVM',
@@ -53,257 +53,6 @@ void main() {
   });
 
   testWithoutContext('Coverage collector processes coverage and script data', () async {
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
-      requests: <VmServiceExpectation>[
-        FakeVmServiceRequest(
-          method: 'getVersion',
-          jsonResponse: Version(major: 3, minor: 50).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getVM',
-          jsonResponse: (VM.parse(<String, Object>{})
-            ..isolates = <IsolateRef>[
-              IsolateRef.parse(<String, Object>{
-                'id': '1',
-              }),
-            ]
-          ).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getScripts',
-          args: <String, Object>{
-            'isolateId': '1',
-          },
-          jsonResponse: ScriptList(scripts: <ScriptRef>[
-            ScriptRef(uri: 'package:foo/foo.dart', id: '1'),
-            ScriptRef(uri: 'package:bar/bar.dart', id: '2'),
-          ]).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getSourceReport',
-          args: <String, Object>{
-            'isolateId': '1',
-            'reports': <Object>['Coverage'],
-            'scriptId': '1',
-            'forceCompile': true,
-          },
-          jsonResponse: SourceReport(
-            ranges: <SourceReportRange>[
-              SourceReportRange(
-                scriptIndex: 0,
-                startPos: 0,
-                endPos: 0,
-                compiled: true,
-                coverage: SourceReportCoverage(
-                  hits: <int>[],
-                  misses: <int>[],
-                ),
-              ),
-            ],
-            scripts: <ScriptRef>[
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: '1',
-              ),
-            ],
-          ).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getObject',
-          args: <String, Object>{
-            'isolateId': '1',
-            'objectId': '1',
-          },
-          jsonResponse: Script(
-            uri: 'package:foo/foo.dart',
-            id: '1',
-            library: LibraryRef(name: '', id: '1111', uri: 'foo.dart'),
-            tokenPosTable: <List<int>>[],
-          ).toJson(),
-        ),
-      ],
-    );
-
-    final Map<String, Object> result = await collect(
-      null,
-      {'foo'},
-      connector: (Uri uri) async {
-        return fakeVmServiceHost.vmService;
-      },
-    );
-
-    expect(result, <String, Object>{
-      'type': 'CodeCoverage',
-      'coverage': <Object>[
-        <String, Object>{
-          'source': 'package:foo/foo.dart',
-          'script': <String, Object>{
-            'type': '@Script',
-            'fixedId': true,
-            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
-            'uri': 'package:foo/foo.dart',
-            '_kind': 'library',
-          },
-          'hits': <Object>[],
-        },
-      ],
-    });
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
-  });
-
-  testWithoutContext('Coverage collector with null libraryNames accepts all libraries', () async {
-    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
-      requests: <VmServiceExpectation>[
-        FakeVmServiceRequest(
-          method: 'getVersion',
-          jsonResponse: Version(major: 3, minor: 50).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getVM',
-          jsonResponse: (VM.parse(<String, Object>{})
-            ..isolates = <IsolateRef>[
-              IsolateRef.parse(<String, Object>{
-                'id': '1',
-              }),
-            ]
-          ).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getScripts',
-          args: <String, Object>{
-            'isolateId': '1',
-          },
-          jsonResponse: ScriptList(scripts: <ScriptRef>[
-            ScriptRef(uri: 'package:foo/foo.dart', id: '1'),
-            ScriptRef(uri: 'package:bar/bar.dart', id: '2'),
-          ]).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getSourceReport',
-          args: <String, Object>{
-            'isolateId': '1',
-            'reports': <Object>['Coverage'],
-            'scriptId': '1',
-            'forceCompile': true,
-          },
-          jsonResponse: SourceReport(
-            ranges: <SourceReportRange>[
-              SourceReportRange(
-                scriptIndex: 0,
-                startPos: 0,
-                endPos: 0,
-                compiled: true,
-                coverage: SourceReportCoverage(
-                  hits: <int>[],
-                  misses: <int>[],
-                ),
-              ),
-            ],
-            scripts: <ScriptRef>[
-              ScriptRef(
-                uri: 'package:foo/foo.dart',
-                id: '1',
-              ),
-            ],
-          ).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getObject',
-          args: <String, Object>{
-            'isolateId': '1',
-            'objectId': '1',
-          },
-          jsonResponse: Script(
-            uri: 'package:foo/foo.dart',
-            id: '1',
-            library: LibraryRef(name: '', id: '1111', uri: 'foo.dart'),
-            tokenPosTable: <List<int>>[],
-          ).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getSourceReport',
-          args: <String, Object>{
-            'isolateId': '1',
-            'reports': <Object>['Coverage'],
-            'scriptId': '2',
-            'forceCompile': true,
-          },
-          jsonResponse: SourceReport(
-            ranges: <SourceReportRange>[
-              SourceReportRange(
-                scriptIndex: 0,
-                startPos: 0,
-                endPos: 0,
-                compiled: true,
-                coverage: SourceReportCoverage(
-                  hits: <int>[],
-                  misses: <int>[],
-                ),
-              ),
-            ],
-            scripts: <ScriptRef>[
-              ScriptRef(
-                uri: 'package:bar/bar.dart',
-                id: '2',
-              ),
-            ],
-          ).toJson(),
-        ),
-        FakeVmServiceRequest(
-          method: 'getObject',
-          args: <String, Object>{
-            'isolateId': '1',
-            'objectId': '2',
-          },
-          jsonResponse: Script(
-            uri: 'package:bar/bar.dart',
-            id: '2',
-            library: LibraryRef(name: '', id: '1111', uri: 'bar.dart'),
-            tokenPosTable: <List<int>>[],
-          ).toJson(),
-        ),
-      ],
-    );
-
-    final Map<String, Object> result = await collect(
-      null,
-      null,
-      connector: (Uri uri) async {
-        return fakeVmServiceHost.vmService;
-      },
-    );
-
-    expect(result, <String, Object>{
-      'type': 'CodeCoverage',
-      'coverage': <Object>[
-        <String, Object>{
-          'source': 'package:foo/foo.dart',
-          'script': <String, Object>{
-            'type': '@Script',
-            'fixedId': true,
-            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
-            'uri': 'package:foo/foo.dart',
-            '_kind': 'library',
-          },
-          'hits': <Object>[],
-        },
-        <String, Object>{
-          'source': 'package:bar/bar.dart',
-          'script': <String, Object>{
-            'type': '@Script',
-            'fixedId': true,
-            'id': 'libraries/1/scripts/package%3Abar%2Fbar.dart',
-            'uri': 'package:bar/bar.dart',
-            '_kind': 'library',
-          },
-          'hits': <Object>[],
-        },
-      ],
-    });
-    expect(fakeVmServiceHost.hasRemainingExpectations, false);
-  });
-
-  testWithoutContext('Coverage collector skips loading Script objects when reportLines is available', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
       requests: <VmServiceExpectation>[
         FakeVmServiceRequest(
@@ -384,6 +133,134 @@ void main() {
             '_kind': 'library',
           },
           'hits': <Object>[1, 1, 3, 1, 2, 0],
+        },
+      ],
+    });
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
+
+  testWithoutContext('Coverage collector with null libraryNames accepts all libraries', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        FakeVmServiceRequest(
+          method: 'getVersion',
+          jsonResponse: Version(major: 3, minor: 51).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getVM',
+          jsonResponse: (VM.parse(<String, Object>{})
+            ..isolates = <IsolateRef>[
+              IsolateRef.parse(<String, Object>{
+                'id': '1',
+              }),
+            ]
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getScripts',
+          args: <String, Object>{
+            'isolateId': '1',
+          },
+          jsonResponse: ScriptList(scripts: <ScriptRef>[
+            ScriptRef(uri: 'package:foo/foo.dart', id: '1'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: '2'),
+          ]).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'scriptId': '1',
+            'forceCompile': true,
+            'reportLines': true,
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[1, 3],
+                  misses: <int>[2],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'package:foo/foo.dart',
+                id: '1',
+              ),
+            ],
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'scriptId': '2',
+            'forceCompile': true,
+            'reportLines': true,
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[47, 21],
+                  misses: <int>[32, 86],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'package:bar/bar.dart',
+                id: '2',
+              ),
+            ],
+          ).toJson(),
+        ),
+      ],
+    );
+
+    final Map<String, Object> result = await collect(
+      null,
+      null,
+      connector: (Uri uri) async {
+        return fakeVmServiceHost.vmService;
+      },
+    );
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Object>[
+        <String, Object>{
+          'source': 'package:foo/foo.dart',
+          'script': <String, Object>{
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
+            'uri': 'package:foo/foo.dart',
+            '_kind': 'library',
+          },
+          'hits': <Object>[1, 1, 3, 1, 2, 0],
+        },
+        <String, Object>{
+          'source': 'package:bar/bar.dart',
+          'script': <String, Object>{
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/package%3Abar%2Fbar.dart',
+            'uri': 'package:bar/bar.dart',
+            '_kind': 'library',
+          },
+          'hits': <Object>[47, 1, 21, 1, 32, 0, 86, 0],
         },
       ],
     });

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -42,7 +42,7 @@ void main() {
 
     final Map<String, Object> result = await collect(
       null,
-      (String predicate) => true,
+      {'foo'},
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
@@ -75,7 +75,8 @@ void main() {
             'isolateId': '1',
           },
           jsonResponse: ScriptList(scripts: <ScriptRef>[
-            ScriptRef(uri: 'foo.dart', id: '1'),
+            ScriptRef(uri: 'package:foo/foo.dart', id: '1'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: '2'),
           ]).toJson(),
         ),
         FakeVmServiceRequest(
@@ -101,7 +102,7 @@ void main() {
             ],
             scripts: <ScriptRef>[
               ScriptRef(
-                uri: 'foo.dart',
+                uri: 'package:foo/foo.dart',
                 id: '1',
               ),
             ],
@@ -114,7 +115,7 @@ void main() {
             'objectId': '1',
           },
           jsonResponse: Script(
-            uri: 'foo.dart',
+            uri: 'package:foo/foo.dart',
             id: '1',
             library: LibraryRef(name: '', id: '1111', uri: 'foo.dart'),
             tokenPosTable: <List<int>>[],
@@ -125,7 +126,7 @@ void main() {
 
     final Map<String, Object> result = await collect(
       null,
-      (String predicate) => true,
+      {'foo'},
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
@@ -135,12 +136,12 @@ void main() {
       'type': 'CodeCoverage',
       'coverage': <Object>[
         <String, Object>{
-          'source': 'foo.dart',
+          'source': 'package:foo/foo.dart',
           'script': <String, Object>{
             'type': '@Script',
             'fixedId': true,
-            'id': 'libraries/1/scripts/foo.dart',
-            'uri': 'foo.dart',
+            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
+            'uri': 'package:foo/foo.dart',
             '_kind': 'library',
           },
           'hits': <Object>[],
@@ -173,7 +174,8 @@ void main() {
             'isolateId': '1',
           },
           jsonResponse: ScriptList(scripts: <ScriptRef>[
-            ScriptRef(uri: 'foo.dart', id: '1'),
+            ScriptRef(uri: 'package:foo/foo.dart', id: '1'),
+            ScriptRef(uri: 'package:bar/bar.dart', id: '2'),
           ]).toJson(),
         ),
         FakeVmServiceRequest(
@@ -200,7 +202,7 @@ void main() {
             ],
             scripts: <ScriptRef>[
               ScriptRef(
-                uri: 'foo.dart',
+                uri: 'package:foo/foo.dart',
                 id: '1',
               ),
             ],
@@ -211,7 +213,7 @@ void main() {
 
     final Map<String, Object> result = await collect(
       null,
-      (String predicate) => true,
+      {'foo'},
       connector: (Uri uri) async {
         return fakeVmServiceHost.vmService;
       },
@@ -221,12 +223,89 @@ void main() {
       'type': 'CodeCoverage',
       'coverage': <Object>[
         <String, Object>{
-          'source': 'foo.dart',
+          'source': 'package:foo/foo.dart',
           'script': <String, Object>{
             'type': '@Script',
             'fixedId': true,
-            'id': 'libraries/1/scripts/foo.dart',
-            'uri': 'foo.dart',
+            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
+            'uri': 'package:foo/foo.dart',
+            '_kind': 'library',
+          },
+          'hits': <Object>[1, 1, 3, 1, 2, 0],
+        },
+      ],
+    });
+    expect(fakeVmServiceHost.hasRemainingExpectations, false);
+  });
+
+  testWithoutContext('Coverage collector with libraryFilters', () async {
+    final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(
+      requests: <VmServiceExpectation>[
+        FakeVmServiceRequest(
+          method: 'getVersion',
+          jsonResponse: Version(major: 3, minor: 57).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getVM',
+          jsonResponse: (VM.parse(<String, Object>{})
+            ..isolates = <IsolateRef>[
+              IsolateRef.parse(<String, Object>{
+                'id': '1',
+              }),
+            ]
+          ).toJson(),
+        ),
+        FakeVmServiceRequest(
+          method: 'getSourceReport',
+          args: <String, Object>{
+            'isolateId': '1',
+            'reports': <Object>['Coverage'],
+            'forceCompile': true,
+            'reportLines': true,
+            'libraryFilters': <Object>['package:foo/'],
+          },
+          jsonResponse: SourceReport(
+            ranges: <SourceReportRange>[
+              SourceReportRange(
+                scriptIndex: 0,
+                startPos: 0,
+                endPos: 0,
+                compiled: true,
+                coverage: SourceReportCoverage(
+                  hits: <int>[1, 3],
+                  misses: <int>[2],
+                ),
+              ),
+            ],
+            scripts: <ScriptRef>[
+              ScriptRef(
+                uri: 'package:foo/foo.dart',
+                id: '1',
+              ),
+            ],
+          ).toJson(),
+        ),
+      ],
+    );
+
+    final Map<String, Object> result = await collect(
+      null,
+      {'foo'},
+      connector: (Uri uri) async {
+        return fakeVmServiceHost.vmService;
+      },
+    );
+
+    expect(result, <String, Object>{
+      'type': 'CodeCoverage',
+      'coverage': <Object>[
+        <String, Object>{
+          'source': 'package:foo/foo.dart',
+          'script': <String, Object>{
+            'type': '@Script',
+            'fixedId': true,
+            'id': 'libraries/1/scripts/package%3Afoo%2Ffoo.dart',
+            'uri': 'package:foo/foo.dart',
             '_kind': 'library',
           },
           'hits': <Object>[1, 1, 3, 1, 2, 0],


### PR DESCRIPTION
Use the new libraryFilters flag in getSourceReport to speed up coverage collection.

This reduces the typical number of RPCs per test from 2N+3 (where N is the number of source files in the library) to just 3.

Time taken to run all the flutter tests:

| Without coverage | With coverage, no libraryFilters | With coverage, with libraryFilters |
| --- | --- | --- |
| 4:28 | 37:22 | 15:38 |

#100751