### PR TITLE
Revert "Fix `DropdownButton` menu clip"

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -286,30 +286,27 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           namesRoute: true,
           explicitChildNodes: true,
           label: localizations.popupMenuLabel,
-          child: ClipRRect(
-            borderRadius: widget.borderRadius ?? BorderRadius.zero,
-            child: Material(
-              type: MaterialType.transparency,
-              textStyle: route.style,
-              child: ScrollConfiguration(
-                // Dropdown menus should never overscroll or display an overscroll indicator.
-                // Scrollbars are built-in below.
-                // Platform must use Theme and ScrollPhysics must be Clamping.
-                behavior: ScrollConfiguration.of(context).copyWith(
-                  scrollbars: false,
-                  overscroll: false,
-                  physics: const ClampingScrollPhysics(),
-                  platform: Theme.of(context).platform,
-                ),
-                child: PrimaryScrollController(
-                  controller: widget.route.scrollController!,
-                  child: Scrollbar(
-                    thumbVisibility: true,
-                    child: ListView(
-                      padding: kMaterialListPadding,
-                      shrinkWrap: true,
-                      children: children,
-                    ),
+          child: Material(
+            type: MaterialType.transparency,
+            textStyle: route.style,
+            child: ScrollConfiguration(
+              // Dropdown menus should never overscroll or display an overscroll indicator.
+              // Scrollbars are built-in below.
+              // Platform must use Theme and ScrollPhysics must be Clamping.
+              behavior: ScrollConfiguration.of(context).copyWith(
+                scrollbars: false,
+                overscroll: false,
+                physics: const ClampingScrollPhysics(),
+                platform: Theme.of(context).platform,
+              ),
+              child: PrimaryScrollController(
+                controller: widget.route.scrollController!,
+                child: Scrollbar(
+                  thumbVisibility: true,
+                  child: ListView(
+                    padding: kMaterialListPadding,
+                    shrinkWrap: true,
+                    children: children,
                   ),
                 ),
               ),

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -3839,35 +3839,4 @@ void main() {
     expect(tester.getBottomRight(find.text(hintText)).dx, 776.0);
     expect(tester.getBottomRight(find.text(hintText)).dy, 350.0);
   });
-
-  testWidgets('BorderRadius property clips dropdown menu', (WidgetTester tester) async {
-    const double radius = 20.0;
-
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: DropdownButtonFormField<String>(
-              borderRadius: BorderRadius.circular(radius),
-              value: 'One',
-              items: <String>['One', 'Two', 'Three', 'Four']
-                .map<DropdownMenuItem<String>>((String value) {
-                  return DropdownMenuItem<String>(
-                    value: value,
-                    child: Text(value),
-                  );
-              }).toList(),
-              onChanged: (_) { },
-            ),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tap(find.text('One'));
-    await tester.pumpAndSettle();
-
-    final RenderClipRRect renderClip = tester.allRenderObjects.whereType<RenderClipRRect>().first;
-    expect(renderClip.borderRadius, BorderRadius.circular(radius));
-  });
 }


### PR DESCRIPTION
Reverts flutter/flutter#102970

There is an internal customer broken by this change. The ability for content to overflow is expected. The image in the PR reflected this, but was not determined to be breaking at the time.

FYI @TahaTesser 