### PR TITLE
[packaging] Move chromium mirror to flutter mirror

### DIFF
--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -16,7 +16,7 @@ import 'package:platform/platform.dart' show Platform, LocalPlatform;
 import 'package:process/process.dart';
 
 const String gobMirror =
-'https://flutter.googlesource.com/mirrors/flutter';
+    'https://flutter.googlesource.com/mirrors/flutter';
 const String githubRepo = 'https://github.com/flutter/flutter.git';
 const String mingitForWindowsUrl = 'https://storage.googleapis.com/flutter_infra_release/mingit/'
     '603511c649b00bbef0a6122a827ac419b656bc19/mingit.zip';

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -15,7 +15,8 @@ import 'package:path/path.dart' as path;
 import 'package:platform/platform.dart' show Platform, LocalPlatform;
 import 'package:process/process.dart';
 
-const String chromiumRepo = 'https://chromium.googlesource.com/external/github.com/flutter/flutter';
+const String gobMirror =
+'https://flutter.googlesource.com/mirrors/flutter';
 const String githubRepo = 'https://github.com/flutter/flutter.git';
 const String mingitForWindowsUrl = 'https://storage.googleapis.com/flutter_infra_release/mingit/'
     '603511c649b00bbef0a6122a827ac419b656bc19/mingit.zip';
@@ -424,7 +425,7 @@ class ArchiveCreator {
     // We want the user to start out the in the specified branch instead of a
     // detached head. To do that, we need to make sure the branch points at the
     // desired revision.
-    await _runGit(<String>['clone', '-b', branchName, chromiumRepo], workingDirectory: tempDir);
+    await _runGit(<String>['clone', '-b', branchName, gobMirror], workingDirectory: tempDir);
     await _runGit(<String>['reset', '--hard', revision]);
 
     // Make the origin point to github instead of the chromium mirror.

--- a/dev/bots/test/prepare_package_test.dart
+++ b/dev/bots/test/prepare_package_test.dart
@@ -123,7 +123,7 @@ void main() {
             'flutter_${platformName}_v1.2.3-dev${platform.isLinux ? '.tar.xz' : '.zip'}');
 
         processManager.addCommands(convertResults(<String, List<ProcessResult>?>{
-          'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter': null,
+          'git clone -b dev https://flutter.googlesource.com/mirrors/flutter': null,
           'git reset --hard $testRef': null,
           'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --exact-match $testRef': <ProcessResult>[ProcessResult(0, 0, 'v1.2.3', '')],
@@ -159,7 +159,7 @@ void main() {
         final String archiveName = path.join(tempDir.absolute.path,
             'flutter_${platformName}_v1.2.3-dev${platform.isLinux ? '.tar.xz' : '.zip'}');
         final Map<String, List<ProcessResult>?> calls = <String, List<ProcessResult>?>{
-          'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter': null,
+          'git clone -b dev https://flutter.googlesource.com/mirrors/flutter': null,
           'git reset --hard $testRef': null,
           'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --exact-match $testRef': <ProcessResult>[ProcessResult(0, 0, 'v1.2.3', '')],
@@ -206,7 +206,7 @@ void main() {
         final String archiveName = path.join(tempDir.absolute.path,
             'flutter_${platformName}_arm64_v1.2.3-dev${platform.isLinux ? '.tar.xz' : '.zip'}');
         final Map<String, List<ProcessResult>?> calls = <String, List<ProcessResult>?>{
-          'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter': null,
+          'git clone -b dev https://flutter.googlesource.com/mirrors/flutter': null,
           'git reset --hard $testRef': null,
           'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --exact-match $testRef': <ProcessResult>[ProcessResult(0, 0, 'v1.2.3', '')],
@@ -250,7 +250,7 @@ void main() {
 
       test('throws when a command errors out', () async {
         final Map<String, List<ProcessResult>> calls = <String, List<ProcessResult>>{
-          'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter':
+          'git clone -b dev https://flutter.googlesource.com/mirrors/flutter':
               <ProcessResult>[ProcessResult(0, 0, 'output1', '')],
           'git reset --hard $testRef': <ProcessResult>[ProcessResult(0, -1, 'output2', '')],
         };
@@ -263,7 +263,7 @@ void main() {
         final String archiveName = path.join(tempDir.absolute.path,
             'flutter_${platformName}_v1.2.3-dev${platform.isLinux ? '.tar.xz' : '.zip'}');
         final Map<String, List<ProcessResult>?> calls = <String, List<ProcessResult>?>{
-          'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter': null,
+          'git clone -b dev https://flutter.googlesource.com/mirrors/flutter': null,
           'git reset --hard $testRef': null,
           'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --abbrev=0 $testRef': <ProcessResult>[ProcessResult(0, 0, 'v1.2.3', '')],
@@ -312,7 +312,7 @@ void main() {
         final ProcessResult codesignFailure = ProcessResult(1, 1, '', 'code object is not signed at all');
         final String binPath = path.join(tempDir.path, 'flutter', 'bin', 'cache', 'dart-sdk', 'bin', 'dart');
         final Map<String, List<ProcessResult>?> calls = <String, List<ProcessResult>?>{
-          'git clone -b dev https://chromium.googlesource.com/external/github.com/flutter/flutter': null,
+          'git clone -b dev https://flutter.googlesource.com/mirrors/flutter': null,
           'git reset --hard $testRef': null,
           'git remote set-url origin https://github.com/flutter/flutter.git': null,
           'git describe --tags --exact-match $testRef': <ProcessResult>[ProcessResult(0, 0, 'v1.2.3', '')],


### PR DESCRIPTION
Fixes the breakages on the stable packaging.

The issue is the LUCI scheduler is based on the copybara mirror which is <1 minute mirror time, but the chromium one has not mirrored yet.