### PR TITLE
Adds new_gallery_impeller__transition_perf benchmark for Android

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1941,6 +1941,28 @@ targets:
       task_name: new_gallery__transition_perf
     scheduler: luci
 
+  - name: Linux_android new_gallery_impeller__transition_perf
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux"]
+      task_name: new_gallery_impeller__transition_perf
+    scheduler: luci
+
+  - name: Linux_samsung_s10 new_gallery_impeller__transition_perf
+    recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "android", "linux", "samsung", "s10"]
+      task_name: new_gallery_impeller__transition_perf
+    scheduler: luci
+
   - name: Linux_android picture_cache_perf__e2e_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -124,6 +124,7 @@
 /dev/devicelab/bin/tasks/integration_ui_textfield.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/microbenchmarks.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/new_gallery__transition_perf.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/new_gallery_impeller__transition_perf.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/picture_cache_perf__timeline_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/platform_channel_sample_test.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/platform_interaction_test.dart @stuartmorgan @flutter/plugin

--- a/dev/devicelab/bin/tasks/new_gallery_impeller__transition_perf.dart
+++ b/dev/devicelab/bin/tasks/new_gallery_impeller__transition_perf.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/framework/utils.dart';
+import 'package:flutter_devicelab/tasks/new_gallery.dart';
+import 'package:path/path.dart' as path;
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.android;
+
+  final Directory galleryParentDir = Directory.systemTemp.createTempSync('flutter_new_gallery_test.');
+  final Directory galleryDir = Directory(path.join(galleryParentDir.path, 'gallery'));
+
+  try {
+    await task(NewGalleryPerfTest(galleryDir, enableImpeller: true).run);
+  } finally {
+    rmTree(galleryParentDir);
+  }
+}


### PR DESCRIPTION
Work for Android is still in progress, but we can get this going in the meantime to help guide/track progress.