### PR TITLE
Make TextInputClient a mixin

### DIFF
--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1086,11 +1086,7 @@ mixin TextSelectionDelegate {
 ///  * [EditableText], a [TextInputClient] implementation.
 ///  * [DeltaTextInputClient], a [TextInputClient] extension that receives
 ///    granular information from the platform's text input.
-abstract class TextInputClient {
-  /// Abstract const constructor. This constructor enables subclasses to provide
-  /// const constructors so that they can be used in const expressions.
-  const TextInputClient();
-
+mixin TextInputClient {
   /// The current state of the [TextEditingValue] held by this client.
   TextEditingValue? get currentTextEditingValue;
 
@@ -1225,7 +1221,7 @@ class SelectionRect {
 ///  * [TextInputConfiguration], to opt-in to receive [TextEditingDelta]'s from
 ///    the platforms [TextInput] you must set [TextInputConfiguration.enableDeltaModel]
 ///    to true.
-abstract class DeltaTextInputClient extends TextInputClient {
+mixin DeltaTextInputClient implements TextInputClient {
   /// Requests that this client update its editing state by applying the deltas
   /// received from the engine.
   ///

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1676,7 +1676,7 @@ class EditableText extends StatefulWidget {
 }
 
 /// State for a [EditableText].
-class EditableTextState extends State<EditableText> with AutomaticKeepAliveClientMixin<EditableText>, WidgetsBindingObserver, TickerProviderStateMixin<EditableText>, TextSelectionDelegate implements TextInputClient, AutofillClient {
+class EditableTextState extends State<EditableText> with AutomaticKeepAliveClientMixin<EditableText>, WidgetsBindingObserver, TickerProviderStateMixin<EditableText>, TextSelectionDelegate, TextInputClient implements AutofillClient {
   Timer? _cursorTimer;
   AnimationController get _cursorBlinkOpacityController {
     return _backingCursorBlinkOpacityController ??= AnimationController(

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -701,7 +701,7 @@ void main() {
   });
 }
 
-class FakeTextInputClient implements TextInputClient {
+class FakeTextInputClient with TextInputClient {
   FakeTextInputClient(this.currentTextEditingValue);
 
   String latestMethodCall = '';


### PR DESCRIPTION
This PR makes TextInputClient a mixin instead of an abstract class.  It does the same for DeltaTextInputClient.

The reason for this is to discourage users from using `implements` on these abstract classes, which causes a breaking change when changes are made to the abstract class.  This is a common occurrence on these classes related to platform APIs.

### Migration guide
Users of TextInputClient and DeltaTextInputClient should mix them into their own classes via the `with` keyword, similar to how this PR changes EditableTextState to use TextInputClient via `with`.

:heavy_check_mark: 
```dart
class MyEditorState extends State<MyEditor> with TextInputClient {
  // ...
}
```

If users were using TextInputClient or DeltaTextInputClient via the `implements` keyword, they will not be broken by this change, but the above approach with `with` is still recommended.  The advantage of `with` is that `implements` requires implementations of all methods, even if the mixin has one, so future additions to the mixin will be a breaking change.

:warning: 
```dart
class MyEditorState extends State<MyEditor> implements TextInputClient {
  // ...
}
```

If any user were using TextInputClient or DeltaTextInputClient via the `extends` keyword, they would be broken, and should use the `with` keyword instead as above.

:x: 
```dart
class MyEditor extends TextInputClient {
  // ...
}
```

### See also

  * Similar PR making the scribble feature a mixin: https://github.com/flutter/flutter/pull/104128
  * Design doc [Minimizing Breaking Changes from Platform APIs](https://docs.google.com/document/d/1OxDsf_eot7TlsRn57z-1_dGbvuqnMxO7QEGIAmOCZtA/edit#)