### PR TITLE
Ignore replacement characters from vswhere.exe output

### DIFF
--- a/packages/flutter_tools/lib/src/convert.dart
+++ b/packages/flutter_tools/lib/src/convert.dart
@@ -26,10 +26,14 @@ const Encoding utf8ForTesting = cnv.utf8;
 /// that aren't UTF-8 and we're not quite sure how this is happening.
 /// This tells people to report a bug when they see this.
 class Utf8Codec extends Encoding {
-  const Utf8Codec();
+  const Utf8Codec({this.reportErrors = true});
+
+  final bool reportErrors;
 
   @override
-  Converter<List<int>, String> get decoder => const Utf8Decoder();
+  Converter<List<int>, String> get decoder => reportErrors
+    ? const Utf8Decoder()
+    : const Utf8Decoder(reportErrors: false);
 
   @override
   Converter<String, List<int>> get encoder => cnv.utf8.encoder;

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -47,7 +47,8 @@ class VisualStudio {
 
   /// The name of the Visual Studio install.
   ///
-  /// For instance: "Visual Studio Community 2019".
+  /// For instance: "Visual Studio Community 2019". This should only be used for
+  /// display purposes.
   String? get displayName => _bestVisualStudioDetails?.displayName;
 
   /// The user-friendly version number of the Visual Studio install.
@@ -427,11 +428,11 @@ class VswhereDetails {
 
       // Below are strings that must be well-formed without replacement characters.
       installationPath: _validateString(details['installationPath'] as String?),
-      displayName: _validateString(details['displayName'] as String?),
       fullVersion: _validateString(details['installationVersion'] as String?),
 
       // Below are strings that are used only for display purposes and are allowed to
       // contain replacement characters.
+      displayName: details['displayName'] as String?,
       catalogDisplayVersion: catalog == null ? null : catalog['productDisplayVersion'] as String?,
     );
   }

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -282,16 +282,15 @@ class VisualStudio {
         '-utf8',
         '-latest',
       ];
-      // Ideally this would use Flutter's utf8 encoding which errors on malformed UTF-8.
-      // However, vswhere.exe is known to output unicode replacement characters.
-      // These replacement characters will be ignored unless they affect used properties.
+      // Ignore replacement characters as vswhere.exe is known to output them.
       // See: https://github.com/flutter/flutter/issues/102451
+      const Encoding encoding = Utf8Codec(reportErrors: false);
       final RunResult whereResult = _processUtils.runSync(<String>[
         _vswherePath,
         ...defaultArguments,
         ...?additionalArguments,
         ...requirementArguments,
-      ], encoding: const Utf8Codec(reportErrors: false));
+      ], encoding: encoding);
       if (whereResult.exitCode == 0) {
         final List<Map<String, dynamic>> installations =
             (json.decode(whereResult.stdout) as List<dynamic>).cast<Map<String, dynamic>>();

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -922,7 +922,7 @@ void main() {
           throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
     });
 
-    testWithoutContext("Throws ToolExit on bad UTF-8 in catalog's productDisplayVersion", () {
+    testWithoutContext("Ignores bad UTF-8 in catalog's productDisplayVersion", () {
       final Map<String, dynamic> catalog = Map<String, dynamic>.of(_defaultResponse['catalog'] as Map<String, dynamic>)
         ..['productDisplayVersion'] = '\u{FFFD}';
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
@@ -930,8 +930,12 @@ void main() {
 
       setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
 
-      expect(() => visualStudio.isInstalled,
-          throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, true);
+      expect(visualStudio.hasNecessaryComponents, true);
+      expect(visualStudio.cmakePath, equals(cmakePath));
+      expect(visualStudio.cmakeGenerator, equals('Visual Studio 16 2019'));
+      expect(visualStudio.displayVersion, '\u{FFFD}');
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -862,42 +862,17 @@ void main() {
 
       expect(visualStudio.getWindows10SDKVersion(), null);
     });
+  });
 
-    testWithoutContext('Reports unicode replacement char in used properties', () {
-      const String badUtf8 = 'Bad UTF8 \u{FFFD}';
-      final List<void Function(Map<String, dynamic>)> propertyOverrides = <void Function(Map<String, dynamic>)> [
-        (Map<String, dynamic> response) => response['installationPath'] = badUtf8,
-        (Map<String, dynamic> response) => response['displayName'] = badUtf8,
-        (Map<String, dynamic> response) => response['installationVersion'] = badUtf8,
-        (Map<String, dynamic> response) {
-          final Map<String, dynamic> catalog = Map<String, dynamic>.of(response['catalog'] as Map<String, dynamic>);
-          response['catalog'] = catalog;
-          catalog['productDisplayVersion'] = badUtf8;
-        }
-      ];
-
-      for (final void Function(Map<String, dynamic>) propertyOverride in propertyOverrides) {
-        final VisualStudioFixture fixture = setUpVisualStudio();
-        final VisualStudio visualStudio = fixture.visualStudio;
-        final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse);
-        propertyOverride(response);
-
-        setMockCompatibleVisualStudioInstallation(
-          response,
-          fixture.fileSystem,
-          fixture.processManager,
-        );
-
-        expect(() => visualStudio.isInstalled,
-             throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
-      }
-    });
-
+  // The output of vswhere.exe is known to contain bad UTF8.
+  // See: https://github.com/flutter/flutter/issues/102451
+  group('Correctly handles bad UTF-8 from vswhere.exe output', () {
     testWithoutContext('Ignores unicode replacement char in unused properties', () {
-      final VisualStudioFixture fixture = setUpVisualStudio();
-      final VisualStudio visualStudio = fixture.visualStudio;
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['unused'] = 'Bad UTF8 \u{FFFD}';
+
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
 
       setMockCompatibleVisualStudioInstallation(
         response,
@@ -910,6 +885,60 @@ void main() {
       expect(visualStudio.hasNecessaryComponents, true);
       expect(visualStudio.cmakePath, equals(cmakePath));
       expect(visualStudio.cmakeGenerator, equals('Visual Studio 16 2019'));
+    });
+
+    testWithoutContext('Throws ToolExit on bad UTF-8 in installationPath', () {
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
+        ..['installationPath'] = '\u{FFFD}';
+
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
+
+      expect(() => visualStudio.isInstalled,
+          throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
+    });
+
+    testWithoutContext('Throws ToolExit on bad UTF-8 in displayName', () {
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
+        ..['displayName'] = '\u{FFFD}';
+
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
+
+      expect(() => visualStudio.isInstalled,
+          throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
+    });
+
+    testWithoutContext('Throws ToolExit on bad UTF-8 in installationVersion', () {
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
+        ..['installationVersion'] = '\u{FFFD}';
+
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
+
+      expect(() => visualStudio.isInstalled,
+          throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
+    });
+
+    testWithoutContext("Throws ToolExit on bad UTF-8 in catalog's productDisplayVersion", () {
+      final Map<String, dynamic> catalog = Map<String, dynamic>.of(_defaultResponse['catalog'] as Map<String, dynamic>)
+        ..['productDisplayVersion'] = '\u{FFFD}';
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
+        ..['catalog'] = catalog;
+
+      final VisualStudioFixture fixture = setUpVisualStudio();
+      final VisualStudio visualStudio = fixture.visualStudio;
+
+      setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
+
+      expect(() => visualStudio.isInstalled,
+          throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -902,16 +902,6 @@ void main() {
           throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
     });
 
-    testWithoutContext('Throws ToolExit on bad UTF-8 in displayName', () {
-      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
-        ..['displayName'] = '\u{FFFD}';
-
-      setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
-
-      expect(() => visualStudio.isInstalled,
-          throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
-    });
-
     testWithoutContext('Throws ToolExit on bad UTF-8 in installationVersion', () {
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['installationVersion'] = '\u{FFFD}';
@@ -920,6 +910,20 @@ void main() {
 
       expect(() => visualStudio.isInstalled,
           throwsToolExit(message: 'Bad UTF-8 encoding (U+FFFD; REPLACEMENT CHARACTER) found in string'));
+    });
+
+    testWithoutContext('Ignores bad UTF-8 in displayName', () {
+      final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
+        ..['displayName'] = '\u{FFFD}';
+
+      setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
+
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, true);
+      expect(visualStudio.hasNecessaryComponents, true);
+      expect(visualStudio.cmakePath, equals(cmakePath));
+      expect(visualStudio.cmakeGenerator, equals('Visual Studio 16 2019'));
+      expect(visualStudio.displayName, equals('\u{FFFD}'));
     });
 
     testWithoutContext("Ignores bad UTF-8 in catalog's productDisplayVersion", () {
@@ -935,7 +939,7 @@ void main() {
       expect(visualStudio.hasNecessaryComponents, true);
       expect(visualStudio.cmakePath, equals(cmakePath));
       expect(visualStudio.cmakeGenerator, equals('Visual Studio 16 2019'));
-      expect(visualStudio.displayVersion, '\u{FFFD}');
+      expect(visualStudio.displayVersion, equals('\u{FFFD}'));
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -867,12 +867,17 @@ void main() {
   // The output of vswhere.exe is known to contain bad UTF8.
   // See: https://github.com/flutter/flutter/issues/102451
   group('Correctly handles bad UTF-8 from vswhere.exe output', () {
+    late VisualStudioFixture fixture;
+    late VisualStudio visualStudio;
+
+    setUp(() {
+      fixture = setUpVisualStudio();
+      visualStudio = fixture.visualStudio;
+    });
+
     testWithoutContext('Ignores unicode replacement char in unused properties', () {
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['unused'] = 'Bad UTF8 \u{FFFD}';
-
-      final VisualStudioFixture fixture = setUpVisualStudio();
-      final VisualStudio visualStudio = fixture.visualStudio;
 
       setMockCompatibleVisualStudioInstallation(
         response,
@@ -891,9 +896,6 @@ void main() {
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['installationPath'] = '\u{FFFD}';
 
-      final VisualStudioFixture fixture = setUpVisualStudio();
-      final VisualStudio visualStudio = fixture.visualStudio;
-
       setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
 
       expect(() => visualStudio.isInstalled,
@@ -904,9 +906,6 @@ void main() {
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['displayName'] = '\u{FFFD}';
 
-      final VisualStudioFixture fixture = setUpVisualStudio();
-      final VisualStudio visualStudio = fixture.visualStudio;
-
       setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
 
       expect(() => visualStudio.isInstalled,
@@ -916,9 +915,6 @@ void main() {
     testWithoutContext('Throws ToolExit on bad UTF-8 in installationVersion', () {
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['installationVersion'] = '\u{FFFD}';
-
-      final VisualStudioFixture fixture = setUpVisualStudio();
-      final VisualStudio visualStudio = fixture.visualStudio;
 
       setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
 
@@ -931,9 +927,6 @@ void main() {
         ..['productDisplayVersion'] = '\u{FFFD}';
       final Map<String, dynamic> response = Map<String, dynamic>.of(_defaultResponse)
         ..['catalog'] = catalog;
-
-      final VisualStudioFixture fixture = setUpVisualStudio();
-      final VisualStudio visualStudio = fixture.visualStudio;
 
       setMockCompatibleVisualStudioInstallation(response, fixture.fileSystem, fixture.processManager);
 


### PR DESCRIPTION
Flutter uses `vswhere.exe` to find Visual Studio installations and determine if they satisfy Flutter's requirements. However, `vswhere.exe`'s JSON output is known to contain bad UTF-8. This change ignores bad UTF-8 as long as they affect JSON properties that are unused by Flutter.

Fixes: https://github.com/flutter/flutter/issues/102451

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
