### PR TITLE
fix11068 InputDecoration 'errorText' custom builder

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -44,11 +44,13 @@ class _InputBorderGap extends ChangeNotifier {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes, this class is not used in collection
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return other is _InputBorderGap &&
-        other.start == start &&
-        other.extent == extent;
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is _InputBorderGap
+        && other.start == start
+        && other.extent == extent;
   }
 
   @override
@@ -90,8 +92,7 @@ class _InputBorderPainter extends CustomPainter {
   final ColorTween hoverColorTween;
   final Animation<double> hoverAnimation;
 
-  Color get blendedColor =>
-      Color.alphaBlend(hoverColorTween.evaluate(hoverAnimation)!, fillColor);
+  Color get blendedColor => Color.alphaBlend(hoverColorTween.evaluate(hoverAnimation)!, fillColor);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -119,12 +120,12 @@ class _InputBorderPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_InputBorderPainter oldPainter) {
-    return borderAnimation != oldPainter.borderAnimation ||
-        hoverAnimation != oldPainter.hoverAnimation ||
-        gapAnimation != oldPainter.gapAnimation ||
-        border != oldPainter.border ||
-        gap != oldPainter.gap ||
-        textDirection != oldPainter.textDirection;
+    return borderAnimation != oldPainter.borderAnimation
+        || hoverAnimation != oldPainter.hoverAnimation
+        || gapAnimation != oldPainter.gapAnimation
+        || border != oldPainter.border
+        || gap != oldPainter.gap
+        || textDirection != oldPainter.textDirection;
   }
 
   @override
@@ -143,9 +144,9 @@ class _BorderContainer extends StatefulWidget {
     required this.fillColor,
     required this.hoverColor,
     required this.isHovering,
-  })  : assert(border != null),
-        assert(gap != null),
-        assert(fillColor != null);
+  }) : assert(border != null),
+       assert(gap != null),
+       assert(fillColor != null);
 
   final InputBorder border;
   final _InputBorderGap gap;
@@ -158,8 +159,7 @@ class _BorderContainer extends StatefulWidget {
   _BorderContainerState createState() => _BorderContainerState();
 }
 
-class _BorderContainerState extends State<_BorderContainer>
-    with TickerProviderStateMixin {
+class _BorderContainerState extends State<_BorderContainer> with TickerProviderStateMixin {
   static const Duration _kHoverDuration = Duration(milliseconds: 15);
 
   late AnimationController _controller;
@@ -193,8 +193,7 @@ class _BorderContainerState extends State<_BorderContainer>
       parent: _hoverColorController,
       curve: Curves.linear,
     );
-    _hoverColorTween =
-        ColorTween(begin: Colors.transparent, end: widget.hoverColor);
+    _hoverColorTween = ColorTween(begin: Colors.transparent, end: widget.hoverColor);
   }
 
   @override
@@ -217,8 +216,7 @@ class _BorderContainerState extends State<_BorderContainer>
         ..forward();
     }
     if (widget.hoverColor != oldWidget.hoverColor) {
-      _hoverColorTween =
-          ColorTween(begin: Colors.transparent, end: widget.hoverColor);
+      _hoverColorTween = ColorTween(begin: Colors.transparent, end: widget.hoverColor);
     }
     if (widget.isHovering != oldWidget.isHovering) {
       if (widget.isHovering) {
@@ -295,7 +293,6 @@ class _HelperError extends StatefulWidget {
     this.errorText,
     this.errorStyle,
     this.errorMaxLines,
-    this.errorWidgetBuilder,
   });
 
   final TextAlign? textAlign;
@@ -303,7 +300,6 @@ class _HelperError extends StatefulWidget {
   final TextStyle? helperStyle;
   final int? helperMaxLines;
   final String? errorText;
-  final Widget Function(String errorText)? errorWidgetBuilder;
   final TextStyle? errorStyle;
   final int? errorMaxLines;
 
@@ -311,8 +307,7 @@ class _HelperError extends StatefulWidget {
   _HelperErrorState createState() => _HelperErrorState();
 }
 
-class _HelperErrorState extends State<_HelperError>
-    with SingleTickerProviderStateMixin {
+class _HelperErrorState extends State<_HelperError> with SingleTickerProviderStateMixin {
   // If the height of this widget and the counter are zero ("empty") at
   // layout time, no space is allocated for the subtext.
   static const Widget empty = SizedBox();
@@ -358,10 +353,8 @@ class _HelperErrorState extends State<_HelperError>
     final String? oldErrorText = old.errorText;
     final String? oldHelperText = old.helperText;
 
-    final bool errorTextStateChanged =
-        (newErrorText != null) != (oldErrorText != null);
-    final bool helperTextStateChanged = newErrorText == null &&
-        (newHelperText != null) != (oldHelperText != null);
+    final bool errorTextStateChanged = (newErrorText != null) != (oldErrorText != null);
+    final bool helperTextStateChanged = newErrorText == null && (newHelperText != null) != (oldHelperText != null);
 
     if (errorTextStateChanged || helperTextStateChanged) {
       if (newErrorText != null) {
@@ -405,15 +398,13 @@ class _HelperErrorState extends State<_HelperError>
             begin: const Offset(0.0, -0.25),
             end: Offset.zero,
           ).evaluate(_controller.view),
-          child: widget.errorWidgetBuilder == null
-              ? Text(
-                  widget.errorText!,
-                  style: widget.errorStyle,
-                  textAlign: widget.textAlign,
-                  overflow: TextOverflow.ellipsis,
-                  maxLines: widget.errorMaxLines,
-                )
-              : widget.errorWidgetBuilder!(widget.errorText!),
+          child: Text(
+            widget.errorText!,
+            style: widget.errorStyle,
+            textAlign: widget.textAlign,
+            overflow: TextOverflow.ellipsis,
+            maxLines: widget.errorMaxLines,
+          ),
         ),
       ),
     );
@@ -441,9 +432,11 @@ class _HelperErrorState extends State<_HelperError>
       }
     }
 
-    if (_helper == null && widget.errorText != null) return _buildError();
+    if (_helper == null && widget.errorText != null)
+      return _buildError();
 
-    if (_error == null && widget.helperText != null) return _buildHelper();
+    if (_error == null && widget.helperText != null)
+      return _buildHelper();
 
     if (widget.errorText != null) {
       return Stack(
@@ -484,10 +477,8 @@ class _HelperErrorState extends State<_HelperError>
 enum FloatingLabelBehavior {
   /// The label will always be positioned within the content, or hidden.
   never,
-
   /// The label will float when the input is focused, or has content.
   auto,
-
   /// The label will always float above the content.
   always,
 }
@@ -503,9 +494,8 @@ enum FloatingLabelBehavior {
 ///    behave.
 @immutable
 class FloatingLabelAlignment {
-  const FloatingLabelAlignment._(this._x)
-      : assert(_x != null),
-        assert(_x >= -1.0 && _x <= 1.0);
+  const FloatingLabelAlignment._(this._x) : assert(_x != null),
+       assert(_x >= -1.0 && _x <= 1.0);
 
   // -1 denotes start, 0 denotes center, and 1 denotes end.
   final double _x;
@@ -516,7 +506,6 @@ class FloatingLabelAlignment {
   ///
   /// For right-to-left text ([TextDirection.rtl]), this is the right edge.
   static const FloatingLabelAlignment start = FloatingLabelAlignment._(-1.0);
-
   /// Aligns the floating label to the center of an [InputDecorator].
   static const FloatingLabelAlignment center = FloatingLabelAlignment._(0.0);
 
@@ -525,14 +514,19 @@ class FloatingLabelAlignment {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return other is FloatingLabelAlignment && _x == other._x;
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is FloatingLabelAlignment
+            && _x == other._x;
   }
 
   static String _stringify(double x) {
-    if (x == -1.0) return 'FloatingLabelAlignment.start';
-    if (x == 0.0) return 'FloatingLabelAlignment.center';
+    if (x == -1.0)
+      return 'FloatingLabelAlignment.start';
+    if (x == 0.0)
+      return 'FloatingLabelAlignment.center';
     return 'FloatingLabelAlignment(x: ${x.toStringAsFixed(1)})';
   }
 
@@ -580,11 +574,11 @@ class _Decoration {
     this.helperError,
     this.counter,
     this.container,
-  })  : assert(contentPadding != null),
-        assert(isCollapsed != null),
-        assert(floatingLabelHeight != null),
-        assert(floatingLabelProgress != null),
-        assert(floatingLabelAlignment != null);
+  }) : assert(contentPadding != null),
+       assert(isCollapsed != null),
+       assert(floatingLabelHeight != null),
+       assert(floatingLabelProgress != null),
+       assert(floatingLabelAlignment != null);
 
   final EdgeInsetsGeometry contentPadding;
   final bool isCollapsed;
@@ -610,55 +604,57 @@ class _Decoration {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return other is _Decoration &&
-        other.contentPadding == contentPadding &&
-        other.isCollapsed == isCollapsed &&
-        other.floatingLabelHeight == floatingLabelHeight &&
-        other.floatingLabelProgress == floatingLabelProgress &&
-        other.floatingLabelAlignment == floatingLabelAlignment &&
-        other.border == border &&
-        other.borderGap == borderGap &&
-        other.alignLabelWithHint == alignLabelWithHint &&
-        other.isDense == isDense &&
-        other.visualDensity == visualDensity &&
-        other.icon == icon &&
-        other.input == input &&
-        other.label == label &&
-        other.hint == hint &&
-        other.prefix == prefix &&
-        other.suffix == suffix &&
-        other.prefixIcon == prefixIcon &&
-        other.suffixIcon == suffixIcon &&
-        other.helperError == helperError &&
-        other.counter == counter &&
-        other.container == container;
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is _Decoration
+        && other.contentPadding == contentPadding
+        && other.isCollapsed == isCollapsed
+        && other.floatingLabelHeight == floatingLabelHeight
+        && other.floatingLabelProgress == floatingLabelProgress
+        && other.floatingLabelAlignment == floatingLabelAlignment
+        && other.border == border
+        && other.borderGap == borderGap
+        && other.alignLabelWithHint == alignLabelWithHint
+        && other.isDense == isDense
+        && other.visualDensity == visualDensity
+        && other.icon == icon
+        && other.input == input
+        && other.label == label
+        && other.hint == hint
+        && other.prefix == prefix
+        && other.suffix == suffix
+        && other.prefixIcon == prefixIcon
+        && other.suffixIcon == suffixIcon
+        && other.helperError == helperError
+        && other.counter == counter
+        && other.container == container;
   }
 
   @override
   int get hashCode => Object.hash(
-        contentPadding,
-        floatingLabelHeight,
-        floatingLabelProgress,
-        floatingLabelAlignment,
-        border,
-        borderGap,
-        alignLabelWithHint,
-        isDense,
-        visualDensity,
-        icon,
-        input,
-        label,
-        hint,
-        prefix,
-        suffix,
-        prefixIcon,
-        suffixIcon,
-        helperError,
-        counter,
-        container,
-      );
+    contentPadding,
+    floatingLabelHeight,
+    floatingLabelProgress,
+    floatingLabelAlignment,
+    border,
+    borderGap,
+    alignLabelWithHint,
+    isDense,
+    visualDensity,
+    icon,
+    input,
+    label,
+    hint,
+    prefix,
+    suffix,
+    prefixIcon,
+    suffixIcon,
+    helperError,
+    counter,
+    container,
+  );
 }
 
 // A container for the layout values computed by _RenderDecoration._layout.
@@ -683,8 +679,7 @@ class _RenderDecorationLayout {
 }
 
 // The workhorse: layout and paint a _Decorator widget's _Decoration.
-class _RenderDecoration extends RenderBox
-    with SlottedContainerRenderObjectMixin<_DecorationSlot> {
+class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin<_DecorationSlot> {
   _RenderDecoration({
     required _Decoration decoration,
     required TextDirection textDirection,
@@ -692,16 +687,16 @@ class _RenderDecoration extends RenderBox
     required bool isFocused,
     required bool expands,
     TextAlignVertical? textAlignVertical,
-  })  : assert(decoration != null),
-        assert(textDirection != null),
-        assert(textBaseline != null),
-        assert(expands != null),
-        _decoration = decoration,
-        _textDirection = textDirection,
-        _textBaseline = textBaseline,
-        _textAlignVertical = textAlignVertical,
-        _isFocused = isFocused,
-        _expands = expands;
+  }) : assert(decoration != null),
+       assert(textDirection != null),
+       assert(textBaseline != null),
+       assert(expands != null),
+       _decoration = decoration,
+       _textDirection = textDirection,
+       _textBaseline = textBaseline,
+       _textAlignVertical = textAlignVertical,
+       _isFocused = isFocused,
+       _expands = expands;
 
   static const double subtextGap = 8.0;
 
@@ -721,17 +716,28 @@ class _RenderDecoration extends RenderBox
   @override
   Iterable<RenderBox> get children {
     return <RenderBox>[
-      if (icon != null) icon!,
-      if (input != null) input!,
-      if (prefixIcon != null) prefixIcon!,
-      if (suffixIcon != null) suffixIcon!,
-      if (prefix != null) prefix!,
-      if (suffix != null) suffix!,
-      if (label != null) label!,
-      if (hint != null) hint!,
-      if (helperError != null) helperError!,
-      if (counter != null) counter!,
-      if (container != null) container!,
+      if (icon != null)
+        icon!,
+      if (input != null)
+        input!,
+      if (prefixIcon != null)
+        prefixIcon!,
+      if (suffixIcon != null)
+        suffixIcon!,
+      if (prefix != null)
+        prefix!,
+      if (suffix != null)
+        suffix!,
+      if (label != null)
+        label!,
+      if (hint != null)
+        hint!,
+      if (helperError != null)
+        helperError!,
+      if (counter != null)
+        counter!,
+      if (container != null)
+        container!,
     ];
   }
 
@@ -739,7 +745,8 @@ class _RenderDecoration extends RenderBox
   _Decoration _decoration;
   set decoration(_Decoration value) {
     assert(value != null);
-    if (_decoration == value) return;
+    if (_decoration == value)
+      return;
     _decoration = value;
     markNeedsLayout();
   }
@@ -748,7 +755,8 @@ class _RenderDecoration extends RenderBox
   TextDirection _textDirection;
   set textDirection(TextDirection value) {
     assert(value != null);
-    if (_textDirection == value) return;
+    if (_textDirection == value)
+      return;
     _textDirection = value;
     markNeedsLayout();
   }
@@ -757,15 +765,16 @@ class _RenderDecoration extends RenderBox
   TextBaseline _textBaseline;
   set textBaseline(TextBaseline value) {
     assert(value != null);
-    if (_textBaseline == value) return;
+    if (_textBaseline == value)
+      return;
     _textBaseline = value;
     markNeedsLayout();
   }
 
-  TextAlignVertical get _defaultTextAlignVertical =>
-      _isOutlineAligned ? TextAlignVertical.center : TextAlignVertical.top;
-  TextAlignVertical? get textAlignVertical =>
-      _textAlignVertical ?? _defaultTextAlignVertical;
+  TextAlignVertical get _defaultTextAlignVertical => _isOutlineAligned
+      ? TextAlignVertical.center
+      : TextAlignVertical.top;
+  TextAlignVertical? get textAlignVertical => _textAlignVertical ?? _defaultTextAlignVertical;
   TextAlignVertical? _textAlignVertical;
   set textAlignVertical(TextAlignVertical? value) {
     if (_textAlignVertical == value) {
@@ -784,7 +793,8 @@ class _RenderDecoration extends RenderBox
   bool _isFocused;
   set isFocused(bool value) {
     assert(value != null);
-    if (_isFocused == value) return;
+    if (_isFocused == value)
+      return;
     _isFocused = value;
     markNeedsSemanticsUpdate();
   }
@@ -793,7 +803,8 @@ class _RenderDecoration extends RenderBox
   bool _expands = false;
   set expands(bool value) {
     assert(value != null);
-    if (_expands == value) return;
+    if (_expands == value)
+      return;
     _expands = value;
     markNeedsLayout();
   }
@@ -806,9 +817,12 @@ class _RenderDecoration extends RenderBox
 
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
-    if (icon != null) visitor(icon!);
-    if (prefix != null) visitor(prefix!);
-    if (prefixIcon != null) visitor(prefixIcon!);
+    if (icon != null)
+      visitor(icon!);
+    if (prefix != null)
+      visitor(prefix!);
+    if (prefixIcon != null)
+      visitor(prefixIcon!);
 
     if (label != null) {
       visitor(label!);
@@ -821,12 +835,18 @@ class _RenderDecoration extends RenderBox
       }
     }
 
-    if (input != null) visitor(input!);
-    if (suffixIcon != null) visitor(suffixIcon!);
-    if (suffix != null) visitor(suffix!);
-    if (container != null) visitor(container!);
-    if (helperError != null) visitor(helperError!);
-    if (counter != null) visitor(counter!);
+    if (input != null)
+      visitor(input!);
+    if (suffixIcon != null)
+      visitor(suffixIcon!);
+    if (suffix != null)
+      visitor(suffix!);
+    if (container != null)
+      visitor(container!);
+    if (helperError != null)
+      visitor(helperError!);
+    if (counter != null)
+      visitor(counter!);
   }
 
   @override
@@ -846,8 +866,7 @@ class _RenderDecoration extends RenderBox
 
   static Size _boxSize(RenderBox? box) => box == null ? Size.zero : box.size;
 
-  static BoxParentData _boxParentData(RenderBox box) =>
-      box.parentData! as BoxParentData;
+  static BoxParentData _boxParentData(RenderBox box) => box.parentData! as BoxParentData;
 
   EdgeInsets get contentPadding => decoration.contentPadding as EdgeInsets;
 
@@ -866,10 +885,10 @@ class _RenderDecoration extends RenderBox
     final double baseline = box.getDistanceToBaseline(TextBaseline.alphabetic)!;
 
     assert(() {
-      if (baseline >= 0) return true;
+      if (baseline >= 0)
+        return true;
       throw FlutterError.fromParts(<DiagnosticsNode>[
-        ErrorSummary(
-            "One of InputDecorator's children reported a negative baseline offset."),
+        ErrorSummary("One of InputDecorator's children reported a negative baseline offset."),
         ErrorDescription(
           '${box.runtimeType}, of size ${box.size}, reported a negative '
           'alphabetic baseline of $baseline.',
@@ -903,10 +922,8 @@ class _RenderDecoration extends RenderBox
     final BoxConstraints containerConstraints = boxConstraints.copyWith(
       maxWidth: boxConstraints.maxWidth - _boxSize(icon).width,
     );
-    boxToBaseline[prefixIcon] =
-        _layoutLineBox(prefixIcon, containerConstraints);
-    boxToBaseline[suffixIcon] =
-        _layoutLineBox(suffixIcon, containerConstraints);
+    boxToBaseline[prefixIcon] = _layoutLineBox(prefixIcon, containerConstraints);
+    boxToBaseline[suffixIcon] = _layoutLineBox(suffixIcon, containerConstraints);
     final BoxConstraints contentConstraints = containerConstraints.copyWith(
       maxWidth: containerConstraints.maxWidth - contentPadding.horizontal,
     );
@@ -915,31 +932,29 @@ class _RenderDecoration extends RenderBox
 
     final double inputWidth = math.max(
       0.0,
-      constraints.maxWidth -
-          (_boxSize(icon).width +
-              contentPadding.left +
-              _boxSize(prefixIcon).width +
-              _boxSize(prefix).width +
-              _boxSize(suffix).width +
-              _boxSize(suffixIcon).width +
-              contentPadding.right),
+      constraints.maxWidth - (
+        _boxSize(icon).width
+        + contentPadding.left
+        + _boxSize(prefixIcon).width
+        + _boxSize(prefix).width
+        + _boxSize(suffix).width
+        + _boxSize(suffixIcon).width
+        + contentPadding.right),
     );
     // Increase the available width for the label when it is scaled down.
-    final double invertedLabelScale = lerpDouble(
-        1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress)!;
+    final double invertedLabelScale = lerpDouble(1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress)!;
     double suffixIconWidth = _boxSize(suffixIcon).width;
     if (decoration.border!.isOutline) {
-      suffixIconWidth =
-          lerpDouble(suffixIconWidth, 0.0, decoration.floatingLabelProgress)!;
+      suffixIconWidth = lerpDouble(suffixIconWidth, 0.0, decoration.floatingLabelProgress)!;
     }
     final double labelWidth = math.max(
       0.0,
-      constraints.maxWidth -
-          (_boxSize(icon).width +
-              contentPadding.left +
-              _boxSize(prefixIcon).width +
-              suffixIconWidth +
-              contentPadding.right),
+      constraints.maxWidth - (
+        _boxSize(icon).width
+        + contentPadding.left
+        + _boxSize(prefixIcon).width
+        + suffixIconWidth
+        + contentPadding.right),
     );
     boxToBaseline[label] = _layoutLineBox(
       label,
@@ -956,24 +971,26 @@ class _RenderDecoration extends RenderBox
     boxToBaseline[helperError] = _layoutLineBox(
       helperError,
       contentConstraints.copyWith(
-        maxWidth: math.max(
-            0.0, contentConstraints.maxWidth - _boxSize(counter).width),
+        maxWidth: math.max(0.0, contentConstraints.maxWidth - _boxSize(counter).width),
       ),
     );
 
     // The height of the input needs to accommodate label above and counter and
     // helperError below, when they exist.
-    final double labelHeight =
-        label == null ? 0 : decoration.floatingLabelHeight;
+    final double labelHeight = label == null
+      ? 0
+      : decoration.floatingLabelHeight;
     final double topHeight = decoration.border!.isOutline
-        ? math.max(labelHeight - boxToBaseline[label]!, 0)
-        : labelHeight;
-    final double counterHeight =
-        counter == null ? 0 : boxToBaseline[counter]! + subtextGap;
-    final bool helperErrorExists =
-        helperError?.size != null && helperError!.size.height > 0;
-    final double helperErrorHeight =
-        !helperErrorExists ? 0 : helperError!.size.height + subtextGap;
+      ? math.max(labelHeight - boxToBaseline[label]!, 0)
+      : labelHeight;
+    final double counterHeight = counter == null
+      ? 0
+      : boxToBaseline[counter]! + subtextGap;
+    final bool helperErrorExists = helperError?.size != null
+        && helperError!.size.height > 0;
+    final double helperErrorHeight = !helperErrorExists
+      ? 0
+      : helperError!.size.height + subtextGap;
     final double bottomHeight = math.max(
       counterHeight,
       helperErrorHeight,
@@ -981,15 +998,13 @@ class _RenderDecoration extends RenderBox
     final Offset densityOffset = decoration.visualDensity!.baseSizeAdjustment;
     boxToBaseline[input] = _layoutLineBox(
       input,
-      boxConstraints
-          .deflate(EdgeInsets.only(
-            top: contentPadding.top + topHeight + densityOffset.dy / 2,
-            bottom: contentPadding.bottom + bottomHeight + densityOffset.dy / 2,
-          ))
-          .copyWith(
-            minWidth: inputWidth,
-            maxWidth: inputWidth,
-          ),
+      boxConstraints.deflate(EdgeInsets.only(
+        top: contentPadding.top + topHeight + densityOffset.dy / 2,
+        bottom: contentPadding.bottom + bottomHeight + densityOffset.dy / 2,
+      )).copyWith(
+        minWidth: inputWidth,
+        maxWidth: inputWidth,
+      ),
     );
 
     // The field can be occupied by a hint or by the input itself
@@ -1023,36 +1038,32 @@ class _RenderDecoration extends RenderBox
     );
 
     // Calculate the height of the input text container.
-    final double prefixIconHeight =
-        prefixIcon == null ? 0 : prefixIcon!.size.height;
-    final double suffixIconHeight =
-        suffixIcon == null ? 0 : suffixIcon!.size.height;
+    final double prefixIconHeight = prefixIcon == null ? 0 : prefixIcon!.size.height;
+    final double suffixIconHeight = suffixIcon == null ? 0 : suffixIcon!.size.height;
     final double fixIconHeight = math.max(prefixIconHeight, suffixIconHeight);
     final double contentHeight = math.max(
       fixIconHeight,
-      topHeight +
-          contentPadding.top +
-          fixAboveInput +
-          inputHeight +
-          fixBelowInput +
-          contentPadding.bottom +
-          densityOffset.dy,
+      topHeight
+      + contentPadding.top
+      + fixAboveInput
+      + inputHeight
+      + fixBelowInput
+      + contentPadding.bottom
+      + densityOffset.dy,
     );
-    final double minContainerHeight =
-        decoration.isDense! || decoration.isCollapsed || expands
-            ? 0.0
-            : kMinInteractiveDimension;
+    final double minContainerHeight = decoration.isDense! || decoration.isCollapsed || expands
+      ? 0.0
+      : kMinInteractiveDimension;
     final double maxContainerHeight = boxConstraints.maxHeight - bottomHeight;
     final double containerHeight = expands
-        ? maxContainerHeight
-        : math.min(
-            math.max(contentHeight, minContainerHeight), maxContainerHeight);
+      ? maxContainerHeight
+      : math.min(math.max(contentHeight, minContainerHeight), maxContainerHeight);
 
     // Ensure the text is vertically centered in cases where the content is
     // shorter than kMinInteractiveDimension.
     final double interactiveAdjustment = minContainerHeight > contentHeight
-        ? (minContainerHeight - contentHeight) / 2.0
-        : 0.0;
+      ? (minContainerHeight - contentHeight) / 2.0
+      : 0.0;
 
     // Try to consider the prefix/suffix as part of the text when aligning it.
     // If the prefix/suffix overflows however, allow it to extend outside of the
@@ -1064,25 +1075,22 @@ class _RenderDecoration extends RenderBox
     // Adjust to try to fit top overflow inside the input on an inverse scale of
     // textAlignVertical, so that top aligned text adjusts the most and bottom
     // aligned text doesn't adjust at all.
-    final double baselineAdjustment =
-        fixAboveInput - overflow * (1 - textAlignVerticalFactor);
+    final double baselineAdjustment = fixAboveInput - overflow * (1 - textAlignVerticalFactor);
 
     // The baselines that will be used to draw the actual input text content.
-    final double topInputBaseline = contentPadding.top +
-        topHeight +
-        inputInternalBaseline +
-        baselineAdjustment +
-        interactiveAdjustment;
-    final double maxContentHeight = containerHeight -
-        contentPadding.top -
-        topHeight -
-        contentPadding.bottom;
+    final double topInputBaseline = contentPadding.top
+      + topHeight
+      + inputInternalBaseline
+      + baselineAdjustment
+      + interactiveAdjustment;
+    final double maxContentHeight = containerHeight
+      - contentPadding.top
+      - topHeight
+      - contentPadding.bottom;
     final double alignableHeight = fixAboveInput + inputHeight + fixBelowInput;
     final double maxVerticalOffset = maxContentHeight - alignableHeight;
-    final double textAlignVerticalOffset =
-        maxVerticalOffset * textAlignVerticalFactor;
-    final double inputBaseline =
-        topInputBaseline + textAlignVerticalOffset + densityOffset.dy / 2.0;
+    final double textAlignVerticalOffset = maxVerticalOffset * textAlignVerticalFactor;
+    final double inputBaseline = topInputBaseline + textAlignVerticalOffset + densityOffset.dy / 2.0;
 
     // The three main alignments for the baseline when an outline is present are
     //
@@ -1094,9 +1102,9 @@ class _RenderDecoration extends RenderBox
     // That means that if the padding is uneven, center is not the exact
     // midpoint of top and bottom. To account for this, the above center and
     // below center alignments are interpolated independently.
-    final double outlineCenterBaseline = inputInternalBaseline +
-        baselineAdjustment / 2.0 +
-        (containerHeight - (2.0 + inputHeight)) / 2.0;
+    final double outlineCenterBaseline = inputInternalBaseline
+      + baselineAdjustment / 2.0
+      + (containerHeight - (2.0 + inputHeight)) / 2.0;
     final double outlineTopBaseline = topInputBaseline;
     final double outlineBottomBaseline = topInputBaseline + maxVerticalOffset;
     final double outlineBaseline = _interpolateThree(
@@ -1113,12 +1121,12 @@ class _RenderDecoration extends RenderBox
     double subtextHelperHeight = 0;
     if (counter != null) {
       subtextCounterBaseline =
-          containerHeight + subtextGap + boxToBaseline[counter]!;
+        containerHeight + subtextGap + boxToBaseline[counter]!;
       subtextCounterHeight = counter!.size.height + subtextGap;
     }
     if (helperErrorExists) {
       subtextHelperBaseline =
-          containerHeight + subtextGap + boxToBaseline[helperError]!;
+        containerHeight + subtextGap + boxToBaseline[helperError]!;
       subtextHelperHeight = helperErrorHeight;
     }
     final double subtextBaseline = math.max(
@@ -1147,8 +1155,7 @@ class _RenderDecoration extends RenderBox
   // alignment is greater than zero, it interpolates between the centered box's
   // top and the position that would align the bottom of the box with the bottom
   // padding.
-  double _interpolateThree(double begin, double middle, double end,
-      TextAlignVertical textAlignVertical) {
+  double _interpolateThree(double begin, double middle, double end, TextAlignVertical textAlignVertical) {
     if (textAlignVertical.y <= 0) {
       // It's possible for begin, middle, and end to not be in order because of
       // excessive padding. Those cases are handled by using middle.
@@ -1172,32 +1179,33 @@ class _RenderDecoration extends RenderBox
 
   @override
   double computeMinIntrinsicWidth(double height) {
-    return _minWidth(icon, height) +
-        contentPadding.left +
-        _minWidth(prefixIcon, height) +
-        _minWidth(prefix, height) +
-        math.max(_minWidth(input, height), _minWidth(hint, height)) +
-        _minWidth(suffix, height) +
-        _minWidth(suffixIcon, height) +
-        contentPadding.right;
+    return _minWidth(icon, height)
+      + contentPadding.left
+      + _minWidth(prefixIcon, height)
+      + _minWidth(prefix, height)
+      + math.max(_minWidth(input, height), _minWidth(hint, height))
+      + _minWidth(suffix, height)
+      + _minWidth(suffixIcon, height)
+      + contentPadding.right;
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    return _maxWidth(icon, height) +
-        contentPadding.left +
-        _maxWidth(prefixIcon, height) +
-        _maxWidth(prefix, height) +
-        math.max(_maxWidth(input, height), _maxWidth(hint, height)) +
-        _maxWidth(suffix, height) +
-        _maxWidth(suffixIcon, height) +
-        contentPadding.right;
+    return _maxWidth(icon, height)
+      + contentPadding.left
+      + _maxWidth(prefixIcon, height)
+      + _maxWidth(prefix, height)
+      + math.max(_maxWidth(input, height), _maxWidth(hint, height))
+      + _maxWidth(suffix, height)
+      + _maxWidth(suffixIcon, height)
+      + contentPadding.right;
   }
 
   double _lineHeight(double width, List<RenderBox?> boxes) {
     double height = 0.0;
     for (final RenderBox? box in boxes) {
-      if (box == null) continue;
+      if (box == null)
+        continue;
       height = math.max(_minHeight(box, width), height);
     }
     return height;
@@ -1224,12 +1232,11 @@ class _RenderDecoration extends RenderBox
     final double counterHeight = _minHeight(counter, width);
     final double counterWidth = _minWidth(counter, counterHeight);
 
-    final double helperErrorAvailableWidth =
-        math.max(width - counterWidth, 0.0);
-    final double helperErrorHeight =
-        _minHeight(helperError, helperErrorAvailableWidth);
+    final double helperErrorAvailableWidth = math.max(width - counterWidth, 0.0);
+    final double helperErrorHeight = _minHeight(helperError, helperErrorAvailableWidth);
     double subtextHeight = math.max(counterHeight, helperErrorHeight);
-    if (subtextHeight > 0.0) subtextHeight += subtextGap;
+    if (subtextHeight > 0.0)
+      subtextHeight += subtextGap;
 
     final double prefixHeight = _minHeight(prefix, width);
     final double prefixWidth = _minWidth(prefix, prefixHeight);
@@ -1237,28 +1244,20 @@ class _RenderDecoration extends RenderBox
     final double suffixHeight = _minHeight(suffix, width);
     final double suffixWidth = _minWidth(suffix, suffixHeight);
 
-    final double availableInputWidth = math.max(
-        width - prefixWidth - suffixWidth - prefixIconWidth - suffixIconWidth,
-        0.0);
-    final double inputHeight =
-        _lineHeight(availableInputWidth, <RenderBox?>[input, hint]);
-    final double inputMaxHeight =
-        <double>[inputHeight, prefixHeight, suffixHeight].reduce(math.max);
+    final double availableInputWidth = math.max(width - prefixWidth - suffixWidth - prefixIconWidth - suffixIconWidth, 0.0);
+    final double inputHeight = _lineHeight(availableInputWidth, <RenderBox?>[input, hint]);
+    final double inputMaxHeight = <double>[inputHeight, prefixHeight, suffixHeight].reduce(math.max);
 
     final Offset densityOffset = decoration.visualDensity!.baseSizeAdjustment;
-    final double contentHeight = contentPadding.top +
-        (label == null ? 0.0 : decoration.floatingLabelHeight) +
-        inputMaxHeight +
-        contentPadding.bottom +
-        densityOffset.dy;
-    final double containerHeight = <double>[
-      iconHeight,
-      contentHeight,
-      prefixIconHeight,
-      suffixIconHeight
-    ].reduce(math.max);
-    final double minContainerHeight =
-        decoration.isDense! || expands ? 0.0 : kMinInteractiveDimension;
+    final double contentHeight = contentPadding.top
+      + (label == null ? 0.0 : decoration.floatingLabelHeight)
+      + inputMaxHeight
+      + contentPadding.bottom
+      + densityOffset.dy;
+    final double containerHeight = <double>[iconHeight, contentHeight, prefixIconHeight, suffixIconHeight].reduce(math.max);
+    final double minContainerHeight = decoration.isDense! || expands
+      ? 0.0
+      : kMinInteractiveDimension;
     return math.max(containerHeight, minContainerHeight) + subtextHeight;
   }
 
@@ -1269,8 +1268,7 @@ class _RenderDecoration extends RenderBox
 
   @override
   double computeDistanceToActualBaseline(TextBaseline baseline) {
-    return _boxParentData(input!).offset.dy +
-        input!.computeDistanceToActualBaseline(baseline)!;
+    return _boxParentData(input!).offset.dy + input!.computeDistanceToActualBaseline(baseline)!;
   }
 
   // Records where the label was painted.
@@ -1279,8 +1277,7 @@ class _RenderDecoration extends RenderBox
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     assert(debugCannotComputeDryLayout(
-      reason:
-          'Layout requires baseline metrics, which are only available after a full layout.',
+      reason: 'Layout requires baseline metrics, which are only available after a full layout.',
     ));
     return Size.zero;
   }
@@ -1308,7 +1305,7 @@ class _RenderDecoration extends RenderBox
         case TextDirection.ltr:
           x = _boxSize(icon).width;
           break;
-      }
+       }
       _boxParentData(container!).offset = Offset(x, 0.0);
     }
 
@@ -1320,8 +1317,7 @@ class _RenderDecoration extends RenderBox
 
     double? baseline;
     double baselineLayout(RenderBox box, double x) {
-      _boxParentData(box).offset =
-          Offset(x, baseline! - layout.boxToBaseline[box]!);
+      _boxParentData(box).offset = Offset(x, baseline! - layout.boxToBaseline[box]!);
       return box.size.width;
     }
 
@@ -1329,8 +1325,7 @@ class _RenderDecoration extends RenderBox
     final double right = overallWidth - contentPadding.right;
 
     height = layout.containerHeight;
-    baseline =
-        _isOutlineAligned ? layout.outlineBaseline : layout.inputBaseline;
+    baseline = _isOutlineAligned ? layout.outlineBaseline : layout.inputBaseline;
 
     if (icon != null) {
       final double x;
@@ -1341,63 +1336,67 @@ class _RenderDecoration extends RenderBox
         case TextDirection.ltr:
           x = 0.0;
           break;
-      }
+       }
       centerLayout(icon!, x);
     }
 
     switch (textDirection) {
-      case TextDirection.rtl:
-        {
-          double start = right - _boxSize(icon).width;
-          double end = left;
-          if (prefixIcon != null) {
-            start += contentPadding.left;
-            start -= centerLayout(prefixIcon!, start - prefixIcon!.size.width);
-          }
-          if (label != null) {
-            if (decoration.alignLabelWithHint) {
-              baselineLayout(label!, start - label!.size.width);
-            } else {
-              centerLayout(label!, start - label!.size.width);
-            }
-          }
-          if (prefix != null)
-            start -= baselineLayout(prefix!, start - prefix!.size.width);
-          if (input != null) baselineLayout(input!, start - input!.size.width);
-          if (hint != null) baselineLayout(hint!, start - hint!.size.width);
-          if (suffixIcon != null) {
-            end -= contentPadding.left;
-            end += centerLayout(suffixIcon!, end);
-          }
-          if (suffix != null) end += baselineLayout(suffix!, end);
-          break;
+      case TextDirection.rtl: {
+        double start = right - _boxSize(icon).width;
+        double end = left;
+        if (prefixIcon != null) {
+          start += contentPadding.left;
+          start -= centerLayout(prefixIcon!, start - prefixIcon!.size.width);
         }
-      case TextDirection.ltr:
-        {
-          double start = left + _boxSize(icon).width;
-          double end = right;
-          if (prefixIcon != null) {
-            start -= contentPadding.left;
-            start += centerLayout(prefixIcon!, start);
+        if (label != null) {
+          if (decoration.alignLabelWithHint) {
+            baselineLayout(label!, start - label!.size.width);
+          } else {
+            centerLayout(label!, start - label!.size.width);
           }
-          if (label != null) {
-            if (decoration.alignLabelWithHint) {
-              baselineLayout(label!, start);
-            } else {
-              centerLayout(label!, start);
-            }
-          }
-          if (prefix != null) start += baselineLayout(prefix!, start);
-          if (input != null) baselineLayout(input!, start);
-          if (hint != null) baselineLayout(hint!, start);
-          if (suffixIcon != null) {
-            end += contentPadding.right;
-            end -= centerLayout(suffixIcon!, end - suffixIcon!.size.width);
-          }
-          if (suffix != null)
-            end -= baselineLayout(suffix!, end - suffix!.size.width);
-          break;
         }
+        if (prefix != null)
+          start -= baselineLayout(prefix!, start - prefix!.size.width);
+        if (input != null)
+          baselineLayout(input!, start - input!.size.width);
+        if (hint != null)
+          baselineLayout(hint!, start - hint!.size.width);
+        if (suffixIcon != null) {
+          end -= contentPadding.left;
+          end += centerLayout(suffixIcon!, end);
+        }
+        if (suffix != null)
+          end += baselineLayout(suffix!, end);
+        break;
+      }
+      case TextDirection.ltr: {
+        double start = left + _boxSize(icon).width;
+        double end = right;
+        if (prefixIcon != null) {
+          start -= contentPadding.left;
+          start += centerLayout(prefixIcon!, start);
+        }
+        if (label != null) {
+          if (decoration.alignLabelWithHint) {
+            baselineLayout(label!, start);
+          } else {
+            centerLayout(label!, start);
+          }
+        }
+        if (prefix != null)
+          start += baselineLayout(prefix!, start);
+        if (input != null)
+          baselineLayout(input!, start);
+        if (hint != null)
+          baselineLayout(hint!, start);
+        if (suffixIcon != null) {
+          end += contentPadding.right;
+          end -= centerLayout(suffixIcon!, end - suffixIcon!.size.width);
+        }
+        if (suffix != null)
+          end -= baselineLayout(suffix!, end - suffix!.size.width);
+        break;
+      }
     }
 
     if (helperError != null || counter != null) {
@@ -1407,9 +1406,9 @@ class _RenderDecoration extends RenderBox
       switch (textDirection) {
         case TextDirection.rtl:
           if (helperError != null)
-            baselineLayout(helperError!,
-                right - helperError!.size.width - _boxSize(icon).width);
-          if (counter != null) baselineLayout(counter!, left);
+            baselineLayout(helperError!, right - helperError!.size.width - _boxSize(icon).width);
+          if (counter != null)
+            baselineLayout(counter!, left);
           break;
         case TextDirection.ltr:
           if (helperError != null)
@@ -1429,8 +1428,7 @@ class _RenderDecoration extends RenderBox
       // _BorderContainer's x and is independent of label's x.
       switch (textDirection) {
         case TextDirection.rtl:
-          decoration.borderGap!.start = lerpDouble(
-              labelX + _boxSize(label).width,
+          decoration.borderGap!.start = lerpDouble(labelX + _boxSize(label).width,
               _boxSize(container).width / 2.0 + floatWidth / 2.0,
               floatAlign);
 
@@ -1439,8 +1437,7 @@ class _RenderDecoration extends RenderBox
           // The value of _InputBorderGap.start is relative to the origin of the
           // _BorderContainer which is inset by the icon's width. Although, when
           // floating label is centered, it's already relative to _BorderContainer.
-          decoration.borderGap!.start = lerpDouble(
-              labelX - _boxSize(icon).width,
+          decoration.borderGap!.start = lerpDouble(labelX - _boxSize(icon).width,
               _boxSize(container).width / 2.0 - floatWidth / 2.0,
               floatAlign);
           break;
@@ -1466,7 +1463,6 @@ class _RenderDecoration extends RenderBox
       if (child != null)
         context.paintChild(child, _boxParentData(child).offset + offset);
     }
-
     doPaint(container);
 
     if (label != null) {
@@ -1480,17 +1476,13 @@ class _RenderDecoration extends RenderBox
       final double t = decoration.floatingLabelProgress;
       // The center of the outline border label ends up a little below the
       // center of the top border line.
-      final bool isOutlineBorder =
-          decoration.border != null && decoration.border!.isOutline;
+      final bool isOutlineBorder = decoration.border != null && decoration.border!.isOutline;
       // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
       // Center the scaled label relative to the border.
-      final double floatingY = isOutlineBorder
-          ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0
-          : contentPadding.top;
+      final double floatingY = isOutlineBorder ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0 : contentPadding.top;
       final double scale = lerpDouble(1.0, _kFinalLabelScale, t)!;
       final double centeredFloatX = _boxParentData(container!).offset.dx +
-          _boxSize(container).width / 2.0 -
-          floatWidth / 2.0;
+          _boxSize(container).width / 2.0 - floatWidth / 2.0;
       final double floatStartX;
       switch (textDirection) {
         case TextDirection.rtl: // origin is on the right
@@ -1500,8 +1492,7 @@ class _RenderDecoration extends RenderBox
           floatStartX = labelOffset.dx;
           break;
       }
-      final double floatEndX =
-          lerpDouble(floatStartX, centeredFloatX, floatAlign)!;
+      final double floatEndX = lerpDouble(floatStartX, centeredFloatX, floatAlign)!;
       final double dx = lerpDouble(floatStartX, floatEndX, t)!;
       final double dy = lerpDouble(0.0, floatingY - labelOffset.dy, t)!;
       _labelTransform = Matrix4.identity()
@@ -1533,7 +1524,7 @@ class _RenderDecoration extends RenderBox
   bool hitTestSelf(Offset position) => true;
 
   @override
-  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
+  bool hitTestChildren(BoxHitTestResult result, { required Offset position }) {
     assert(position != null);
     for (final RenderBox child in children) {
       // The label must be handled specially since we've transformed it.
@@ -1546,7 +1537,8 @@ class _RenderDecoration extends RenderBox
           return child.hitTest(result, position: transformed);
         },
       );
-      if (isHit) return true;
+      if (isHit)
+        return true;
     }
     return false;
   }
@@ -1563,8 +1555,7 @@ class _RenderDecoration extends RenderBox
   }
 }
 
-class _Decorator extends RenderObjectWidget
-    with SlottedMultiChildRenderObjectWidgetMixin<_DecorationSlot> {
+class _Decorator extends RenderObjectWidget with SlottedMultiChildRenderObjectWidgetMixin<_DecorationSlot> {
   const _Decorator({
     required this.textAlignVertical,
     required this.decoration,
@@ -1572,10 +1563,10 @@ class _Decorator extends RenderObjectWidget
     required this.textBaseline,
     required this.isFocused,
     required this.expands,
-  })  : assert(decoration != null),
-        assert(textDirection != null),
-        assert(textBaseline != null),
-        assert(expands != null);
+  }) : assert(decoration != null),
+       assert(textDirection != null),
+       assert(textBaseline != null),
+       assert(expands != null);
 
   final _Decoration decoration;
   final TextDirection textDirection;
@@ -1628,15 +1619,14 @@ class _Decorator extends RenderObjectWidget
   }
 
   @override
-  void updateRenderObject(
-      BuildContext context, _RenderDecoration renderObject) {
+  void updateRenderObject(BuildContext context, _RenderDecoration renderObject) {
     renderObject
-      ..decoration = decoration
-      ..expands = expands
-      ..isFocused = isFocused
-      ..textAlignVertical = textAlignVertical
-      ..textBaseline = textBaseline
-      ..textDirection = textDirection;
+     ..decoration = decoration
+     ..expands = expands
+     ..isFocused = isFocused
+     ..textAlignVertical = textAlignVertical
+     ..textBaseline = textBaseline
+     ..textDirection = textDirection;
   }
 }
 
@@ -1706,11 +1696,11 @@ class InputDecorator extends StatefulWidget {
     this.expands = false,
     this.isEmpty = false,
     this.child,
-  })  : assert(decoration != null),
-        assert(isFocused != null),
-        assert(isHovering != null),
-        assert(expands != null),
-        assert(isEmpty != null);
+  }) : assert(decoration != null),
+       assert(isFocused != null),
+       assert(isHovering != null),
+       assert(expands != null),
+       assert(isEmpty != null);
 
   /// The text and styles to use when decorating the child.
   ///
@@ -1800,8 +1790,7 @@ class InputDecorator extends StatefulWidget {
   /// floating or disappearing.
   ///
   /// Will withdraw when not empty, or when focused while enabled.
-  bool get _labelShouldWithdraw =>
-      !isEmpty || (isFocused && decoration.enabled);
+  bool get _labelShouldWithdraw => !isEmpty || (isFocused && decoration.enabled);
 
   @override
   State<InputDecorator> createState() => _InputDecoratorState();
@@ -1814,27 +1803,22 @@ class InputDecorator extends StatefulWidget {
   ///
   /// [TextField] renders ink splashes within the container.
   static RenderBox? containerOf(BuildContext context) {
-    final _RenderDecoration? result =
-        context.findAncestorRenderObjectOfType<_RenderDecoration>();
+    final _RenderDecoration? result = context.findAncestorRenderObjectOfType<_RenderDecoration>();
     return result?.container;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties
-        .add(DiagnosticsProperty<InputDecoration>('decoration', decoration));
-    properties.add(DiagnosticsProperty<TextStyle>('baseStyle', baseStyle,
-        defaultValue: null));
+    properties.add(DiagnosticsProperty<InputDecoration>('decoration', decoration));
+    properties.add(DiagnosticsProperty<TextStyle>('baseStyle', baseStyle, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('isFocused', isFocused));
-    properties.add(
-        DiagnosticsProperty<bool>('expands', expands, defaultValue: false));
+    properties.add(DiagnosticsProperty<bool>('expands', expands, defaultValue: false));
     properties.add(DiagnosticsProperty<bool>('isEmpty', isEmpty));
   }
 }
 
-class _InputDecoratorState extends State<InputDecorator>
-    with TickerProviderStateMixin {
+class _InputDecoratorState extends State<InputDecorator> with TickerProviderStateMixin {
   late AnimationController _floatingLabelController;
   late AnimationController _shakingLabelController;
   final _InputBorderGap _borderGap = _InputBorderGap();
@@ -1843,12 +1827,9 @@ class _InputDecoratorState extends State<InputDecorator>
   void initState() {
     super.initState();
 
-    final bool labelIsInitiallyFloating =
-        widget.decoration.floatingLabelBehavior ==
-                FloatingLabelBehavior.always ||
-            (widget.decoration.floatingLabelBehavior !=
-                    FloatingLabelBehavior.never &&
-                widget._labelShouldWithdraw);
+    final bool labelIsInitiallyFloating = widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always
+        || (widget.decoration.floatingLabelBehavior != FloatingLabelBehavior.never &&
+            widget._labelShouldWithdraw);
 
     _floatingLabelController = AnimationController(
       duration: _kTransitionDuration,
@@ -1901,17 +1882,14 @@ class _InputDecoratorState extends State<InputDecorator>
   @override
   void didUpdateWidget(InputDecorator old) {
     super.didUpdateWidget(old);
-    if (widget.decoration != old.decoration) _effectiveDecoration = null;
+    if (widget.decoration != old.decoration)
+      _effectiveDecoration = null;
 
-    final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior !=
-        old.decoration.floatingLabelBehavior;
+    final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior;
 
-    if (widget._labelShouldWithdraw != old._labelShouldWithdraw ||
-        floatBehaviorChanged) {
-      if (_floatingLabelEnabled &&
-          (widget._labelShouldWithdraw ||
-              widget.decoration.floatingLabelBehavior ==
-                  FloatingLabelBehavior.always))
+    if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviorChanged) {
+      if (_floatingLabelEnabled
+          && (widget._labelShouldWithdraw || widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always))
         _floatingLabelController.forward();
       else
         _floatingLabelController.reverse();
@@ -1920,9 +1898,7 @@ class _InputDecoratorState extends State<InputDecorator>
     final String? errorText = decoration!.errorText;
     final String? oldErrorText = old.decoration.errorText;
 
-    if (_floatingLabelController.isCompleted &&
-        errorText != null &&
-        errorText != oldErrorText) {
+    if (_floatingLabelController.isCompleted && errorText != null && errorText != oldErrorText) {
       _shakingLabelController
         ..value = 0.0
         ..forward();
@@ -1943,12 +1919,9 @@ class _InputDecoratorState extends State<InputDecorator>
     if (decoration!.filled!) {
       return themeData.hintColor;
     }
-    final Color enabledColor =
-        themeData.colorScheme.onSurface.withOpacity(0.38);
+    final Color enabledColor = themeData.colorScheme.onSurface.withOpacity(0.38);
     if (isHovering) {
-      final Color hoverColor = decoration!.hoverColor ??
-          themeData.inputDecorationTheme.hoverColor ??
-          themeData.hoverColor;
+      final Color hoverColor = decoration!.hoverColor ?? themeData.inputDecorationTheme.hoverColor ?? themeData.hoverColor;
       return Color.alphaBlend(hoverColor.withOpacity(0.12), enabledColor);
     }
     return enabledColor;
@@ -1958,8 +1931,7 @@ class _InputDecoratorState extends State<InputDecorator>
     if (decoration!.filled != true) // filled == null same as filled == false
       return Colors.transparent;
     if (decoration!.fillColor != null)
-      return MaterialStateProperty.resolveAs(
-          decoration!.fillColor!, materialState);
+      return MaterialStateProperty.resolveAs(decoration!.fillColor!, materialState);
 
     // dark theme: 10% white (enabled), 5% white (disabled)
     // light theme: 4% black (enabled), 2% black (disabled)
@@ -1977,19 +1949,14 @@ class _InputDecoratorState extends State<InputDecorator>
   }
 
   Color _getHoverColor(ThemeData themeData) {
-    if (decoration!.filled == null ||
-        !decoration!.filled! ||
-        isFocused ||
-        !decoration!.enabled) return Colors.transparent;
-    return decoration!.hoverColor ??
-        themeData.inputDecorationTheme.hoverColor ??
-        themeData.hoverColor;
+    if (decoration!.filled == null || !decoration!.filled! || isFocused || !decoration!.enabled)
+      return Colors.transparent;
+    return decoration!.hoverColor ?? themeData.inputDecorationTheme.hoverColor ?? themeData.hoverColor;
   }
 
   Color _getIconColor(ThemeData themeData) {
     Color resolveIconColor(Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled) &&
-          !states.contains(MaterialState.focused))
+      if (states.contains(MaterialState.disabled) && !states.contains(MaterialState.focused))
         return themeData.disabledColor;
 
       if (states.contains(MaterialState.focused))
@@ -2002,23 +1969,18 @@ class _InputDecoratorState extends State<InputDecorator>
           return Colors.black45;
       }
     }
-
-    return MaterialStateProperty.resolveAs(
-            themeData.inputDecorationTheme.iconColor, materialState) ??
-        MaterialStateProperty.resolveWith(resolveIconColor)
-            .resolve(materialState);
+    return MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.iconColor, materialState)
+      ?? MaterialStateProperty.resolveWith(resolveIconColor).resolve(materialState);
   }
 
   Color _getPrefixIconColor(ThemeData themeData) {
-    return MaterialStateProperty.resolveAs(
-            themeData.inputDecorationTheme.prefixIconColor, materialState) ??
-        _getIconColor(themeData);
+    return MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.prefixIconColor, materialState)
+      ?? _getIconColor(themeData);
   }
 
   Color _getSuffixIconColor(ThemeData themeData) {
-    return MaterialStateProperty.resolveAs(
-            themeData.inputDecorationTheme.suffixIconColor, materialState) ??
-        _getIconColor(themeData);
+    return MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.suffixIconColor, materialState)
+      ?? _getIconColor(themeData);
   }
 
   // True if the label will be shown and the hint will not.
@@ -2026,9 +1988,9 @@ class _InputDecoratorState extends State<InputDecorator>
   // floatingLabelBehavior isn't set to always, then the label appears where the
   // hint would.
   bool get _hasInlineLabel {
-    return !widget._labelShouldWithdraw &&
-        (decoration!.labelText != null || decoration!.label != null) &&
-        decoration!.floatingLabelBehavior != FloatingLabelBehavior.always;
+    return !widget._labelShouldWithdraw
+        && (decoration!.labelText != null || decoration!.label != null)
+        && decoration!.floatingLabelBehavior != FloatingLabelBehavior.always;
   }
 
   // If the label is a floating placeholder, it's always shown.
@@ -2038,78 +2000,63 @@ class _InputDecoratorState extends State<InputDecorator>
   // i.e. when they appear in place of the empty text field.
   TextStyle _getInlineLabelStyle(ThemeData themeData) {
     final TextStyle defaultStyle = TextStyle(
-      color:
-          decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
+      color: decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
     );
 
-    final TextStyle? style = MaterialStateProperty.resolveAs(
-            decoration!.labelStyle, materialState) ??
-        MaterialStateProperty.resolveAs(
-            themeData.inputDecorationTheme.labelStyle, materialState);
+    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.labelStyle, materialState)
+      ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.labelStyle, materialState);
 
     return themeData.textTheme.subtitle1!
-        .merge(widget.baseStyle)
-        .merge(defaultStyle)
-        .merge(style)
-        .copyWith(height: 1);
+      .merge(widget.baseStyle)
+      .merge(defaultStyle)
+      .merge(style)
+      .copyWith(height: 1);
   }
 
   // The base style for the inline hint when they're displayed "inline",
   // i.e. when they appear in place of the empty text field.
   TextStyle _getInlineHintStyle(ThemeData themeData) {
     final TextStyle defaultStyle = TextStyle(
-      color:
-          decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
+      color: decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
     );
 
-    final TextStyle? style =
-        MaterialStateProperty.resolveAs(decoration!.hintStyle, materialState) ??
-            MaterialStateProperty.resolveAs(
-                themeData.inputDecorationTheme.hintStyle, materialState);
+    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.hintStyle, materialState)
+      ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.hintStyle, materialState);
 
     return themeData.textTheme.subtitle1!
-        .merge(widget.baseStyle)
-        .merge(defaultStyle)
-        .merge(style);
+      .merge(widget.baseStyle)
+      .merge(defaultStyle)
+      .merge(style);
   }
 
   TextStyle _getFloatingLabelStyle(ThemeData themeData) {
     TextStyle getFallbackTextStyle() {
       final Color color = decoration!.errorText != null
-          ? decoration!.errorStyle?.color ?? themeData.errorColor
-          : _getActiveColor(themeData);
+        ? decoration!.errorStyle?.color ?? themeData.errorColor
+        : _getActiveColor(themeData);
 
-      return TextStyle(
-              color: decoration!.enabled ? color : themeData.disabledColor)
-          .merge(decoration!.floatingLabelStyle ?? decoration!.labelStyle);
+      return TextStyle(color: decoration!.enabled ? color : themeData.disabledColor)
+        .merge(decoration!.floatingLabelStyle ?? decoration!.labelStyle);
     }
 
-    final TextStyle? style = MaterialStateProperty.resolveAs(
-            decoration!.floatingLabelStyle, materialState) ??
-        MaterialStateProperty.resolveAs(
-            themeData.inputDecorationTheme.floatingLabelStyle, materialState);
+    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.floatingLabelStyle, materialState)
+      ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.floatingLabelStyle, materialState);
 
     return themeData.textTheme.subtitle1!
-        .merge(widget.baseStyle)
-        .copyWith(height: 1)
-        .merge(getFallbackTextStyle())
-        .merge(style);
+      .merge(widget.baseStyle)
+      .copyWith(height: 1)
+      .merge(getFallbackTextStyle())
+      .merge(style);
   }
 
   TextStyle _getHelperStyle(ThemeData themeData) {
-    final Color color =
-        decoration!.enabled ? themeData.hintColor : Colors.transparent;
-    return themeData.textTheme.caption!.copyWith(color: color).merge(
-        MaterialStateProperty.resolveAs(
-            decoration!.helperStyle, materialState));
+    final Color color = decoration!.enabled ? themeData.hintColor : Colors.transparent;
+    return themeData.textTheme.caption!.copyWith(color: color).merge(MaterialStateProperty.resolveAs(decoration!.helperStyle, materialState));
   }
 
   TextStyle _getErrorStyle(ThemeData themeData) {
-    final Color color =
-        decoration!.enabled ? themeData.errorColor : Colors.transparent;
-    return themeData.textTheme.caption!
-        .copyWith(color: color)
-        .merge(decoration!.errorStyle);
+    final Color color = decoration!.enabled ? themeData.errorColor : Colors.transparent;
+    return themeData.textTheme.caption!.copyWith(color: color).merge(decoration!.errorStyle);
   }
 
   Set<MaterialState> get materialState {
@@ -2122,9 +2069,8 @@ class _InputDecoratorState extends State<InputDecorator>
   }
 
   InputBorder _getDefaultBorder(ThemeData themeData) {
-    final InputBorder border =
-        MaterialStateProperty.resolveAs(decoration!.border, materialState) ??
-            const UnderlineInputBorder();
+    final InputBorder border =  MaterialStateProperty.resolveAs(decoration!.border, materialState)
+      ?? const UnderlineInputBorder();
 
     if (decoration!.border is MaterialStateProperty<InputBorder>) {
       return border;
@@ -2137,25 +2083,21 @@ class _InputDecoratorState extends State<InputDecorator>
     final Color borderColor;
     if (decoration!.enabled || isFocused) {
       borderColor = decoration!.errorText == null
-          ? _getDefaultBorderColor(themeData)
-          : themeData.errorColor;
+        ? _getDefaultBorderColor(themeData)
+        : themeData.errorColor;
     } else {
-      borderColor = ((decoration!.filled ?? false) &&
-              !(decoration!.border?.isOutline ?? false))
-          ? Colors.transparent
-          : themeData.disabledColor;
+      borderColor = ((decoration!.filled ?? false) && !(decoration!.border?.isOutline ?? false))
+        ? Colors.transparent
+        : themeData.disabledColor;
     }
 
     final double borderWeight;
-    if (decoration!.isCollapsed ||
-        decoration?.border == InputBorder.none ||
-        !decoration!.enabled)
+    if (decoration!.isCollapsed || decoration?.border == InputBorder.none || !decoration!.enabled)
       borderWeight = 0.0;
     else
       borderWeight = isFocused ? 2.0 : 1.0;
 
-    return border.copyWith(
-        borderSide: BorderSide(color: borderColor, width: borderWeight));
+    return border.copyWith(borderSide: BorderSide(color: borderColor, width: borderWeight));
   }
 
   @override
@@ -2165,30 +2107,27 @@ class _InputDecoratorState extends State<InputDecorator>
     final TextBaseline textBaseline = labelStyle.textBaseline!;
 
     final TextStyle hintStyle = _getInlineHintStyle(themeData);
-    final Widget? hint = decoration!.hintText == null
-        ? null
-        : AnimatedOpacity(
-            opacity: (isEmpty && !_hasInlineLabel) ? 1.0 : 0.0,
-            duration: _kTransitionDuration,
-            curve: _kTransitionCurve,
-            alwaysIncludeSemantics: true,
-            child: Text(
-              decoration!.hintText!,
-              style: hintStyle,
-              textDirection: decoration!.hintTextDirection,
-              overflow: TextOverflow.ellipsis,
-              textAlign: textAlign,
-              maxLines: decoration!.hintMaxLines,
-            ),
-          );
+    final Widget? hint = decoration!.hintText == null ? null : AnimatedOpacity(
+      opacity: (isEmpty && !_hasInlineLabel) ? 1.0 : 0.0,
+      duration: _kTransitionDuration,
+      curve: _kTransitionCurve,
+      alwaysIncludeSemantics: true,
+      child: Text(
+        decoration!.hintText!,
+        style: hintStyle,
+        textDirection: decoration!.hintTextDirection,
+        overflow: TextOverflow.ellipsis,
+        textAlign: textAlign,
+        maxLines: decoration!.hintMaxLines,
+      ),
+    );
 
     final bool isError = decoration!.errorText != null;
     InputBorder? border;
     if (!decoration!.enabled)
       border = isError ? decoration!.errorBorder : decoration!.disabledBorder;
     else if (isFocused)
-      border =
-          isError ? decoration!.focusedErrorBorder : decoration!.focusedBorder;
+      border = isError ? decoration!.focusedErrorBorder : decoration!.focusedBorder;
     else
       border = isError ? decoration!.errorBorder : decoration!.enabledBorder;
     border ??= _getDefaultBorder(themeData);
@@ -2202,116 +2141,100 @@ class _InputDecoratorState extends State<InputDecorator>
       isHovering: isHovering,
     );
 
-    final Widget? label =
-        decoration!.labelText == null && decoration!.label == null
-            ? null
-            : _Shaker(
-                animation: _shakingLabelController.view,
-                child: AnimatedOpacity(
-                  duration: _kTransitionDuration,
-                  curve: _kTransitionCurve,
-                  opacity: _shouldShowLabel ? 1.0 : 0.0,
-                  child: AnimatedDefaultTextStyle(
-                    duration: _kTransitionDuration,
-                    curve: _kTransitionCurve,
-                    style: widget._labelShouldWithdraw
-                        ? _getFloatingLabelStyle(themeData)
-                        : labelStyle,
-                    child: decoration!.label ??
-                        Text(
-                          decoration!.labelText!,
-                          overflow: TextOverflow.ellipsis,
-                          textAlign: textAlign,
-                        ),
-                  ),
-                ),
-              );
+    final Widget? label = decoration!.labelText == null && decoration!.label == null ? null : _Shaker(
+      animation: _shakingLabelController.view,
+      child: AnimatedOpacity(
+        duration: _kTransitionDuration,
+        curve: _kTransitionCurve,
+        opacity: _shouldShowLabel ? 1.0 : 0.0,
+        child: AnimatedDefaultTextStyle(
+          duration:_kTransitionDuration,
+          curve: _kTransitionCurve,
+          style: widget._labelShouldWithdraw
+            ? _getFloatingLabelStyle(themeData)
+            : labelStyle,
+          child: decoration!.label ?? Text(
+            decoration!.labelText!,
+            overflow: TextOverflow.ellipsis,
+            textAlign: textAlign,
+          ),
+        ),
+      ),
+    );
 
-    final Widget? prefix =
-        decoration!.prefix == null && decoration!.prefixText == null
-            ? null
-            : _AffixText(
-                labelIsFloating: widget._labelShouldWithdraw,
-                text: decoration!.prefixText,
-                style: MaterialStateProperty.resolveAs(
-                        decoration!.prefixStyle, materialState) ??
-                    hintStyle,
-                child: decoration!.prefix,
-              );
+    final Widget? prefix = decoration!.prefix == null && decoration!.prefixText == null ? null :
+      _AffixText(
+        labelIsFloating: widget._labelShouldWithdraw,
+        text: decoration!.prefixText,
+        style: MaterialStateProperty.resolveAs(decoration!.prefixStyle, materialState) ?? hintStyle,
+        child: decoration!.prefix,
+      );
 
-    final Widget? suffix =
-        decoration!.suffix == null && decoration!.suffixText == null
-            ? null
-            : _AffixText(
-                labelIsFloating: widget._labelShouldWithdraw,
-                text: decoration!.suffixText,
-                style: MaterialStateProperty.resolveAs(
-                        decoration!.suffixStyle, materialState) ??
-                    hintStyle,
-                child: decoration!.suffix,
-              );
+    final Widget? suffix = decoration!.suffix == null && decoration!.suffixText == null ? null :
+      _AffixText(
+        labelIsFloating: widget._labelShouldWithdraw,
+        text: decoration!.suffixText,
+        style: MaterialStateProperty.resolveAs(decoration!.suffixStyle, materialState) ?? hintStyle,
+        child: decoration!.suffix,
+      );
+
 
     final bool decorationIsDense = decoration!.isDense ?? false;
     final double iconSize = decorationIsDense ? 18.0 : 24.0;
 
-    final Widget? icon = decoration!.icon == null
-        ? null
-        : Padding(
-            padding: const EdgeInsetsDirectional.only(end: 16.0),
-            child: IconTheme.merge(
-              data: IconThemeData(
-                color: _getIconColor(themeData),
-                size: iconSize,
-              ),
-              child: decoration!.icon!,
-            ),
-          );
+    final Widget? icon = decoration!.icon == null ? null :
+      Padding(
+        padding: const EdgeInsetsDirectional.only(end: 16.0),
+        child: IconTheme.merge(
+          data: IconThemeData(
+            color: _getIconColor(themeData),
+            size: iconSize,
+          ),
+          child: decoration!.icon!,
+        ),
+      );
 
-    final Widget? prefixIcon = decoration!.prefixIcon == null
-        ? null
-        : Center(
-            widthFactor: 1.0,
-            heightFactor: 1.0,
-            child: ConstrainedBox(
-              constraints: decoration!.prefixIconConstraints ??
-                  themeData.visualDensity.effectiveConstraints(
-                    const BoxConstraints(
-                      minWidth: kMinInteractiveDimension,
-                      minHeight: kMinInteractiveDimension,
-                    ),
-                  ),
-              child: IconTheme.merge(
-                data: IconThemeData(
-                  color: _getPrefixIconColor(themeData),
-                  size: iconSize,
-                ),
-                child: decoration!.prefixIcon!,
-              ),
+    final Widget? prefixIcon = decoration!.prefixIcon == null ? null :
+      Center(
+        widthFactor: 1.0,
+        heightFactor: 1.0,
+        child: ConstrainedBox(
+          constraints: decoration!.prefixIconConstraints ?? themeData.visualDensity.effectiveConstraints(
+            const BoxConstraints(
+              minWidth: kMinInteractiveDimension,
+              minHeight: kMinInteractiveDimension,
             ),
-          );
+          ),
+          child: IconTheme.merge(
+            data: IconThemeData(
+              color: _getPrefixIconColor(themeData),
+              size: iconSize,
+            ),
+            child: decoration!.prefixIcon!,
+          ),
+        ),
+      );
 
-    final Widget? suffixIcon = decoration!.suffixIcon == null
-        ? null
-        : Center(
-            widthFactor: 1.0,
-            heightFactor: 1.0,
-            child: ConstrainedBox(
-              constraints: decoration!.suffixIconConstraints ??
-                  themeData.visualDensity.effectiveConstraints(
-                    const BoxConstraints(
-                      minWidth: kMinInteractiveDimension,
-                      minHeight: kMinInteractiveDimension,
-                    ),
-                  ),
-              child: IconTheme.merge(
-                data: IconThemeData(
-                  color: _getSuffixIconColor(themeData),
-                  size: iconSize,
-                ),
-                child: decoration!.suffixIcon!,
-              ),
+    final Widget? suffixIcon = decoration!.suffixIcon == null ? null :
+      Center(
+        widthFactor: 1.0,
+        heightFactor: 1.0,
+        child: ConstrainedBox(
+          constraints: decoration!.suffixIconConstraints ?? themeData.visualDensity.effectiveConstraints(
+            const BoxConstraints(
+              minWidth: kMinInteractiveDimension,
+              minHeight: kMinInteractiveDimension,
             ),
-          );
+          ),
+          child: IconTheme.merge(
+            data: IconThemeData(
+              color: _getSuffixIconColor(themeData),
+              size: iconSize,
+            ),
+            child: decoration!.suffixIcon!,
+          ),
+        ),
+      );
 
     final Widget helperError = _HelperError(
       textAlign: textAlign,
@@ -2321,22 +2244,18 @@ class _InputDecoratorState extends State<InputDecorator>
       errorText: decoration!.errorText,
       errorStyle: _getErrorStyle(themeData),
       errorMaxLines: decoration!.errorMaxLines,
-      errorWidgetBuilder: decoration!.errorWidgetBuilder,
     );
 
     Widget? counter;
     if (decoration!.counter != null) {
       counter = decoration!.counter;
-    } else if (decoration!.counterText != null &&
-        decoration!.counterText != '') {
+    } else if (decoration!.counterText != null && decoration!.counterText != '') {
       counter = Semantics(
         container: true,
         liveRegion: isFocused,
         child: Text(
           decoration!.counterText!,
-          style: _getHelperStyle(themeData).merge(
-              MaterialStateProperty.resolveAs(
-                  decoration!.counterStyle, materialState)),
+          style: _getHelperStyle(themeData).merge(MaterialStateProperty.resolveAs(decoration!.counterStyle, materialState)),
           overflow: TextOverflow.ellipsis,
           semanticsLabel: decoration!.semanticCounterText,
         ),
@@ -2346,8 +2265,7 @@ class _InputDecoratorState extends State<InputDecorator>
     // The _Decoration widget and _RenderDecoration assume that contentPadding
     // has been resolved to EdgeInsets.
     final TextDirection textDirection = Directionality.of(context);
-    final EdgeInsets? decorationContentPadding =
-        decoration!.contentPadding?.resolve(textDirection);
+    final EdgeInsets? decorationContentPadding = decoration!.contentPadding?.resolve(textDirection);
 
     final EdgeInsets contentPadding;
     final double floatingLabelHeight;
@@ -2356,53 +2274,50 @@ class _InputDecoratorState extends State<InputDecorator>
       contentPadding = decorationContentPadding ?? EdgeInsets.zero;
     } else if (!border.isOutline) {
       // 4.0: the vertical gap between the inline elements and the floating label.
-      floatingLabelHeight = (4.0 + 0.75 * labelStyle.fontSize!) *
-          MediaQuery.textScaleFactorOf(context);
+      floatingLabelHeight = (4.0 + 0.75 * labelStyle.fontSize!) * MediaQuery.textScaleFactorOf(context);
       if (decoration!.filled ?? false) {
-        contentPadding = decorationContentPadding ??
-            (decorationIsDense
-                ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
-                : const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 12.0));
+        contentPadding = decorationContentPadding ?? (decorationIsDense
+          ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
+          : const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 12.0));
       } else {
         // Not left or right padding for underline borders that aren't filled
         // is a small concession to backwards compatibility. This eliminates
         // the most noticeable layout change introduced by #13734.
-        contentPadding = decorationContentPadding ??
-            (decorationIsDense
-                ? const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
-                : const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
+        contentPadding = decorationContentPadding ?? (decorationIsDense
+          ? const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
+          : const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
       }
     } else {
       floatingLabelHeight = 0.0;
-      contentPadding = decorationContentPadding ??
-          (decorationIsDense
-              ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
-              : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
+      contentPadding = decorationContentPadding ?? (decorationIsDense
+        ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
+        : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
     }
 
     final _Decorator decorator = _Decorator(
       decoration: _Decoration(
-          contentPadding: contentPadding,
-          isCollapsed: decoration!.isCollapsed,
-          floatingLabelHeight: floatingLabelHeight,
-          floatingLabelAlignment: decoration!.floatingLabelAlignment!,
-          floatingLabelProgress: _floatingLabelController.value,
-          border: border,
-          borderGap: _borderGap,
-          alignLabelWithHint: decoration!.alignLabelWithHint ?? false,
-          isDense: decoration!.isDense,
-          visualDensity: themeData.visualDensity,
-          icon: icon,
-          input: widget.child,
-          label: label,
-          hint: hint,
-          prefix: prefix,
-          suffix: suffix,
-          prefixIcon: prefixIcon,
-          suffixIcon: suffixIcon,
-          helperError: helperError,
-          counter: counter,
-          container: container),
+        contentPadding: contentPadding,
+        isCollapsed: decoration!.isCollapsed,
+        floatingLabelHeight: floatingLabelHeight,
+        floatingLabelAlignment: decoration!.floatingLabelAlignment!,
+        floatingLabelProgress: _floatingLabelController.value,
+        border: border,
+        borderGap: _borderGap,
+        alignLabelWithHint: decoration!.alignLabelWithHint ?? false,
+        isDense: decoration!.isDense,
+        visualDensity: themeData.visualDensity,
+        icon: icon,
+        input: widget.child,
+        label: label,
+        hint: hint,
+        prefix: prefix,
+        suffix: suffix,
+        prefixIcon: prefixIcon,
+        suffixIcon: suffixIcon,
+        helperError: helperError,
+        counter: counter,
+        container: container
+      ),
       textDirection: textDirection,
       textBaseline: textBaseline,
       textAlignVertical: widget.textAlignVertical,
@@ -2410,8 +2325,7 @@ class _InputDecoratorState extends State<InputDecorator>
       expands: widget.expands,
     );
 
-    final BoxConstraints? constraints =
-        decoration!.constraints ?? themeData.inputDecorationTheme.constraints;
+    final BoxConstraints? constraints = decoration!.constraints ?? themeData.inputDecorationTheme.constraints;
     if (constraints != null) {
       return ConstrainedBox(
         constraints: constraints,
@@ -2525,7 +2439,6 @@ class InputDecoration {
     this.hintTextDirection,
     this.hintMaxLines,
     this.errorText,
-    this.errorWidgetBuilder,
     this.errorStyle,
     this.errorMaxLines,
     this.floatingLabelBehavior,
@@ -2562,13 +2475,10 @@ class InputDecoration {
     this.semanticCounterText,
     this.alignLabelWithHint,
     this.constraints,
-  })  : assert(enabled != null),
-        assert(!(label != null && labelText != null),
-            'Declaring both label and labelText is not supported.'),
-        assert(!(prefix != null && prefixText != null),
-            'Declaring both prefix and prefixText is not supported.'),
-        assert(!(suffix != null && suffixText != null),
-            'Declaring both suffix and suffixText is not supported.');
+  }) : assert(enabled != null),
+       assert(!(label != null && labelText != null), 'Declaring both label and labelText is not supported.'),
+       assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
+       assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.');
 
   /// Defines an [InputDecorator] that is the same size as the input field.
   ///
@@ -2587,47 +2497,46 @@ class InputDecoration {
     this.hoverColor,
     this.border = InputBorder.none,
     this.enabled = true,
-  })  : assert(enabled != null),
-        icon = null,
-        iconColor = null,
-        label = null,
-        labelText = null,
-        labelStyle = null,
-        floatingLabelStyle = null,
-        helperText = null,
-        helperStyle = null,
-        helperMaxLines = null,
-        hintMaxLines = null,
-        errorText = null,
-        errorWidgetBuilder = null,
-        errorStyle = null,
-        errorMaxLines = null,
-        isDense = false,
-        contentPadding = EdgeInsets.zero,
-        isCollapsed = true,
-        prefixIcon = null,
-        prefix = null,
-        prefixText = null,
-        prefixStyle = null,
-        prefixIconColor = null,
-        prefixIconConstraints = null,
-        suffix = null,
-        suffixIcon = null,
-        suffixText = null,
-        suffixStyle = null,
-        suffixIconColor = null,
-        suffixIconConstraints = null,
-        counter = null,
-        counterText = null,
-        counterStyle = null,
-        errorBorder = null,
-        focusedBorder = null,
-        focusedErrorBorder = null,
-        disabledBorder = null,
-        enabledBorder = null,
-        semanticCounterText = null,
-        alignLabelWithHint = false,
-        constraints = null;
+  }) : assert(enabled != null),
+       icon = null,
+       iconColor = null,
+       label = null,
+       labelText = null,
+       labelStyle = null,
+       floatingLabelStyle = null,
+       helperText = null,
+       helperStyle = null,
+       helperMaxLines = null,
+       hintMaxLines = null,
+       errorText = null,
+       errorStyle = null,
+       errorMaxLines = null,
+       isDense = false,
+       contentPadding = EdgeInsets.zero,
+       isCollapsed = true,
+       prefixIcon = null,
+       prefix = null,
+       prefixText = null,
+       prefixStyle = null,
+       prefixIconColor = null,
+       prefixIconConstraints = null,
+       suffix = null,
+       suffixIcon = null,
+       suffixText = null,
+       suffixStyle = null,
+       suffixIconColor = null,
+       suffixIconConstraints = null,
+       counter = null,
+       counterText = null,
+       counterStyle = null,
+       errorBorder = null,
+       focusedBorder = null,
+       focusedErrorBorder = null,
+       disabledBorder = null,
+       enabledBorder = null,
+       semanticCounterText = null,
+       alignLabelWithHint = false,
+       constraints = null;
 
   /// An icon to show before the input field and outside of the decoration's
   /// container.
@@ -2820,15 +2729,6 @@ class InputDecoration {
   /// [TextFormField.validator], if that is not null.
   final String? errorText;
 
-  /// Widget that appears below the [InputDecorator.child] and the border.
-  ///
-  /// If non-null, the border's color animates to red and the [helperText] is
-  /// not shown.
-  ///
-  /// In a [TextFormField], this is overridden by the value returned from
-  /// [TextFormField.validator], if that is not null.
-  final Widget Function(String errorText)? errorWidgetBuilder;
-
   /// {@template flutter.material.inputDecoration.errorStyle}
   /// The style to use for the [InputDecoration.errorText].
   ///
@@ -2842,6 +2742,7 @@ class InputDecoration {
   /// style.
   /// {@endtemplate}
   final TextStyle? errorStyle;
+
 
   /// The maximum number of lines the [errorText] can occupy.
   ///
@@ -3467,7 +3368,6 @@ class InputDecoration {
     TextDirection? hintTextDirection,
     int? hintMaxLines,
     String? errorText,
-    Widget Function(String errorText)? errorWidgetBuilder,
     TextStyle? errorStyle,
     int? errorMaxLines,
     FloatingLabelBehavior? floatingLabelBehavior,
@@ -3514,19 +3414,16 @@ class InputDecoration {
       floatingLabelStyle: floatingLabelStyle ?? this.floatingLabelStyle,
       helperText: helperText ?? this.helperText,
       helperStyle: helperStyle ?? this.helperStyle,
-      helperMaxLines: helperMaxLines ?? this.helperMaxLines,
+      helperMaxLines : helperMaxLines ?? this.helperMaxLines,
       hintText: hintText ?? this.hintText,
       hintStyle: hintStyle ?? this.hintStyle,
       hintTextDirection: hintTextDirection ?? this.hintTextDirection,
       hintMaxLines: hintMaxLines ?? this.hintMaxLines,
       errorText: errorText ?? this.errorText,
-      errorWidgetBuilder: errorWidgetBuilder ?? this.errorWidgetBuilder,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
-      floatingLabelBehavior:
-          floatingLabelBehavior ?? this.floatingLabelBehavior,
-      floatingLabelAlignment:
-          floatingLabelAlignment ?? this.floatingLabelAlignment,
+      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
+      floatingLabelAlignment: floatingLabelAlignment ?? this.floatingLabelAlignment,
       isCollapsed: isCollapsed ?? this.isCollapsed,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
@@ -3535,15 +3432,13 @@ class InputDecoration {
       prefixText: prefixText ?? this.prefixText,
       prefixStyle: prefixStyle ?? this.prefixStyle,
       prefixIconColor: prefixIconColor ?? this.prefixIconColor,
-      prefixIconConstraints:
-          prefixIconConstraints ?? this.prefixIconConstraints,
+      prefixIconConstraints: prefixIconConstraints ?? this.prefixIconConstraints,
       suffixIcon: suffixIcon ?? this.suffixIcon,
       suffix: suffix ?? this.suffix,
       suffixText: suffixText ?? this.suffixText,
       suffixStyle: suffixStyle ?? this.suffixStyle,
       suffixIconColor: suffixIconColor ?? this.suffixIconColor,
-      suffixIconConstraints:
-          suffixIconConstraints ?? this.suffixIconConstraints,
+      suffixIconConstraints: suffixIconConstraints ?? this.suffixIconConstraints,
       counter: counter ?? this.counter,
       counterText: counterText ?? this.counterText,
       counterStyle: counterStyle ?? this.counterStyle,
@@ -3574,14 +3469,12 @@ class InputDecoration {
       labelStyle: labelStyle ?? theme.labelStyle,
       floatingLabelStyle: floatingLabelStyle ?? theme.floatingLabelStyle,
       helperStyle: helperStyle ?? theme.helperStyle,
-      helperMaxLines: helperMaxLines ?? theme.helperMaxLines,
+      helperMaxLines : helperMaxLines ?? theme.helperMaxLines,
       hintStyle: hintStyle ?? theme.hintStyle,
       errorStyle: errorStyle ?? theme.errorStyle,
       errorMaxLines: errorMaxLines ?? theme.errorMaxLines,
-      floatingLabelBehavior:
-          floatingLabelBehavior ?? theme.floatingLabelBehavior,
-      floatingLabelAlignment:
-          floatingLabelAlignment ?? theme.floatingLabelAlignment,
+      floatingLabelBehavior: floatingLabelBehavior ?? theme.floatingLabelBehavior,
+      floatingLabelAlignment: floatingLabelAlignment ?? theme.floatingLabelAlignment,
       isCollapsed: isCollapsed,
       isDense: isDense ?? theme.isDense,
       contentPadding: contentPadding ?? theme.contentPadding,
@@ -3605,59 +3498,61 @@ class InputDecoration {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return other is InputDecoration &&
-        other.icon == icon &&
-        other.iconColor == iconColor &&
-        other.label == label &&
-        other.labelText == labelText &&
-        other.labelStyle == labelStyle &&
-        other.floatingLabelStyle == floatingLabelStyle &&
-        other.helperText == helperText &&
-        other.helperStyle == helperStyle &&
-        other.helperMaxLines == helperMaxLines &&
-        other.hintText == hintText &&
-        other.hintStyle == hintStyle &&
-        other.hintTextDirection == hintTextDirection &&
-        other.hintMaxLines == hintMaxLines &&
-        other.errorText == errorText &&
-        other.errorStyle == errorStyle &&
-        other.errorMaxLines == errorMaxLines &&
-        other.floatingLabelBehavior == floatingLabelBehavior &&
-        other.floatingLabelAlignment == floatingLabelAlignment &&
-        other.isDense == isDense &&
-        other.contentPadding == contentPadding &&
-        other.isCollapsed == isCollapsed &&
-        other.prefixIcon == prefixIcon &&
-        other.prefixIconColor == prefixIconColor &&
-        other.prefix == prefix &&
-        other.prefixText == prefixText &&
-        other.prefixStyle == prefixStyle &&
-        other.prefixIconConstraints == prefixIconConstraints &&
-        other.suffixIcon == suffixIcon &&
-        other.suffixIconColor == suffixIconColor &&
-        other.suffix == suffix &&
-        other.suffixText == suffixText &&
-        other.suffixStyle == suffixStyle &&
-        other.suffixIconConstraints == suffixIconConstraints &&
-        other.counter == counter &&
-        other.counterText == counterText &&
-        other.counterStyle == counterStyle &&
-        other.filled == filled &&
-        other.fillColor == fillColor &&
-        other.focusColor == focusColor &&
-        other.hoverColor == hoverColor &&
-        other.errorBorder == errorBorder &&
-        other.focusedBorder == focusedBorder &&
-        other.focusedErrorBorder == focusedErrorBorder &&
-        other.disabledBorder == disabledBorder &&
-        other.enabledBorder == enabledBorder &&
-        other.border == border &&
-        other.enabled == enabled &&
-        other.semanticCounterText == semanticCounterText &&
-        other.alignLabelWithHint == alignLabelWithHint &&
-        other.constraints == constraints;
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is InputDecoration
+        && other.icon == icon
+        && other.iconColor == iconColor
+        && other.label == label
+        && other.labelText == labelText
+        && other.labelStyle == labelStyle
+        && other.floatingLabelStyle == floatingLabelStyle
+        && other.helperText == helperText
+        && other.helperStyle == helperStyle
+        && other.helperMaxLines == helperMaxLines
+        && other.hintText == hintText
+        && other.hintStyle == hintStyle
+        && other.hintTextDirection == hintTextDirection
+        && other.hintMaxLines == hintMaxLines
+        && other.errorText == errorText
+        && other.errorStyle == errorStyle
+        && other.errorMaxLines == errorMaxLines
+        && other.floatingLabelBehavior == floatingLabelBehavior
+        && other.floatingLabelAlignment == floatingLabelAlignment
+        && other.isDense == isDense
+        && other.contentPadding == contentPadding
+        && other.isCollapsed == isCollapsed
+        && other.prefixIcon == prefixIcon
+        && other.prefixIconColor == prefixIconColor
+        && other.prefix == prefix
+        && other.prefixText == prefixText
+        && other.prefixStyle == prefixStyle
+        && other.prefixIconConstraints == prefixIconConstraints
+        && other.suffixIcon == suffixIcon
+        && other.suffixIconColor == suffixIconColor
+        && other.suffix == suffix
+        && other.suffixText == suffixText
+        && other.suffixStyle == suffixStyle
+        && other.suffixIconConstraints == suffixIconConstraints
+        && other.counter == counter
+        && other.counterText == counterText
+        && other.counterStyle == counterStyle
+        && other.filled == filled
+        && other.fillColor == fillColor
+        && other.focusColor == focusColor
+        && other.hoverColor == hoverColor
+        && other.errorBorder == errorBorder
+        && other.focusedBorder == focusedBorder
+        && other.focusedErrorBorder == focusedErrorBorder
+        && other.disabledBorder == disabledBorder
+        && other.enabledBorder == enabledBorder
+        && other.border == border
+        && other.enabled == enabled
+        && other.semanticCounterText == semanticCounterText
+        && other.alignLabelWithHint == alignLabelWithHint
+        && other.constraints == constraints;
   }
 
   @override
@@ -3724,8 +3619,7 @@ class InputDecoration {
       if (iconColor != null) 'iconColor: $iconColor',
       if (label != null) 'label: $label',
       if (labelText != null) 'labelText: "$labelText"',
-      if (floatingLabelStyle != null)
-        'floatingLabelStyle: "$floatingLabelStyle"',
+      if (floatingLabelStyle != null) 'floatingLabelStyle: "$floatingLabelStyle"',
       if (helperText != null) 'helperText: "$helperText"',
       if (helperMaxLines != null) 'helperMaxLines: "$helperMaxLines"',
       if (hintText != null) 'hintText: "$hintText"',
@@ -3733,10 +3627,8 @@ class InputDecoration {
       if (errorText != null) 'errorText: "$errorText"',
       if (errorStyle != null) 'errorStyle: "$errorStyle"',
       if (errorMaxLines != null) 'errorMaxLines: "$errorMaxLines"',
-      if (floatingLabelBehavior != null)
-        'floatingLabelBehavior: $floatingLabelBehavior',
-      if (floatingLabelAlignment != null)
-        'floatingLabelAlignment: $floatingLabelAlignment',
+      if (floatingLabelBehavior != null) 'floatingLabelBehavior: $floatingLabelBehavior',
+      if (floatingLabelAlignment != null) 'floatingLabelAlignment: $floatingLabelAlignment',
       if (isDense ?? false) 'isDense: $isDense',
       if (contentPadding != null) 'contentPadding: $contentPadding',
       if (isCollapsed) 'isCollapsed: $isCollapsed',
@@ -3745,15 +3637,13 @@ class InputDecoration {
       if (prefix != null) 'prefix: $prefix',
       if (prefixText != null) 'prefixText: $prefixText',
       if (prefixStyle != null) 'prefixStyle: $prefixStyle',
-      if (prefixIconConstraints != null)
-        'prefixIconConstraints: $prefixIconConstraints',
+      if (prefixIconConstraints != null) 'prefixIconConstraints: $prefixIconConstraints',
       if (suffixIcon != null) 'suffixIcon: $suffixIcon',
       if (suffixIconColor != null) 'suffixIconColor: $suffixIconColor',
       if (suffix != null) 'suffix: $suffix',
       if (suffixText != null) 'suffixText: $suffixText',
       if (suffixStyle != null) 'suffixStyle: $suffixStyle',
-      if (suffixIconConstraints != null)
-        'suffixIconConstraints: $suffixIconConstraints',
+      if (suffixIconConstraints != null) 'suffixIconConstraints: $suffixIconConstraints',
       if (counter != null) 'counter: $counter',
       if (counterText != null) 'counterText: $counterText',
       if (counterStyle != null) 'counterStyle: $counterStyle',
@@ -3768,8 +3658,7 @@ class InputDecoration {
       if (enabledBorder != null) 'enabledBorder: $enabledBorder',
       if (border != null) 'border: $border',
       if (!enabled) 'enabled: false',
-      if (semanticCounterText != null)
-        'semanticCounterText: $semanticCounterText',
+      if (semanticCounterText != null) 'semanticCounterText: $semanticCounterText',
       if (alignLabelWithHint != null) 'alignLabelWithHint: $alignLabelWithHint',
       if (constraints != null) 'constraints: $constraints',
     ];
@@ -3824,11 +3713,11 @@ class InputDecorationTheme with Diagnosticable {
     this.border,
     this.alignLabelWithHint = false,
     this.constraints,
-  })  : assert(isDense != null),
-        assert(isCollapsed != null),
-        assert(floatingLabelAlignment != null),
-        assert(filled != null),
-        assert(alignLabelWithHint != null);
+  }) : assert(isDense != null),
+       assert(isCollapsed != null),
+       assert(floatingLabelAlignment != null),
+       assert(filled != null),
+       assert(alignLabelWithHint != null);
 
   /// {@macro flutter.material.inputDecoration.labelStyle}
   final TextStyle? labelStyle;
@@ -4236,10 +4125,8 @@ class InputDecorationTheme with Diagnosticable {
       hintStyle: hintStyle ?? this.hintStyle,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
-      floatingLabelBehavior:
-          floatingLabelBehavior ?? this.floatingLabelBehavior,
-      floatingLabelAlignment:
-          floatingLabelAlignment ?? this.floatingLabelAlignment,
+      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
+      floatingLabelAlignment: floatingLabelAlignment ?? this.floatingLabelAlignment,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
       iconColor: iconColor,
@@ -4266,153 +4153,113 @@ class InputDecorationTheme with Diagnosticable {
 
   @override
   int get hashCode => Object.hash(
-        labelStyle,
-        floatingLabelStyle,
-        helperStyle,
-        helperMaxLines,
-        hintStyle,
-        errorStyle,
-        errorMaxLines,
-        floatingLabelBehavior,
-        floatingLabelAlignment,
-        isDense,
-        contentPadding,
-        isCollapsed,
-        iconColor,
-        prefixStyle,
-        prefixIconColor,
-        suffixStyle,
-        suffixIconColor,
-        counterStyle,
-        filled,
-        Object.hash(
-          fillColor,
-          focusColor,
-          hoverColor,
-          errorBorder,
-          focusedBorder,
-          focusedErrorBorder,
-          disabledBorder,
-          enabledBorder,
-          border,
-          alignLabelWithHint,
-          constraints,
-        ),
-      );
+    labelStyle,
+    floatingLabelStyle,
+    helperStyle,
+    helperMaxLines,
+    hintStyle,
+    errorStyle,
+    errorMaxLines,
+    floatingLabelBehavior,
+    floatingLabelAlignment,
+    isDense,
+    contentPadding,
+    isCollapsed,
+    iconColor,
+    prefixStyle,
+    prefixIconColor,
+    suffixStyle,
+    suffixIconColor,
+    counterStyle,
+    filled,
+    Object.hash(
+      fillColor,
+      focusColor,
+      hoverColor,
+      errorBorder,
+      focusedBorder,
+      focusedErrorBorder,
+      disabledBorder,
+      enabledBorder,
+      border,
+      alignLabelWithHint,
+      constraints,
+    ),
+  );
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-    if (other.runtimeType != runtimeType) return false;
-    return other is InputDecorationTheme &&
-        other.labelStyle == labelStyle &&
-        other.floatingLabelStyle == floatingLabelStyle &&
-        other.helperStyle == helperStyle &&
-        other.helperMaxLines == helperMaxLines &&
-        other.hintStyle == hintStyle &&
-        other.errorStyle == errorStyle &&
-        other.errorMaxLines == errorMaxLines &&
-        other.isDense == isDense &&
-        other.contentPadding == contentPadding &&
-        other.isCollapsed == isCollapsed &&
-        other.iconColor == iconColor &&
-        other.prefixStyle == prefixStyle &&
-        other.prefixIconColor == prefixIconColor &&
-        other.suffixStyle == suffixStyle &&
-        other.suffixIconColor == suffixIconColor &&
-        other.counterStyle == counterStyle &&
-        other.floatingLabelBehavior == floatingLabelBehavior &&
-        other.floatingLabelAlignment == floatingLabelAlignment &&
-        other.filled == filled &&
-        other.fillColor == fillColor &&
-        other.focusColor == focusColor &&
-        other.hoverColor == hoverColor &&
-        other.errorBorder == errorBorder &&
-        other.focusedBorder == focusedBorder &&
-        other.focusedErrorBorder == focusedErrorBorder &&
-        other.disabledBorder == disabledBorder &&
-        other.enabledBorder == enabledBorder &&
-        other.border == border &&
-        other.alignLabelWithHint == alignLabelWithHint &&
-        other.constraints == constraints &&
-        other.disabledBorder == disabledBorder;
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is InputDecorationTheme
+        && other.labelStyle == labelStyle
+        && other.floatingLabelStyle == floatingLabelStyle
+        && other.helperStyle == helperStyle
+        && other.helperMaxLines == helperMaxLines
+        && other.hintStyle == hintStyle
+        && other.errorStyle == errorStyle
+        && other.errorMaxLines == errorMaxLines
+        && other.isDense == isDense
+        && other.contentPadding == contentPadding
+        && other.isCollapsed == isCollapsed
+        && other.iconColor == iconColor
+        && other.prefixStyle == prefixStyle
+        && other.prefixIconColor == prefixIconColor
+        && other.suffixStyle == suffixStyle
+        && other.suffixIconColor == suffixIconColor
+        && other.counterStyle == counterStyle
+        && other.floatingLabelBehavior == floatingLabelBehavior
+        && other.floatingLabelAlignment == floatingLabelAlignment
+        && other.filled == filled
+        && other.fillColor == fillColor
+        && other.focusColor == focusColor
+        && other.hoverColor == hoverColor
+        && other.errorBorder == errorBorder
+        && other.focusedBorder == focusedBorder
+        && other.focusedErrorBorder == focusedErrorBorder
+        && other.disabledBorder == disabledBorder
+        && other.enabledBorder == enabledBorder
+        && other.border == border
+        && other.alignLabelWithHint == alignLabelWithHint
+        && other.constraints == constraints
+        && other.disabledBorder == disabledBorder;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     const InputDecorationTheme defaultTheme = InputDecorationTheme();
-    properties.add(DiagnosticsProperty<TextStyle>('labelStyle', labelStyle,
-        defaultValue: defaultTheme.labelStyle));
-    properties.add(DiagnosticsProperty<TextStyle>(
-        'floatingLabelStyle', floatingLabelStyle,
-        defaultValue: defaultTheme.floatingLabelStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('helperStyle', helperStyle,
-        defaultValue: defaultTheme.helperStyle));
-    properties.add(IntProperty('helperMaxLines', helperMaxLines,
-        defaultValue: defaultTheme.helperMaxLines));
-    properties.add(DiagnosticsProperty<TextStyle>('hintStyle', hintStyle,
-        defaultValue: defaultTheme.hintStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle,
-        defaultValue: defaultTheme.errorStyle));
-    properties.add(IntProperty('errorMaxLines', errorMaxLines,
-        defaultValue: defaultTheme.errorMaxLines));
-    properties.add(DiagnosticsProperty<FloatingLabelBehavior>(
-        'floatingLabelBehavior', floatingLabelBehavior,
-        defaultValue: defaultTheme.floatingLabelBehavior));
-    properties.add(DiagnosticsProperty<FloatingLabelAlignment>(
-        'floatingLabelAlignment', floatingLabelAlignment,
-        defaultValue: defaultTheme.floatingLabelAlignment));
-    properties.add(DiagnosticsProperty<bool>('isDense', isDense,
-        defaultValue: defaultTheme.isDense));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>(
-        'contentPadding', contentPadding,
-        defaultValue: defaultTheme.contentPadding));
-    properties.add(DiagnosticsProperty<bool>('isCollapsed', isCollapsed,
-        defaultValue: defaultTheme.isCollapsed));
-    properties.add(DiagnosticsProperty<Color>('iconColor', iconColor,
-        defaultValue: defaultTheme.iconColor));
-    properties.add(DiagnosticsProperty<Color>(
-        'prefixIconColor', prefixIconColor,
-        defaultValue: defaultTheme.prefixIconColor));
-    properties.add(DiagnosticsProperty<TextStyle>('prefixStyle', prefixStyle,
-        defaultValue: defaultTheme.prefixStyle));
-    properties.add(DiagnosticsProperty<Color>(
-        'suffixIconColor', suffixIconColor,
-        defaultValue: defaultTheme.suffixIconColor));
-    properties.add(DiagnosticsProperty<TextStyle>('suffixStyle', suffixStyle,
-        defaultValue: defaultTheme.suffixStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('counterStyle', counterStyle,
-        defaultValue: defaultTheme.counterStyle));
-    properties.add(DiagnosticsProperty<bool>('filled', filled,
-        defaultValue: defaultTheme.filled));
-    properties.add(ColorProperty('fillColor', fillColor,
-        defaultValue: defaultTheme.fillColor));
-    properties.add(ColorProperty('focusColor', focusColor,
-        defaultValue: defaultTheme.focusColor));
-    properties.add(ColorProperty('hoverColor', hoverColor,
-        defaultValue: defaultTheme.hoverColor));
-    properties.add(DiagnosticsProperty<InputBorder>('errorBorder', errorBorder,
-        defaultValue: defaultTheme.errorBorder));
-    properties.add(DiagnosticsProperty<InputBorder>(
-        'focusedBorder', focusedBorder,
-        defaultValue: defaultTheme.focusedErrorBorder));
-    properties.add(DiagnosticsProperty<InputBorder>(
-        'focusedErrorBorder', focusedErrorBorder,
-        defaultValue: defaultTheme.focusedErrorBorder));
-    properties.add(DiagnosticsProperty<InputBorder>(
-        'disabledBorder', disabledBorder,
-        defaultValue: defaultTheme.disabledBorder));
-    properties.add(DiagnosticsProperty<InputBorder>(
-        'enabledBorder', enabledBorder,
-        defaultValue: defaultTheme.enabledBorder));
-    properties.add(DiagnosticsProperty<InputBorder>('border', border,
-        defaultValue: defaultTheme.border));
-    properties.add(DiagnosticsProperty<bool>(
-        'alignLabelWithHint', alignLabelWithHint,
-        defaultValue: defaultTheme.alignLabelWithHint));
-    properties.add(DiagnosticsProperty<BoxConstraints>(
-        'constraints', constraints,
-        defaultValue: defaultTheme.constraints));
+    properties.add(DiagnosticsProperty<TextStyle>('labelStyle', labelStyle, defaultValue: defaultTheme.labelStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('floatingLabelStyle', floatingLabelStyle, defaultValue: defaultTheme.floatingLabelStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('helperStyle', helperStyle, defaultValue: defaultTheme.helperStyle));
+    properties.add(IntProperty('helperMaxLines', helperMaxLines, defaultValue: defaultTheme.helperMaxLines));
+    properties.add(DiagnosticsProperty<TextStyle>('hintStyle', hintStyle, defaultValue: defaultTheme.hintStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle, defaultValue: defaultTheme.errorStyle));
+    properties.add(IntProperty('errorMaxLines', errorMaxLines, defaultValue: defaultTheme.errorMaxLines));
+    properties.add(DiagnosticsProperty<FloatingLabelBehavior>('floatingLabelBehavior', floatingLabelBehavior, defaultValue: defaultTheme.floatingLabelBehavior));
+    properties.add(DiagnosticsProperty<FloatingLabelAlignment>('floatingLabelAlignment', floatingLabelAlignment, defaultValue: defaultTheme.floatingLabelAlignment));
+    properties.add(DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('contentPadding', contentPadding, defaultValue: defaultTheme.contentPadding));
+    properties.add(DiagnosticsProperty<bool>('isCollapsed', isCollapsed, defaultValue: defaultTheme.isCollapsed));
+    properties.add(DiagnosticsProperty<Color>('iconColor', iconColor, defaultValue: defaultTheme.iconColor));
+    properties.add(DiagnosticsProperty<Color>('prefixIconColor', prefixIconColor, defaultValue: defaultTheme.prefixIconColor));
+    properties.add(DiagnosticsProperty<TextStyle>('prefixStyle', prefixStyle, defaultValue: defaultTheme.prefixStyle));
+    properties.add(DiagnosticsProperty<Color>('suffixIconColor', suffixIconColor, defaultValue: defaultTheme.suffixIconColor));
+    properties.add(DiagnosticsProperty<TextStyle>('suffixStyle', suffixStyle, defaultValue: defaultTheme.suffixStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('counterStyle', counterStyle, defaultValue: defaultTheme.counterStyle));
+    properties.add(DiagnosticsProperty<bool>('filled', filled, defaultValue: defaultTheme.filled));
+    properties.add(ColorProperty('fillColor', fillColor, defaultValue: defaultTheme.fillColor));
+    properties.add(ColorProperty('focusColor', focusColor, defaultValue: defaultTheme.focusColor));
+    properties.add(ColorProperty('hoverColor', hoverColor, defaultValue: defaultTheme.hoverColor));
+    properties.add(DiagnosticsProperty<InputBorder>('errorBorder', errorBorder, defaultValue: defaultTheme.errorBorder));
+    properties.add(DiagnosticsProperty<InputBorder>('focusedBorder', focusedBorder, defaultValue: defaultTheme.focusedErrorBorder));
+    properties.add(DiagnosticsProperty<InputBorder>('focusedErrorBorder', focusedErrorBorder, defaultValue: defaultTheme.focusedErrorBorder));
+    properties.add(DiagnosticsProperty<InputBorder>('disabledBorder', disabledBorder, defaultValue: defaultTheme.disabledBorder));
+    properties.add(DiagnosticsProperty<InputBorder>('enabledBorder', enabledBorder, defaultValue: defaultTheme.enabledBorder));
+    properties.add(DiagnosticsProperty<InputBorder>('border', border, defaultValue: defaultTheme.border));
+    properties.add(DiagnosticsProperty<bool>('alignLabelWithHint', alignLabelWithHint, defaultValue: defaultTheme.alignLabelWithHint));
+    properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: defaultTheme.constraints));
   }
 }

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -292,13 +292,15 @@ class _HelperError extends StatefulWidget {
     this.helperMaxLines,
     this.errorText,
     this.errorStyle,
-    this.errorMaxLines,
+    this.errorMaxLines, 
+    this.errorWidget,
   });
 
   final TextAlign? textAlign;
   final String? helperText;
   final TextStyle? helperStyle;
   final int? helperMaxLines;
+  final Widget? errorWidget;
   final String? errorText;
   final TextStyle? errorStyle;
   final int? errorMaxLines;
@@ -323,7 +325,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
       duration: _kTransitionDuration,
       vsync: this,
     );
-    if (widget.errorText != null) {
+    if (widget.errorText != null || widget.errorWidget != null) {
       _error = _buildError();
       _controller.value = 1.0;
     } else if (widget.helperText != null) {
@@ -387,7 +389,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
   }
 
   Widget _buildError() {
-    assert(widget.errorText != null);
+    assert(widget.errorText != null || widget.errorWidget != null);
     return Semantics(
       container: true,
       liveRegion: true,
@@ -398,7 +400,7 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
             begin: const Offset(0.0, -0.25),
             end: Offset.zero,
           ).evaluate(_controller.view),
-          child: Text(
+          child: widget.errorWidget ?? Text(
             widget.errorText!,
             style: widget.errorStyle,
             textAlign: widget.textAlign,
@@ -412,6 +414,10 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
 
   @override
   Widget build(BuildContext context) {
+    if(widget.errorWidget != null) {
+      return _error = _buildError();
+    }
+
     if (_controller.isDismissed) {
       _error = null;
       if (widget.helperText != null) {
@@ -538,7 +544,6 @@ class FloatingLabelAlignment {
 enum _DecorationSlot {
   icon,
   input,
-  errorWidget,
   label,
   hint,
   prefix,
@@ -566,7 +571,6 @@ class _Decoration {
     this.visualDensity,
     this.icon,
     this.input,
-    this.errorWidget,
     this.label,
     this.hint,
     this.prefix,
@@ -594,7 +598,6 @@ class _Decoration {
   final VisualDensity? visualDensity;
   final Widget? icon;
   final Widget? input;
-  final Widget? errorWidget;
   final Widget? label;
   final Widget? hint;
   final Widget? prefix;
@@ -624,7 +627,6 @@ class _Decoration {
         && other.visualDensity == visualDensity
         && other.icon == icon
         && other.input == input
-        && other.errorWidget == errorWidget
         && other.label == label
         && other.hint == hint
         && other.prefix == prefix
@@ -706,7 +708,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   RenderBox? get icon => childForSlot(_DecorationSlot.icon);
   RenderBox? get input => childForSlot(_DecorationSlot.input);
-  RenderBox? get errorWidget => childForSlot(_DecorationSlot.errorWidget);
   RenderBox? get label => childForSlot(_DecorationSlot.label);
   RenderBox? get hint => childForSlot(_DecorationSlot.hint);
   RenderBox? get prefix => childForSlot(_DecorationSlot.prefix);
@@ -743,8 +744,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
         counter!,
       if (container != null)
         container!,
-      if(errorWidget != null)
-        errorWidget!
     ];
   }
 
@@ -833,10 +832,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
     if (label != null) {
       visitor(label!);
-    }
-
-    if(errorWidget != null){
-      visitor(errorWidget!);
     }
 
     if (hint != null) {
@@ -1616,8 +1611,6 @@ class _Decorator extends RenderObjectWidget with SlottedMultiChildRenderObjectWi
         return decoration.counter;
       case _DecorationSlot.container:
         return decoration.container;
-      case _DecorationSlot.errorWidget:
-      return decoration.errorWidget;
     }
   }
 
@@ -2184,18 +2177,6 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       ),
     );
 
-    final Widget? errorWidget = decoration!.errorWidget == null && decoration!.errorText == null ? null : _Shaker(
-      animation: _shakingErrorController.view,
-      child: decoration!.errorWidget ?? Text(
-        decoration!.errorText!,
-        overflow: TextOverflow.ellipsis,
-        textAlign: textAlign,
-      ),
-    );
-
-
-    
-
     final Widget? prefix = decoration!.prefix == null && decoration!.prefixText == null ? null :
       _AffixText(
         labelIsFloating: widget._labelShouldWithdraw,
@@ -2275,6 +2256,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       helperText: decoration!.helperText,
       helperStyle: _getHelperStyle(themeData),
       helperMaxLines: decoration!.helperMaxLines,
+      errorWidget: decoration!.errorWidget,
       errorText: decoration!.errorText,
       errorStyle: _getErrorStyle(themeData),
       errorMaxLines: decoration!.errorMaxLines,
@@ -2342,7 +2324,6 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         visualDensity: themeData.visualDensity,
         icon: icon,
         input: widget.child,
-        errorWidget: errorWidget,
         label: label,
         hint: hint,
         prefix: prefix,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -44,13 +44,11 @@ class _InputBorderGap extends ChangeNotifier {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes, this class is not used in collection
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
-    return other is _InputBorderGap
-        && other.start == start
-        && other.extent == extent;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is _InputBorderGap &&
+        other.start == start &&
+        other.extent == extent;
   }
 
   @override
@@ -92,7 +90,8 @@ class _InputBorderPainter extends CustomPainter {
   final ColorTween hoverColorTween;
   final Animation<double> hoverAnimation;
 
-  Color get blendedColor => Color.alphaBlend(hoverColorTween.evaluate(hoverAnimation)!, fillColor);
+  Color get blendedColor =>
+      Color.alphaBlend(hoverColorTween.evaluate(hoverAnimation)!, fillColor);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -120,12 +119,12 @@ class _InputBorderPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(_InputBorderPainter oldPainter) {
-    return borderAnimation != oldPainter.borderAnimation
-        || hoverAnimation != oldPainter.hoverAnimation
-        || gapAnimation != oldPainter.gapAnimation
-        || border != oldPainter.border
-        || gap != oldPainter.gap
-        || textDirection != oldPainter.textDirection;
+    return borderAnimation != oldPainter.borderAnimation ||
+        hoverAnimation != oldPainter.hoverAnimation ||
+        gapAnimation != oldPainter.gapAnimation ||
+        border != oldPainter.border ||
+        gap != oldPainter.gap ||
+        textDirection != oldPainter.textDirection;
   }
 
   @override
@@ -144,9 +143,9 @@ class _BorderContainer extends StatefulWidget {
     required this.fillColor,
     required this.hoverColor,
     required this.isHovering,
-  }) : assert(border != null),
-       assert(gap != null),
-       assert(fillColor != null);
+  })  : assert(border != null),
+        assert(gap != null),
+        assert(fillColor != null);
 
   final InputBorder border;
   final _InputBorderGap gap;
@@ -159,7 +158,8 @@ class _BorderContainer extends StatefulWidget {
   _BorderContainerState createState() => _BorderContainerState();
 }
 
-class _BorderContainerState extends State<_BorderContainer> with TickerProviderStateMixin {
+class _BorderContainerState extends State<_BorderContainer>
+    with TickerProviderStateMixin {
   static const Duration _kHoverDuration = Duration(milliseconds: 15);
 
   late AnimationController _controller;
@@ -193,7 +193,8 @@ class _BorderContainerState extends State<_BorderContainer> with TickerProviderS
       parent: _hoverColorController,
       curve: Curves.linear,
     );
-    _hoverColorTween = ColorTween(begin: Colors.transparent, end: widget.hoverColor);
+    _hoverColorTween =
+        ColorTween(begin: Colors.transparent, end: widget.hoverColor);
   }
 
   @override
@@ -216,7 +217,8 @@ class _BorderContainerState extends State<_BorderContainer> with TickerProviderS
         ..forward();
     }
     if (widget.hoverColor != oldWidget.hoverColor) {
-      _hoverColorTween = ColorTween(begin: Colors.transparent, end: widget.hoverColor);
+      _hoverColorTween =
+          ColorTween(begin: Colors.transparent, end: widget.hoverColor);
     }
     if (widget.isHovering != oldWidget.isHovering) {
       if (widget.isHovering) {
@@ -293,6 +295,7 @@ class _HelperError extends StatefulWidget {
     this.errorText,
     this.errorStyle,
     this.errorMaxLines,
+    this.errorWidgetBuilder,
   });
 
   final TextAlign? textAlign;
@@ -300,6 +303,7 @@ class _HelperError extends StatefulWidget {
   final TextStyle? helperStyle;
   final int? helperMaxLines;
   final String? errorText;
+  final Widget Function(String errorText)? errorWidgetBuilder;
   final TextStyle? errorStyle;
   final int? errorMaxLines;
 
@@ -307,7 +311,8 @@ class _HelperError extends StatefulWidget {
   _HelperErrorState createState() => _HelperErrorState();
 }
 
-class _HelperErrorState extends State<_HelperError> with SingleTickerProviderStateMixin {
+class _HelperErrorState extends State<_HelperError>
+    with SingleTickerProviderStateMixin {
   // If the height of this widget and the counter are zero ("empty") at
   // layout time, no space is allocated for the subtext.
   static const Widget empty = SizedBox();
@@ -353,8 +358,10 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
     final String? oldErrorText = old.errorText;
     final String? oldHelperText = old.helperText;
 
-    final bool errorTextStateChanged = (newErrorText != null) != (oldErrorText != null);
-    final bool helperTextStateChanged = newErrorText == null && (newHelperText != null) != (oldHelperText != null);
+    final bool errorTextStateChanged =
+        (newErrorText != null) != (oldErrorText != null);
+    final bool helperTextStateChanged = newErrorText == null &&
+        (newHelperText != null) != (oldHelperText != null);
 
     if (errorTextStateChanged || helperTextStateChanged) {
       if (newErrorText != null) {
@@ -398,13 +405,15 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
             begin: const Offset(0.0, -0.25),
             end: Offset.zero,
           ).evaluate(_controller.view),
-          child: Text(
-            widget.errorText!,
-            style: widget.errorStyle,
-            textAlign: widget.textAlign,
-            overflow: TextOverflow.ellipsis,
-            maxLines: widget.errorMaxLines,
-          ),
+          child: widget.errorWidgetBuilder == null
+              ? Text(
+                  widget.errorText!,
+                  style: widget.errorStyle,
+                  textAlign: widget.textAlign,
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: widget.errorMaxLines,
+                )
+              : widget.errorWidgetBuilder!(widget.errorText!),
         ),
       ),
     );
@@ -432,11 +441,9 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
       }
     }
 
-    if (_helper == null && widget.errorText != null)
-      return _buildError();
+    if (_helper == null && widget.errorText != null) return _buildError();
 
-    if (_error == null && widget.helperText != null)
-      return _buildHelper();
+    if (_error == null && widget.helperText != null) return _buildHelper();
 
     if (widget.errorText != null) {
       return Stack(
@@ -477,8 +484,10 @@ class _HelperErrorState extends State<_HelperError> with SingleTickerProviderSta
 enum FloatingLabelBehavior {
   /// The label will always be positioned within the content, or hidden.
   never,
+
   /// The label will float when the input is focused, or has content.
   auto,
+
   /// The label will always float above the content.
   always,
 }
@@ -494,8 +503,9 @@ enum FloatingLabelBehavior {
 ///    behave.
 @immutable
 class FloatingLabelAlignment {
-  const FloatingLabelAlignment._(this._x) : assert(_x != null),
-       assert(_x >= -1.0 && _x <= 1.0);
+  const FloatingLabelAlignment._(this._x)
+      : assert(_x != null),
+        assert(_x >= -1.0 && _x <= 1.0);
 
   // -1 denotes start, 0 denotes center, and 1 denotes end.
   final double _x;
@@ -506,6 +516,7 @@ class FloatingLabelAlignment {
   ///
   /// For right-to-left text ([TextDirection.rtl]), this is the right edge.
   static const FloatingLabelAlignment start = FloatingLabelAlignment._(-1.0);
+
   /// Aligns the floating label to the center of an [InputDecorator].
   static const FloatingLabelAlignment center = FloatingLabelAlignment._(0.0);
 
@@ -514,19 +525,14 @@ class FloatingLabelAlignment {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
-    return other is FloatingLabelAlignment
-            && _x == other._x;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is FloatingLabelAlignment && _x == other._x;
   }
 
   static String _stringify(double x) {
-    if (x == -1.0)
-      return 'FloatingLabelAlignment.start';
-    if (x == 0.0)
-      return 'FloatingLabelAlignment.center';
+    if (x == -1.0) return 'FloatingLabelAlignment.start';
+    if (x == 0.0) return 'FloatingLabelAlignment.center';
     return 'FloatingLabelAlignment(x: ${x.toStringAsFixed(1)})';
   }
 
@@ -574,11 +580,11 @@ class _Decoration {
     this.helperError,
     this.counter,
     this.container,
-  }) : assert(contentPadding != null),
-       assert(isCollapsed != null),
-       assert(floatingLabelHeight != null),
-       assert(floatingLabelProgress != null),
-       assert(floatingLabelAlignment != null);
+  })  : assert(contentPadding != null),
+        assert(isCollapsed != null),
+        assert(floatingLabelHeight != null),
+        assert(floatingLabelProgress != null),
+        assert(floatingLabelAlignment != null);
 
   final EdgeInsetsGeometry contentPadding;
   final bool isCollapsed;
@@ -604,57 +610,55 @@ class _Decoration {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
-    return other is _Decoration
-        && other.contentPadding == contentPadding
-        && other.isCollapsed == isCollapsed
-        && other.floatingLabelHeight == floatingLabelHeight
-        && other.floatingLabelProgress == floatingLabelProgress
-        && other.floatingLabelAlignment == floatingLabelAlignment
-        && other.border == border
-        && other.borderGap == borderGap
-        && other.alignLabelWithHint == alignLabelWithHint
-        && other.isDense == isDense
-        && other.visualDensity == visualDensity
-        && other.icon == icon
-        && other.input == input
-        && other.label == label
-        && other.hint == hint
-        && other.prefix == prefix
-        && other.suffix == suffix
-        && other.prefixIcon == prefixIcon
-        && other.suffixIcon == suffixIcon
-        && other.helperError == helperError
-        && other.counter == counter
-        && other.container == container;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is _Decoration &&
+        other.contentPadding == contentPadding &&
+        other.isCollapsed == isCollapsed &&
+        other.floatingLabelHeight == floatingLabelHeight &&
+        other.floatingLabelProgress == floatingLabelProgress &&
+        other.floatingLabelAlignment == floatingLabelAlignment &&
+        other.border == border &&
+        other.borderGap == borderGap &&
+        other.alignLabelWithHint == alignLabelWithHint &&
+        other.isDense == isDense &&
+        other.visualDensity == visualDensity &&
+        other.icon == icon &&
+        other.input == input &&
+        other.label == label &&
+        other.hint == hint &&
+        other.prefix == prefix &&
+        other.suffix == suffix &&
+        other.prefixIcon == prefixIcon &&
+        other.suffixIcon == suffixIcon &&
+        other.helperError == helperError &&
+        other.counter == counter &&
+        other.container == container;
   }
 
   @override
   int get hashCode => Object.hash(
-    contentPadding,
-    floatingLabelHeight,
-    floatingLabelProgress,
-    floatingLabelAlignment,
-    border,
-    borderGap,
-    alignLabelWithHint,
-    isDense,
-    visualDensity,
-    icon,
-    input,
-    label,
-    hint,
-    prefix,
-    suffix,
-    prefixIcon,
-    suffixIcon,
-    helperError,
-    counter,
-    container,
-  );
+        contentPadding,
+        floatingLabelHeight,
+        floatingLabelProgress,
+        floatingLabelAlignment,
+        border,
+        borderGap,
+        alignLabelWithHint,
+        isDense,
+        visualDensity,
+        icon,
+        input,
+        label,
+        hint,
+        prefix,
+        suffix,
+        prefixIcon,
+        suffixIcon,
+        helperError,
+        counter,
+        container,
+      );
 }
 
 // A container for the layout values computed by _RenderDecoration._layout.
@@ -679,7 +683,8 @@ class _RenderDecorationLayout {
 }
 
 // The workhorse: layout and paint a _Decorator widget's _Decoration.
-class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin<_DecorationSlot> {
+class _RenderDecoration extends RenderBox
+    with SlottedContainerRenderObjectMixin<_DecorationSlot> {
   _RenderDecoration({
     required _Decoration decoration,
     required TextDirection textDirection,
@@ -687,16 +692,16 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     required bool isFocused,
     required bool expands,
     TextAlignVertical? textAlignVertical,
-  }) : assert(decoration != null),
-       assert(textDirection != null),
-       assert(textBaseline != null),
-       assert(expands != null),
-       _decoration = decoration,
-       _textDirection = textDirection,
-       _textBaseline = textBaseline,
-       _textAlignVertical = textAlignVertical,
-       _isFocused = isFocused,
-       _expands = expands;
+  })  : assert(decoration != null),
+        assert(textDirection != null),
+        assert(textBaseline != null),
+        assert(expands != null),
+        _decoration = decoration,
+        _textDirection = textDirection,
+        _textBaseline = textBaseline,
+        _textAlignVertical = textAlignVertical,
+        _isFocused = isFocused,
+        _expands = expands;
 
   static const double subtextGap = 8.0;
 
@@ -716,28 +721,17 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   @override
   Iterable<RenderBox> get children {
     return <RenderBox>[
-      if (icon != null)
-        icon!,
-      if (input != null)
-        input!,
-      if (prefixIcon != null)
-        prefixIcon!,
-      if (suffixIcon != null)
-        suffixIcon!,
-      if (prefix != null)
-        prefix!,
-      if (suffix != null)
-        suffix!,
-      if (label != null)
-        label!,
-      if (hint != null)
-        hint!,
-      if (helperError != null)
-        helperError!,
-      if (counter != null)
-        counter!,
-      if (container != null)
-        container!,
+      if (icon != null) icon!,
+      if (input != null) input!,
+      if (prefixIcon != null) prefixIcon!,
+      if (suffixIcon != null) suffixIcon!,
+      if (prefix != null) prefix!,
+      if (suffix != null) suffix!,
+      if (label != null) label!,
+      if (hint != null) hint!,
+      if (helperError != null) helperError!,
+      if (counter != null) counter!,
+      if (container != null) container!,
     ];
   }
 
@@ -745,8 +739,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   _Decoration _decoration;
   set decoration(_Decoration value) {
     assert(value != null);
-    if (_decoration == value)
-      return;
+    if (_decoration == value) return;
     _decoration = value;
     markNeedsLayout();
   }
@@ -755,8 +748,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   TextDirection _textDirection;
   set textDirection(TextDirection value) {
     assert(value != null);
-    if (_textDirection == value)
-      return;
+    if (_textDirection == value) return;
     _textDirection = value;
     markNeedsLayout();
   }
@@ -765,16 +757,15 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   TextBaseline _textBaseline;
   set textBaseline(TextBaseline value) {
     assert(value != null);
-    if (_textBaseline == value)
-      return;
+    if (_textBaseline == value) return;
     _textBaseline = value;
     markNeedsLayout();
   }
 
-  TextAlignVertical get _defaultTextAlignVertical => _isOutlineAligned
-      ? TextAlignVertical.center
-      : TextAlignVertical.top;
-  TextAlignVertical? get textAlignVertical => _textAlignVertical ?? _defaultTextAlignVertical;
+  TextAlignVertical get _defaultTextAlignVertical =>
+      _isOutlineAligned ? TextAlignVertical.center : TextAlignVertical.top;
+  TextAlignVertical? get textAlignVertical =>
+      _textAlignVertical ?? _defaultTextAlignVertical;
   TextAlignVertical? _textAlignVertical;
   set textAlignVertical(TextAlignVertical? value) {
     if (_textAlignVertical == value) {
@@ -793,8 +784,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   bool _isFocused;
   set isFocused(bool value) {
     assert(value != null);
-    if (_isFocused == value)
-      return;
+    if (_isFocused == value) return;
     _isFocused = value;
     markNeedsSemanticsUpdate();
   }
@@ -803,8 +793,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   bool _expands = false;
   set expands(bool value) {
     assert(value != null);
-    if (_expands == value)
-      return;
+    if (_expands == value) return;
     _expands = value;
     markNeedsLayout();
   }
@@ -817,12 +806,9 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
-    if (icon != null)
-      visitor(icon!);
-    if (prefix != null)
-      visitor(prefix!);
-    if (prefixIcon != null)
-      visitor(prefixIcon!);
+    if (icon != null) visitor(icon!);
+    if (prefix != null) visitor(prefix!);
+    if (prefixIcon != null) visitor(prefixIcon!);
 
     if (label != null) {
       visitor(label!);
@@ -835,18 +821,12 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       }
     }
 
-    if (input != null)
-      visitor(input!);
-    if (suffixIcon != null)
-      visitor(suffixIcon!);
-    if (suffix != null)
-      visitor(suffix!);
-    if (container != null)
-      visitor(container!);
-    if (helperError != null)
-      visitor(helperError!);
-    if (counter != null)
-      visitor(counter!);
+    if (input != null) visitor(input!);
+    if (suffixIcon != null) visitor(suffixIcon!);
+    if (suffix != null) visitor(suffix!);
+    if (container != null) visitor(container!);
+    if (helperError != null) visitor(helperError!);
+    if (counter != null) visitor(counter!);
   }
 
   @override
@@ -866,7 +846,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   static Size _boxSize(RenderBox? box) => box == null ? Size.zero : box.size;
 
-  static BoxParentData _boxParentData(RenderBox box) => box.parentData! as BoxParentData;
+  static BoxParentData _boxParentData(RenderBox box) =>
+      box.parentData! as BoxParentData;
 
   EdgeInsets get contentPadding => decoration.contentPadding as EdgeInsets;
 
@@ -885,10 +866,10 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     final double baseline = box.getDistanceToBaseline(TextBaseline.alphabetic)!;
 
     assert(() {
-      if (baseline >= 0)
-        return true;
+      if (baseline >= 0) return true;
       throw FlutterError.fromParts(<DiagnosticsNode>[
-        ErrorSummary("One of InputDecorator's children reported a negative baseline offset."),
+        ErrorSummary(
+            "One of InputDecorator's children reported a negative baseline offset."),
         ErrorDescription(
           '${box.runtimeType}, of size ${box.size}, reported a negative '
           'alphabetic baseline of $baseline.',
@@ -922,8 +903,10 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     final BoxConstraints containerConstraints = boxConstraints.copyWith(
       maxWidth: boxConstraints.maxWidth - _boxSize(icon).width,
     );
-    boxToBaseline[prefixIcon] = _layoutLineBox(prefixIcon, containerConstraints);
-    boxToBaseline[suffixIcon] = _layoutLineBox(suffixIcon, containerConstraints);
+    boxToBaseline[prefixIcon] =
+        _layoutLineBox(prefixIcon, containerConstraints);
+    boxToBaseline[suffixIcon] =
+        _layoutLineBox(suffixIcon, containerConstraints);
     final BoxConstraints contentConstraints = containerConstraints.copyWith(
       maxWidth: containerConstraints.maxWidth - contentPadding.horizontal,
     );
@@ -932,29 +915,31 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
     final double inputWidth = math.max(
       0.0,
-      constraints.maxWidth - (
-        _boxSize(icon).width
-        + contentPadding.left
-        + _boxSize(prefixIcon).width
-        + _boxSize(prefix).width
-        + _boxSize(suffix).width
-        + _boxSize(suffixIcon).width
-        + contentPadding.right),
+      constraints.maxWidth -
+          (_boxSize(icon).width +
+              contentPadding.left +
+              _boxSize(prefixIcon).width +
+              _boxSize(prefix).width +
+              _boxSize(suffix).width +
+              _boxSize(suffixIcon).width +
+              contentPadding.right),
     );
     // Increase the available width for the label when it is scaled down.
-    final double invertedLabelScale = lerpDouble(1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress)!;
+    final double invertedLabelScale = lerpDouble(
+        1.00, 1 / _kFinalLabelScale, decoration.floatingLabelProgress)!;
     double suffixIconWidth = _boxSize(suffixIcon).width;
     if (decoration.border!.isOutline) {
-      suffixIconWidth = lerpDouble(suffixIconWidth, 0.0, decoration.floatingLabelProgress)!;
+      suffixIconWidth =
+          lerpDouble(suffixIconWidth, 0.0, decoration.floatingLabelProgress)!;
     }
     final double labelWidth = math.max(
       0.0,
-      constraints.maxWidth - (
-        _boxSize(icon).width
-        + contentPadding.left
-        + _boxSize(prefixIcon).width
-        + suffixIconWidth
-        + contentPadding.right),
+      constraints.maxWidth -
+          (_boxSize(icon).width +
+              contentPadding.left +
+              _boxSize(prefixIcon).width +
+              suffixIconWidth +
+              contentPadding.right),
     );
     boxToBaseline[label] = _layoutLineBox(
       label,
@@ -971,26 +956,24 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     boxToBaseline[helperError] = _layoutLineBox(
       helperError,
       contentConstraints.copyWith(
-        maxWidth: math.max(0.0, contentConstraints.maxWidth - _boxSize(counter).width),
+        maxWidth: math.max(
+            0.0, contentConstraints.maxWidth - _boxSize(counter).width),
       ),
     );
 
     // The height of the input needs to accommodate label above and counter and
     // helperError below, when they exist.
-    final double labelHeight = label == null
-      ? 0
-      : decoration.floatingLabelHeight;
+    final double labelHeight =
+        label == null ? 0 : decoration.floatingLabelHeight;
     final double topHeight = decoration.border!.isOutline
-      ? math.max(labelHeight - boxToBaseline[label]!, 0)
-      : labelHeight;
-    final double counterHeight = counter == null
-      ? 0
-      : boxToBaseline[counter]! + subtextGap;
-    final bool helperErrorExists = helperError?.size != null
-        && helperError!.size.height > 0;
-    final double helperErrorHeight = !helperErrorExists
-      ? 0
-      : helperError!.size.height + subtextGap;
+        ? math.max(labelHeight - boxToBaseline[label]!, 0)
+        : labelHeight;
+    final double counterHeight =
+        counter == null ? 0 : boxToBaseline[counter]! + subtextGap;
+    final bool helperErrorExists =
+        helperError?.size != null && helperError!.size.height > 0;
+    final double helperErrorHeight =
+        !helperErrorExists ? 0 : helperError!.size.height + subtextGap;
     final double bottomHeight = math.max(
       counterHeight,
       helperErrorHeight,
@@ -998,13 +981,15 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     final Offset densityOffset = decoration.visualDensity!.baseSizeAdjustment;
     boxToBaseline[input] = _layoutLineBox(
       input,
-      boxConstraints.deflate(EdgeInsets.only(
-        top: contentPadding.top + topHeight + densityOffset.dy / 2,
-        bottom: contentPadding.bottom + bottomHeight + densityOffset.dy / 2,
-      )).copyWith(
-        minWidth: inputWidth,
-        maxWidth: inputWidth,
-      ),
+      boxConstraints
+          .deflate(EdgeInsets.only(
+            top: contentPadding.top + topHeight + densityOffset.dy / 2,
+            bottom: contentPadding.bottom + bottomHeight + densityOffset.dy / 2,
+          ))
+          .copyWith(
+            minWidth: inputWidth,
+            maxWidth: inputWidth,
+          ),
     );
 
     // The field can be occupied by a hint or by the input itself
@@ -1038,32 +1023,36 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     );
 
     // Calculate the height of the input text container.
-    final double prefixIconHeight = prefixIcon == null ? 0 : prefixIcon!.size.height;
-    final double suffixIconHeight = suffixIcon == null ? 0 : suffixIcon!.size.height;
+    final double prefixIconHeight =
+        prefixIcon == null ? 0 : prefixIcon!.size.height;
+    final double suffixIconHeight =
+        suffixIcon == null ? 0 : suffixIcon!.size.height;
     final double fixIconHeight = math.max(prefixIconHeight, suffixIconHeight);
     final double contentHeight = math.max(
       fixIconHeight,
-      topHeight
-      + contentPadding.top
-      + fixAboveInput
-      + inputHeight
-      + fixBelowInput
-      + contentPadding.bottom
-      + densityOffset.dy,
+      topHeight +
+          contentPadding.top +
+          fixAboveInput +
+          inputHeight +
+          fixBelowInput +
+          contentPadding.bottom +
+          densityOffset.dy,
     );
-    final double minContainerHeight = decoration.isDense! || decoration.isCollapsed || expands
-      ? 0.0
-      : kMinInteractiveDimension;
+    final double minContainerHeight =
+        decoration.isDense! || decoration.isCollapsed || expands
+            ? 0.0
+            : kMinInteractiveDimension;
     final double maxContainerHeight = boxConstraints.maxHeight - bottomHeight;
     final double containerHeight = expands
-      ? maxContainerHeight
-      : math.min(math.max(contentHeight, minContainerHeight), maxContainerHeight);
+        ? maxContainerHeight
+        : math.min(
+            math.max(contentHeight, minContainerHeight), maxContainerHeight);
 
     // Ensure the text is vertically centered in cases where the content is
     // shorter than kMinInteractiveDimension.
     final double interactiveAdjustment = minContainerHeight > contentHeight
-      ? (minContainerHeight - contentHeight) / 2.0
-      : 0.0;
+        ? (minContainerHeight - contentHeight) / 2.0
+        : 0.0;
 
     // Try to consider the prefix/suffix as part of the text when aligning it.
     // If the prefix/suffix overflows however, allow it to extend outside of the
@@ -1075,22 +1064,25 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     // Adjust to try to fit top overflow inside the input on an inverse scale of
     // textAlignVertical, so that top aligned text adjusts the most and bottom
     // aligned text doesn't adjust at all.
-    final double baselineAdjustment = fixAboveInput - overflow * (1 - textAlignVerticalFactor);
+    final double baselineAdjustment =
+        fixAboveInput - overflow * (1 - textAlignVerticalFactor);
 
     // The baselines that will be used to draw the actual input text content.
-    final double topInputBaseline = contentPadding.top
-      + topHeight
-      + inputInternalBaseline
-      + baselineAdjustment
-      + interactiveAdjustment;
-    final double maxContentHeight = containerHeight
-      - contentPadding.top
-      - topHeight
-      - contentPadding.bottom;
+    final double topInputBaseline = contentPadding.top +
+        topHeight +
+        inputInternalBaseline +
+        baselineAdjustment +
+        interactiveAdjustment;
+    final double maxContentHeight = containerHeight -
+        contentPadding.top -
+        topHeight -
+        contentPadding.bottom;
     final double alignableHeight = fixAboveInput + inputHeight + fixBelowInput;
     final double maxVerticalOffset = maxContentHeight - alignableHeight;
-    final double textAlignVerticalOffset = maxVerticalOffset * textAlignVerticalFactor;
-    final double inputBaseline = topInputBaseline + textAlignVerticalOffset + densityOffset.dy / 2.0;
+    final double textAlignVerticalOffset =
+        maxVerticalOffset * textAlignVerticalFactor;
+    final double inputBaseline =
+        topInputBaseline + textAlignVerticalOffset + densityOffset.dy / 2.0;
 
     // The three main alignments for the baseline when an outline is present are
     //
@@ -1102,9 +1094,9 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     // That means that if the padding is uneven, center is not the exact
     // midpoint of top and bottom. To account for this, the above center and
     // below center alignments are interpolated independently.
-    final double outlineCenterBaseline = inputInternalBaseline
-      + baselineAdjustment / 2.0
-      + (containerHeight - (2.0 + inputHeight)) / 2.0;
+    final double outlineCenterBaseline = inputInternalBaseline +
+        baselineAdjustment / 2.0 +
+        (containerHeight - (2.0 + inputHeight)) / 2.0;
     final double outlineTopBaseline = topInputBaseline;
     final double outlineBottomBaseline = topInputBaseline + maxVerticalOffset;
     final double outlineBaseline = _interpolateThree(
@@ -1121,12 +1113,12 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     double subtextHelperHeight = 0;
     if (counter != null) {
       subtextCounterBaseline =
-        containerHeight + subtextGap + boxToBaseline[counter]!;
+          containerHeight + subtextGap + boxToBaseline[counter]!;
       subtextCounterHeight = counter!.size.height + subtextGap;
     }
     if (helperErrorExists) {
       subtextHelperBaseline =
-        containerHeight + subtextGap + boxToBaseline[helperError]!;
+          containerHeight + subtextGap + boxToBaseline[helperError]!;
       subtextHelperHeight = helperErrorHeight;
     }
     final double subtextBaseline = math.max(
@@ -1155,7 +1147,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   // alignment is greater than zero, it interpolates between the centered box's
   // top and the position that would align the bottom of the box with the bottom
   // padding.
-  double _interpolateThree(double begin, double middle, double end, TextAlignVertical textAlignVertical) {
+  double _interpolateThree(double begin, double middle, double end,
+      TextAlignVertical textAlignVertical) {
     if (textAlignVertical.y <= 0) {
       // It's possible for begin, middle, and end to not be in order because of
       // excessive padding. Those cases are handled by using middle.
@@ -1179,33 +1172,32 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   @override
   double computeMinIntrinsicWidth(double height) {
-    return _minWidth(icon, height)
-      + contentPadding.left
-      + _minWidth(prefixIcon, height)
-      + _minWidth(prefix, height)
-      + math.max(_minWidth(input, height), _minWidth(hint, height))
-      + _minWidth(suffix, height)
-      + _minWidth(suffixIcon, height)
-      + contentPadding.right;
+    return _minWidth(icon, height) +
+        contentPadding.left +
+        _minWidth(prefixIcon, height) +
+        _minWidth(prefix, height) +
+        math.max(_minWidth(input, height), _minWidth(hint, height)) +
+        _minWidth(suffix, height) +
+        _minWidth(suffixIcon, height) +
+        contentPadding.right;
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    return _maxWidth(icon, height)
-      + contentPadding.left
-      + _maxWidth(prefixIcon, height)
-      + _maxWidth(prefix, height)
-      + math.max(_maxWidth(input, height), _maxWidth(hint, height))
-      + _maxWidth(suffix, height)
-      + _maxWidth(suffixIcon, height)
-      + contentPadding.right;
+    return _maxWidth(icon, height) +
+        contentPadding.left +
+        _maxWidth(prefixIcon, height) +
+        _maxWidth(prefix, height) +
+        math.max(_maxWidth(input, height), _maxWidth(hint, height)) +
+        _maxWidth(suffix, height) +
+        _maxWidth(suffixIcon, height) +
+        contentPadding.right;
   }
 
   double _lineHeight(double width, List<RenderBox?> boxes) {
     double height = 0.0;
     for (final RenderBox? box in boxes) {
-      if (box == null)
-        continue;
+      if (box == null) continue;
       height = math.max(_minHeight(box, width), height);
     }
     return height;
@@ -1232,11 +1224,12 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     final double counterHeight = _minHeight(counter, width);
     final double counterWidth = _minWidth(counter, counterHeight);
 
-    final double helperErrorAvailableWidth = math.max(width - counterWidth, 0.0);
-    final double helperErrorHeight = _minHeight(helperError, helperErrorAvailableWidth);
+    final double helperErrorAvailableWidth =
+        math.max(width - counterWidth, 0.0);
+    final double helperErrorHeight =
+        _minHeight(helperError, helperErrorAvailableWidth);
     double subtextHeight = math.max(counterHeight, helperErrorHeight);
-    if (subtextHeight > 0.0)
-      subtextHeight += subtextGap;
+    if (subtextHeight > 0.0) subtextHeight += subtextGap;
 
     final double prefixHeight = _minHeight(prefix, width);
     final double prefixWidth = _minWidth(prefix, prefixHeight);
@@ -1244,20 +1237,28 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     final double suffixHeight = _minHeight(suffix, width);
     final double suffixWidth = _minWidth(suffix, suffixHeight);
 
-    final double availableInputWidth = math.max(width - prefixWidth - suffixWidth - prefixIconWidth - suffixIconWidth, 0.0);
-    final double inputHeight = _lineHeight(availableInputWidth, <RenderBox?>[input, hint]);
-    final double inputMaxHeight = <double>[inputHeight, prefixHeight, suffixHeight].reduce(math.max);
+    final double availableInputWidth = math.max(
+        width - prefixWidth - suffixWidth - prefixIconWidth - suffixIconWidth,
+        0.0);
+    final double inputHeight =
+        _lineHeight(availableInputWidth, <RenderBox?>[input, hint]);
+    final double inputMaxHeight =
+        <double>[inputHeight, prefixHeight, suffixHeight].reduce(math.max);
 
     final Offset densityOffset = decoration.visualDensity!.baseSizeAdjustment;
-    final double contentHeight = contentPadding.top
-      + (label == null ? 0.0 : decoration.floatingLabelHeight)
-      + inputMaxHeight
-      + contentPadding.bottom
-      + densityOffset.dy;
-    final double containerHeight = <double>[iconHeight, contentHeight, prefixIconHeight, suffixIconHeight].reduce(math.max);
-    final double minContainerHeight = decoration.isDense! || expands
-      ? 0.0
-      : kMinInteractiveDimension;
+    final double contentHeight = contentPadding.top +
+        (label == null ? 0.0 : decoration.floatingLabelHeight) +
+        inputMaxHeight +
+        contentPadding.bottom +
+        densityOffset.dy;
+    final double containerHeight = <double>[
+      iconHeight,
+      contentHeight,
+      prefixIconHeight,
+      suffixIconHeight
+    ].reduce(math.max);
+    final double minContainerHeight =
+        decoration.isDense! || expands ? 0.0 : kMinInteractiveDimension;
     return math.max(containerHeight, minContainerHeight) + subtextHeight;
   }
 
@@ -1268,7 +1269,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   @override
   double computeDistanceToActualBaseline(TextBaseline baseline) {
-    return _boxParentData(input!).offset.dy + input!.computeDistanceToActualBaseline(baseline)!;
+    return _boxParentData(input!).offset.dy +
+        input!.computeDistanceToActualBaseline(baseline)!;
   }
 
   // Records where the label was painted.
@@ -1277,7 +1279,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   @override
   Size computeDryLayout(BoxConstraints constraints) {
     assert(debugCannotComputeDryLayout(
-      reason: 'Layout requires baseline metrics, which are only available after a full layout.',
+      reason:
+          'Layout requires baseline metrics, which are only available after a full layout.',
     ));
     return Size.zero;
   }
@@ -1305,7 +1308,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
         case TextDirection.ltr:
           x = _boxSize(icon).width;
           break;
-       }
+      }
       _boxParentData(container!).offset = Offset(x, 0.0);
     }
 
@@ -1317,7 +1320,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
     double? baseline;
     double baselineLayout(RenderBox box, double x) {
-      _boxParentData(box).offset = Offset(x, baseline! - layout.boxToBaseline[box]!);
+      _boxParentData(box).offset =
+          Offset(x, baseline! - layout.boxToBaseline[box]!);
       return box.size.width;
     }
 
@@ -1325,7 +1329,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     final double right = overallWidth - contentPadding.right;
 
     height = layout.containerHeight;
-    baseline = _isOutlineAligned ? layout.outlineBaseline : layout.inputBaseline;
+    baseline =
+        _isOutlineAligned ? layout.outlineBaseline : layout.inputBaseline;
 
     if (icon != null) {
       final double x;
@@ -1336,67 +1341,63 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
         case TextDirection.ltr:
           x = 0.0;
           break;
-       }
+      }
       centerLayout(icon!, x);
     }
 
     switch (textDirection) {
-      case TextDirection.rtl: {
-        double start = right - _boxSize(icon).width;
-        double end = left;
-        if (prefixIcon != null) {
-          start += contentPadding.left;
-          start -= centerLayout(prefixIcon!, start - prefixIcon!.size.width);
-        }
-        if (label != null) {
-          if (decoration.alignLabelWithHint) {
-            baselineLayout(label!, start - label!.size.width);
-          } else {
-            centerLayout(label!, start - label!.size.width);
+      case TextDirection.rtl:
+        {
+          double start = right - _boxSize(icon).width;
+          double end = left;
+          if (prefixIcon != null) {
+            start += contentPadding.left;
+            start -= centerLayout(prefixIcon!, start - prefixIcon!.size.width);
           }
-        }
-        if (prefix != null)
-          start -= baselineLayout(prefix!, start - prefix!.size.width);
-        if (input != null)
-          baselineLayout(input!, start - input!.size.width);
-        if (hint != null)
-          baselineLayout(hint!, start - hint!.size.width);
-        if (suffixIcon != null) {
-          end -= contentPadding.left;
-          end += centerLayout(suffixIcon!, end);
-        }
-        if (suffix != null)
-          end += baselineLayout(suffix!, end);
-        break;
-      }
-      case TextDirection.ltr: {
-        double start = left + _boxSize(icon).width;
-        double end = right;
-        if (prefixIcon != null) {
-          start -= contentPadding.left;
-          start += centerLayout(prefixIcon!, start);
-        }
-        if (label != null) {
-          if (decoration.alignLabelWithHint) {
-            baselineLayout(label!, start);
-          } else {
-            centerLayout(label!, start);
+          if (label != null) {
+            if (decoration.alignLabelWithHint) {
+              baselineLayout(label!, start - label!.size.width);
+            } else {
+              centerLayout(label!, start - label!.size.width);
+            }
           }
+          if (prefix != null)
+            start -= baselineLayout(prefix!, start - prefix!.size.width);
+          if (input != null) baselineLayout(input!, start - input!.size.width);
+          if (hint != null) baselineLayout(hint!, start - hint!.size.width);
+          if (suffixIcon != null) {
+            end -= contentPadding.left;
+            end += centerLayout(suffixIcon!, end);
+          }
+          if (suffix != null) end += baselineLayout(suffix!, end);
+          break;
         }
-        if (prefix != null)
-          start += baselineLayout(prefix!, start);
-        if (input != null)
-          baselineLayout(input!, start);
-        if (hint != null)
-          baselineLayout(hint!, start);
-        if (suffixIcon != null) {
-          end += contentPadding.right;
-          end -= centerLayout(suffixIcon!, end - suffixIcon!.size.width);
+      case TextDirection.ltr:
+        {
+          double start = left + _boxSize(icon).width;
+          double end = right;
+          if (prefixIcon != null) {
+            start -= contentPadding.left;
+            start += centerLayout(prefixIcon!, start);
+          }
+          if (label != null) {
+            if (decoration.alignLabelWithHint) {
+              baselineLayout(label!, start);
+            } else {
+              centerLayout(label!, start);
+            }
+          }
+          if (prefix != null) start += baselineLayout(prefix!, start);
+          if (input != null) baselineLayout(input!, start);
+          if (hint != null) baselineLayout(hint!, start);
+          if (suffixIcon != null) {
+            end += contentPadding.right;
+            end -= centerLayout(suffixIcon!, end - suffixIcon!.size.width);
+          }
+          if (suffix != null)
+            end -= baselineLayout(suffix!, end - suffix!.size.width);
+          break;
         }
-        if (suffix != null)
-          end -= baselineLayout(suffix!, end - suffix!.size.width);
-        break;
-      }
     }
 
     if (helperError != null || counter != null) {
@@ -1406,9 +1407,9 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       switch (textDirection) {
         case TextDirection.rtl:
           if (helperError != null)
-            baselineLayout(helperError!, right - helperError!.size.width - _boxSize(icon).width);
-          if (counter != null)
-            baselineLayout(counter!, left);
+            baselineLayout(helperError!,
+                right - helperError!.size.width - _boxSize(icon).width);
+          if (counter != null) baselineLayout(counter!, left);
           break;
         case TextDirection.ltr:
           if (helperError != null)
@@ -1428,7 +1429,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       // _BorderContainer's x and is independent of label's x.
       switch (textDirection) {
         case TextDirection.rtl:
-          decoration.borderGap!.start = lerpDouble(labelX + _boxSize(label).width,
+          decoration.borderGap!.start = lerpDouble(
+              labelX + _boxSize(label).width,
               _boxSize(container).width / 2.0 + floatWidth / 2.0,
               floatAlign);
 
@@ -1437,7 +1439,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           // The value of _InputBorderGap.start is relative to the origin of the
           // _BorderContainer which is inset by the icon's width. Although, when
           // floating label is centered, it's already relative to _BorderContainer.
-          decoration.borderGap!.start = lerpDouble(labelX - _boxSize(icon).width,
+          decoration.borderGap!.start = lerpDouble(
+              labelX - _boxSize(icon).width,
               _boxSize(container).width / 2.0 - floatWidth / 2.0,
               floatAlign);
           break;
@@ -1463,6 +1466,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       if (child != null)
         context.paintChild(child, _boxParentData(child).offset + offset);
     }
+
     doPaint(container);
 
     if (label != null) {
@@ -1476,13 +1480,17 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       final double t = decoration.floatingLabelProgress;
       // The center of the outline border label ends up a little below the
       // center of the top border line.
-      final bool isOutlineBorder = decoration.border != null && decoration.border!.isOutline;
+      final bool isOutlineBorder =
+          decoration.border != null && decoration.border!.isOutline;
       // Temporary opt-in fix for https://github.com/flutter/flutter/issues/54028
       // Center the scaled label relative to the border.
-      final double floatingY = isOutlineBorder ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0 : contentPadding.top;
+      final double floatingY = isOutlineBorder
+          ? (-labelHeight * _kFinalLabelScale) / 2.0 + borderWeight / 2.0
+          : contentPadding.top;
       final double scale = lerpDouble(1.0, _kFinalLabelScale, t)!;
       final double centeredFloatX = _boxParentData(container!).offset.dx +
-          _boxSize(container).width / 2.0 - floatWidth / 2.0;
+          _boxSize(container).width / 2.0 -
+          floatWidth / 2.0;
       final double floatStartX;
       switch (textDirection) {
         case TextDirection.rtl: // origin is on the right
@@ -1492,7 +1500,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           floatStartX = labelOffset.dx;
           break;
       }
-      final double floatEndX = lerpDouble(floatStartX, centeredFloatX, floatAlign)!;
+      final double floatEndX =
+          lerpDouble(floatStartX, centeredFloatX, floatAlign)!;
       final double dx = lerpDouble(floatStartX, floatEndX, t)!;
       final double dy = lerpDouble(0.0, floatingY - labelOffset.dy, t)!;
       _labelTransform = Matrix4.identity()
@@ -1524,7 +1533,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   bool hitTestSelf(Offset position) => true;
 
   @override
-  bool hitTestChildren(BoxHitTestResult result, { required Offset position }) {
+  bool hitTestChildren(BoxHitTestResult result, {required Offset position}) {
     assert(position != null);
     for (final RenderBox child in children) {
       // The label must be handled specially since we've transformed it.
@@ -1537,8 +1546,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
           return child.hitTest(result, position: transformed);
         },
       );
-      if (isHit)
-        return true;
+      if (isHit) return true;
     }
     return false;
   }
@@ -1555,7 +1563,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
   }
 }
 
-class _Decorator extends RenderObjectWidget with SlottedMultiChildRenderObjectWidgetMixin<_DecorationSlot> {
+class _Decorator extends RenderObjectWidget
+    with SlottedMultiChildRenderObjectWidgetMixin<_DecorationSlot> {
   const _Decorator({
     required this.textAlignVertical,
     required this.decoration,
@@ -1563,10 +1572,10 @@ class _Decorator extends RenderObjectWidget with SlottedMultiChildRenderObjectWi
     required this.textBaseline,
     required this.isFocused,
     required this.expands,
-  }) : assert(decoration != null),
-       assert(textDirection != null),
-       assert(textBaseline != null),
-       assert(expands != null);
+  })  : assert(decoration != null),
+        assert(textDirection != null),
+        assert(textBaseline != null),
+        assert(expands != null);
 
   final _Decoration decoration;
   final TextDirection textDirection;
@@ -1619,14 +1628,15 @@ class _Decorator extends RenderObjectWidget with SlottedMultiChildRenderObjectWi
   }
 
   @override
-  void updateRenderObject(BuildContext context, _RenderDecoration renderObject) {
+  void updateRenderObject(
+      BuildContext context, _RenderDecoration renderObject) {
     renderObject
-     ..decoration = decoration
-     ..expands = expands
-     ..isFocused = isFocused
-     ..textAlignVertical = textAlignVertical
-     ..textBaseline = textBaseline
-     ..textDirection = textDirection;
+      ..decoration = decoration
+      ..expands = expands
+      ..isFocused = isFocused
+      ..textAlignVertical = textAlignVertical
+      ..textBaseline = textBaseline
+      ..textDirection = textDirection;
   }
 }
 
@@ -1696,11 +1706,11 @@ class InputDecorator extends StatefulWidget {
     this.expands = false,
     this.isEmpty = false,
     this.child,
-  }) : assert(decoration != null),
-       assert(isFocused != null),
-       assert(isHovering != null),
-       assert(expands != null),
-       assert(isEmpty != null);
+  })  : assert(decoration != null),
+        assert(isFocused != null),
+        assert(isHovering != null),
+        assert(expands != null),
+        assert(isEmpty != null);
 
   /// The text and styles to use when decorating the child.
   ///
@@ -1790,7 +1800,8 @@ class InputDecorator extends StatefulWidget {
   /// floating or disappearing.
   ///
   /// Will withdraw when not empty, or when focused while enabled.
-  bool get _labelShouldWithdraw => !isEmpty || (isFocused && decoration.enabled);
+  bool get _labelShouldWithdraw =>
+      !isEmpty || (isFocused && decoration.enabled);
 
   @override
   State<InputDecorator> createState() => _InputDecoratorState();
@@ -1803,22 +1814,27 @@ class InputDecorator extends StatefulWidget {
   ///
   /// [TextField] renders ink splashes within the container.
   static RenderBox? containerOf(BuildContext context) {
-    final _RenderDecoration? result = context.findAncestorRenderObjectOfType<_RenderDecoration>();
+    final _RenderDecoration? result =
+        context.findAncestorRenderObjectOfType<_RenderDecoration>();
     return result?.container;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<InputDecoration>('decoration', decoration));
-    properties.add(DiagnosticsProperty<TextStyle>('baseStyle', baseStyle, defaultValue: null));
+    properties
+        .add(DiagnosticsProperty<InputDecoration>('decoration', decoration));
+    properties.add(DiagnosticsProperty<TextStyle>('baseStyle', baseStyle,
+        defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('isFocused', isFocused));
-    properties.add(DiagnosticsProperty<bool>('expands', expands, defaultValue: false));
+    properties.add(
+        DiagnosticsProperty<bool>('expands', expands, defaultValue: false));
     properties.add(DiagnosticsProperty<bool>('isEmpty', isEmpty));
   }
 }
 
-class _InputDecoratorState extends State<InputDecorator> with TickerProviderStateMixin {
+class _InputDecoratorState extends State<InputDecorator>
+    with TickerProviderStateMixin {
   late AnimationController _floatingLabelController;
   late AnimationController _shakingLabelController;
   final _InputBorderGap _borderGap = _InputBorderGap();
@@ -1827,9 +1843,12 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   void initState() {
     super.initState();
 
-    final bool labelIsInitiallyFloating = widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always
-        || (widget.decoration.floatingLabelBehavior != FloatingLabelBehavior.never &&
-            widget._labelShouldWithdraw);
+    final bool labelIsInitiallyFloating =
+        widget.decoration.floatingLabelBehavior ==
+                FloatingLabelBehavior.always ||
+            (widget.decoration.floatingLabelBehavior !=
+                    FloatingLabelBehavior.never &&
+                widget._labelShouldWithdraw);
 
     _floatingLabelController = AnimationController(
       duration: _kTransitionDuration,
@@ -1882,14 +1901,17 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   @override
   void didUpdateWidget(InputDecorator old) {
     super.didUpdateWidget(old);
-    if (widget.decoration != old.decoration)
-      _effectiveDecoration = null;
+    if (widget.decoration != old.decoration) _effectiveDecoration = null;
 
-    final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior != old.decoration.floatingLabelBehavior;
+    final bool floatBehaviorChanged = widget.decoration.floatingLabelBehavior !=
+        old.decoration.floatingLabelBehavior;
 
-    if (widget._labelShouldWithdraw != old._labelShouldWithdraw || floatBehaviorChanged) {
-      if (_floatingLabelEnabled
-          && (widget._labelShouldWithdraw || widget.decoration.floatingLabelBehavior == FloatingLabelBehavior.always))
+    if (widget._labelShouldWithdraw != old._labelShouldWithdraw ||
+        floatBehaviorChanged) {
+      if (_floatingLabelEnabled &&
+          (widget._labelShouldWithdraw ||
+              widget.decoration.floatingLabelBehavior ==
+                  FloatingLabelBehavior.always))
         _floatingLabelController.forward();
       else
         _floatingLabelController.reverse();
@@ -1898,7 +1920,9 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final String? errorText = decoration!.errorText;
     final String? oldErrorText = old.decoration.errorText;
 
-    if (_floatingLabelController.isCompleted && errorText != null && errorText != oldErrorText) {
+    if (_floatingLabelController.isCompleted &&
+        errorText != null &&
+        errorText != oldErrorText) {
       _shakingLabelController
         ..value = 0.0
         ..forward();
@@ -1919,9 +1943,12 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (decoration!.filled!) {
       return themeData.hintColor;
     }
-    final Color enabledColor = themeData.colorScheme.onSurface.withOpacity(0.38);
+    final Color enabledColor =
+        themeData.colorScheme.onSurface.withOpacity(0.38);
     if (isHovering) {
-      final Color hoverColor = decoration!.hoverColor ?? themeData.inputDecorationTheme.hoverColor ?? themeData.hoverColor;
+      final Color hoverColor = decoration!.hoverColor ??
+          themeData.inputDecorationTheme.hoverColor ??
+          themeData.hoverColor;
       return Color.alphaBlend(hoverColor.withOpacity(0.12), enabledColor);
     }
     return enabledColor;
@@ -1931,7 +1958,8 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     if (decoration!.filled != true) // filled == null same as filled == false
       return Colors.transparent;
     if (decoration!.fillColor != null)
-      return MaterialStateProperty.resolveAs(decoration!.fillColor!, materialState);
+      return MaterialStateProperty.resolveAs(
+          decoration!.fillColor!, materialState);
 
     // dark theme: 10% white (enabled), 5% white (disabled)
     // light theme: 4% black (enabled), 2% black (disabled)
@@ -1949,14 +1977,19 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   }
 
   Color _getHoverColor(ThemeData themeData) {
-    if (decoration!.filled == null || !decoration!.filled! || isFocused || !decoration!.enabled)
-      return Colors.transparent;
-    return decoration!.hoverColor ?? themeData.inputDecorationTheme.hoverColor ?? themeData.hoverColor;
+    if (decoration!.filled == null ||
+        !decoration!.filled! ||
+        isFocused ||
+        !decoration!.enabled) return Colors.transparent;
+    return decoration!.hoverColor ??
+        themeData.inputDecorationTheme.hoverColor ??
+        themeData.hoverColor;
   }
 
   Color _getIconColor(ThemeData themeData) {
     Color resolveIconColor(Set<MaterialState> states) {
-      if (states.contains(MaterialState.disabled) && !states.contains(MaterialState.focused))
+      if (states.contains(MaterialState.disabled) &&
+          !states.contains(MaterialState.focused))
         return themeData.disabledColor;
 
       if (states.contains(MaterialState.focused))
@@ -1969,18 +2002,23 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
           return Colors.black45;
       }
     }
-    return MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.iconColor, materialState)
-      ?? MaterialStateProperty.resolveWith(resolveIconColor).resolve(materialState);
+
+    return MaterialStateProperty.resolveAs(
+            themeData.inputDecorationTheme.iconColor, materialState) ??
+        MaterialStateProperty.resolveWith(resolveIconColor)
+            .resolve(materialState);
   }
 
   Color _getPrefixIconColor(ThemeData themeData) {
-    return MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.prefixIconColor, materialState)
-      ?? _getIconColor(themeData);
+    return MaterialStateProperty.resolveAs(
+            themeData.inputDecorationTheme.prefixIconColor, materialState) ??
+        _getIconColor(themeData);
   }
 
   Color _getSuffixIconColor(ThemeData themeData) {
-    return MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.suffixIconColor, materialState)
-      ?? _getIconColor(themeData);
+    return MaterialStateProperty.resolveAs(
+            themeData.inputDecorationTheme.suffixIconColor, materialState) ??
+        _getIconColor(themeData);
   }
 
   // True if the label will be shown and the hint will not.
@@ -1988,9 +2026,9 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   // floatingLabelBehavior isn't set to always, then the label appears where the
   // hint would.
   bool get _hasInlineLabel {
-    return !widget._labelShouldWithdraw
-        && (decoration!.labelText != null || decoration!.label != null)
-        && decoration!.floatingLabelBehavior != FloatingLabelBehavior.always;
+    return !widget._labelShouldWithdraw &&
+        (decoration!.labelText != null || decoration!.label != null) &&
+        decoration!.floatingLabelBehavior != FloatingLabelBehavior.always;
   }
 
   // If the label is a floating placeholder, it's always shown.
@@ -2000,63 +2038,78 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   // i.e. when they appear in place of the empty text field.
   TextStyle _getInlineLabelStyle(ThemeData themeData) {
     final TextStyle defaultStyle = TextStyle(
-      color: decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
+      color:
+          decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
     );
 
-    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.labelStyle, materialState)
-      ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.labelStyle, materialState);
+    final TextStyle? style = MaterialStateProperty.resolveAs(
+            decoration!.labelStyle, materialState) ??
+        MaterialStateProperty.resolveAs(
+            themeData.inputDecorationTheme.labelStyle, materialState);
 
     return themeData.textTheme.subtitle1!
-      .merge(widget.baseStyle)
-      .merge(defaultStyle)
-      .merge(style)
-      .copyWith(height: 1);
+        .merge(widget.baseStyle)
+        .merge(defaultStyle)
+        .merge(style)
+        .copyWith(height: 1);
   }
 
   // The base style for the inline hint when they're displayed "inline",
   // i.e. when they appear in place of the empty text field.
   TextStyle _getInlineHintStyle(ThemeData themeData) {
     final TextStyle defaultStyle = TextStyle(
-      color: decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
+      color:
+          decoration!.enabled ? themeData.hintColor : themeData.disabledColor,
     );
 
-    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.hintStyle, materialState)
-      ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.hintStyle, materialState);
+    final TextStyle? style =
+        MaterialStateProperty.resolveAs(decoration!.hintStyle, materialState) ??
+            MaterialStateProperty.resolveAs(
+                themeData.inputDecorationTheme.hintStyle, materialState);
 
     return themeData.textTheme.subtitle1!
-      .merge(widget.baseStyle)
-      .merge(defaultStyle)
-      .merge(style);
+        .merge(widget.baseStyle)
+        .merge(defaultStyle)
+        .merge(style);
   }
 
   TextStyle _getFloatingLabelStyle(ThemeData themeData) {
     TextStyle getFallbackTextStyle() {
       final Color color = decoration!.errorText != null
-        ? decoration!.errorStyle?.color ?? themeData.errorColor
-        : _getActiveColor(themeData);
+          ? decoration!.errorStyle?.color ?? themeData.errorColor
+          : _getActiveColor(themeData);
 
-      return TextStyle(color: decoration!.enabled ? color : themeData.disabledColor)
-        .merge(decoration!.floatingLabelStyle ?? decoration!.labelStyle);
+      return TextStyle(
+              color: decoration!.enabled ? color : themeData.disabledColor)
+          .merge(decoration!.floatingLabelStyle ?? decoration!.labelStyle);
     }
 
-    final TextStyle? style = MaterialStateProperty.resolveAs(decoration!.floatingLabelStyle, materialState)
-      ?? MaterialStateProperty.resolveAs(themeData.inputDecorationTheme.floatingLabelStyle, materialState);
+    final TextStyle? style = MaterialStateProperty.resolveAs(
+            decoration!.floatingLabelStyle, materialState) ??
+        MaterialStateProperty.resolveAs(
+            themeData.inputDecorationTheme.floatingLabelStyle, materialState);
 
     return themeData.textTheme.subtitle1!
-      .merge(widget.baseStyle)
-      .copyWith(height: 1)
-      .merge(getFallbackTextStyle())
-      .merge(style);
+        .merge(widget.baseStyle)
+        .copyWith(height: 1)
+        .merge(getFallbackTextStyle())
+        .merge(style);
   }
 
   TextStyle _getHelperStyle(ThemeData themeData) {
-    final Color color = decoration!.enabled ? themeData.hintColor : Colors.transparent;
-    return themeData.textTheme.caption!.copyWith(color: color).merge(MaterialStateProperty.resolveAs(decoration!.helperStyle, materialState));
+    final Color color =
+        decoration!.enabled ? themeData.hintColor : Colors.transparent;
+    return themeData.textTheme.caption!.copyWith(color: color).merge(
+        MaterialStateProperty.resolveAs(
+            decoration!.helperStyle, materialState));
   }
 
   TextStyle _getErrorStyle(ThemeData themeData) {
-    final Color color = decoration!.enabled ? themeData.errorColor : Colors.transparent;
-    return themeData.textTheme.caption!.copyWith(color: color).merge(decoration!.errorStyle);
+    final Color color =
+        decoration!.enabled ? themeData.errorColor : Colors.transparent;
+    return themeData.textTheme.caption!
+        .copyWith(color: color)
+        .merge(decoration!.errorStyle);
   }
 
   Set<MaterialState> get materialState {
@@ -2069,8 +2122,9 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
   }
 
   InputBorder _getDefaultBorder(ThemeData themeData) {
-    final InputBorder border =  MaterialStateProperty.resolveAs(decoration!.border, materialState)
-      ?? const UnderlineInputBorder();
+    final InputBorder border =
+        MaterialStateProperty.resolveAs(decoration!.border, materialState) ??
+            const UnderlineInputBorder();
 
     if (decoration!.border is MaterialStateProperty<InputBorder>) {
       return border;
@@ -2083,21 +2137,25 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final Color borderColor;
     if (decoration!.enabled || isFocused) {
       borderColor = decoration!.errorText == null
-        ? _getDefaultBorderColor(themeData)
-        : themeData.errorColor;
+          ? _getDefaultBorderColor(themeData)
+          : themeData.errorColor;
     } else {
-      borderColor = ((decoration!.filled ?? false) && !(decoration!.border?.isOutline ?? false))
-        ? Colors.transparent
-        : themeData.disabledColor;
+      borderColor = ((decoration!.filled ?? false) &&
+              !(decoration!.border?.isOutline ?? false))
+          ? Colors.transparent
+          : themeData.disabledColor;
     }
 
     final double borderWeight;
-    if (decoration!.isCollapsed || decoration?.border == InputBorder.none || !decoration!.enabled)
+    if (decoration!.isCollapsed ||
+        decoration?.border == InputBorder.none ||
+        !decoration!.enabled)
       borderWeight = 0.0;
     else
       borderWeight = isFocused ? 2.0 : 1.0;
 
-    return border.copyWith(borderSide: BorderSide(color: borderColor, width: borderWeight));
+    return border.copyWith(
+        borderSide: BorderSide(color: borderColor, width: borderWeight));
   }
 
   @override
@@ -2107,27 +2165,30 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final TextBaseline textBaseline = labelStyle.textBaseline!;
 
     final TextStyle hintStyle = _getInlineHintStyle(themeData);
-    final Widget? hint = decoration!.hintText == null ? null : AnimatedOpacity(
-      opacity: (isEmpty && !_hasInlineLabel) ? 1.0 : 0.0,
-      duration: _kTransitionDuration,
-      curve: _kTransitionCurve,
-      alwaysIncludeSemantics: true,
-      child: Text(
-        decoration!.hintText!,
-        style: hintStyle,
-        textDirection: decoration!.hintTextDirection,
-        overflow: TextOverflow.ellipsis,
-        textAlign: textAlign,
-        maxLines: decoration!.hintMaxLines,
-      ),
-    );
+    final Widget? hint = decoration!.hintText == null
+        ? null
+        : AnimatedOpacity(
+            opacity: (isEmpty && !_hasInlineLabel) ? 1.0 : 0.0,
+            duration: _kTransitionDuration,
+            curve: _kTransitionCurve,
+            alwaysIncludeSemantics: true,
+            child: Text(
+              decoration!.hintText!,
+              style: hintStyle,
+              textDirection: decoration!.hintTextDirection,
+              overflow: TextOverflow.ellipsis,
+              textAlign: textAlign,
+              maxLines: decoration!.hintMaxLines,
+            ),
+          );
 
     final bool isError = decoration!.errorText != null;
     InputBorder? border;
     if (!decoration!.enabled)
       border = isError ? decoration!.errorBorder : decoration!.disabledBorder;
     else if (isFocused)
-      border = isError ? decoration!.focusedErrorBorder : decoration!.focusedBorder;
+      border =
+          isError ? decoration!.focusedErrorBorder : decoration!.focusedBorder;
     else
       border = isError ? decoration!.errorBorder : decoration!.enabledBorder;
     border ??= _getDefaultBorder(themeData);
@@ -2141,100 +2202,116 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       isHovering: isHovering,
     );
 
-    final Widget? label = decoration!.labelText == null && decoration!.label == null ? null : _Shaker(
-      animation: _shakingLabelController.view,
-      child: AnimatedOpacity(
-        duration: _kTransitionDuration,
-        curve: _kTransitionCurve,
-        opacity: _shouldShowLabel ? 1.0 : 0.0,
-        child: AnimatedDefaultTextStyle(
-          duration:_kTransitionDuration,
-          curve: _kTransitionCurve,
-          style: widget._labelShouldWithdraw
-            ? _getFloatingLabelStyle(themeData)
-            : labelStyle,
-          child: decoration!.label ?? Text(
-            decoration!.labelText!,
-            overflow: TextOverflow.ellipsis,
-            textAlign: textAlign,
-          ),
-        ),
-      ),
-    );
+    final Widget? label =
+        decoration!.labelText == null && decoration!.label == null
+            ? null
+            : _Shaker(
+                animation: _shakingLabelController.view,
+                child: AnimatedOpacity(
+                  duration: _kTransitionDuration,
+                  curve: _kTransitionCurve,
+                  opacity: _shouldShowLabel ? 1.0 : 0.0,
+                  child: AnimatedDefaultTextStyle(
+                    duration: _kTransitionDuration,
+                    curve: _kTransitionCurve,
+                    style: widget._labelShouldWithdraw
+                        ? _getFloatingLabelStyle(themeData)
+                        : labelStyle,
+                    child: decoration!.label ??
+                        Text(
+                          decoration!.labelText!,
+                          overflow: TextOverflow.ellipsis,
+                          textAlign: textAlign,
+                        ),
+                  ),
+                ),
+              );
 
-    final Widget? prefix = decoration!.prefix == null && decoration!.prefixText == null ? null :
-      _AffixText(
-        labelIsFloating: widget._labelShouldWithdraw,
-        text: decoration!.prefixText,
-        style: MaterialStateProperty.resolveAs(decoration!.prefixStyle, materialState) ?? hintStyle,
-        child: decoration!.prefix,
-      );
+    final Widget? prefix =
+        decoration!.prefix == null && decoration!.prefixText == null
+            ? null
+            : _AffixText(
+                labelIsFloating: widget._labelShouldWithdraw,
+                text: decoration!.prefixText,
+                style: MaterialStateProperty.resolveAs(
+                        decoration!.prefixStyle, materialState) ??
+                    hintStyle,
+                child: decoration!.prefix,
+              );
 
-    final Widget? suffix = decoration!.suffix == null && decoration!.suffixText == null ? null :
-      _AffixText(
-        labelIsFloating: widget._labelShouldWithdraw,
-        text: decoration!.suffixText,
-        style: MaterialStateProperty.resolveAs(decoration!.suffixStyle, materialState) ?? hintStyle,
-        child: decoration!.suffix,
-      );
-
+    final Widget? suffix =
+        decoration!.suffix == null && decoration!.suffixText == null
+            ? null
+            : _AffixText(
+                labelIsFloating: widget._labelShouldWithdraw,
+                text: decoration!.suffixText,
+                style: MaterialStateProperty.resolveAs(
+                        decoration!.suffixStyle, materialState) ??
+                    hintStyle,
+                child: decoration!.suffix,
+              );
 
     final bool decorationIsDense = decoration!.isDense ?? false;
     final double iconSize = decorationIsDense ? 18.0 : 24.0;
 
-    final Widget? icon = decoration!.icon == null ? null :
-      Padding(
-        padding: const EdgeInsetsDirectional.only(end: 16.0),
-        child: IconTheme.merge(
-          data: IconThemeData(
-            color: _getIconColor(themeData),
-            size: iconSize,
-          ),
-          child: decoration!.icon!,
-        ),
-      );
+    final Widget? icon = decoration!.icon == null
+        ? null
+        : Padding(
+            padding: const EdgeInsetsDirectional.only(end: 16.0),
+            child: IconTheme.merge(
+              data: IconThemeData(
+                color: _getIconColor(themeData),
+                size: iconSize,
+              ),
+              child: decoration!.icon!,
+            ),
+          );
 
-    final Widget? prefixIcon = decoration!.prefixIcon == null ? null :
-      Center(
-        widthFactor: 1.0,
-        heightFactor: 1.0,
-        child: ConstrainedBox(
-          constraints: decoration!.prefixIconConstraints ?? themeData.visualDensity.effectiveConstraints(
-            const BoxConstraints(
-              minWidth: kMinInteractiveDimension,
-              minHeight: kMinInteractiveDimension,
+    final Widget? prefixIcon = decoration!.prefixIcon == null
+        ? null
+        : Center(
+            widthFactor: 1.0,
+            heightFactor: 1.0,
+            child: ConstrainedBox(
+              constraints: decoration!.prefixIconConstraints ??
+                  themeData.visualDensity.effectiveConstraints(
+                    const BoxConstraints(
+                      minWidth: kMinInteractiveDimension,
+                      minHeight: kMinInteractiveDimension,
+                    ),
+                  ),
+              child: IconTheme.merge(
+                data: IconThemeData(
+                  color: _getPrefixIconColor(themeData),
+                  size: iconSize,
+                ),
+                child: decoration!.prefixIcon!,
+              ),
             ),
-          ),
-          child: IconTheme.merge(
-            data: IconThemeData(
-              color: _getPrefixIconColor(themeData),
-              size: iconSize,
-            ),
-            child: decoration!.prefixIcon!,
-          ),
-        ),
-      );
+          );
 
-    final Widget? suffixIcon = decoration!.suffixIcon == null ? null :
-      Center(
-        widthFactor: 1.0,
-        heightFactor: 1.0,
-        child: ConstrainedBox(
-          constraints: decoration!.suffixIconConstraints ?? themeData.visualDensity.effectiveConstraints(
-            const BoxConstraints(
-              minWidth: kMinInteractiveDimension,
-              minHeight: kMinInteractiveDimension,
+    final Widget? suffixIcon = decoration!.suffixIcon == null
+        ? null
+        : Center(
+            widthFactor: 1.0,
+            heightFactor: 1.0,
+            child: ConstrainedBox(
+              constraints: decoration!.suffixIconConstraints ??
+                  themeData.visualDensity.effectiveConstraints(
+                    const BoxConstraints(
+                      minWidth: kMinInteractiveDimension,
+                      minHeight: kMinInteractiveDimension,
+                    ),
+                  ),
+              child: IconTheme.merge(
+                data: IconThemeData(
+                  color: _getSuffixIconColor(themeData),
+                  size: iconSize,
+                ),
+                child: decoration!.suffixIcon!,
+              ),
             ),
-          ),
-          child: IconTheme.merge(
-            data: IconThemeData(
-              color: _getSuffixIconColor(themeData),
-              size: iconSize,
-            ),
-            child: decoration!.suffixIcon!,
-          ),
-        ),
-      );
+          );
 
     final Widget helperError = _HelperError(
       textAlign: textAlign,
@@ -2244,18 +2321,22 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       errorText: decoration!.errorText,
       errorStyle: _getErrorStyle(themeData),
       errorMaxLines: decoration!.errorMaxLines,
+      errorWidgetBuilder: decoration!.errorWidgetBuilder,
     );
 
     Widget? counter;
     if (decoration!.counter != null) {
       counter = decoration!.counter;
-    } else if (decoration!.counterText != null && decoration!.counterText != '') {
+    } else if (decoration!.counterText != null &&
+        decoration!.counterText != '') {
       counter = Semantics(
         container: true,
         liveRegion: isFocused,
         child: Text(
           decoration!.counterText!,
-          style: _getHelperStyle(themeData).merge(MaterialStateProperty.resolveAs(decoration!.counterStyle, materialState)),
+          style: _getHelperStyle(themeData).merge(
+              MaterialStateProperty.resolveAs(
+                  decoration!.counterStyle, materialState)),
           overflow: TextOverflow.ellipsis,
           semanticsLabel: decoration!.semanticCounterText,
         ),
@@ -2265,7 +2346,8 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     // The _Decoration widget and _RenderDecoration assume that contentPadding
     // has been resolved to EdgeInsets.
     final TextDirection textDirection = Directionality.of(context);
-    final EdgeInsets? decorationContentPadding = decoration!.contentPadding?.resolve(textDirection);
+    final EdgeInsets? decorationContentPadding =
+        decoration!.contentPadding?.resolve(textDirection);
 
     final EdgeInsets contentPadding;
     final double floatingLabelHeight;
@@ -2274,50 +2356,53 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       contentPadding = decorationContentPadding ?? EdgeInsets.zero;
     } else if (!border.isOutline) {
       // 4.0: the vertical gap between the inline elements and the floating label.
-      floatingLabelHeight = (4.0 + 0.75 * labelStyle.fontSize!) * MediaQuery.textScaleFactorOf(context);
+      floatingLabelHeight = (4.0 + 0.75 * labelStyle.fontSize!) *
+          MediaQuery.textScaleFactorOf(context);
       if (decoration!.filled ?? false) {
-        contentPadding = decorationContentPadding ?? (decorationIsDense
-          ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
-          : const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 12.0));
+        contentPadding = decorationContentPadding ??
+            (decorationIsDense
+                ? const EdgeInsets.fromLTRB(12.0, 8.0, 12.0, 8.0)
+                : const EdgeInsets.fromLTRB(12.0, 12.0, 12.0, 12.0));
       } else {
         // Not left or right padding for underline borders that aren't filled
         // is a small concession to backwards compatibility. This eliminates
         // the most noticeable layout change introduced by #13734.
-        contentPadding = decorationContentPadding ?? (decorationIsDense
-          ? const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
-          : const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
+        contentPadding = decorationContentPadding ??
+            (decorationIsDense
+                ? const EdgeInsets.fromLTRB(0.0, 8.0, 0.0, 8.0)
+                : const EdgeInsets.fromLTRB(0.0, 12.0, 0.0, 12.0));
       }
     } else {
       floatingLabelHeight = 0.0;
-      contentPadding = decorationContentPadding ?? (decorationIsDense
-        ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
-        : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
+      contentPadding = decorationContentPadding ??
+          (decorationIsDense
+              ? const EdgeInsets.fromLTRB(12.0, 20.0, 12.0, 12.0)
+              : const EdgeInsets.fromLTRB(12.0, 24.0, 12.0, 16.0));
     }
 
     final _Decorator decorator = _Decorator(
       decoration: _Decoration(
-        contentPadding: contentPadding,
-        isCollapsed: decoration!.isCollapsed,
-        floatingLabelHeight: floatingLabelHeight,
-        floatingLabelAlignment: decoration!.floatingLabelAlignment!,
-        floatingLabelProgress: _floatingLabelController.value,
-        border: border,
-        borderGap: _borderGap,
-        alignLabelWithHint: decoration!.alignLabelWithHint ?? false,
-        isDense: decoration!.isDense,
-        visualDensity: themeData.visualDensity,
-        icon: icon,
-        input: widget.child,
-        label: label,
-        hint: hint,
-        prefix: prefix,
-        suffix: suffix,
-        prefixIcon: prefixIcon,
-        suffixIcon: suffixIcon,
-        helperError: helperError,
-        counter: counter,
-        container: container
-      ),
+          contentPadding: contentPadding,
+          isCollapsed: decoration!.isCollapsed,
+          floatingLabelHeight: floatingLabelHeight,
+          floatingLabelAlignment: decoration!.floatingLabelAlignment!,
+          floatingLabelProgress: _floatingLabelController.value,
+          border: border,
+          borderGap: _borderGap,
+          alignLabelWithHint: decoration!.alignLabelWithHint ?? false,
+          isDense: decoration!.isDense,
+          visualDensity: themeData.visualDensity,
+          icon: icon,
+          input: widget.child,
+          label: label,
+          hint: hint,
+          prefix: prefix,
+          suffix: suffix,
+          prefixIcon: prefixIcon,
+          suffixIcon: suffixIcon,
+          helperError: helperError,
+          counter: counter,
+          container: container),
       textDirection: textDirection,
       textBaseline: textBaseline,
       textAlignVertical: widget.textAlignVertical,
@@ -2325,7 +2410,8 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
       expands: widget.expands,
     );
 
-    final BoxConstraints? constraints = decoration!.constraints ?? themeData.inputDecorationTheme.constraints;
+    final BoxConstraints? constraints =
+        decoration!.constraints ?? themeData.inputDecorationTheme.constraints;
     if (constraints != null) {
       return ConstrainedBox(
         constraints: constraints,
@@ -2439,6 +2525,7 @@ class InputDecoration {
     this.hintTextDirection,
     this.hintMaxLines,
     this.errorText,
+    this.errorWidgetBuilder,
     this.errorStyle,
     this.errorMaxLines,
     this.floatingLabelBehavior,
@@ -2475,10 +2562,13 @@ class InputDecoration {
     this.semanticCounterText,
     this.alignLabelWithHint,
     this.constraints,
-  }) : assert(enabled != null),
-       assert(!(label != null && labelText != null), 'Declaring both label and labelText is not supported.'),
-       assert(!(prefix != null && prefixText != null), 'Declaring both prefix and prefixText is not supported.'),
-       assert(!(suffix != null && suffixText != null), 'Declaring both suffix and suffixText is not supported.');
+  })  : assert(enabled != null),
+        assert(!(label != null && labelText != null),
+            'Declaring both label and labelText is not supported.'),
+        assert(!(prefix != null && prefixText != null),
+            'Declaring both prefix and prefixText is not supported.'),
+        assert(!(suffix != null && suffixText != null),
+            'Declaring both suffix and suffixText is not supported.');
 
   /// Defines an [InputDecorator] that is the same size as the input field.
   ///
@@ -2497,46 +2587,47 @@ class InputDecoration {
     this.hoverColor,
     this.border = InputBorder.none,
     this.enabled = true,
-  }) : assert(enabled != null),
-       icon = null,
-       iconColor = null,
-       label = null,
-       labelText = null,
-       labelStyle = null,
-       floatingLabelStyle = null,
-       helperText = null,
-       helperStyle = null,
-       helperMaxLines = null,
-       hintMaxLines = null,
-       errorText = null,
-       errorStyle = null,
-       errorMaxLines = null,
-       isDense = false,
-       contentPadding = EdgeInsets.zero,
-       isCollapsed = true,
-       prefixIcon = null,
-       prefix = null,
-       prefixText = null,
-       prefixStyle = null,
-       prefixIconColor = null,
-       prefixIconConstraints = null,
-       suffix = null,
-       suffixIcon = null,
-       suffixText = null,
-       suffixStyle = null,
-       suffixIconColor = null,
-       suffixIconConstraints = null,
-       counter = null,
-       counterText = null,
-       counterStyle = null,
-       errorBorder = null,
-       focusedBorder = null,
-       focusedErrorBorder = null,
-       disabledBorder = null,
-       enabledBorder = null,
-       semanticCounterText = null,
-       alignLabelWithHint = false,
-       constraints = null;
+  })  : assert(enabled != null),
+        icon = null,
+        iconColor = null,
+        label = null,
+        labelText = null,
+        labelStyle = null,
+        floatingLabelStyle = null,
+        helperText = null,
+        helperStyle = null,
+        helperMaxLines = null,
+        hintMaxLines = null,
+        errorText = null,
+        errorWidgetBuilder = null,
+        errorStyle = null,
+        errorMaxLines = null,
+        isDense = false,
+        contentPadding = EdgeInsets.zero,
+        isCollapsed = true,
+        prefixIcon = null,
+        prefix = null,
+        prefixText = null,
+        prefixStyle = null,
+        prefixIconColor = null,
+        prefixIconConstraints = null,
+        suffix = null,
+        suffixIcon = null,
+        suffixText = null,
+        suffixStyle = null,
+        suffixIconColor = null,
+        suffixIconConstraints = null,
+        counter = null,
+        counterText = null,
+        counterStyle = null,
+        errorBorder = null,
+        focusedBorder = null,
+        focusedErrorBorder = null,
+        disabledBorder = null,
+        enabledBorder = null,
+        semanticCounterText = null,
+        alignLabelWithHint = false,
+        constraints = null;
 
   /// An icon to show before the input field and outside of the decoration's
   /// container.
@@ -2729,6 +2820,15 @@ class InputDecoration {
   /// [TextFormField.validator], if that is not null.
   final String? errorText;
 
+  /// Widget that appears below the [InputDecorator.child] and the border.
+  ///
+  /// If non-null, the border's color animates to red and the [helperText] is
+  /// not shown.
+  ///
+  /// In a [TextFormField], this is overridden by the value returned from
+  /// [TextFormField.validator], if that is not null.
+  final Widget Function(String errorText)? errorWidgetBuilder;
+
   /// {@template flutter.material.inputDecoration.errorStyle}
   /// The style to use for the [InputDecoration.errorText].
   ///
@@ -2742,7 +2842,6 @@ class InputDecoration {
   /// style.
   /// {@endtemplate}
   final TextStyle? errorStyle;
-
 
   /// The maximum number of lines the [errorText] can occupy.
   ///
@@ -3368,6 +3467,7 @@ class InputDecoration {
     TextDirection? hintTextDirection,
     int? hintMaxLines,
     String? errorText,
+    Widget Function(String errorText)? errorWidgetBuilder,
     TextStyle? errorStyle,
     int? errorMaxLines,
     FloatingLabelBehavior? floatingLabelBehavior,
@@ -3414,16 +3514,19 @@ class InputDecoration {
       floatingLabelStyle: floatingLabelStyle ?? this.floatingLabelStyle,
       helperText: helperText ?? this.helperText,
       helperStyle: helperStyle ?? this.helperStyle,
-      helperMaxLines : helperMaxLines ?? this.helperMaxLines,
+      helperMaxLines: helperMaxLines ?? this.helperMaxLines,
       hintText: hintText ?? this.hintText,
       hintStyle: hintStyle ?? this.hintStyle,
       hintTextDirection: hintTextDirection ?? this.hintTextDirection,
       hintMaxLines: hintMaxLines ?? this.hintMaxLines,
       errorText: errorText ?? this.errorText,
+      errorWidgetBuilder: errorWidgetBuilder ?? this.errorWidgetBuilder,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
-      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
-      floatingLabelAlignment: floatingLabelAlignment ?? this.floatingLabelAlignment,
+      floatingLabelBehavior:
+          floatingLabelBehavior ?? this.floatingLabelBehavior,
+      floatingLabelAlignment:
+          floatingLabelAlignment ?? this.floatingLabelAlignment,
       isCollapsed: isCollapsed ?? this.isCollapsed,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
@@ -3432,13 +3535,15 @@ class InputDecoration {
       prefixText: prefixText ?? this.prefixText,
       prefixStyle: prefixStyle ?? this.prefixStyle,
       prefixIconColor: prefixIconColor ?? this.prefixIconColor,
-      prefixIconConstraints: prefixIconConstraints ?? this.prefixIconConstraints,
+      prefixIconConstraints:
+          prefixIconConstraints ?? this.prefixIconConstraints,
       suffixIcon: suffixIcon ?? this.suffixIcon,
       suffix: suffix ?? this.suffix,
       suffixText: suffixText ?? this.suffixText,
       suffixStyle: suffixStyle ?? this.suffixStyle,
       suffixIconColor: suffixIconColor ?? this.suffixIconColor,
-      suffixIconConstraints: suffixIconConstraints ?? this.suffixIconConstraints,
+      suffixIconConstraints:
+          suffixIconConstraints ?? this.suffixIconConstraints,
       counter: counter ?? this.counter,
       counterText: counterText ?? this.counterText,
       counterStyle: counterStyle ?? this.counterStyle,
@@ -3469,12 +3574,14 @@ class InputDecoration {
       labelStyle: labelStyle ?? theme.labelStyle,
       floatingLabelStyle: floatingLabelStyle ?? theme.floatingLabelStyle,
       helperStyle: helperStyle ?? theme.helperStyle,
-      helperMaxLines : helperMaxLines ?? theme.helperMaxLines,
+      helperMaxLines: helperMaxLines ?? theme.helperMaxLines,
       hintStyle: hintStyle ?? theme.hintStyle,
       errorStyle: errorStyle ?? theme.errorStyle,
       errorMaxLines: errorMaxLines ?? theme.errorMaxLines,
-      floatingLabelBehavior: floatingLabelBehavior ?? theme.floatingLabelBehavior,
-      floatingLabelAlignment: floatingLabelAlignment ?? theme.floatingLabelAlignment,
+      floatingLabelBehavior:
+          floatingLabelBehavior ?? theme.floatingLabelBehavior,
+      floatingLabelAlignment:
+          floatingLabelAlignment ?? theme.floatingLabelAlignment,
       isCollapsed: isCollapsed,
       isDense: isDense ?? theme.isDense,
       contentPadding: contentPadding ?? theme.contentPadding,
@@ -3498,61 +3605,59 @@ class InputDecoration {
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
-    return other is InputDecoration
-        && other.icon == icon
-        && other.iconColor == iconColor
-        && other.label == label
-        && other.labelText == labelText
-        && other.labelStyle == labelStyle
-        && other.floatingLabelStyle == floatingLabelStyle
-        && other.helperText == helperText
-        && other.helperStyle == helperStyle
-        && other.helperMaxLines == helperMaxLines
-        && other.hintText == hintText
-        && other.hintStyle == hintStyle
-        && other.hintTextDirection == hintTextDirection
-        && other.hintMaxLines == hintMaxLines
-        && other.errorText == errorText
-        && other.errorStyle == errorStyle
-        && other.errorMaxLines == errorMaxLines
-        && other.floatingLabelBehavior == floatingLabelBehavior
-        && other.floatingLabelAlignment == floatingLabelAlignment
-        && other.isDense == isDense
-        && other.contentPadding == contentPadding
-        && other.isCollapsed == isCollapsed
-        && other.prefixIcon == prefixIcon
-        && other.prefixIconColor == prefixIconColor
-        && other.prefix == prefix
-        && other.prefixText == prefixText
-        && other.prefixStyle == prefixStyle
-        && other.prefixIconConstraints == prefixIconConstraints
-        && other.suffixIcon == suffixIcon
-        && other.suffixIconColor == suffixIconColor
-        && other.suffix == suffix
-        && other.suffixText == suffixText
-        && other.suffixStyle == suffixStyle
-        && other.suffixIconConstraints == suffixIconConstraints
-        && other.counter == counter
-        && other.counterText == counterText
-        && other.counterStyle == counterStyle
-        && other.filled == filled
-        && other.fillColor == fillColor
-        && other.focusColor == focusColor
-        && other.hoverColor == hoverColor
-        && other.errorBorder == errorBorder
-        && other.focusedBorder == focusedBorder
-        && other.focusedErrorBorder == focusedErrorBorder
-        && other.disabledBorder == disabledBorder
-        && other.enabledBorder == enabledBorder
-        && other.border == border
-        && other.enabled == enabled
-        && other.semanticCounterText == semanticCounterText
-        && other.alignLabelWithHint == alignLabelWithHint
-        && other.constraints == constraints;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is InputDecoration &&
+        other.icon == icon &&
+        other.iconColor == iconColor &&
+        other.label == label &&
+        other.labelText == labelText &&
+        other.labelStyle == labelStyle &&
+        other.floatingLabelStyle == floatingLabelStyle &&
+        other.helperText == helperText &&
+        other.helperStyle == helperStyle &&
+        other.helperMaxLines == helperMaxLines &&
+        other.hintText == hintText &&
+        other.hintStyle == hintStyle &&
+        other.hintTextDirection == hintTextDirection &&
+        other.hintMaxLines == hintMaxLines &&
+        other.errorText == errorText &&
+        other.errorStyle == errorStyle &&
+        other.errorMaxLines == errorMaxLines &&
+        other.floatingLabelBehavior == floatingLabelBehavior &&
+        other.floatingLabelAlignment == floatingLabelAlignment &&
+        other.isDense == isDense &&
+        other.contentPadding == contentPadding &&
+        other.isCollapsed == isCollapsed &&
+        other.prefixIcon == prefixIcon &&
+        other.prefixIconColor == prefixIconColor &&
+        other.prefix == prefix &&
+        other.prefixText == prefixText &&
+        other.prefixStyle == prefixStyle &&
+        other.prefixIconConstraints == prefixIconConstraints &&
+        other.suffixIcon == suffixIcon &&
+        other.suffixIconColor == suffixIconColor &&
+        other.suffix == suffix &&
+        other.suffixText == suffixText &&
+        other.suffixStyle == suffixStyle &&
+        other.suffixIconConstraints == suffixIconConstraints &&
+        other.counter == counter &&
+        other.counterText == counterText &&
+        other.counterStyle == counterStyle &&
+        other.filled == filled &&
+        other.fillColor == fillColor &&
+        other.focusColor == focusColor &&
+        other.hoverColor == hoverColor &&
+        other.errorBorder == errorBorder &&
+        other.focusedBorder == focusedBorder &&
+        other.focusedErrorBorder == focusedErrorBorder &&
+        other.disabledBorder == disabledBorder &&
+        other.enabledBorder == enabledBorder &&
+        other.border == border &&
+        other.enabled == enabled &&
+        other.semanticCounterText == semanticCounterText &&
+        other.alignLabelWithHint == alignLabelWithHint &&
+        other.constraints == constraints;
   }
 
   @override
@@ -3619,7 +3724,8 @@ class InputDecoration {
       if (iconColor != null) 'iconColor: $iconColor',
       if (label != null) 'label: $label',
       if (labelText != null) 'labelText: "$labelText"',
-      if (floatingLabelStyle != null) 'floatingLabelStyle: "$floatingLabelStyle"',
+      if (floatingLabelStyle != null)
+        'floatingLabelStyle: "$floatingLabelStyle"',
       if (helperText != null) 'helperText: "$helperText"',
       if (helperMaxLines != null) 'helperMaxLines: "$helperMaxLines"',
       if (hintText != null) 'hintText: "$hintText"',
@@ -3627,8 +3733,10 @@ class InputDecoration {
       if (errorText != null) 'errorText: "$errorText"',
       if (errorStyle != null) 'errorStyle: "$errorStyle"',
       if (errorMaxLines != null) 'errorMaxLines: "$errorMaxLines"',
-      if (floatingLabelBehavior != null) 'floatingLabelBehavior: $floatingLabelBehavior',
-      if (floatingLabelAlignment != null) 'floatingLabelAlignment: $floatingLabelAlignment',
+      if (floatingLabelBehavior != null)
+        'floatingLabelBehavior: $floatingLabelBehavior',
+      if (floatingLabelAlignment != null)
+        'floatingLabelAlignment: $floatingLabelAlignment',
       if (isDense ?? false) 'isDense: $isDense',
       if (contentPadding != null) 'contentPadding: $contentPadding',
       if (isCollapsed) 'isCollapsed: $isCollapsed',
@@ -3637,13 +3745,15 @@ class InputDecoration {
       if (prefix != null) 'prefix: $prefix',
       if (prefixText != null) 'prefixText: $prefixText',
       if (prefixStyle != null) 'prefixStyle: $prefixStyle',
-      if (prefixIconConstraints != null) 'prefixIconConstraints: $prefixIconConstraints',
+      if (prefixIconConstraints != null)
+        'prefixIconConstraints: $prefixIconConstraints',
       if (suffixIcon != null) 'suffixIcon: $suffixIcon',
       if (suffixIconColor != null) 'suffixIconColor: $suffixIconColor',
       if (suffix != null) 'suffix: $suffix',
       if (suffixText != null) 'suffixText: $suffixText',
       if (suffixStyle != null) 'suffixStyle: $suffixStyle',
-      if (suffixIconConstraints != null) 'suffixIconConstraints: $suffixIconConstraints',
+      if (suffixIconConstraints != null)
+        'suffixIconConstraints: $suffixIconConstraints',
       if (counter != null) 'counter: $counter',
       if (counterText != null) 'counterText: $counterText',
       if (counterStyle != null) 'counterStyle: $counterStyle',
@@ -3658,7 +3768,8 @@ class InputDecoration {
       if (enabledBorder != null) 'enabledBorder: $enabledBorder',
       if (border != null) 'border: $border',
       if (!enabled) 'enabled: false',
-      if (semanticCounterText != null) 'semanticCounterText: $semanticCounterText',
+      if (semanticCounterText != null)
+        'semanticCounterText: $semanticCounterText',
       if (alignLabelWithHint != null) 'alignLabelWithHint: $alignLabelWithHint',
       if (constraints != null) 'constraints: $constraints',
     ];
@@ -3713,11 +3824,11 @@ class InputDecorationTheme with Diagnosticable {
     this.border,
     this.alignLabelWithHint = false,
     this.constraints,
-  }) : assert(isDense != null),
-       assert(isCollapsed != null),
-       assert(floatingLabelAlignment != null),
-       assert(filled != null),
-       assert(alignLabelWithHint != null);
+  })  : assert(isDense != null),
+        assert(isCollapsed != null),
+        assert(floatingLabelAlignment != null),
+        assert(filled != null),
+        assert(alignLabelWithHint != null);
 
   /// {@macro flutter.material.inputDecoration.labelStyle}
   final TextStyle? labelStyle;
@@ -4125,8 +4236,10 @@ class InputDecorationTheme with Diagnosticable {
       hintStyle: hintStyle ?? this.hintStyle,
       errorStyle: errorStyle ?? this.errorStyle,
       errorMaxLines: errorMaxLines ?? this.errorMaxLines,
-      floatingLabelBehavior: floatingLabelBehavior ?? this.floatingLabelBehavior,
-      floatingLabelAlignment: floatingLabelAlignment ?? this.floatingLabelAlignment,
+      floatingLabelBehavior:
+          floatingLabelBehavior ?? this.floatingLabelBehavior,
+      floatingLabelAlignment:
+          floatingLabelAlignment ?? this.floatingLabelAlignment,
       isDense: isDense ?? this.isDense,
       contentPadding: contentPadding ?? this.contentPadding,
       iconColor: iconColor,
@@ -4153,113 +4266,153 @@ class InputDecorationTheme with Diagnosticable {
 
   @override
   int get hashCode => Object.hash(
-    labelStyle,
-    floatingLabelStyle,
-    helperStyle,
-    helperMaxLines,
-    hintStyle,
-    errorStyle,
-    errorMaxLines,
-    floatingLabelBehavior,
-    floatingLabelAlignment,
-    isDense,
-    contentPadding,
-    isCollapsed,
-    iconColor,
-    prefixStyle,
-    prefixIconColor,
-    suffixStyle,
-    suffixIconColor,
-    counterStyle,
-    filled,
-    Object.hash(
-      fillColor,
-      focusColor,
-      hoverColor,
-      errorBorder,
-      focusedBorder,
-      focusedErrorBorder,
-      disabledBorder,
-      enabledBorder,
-      border,
-      alignLabelWithHint,
-      constraints,
-    ),
-  );
+        labelStyle,
+        floatingLabelStyle,
+        helperStyle,
+        helperMaxLines,
+        hintStyle,
+        errorStyle,
+        errorMaxLines,
+        floatingLabelBehavior,
+        floatingLabelAlignment,
+        isDense,
+        contentPadding,
+        isCollapsed,
+        iconColor,
+        prefixStyle,
+        prefixIconColor,
+        suffixStyle,
+        suffixIconColor,
+        counterStyle,
+        filled,
+        Object.hash(
+          fillColor,
+          focusColor,
+          hoverColor,
+          errorBorder,
+          focusedBorder,
+          focusedErrorBorder,
+          disabledBorder,
+          enabledBorder,
+          border,
+          alignLabelWithHint,
+          constraints,
+        ),
+      );
 
   @override
   bool operator ==(Object other) {
-    if (identical(this, other))
-      return true;
-    if (other.runtimeType != runtimeType)
-      return false;
-    return other is InputDecorationTheme
-        && other.labelStyle == labelStyle
-        && other.floatingLabelStyle == floatingLabelStyle
-        && other.helperStyle == helperStyle
-        && other.helperMaxLines == helperMaxLines
-        && other.hintStyle == hintStyle
-        && other.errorStyle == errorStyle
-        && other.errorMaxLines == errorMaxLines
-        && other.isDense == isDense
-        && other.contentPadding == contentPadding
-        && other.isCollapsed == isCollapsed
-        && other.iconColor == iconColor
-        && other.prefixStyle == prefixStyle
-        && other.prefixIconColor == prefixIconColor
-        && other.suffixStyle == suffixStyle
-        && other.suffixIconColor == suffixIconColor
-        && other.counterStyle == counterStyle
-        && other.floatingLabelBehavior == floatingLabelBehavior
-        && other.floatingLabelAlignment == floatingLabelAlignment
-        && other.filled == filled
-        && other.fillColor == fillColor
-        && other.focusColor == focusColor
-        && other.hoverColor == hoverColor
-        && other.errorBorder == errorBorder
-        && other.focusedBorder == focusedBorder
-        && other.focusedErrorBorder == focusedErrorBorder
-        && other.disabledBorder == disabledBorder
-        && other.enabledBorder == enabledBorder
-        && other.border == border
-        && other.alignLabelWithHint == alignLabelWithHint
-        && other.constraints == constraints
-        && other.disabledBorder == disabledBorder;
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is InputDecorationTheme &&
+        other.labelStyle == labelStyle &&
+        other.floatingLabelStyle == floatingLabelStyle &&
+        other.helperStyle == helperStyle &&
+        other.helperMaxLines == helperMaxLines &&
+        other.hintStyle == hintStyle &&
+        other.errorStyle == errorStyle &&
+        other.errorMaxLines == errorMaxLines &&
+        other.isDense == isDense &&
+        other.contentPadding == contentPadding &&
+        other.isCollapsed == isCollapsed &&
+        other.iconColor == iconColor &&
+        other.prefixStyle == prefixStyle &&
+        other.prefixIconColor == prefixIconColor &&
+        other.suffixStyle == suffixStyle &&
+        other.suffixIconColor == suffixIconColor &&
+        other.counterStyle == counterStyle &&
+        other.floatingLabelBehavior == floatingLabelBehavior &&
+        other.floatingLabelAlignment == floatingLabelAlignment &&
+        other.filled == filled &&
+        other.fillColor == fillColor &&
+        other.focusColor == focusColor &&
+        other.hoverColor == hoverColor &&
+        other.errorBorder == errorBorder &&
+        other.focusedBorder == focusedBorder &&
+        other.focusedErrorBorder == focusedErrorBorder &&
+        other.disabledBorder == disabledBorder &&
+        other.enabledBorder == enabledBorder &&
+        other.border == border &&
+        other.alignLabelWithHint == alignLabelWithHint &&
+        other.constraints == constraints &&
+        other.disabledBorder == disabledBorder;
   }
 
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     const InputDecorationTheme defaultTheme = InputDecorationTheme();
-    properties.add(DiagnosticsProperty<TextStyle>('labelStyle', labelStyle, defaultValue: defaultTheme.labelStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('floatingLabelStyle', floatingLabelStyle, defaultValue: defaultTheme.floatingLabelStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('helperStyle', helperStyle, defaultValue: defaultTheme.helperStyle));
-    properties.add(IntProperty('helperMaxLines', helperMaxLines, defaultValue: defaultTheme.helperMaxLines));
-    properties.add(DiagnosticsProperty<TextStyle>('hintStyle', hintStyle, defaultValue: defaultTheme.hintStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle, defaultValue: defaultTheme.errorStyle));
-    properties.add(IntProperty('errorMaxLines', errorMaxLines, defaultValue: defaultTheme.errorMaxLines));
-    properties.add(DiagnosticsProperty<FloatingLabelBehavior>('floatingLabelBehavior', floatingLabelBehavior, defaultValue: defaultTheme.floatingLabelBehavior));
-    properties.add(DiagnosticsProperty<FloatingLabelAlignment>('floatingLabelAlignment', floatingLabelAlignment, defaultValue: defaultTheme.floatingLabelAlignment));
-    properties.add(DiagnosticsProperty<bool>('isDense', isDense, defaultValue: defaultTheme.isDense));
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('contentPadding', contentPadding, defaultValue: defaultTheme.contentPadding));
-    properties.add(DiagnosticsProperty<bool>('isCollapsed', isCollapsed, defaultValue: defaultTheme.isCollapsed));
-    properties.add(DiagnosticsProperty<Color>('iconColor', iconColor, defaultValue: defaultTheme.iconColor));
-    properties.add(DiagnosticsProperty<Color>('prefixIconColor', prefixIconColor, defaultValue: defaultTheme.prefixIconColor));
-    properties.add(DiagnosticsProperty<TextStyle>('prefixStyle', prefixStyle, defaultValue: defaultTheme.prefixStyle));
-    properties.add(DiagnosticsProperty<Color>('suffixIconColor', suffixIconColor, defaultValue: defaultTheme.suffixIconColor));
-    properties.add(DiagnosticsProperty<TextStyle>('suffixStyle', suffixStyle, defaultValue: defaultTheme.suffixStyle));
-    properties.add(DiagnosticsProperty<TextStyle>('counterStyle', counterStyle, defaultValue: defaultTheme.counterStyle));
-    properties.add(DiagnosticsProperty<bool>('filled', filled, defaultValue: defaultTheme.filled));
-    properties.add(ColorProperty('fillColor', fillColor, defaultValue: defaultTheme.fillColor));
-    properties.add(ColorProperty('focusColor', focusColor, defaultValue: defaultTheme.focusColor));
-    properties.add(ColorProperty('hoverColor', hoverColor, defaultValue: defaultTheme.hoverColor));
-    properties.add(DiagnosticsProperty<InputBorder>('errorBorder', errorBorder, defaultValue: defaultTheme.errorBorder));
-    properties.add(DiagnosticsProperty<InputBorder>('focusedBorder', focusedBorder, defaultValue: defaultTheme.focusedErrorBorder));
-    properties.add(DiagnosticsProperty<InputBorder>('focusedErrorBorder', focusedErrorBorder, defaultValue: defaultTheme.focusedErrorBorder));
-    properties.add(DiagnosticsProperty<InputBorder>('disabledBorder', disabledBorder, defaultValue: defaultTheme.disabledBorder));
-    properties.add(DiagnosticsProperty<InputBorder>('enabledBorder', enabledBorder, defaultValue: defaultTheme.enabledBorder));
-    properties.add(DiagnosticsProperty<InputBorder>('border', border, defaultValue: defaultTheme.border));
-    properties.add(DiagnosticsProperty<bool>('alignLabelWithHint', alignLabelWithHint, defaultValue: defaultTheme.alignLabelWithHint));
-    properties.add(DiagnosticsProperty<BoxConstraints>('constraints', constraints, defaultValue: defaultTheme.constraints));
+    properties.add(DiagnosticsProperty<TextStyle>('labelStyle', labelStyle,
+        defaultValue: defaultTheme.labelStyle));
+    properties.add(DiagnosticsProperty<TextStyle>(
+        'floatingLabelStyle', floatingLabelStyle,
+        defaultValue: defaultTheme.floatingLabelStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('helperStyle', helperStyle,
+        defaultValue: defaultTheme.helperStyle));
+    properties.add(IntProperty('helperMaxLines', helperMaxLines,
+        defaultValue: defaultTheme.helperMaxLines));
+    properties.add(DiagnosticsProperty<TextStyle>('hintStyle', hintStyle,
+        defaultValue: defaultTheme.hintStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('errorStyle', errorStyle,
+        defaultValue: defaultTheme.errorStyle));
+    properties.add(IntProperty('errorMaxLines', errorMaxLines,
+        defaultValue: defaultTheme.errorMaxLines));
+    properties.add(DiagnosticsProperty<FloatingLabelBehavior>(
+        'floatingLabelBehavior', floatingLabelBehavior,
+        defaultValue: defaultTheme.floatingLabelBehavior));
+    properties.add(DiagnosticsProperty<FloatingLabelAlignment>(
+        'floatingLabelAlignment', floatingLabelAlignment,
+        defaultValue: defaultTheme.floatingLabelAlignment));
+    properties.add(DiagnosticsProperty<bool>('isDense', isDense,
+        defaultValue: defaultTheme.isDense));
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>(
+        'contentPadding', contentPadding,
+        defaultValue: defaultTheme.contentPadding));
+    properties.add(DiagnosticsProperty<bool>('isCollapsed', isCollapsed,
+        defaultValue: defaultTheme.isCollapsed));
+    properties.add(DiagnosticsProperty<Color>('iconColor', iconColor,
+        defaultValue: defaultTheme.iconColor));
+    properties.add(DiagnosticsProperty<Color>(
+        'prefixIconColor', prefixIconColor,
+        defaultValue: defaultTheme.prefixIconColor));
+    properties.add(DiagnosticsProperty<TextStyle>('prefixStyle', prefixStyle,
+        defaultValue: defaultTheme.prefixStyle));
+    properties.add(DiagnosticsProperty<Color>(
+        'suffixIconColor', suffixIconColor,
+        defaultValue: defaultTheme.suffixIconColor));
+    properties.add(DiagnosticsProperty<TextStyle>('suffixStyle', suffixStyle,
+        defaultValue: defaultTheme.suffixStyle));
+    properties.add(DiagnosticsProperty<TextStyle>('counterStyle', counterStyle,
+        defaultValue: defaultTheme.counterStyle));
+    properties.add(DiagnosticsProperty<bool>('filled', filled,
+        defaultValue: defaultTheme.filled));
+    properties.add(ColorProperty('fillColor', fillColor,
+        defaultValue: defaultTheme.fillColor));
+    properties.add(ColorProperty('focusColor', focusColor,
+        defaultValue: defaultTheme.focusColor));
+    properties.add(ColorProperty('hoverColor', hoverColor,
+        defaultValue: defaultTheme.hoverColor));
+    properties.add(DiagnosticsProperty<InputBorder>('errorBorder', errorBorder,
+        defaultValue: defaultTheme.errorBorder));
+    properties.add(DiagnosticsProperty<InputBorder>(
+        'focusedBorder', focusedBorder,
+        defaultValue: defaultTheme.focusedErrorBorder));
+    properties.add(DiagnosticsProperty<InputBorder>(
+        'focusedErrorBorder', focusedErrorBorder,
+        defaultValue: defaultTheme.focusedErrorBorder));
+    properties.add(DiagnosticsProperty<InputBorder>(
+        'disabledBorder', disabledBorder,
+        defaultValue: defaultTheme.disabledBorder));
+    properties.add(DiagnosticsProperty<InputBorder>(
+        'enabledBorder', enabledBorder,
+        defaultValue: defaultTheme.enabledBorder));
+    properties.add(DiagnosticsProperty<InputBorder>('border', border,
+        defaultValue: defaultTheme.border));
+    properties.add(DiagnosticsProperty<bool>(
+        'alignLabelWithHint', alignLabelWithHint,
+        defaultValue: defaultTheme.alignLabelWithHint));
+    properties.add(DiagnosticsProperty<BoxConstraints>(
+        'constraints', constraints,
+        defaultValue: defaultTheme.constraints));
   }
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1945,24 +1945,24 @@ void main() {
   testWidgets('ErrorWidget', (WidgetTester tester) async {
     await tester.pumpWidget(
       buildInputDecorator(
-        decoration: const InputDecoration(
-          errorWidget: Text('errorWidget'),
+        decoration: InputDecoration(
+          errorBuilder: (String? errorMessage) => Text('$errorMessage'),
         )
       )
     );
 
-    /// Check that errorWidget is displayed under the border
+    /// When errorText and errorBuilder is defined,
+    ///  the errorMessage will never be null.
 
     await tester.pumpWidget(
       buildInputDecorator(
         decoration: InputDecoration(
-          errorWidget: const Text('errorWidget'),
+          errorBuilder: (String? errorMessage) => Text(errorMessage!),
           errorText: 'errorText'
         )
       )
     );
 
-    /// Check that we can't define both errorWidget and errorText
 
   });
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1942,6 +1942,30 @@ void main() {
     expect(getBorderWeight(tester), 2.0);
   });
 
+  testWidgets('ErrorWidget', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: const InputDecoration(
+          errorWidget: Text('errorWidget'),
+        )
+      )
+    );
+
+    /// Check that errorWidget is displayed under the border
+
+    await tester.pumpWidget(
+      buildInputDecorator(
+        decoration: InputDecoration(
+          errorWidget: const Text('errorWidget'),
+          errorText: 'errorText'
+        )
+      )
+    );
+
+    /// Check that we can't define both errorWidget and errorText
+
+  });
+
   testWidgets('InputDecorator respects increased theme visualDensity', (WidgetTester tester) async {
     // Label is visible, hint is not (opacity 0.0).
     await tester.pumpWidget(


### PR DESCRIPTION
Me, [Daniele Cambi](https://github.com/dancamdev) and [Cosimo Tassone](https://github.com/ctechdev) made this PR that allows to customize the errorText of an InputDecoration with an errorWidgetBuilder function that takes in input the errorText String that cames from InputDecoration, when it is not null, and allows to build a custom Widget for the error.
The default behavior doesn't change if the errorWidgetBuilder is not provided.

Without error widget builder:

<a href="https://ibb.co/jWtQQRR"><img src="https://i.ibb.co/mXp2288/Simulator-Screen-Shot-i-Phone-13-mini-2022-05-19-at-11-38-16.png" alt="Simulator-Screen-Shot-i-Phone-13-mini-2022-05-19-at-11-38-16" border="0"></a>

With custom errorWidgetBuilder:

<a href="https://ibb.co/CJ50Wtj"><img src="https://i.ibb.co/JxRkCdY/Simulator-Screen-Shot-i-Phone-13-mini-2022-05-19-at-11-40-30.png" alt="Simulator-Screen-Shot-i-Phone-13-mini-2022-05-19-at-11-40-30" border="0"></a>

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes #11068

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
