### PR TITLE
Started sharing SemanticsProperties between the Widget and the RenderObject

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3950,122 +3950,38 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// If the [attributedLabel] is not null, the [textDirection] must also not be null.
   RenderSemanticsAnnotations({
     RenderBox? child,
+    required SemanticsProperties properties,
     bool container = false,
     bool explicitChildNodes = false,
     bool excludeSemantics = false,
-    bool? enabled,
-    bool? checked,
-    bool? toggled,
-    bool? selected,
-    bool? button,
-    bool? slider,
-    bool? keyboardKey,
-    bool? link,
-    bool? header,
-    bool? textField,
-    bool? readOnly,
-    bool? focusable,
-    bool? focused,
-    bool? inMutuallyExclusiveGroup,
-    bool? obscured,
-    bool? multiline,
-    bool? scopesRoute,
-    bool? namesRoute,
-    bool? hidden,
-    bool? image,
-    bool? liveRegion,
-    int? maxValueLength,
-    int? currentValueLength,
     AttributedString? attributedLabel,
     AttributedString? attributedValue,
     AttributedString? attributedIncreasedValue,
     AttributedString? attributedDecreasedValue,
     AttributedString? attributedHint,
-    String? tooltip,
-    SemanticsHintOverrides? hintOverrides,
     TextDirection? textDirection,
-    SemanticsSortKey? sortKey,
-    SemanticsTag? tagForChildren,
-    VoidCallback? onTap,
-    VoidCallback? onDismiss,
-    VoidCallback? onLongPress,
-    VoidCallback? onScrollLeft,
-    VoidCallback? onScrollRight,
-    VoidCallback? onScrollUp,
-    VoidCallback? onScrollDown,
-    VoidCallback? onIncrease,
-    VoidCallback? onDecrease,
-    VoidCallback? onCopy,
-    VoidCallback? onCut,
-    VoidCallback? onPaste,
-    MoveCursorHandler? onMoveCursorForwardByCharacter,
-    MoveCursorHandler? onMoveCursorBackwardByCharacter,
-    MoveCursorHandler? onMoveCursorForwardByWord,
-    MoveCursorHandler? onMoveCursorBackwardByWord,
-    SetSelectionHandler? onSetSelection,
-    SetTextHandler? onSetText,
-    VoidCallback? onDidGainAccessibilityFocus,
-    VoidCallback? onDidLoseAccessibilityFocus,
-    Map<CustomSemanticsAction, VoidCallback>? customSemanticsActions,
   }) : assert(container != null),
        _container = container,
        _explicitChildNodes = explicitChildNodes,
        _excludeSemantics = excludeSemantics,
-       _enabled = enabled,
-       _checked = checked,
-       _toggled = toggled,
-       _selected = selected,
-       _button = button,
-       _slider = slider,
-       _keyboardKey = keyboardKey,
-       _link = link,
-       _header = header,
-       _textField = textField,
-       _readOnly = readOnly,
-       _focusable = focusable,
-       _focused = focused,
-       _inMutuallyExclusiveGroup = inMutuallyExclusiveGroup,
-       _obscured = obscured,
-       _multiline = multiline,
-       _scopesRoute = scopesRoute,
-       _namesRoute = namesRoute,
-       _liveRegion = liveRegion,
-       _maxValueLength = maxValueLength,
-       _currentValueLength = currentValueLength,
-       _hidden = hidden,
-       _image = image,
-       _onDismiss = onDismiss,
        _attributedLabel = attributedLabel,
        _attributedValue = attributedValue,
        _attributedIncreasedValue = attributedIncreasedValue,
        _attributedDecreasedValue = attributedDecreasedValue,
        _attributedHint = attributedHint,
-       _tooltip = tooltip,
-       _hintOverrides = hintOverrides,
        _textDirection = textDirection,
-       _sortKey = sortKey,
-       _tagForChildren = tagForChildren,
-       _onTap = onTap,
-       _onLongPress = onLongPress,
-       _onScrollLeft = onScrollLeft,
-       _onScrollRight = onScrollRight,
-       _onScrollUp = onScrollUp,
-       _onScrollDown = onScrollDown,
-       _onIncrease = onIncrease,
-       _onDecrease = onDecrease,
-       _onCopy = onCopy,
-       _onCut = onCut,
-       _onPaste = onPaste,
-       _onMoveCursorForwardByCharacter = onMoveCursorForwardByCharacter,
-       _onMoveCursorBackwardByCharacter = onMoveCursorBackwardByCharacter,
-       _onMoveCursorForwardByWord = onMoveCursorForwardByWord,
-       _onMoveCursorBackwardByWord = onMoveCursorBackwardByWord,
-       _onSetSelection = onSetSelection,
-       _onSetText = onSetText,
-       _onDidGainAccessibilityFocus = onDidGainAccessibilityFocus,
-       _onDidLoseAccessibilityFocus = onDidLoseAccessibilityFocus,
-       _customSemanticsActions = customSemanticsActions,
+       _properties = properties,
        super(child);
+
+  SemanticsProperties _properties;
+  /// Sets the [SemanticsProperties] en masse.
+  void updateProperties(SemanticsProperties value) {
+    assert(value != null);
+    if (_properties == value)
+      return;
+    _properties = value;
+    markNeedsSemanticsUpdate();
+  }
 
   /// If 'container' is true, this [RenderObject] will introduce a new
   /// node in the semantics tree. Otherwise, the semantics will be
@@ -4125,255 +4041,95 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
 
   /// If non-null, sets the [SemanticsFlag.hasCheckedState] semantic to true and
   /// the [SemanticsConfiguration.isChecked] semantic to the given value.
-  bool? get checked => _checked;
-  bool? _checked;
-  set checked(bool? value) {
-    if (checked == value)
-      return;
-    _checked = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get checked => _properties.checked;
 
   /// If non-null, sets the [SemanticsFlag.hasEnabledState] semantic to true and
   /// the [SemanticsConfiguration.isEnabled] semantic to the given value.
-  bool? get enabled => _enabled;
-  bool? _enabled;
-  set enabled(bool? value) {
-    if (enabled == value)
-      return;
-    _enabled = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get enabled => _properties.enabled;
 
   /// If non-null, sets the [SemanticsConfiguration.isSelected] semantic to the
   /// given value.
-  bool? get selected => _selected;
-  bool? _selected;
-  set selected(bool? value) {
-    if (selected == value)
-      return;
-    _selected = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get selected => _properties.selected;
 
   /// If non-null, sets the [SemanticsConfiguration.isButton] semantic to the
   /// given value.
-  bool? get button => _button;
-  bool? _button;
-  set button(bool? value) {
-    if (button == value)
-      return;
-    _button = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get button => _properties.button;
 
   /// If non-null, sets the [SemanticsConfiguration.isSlider] semantic to the
   /// given value.
-  bool? get slider => _slider;
-  bool? _slider;
-  set slider(bool? value) {
-    if (slider == value)
-      return;
-    _slider = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get slider => _properties.slider;
 
   /// If non-null, sets the [SemanticsConfiguration.isKeyboardKey] semantic to the
   /// given value.
-  bool? get keyboardKey => _keyboardKey;
-  bool? _keyboardKey;
-  set keyboardKey(bool? value) {
-    if (keyboardKey == value)
-      return;
-    _keyboardKey = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get keyboardKey => _properties.keyboardKey;
 
   /// If non-null, sets the [SemanticsConfiguration.isLink] semantic to the
   /// given value.
-  bool? get link => _link;
-  bool? _link;
-  set link(bool? value) {
-    if (link == value)
-      return;
-    _link = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get link => _properties.link;
 
   /// If non-null, sets the [SemanticsConfiguration.isHeader] semantic to the
   /// given value.
-  bool? get header => _header;
-  bool? _header;
-  set header(bool? value) {
-    if (header == value)
-      return;
-    _header = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get header => _properties.header;
 
   /// If non-null, sets the [SemanticsConfiguration.isTextField] semantic to the
   /// given value.
-  bool? get textField => _textField;
-  bool? _textField;
-  set textField(bool? value) {
-    if (textField == value)
-      return;
-    _textField = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get textField => _properties.textField;
 
   /// If non-null, sets the [SemanticsConfiguration.isReadOnly] semantic to the
   /// given value.
-  bool? get readOnly => _readOnly;
-  bool? _readOnly;
-  set readOnly(bool? value) {
-    if (readOnly == value)
-      return;
-    _readOnly = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get readOnly => _properties.readOnly;
 
   /// If non-null, sets the [SemanticsConfiguration.isFocusable] semantic to the
   /// given value.
-  bool? get focusable => _focusable;
-  bool? _focusable;
-  set focusable(bool? value) {
-    if (focusable == value)
-      return;
-    _focusable = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get focusable => _properties.focusable;
 
   /// If non-null, sets the [SemanticsConfiguration.isFocused] semantic to the
   /// given value.
-  bool? get focused => _focused;
-  bool? _focused;
-  set focused(bool? value) {
-    if (focused == value)
-      return;
-    _focused = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get focused => _properties.focused;
 
   /// If non-null, sets the [SemanticsConfiguration.isInMutuallyExclusiveGroup]
   /// semantic to the given value.
-  bool? get inMutuallyExclusiveGroup => _inMutuallyExclusiveGroup;
-  bool? _inMutuallyExclusiveGroup;
-  set inMutuallyExclusiveGroup(bool? value) {
-    if (inMutuallyExclusiveGroup == value)
-      return;
-    _inMutuallyExclusiveGroup = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get inMutuallyExclusiveGroup => _properties.inMutuallyExclusiveGroup;
 
   /// If non-null, sets the [SemanticsConfiguration.isObscured] semantic to the
   /// given value.
-  bool? get obscured => _obscured;
-  bool? _obscured;
-  set obscured(bool? value) {
-    if (obscured == value)
-      return;
-    _obscured = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get obscured => _properties.obscured;
 
   /// If non-null, sets the [SemanticsNode.isMultiline] semantic to the given
   /// value.
-  bool? get multiline => _multiline;
-  bool? _multiline;
-  set multiline(bool? value) {
-    if (multiline == value)
-      return;
-    _multiline = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get multiline => _properties.multiline;
 
   /// If non-null, sets the [SemanticsConfiguration.scopesRoute] semantic to the
   /// give value.
-  bool? get scopesRoute => _scopesRoute;
-  bool? _scopesRoute;
-  set scopesRoute(bool? value) {
-    if (scopesRoute == value)
-      return;
-    _scopesRoute = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get scopesRoute => _properties.scopesRoute;
 
   /// If non-null, sets the [SemanticsConfiguration.namesRoute] semantic to the
   /// give value.
-  bool? get namesRoute => _namesRoute;
-  bool? _namesRoute;
-  set namesRoute(bool? value) {
-    if (_namesRoute == value)
-      return;
-    _namesRoute = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get namesRoute => _properties.namesRoute;
 
   /// If non-null, sets the [SemanticsConfiguration.isHidden] semantic to the
   /// given value.
-  bool? get hidden => _hidden;
-  bool? _hidden;
-  set hidden(bool? value) {
-    if (hidden == value)
-      return;
-    _hidden = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get hidden => _properties.hidden;
 
   /// If non-null, sets the [SemanticsConfiguration.isImage] semantic to the
   /// given value.
-  bool? get image => _image;
-  bool? _image;
-  set image(bool? value) {
-    if (_image == value)
-      return;
-    _image = value;
-  }
+  bool? get image => _properties.image;
 
   /// If non-null, sets the [SemanticsConfiguration.liveRegion] semantic to
   /// the given value.
-  bool? get liveRegion => _liveRegion;
-  bool? _liveRegion;
-  set liveRegion(bool? value) {
-    if (_liveRegion == value)
-      return;
-    _liveRegion = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get liveRegion => _properties.liveRegion;
 
   /// If non-null, sets the [SemanticsNode.maxValueLength] semantic to the given
   /// value.
-  int? get maxValueLength => _maxValueLength;
-  int? _maxValueLength;
-  set maxValueLength(int? value) {
-    if (_maxValueLength == value)
-      return;
-    _maxValueLength = value;
-    markNeedsSemanticsUpdate();
-  }
+  int? get maxValueLength => _properties.maxValueLength;
 
   /// If non-null, sets the [SemanticsNode.currentValueLength] semantic to the
   /// given value.
-  int? get currentValueLength => _currentValueLength;
-  int? _currentValueLength;
-  set currentValueLength(int? value) {
-    if (_currentValueLength == value)
-      return;
-    _currentValueLength = value;
-    markNeedsSemanticsUpdate();
-  }
+  int? get currentValueLength => _properties.currentValueLength;
 
   /// If non-null, sets the [SemanticsConfiguration.isToggled] semantic to the given
   /// value.
-  bool? get toggled => _toggled;
-  bool? _toggled;
-  set toggled(bool? value) {
-    if (_toggled == value)
-      return;
-    _toggled = value;
-    markNeedsSemanticsUpdate();
-  }
+  bool? get toggled => _properties.toggled;
 
   /// If non-null, sets the [SemanticsNode.attributedLabel] semantic to the given value.
   ///
@@ -4438,24 +4194,10 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// If non-null, sets the [SemanticsNode.tooltip] semantic to the given value.
   ///
   /// The reading direction is given by [textDirection].
-  String? get tooltip => _tooltip;
-  String? _tooltip;
-  set tooltip(String? value) {
-    if (_tooltip == value)
-      return;
-    _tooltip = value;
-    markNeedsSemanticsUpdate();
-  }
+  String? get tooltip => _properties.tooltip;
 
   /// If non-null, sets the [SemanticsConfiguration.hintOverrides] to the given value.
-  SemanticsHintOverrides? get hintOverrides => _hintOverrides;
-  SemanticsHintOverrides? _hintOverrides;
-  set hintOverrides(SemanticsHintOverrides? value) {
-    if (_hintOverrides == value)
-      return;
-    _hintOverrides = value;
-    markNeedsSemanticsUpdate();
-  }
+  SemanticsHintOverrides? get hintOverrides => _properties.hintOverrides;
 
   /// If non-null, sets the [SemanticsNode.textDirection] semantic to the given
   /// value.
@@ -4477,24 +4219,10 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// This defines how this node is sorted among the sibling semantics nodes
   /// to determine the order in which they are traversed by the accessibility
   /// services on the platform (e.g. VoiceOver on iOS and TalkBack on Android).
-  SemanticsSortKey? get sortKey => _sortKey;
-  SemanticsSortKey? _sortKey;
-  set sortKey(SemanticsSortKey? value) {
-    if (sortKey == value)
-      return;
-    _sortKey = value;
-    markNeedsSemanticsUpdate();
-  }
+  SemanticsSortKey? get sortKey => _properties.sortKey;
 
   /// Adds a semantics tag to the semantics subtree.
-  SemanticsTag? get tagForChildren => _tagForChildren;
-  SemanticsTag? _tagForChildren;
-  set tagForChildren(SemanticsTag? value) {
-    if (_tagForChildren == value)
-      return;
-    markNeedsSemanticsUpdate();
-    _tagForChildren = value;
-  }
+  SemanticsTag? get tagForChildren => _properties.tagForChildren;
 
   /// The handler for [SemanticsAction.tap].
   ///
@@ -4504,16 +4232,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// VoiceOver users on iOS and TalkBack users on Android can trigger this
   /// action by double-tapping the screen while an element is focused.
-  VoidCallback? get onTap => _onTap;
-  VoidCallback? _onTap;
-  set onTap(VoidCallback? handler) {
-    if (_onTap == handler)
-      return;
-    final bool hadValue = _onTap != null;
-    _onTap = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onTap => _properties.onTap;
 
   /// The handler for [SemanticsAction.dismiss].
   ///
@@ -4522,16 +4241,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// TalkBack users on Android can trigger this action in the local context
   /// menu, and VoiceOver users on iOS can trigger this action with a standard
   /// gesture or menu option.
-  VoidCallback? get onDismiss => _onDismiss;
-  VoidCallback? _onDismiss;
-  set onDismiss(VoidCallback? handler) {
-    if (_onDismiss == handler)
-      return;
-    final bool hadValue = _onDismiss != null;
-    _onDismiss = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onDismiss => _properties.onDismiss;
 
   /// The handler for [SemanticsAction.longPress].
   ///
@@ -4541,16 +4251,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// VoiceOver users on iOS and TalkBack users on Android can trigger this
   /// action by double-tapping the screen without lifting the finger after the
   /// second tap.
-  VoidCallback? get onLongPress => _onLongPress;
-  VoidCallback? _onLongPress;
-  set onLongPress(VoidCallback? handler) {
-    if (_onLongPress == handler)
-      return;
-    final bool hadValue = _onLongPress != null;
-    _onLongPress = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onLongPress => _properties.onLongPress;
 
   /// The handler for [SemanticsAction.scrollLeft].
   ///
@@ -4563,16 +4264,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// right and then left in one motion path. On Android, [onScrollUp] and
   /// [onScrollLeft] share the same gesture. Therefore, only on of them should
   /// be provided.
-  VoidCallback? get onScrollLeft => _onScrollLeft;
-  VoidCallback? _onScrollLeft;
-  set onScrollLeft(VoidCallback? handler) {
-    if (_onScrollLeft == handler)
-      return;
-    final bool hadValue = _onScrollLeft != null;
-    _onScrollLeft = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onScrollLeft => _properties.onScrollLeft;
 
   /// The handler for [SemanticsAction.scrollRight].
   ///
@@ -4585,16 +4277,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// left and then right in one motion path. On Android, [onScrollDown] and
   /// [onScrollRight] share the same gesture. Therefore, only on of them should
   /// be provided.
-  VoidCallback? get onScrollRight => _onScrollRight;
-  VoidCallback? _onScrollRight;
-  set onScrollRight(VoidCallback? handler) {
-    if (_onScrollRight == handler)
-      return;
-    final bool hadValue = _onScrollRight != null;
-    _onScrollRight = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onScrollRight => _properties.onScrollRight;
 
   /// The handler for [SemanticsAction.scrollUp].
   ///
@@ -4607,16 +4290,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// right and then left in one motion path. On Android, [onScrollUp] and
   /// [onScrollLeft] share the same gesture. Therefore, only on of them should
   /// be provided.
-  VoidCallback? get onScrollUp => _onScrollUp;
-  VoidCallback? _onScrollUp;
-  set onScrollUp(VoidCallback? handler) {
-    if (_onScrollUp == handler)
-      return;
-    final bool hadValue = _onScrollUp != null;
-    _onScrollUp = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onScrollUp => _properties.onScrollUp;
 
   /// The handler for [SemanticsAction.scrollDown].
   ///
@@ -4629,16 +4303,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// left and then right in one motion path. On Android, [onScrollDown] and
   /// [onScrollRight] share the same gesture. Therefore, only on of them should
   /// be provided.
-  VoidCallback? get onScrollDown => _onScrollDown;
-  VoidCallback? _onScrollDown;
-  set onScrollDown(VoidCallback? handler) {
-    if (_onScrollDown == handler)
-      return;
-    final bool hadValue = _onScrollDown != null;
-    _onScrollDown = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onScrollDown => _properties.onScrollDown;
 
   /// The handler for [SemanticsAction.increase].
   ///
@@ -4648,16 +4313,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// VoiceOver users on iOS can trigger this action by swiping up with one
   /// finger. TalkBack users on Android can trigger this action by pressing the
   /// volume up button.
-  VoidCallback? get onIncrease => _onIncrease;
-  VoidCallback? _onIncrease;
-  set onIncrease(VoidCallback? handler) {
-    if (_onIncrease == handler)
-      return;
-    final bool hadValue = _onIncrease != null;
-    _onIncrease = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onIncrease => _properties.onIncrease;
 
   /// The handler for [SemanticsAction.decrease].
   ///
@@ -4667,16 +4323,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// VoiceOver users on iOS can trigger this action by swiping down with one
   /// finger. TalkBack users on Android can trigger this action by pressing the
   /// volume down button.
-  VoidCallback? get onDecrease => _onDecrease;
-  VoidCallback? _onDecrease;
-  set onDecrease(VoidCallback? handler) {
-    if (_onDecrease == handler)
-      return;
-    final bool hadValue = _onDecrease != null;
-    _onDecrease = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onDecrease => _properties.onDecrease;
 
   /// The handler for [SemanticsAction.copy].
   ///
@@ -4684,16 +4331,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users on Android can trigger this action from the local context
   /// menu of a text field, for example.
-  VoidCallback? get onCopy => _onCopy;
-  VoidCallback? _onCopy;
-  set onCopy(VoidCallback? handler) {
-    if (_onCopy == handler)
-      return;
-    final bool hadValue = _onCopy != null;
-    _onCopy = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onCopy => _properties.onCopy;
 
   /// The handler for [SemanticsAction.cut].
   ///
@@ -4702,16 +4340,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users on Android can trigger this action from the local context
   /// menu of a text field, for example.
-  VoidCallback? get onCut => _onCut;
-  VoidCallback? _onCut;
-  set onCut(VoidCallback? handler) {
-    if (_onCut == handler)
-      return;
-    final bool hadValue = _onCut != null;
-    _onCut = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onCut => _properties.onCut;
 
   /// The handler for [SemanticsAction.paste].
   ///
@@ -4719,16 +4348,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users on Android can trigger this action from the local context
   /// menu of a text field, for example.
-  VoidCallback? get onPaste => _onPaste;
-  VoidCallback? _onPaste;
-  set onPaste(VoidCallback? handler) {
-    if (_onPaste == handler)
-      return;
-    final bool hadValue = _onPaste != null;
-    _onPaste = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onPaste => _properties.onPaste;
 
   /// The handler for [SemanticsAction.moveCursorForwardByCharacter].
   ///
@@ -4737,16 +4357,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users can trigger this by pressing the volume up key while the
   /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorForwardByCharacter => _onMoveCursorForwardByCharacter;
-  MoveCursorHandler? _onMoveCursorForwardByCharacter;
-  set onMoveCursorForwardByCharacter(MoveCursorHandler? handler) {
-    if (_onMoveCursorForwardByCharacter == handler)
-      return;
-    final bool hadValue = _onMoveCursorForwardByCharacter != null;
-    _onMoveCursorForwardByCharacter = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  MoveCursorHandler? get onMoveCursorForwardByCharacter => _properties.onMoveCursorForwardByCharacter;
 
   /// The handler for [SemanticsAction.moveCursorBackwardByCharacter].
   ///
@@ -4755,16 +4366,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users can trigger this by pressing the volume down key while the
   /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorBackwardByCharacter => _onMoveCursorBackwardByCharacter;
-  MoveCursorHandler? _onMoveCursorBackwardByCharacter;
-  set onMoveCursorBackwardByCharacter(MoveCursorHandler? handler) {
-    if (_onMoveCursorBackwardByCharacter == handler)
-      return;
-    final bool hadValue = _onMoveCursorBackwardByCharacter != null;
-    _onMoveCursorBackwardByCharacter = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  MoveCursorHandler? get onMoveCursorBackwardByCharacter => _properties.onMoveCursorBackwardByCharacter;
 
   /// The handler for [SemanticsAction.moveCursorForwardByWord].
   ///
@@ -4773,16 +4375,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users can trigger this by pressing the volume down key while the
   /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorForwardByWord => _onMoveCursorForwardByWord;
-  MoveCursorHandler? _onMoveCursorForwardByWord;
-  set onMoveCursorForwardByWord(MoveCursorHandler? handler) {
-    if (_onMoveCursorForwardByWord == handler)
-      return;
-    final bool hadValue = _onMoveCursorForwardByWord != null;
-    _onMoveCursorForwardByWord = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  MoveCursorHandler? get onMoveCursorForwardByWord => _properties.onMoveCursorForwardByWord;
 
   /// The handler for [SemanticsAction.moveCursorBackwardByWord].
   ///
@@ -4791,16 +4384,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users can trigger this by pressing the volume down key while the
   /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorBackwardByWord => _onMoveCursorBackwardByWord;
-  MoveCursorHandler? _onMoveCursorBackwardByWord;
-  set onMoveCursorBackwardByWord(MoveCursorHandler? handler) {
-    if (_onMoveCursorBackwardByWord == handler)
-      return;
-    final bool hadValue = _onMoveCursorBackwardByWord != null;
-    _onMoveCursorBackwardByWord = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  MoveCursorHandler? get onMoveCursorBackwardByWord => _properties.onMoveCursorBackwardByWord;
 
   /// The handler for [SemanticsAction.setSelection].
   ///
@@ -4809,16 +4393,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// TalkBack users can trigger this handler by selecting "Move cursor to
   /// beginning/end" or "Select all" from the local context menu.
-  SetSelectionHandler? get onSetSelection => _onSetSelection;
-  SetSelectionHandler? _onSetSelection;
-  set onSetSelection(SetSelectionHandler? handler) {
-    if (_onSetSelection == handler)
-      return;
-    final bool hadValue = _onSetSelection != null;
-    _onSetSelection = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  SetSelectionHandler? get onSetSelection => _properties.onSetSelection;
 
   /// The handler for [SemanticsAction.setText].
   ///
@@ -4827,16 +4402,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// Voice access users can trigger this handler by speaking "type <text>" to
   /// their Android devices.
-  SetTextHandler? get onSetText => _onSetText;
-  SetTextHandler? _onSetText;
-  set onSetText(SetTextHandler? handler) {
-    if (_onSetText == handler)
-      return;
-    final bool hadValue = _onSetText != null;
-    _onSetText = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  SetTextHandler? get onSetText => _properties.onSetText;
 
   /// The handler for [SemanticsAction.didGainAccessibilityFocus].
   ///
@@ -4855,16 +4421,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///  * [onDidLoseAccessibilityFocus], which is invoked when the accessibility
   ///    focus is removed from the node.
   ///  * [FocusNode], [FocusScope], [FocusManager], which manage the input focus.
-  VoidCallback? get onDidGainAccessibilityFocus => _onDidGainAccessibilityFocus;
-  VoidCallback? _onDidGainAccessibilityFocus;
-  set onDidGainAccessibilityFocus(VoidCallback? handler) {
-    if (_onDidGainAccessibilityFocus == handler)
-      return;
-    final bool hadValue = _onDidGainAccessibilityFocus != null;
-    _onDidGainAccessibilityFocus = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onDidGainAccessibilityFocus => _properties.onDidGainAccessibilityFocus;
 
   /// The handler for [SemanticsAction.didLoseAccessibilityFocus].
   ///
@@ -4883,16 +4440,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///  * [onDidGainAccessibilityFocus], which is invoked when the node gains
   ///    accessibility focus.
   ///  * [FocusNode], [FocusScope], [FocusManager], which manage the input focus.
-  VoidCallback? get onDidLoseAccessibilityFocus => _onDidLoseAccessibilityFocus;
-  VoidCallback? _onDidLoseAccessibilityFocus;
-  set onDidLoseAccessibilityFocus(VoidCallback? handler) {
-    if (_onDidLoseAccessibilityFocus == handler)
-      return;
-    final bool hadValue = _onDidLoseAccessibilityFocus != null;
-    _onDidLoseAccessibilityFocus = handler;
-    if ((handler != null) != hadValue)
-      markNeedsSemanticsUpdate();
-  }
+  VoidCallback? get onDidLoseAccessibilityFocus => _properties.onDidLoseAccessibilityFocus;
 
   /// The handlers and supported [CustomSemanticsAction]s for this node.
   ///
@@ -4903,14 +4451,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// See also:
   ///
   ///  * [CustomSemanticsAction], for an explanation of custom actions.
-  Map<CustomSemanticsAction, VoidCallback>? get customSemanticsActions => _customSemanticsActions;
-  Map<CustomSemanticsAction, VoidCallback>? _customSemanticsActions;
-  set customSemanticsActions(Map<CustomSemanticsAction, VoidCallback>? value) {
-    if (_customSemanticsActions == value)
-      return;
-    _customSemanticsActions = value;
-    markNeedsSemanticsUpdate();
-  }
+  Map<CustomSemanticsAction, VoidCallback>? get customSemanticsActions => _properties.customSemanticsActions;
 
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
@@ -5045,7 +4586,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (onDidLoseAccessibilityFocus != null)
       config.onDidLoseAccessibilityFocus = _performDidLoseAccessibilityFocus;
     if (customSemanticsActions != null)
-      config.customSemanticsActions = _customSemanticsActions!;
+      config.customSemanticsActions = customSemanticsActions!;
   }
 
   void _performTap() {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4039,98 +4039,6 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     markNeedsSemanticsUpdate();
   }
 
-  /// If non-null, sets the [SemanticsFlag.hasCheckedState] semantic to true and
-  /// the [SemanticsConfiguration.isChecked] semantic to the given value.
-  bool? get checked => _properties.checked;
-
-  /// If non-null, sets the [SemanticsFlag.hasEnabledState] semantic to true and
-  /// the [SemanticsConfiguration.isEnabled] semantic to the given value.
-  bool? get enabled => _properties.enabled;
-
-  /// If non-null, sets the [SemanticsConfiguration.isSelected] semantic to the
-  /// given value.
-  bool? get selected => _properties.selected;
-
-  /// If non-null, sets the [SemanticsConfiguration.isButton] semantic to the
-  /// given value.
-  bool? get button => _properties.button;
-
-  /// If non-null, sets the [SemanticsConfiguration.isSlider] semantic to the
-  /// given value.
-  bool? get slider => _properties.slider;
-
-  /// If non-null, sets the [SemanticsConfiguration.isKeyboardKey] semantic to the
-  /// given value.
-  bool? get keyboardKey => _properties.keyboardKey;
-
-  /// If non-null, sets the [SemanticsConfiguration.isLink] semantic to the
-  /// given value.
-  bool? get link => _properties.link;
-
-  /// If non-null, sets the [SemanticsConfiguration.isHeader] semantic to the
-  /// given value.
-  bool? get header => _properties.header;
-
-  /// If non-null, sets the [SemanticsConfiguration.isTextField] semantic to the
-  /// given value.
-  bool? get textField => _properties.textField;
-
-  /// If non-null, sets the [SemanticsConfiguration.isReadOnly] semantic to the
-  /// given value.
-  bool? get readOnly => _properties.readOnly;
-
-  /// If non-null, sets the [SemanticsConfiguration.isFocusable] semantic to the
-  /// given value.
-  bool? get focusable => _properties.focusable;
-
-  /// If non-null, sets the [SemanticsConfiguration.isFocused] semantic to the
-  /// given value.
-  bool? get focused => _properties.focused;
-
-  /// If non-null, sets the [SemanticsConfiguration.isInMutuallyExclusiveGroup]
-  /// semantic to the given value.
-  bool? get inMutuallyExclusiveGroup => _properties.inMutuallyExclusiveGroup;
-
-  /// If non-null, sets the [SemanticsConfiguration.isObscured] semantic to the
-  /// given value.
-  bool? get obscured => _properties.obscured;
-
-  /// If non-null, sets the [SemanticsNode.isMultiline] semantic to the given
-  /// value.
-  bool? get multiline => _properties.multiline;
-
-  /// If non-null, sets the [SemanticsConfiguration.scopesRoute] semantic to the
-  /// give value.
-  bool? get scopesRoute => _properties.scopesRoute;
-
-  /// If non-null, sets the [SemanticsConfiguration.namesRoute] semantic to the
-  /// give value.
-  bool? get namesRoute => _properties.namesRoute;
-
-  /// If non-null, sets the [SemanticsConfiguration.isHidden] semantic to the
-  /// given value.
-  bool? get hidden => _properties.hidden;
-
-  /// If non-null, sets the [SemanticsConfiguration.isImage] semantic to the
-  /// given value.
-  bool? get image => _properties.image;
-
-  /// If non-null, sets the [SemanticsConfiguration.liveRegion] semantic to
-  /// the given value.
-  bool? get liveRegion => _properties.liveRegion;
-
-  /// If non-null, sets the [SemanticsNode.maxValueLength] semantic to the given
-  /// value.
-  int? get maxValueLength => _properties.maxValueLength;
-
-  /// If non-null, sets the [SemanticsNode.currentValueLength] semantic to the
-  /// given value.
-  int? get currentValueLength => _properties.currentValueLength;
-
-  /// If non-null, sets the [SemanticsConfiguration.isToggled] semantic to the given
-  /// value.
-  bool? get toggled => _properties.toggled;
-
   /// If non-null, sets the [SemanticsNode.attributedLabel] semantic to the given value.
   ///
   /// The reading direction is given by [textDirection].
@@ -4191,14 +4099,6 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     markNeedsSemanticsUpdate();
   }
 
-  /// If non-null, sets the [SemanticsNode.tooltip] semantic to the given value.
-  ///
-  /// The reading direction is given by [textDirection].
-  String? get tooltip => _properties.tooltip;
-
-  /// If non-null, sets the [SemanticsConfiguration.hintOverrides] to the given value.
-  SemanticsHintOverrides? get hintOverrides => _properties.hintOverrides;
-
   /// If non-null, sets the [SemanticsNode.textDirection] semantic to the given
   /// value.
   ///
@@ -4214,245 +4114,6 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     markNeedsSemanticsUpdate();
   }
 
-  /// Sets the [SemanticsNode.sortKey] to the given value.
-  ///
-  /// This defines how this node is sorted among the sibling semantics nodes
-  /// to determine the order in which they are traversed by the accessibility
-  /// services on the platform (e.g. VoiceOver on iOS and TalkBack on Android).
-  SemanticsSortKey? get sortKey => _properties.sortKey;
-
-  /// Adds a semantics tag to the semantics subtree.
-  SemanticsTag? get tagForChildren => _properties.tagForChildren;
-
-  /// The handler for [SemanticsAction.tap].
-  ///
-  /// This is the semantic equivalent of a user briefly tapping the screen with
-  /// the finger without moving it. For example, a button should implement this
-  /// action.
-  ///
-  /// VoiceOver users on iOS and TalkBack users on Android can trigger this
-  /// action by double-tapping the screen while an element is focused.
-  VoidCallback? get onTap => _properties.onTap;
-
-  /// The handler for [SemanticsAction.dismiss].
-  ///
-  /// This is a request to dismiss the currently focused node.
-  ///
-  /// TalkBack users on Android can trigger this action in the local context
-  /// menu, and VoiceOver users on iOS can trigger this action with a standard
-  /// gesture or menu option.
-  VoidCallback? get onDismiss => _properties.onDismiss;
-
-  /// The handler for [SemanticsAction.longPress].
-  ///
-  /// This is the semantic equivalent of a user pressing and holding the screen
-  /// with the finger for a few seconds without moving it.
-  ///
-  /// VoiceOver users on iOS and TalkBack users on Android can trigger this
-  /// action by double-tapping the screen without lifting the finger after the
-  /// second tap.
-  VoidCallback? get onLongPress => _properties.onLongPress;
-
-  /// The handler for [SemanticsAction.scrollLeft].
-  ///
-  /// This is the semantic equivalent of a user moving their finger across the
-  /// screen from right to left. It should be recognized by controls that are
-  /// horizontally scrollable.
-  ///
-  /// VoiceOver users on iOS can trigger this action by swiping left with three
-  /// fingers. TalkBack users on Android can trigger this action by swiping
-  /// right and then left in one motion path. On Android, [onScrollUp] and
-  /// [onScrollLeft] share the same gesture. Therefore, only on of them should
-  /// be provided.
-  VoidCallback? get onScrollLeft => _properties.onScrollLeft;
-
-  /// The handler for [SemanticsAction.scrollRight].
-  ///
-  /// This is the semantic equivalent of a user moving their finger across the
-  /// screen from left to right. It should be recognized by controls that are
-  /// horizontally scrollable.
-  ///
-  /// VoiceOver users on iOS can trigger this action by swiping right with three
-  /// fingers. TalkBack users on Android can trigger this action by swiping
-  /// left and then right in one motion path. On Android, [onScrollDown] and
-  /// [onScrollRight] share the same gesture. Therefore, only on of them should
-  /// be provided.
-  VoidCallback? get onScrollRight => _properties.onScrollRight;
-
-  /// The handler for [SemanticsAction.scrollUp].
-  ///
-  /// This is the semantic equivalent of a user moving their finger across the
-  /// screen from bottom to top. It should be recognized by controls that are
-  /// vertically scrollable.
-  ///
-  /// VoiceOver users on iOS can trigger this action by swiping up with three
-  /// fingers. TalkBack users on Android can trigger this action by swiping
-  /// right and then left in one motion path. On Android, [onScrollUp] and
-  /// [onScrollLeft] share the same gesture. Therefore, only on of them should
-  /// be provided.
-  VoidCallback? get onScrollUp => _properties.onScrollUp;
-
-  /// The handler for [SemanticsAction.scrollDown].
-  ///
-  /// This is the semantic equivalent of a user moving their finger across the
-  /// screen from top to bottom. It should be recognized by controls that are
-  /// vertically scrollable.
-  ///
-  /// VoiceOver users on iOS can trigger this action by swiping down with three
-  /// fingers. TalkBack users on Android can trigger this action by swiping
-  /// left and then right in one motion path. On Android, [onScrollDown] and
-  /// [onScrollRight] share the same gesture. Therefore, only on of them should
-  /// be provided.
-  VoidCallback? get onScrollDown => _properties.onScrollDown;
-
-  /// The handler for [SemanticsAction.increase].
-  ///
-  /// This is a request to increase the value represented by the widget. For
-  /// example, this action might be recognized by a slider control.
-  ///
-  /// VoiceOver users on iOS can trigger this action by swiping up with one
-  /// finger. TalkBack users on Android can trigger this action by pressing the
-  /// volume up button.
-  VoidCallback? get onIncrease => _properties.onIncrease;
-
-  /// The handler for [SemanticsAction.decrease].
-  ///
-  /// This is a request to decrease the value represented by the widget. For
-  /// example, this action might be recognized by a slider control.
-  ///
-  /// VoiceOver users on iOS can trigger this action by swiping down with one
-  /// finger. TalkBack users on Android can trigger this action by pressing the
-  /// volume down button.
-  VoidCallback? get onDecrease => _properties.onDecrease;
-
-  /// The handler for [SemanticsAction.copy].
-  ///
-  /// This is a request to copy the current selection to the clipboard.
-  ///
-  /// TalkBack users on Android can trigger this action from the local context
-  /// menu of a text field, for example.
-  VoidCallback? get onCopy => _properties.onCopy;
-
-  /// The handler for [SemanticsAction.cut].
-  ///
-  /// This is a request to cut the current selection and place it in the
-  /// clipboard.
-  ///
-  /// TalkBack users on Android can trigger this action from the local context
-  /// menu of a text field, for example.
-  VoidCallback? get onCut => _properties.onCut;
-
-  /// The handler for [SemanticsAction.paste].
-  ///
-  /// This is a request to paste the current content of the clipboard.
-  ///
-  /// TalkBack users on Android can trigger this action from the local context
-  /// menu of a text field, for example.
-  VoidCallback? get onPaste => _properties.onPaste;
-
-  /// The handler for [SemanticsAction.moveCursorForwardByCharacter].
-  ///
-  /// This handler is invoked when the user wants to move the cursor in a
-  /// text field forward by one character.
-  ///
-  /// TalkBack users can trigger this by pressing the volume up key while the
-  /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorForwardByCharacter => _properties.onMoveCursorForwardByCharacter;
-
-  /// The handler for [SemanticsAction.moveCursorBackwardByCharacter].
-  ///
-  /// This handler is invoked when the user wants to move the cursor in a
-  /// text field backward by one character.
-  ///
-  /// TalkBack users can trigger this by pressing the volume down key while the
-  /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorBackwardByCharacter => _properties.onMoveCursorBackwardByCharacter;
-
-  /// The handler for [SemanticsAction.moveCursorForwardByWord].
-  ///
-  /// This handler is invoked when the user wants to move the cursor in a
-  /// text field backward by one character.
-  ///
-  /// TalkBack users can trigger this by pressing the volume down key while the
-  /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorForwardByWord => _properties.onMoveCursorForwardByWord;
-
-  /// The handler for [SemanticsAction.moveCursorBackwardByWord].
-  ///
-  /// This handler is invoked when the user wants to move the cursor in a
-  /// text field backward by one character.
-  ///
-  /// TalkBack users can trigger this by pressing the volume down key while the
-  /// input focus is in a text field.
-  MoveCursorHandler? get onMoveCursorBackwardByWord => _properties.onMoveCursorBackwardByWord;
-
-  /// The handler for [SemanticsAction.setSelection].
-  ///
-  /// This handler is invoked when the user either wants to change the currently
-  /// selected text in a text field or change the position of the cursor.
-  ///
-  /// TalkBack users can trigger this handler by selecting "Move cursor to
-  /// beginning/end" or "Select all" from the local context menu.
-  SetSelectionHandler? get onSetSelection => _properties.onSetSelection;
-
-  /// The handler for [SemanticsAction.setText].
-  ///
-  /// This handler is invoked when the user wants to replace the current text in
-  /// the text field with a new text.
-  ///
-  /// Voice access users can trigger this handler by speaking "type <text>" to
-  /// their Android devices.
-  SetTextHandler? get onSetText => _properties.onSetText;
-
-  /// The handler for [SemanticsAction.didGainAccessibilityFocus].
-  ///
-  /// This handler is invoked when the node annotated with this handler gains
-  /// the accessibility focus. The accessibility focus is the
-  /// green (on Android with TalkBack) or black (on iOS with VoiceOver)
-  /// rectangle shown on screen to indicate what element an accessibility
-  /// user is currently interacting with.
-  ///
-  /// The accessibility focus is different from the input focus. The input focus
-  /// is usually held by the element that currently responds to keyboard inputs.
-  /// Accessibility focus and input focus can be held by two different nodes!
-  ///
-  /// See also:
-  ///
-  ///  * [onDidLoseAccessibilityFocus], which is invoked when the accessibility
-  ///    focus is removed from the node.
-  ///  * [FocusNode], [FocusScope], [FocusManager], which manage the input focus.
-  VoidCallback? get onDidGainAccessibilityFocus => _properties.onDidGainAccessibilityFocus;
-
-  /// The handler for [SemanticsAction.didLoseAccessibilityFocus].
-  ///
-  /// This handler is invoked when the node annotated with this handler
-  /// loses the accessibility focus. The accessibility focus is
-  /// the green (on Android with TalkBack) or black (on iOS with VoiceOver)
-  /// rectangle shown on screen to indicate what element an accessibility
-  /// user is currently interacting with.
-  ///
-  /// The accessibility focus is different from the input focus. The input focus
-  /// is usually held by the element that currently responds to keyboard inputs.
-  /// Accessibility focus and input focus can be held by two different nodes!
-  ///
-  /// See also:
-  ///
-  ///  * [onDidGainAccessibilityFocus], which is invoked when the node gains
-  ///    accessibility focus.
-  ///  * [FocusNode], [FocusScope], [FocusManager], which manage the input focus.
-  VoidCallback? get onDidLoseAccessibilityFocus => _properties.onDidLoseAccessibilityFocus;
-
-  /// The handlers and supported [CustomSemanticsAction]s for this node.
-  ///
-  /// These handlers are called whenever the user performs the associated
-  /// custom accessibility action from a special platform menu. Providing any
-  /// custom actions here also adds [SemanticsAction.customAction] to the node.
-  ///
-  /// See also:
-  ///
-  ///  * [CustomSemanticsAction], for an explanation of custom actions.
-  Map<CustomSemanticsAction, VoidCallback>? get customSemanticsActions => _properties.customSemanticsActions;
-
   @override
   void visitChildrenForSemantics(RenderObjectVisitor visitor) {
     if (excludeSemantics)
@@ -4466,50 +4127,50 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     config.isSemanticBoundary = container;
     config.explicitChildNodes = explicitChildNodes;
     assert(
-      ((scopesRoute ?? false) && explicitChildNodes) || !(scopesRoute ?? false),
+      ((_properties.scopesRoute ?? false) && explicitChildNodes) || !(_properties.scopesRoute ?? false),
       'explicitChildNodes must be set to true if scopes route is true',
     );
     assert(
-      !((toggled ?? false) && (checked ?? false)),
+      !((_properties.toggled ?? false) && (_properties.checked ?? false)),
       'A semantics node cannot be toggled and checked at the same time',
     );
 
-    if (enabled != null)
-      config.isEnabled = enabled;
-    if (checked != null)
-      config.isChecked = checked;
-    if (toggled != null)
-      config.isToggled = toggled;
-    if (selected != null)
-      config.isSelected = selected!;
-    if (button != null)
-      config.isButton = button!;
-    if (link != null)
-      config.isLink = link!;
-    if (slider != null)
-      config.isSlider = slider!;
-    if (keyboardKey != null)
-      config.isKeyboardKey = keyboardKey!;
-    if (header != null)
-      config.isHeader = header!;
-    if (textField != null)
-      config.isTextField = textField!;
-    if (readOnly != null)
-      config.isReadOnly = readOnly!;
-    if (focusable != null)
-      config.isFocusable = focusable!;
-    if (focused != null)
-      config.isFocused = focused!;
-    if (inMutuallyExclusiveGroup != null)
-      config.isInMutuallyExclusiveGroup = inMutuallyExclusiveGroup!;
-    if (obscured != null)
-      config.isObscured = obscured!;
-    if (multiline != null)
-      config.isMultiline = multiline!;
-    if (hidden != null)
-      config.isHidden = hidden!;
-    if (image != null)
-      config.isImage = image!;
+    if (_properties.enabled != null)
+      config.isEnabled = _properties.enabled;
+    if (_properties.checked != null)
+      config.isChecked = _properties.checked;
+    if (_properties.toggled != null)
+      config.isToggled = _properties.toggled;
+    if (_properties.selected != null)
+      config.isSelected = _properties.selected!;
+    if (_properties.button != null)
+      config.isButton = _properties.button!;
+    if (_properties.link != null)
+      config.isLink = _properties.link!;
+    if (_properties.slider != null)
+      config.isSlider = _properties.slider!;
+    if (_properties.keyboardKey != null)
+      config.isKeyboardKey = _properties.keyboardKey!;
+    if (_properties.header != null)
+      config.isHeader = _properties.header!;
+    if (_properties.textField != null)
+      config.isTextField = _properties.textField!;
+    if (_properties.readOnly != null)
+      config.isReadOnly = _properties.readOnly!;
+    if (_properties.focusable != null)
+      config.isFocusable = _properties.focusable!;
+    if (_properties.focused != null)
+      config.isFocused = _properties.focused!;
+    if (_properties.inMutuallyExclusiveGroup != null)
+      config.isInMutuallyExclusiveGroup = _properties.inMutuallyExclusiveGroup!;
+    if (_properties.obscured != null)
+      config.isObscured = _properties.obscured!;
+    if (_properties.multiline != null)
+      config.isMultiline = _properties.multiline!;
+    if (_properties.hidden != null)
+      config.isHidden = _properties.hidden!;
+    if (_properties.image != null)
+      config.isImage = _properties.image!;
     if (attributedLabel != null)
       config.attributedLabel = attributedLabel!;
     if (attributedValue != null)
@@ -4520,153 +4181,153 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.attributedDecreasedValue = attributedDecreasedValue!;
     if (attributedHint != null)
       config.attributedHint = attributedHint!;
-    if (tooltip != null)
-      config.tooltip = tooltip!;
-    if (hintOverrides != null && hintOverrides!.isNotEmpty)
-      config.hintOverrides = hintOverrides;
-    if (scopesRoute != null)
-      config.scopesRoute = scopesRoute!;
-    if (namesRoute != null)
-      config.namesRoute = namesRoute!;
-    if (liveRegion != null)
-      config.liveRegion = liveRegion!;
-    if (maxValueLength != null) {
-      config.maxValueLength = maxValueLength;
+    if (_properties.tooltip != null)
+      config.tooltip = _properties.tooltip!;
+    if (_properties.hintOverrides != null && _properties.hintOverrides!.isNotEmpty)
+      config.hintOverrides = _properties.hintOverrides;
+    if (_properties.scopesRoute != null)
+      config.scopesRoute = _properties.scopesRoute!;
+    if (_properties.namesRoute != null)
+      config.namesRoute = _properties.namesRoute!;
+    if (_properties.liveRegion != null)
+      config.liveRegion = _properties.liveRegion!;
+    if (_properties.maxValueLength != null) {
+      config.maxValueLength = _properties.maxValueLength;
     }
-    if (currentValueLength != null) {
-      config.currentValueLength = currentValueLength;
+    if (_properties.currentValueLength != null) {
+      config.currentValueLength = _properties.currentValueLength;
     }
     if (textDirection != null)
       config.textDirection = textDirection;
-    if (sortKey != null)
-      config.sortKey = sortKey;
-    if (tagForChildren != null)
-      config.addTagForChildren(tagForChildren!);
+    if (_properties.sortKey != null)
+      config.sortKey = _properties.sortKey;
+    if (_properties.tagForChildren != null)
+      config.addTagForChildren(_properties.tagForChildren!);
     // Registering _perform* as action handlers instead of the user provided
     // ones to ensure that changing a user provided handler from a non-null to
     // another non-null value doesn't require a semantics update.
-    if (onTap != null)
+    if (_properties.onTap != null)
       config.onTap = _performTap;
-    if (onLongPress != null)
+    if (_properties.onLongPress != null)
       config.onLongPress = _performLongPress;
-    if (onDismiss != null)
+    if (_properties.onDismiss != null)
       config.onDismiss = _performDismiss;
-    if (onScrollLeft != null)
+    if (_properties.onScrollLeft != null)
       config.onScrollLeft = _performScrollLeft;
-    if (onScrollRight != null)
+    if (_properties.onScrollRight != null)
       config.onScrollRight = _performScrollRight;
-    if (onScrollUp != null)
+    if (_properties.onScrollUp != null)
       config.onScrollUp = _performScrollUp;
-    if (onScrollDown != null)
+    if (_properties.onScrollDown != null)
       config.onScrollDown = _performScrollDown;
-    if (onIncrease != null)
+    if (_properties.onIncrease != null)
       config.onIncrease = _performIncrease;
-    if (onDecrease != null)
+    if (_properties.onDecrease != null)
       config.onDecrease = _performDecrease;
-    if (onCopy != null)
+    if (_properties.onCopy != null)
       config.onCopy = _performCopy;
-    if (onCut != null)
+    if (_properties.onCut != null)
       config.onCut = _performCut;
-    if (onPaste != null)
+    if (_properties.onPaste != null)
       config.onPaste = _performPaste;
-    if (onMoveCursorForwardByCharacter != null)
+    if (_properties.onMoveCursorForwardByCharacter != null)
       config.onMoveCursorForwardByCharacter = _performMoveCursorForwardByCharacter;
-    if (onMoveCursorBackwardByCharacter != null)
+    if (_properties.onMoveCursorBackwardByCharacter != null)
       config.onMoveCursorBackwardByCharacter = _performMoveCursorBackwardByCharacter;
-    if (onMoveCursorForwardByWord != null)
+    if (_properties.onMoveCursorForwardByWord != null)
       config.onMoveCursorForwardByWord = _performMoveCursorForwardByWord;
-    if (onMoveCursorBackwardByWord != null)
+    if (_properties.onMoveCursorBackwardByWord != null)
       config.onMoveCursorBackwardByWord = _performMoveCursorBackwardByWord;
-    if (onSetSelection != null)
+    if (_properties.onSetSelection != null)
       config.onSetSelection = _performSetSelection;
-    if (onSetText != null)
+    if (_properties.onSetText != null)
       config.onSetText = _performSetText;
-    if (onDidGainAccessibilityFocus != null)
+    if (_properties.onDidGainAccessibilityFocus != null)
       config.onDidGainAccessibilityFocus = _performDidGainAccessibilityFocus;
-    if (onDidLoseAccessibilityFocus != null)
+    if (_properties.onDidLoseAccessibilityFocus != null)
       config.onDidLoseAccessibilityFocus = _performDidLoseAccessibilityFocus;
-    if (customSemanticsActions != null)
-      config.customSemanticsActions = customSemanticsActions!;
+    if (_properties.customSemanticsActions != null)
+      config.customSemanticsActions = _properties.customSemanticsActions!;
   }
 
   void _performTap() {
-    onTap?.call();
+    _properties.onTap?.call();
   }
 
   void _performLongPress() {
-    onLongPress?.call();
+    _properties.onLongPress?.call();
   }
 
   void _performDismiss() {
-    onDismiss?.call();
+    _properties.onDismiss?.call();
   }
 
   void _performScrollLeft() {
-    onScrollLeft?.call();
+    _properties.onScrollLeft?.call();
   }
 
   void _performScrollRight() {
-    onScrollRight?.call();
+    _properties.onScrollRight?.call();
   }
 
   void _performScrollUp() {
-    onScrollUp?.call();
+    _properties.onScrollUp?.call();
   }
 
   void _performScrollDown() {
-    onScrollDown?.call();
+    _properties.onScrollDown?.call();
   }
 
   void _performIncrease() {
-    onIncrease?.call();
+    _properties.onIncrease?.call();
   }
 
   void _performDecrease() {
-    onDecrease?.call();
+    _properties.onDecrease?.call();
   }
 
   void _performCopy() {
-    onCopy?.call();
+    _properties.onCopy?.call();
   }
 
   void _performCut() {
-    onCut?.call();
+    _properties.onCut?.call();
   }
 
   void _performPaste() {
-    onPaste?.call();
+    _properties.onPaste?.call();
   }
 
   void _performMoveCursorForwardByCharacter(bool extendSelection) {
-    onMoveCursorForwardByCharacter?.call(extendSelection);
+    _properties.onMoveCursorForwardByCharacter?.call(extendSelection);
   }
 
   void _performMoveCursorBackwardByCharacter(bool extendSelection) {
-    onMoveCursorBackwardByCharacter?.call(extendSelection);
+    _properties.onMoveCursorBackwardByCharacter?.call(extendSelection);
   }
 
   void _performMoveCursorForwardByWord(bool extendSelection) {
-    onMoveCursorForwardByWord?.call(extendSelection);
+    _properties.onMoveCursorForwardByWord?.call(extendSelection);
   }
 
   void _performMoveCursorBackwardByWord(bool extendSelection) {
-    onMoveCursorBackwardByWord?.call(extendSelection);
+    _properties.onMoveCursorBackwardByWord?.call(extendSelection);
   }
 
   void _performSetSelection(TextSelection selection) {
-    onSetSelection?.call(selection);
+    _properties.onSetSelection?.call(selection);
   }
 
   void _performSetText(String text) {
-    onSetText?.call(text);
+    _properties.onSetText?.call(text);
   }
 
   void _performDidGainAccessibilityFocus() {
-    onDidGainAccessibilityFocus?.call();
+    _properties.onDidGainAccessibilityFocus?.call();
   }
 
   void _performDidLoseAccessibilityFocus() {
-    onDidLoseAccessibilityFocus?.call();
+    _properties.onDidLoseAccessibilityFocus?.call();
   }
 }
 

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3947,7 +3947,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// The [container] argument must not be null.
   ///
-  /// If the [properties.attributedLabel] is not null, the [textDirection] must also not be null.
+  /// If the [SemanticsProperties.attributedLabel] is not null, the [textDirection] must also not be null.
   RenderSemanticsAnnotations({
     RenderBox? child,
     required SemanticsProperties properties,
@@ -4081,10 +4081,11 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// If non-null, sets the [SemanticsNode.textDirection] semantic to the given
   /// value.
   ///
-  /// This must not be null if [properties.attributedLabel],
-  /// [properties.attributedHint], [properties.attributedValue],
-  /// [properties.attributedIncreasedValue], or
-  /// [properties.attributedDecreasedValue] are not null.
+  /// This must not be null if [SemanticsProperties.attributedLabel],
+  /// [SemanticsProperties.attributedHint],
+  /// [SemanticsProperties.attributedValue],
+  /// [SemanticsProperties.attributedIncreasedValue], or
+  /// [SemanticsProperties.attributedDecreasedValue] are not null.
   TextDirection? get textDirection => _textDirection;
   TextDirection? _textDirection;
   set textDirection(TextDirection? value) {

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3954,24 +3954,16 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     bool container = false,
     bool explicitChildNodes = false,
     bool excludeSemantics = false,
-    AttributedString? attributedLabel,
-    AttributedString? attributedValue,
-    AttributedString? attributedIncreasedValue,
-    AttributedString? attributedDecreasedValue,
-    AttributedString? attributedHint,
     TextDirection? textDirection,
-  }) : assert(container != null),
-       _container = container,
-       _explicitChildNodes = explicitChildNodes,
-       _excludeSemantics = excludeSemantics,
-       _attributedLabel = attributedLabel,
-       _attributedValue = attributedValue,
-       _attributedIncreasedValue = attributedIncreasedValue,
-       _attributedDecreasedValue = attributedDecreasedValue,
-       _attributedHint = attributedHint,
-       _textDirection = textDirection,
-       _properties = properties,
-       super(child);
+  })  : assert(container != null),
+        _container = container,
+        _explicitChildNodes = explicitChildNodes,
+        _excludeSemantics = excludeSemantics,
+        _textDirection = textDirection,
+        _properties = properties,
+        super(child) {
+    _updateAttributedFields(_properties);
+  }
 
   SemanticsProperties _properties;
   /// Sets the [SemanticsProperties] en masse.
@@ -3980,6 +3972,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     if (_properties == value)
       return;
     _properties = value;
+    _updateAttributedFields(_properties);
     markNeedsSemanticsUpdate();
   }
 
@@ -4039,65 +4032,50 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     markNeedsSemanticsUpdate();
   }
 
-  /// If non-null, sets the [SemanticsNode.attributedLabel] semantic to the given value.
-  ///
-  /// The reading direction is given by [textDirection].
-  AttributedString? get attributedLabel => _attributedLabel;
+  void _updateAttributedFields(SemanticsProperties properties) {
+    _attributedLabel = _effectiveAttributedLabel(properties);
+    _attributedValue = _effectiveAttributedValue(properties);
+    _attributedIncreasedValue = _effectiveAttributedIncreasedValue(properties);
+    _attributedDecreasedValue = _effectiveAttributedDecreasedValue(properties);
+    _attributedHint = _effectiveAttributedHint(properties);
+  }
+
+  AttributedString? _effectiveAttributedLabel(SemanticsProperties properties) {
+    return properties.attributedLabel ??
+        (properties.label == null ? null : AttributedString(properties.label!));
+  }
+
+  AttributedString? _effectiveAttributedValue(SemanticsProperties properties) {
+    return properties.attributedValue ??
+        (properties.value == null ? null : AttributedString(properties.value!));
+  }
+
+  AttributedString? _effectiveAttributedIncreasedValue(
+      SemanticsProperties properties) {
+    return properties.attributedIncreasedValue ??
+        (properties.increasedValue == null
+            ? null
+            : AttributedString(properties.increasedValue!));
+  }
+
+  AttributedString? _effectiveAttributedDecreasedValue(
+      SemanticsProperties properties) {
+    return properties.attributedDecreasedValue ??
+        (properties.decreasedValue == null
+            ? null
+            : AttributedString(properties.decreasedValue!));
+  }
+
+  AttributedString? _effectiveAttributedHint(SemanticsProperties properties) {
+    return properties.attributedHint ??
+        (properties.hint == null ? null : AttributedString(properties.hint!));
+  }
+
   AttributedString? _attributedLabel;
-  set attributedLabel(AttributedString? value) {
-    if (_attributedLabel == value)
-      return;
-    _attributedLabel = value;
-    markNeedsSemanticsUpdate();
-  }
-
-  /// If non-null, sets the [SemanticsNode.attributedValue] semantic to the given value.
-  ///
-  /// The reading direction is given by [textDirection].
-  AttributedString? get attributedValue => _attributedValue;
   AttributedString? _attributedValue;
-  set attributedValue(AttributedString? value) {
-    if (_attributedValue == value)
-      return;
-    _attributedValue = value;
-    markNeedsSemanticsUpdate();
-  }
-
-  /// If non-null, sets the [SemanticsNode.attributedIncreasedValue] semantic to the given value.
-  ///
-  /// The reading direction is given by [textDirection].
-  AttributedString? get attributedIncreasedValue => _attributedIncreasedValue;
   AttributedString? _attributedIncreasedValue;
-  set attributedIncreasedValue(AttributedString? value) {
-    if (_attributedIncreasedValue == value)
-      return;
-    _attributedIncreasedValue = value;
-    markNeedsSemanticsUpdate();
-  }
-
-  /// If non-null, sets the [SemanticsNode.attributedDecreasedValue] semantic to the given value.
-  ///
-  /// The reading direction is given by [textDirection].
-  AttributedString? get attributedDecreasedValue => _attributedDecreasedValue;
   AttributedString? _attributedDecreasedValue;
-  set attributedDecreasedValue(AttributedString? value) {
-    if (_attributedDecreasedValue == value)
-      return;
-    _attributedDecreasedValue = value;
-    markNeedsSemanticsUpdate();
-  }
-
-  /// If non-null, sets the [SemanticsNode.attributedHint] semantic to the given value.
-  ///
-  /// The reading direction is given by [textDirection].
-  AttributedString? get attributedHint => _attributedHint;
   AttributedString? _attributedHint;
-  set attributedHint(AttributedString? value) {
-    if (_attributedHint == value)
-      return;
-    _attributedHint = value;
-    markNeedsSemanticsUpdate();
-  }
 
   /// If non-null, sets the [SemanticsNode.textDirection] semantic to the given
   /// value.
@@ -4171,16 +4149,16 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
       config.isHidden = _properties.hidden!;
     if (_properties.image != null)
       config.isImage = _properties.image!;
-    if (attributedLabel != null)
-      config.attributedLabel = attributedLabel!;
-    if (attributedValue != null)
-      config.attributedValue = attributedValue!;
-    if (attributedIncreasedValue != null)
-      config.attributedIncreasedValue = attributedIncreasedValue!;
-    if (attributedDecreasedValue != null)
-      config.attributedDecreasedValue = attributedDecreasedValue!;
-    if (attributedHint != null)
-      config.attributedHint = attributedHint!;
+    if (_attributedLabel != null)
+      config.attributedLabel = _attributedLabel!;
+    if (_attributedValue != null)
+      config.attributedValue = _attributedValue!;
+    if (_attributedIncreasedValue != null)
+      config.attributedIncreasedValue = _attributedIncreasedValue!;
+    if (_attributedDecreasedValue != null)
+      config.attributedDecreasedValue = _attributedDecreasedValue!;
+    if (_attributedHint != null)
+      config.attributedHint = _attributedHint!;
     if (_properties.tooltip != null)
       config.tooltip = _properties.tooltip!;
     if (_properties.hintOverrides != null && _properties.hintOverrides!.isNotEmpty)

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3947,7 +3947,7 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   ///
   /// The [container] argument must not be null.
   ///
-  /// If the [attributedLabel] is not null, the [textDirection] must also not be null.
+  /// If the [properties.attributedLabel] is not null, the [textDirection] must also not be null.
   RenderSemanticsAnnotations({
     RenderBox? child,
     required SemanticsProperties properties,
@@ -3965,9 +3965,10 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     _updateAttributedFields(_properties);
   }
 
+  /// All of the [SemanticsProperties] for this [RenderSemanticsAnnotations].
+  SemanticsProperties get properties => _properties;
   SemanticsProperties _properties;
-  /// Sets the [SemanticsProperties] en masse.
-  void updateProperties(SemanticsProperties value) {
+  set properties(SemanticsProperties value) {
     assert(value != null);
     if (_properties == value)
       return;
@@ -4032,43 +4033,43 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
     markNeedsSemanticsUpdate();
   }
 
-  void _updateAttributedFields(SemanticsProperties properties) {
-    _attributedLabel = _effectiveAttributedLabel(properties);
-    _attributedValue = _effectiveAttributedValue(properties);
-    _attributedIncreasedValue = _effectiveAttributedIncreasedValue(properties);
-    _attributedDecreasedValue = _effectiveAttributedDecreasedValue(properties);
-    _attributedHint = _effectiveAttributedHint(properties);
+  void _updateAttributedFields(SemanticsProperties value) {
+    _attributedLabel = _effectiveAttributedLabel(value);
+    _attributedValue = _effectiveAttributedValue(value);
+    _attributedIncreasedValue = _effectiveAttributedIncreasedValue(value);
+    _attributedDecreasedValue = _effectiveAttributedDecreasedValue(value);
+    _attributedHint = _effectiveAttributedHint(value);
   }
 
-  AttributedString? _effectiveAttributedLabel(SemanticsProperties properties) {
-    return properties.attributedLabel ??
-        (properties.label == null ? null : AttributedString(properties.label!));
+  AttributedString? _effectiveAttributedLabel(SemanticsProperties value) {
+    return value.attributedLabel ??
+        (value.label == null ? null : AttributedString(value.label!));
   }
 
-  AttributedString? _effectiveAttributedValue(SemanticsProperties properties) {
-    return properties.attributedValue ??
-        (properties.value == null ? null : AttributedString(properties.value!));
+  AttributedString? _effectiveAttributedValue(SemanticsProperties value) {
+    return value.attributedValue ??
+        (value.value == null ? null : AttributedString(value.value!));
   }
 
   AttributedString? _effectiveAttributedIncreasedValue(
-      SemanticsProperties properties) {
-    return properties.attributedIncreasedValue ??
-        (properties.increasedValue == null
+      SemanticsProperties value) {
+    return value.attributedIncreasedValue ??
+        (value.increasedValue == null
             ? null
-            : AttributedString(properties.increasedValue!));
+            : AttributedString(value.increasedValue!));
   }
 
   AttributedString? _effectiveAttributedDecreasedValue(
-      SemanticsProperties properties) {
+      SemanticsProperties value) {
     return properties.attributedDecreasedValue ??
-        (properties.decreasedValue == null
+        (value.decreasedValue == null
             ? null
-            : AttributedString(properties.decreasedValue!));
+            : AttributedString(value.decreasedValue!));
   }
 
-  AttributedString? _effectiveAttributedHint(SemanticsProperties properties) {
-    return properties.attributedHint ??
-        (properties.hint == null ? null : AttributedString(properties.hint!));
+  AttributedString? _effectiveAttributedHint(SemanticsProperties value) {
+    return value.attributedHint ??
+        (value.hint == null ? null : AttributedString(value.hint!));
   }
 
   AttributedString? _attributedLabel;
@@ -4080,9 +4081,10 @@ class RenderSemanticsAnnotations extends RenderProxyBox {
   /// If non-null, sets the [SemanticsNode.textDirection] semantic to the given
   /// value.
   ///
-  /// This must not be null if [attributedLabel], [attributedHint],
-  /// [attributedValue], [attributedIncreasedValue], or
-  /// [attributedDecreasedValue] are not null.
+  /// This must not be null if [properties.attributedLabel],
+  /// [properties.attributedHint], [properties.attributedValue],
+  /// [properties.attributedIncreasedValue], or
+  /// [properties.attributedDecreasedValue] are not null.
   TextDirection? get textDirection => _textDirection;
   TextDirection? _textDirection;
   set textDirection(TextDirection? value) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6903,31 +6903,6 @@ class Semantics extends SingleChildRenderObjectWidget {
   /// an [ExcludeSemantics] widget and then another [Semantics] widget.
   final bool excludeSemantics;
 
-  AttributedString? get _effectiveAttributedLabel {
-    return properties.attributedLabel ??
-          (properties.label == null ? null : AttributedString(properties.label!));
-  }
-
-  AttributedString? get _effectiveAttributedValue {
-    return properties.attributedValue ??
-        (properties.value == null ? null : AttributedString(properties.value!));
-  }
-
-  AttributedString? get _effectiveAttributedIncreasedValue {
-    return properties.attributedIncreasedValue ??
-        (properties.increasedValue == null ? null : AttributedString(properties.increasedValue!));
-  }
-
-  AttributedString? get _effectiveAttributedDecreasedValue {
-    return properties.attributedDecreasedValue ??
-        (properties.decreasedValue == null ? null : AttributedString(properties.decreasedValue!));
-  }
-
-  AttributedString? get _effectiveAttributedHint {
-    return properties.attributedHint ??
-        (properties.hint == null ? null : AttributedString(properties.hint!));
-  }
-
   @override
   RenderSemanticsAnnotations createRenderObject(BuildContext context) {
     return RenderSemanticsAnnotations(
@@ -6935,11 +6910,6 @@ class Semantics extends SingleChildRenderObjectWidget {
       explicitChildNodes: explicitChildNodes,
       excludeSemantics: excludeSemantics,
       properties: properties,
-      attributedLabel: _effectiveAttributedLabel,
-      attributedValue: _effectiveAttributedValue,
-      attributedIncreasedValue: _effectiveAttributedIncreasedValue,
-      attributedDecreasedValue: _effectiveAttributedDecreasedValue,
-      attributedHint: _effectiveAttributedHint,
       textDirection: _getTextDirection(context),
     );
   }
@@ -6967,11 +6937,6 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..explicitChildNodes = explicitChildNodes
       ..excludeSemantics = excludeSemantics
       ..updateProperties(properties)
-      ..attributedLabel = _effectiveAttributedLabel
-      ..attributedValue = _effectiveAttributedValue
-      ..attributedIncreasedValue = _effectiveAttributedIncreasedValue
-      ..attributedDecreasedValue = _effectiveAttributedDecreasedValue
-      ..attributedHint = _effectiveAttributedHint
       ..textDirection = _getTextDirection(context);
   }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6936,7 +6936,7 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..container = container
       ..explicitChildNodes = explicitChildNodes
       ..excludeSemantics = excludeSemantics
-      ..updateProperties(properties)
+      ..properties = properties
       ..textDirection = _getTextDirection(context);
   }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -6934,60 +6934,13 @@ class Semantics extends SingleChildRenderObjectWidget {
       container: container,
       explicitChildNodes: explicitChildNodes,
       excludeSemantics: excludeSemantics,
-      enabled: properties.enabled,
-      checked: properties.checked,
-      toggled: properties.toggled,
-      selected: properties.selected,
-      button: properties.button,
-      slider: properties.slider,
-      keyboardKey: properties.keyboardKey,
-      link: properties.link,
-      header: properties.header,
-      textField: properties.textField,
-      readOnly: properties.readOnly,
-      focusable: properties.focusable,
-      focused: properties.focused,
-      liveRegion: properties.liveRegion,
-      maxValueLength: properties.maxValueLength,
-      currentValueLength: properties.currentValueLength,
-      inMutuallyExclusiveGroup: properties.inMutuallyExclusiveGroup,
-      obscured: properties.obscured,
-      multiline: properties.multiline,
-      scopesRoute: properties.scopesRoute,
-      namesRoute: properties.namesRoute,
-      hidden: properties.hidden,
-      image: properties.image,
+      properties: properties,
       attributedLabel: _effectiveAttributedLabel,
       attributedValue: _effectiveAttributedValue,
       attributedIncreasedValue: _effectiveAttributedIncreasedValue,
       attributedDecreasedValue: _effectiveAttributedDecreasedValue,
       attributedHint: _effectiveAttributedHint,
-      tooltip: properties.tooltip,
-      hintOverrides: properties.hintOverrides,
       textDirection: _getTextDirection(context),
-      sortKey: properties.sortKey,
-      tagForChildren: properties.tagForChildren,
-      onTap: properties.onTap,
-      onLongPress: properties.onLongPress,
-      onScrollLeft: properties.onScrollLeft,
-      onScrollRight: properties.onScrollRight,
-      onScrollUp: properties.onScrollUp,
-      onScrollDown: properties.onScrollDown,
-      onIncrease: properties.onIncrease,
-      onDecrease: properties.onDecrease,
-      onCopy: properties.onCopy,
-      onDismiss: properties.onDismiss,
-      onCut: properties.onCut,
-      onPaste: properties.onPaste,
-      onMoveCursorForwardByCharacter: properties.onMoveCursorForwardByCharacter,
-      onMoveCursorBackwardByCharacter: properties.onMoveCursorBackwardByCharacter,
-      onMoveCursorForwardByWord: properties.onMoveCursorForwardByWord,
-      onMoveCursorBackwardByWord: properties.onMoveCursorBackwardByWord,
-      onSetSelection: properties.onSetSelection,
-      onSetText: properties.onSetText,
-      onDidGainAccessibilityFocus: properties.onDidGainAccessibilityFocus,
-      onDidLoseAccessibilityFocus: properties.onDidLoseAccessibilityFocus,
-      customSemanticsActions: properties.customSemanticsActions,
     );
   }
 
@@ -7013,60 +6966,13 @@ class Semantics extends SingleChildRenderObjectWidget {
       ..container = container
       ..explicitChildNodes = explicitChildNodes
       ..excludeSemantics = excludeSemantics
-      ..scopesRoute = properties.scopesRoute
-      ..enabled = properties.enabled
-      ..checked = properties.checked
-      ..toggled = properties.toggled
-      ..selected = properties.selected
-      ..button = properties.button
-      ..slider = properties.slider
-      ..keyboardKey = properties.keyboardKey
-      ..link = properties.link
-      ..header = properties.header
-      ..textField = properties.textField
-      ..readOnly = properties.readOnly
-      ..focusable = properties.focusable
-      ..focused = properties.focused
-      ..inMutuallyExclusiveGroup = properties.inMutuallyExclusiveGroup
-      ..obscured = properties.obscured
-      ..multiline = properties.multiline
-      ..hidden = properties.hidden
-      ..image = properties.image
-      ..liveRegion = properties.liveRegion
-      ..maxValueLength = properties.maxValueLength
-      ..currentValueLength = properties.currentValueLength
+      ..updateProperties(properties)
       ..attributedLabel = _effectiveAttributedLabel
       ..attributedValue = _effectiveAttributedValue
       ..attributedIncreasedValue = _effectiveAttributedIncreasedValue
       ..attributedDecreasedValue = _effectiveAttributedDecreasedValue
       ..attributedHint = _effectiveAttributedHint
-      ..tooltip = properties.tooltip
-      ..hintOverrides = properties.hintOverrides
-      ..namesRoute = properties.namesRoute
-      ..textDirection = _getTextDirection(context)
-      ..sortKey = properties.sortKey
-      ..tagForChildren = properties.tagForChildren
-      ..onTap = properties.onTap
-      ..onLongPress = properties.onLongPress
-      ..onScrollLeft = properties.onScrollLeft
-      ..onScrollRight = properties.onScrollRight
-      ..onScrollUp = properties.onScrollUp
-      ..onScrollDown = properties.onScrollDown
-      ..onIncrease = properties.onIncrease
-      ..onDismiss = properties.onDismiss
-      ..onDecrease = properties.onDecrease
-      ..onCopy = properties.onCopy
-      ..onCut = properties.onCut
-      ..onPaste = properties.onPaste
-      ..onMoveCursorForwardByCharacter = properties.onMoveCursorForwardByCharacter
-      ..onMoveCursorBackwardByCharacter = properties.onMoveCursorForwardByCharacter
-      ..onMoveCursorForwardByWord = properties.onMoveCursorForwardByWord
-      ..onMoveCursorBackwardByWord = properties.onMoveCursorBackwardByWord
-      ..onSetSelection = properties.onSetSelection
-      ..onSetText = properties.onSetText
-      ..onDidGainAccessibilityFocus = properties.onDidGainAccessibilityFocus
-      ..onDidLoseAccessibilityFocus = properties.onDidLoseAccessibilityFocus
-      ..customSemanticsActions = properties.customSemanticsActions;
+      ..textDirection = _getTextDirection(context);
   }
 
   @override

--- a/packages/flutter/test/rendering/reattach_test.dart
+++ b/packages/flutter/test/rendering/reattach_test.dart
@@ -29,9 +29,8 @@ class TestTree {
                   child: child = RenderConstrainedBox(
                     additionalConstraints: const BoxConstraints.tightFor(height: 20.0, width: 20.0),
                     child: RenderSemanticsAnnotations(
-                      attributedLabel: AttributedString('Hello there foo'),
                       textDirection: TextDirection.ltr,
-                      properties: const SemanticsProperties(),
+                      properties: const SemanticsProperties(label: 'Hello there foo'),
                     ),
                   ),
                 ),

--- a/packages/flutter/test/rendering/reattach_test.dart
+++ b/packages/flutter/test/rendering/reattach_test.dart
@@ -28,7 +28,10 @@ class TestTree {
                 child: RenderPositionedBox(
                   child: child = RenderConstrainedBox(
                     additionalConstraints: const BoxConstraints.tightFor(height: 20.0, width: 20.0),
-                    child: RenderSemanticsAnnotations(attributedLabel: AttributedString('Hello there foo'), textDirection: TextDirection.ltr),
+                    child: RenderSemanticsAnnotations(
+                        attributedLabel: AttributedString('Hello there foo'),
+                        textDirection: TextDirection.ltr,
+                        properties: const SemanticsProperties()),
                   ),
                 ),
               ),

--- a/packages/flutter/test/rendering/reattach_test.dart
+++ b/packages/flutter/test/rendering/reattach_test.dart
@@ -29,9 +29,10 @@ class TestTree {
                   child: child = RenderConstrainedBox(
                     additionalConstraints: const BoxConstraints.tightFor(height: 20.0, width: 20.0),
                     child: RenderSemanticsAnnotations(
-                        attributedLabel: AttributedString('Hello there foo'),
-                        textDirection: TextDirection.ltr,
-                        properties: const SemanticsProperties()),
+                      attributedLabel: AttributedString('Hello there foo'),
+                      textDirection: TextDirection.ltr,
+                      properties: const SemanticsProperties(),
+                    ),
                   ),
                 ),
               ),

--- a/packages/flutter/test/rendering/simple_semantics_test.dart
+++ b/packages/flutter/test/rendering/simple_semantics_test.dart
@@ -61,6 +61,8 @@ void main() {
 }
 
 class TestRender extends RenderSemanticsAnnotations {
+  TestRender() : super(properties: const SemanticsProperties());
+
   int describeSemanticsConfigurationCallCount = 0;
 
   @override

--- a/packages/flutter/test/rendering/simple_semantics_test.dart
+++ b/packages/flutter/test/rendering/simple_semantics_test.dart
@@ -13,7 +13,7 @@ void main() {
 
   test('only send semantics update if semantics have changed', () {
     final TestRender testRender = TestRender()
-      ..updateProperties(const SemanticsProperties(label: 'hello'))
+      ..properties = const SemanticsProperties(label: 'hello')
       ..textDirection = TextDirection.ltr;
 
     final RenderConstrainedBox tree = RenderConstrainedBox(
@@ -48,7 +48,7 @@ void main() {
     semanticsUpdateCount = 0;
 
     // Change semantics and request update.
-    testRender.updateProperties(const SemanticsProperties(label: 'bye'));
+    testRender.properties = const SemanticsProperties(label: 'bye');
     testRender.markNeedsSemanticsUpdate();
     pumpFrame(phase: EnginePhase.flushSemantics);
 

--- a/packages/flutter/test/rendering/simple_semantics_test.dart
+++ b/packages/flutter/test/rendering/simple_semantics_test.dart
@@ -13,7 +13,7 @@ void main() {
 
   test('only send semantics update if semantics have changed', () {
     final TestRender testRender = TestRender()
-      ..attributedLabel = AttributedString('hello')
+      ..updateProperties(const SemanticsProperties(label: 'hello'))
       ..textDirection = TextDirection.ltr;
 
     final RenderConstrainedBox tree = RenderConstrainedBox(
@@ -48,7 +48,7 @@ void main() {
     semanticsUpdateCount = 0;
 
     // Change semantics and request update.
-    testRender.attributedLabel = AttributedString('bye');
+    testRender.updateProperties(const SemanticsProperties(label: 'bye'));
     testRender.markNeedsSemanticsUpdate();
     pumpFrame(phase: EnginePhase.flushSemantics);
 


### PR DESCRIPTION
This starts sharing memory between `Semantics` and `RenderSemanticsAnnotations`.  I noticed a significant decrease in build times in `customer: money` when I ripped out all the `Semantics` while testing something else.  I theorized that the performance increase was related to the large memory cost of `Semantics` where almost all of its 62 instance variables were getting copied to the RenderObject.  In production apps Semantics widgets become ubiquitous and account for a large percentage of the allocations.

I did a bit of testing to see what effect his might have.  I ran a before and after with `customer: money` where I just clicked on the first button to load the main screen and saw 108MB of allocations go to 85MB, where 210 `RenderSemanticsAnnotations` where allocated.  That would mean a savings of ~112 KB per `RenderSemanticsAnnotations`.  That doesn't sound plausible, I'm not sure what Dart is doing under the covers though.  I would have expected something more like (48 removed ivars * ~16 bytes * 210 instances) = 161 KB total.

I did run CPU benchmark tests with `build_bench.dart` and didn't notice a difference, but it also isn't that representative.  I did try my `customer: money` benchmark and didn't notice a difference either but that benchmark isn't quite good either.

I don't think it's worth spending more time trying to track down the exact extent of the changes.  The cleanup of this optimization is value enough.  Writing a microbenchmark just for this may not be worth it.  Hopefully I can get the `customer:money` one showing what we want eventually.

**before:**
<img width="900" alt="Screen Shot 2022-05-20 at 3 44 38 PM" src="https://user-images.githubusercontent.com/30870216/169622802-4b5de5d2-0a0d-43a1-bd9e-75f26f28c256.png">


**after:**
<img width="900" alt="Screen Shot 2022-05-20 at 3 43 35 PM" src="https://user-images.githubusercontent.com/30870216/169622818-0bf522f6-7593-42b2-8e1a-0f03e21ffd66.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
