### PR TITLE
Make it possible to build apps for Android versions still in preview

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -426,7 +426,7 @@ class FlutterPlugin implements Plugin<Project> {
 
     /**
      * Compares semantic versions ignoring labels.
-     * 
+     *
      * If the versions are equal (ignoring labels), returns one of the two strings arbitrarily.
      *
      * If minor or patch are omitted (non-conformant to semantic versioning), they are considered zero.
@@ -455,31 +455,10 @@ class FlutterPlugin implements Plugin<Project> {
         return version2
     }
 
-    /**
-     * Resolves SDK version to API level. 
-     *
-     * Handles sdkVersion being integers and strings (codenames) (when the platform stability is not yet declared).
-     * Must be updated when new android SDK level is released.
-     */
-    private int resolveSdkVersion(String sdkVersion) {
-        int resolvedSdkVersion;
-        if (sdkVersion.startsWith("android-")) {
-            sdkVersion = sdkVersion.substring(8)
-        }
-
-        if (sdkVersion.isInteger()) {
-            resolvedSdkVersion = sdkVersion.toInteger()
-        } else if (sdkVersion.equals("Tiramisu")) {
-            resolvedSdkVersion = 33
-        }
-
-        return resolvedSdkVersion
-    }
-
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
         project.afterEvaluate {
-            def projectCompileSdkVersion = resolveSdkVersion(project.android.compileSdkVersion)
+            int projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified
@@ -505,7 +484,7 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
-        }  
+        }
     }
 
     /**

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -455,24 +455,32 @@ class FlutterPlugin implements Plugin<Project> {
         return version2
     }
 
+    /**
+     * Resolves SDK version to API level. 
+     *
+     * Handles sdkVersion being integers and strings (codenames) (when the platform stability is not yet declared). 
+     */
+    private int resolveSdkVersion(String sdkVersion) {
+        int resolvedSdkVersion;
+        if (sdkVersion.startsWith("android-")) {
+            sdkVersion = sdkVersion.substring(8)
+        }
+
+        if (sdkVersion.isInteger()) {
+            resolvedSdkVersion = sdkVersion.toInteger()
+        } else if (sdkVersion.equals("Tiramisu")) {
+            resolvedSdkVersion = 33
+            println "tiramisu"
+        }
+
+        return resolvedSdkVersion
+    }
+
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
         println "detectLowCompileSdkVersionOrNdkVersion()"
         project.afterEvaluate {
-            def projectCompileSdkVersion = project.android.compileSdkVersion
-            def projectCompileSdkVersionSubstr = projectCompileSdkVersion.substring(8)
-
-            println "projectCompileSdkVersion: ${projectCompileSdkVersion}, projectCompileSdkVersionSubstr: ${projectCompileSdkVersionSubstr}"
-
-            if (projectCompileSdkVersionSubstr.isInteger()) {
-                projectCompileSdkVersion = projectCompileSdkVersionSubstr.toInteger()
-            }
-
-            if (projectCompileSdkVersion.equals("Tiramisu") || projectCompileSdkVersionSubstr.equals("Tiramisu")) {
-                projectCompileSdkVersion = 33
-                println "tiramisu"
-            }
-
+            def projectCompileSdkVersion = resolveSdkVersion(project.android.compileSdkVersion)
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -458,7 +458,8 @@ class FlutterPlugin implements Plugin<Project> {
     /**
      * Resolves SDK version to API level. 
      *
-     * Handles sdkVersion being integers and strings (codenames) (when the platform stability is not yet declared). 
+     * Handles sdkVersion being integers and strings (codenames) (when the platform stability is not yet declared).
+     * Must be updated when new android SDK level is released.
      */
     private int resolveSdkVersion(String sdkVersion) {
         int resolvedSdkVersion;
@@ -470,7 +471,6 @@ class FlutterPlugin implements Plugin<Project> {
             resolvedSdkVersion = sdkVersion.toInteger()
         } else if (sdkVersion.equals("Tiramisu")) {
             resolvedSdkVersion = 33
-            println "tiramisu"
         }
 
         return resolvedSdkVersion
@@ -478,7 +478,6 @@ class FlutterPlugin implements Plugin<Project> {
 
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
-        println "detectLowCompileSdkVersionOrNdkVersion()"
         project.afterEvaluate {
             def projectCompileSdkVersion = resolveSdkVersion(project.android.compileSdkVersion)
             int maxPluginCompileSdkVersion = projectCompileSdkVersion

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -426,7 +426,7 @@ class FlutterPlugin implements Plugin<Project> {
 
     /**
      * Compares semantic versions ignoring labels.
-     *
+     * 
      * If the versions are equal (ignoring labels), returns one of the two strings arbitrarily.
      *
      * If minor or patch are omitted (non-conformant to semantic versioning), they are considered zero.
@@ -457,8 +457,22 @@ class FlutterPlugin implements Plugin<Project> {
 
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
+        println "detectLowCompileSdkVersionOrNdkVersion()"
         project.afterEvaluate {
-            int projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
+            def projectCompileSdkVersion = project.android.compileSdkVersion
+            def projectCompileSdkVersionSubstr = projectCompileSdkVersion.substring(8)
+
+            println "projectCompileSdkVersion: ${projectCompileSdkVersion}, projectCompileSdkVersionSubstr: ${projectCompileSdkVersionSubstr}"
+
+            if (projectCompileSdkVersionSubstr.isInteger()) {
+                projectCompileSdkVersion = projectCompileSdkVersionSubstr.toInteger()
+            }
+
+            if (projectCompileSdkVersion.equals("Tiramisu") || projectCompileSdkVersionSubstr.equals("Tiramisu")) {
+                projectCompileSdkVersion = 33
+                println "tiramisu"
+            }
+
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified
@@ -484,7 +498,7 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
-        }
+        }  
     }
 
     /**

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -458,6 +458,11 @@ class FlutterPlugin implements Plugin<Project> {
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
         project.afterEvaluate {
+            assert project.android.compileSdkVersion.startsWith('android-')
+            if (!project.android.compileSdkVersion.substring(8).isInteger()) {
+                return
+            }
+
             int projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */


### PR DESCRIPTION
Fixes #104170

It makes it possible to use non-integer `compileSdkVersion` in app-level `build.gradle` file.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
