### PR TITLE
Add const `MaterialStatePropertyAll` class.

### DIFF
--- a/dev/tools/gen_defaults/lib/button_template.dart
+++ b/dev/tools/gen_defaults/lib/button_template.dart
@@ -64,7 +64,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<TextStyle?> get textStyle =>
-    MaterialStateProperty.all<TextStyle?>(${textStyle("$tokenGroup.label-text")});
+    MaterialStatePropertyAll<TextStyle?>(${textStyle("$tokenGroup.label-text")});
 
   @override
   MaterialStateProperty<Color?>? get backgroundColor =>${_backgroundColor()};

--- a/examples/api/lib/material/navigation_bar/navigation_bar.0.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.0.dart
@@ -143,7 +143,7 @@ class ListPage extends StatelessWidget {
               padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
               child: OutlinedButton(
                 style: buttonStyle.copyWith(
-                  backgroundColor: MaterialStateProperty.all<Color>(
+                  backgroundColor: MaterialStatePropertyAll<Color>(
                     Color.lerp(destination.color[100], Colors.white, index / itemCount)!
                   ),
                 ),

--- a/examples/api/lib/widgets/actions/actions.0.dart
+++ b/examples/api/lib/widgets/actions/actions.0.dart
@@ -101,7 +101,7 @@ class _SaveButtonState extends State<SaveButton> {
           icon: const Icon(Icons.save),
           label: Text('$savedValue'),
           style: ButtonStyle(
-            foregroundColor: MaterialStateProperty.all<Color>(
+            foregroundColor: MaterialStatePropertyAll<Color>(
               widget.valueNotifier.value ? Colors.red : Colors.green,
             ),
           ),

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -53,7 +53,7 @@ import 'theme_data.dart';
 /// ```dart
 /// ElevatedButton(
 ///   style: ButtonStyle(
-///     backgroundColor: MaterialStateProperty.all<Color>(Colors.green),
+///     backgroundColor: MaterialStatePropertyAll<Color>(Colors.green),
 ///   ),
 /// )
 /// ```

--- a/packages/flutter/lib/src/material/button_style_button.dart
+++ b/packages/flutter/lib/src/material/button_style_button.dart
@@ -148,10 +148,10 @@ abstract class ButtonStyleButton extends StatefulWidget {
     properties.add(DiagnosticsProperty<FocusNode>('focusNode', focusNode, defaultValue: null));
   }
 
-  /// Returns null if [value] is null, otherwise `MaterialStateProperty.all<T>(value)`.
+  /// Returns null if [value] is null, otherwise `MaterialStatePropertyAll<T>(value)`.
   ///
   /// A convenience method for subclasses.
-  static MaterialStateProperty<T>? allOrNull<T>(T? value) => value == null ? null : MaterialStateProperty.all<T>(value);
+  static MaterialStateProperty<T>? allOrNull<T>(T? value) => value == null ? null : MaterialStatePropertyAll<T>(value);
 
   /// Returns an interpolated value based on the [textScaleFactor] parameter:
   ///

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -172,7 +172,7 @@ class ElevatedButton extends ButtonStyleButton {
       : _ElevatedButtonDefaultMouseCursor(enabledMouseCursor, disabledMouseCursor);
 
     return ButtonStyle(
-      textStyle: MaterialStateProperty.all<TextStyle?>(textStyle),
+      textStyle: MaterialStatePropertyAll<TextStyle?>(textStyle),
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
       overlayColor: overlayColor,
@@ -468,7 +468,7 @@ class _ElevatedButtonWithIcon extends ElevatedButton {
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
     );
     return super.defaultStyleOf(context).copyWith(
-      padding: MaterialStateProperty.all<EdgeInsetsGeometry>(scaledPadding),
+      padding: MaterialStatePropertyAll<EdgeInsetsGeometry>(scaledPadding),
     );
   }
 }
@@ -510,7 +510,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<TextStyle?> get textStyle =>
-    MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+    MaterialStatePropertyAll<TextStyle?>(Theme.of(context).textTheme.labelLarge);
 
   @override
   MaterialStateProperty<Color?>? get backgroundColor =>

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -653,6 +653,10 @@ abstract class MaterialStateProperty<T> {
   /// to a single value for all states.
   ///
   /// If you need a const value, use [MaterialStatePropertyAll] directly.
+  ///
+  // TODO(darrenaustin): Deprecate this when we have the ability to create
+  // a dart fix that will replace this with MaterialStatePropertyAll:
+  // https://github.com/dart-lang/sdk/issues/49056.
   static MaterialStateProperty<T> all<T>(T value) => MaterialStatePropertyAll<T>(value);
 }
 

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -651,7 +651,9 @@ abstract class MaterialStateProperty<T> {
 
   /// Convenience method for creating a [MaterialStateProperty] that resolves
   /// to a single value for all states.
-  static MaterialStateProperty<T> all<T>(T value) => _MaterialStatePropertyAll<T>(value);
+  ///
+  /// If you need a const value, use [MaterialStatePropertyAll] directly.
+  static MaterialStateProperty<T> all<T>(T value) => MaterialStatePropertyAll<T>(value);
 }
 
 class _MaterialStatePropertyWith<T> implements MaterialStateProperty<T> {
@@ -663,14 +665,20 @@ class _MaterialStatePropertyWith<T> implements MaterialStateProperty<T> {
   T resolve(Set<MaterialState> states) => _resolve(states);
 }
 
-class _MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
-  _MaterialStatePropertyAll(this.value);
+/// Convenience class for creating a [MaterialStateProperty] that
+/// resolves to the given value for all states.
+class MaterialStatePropertyAll<T> implements MaterialStateProperty<T> {
 
+  /// Constructs a [MaterialStateProperty] that always resolves to the given
+  /// value.
+  const MaterialStatePropertyAll(this.value);
+
+  /// The value of the property that will be used for all states.
   final T value;
 
   @override
   T resolve(Set<MaterialState> states) => value;
 
   @override
-  String toString() => 'MaterialStateProperty.all($value)';
+  String toString() => 'MaterialStatePropertyAll($value)';
 }

--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -1193,7 +1193,7 @@ class _Defaults extends NavigationBarThemeData {
   @override Color? get backgroundColor => ElevationOverlay.colorWithOverlay(_colors.surface, _colors.onSurface, 3.0);
 
   @override MaterialStateProperty<IconThemeData?>? get iconTheme {
-    return MaterialStateProperty.all(IconThemeData(
+    return MaterialStatePropertyAll<IconThemeData>(IconThemeData(
       size: 24,
       color: _colors.onSurface,
     ));
@@ -1201,7 +1201,7 @@ class _Defaults extends NavigationBarThemeData {
 
   @override Color? get indicatorColor => _colors.secondary.withOpacity(0.24);
 
-  @override MaterialStateProperty<TextStyle?>? get labelTextStyle => MaterialStateProperty.all(_theme.textTheme.overline!.copyWith(color: _colors.onSurface));
+  @override MaterialStateProperty<TextStyle?>? get labelTextStyle => MaterialStatePropertyAll<TextStyle?>(_theme.textTheme.overline!.copyWith(color: _colors.onSurface));
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -433,7 +433,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<TextStyle?> get textStyle =>
-    MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+    MaterialStatePropertyAll<TextStyle?>(Theme.of(context).textTheme.labelLarge);
 
   @override
   MaterialStateProperty<Color?>? get backgroundColor =>

--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -504,8 +504,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
                 backgroundColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
                   return _isDark() || states.contains(MaterialState.disabled) ? null : colorScheme.primary;
                 }),
-                padding: MaterialStateProperty.all<EdgeInsetsGeometry>(buttonPadding),
-                shape: MaterialStateProperty.all<OutlinedBorder>(buttonShape),
+                padding: const MaterialStatePropertyAll<EdgeInsetsGeometry>(buttonPadding),
+                shape: const MaterialStatePropertyAll<OutlinedBorder>(buttonShape),
               ),
               child: Text(localizations.continueButtonLabel),
             ),

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -426,7 +426,7 @@ class _TextButtonWithIcon extends TextButton {
       MediaQuery.maybeOf(context)?.textScaleFactor ?? 1,
     );
     return super.defaultStyleOf(context).copyWith(
-      padding: MaterialStateProperty.all<EdgeInsetsGeometry>(scaledPadding),
+      padding: MaterialStatePropertyAll<EdgeInsetsGeometry>(scaledPadding),
     );
   }
 }
@@ -471,7 +471,7 @@ class _TokenDefaultsM3 extends ButtonStyle {
 
   @override
   MaterialStateProperty<TextStyle?> get textStyle =>
-    MaterialStateProperty.all<TextStyle?>(Theme.of(context).textTheme.labelLarge);
+    MaterialStatePropertyAll<TextStyle?>(Theme.of(context).textTheme.labelLarge);
 
   @override
   MaterialStateProperty<Color?>? get backgroundColor =>

--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -742,8 +742,8 @@ class ToggleButtons extends StatelessWidget {
           child: TextButton(
             focusNode: focusNodes != null ? focusNodes![index] : null,
             style: ButtonStyle(
-              backgroundColor: MaterialStateProperty.all<Color?>(effectiveFillColor),
-              foregroundColor: MaterialStateProperty.all<Color?>(currentColor),
+              backgroundColor: MaterialStatePropertyAll<Color?>(effectiveFillColor),
+              foregroundColor: MaterialStatePropertyAll<Color?>(currentColor),
               overlayColor: _ToggleButtonDefaultOverlay(
                 selected:  onPressed != null && isSelected[index],
                 unselected: onPressed != null && !isSelected[index],
@@ -754,15 +754,15 @@ class ToggleButtons extends StatelessWidget {
                 hoverColor: hoverColor ?? toggleButtonsTheme.hoverColor,
                 splashColor: splashColor ?? toggleButtonsTheme.splashColor,
               ),
-              elevation: MaterialStateProperty.all<double>(0),
-              textStyle: MaterialStateProperty.all<TextStyle?>(currentTextStyle.copyWith(
+              elevation: const MaterialStatePropertyAll<double>(0),
+              textStyle: MaterialStatePropertyAll<TextStyle?>(currentTextStyle.copyWith(
                 color: currentColor,
               )),
-              padding: MaterialStateProperty.all<EdgeInsetsGeometry>(EdgeInsets.zero),
-              minimumSize: MaterialStateProperty.all<Size?>(minimumSize),
-              maximumSize: MaterialStateProperty.all<Size?>(maximumSize),
-              shape: MaterialStateProperty.all<OutlinedBorder>(const RoundedRectangleBorder()),
-              mouseCursor: MaterialStateProperty.all<MouseCursor?>(mouseCursor),
+              padding: const MaterialStatePropertyAll<EdgeInsetsGeometry>(EdgeInsets.zero),
+              minimumSize: MaterialStatePropertyAll<Size?>(minimumSize),
+              maximumSize: MaterialStatePropertyAll<Size?>(maximumSize),
+              shape: const MaterialStatePropertyAll<OutlinedBorder>(RoundedRectangleBorder()),
+              mouseCursor: MaterialStatePropertyAll<MouseCursor?>(mouseCursor),
               visualDensity: VisualDensity.standard,
               tapTargetSize: MaterialTapTargetSize.shrinkWrap,
               animationDuration: kThemeChangeDuration,

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -50,22 +50,22 @@ void main() {
 
   testWidgets('ButtonStyle debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    ButtonStyle(
-      textStyle: MaterialStateProperty.all<TextStyle>(const TextStyle(fontSize: 10.0)),
-      backgroundColor: MaterialStateProperty.all<Color>(const Color(0xfffffff1)),
-      foregroundColor: MaterialStateProperty.all<Color>(const Color(0xfffffff2)),
-      overlayColor: MaterialStateProperty.all<Color>(const Color(0xfffffff3)),
-      shadowColor: MaterialStateProperty.all<Color>(const Color(0xfffffff4)),
-      surfaceTintColor: MaterialStateProperty.all<Color>(const Color(0xfffffff5)),
-      elevation: MaterialStateProperty.all<double>(1.5),
-      padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(1.0)),
-      minimumSize: MaterialStateProperty.all<Size>(const Size(1.0, 2.0)),
-      side: MaterialStateProperty.all<BorderSide>(const BorderSide(width: 4.0, color: Color(0xfffffff6))),
-      maximumSize: MaterialStateProperty.all<Size>(const Size(100.0, 200.0)),
-      shape: MaterialStateProperty.all<OutlinedBorder>(const StadiumBorder()),
-      mouseCursor: MaterialStateProperty.all<MouseCursor>(SystemMouseCursors.forbidden),
+    const ButtonStyle(
+      textStyle: MaterialStatePropertyAll<TextStyle>(TextStyle(fontSize: 10.0)),
+      backgroundColor: MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
+      foregroundColor: MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
+      overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff3)),
+      shadowColor: MaterialStatePropertyAll<Color>(Color(0xfffffff4)),
+      surfaceTintColor: MaterialStatePropertyAll<Color>(Color(0xfffffff5)),
+      elevation: MaterialStatePropertyAll<double>(1.5),
+      padding: MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(1.0)),
+      minimumSize: MaterialStatePropertyAll<Size>(Size(1.0, 2.0)),
+      side: MaterialStatePropertyAll<BorderSide>(BorderSide(width: 4.0, color: Color(0xfffffff6))),
+      maximumSize: MaterialStatePropertyAll<Size>(Size(100.0, 200.0)),
+      shape: MaterialStatePropertyAll<OutlinedBorder>(StadiumBorder()),
+      mouseCursor: MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden),
       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      animationDuration: const Duration(seconds: 1),
+      animationDuration: Duration(seconds: 1),
       enableFeedback: true,
     ).debugFillProperties(builder);
 
@@ -75,19 +75,19 @@ void main() {
       .toList();
 
     expect(description, <String>[
-      'textStyle: MaterialStateProperty.all(TextStyle(inherit: true, size: 10.0))',
-      'backgroundColor: MaterialStateProperty.all(Color(0xfffffff1))',
-      'foregroundColor: MaterialStateProperty.all(Color(0xfffffff2))',
-      'overlayColor: MaterialStateProperty.all(Color(0xfffffff3))',
-      'shadowColor: MaterialStateProperty.all(Color(0xfffffff4))',
-      'surfaceTintColor: MaterialStateProperty.all(Color(0xfffffff5))',
-      'elevation: MaterialStateProperty.all(1.5)',
-      'padding: MaterialStateProperty.all(EdgeInsets.all(1.0))',
-      'minimumSize: MaterialStateProperty.all(Size(1.0, 2.0))',
-      'maximumSize: MaterialStateProperty.all(Size(100.0, 200.0))',
-      'side: MaterialStateProperty.all(BorderSide(Color(0xfffffff6), 4.0, BorderStyle.solid))',
-      'shape: MaterialStateProperty.all(StadiumBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none)))',
-      'mouseCursor: MaterialStateProperty.all(SystemMouseCursor(forbidden))',
+      'textStyle: MaterialStatePropertyAll(TextStyle(inherit: true, size: 10.0))',
+      'backgroundColor: MaterialStatePropertyAll(Color(0xfffffff1))',
+      'foregroundColor: MaterialStatePropertyAll(Color(0xfffffff2))',
+      'overlayColor: MaterialStatePropertyAll(Color(0xfffffff3))',
+      'shadowColor: MaterialStatePropertyAll(Color(0xfffffff4))',
+      'surfaceTintColor: MaterialStatePropertyAll(Color(0xfffffff5))',
+      'elevation: MaterialStatePropertyAll(1.5)',
+      'padding: MaterialStatePropertyAll(EdgeInsets.all(1.0))',
+      'minimumSize: MaterialStatePropertyAll(Size(1.0, 2.0))',
+      'maximumSize: MaterialStatePropertyAll(Size(100.0, 200.0))',
+      'side: MaterialStatePropertyAll(BorderSide(Color(0xfffffff6), 4.0, BorderStyle.solid))',
+      'shape: MaterialStatePropertyAll(StadiumBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none)))',
+      'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(forbidden))',
       'tapTargetSize: shrinkWrap',
       'animationDuration: 0:00:01.000000',
       'enableFeedback: true',
@@ -95,26 +95,26 @@ void main() {
   });
 
   testWidgets('ButtonStyle copyWith, merge', (WidgetTester tester) async {
-    final MaterialStateProperty<TextStyle> textStyle = MaterialStateProperty.all<TextStyle>(const TextStyle(fontSize: 10));
-    final MaterialStateProperty<Color> backgroundColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff1));
-    final MaterialStateProperty<Color> foregroundColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff2));
-    final MaterialStateProperty<Color> overlayColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff3));
-    final MaterialStateProperty<Color> shadowColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff4));
-    final MaterialStateProperty<Color> surfaceTintColor =  MaterialStateProperty.all<Color>(const Color(0xfffffff5));
-    final MaterialStateProperty<double> elevation =  MaterialStateProperty.all<double>(1);
-    final MaterialStateProperty<EdgeInsets> padding = MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.all(1));
-    final MaterialStateProperty<Size> minimumSize = MaterialStateProperty.all<Size>(const Size(1, 2));
-    final MaterialStateProperty<Size> fixedSize = MaterialStateProperty.all<Size>(const Size(3, 4));
-    final MaterialStateProperty<Size> maximumSize = MaterialStateProperty.all<Size>(const Size(5, 6));
-    final MaterialStateProperty<BorderSide> side = MaterialStateProperty.all<BorderSide>(const BorderSide());
-    final MaterialStateProperty<OutlinedBorder> shape  = MaterialStateProperty.all<OutlinedBorder>(const StadiumBorder());
-    final MaterialStateProperty<MouseCursor> mouseCursor = MaterialStateProperty.all<MouseCursor>(SystemMouseCursors.forbidden);
+    const MaterialStateProperty<TextStyle> textStyle = MaterialStatePropertyAll<TextStyle>(TextStyle(fontSize: 10));
+    const MaterialStateProperty<Color> backgroundColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
+    const MaterialStateProperty<Color> foregroundColor = MaterialStatePropertyAll<Color>(Color(0xfffffff2));
+    const MaterialStateProperty<Color> overlayColor = MaterialStatePropertyAll<Color>(Color(0xfffffff3));
+    const MaterialStateProperty<Color> shadowColor =  MaterialStatePropertyAll<Color>(Color(0xfffffff4));
+    const MaterialStateProperty<Color> surfaceTintColor = MaterialStatePropertyAll<Color>(Color(0xfffffff5));
+    const MaterialStateProperty<double> elevation = MaterialStatePropertyAll<double>(1);
+    const MaterialStateProperty<EdgeInsets> padding = MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.all(1));
+    const MaterialStateProperty<Size> minimumSize = MaterialStatePropertyAll<Size>(Size(1, 2));
+    const MaterialStateProperty<Size> fixedSize = MaterialStatePropertyAll<Size>(Size(3, 4));
+    const MaterialStateProperty<Size> maximumSize = MaterialStatePropertyAll<Size>(Size(5, 6));
+    const MaterialStateProperty<BorderSide> side = MaterialStatePropertyAll<BorderSide>(BorderSide());
+    const MaterialStateProperty<OutlinedBorder> shape = MaterialStatePropertyAll<OutlinedBorder>(StadiumBorder());
+    const MaterialStateProperty<MouseCursor> mouseCursor = MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.forbidden);
     const VisualDensity visualDensity = VisualDensity.compact;
     const MaterialTapTargetSize tapTargetSize = MaterialTapTargetSize.shrinkWrap;
     const Duration animationDuration = Duration(seconds: 1);
     const bool enableFeedback = true;
 
-    final ButtonStyle style = ButtonStyle(
+    const ButtonStyle style = ButtonStyle(
       textStyle: textStyle,
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
@@ -180,8 +180,8 @@ void main() {
     const BorderSide whiteSide = BorderSide(color: Color(0xFFFFFFFF));
     const BorderSide emptyBlackSide = BorderSide(width: 0, color: Color(0x00000000));
 
-    final ButtonStyle blackStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(blackSide));
-    final ButtonStyle whiteStyle = ButtonStyle(side: MaterialStateProperty.all<BorderSide>(whiteSide));
+    const ButtonStyle blackStyle = ButtonStyle(side: MaterialStatePropertyAll<BorderSide>(blackSide));
+    const ButtonStyle whiteStyle = ButtonStyle(side: MaterialStatePropertyAll<BorderSide>(whiteSide));
 
     // MaterialState.all<Foo>(value) properties resolve to value
     // for any set of MaterialStates.

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -968,7 +968,7 @@ void main() {
             autofocus: focused,
             value: active,
             onChanged: (_) { },
-            fillColor: MaterialStateProperty.all(fillColor),
+            fillColor: const MaterialStatePropertyAll<Color>(fillColor),
             overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
             focusColor: focusColor,

--- a/packages/flutter/test/material/checkbox_theme_test.dart
+++ b/packages/flutter/test/material/checkbox_theme_test.dart
@@ -49,11 +49,11 @@ void main() {
 
   testWidgets('CheckboxThemeData implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    CheckboxThemeData(
-      mouseCursor: MaterialStateProperty.all(SystemMouseCursors.click),
-      fillColor: MaterialStateProperty.all(const Color(0xfffffff0)),
-      checkColor: MaterialStateProperty.all(const Color(0xfffffff1)),
-      overlayColor: MaterialStateProperty.all(const Color(0xfffffff2)),
+    const CheckboxThemeData(
+      mouseCursor: MaterialStatePropertyAll<MouseCursor?>(SystemMouseCursors.click),
+      fillColor: MaterialStatePropertyAll<Color>(Color(0xfffffff0)),
+      checkColor: MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
+      overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
       splashRadius: 1.0,
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       visualDensity: VisualDensity.standard,
@@ -64,10 +64,10 @@ void main() {
       .map((DiagnosticsNode node) => node.toString())
       .toList();
 
-    expect(description[0], 'mouseCursor: MaterialStateProperty.all(SystemMouseCursor(click))');
-    expect(description[1], 'fillColor: MaterialStateProperty.all(Color(0xfffffff0))');
-    expect(description[2], 'checkColor: MaterialStateProperty.all(Color(0xfffffff1))');
-    expect(description[3], 'overlayColor: MaterialStateProperty.all(Color(0xfffffff2))');
+    expect(description[0], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
+    expect(description[1], 'fillColor: MaterialStatePropertyAll(Color(0xfffffff0))');
+    expect(description[2], 'checkColor: MaterialStatePropertyAll(Color(0xfffffff1))');
+    expect(description[3], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff2))');
     expect(description[4], 'splashRadius: 1.0');
     expect(description[5], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
     expect(description[6], equalsIgnoringHashCodes('visualDensity: VisualDensity#00000(h: 0.0, v: 0.0)'));
@@ -91,7 +91,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           checkboxTheme: CheckboxThemeData(
-            mouseCursor: MaterialStateProperty.all(mouseCursor),
+            mouseCursor: const MaterialStatePropertyAll<MouseCursor?>(mouseCursor),
             fillColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedFillColor;
@@ -182,14 +182,14 @@ void main() {
         return MaterialApp(
           theme: ThemeData(
             checkboxTheme: CheckboxThemeData(
-              mouseCursor: MaterialStateProperty.all(themeMouseCursor),
+              mouseCursor: const MaterialStatePropertyAll<MouseCursor?>(themeMouseCursor),
               fillColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.selected)) {
                   return themeSelectedFillColor;
                 }
                 return themeDefaultFillColor;
               }),
-              checkColor: MaterialStateProperty.all(themeCheckColor),
+              checkColor: const MaterialStatePropertyAll<Color?>(themeCheckColor),
               overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
                 if (states.contains(MaterialState.focused)) {
                   return themeFocusOverlayColor;
@@ -361,16 +361,16 @@ void main() {
     Widget buildCheckbox({required bool active}) {
       return MaterialApp(
         theme: ThemeData(
-          checkboxTheme: CheckboxThemeData(
-            checkColor: MaterialStateProperty.all<Color>(globalThemeCheckColor),
-            fillColor: MaterialStateProperty.all<Color>(globalThemeFillColor),
+          checkboxTheme: const CheckboxThemeData(
+            checkColor: MaterialStatePropertyAll<Color>(globalThemeCheckColor),
+            fillColor: MaterialStatePropertyAll<Color>(globalThemeFillColor),
           ),
         ),
         home: Scaffold(
           body: CheckboxTheme(
-            data: CheckboxThemeData(
-              fillColor: MaterialStateProperty.all<Color>(localThemeFillColor),
-              checkColor: MaterialStateProperty.all<Color>(localThemeCheckColor),
+            data: const CheckboxThemeData(
+              fillColor: MaterialStatePropertyAll<Color>(localThemeFillColor),
+              checkColor: MaterialStatePropertyAll<Color>(localThemeCheckColor),
             ),
             child: Checkbox(
               value: active,

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1412,9 +1412,9 @@ void main() {
     const Color checkColor = Color(0xFF0000FF);
 
     final ThemeData themeData = ThemeData(
-      checkboxTheme: CheckboxThemeData(
-        fillColor: MaterialStateProperty.all(fillColor),
-        checkColor: MaterialStateProperty.all(checkColor),
+      checkboxTheme: const CheckboxThemeData(
+        fillColor: MaterialStatePropertyAll<Color?>(fillColor),
+        checkColor: MaterialStatePropertyAll<Color?>(checkColor),
       ),
     );
     Widget buildTable() {

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -92,10 +92,10 @@ void main() {
 
   testWidgets('DataTable is themeable', (WidgetTester tester) async {
     const BoxDecoration decoration = BoxDecoration(color: Color(0xfffffff0));
-    final MaterialStateProperty<Color> dataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const MaterialStateProperty<Color> dataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
     const double dataRowHeight = 51.0;
     const TextStyle dataTextStyle = TextStyle(fontSize: 12.5);
-    final MaterialStateProperty<Color> headingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff2));
+    const MaterialStateProperty<Color> headingRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff2));
     const double headingRowHeight = 52.0;
     const TextStyle headingTextStyle = TextStyle(fontSize: 14.5);
     const double horizontalMargin = 3.0;
@@ -105,7 +105,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          dataTableTheme: DataTableThemeData(
+          dataTableTheme: const DataTableThemeData(
             decoration: decoration,
             dataRowColor: dataRowColor,
             dataRowHeight: dataRowHeight,
@@ -159,10 +159,10 @@ void main() {
 
   testWidgets('DataTable properties are taken over the theme values', (WidgetTester tester) async {
     const BoxDecoration themeDecoration = BoxDecoration(color: Color(0xfffffff1));
-    final MaterialStateProperty<Color> themeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff0));
+    const MaterialStateProperty<Color> themeDataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff0));
     const double themeDataRowHeight = 50.0;
     const TextStyle themeDataTextStyle = TextStyle(fontSize: 11.5);
-    final MaterialStateProperty<Color> themeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const MaterialStateProperty<Color> themeHeadingRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
     const double themeHeadingRowHeight = 51.0;
     const TextStyle themeHeadingTextStyle = TextStyle(fontSize: 13.5);
     const double themeHorizontalMargin = 2.0;
@@ -170,10 +170,10 @@ void main() {
     const double themeDividerThickness = 4.0;
 
     const BoxDecoration decoration = BoxDecoration(color: Color(0xfffffff0));
-    final MaterialStateProperty<Color> dataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const MaterialStateProperty<Color> dataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
     const double dataRowHeight = 51.0;
     const TextStyle dataTextStyle = TextStyle(fontSize: 12.5);
-    final MaterialStateProperty<Color> headingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff2));
+    const MaterialStateProperty<Color> headingRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff2));
     const double headingRowHeight = 52.0;
     const TextStyle headingTextStyle = TextStyle(fontSize: 14.5);
     const double horizontalMargin = 3.0;
@@ -182,7 +182,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          dataTableTheme: DataTableThemeData(
+          dataTableTheme: const DataTableThemeData(
             decoration: themeDecoration,
             dataRowColor: themeDataRowColor,
             dataRowHeight: themeDataRowHeight,
@@ -246,10 +246,10 @@ void main() {
 
   testWidgets('Local DataTableTheme can override global DataTableTheme', (WidgetTester tester) async {
     const BoxDecoration globalThemeDecoration = BoxDecoration(color: Color(0xfffffff1));
-    final MaterialStateProperty<Color> globalThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff0));
+    const MaterialStateProperty<Color> globalThemeDataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff0));
     const double globalThemeDataRowHeight = 50.0;
     const TextStyle globalThemeDataTextStyle = TextStyle(fontSize: 11.5);
-    final MaterialStateProperty<Color> globalThemeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const MaterialStateProperty<Color> globalThemeHeadingRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
     const double globalThemeHeadingRowHeight = 51.0;
     const TextStyle globalThemeHeadingTextStyle = TextStyle(fontSize: 13.5);
     const double globalThemeHorizontalMargin = 2.0;
@@ -257,10 +257,10 @@ void main() {
     const double globalThemeDividerThickness = 4.0;
 
     const BoxDecoration localThemeDecoration = BoxDecoration(color: Color(0xfffffff0));
-    final MaterialStateProperty<Color> localThemeDataRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff1));
+    const MaterialStateProperty<Color> localThemeDataRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff1));
     const double localThemeDataRowHeight = 51.0;
     const TextStyle localThemeDataTextStyle = TextStyle(fontSize: 12.5);
-    final MaterialStateProperty<Color> localThemeHeadingRowColor = MaterialStateProperty.all<Color>(const Color(0xfffffff2));
+    const MaterialStateProperty<Color> localThemeHeadingRowColor = MaterialStatePropertyAll<Color>(Color(0xfffffff2));
     const double localThemeHeadingRowHeight = 52.0;
     const TextStyle localThemeHeadingTextStyle = TextStyle(fontSize: 14.5);
     const double localThemeHorizontalMargin = 3.0;
@@ -270,7 +270,7 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         theme: ThemeData(
-          dataTableTheme: DataTableThemeData(
+          dataTableTheme: const DataTableThemeData(
             decoration: globalThemeDecoration,
             dataRowColor: globalThemeDataRowColor,
             dataRowHeight: globalThemeDataRowHeight,
@@ -285,7 +285,7 @@ void main() {
         ),
         home: Scaffold(
           body: DataTableTheme(
-            data: DataTableThemeData(
+            data: const DataTableThemeData(
               decoration: localThemeDecoration,
               dataRowColor: localThemeDataRowColor,
               dataRowHeight: localThemeDataRowHeight,

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -689,11 +689,11 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: ElevatedButton(
-            style: ButtonStyle(
+            style: const ButtonStyle(
               // Specifying minimumSize to mimic the original minimumSize for
               // RaisedButton so that the semantics tree's rect and transform
               // match the original version of this test.
-              minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+              minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
             ),
             onPressed: () { },
             child: const Text('ABC'),
@@ -728,11 +728,11 @@ void main() {
   });
 
   testWidgets('ElevatedButton size is configurable by ThemeData.materialTapTargetSize', (WidgetTester tester) async {
-    final ButtonStyle style = ButtonStyle(
+    const ButtonStyle style = ButtonStyle(
       // Specifying minimumSize to mimic the original minimumSize for
       // RaisedButton so that the corresponding button size matches
       // the original version of this test.
-      minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+      minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
     );
 
     Widget buildFrame(MaterialTapTargetSize tapTargetSize, Key key) {
@@ -797,7 +797,7 @@ void main() {
                   // Specifying minimumSize to mimic the original minimumSize for
                   // RaisedButton so that the corresponding button size matches
                   // the original version of this test.
-                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+                  minimumSize: const MaterialStatePropertyAll<Size>(Size(88, 36)),
                 ),
                 key: key,
                 onPressed: () {},
@@ -861,8 +861,8 @@ void main() {
         child: Center(
           child: ElevatedButton.icon(
             key: buttonKey,
-            style: ButtonStyle(
-              padding: MaterialStateProperty.all<EdgeInsets>(const EdgeInsets.fromLTRB(16, 5, 10, 12)),
+            style: const ButtonStyle(
+              padding: MaterialStatePropertyAll<EdgeInsets>(EdgeInsets.fromLTRB(16, 5, 10, 12)),
             ),
             onPressed: () {},
             icon: const Icon(Icons.add),

--- a/packages/flutter/test/material/material_state_property_test.dart
+++ b/packages/flutter/test/material/material_state_property_test.dart
@@ -30,4 +30,16 @@ void main() {
     expect(value.resolve(<MaterialState>{MaterialState.disabled}), 123);
     expect(value.resolve(<MaterialState>{MaterialState.error}), 123);
   });
+
+  test('MaterialStatePropertyAll', () {
+    const MaterialStatePropertyAll<int> value = MaterialStatePropertyAll<int>(123);
+    expect(value.resolve(<MaterialState>{}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.hovered}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.focused}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.pressed}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.dragged}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.selected}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.disabled}), 123);
+    expect(value.resolve(<MaterialState>{MaterialState.error}), 123);
+  });
 }

--- a/packages/flutter/test/material/navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/navigation_bar_theme_test.dart
@@ -26,14 +26,14 @@ void main() {
 
   testWidgets('Custom debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    NavigationBarThemeData(
+    const NavigationBarThemeData(
       height: 200.0,
-      backgroundColor: const Color(0x00000099),
+      backgroundColor: Color(0x00000099),
       elevation: 20.0,
-      indicatorColor: const Color(0x00000098),
-      indicatorShape: const CircleBorder(),
-      labelTextStyle: MaterialStateProperty.all(const TextStyle(fontSize: 7.0)),
-      iconTheme: MaterialStateProperty.all(const IconThemeData(color: Color(0x00000097))),
+      indicatorColor: Color(0x00000098),
+      indicatorShape: CircleBorder(),
+      labelTextStyle: MaterialStatePropertyAll<TextStyle>(TextStyle(fontSize: 7.0)),
+      iconTheme: MaterialStatePropertyAll<IconThemeData>(IconThemeData(color: Color(0x00000097))),
       labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
     ).debugFillProperties(builder);
 
@@ -47,10 +47,10 @@ void main() {
     expect(description[2], 'elevation: 20.0');
     expect(description[3], 'indicatorColor: Color(0x00000098)');
     expect(description[4], 'indicatorShape: CircleBorder(BorderSide(Color(0xff000000), 0.0, BorderStyle.none))');
-    expect(description[5], 'labelTextStyle: MaterialStateProperty.all(TextStyle(inherit: true, size: 7.0))');
+    expect(description[5], 'labelTextStyle: MaterialStatePropertyAll(TextStyle(inherit: true, size: 7.0))');
 
     // Ignore instance address for IconThemeData.
-    expect(description[6].contains('iconTheme: MaterialStateProperty.all(IconThemeData'), isTrue);
+    expect(description[6].contains('iconTheme: MaterialStatePropertyAll(IconThemeData'), isTrue);
     expect(description[6].contains('(color: Color(0x00000097))'), isTrue);
 
     expect(description[7], 'labelBehavior: NavigationDestinationLabelBehavior.alwaysHide');

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -922,11 +922,11 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: OutlinedButton(
-            style: ButtonStyle(
+            style: const ButtonStyle(
               // Specifying minimumSize to mimic the original minimumSize for
               // RaisedButton so that the corresponding button size matches
               // the original version of this test.
-              minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+              minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
             ),
             onPressed: () {},
             child: const Text('ABC'),
@@ -971,11 +971,11 @@ void main() {
             data: const MediaQueryData(),
             child: Center(
               child: OutlinedButton(
-                style: ButtonStyle(
+                style: const ButtonStyle(
                   // Specifying minimumSize to mimic the original minimumSize for
                   // RaisedButton so that the corresponding button size matches
                   // the original version of this test.
-                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+                  minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
                 ),
                 onPressed: () {},
                 child: const Text('ABC'),
@@ -1000,11 +1000,11 @@ void main() {
             data: const MediaQueryData(textScaleFactor: 1.3),
             child: Center(
               child: OutlinedButton(
-                style: ButtonStyle(
+                style: const ButtonStyle(
                   // Specifying minimumSize to mimic the original minimumSize for
                   // RaisedButton so that the corresponding button size matches
                   // the original version of this test.
-                  minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+                  minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
                 ),
                 onPressed: () {},
                 child: const Text('ABC'),

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -997,7 +997,7 @@ void main() {
             value: active,
             groupValue: true,
             onChanged: (_) { },
-            fillColor: MaterialStateProperty.all(fillColor),
+            fillColor: const MaterialStatePropertyAll<Color>(fillColor),
             overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
             focusColor: focusColor,

--- a/packages/flutter/test/material/radio_theme_test.dart
+++ b/packages/flutter/test/material/radio_theme_test.dart
@@ -47,10 +47,10 @@ void main() {
 
   testWidgets('RadioThemeData implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    RadioThemeData(
-      mouseCursor: MaterialStateProperty.all(SystemMouseCursors.click),
-      fillColor: MaterialStateProperty.all(const Color(0xfffffff0)),
-      overlayColor: MaterialStateProperty.all(const Color(0xfffffff1)),
+    const RadioThemeData(
+      mouseCursor: MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.click),
+      fillColor: MaterialStatePropertyAll<Color>(Color(0xfffffff0)),
+      overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
       splashRadius: 1.0,
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       visualDensity: VisualDensity.standard,
@@ -61,9 +61,9 @@ void main() {
       .map((DiagnosticsNode node) => node.toString())
       .toList();
 
-    expect(description[0], 'mouseCursor: MaterialStateProperty.all(SystemMouseCursor(click))');
-    expect(description[1], 'fillColor: MaterialStateProperty.all(Color(0xfffffff0))');
-    expect(description[2], 'overlayColor: MaterialStateProperty.all(Color(0xfffffff1))');
+    expect(description[0], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
+    expect(description[1], 'fillColor: MaterialStatePropertyAll(Color(0xfffffff0))');
+    expect(description[2], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff1))');
     expect(description[3], 'splashRadius: 1.0');
     expect(description[4], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
     expect(description[5], equalsIgnoringHashCodes('visualDensity: VisualDensity#00000(h: 0.0, v: 0.0)'));
@@ -85,7 +85,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           radioTheme: RadioThemeData(
-            mouseCursor: MaterialStateProperty.all(mouseCursor),
+            mouseCursor: const MaterialStatePropertyAll<MouseCursor>(mouseCursor),
             fillColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return selectedFillColor;
@@ -167,7 +167,7 @@ void main() {
       return MaterialApp(
         theme: ThemeData(
           radioTheme: RadioThemeData(
-            mouseCursor: MaterialStateProperty.all(themeMouseCursor),
+            mouseCursor: const MaterialStatePropertyAll<MouseCursor>(themeMouseCursor),
             fillColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
                 return themeSelectedFillColor;
@@ -346,14 +346,14 @@ void main() {
     Widget buildRadio({required bool active}) {
       return MaterialApp(
         theme: ThemeData(
-          radioTheme: RadioThemeData(
-            fillColor: MaterialStateProperty.all<Color>(globalThemeFillColor),
+          radioTheme: const RadioThemeData(
+            fillColor: MaterialStatePropertyAll<Color>(globalThemeFillColor),
           ),
         ),
         home: Scaffold(
           body: RadioTheme(
-            data: RadioThemeData(
-              fillColor: MaterialStateProperty.all<Color>(localThemeFillColor),
+            data: const RadioThemeData(
+              fillColor: MaterialStatePropertyAll<Color>(localThemeFillColor),
             ),
             child: Radio<int>(
               value: active ? 1 : 0,

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -1248,7 +1248,7 @@ void main() {
   testWidgets('The mouse cursor is themeable', (WidgetTester tester) async {
     await tester.pumpWidget(_buildApp(
       ThemeData().sliderTheme.copyWith(
-        mouseCursor: MaterialStateProperty.all(SystemMouseCursors.text),
+        mouseCursor: const MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.text),
       )
     ));
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1589,7 +1589,7 @@ void main() {
             autofocus: focused,
             value: active,
             onChanged: (_) { },
-            thumbColor: MaterialStateProperty.all(thumbColor),
+            thumbColor: const MaterialStatePropertyAll<Color>(thumbColor),
             overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
             focusColor: focusColor,

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -47,12 +47,12 @@ void main() {
 
   testWidgets('SwitchThemeData implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    SwitchThemeData(
-      thumbColor: MaterialStateProperty.all(const Color(0xfffffff0)),
-      trackColor: MaterialStateProperty.all(const Color(0xfffffff1)),
-      mouseCursor: MaterialStateProperty.all(SystemMouseCursors.click),
+    const SwitchThemeData(
+      thumbColor: MaterialStatePropertyAll<Color>(Color(0xfffffff0)),
+      trackColor: MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
+      mouseCursor: MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.click),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      overlayColor: MaterialStateProperty.all(const Color(0xfffffff2)),
+      overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
       splashRadius: 1.0,
     ).debugFillProperties(builder);
 
@@ -61,11 +61,11 @@ void main() {
       .map((DiagnosticsNode node) => node.toString())
       .toList();
 
-    expect(description[0], 'thumbColor: MaterialStateProperty.all(Color(0xfffffff0))');
-    expect(description[1], 'trackColor: MaterialStateProperty.all(Color(0xfffffff1))');
+    expect(description[0], 'thumbColor: MaterialStatePropertyAll(Color(0xfffffff0))');
+    expect(description[1], 'trackColor: MaterialStatePropertyAll(Color(0xfffffff1))');
     expect(description[2], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
-    expect(description[3], 'mouseCursor: MaterialStateProperty.all(SystemMouseCursor(click))');
-    expect(description[4], 'overlayColor: MaterialStateProperty.all(Color(0xfffffff2))');
+    expect(description[3], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
+    expect(description[4], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff2))');
     expect(description[5], 'splashRadius: 1.0');
   });
 
@@ -98,7 +98,7 @@ void main() {
               }
               return defaultTrackColor;
             }),
-            mouseCursor: MaterialStateProperty.all(mouseCursor),
+            mouseCursor: const MaterialStatePropertyAll<MouseCursor>(mouseCursor),
             materialTapTargetSize: materialTapTargetSize,
             overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.focused)) {
@@ -203,7 +203,7 @@ void main() {
               }
               return themeDefaultTrackColor;
             }),
-            mouseCursor: MaterialStateProperty.all(themeMouseCursor),
+            mouseCursor: const MaterialStatePropertyAll<MouseCursor>(themeMouseCursor),
             materialTapTargetSize: themeMaterialTapTargetSize,
             overlayColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.focused)) {
@@ -429,16 +429,16 @@ void main() {
     Widget buildSwitch({bool selected = false, bool autofocus = false}) {
       return MaterialApp(
         theme: ThemeData(
-          switchTheme: SwitchThemeData(
-            thumbColor: MaterialStateProperty.all<Color>(globalThemeThumbColor),
-            trackColor: MaterialStateProperty.all<Color>(globalThemeTrackColor),
+          switchTheme: const SwitchThemeData(
+            thumbColor: MaterialStatePropertyAll<Color>(globalThemeThumbColor),
+            trackColor: MaterialStatePropertyAll<Color>(globalThemeTrackColor),
           ),
         ),
         home: Scaffold(
           body: SwitchTheme(
-            data: SwitchThemeData(
-              thumbColor: MaterialStateProperty.all<Color>(localThemeThumbColor),
-              trackColor: MaterialStateProperty.all<Color>(localThemeTrackColor),
+            data: const SwitchThemeData(
+              thumbColor: MaterialStatePropertyAll<Color>(localThemeThumbColor),
+              trackColor: MaterialStatePropertyAll<Color>(localThemeTrackColor),
             ),
             child: Switch(
               value: selected,

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -492,11 +492,11 @@ void main() {
         textDirection: TextDirection.ltr,
         child: Center(
           child: TextButton(
-            style: ButtonStyle(
+            style: const ButtonStyle(
               // Specifying minimumSize to mimic the original minimumSize for
               // RaisedButton so that the semantics tree's rect and transform
               // match the original version of this test.
-              minimumSize: MaterialStateProperty.all<Size>(const Size(88, 36)),
+              minimumSize: MaterialStatePropertyAll<Size>(Size(88, 36)),
             ),
             onPressed: () { },
             child: const Text('ABC'),


### PR DESCRIPTION
Currently if you want to create a `MaterialStateProperty` that always returns the same value regardless of the current states, you could use the `.all` static method:

```dart
final color = MaterialStateColor.all<Color>(Colors.blue);
```

However this can be a const value which makes it harder to use with const ButtonStyles and other structures that could be const otherwise.

This PR adds a new `MaterialStatePropertyAll` class that allows you to convert the above code to:

```dart
const color = MaterialStateColorAll<Color>(Colors.blue);
```

Which can then be used in other const structures.

We may deprecate `MaterialStateProperty.all` in the future, but didn't want to do this without a dart fix for it. As it turns out, this isn't a case that can be [currently handled by dart fix](https://github.com/dart-lang/sdk/issues/49056). When it is, we will probably deprecate it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
