### PR TITLE
Do not assert callbacks contains key if disposed

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -214,7 +214,7 @@ abstract class Layer extends AbstractNode with DiagnosticableTreeMixin {
       }());
     };
     return () {
-      assert(_callbacks.containsKey(callbackId));
+      assert(debugDisposed || _callbacks.containsKey(callbackId));
       _callbacks.remove(callbackId);
       _updateSubtreeCompositionObserverCount(-1);
     };

--- a/packages/flutter/test/rendering/layers_test.dart
+++ b/packages/flutter/test/rendering/layers_test.dart
@@ -965,6 +965,21 @@ void main() {
     expect(root.subtreeHasCompositionCallbacks, false);
     expect(a1.subtreeHasCompositionCallbacks, false);
   });
+
+  test('Double removing a observe callback throws', () {
+    final ContainerLayer root = ContainerLayer();
+    final VoidCallback callback = root.addCompositionCallback((_) { });
+    callback();
+
+    expect(() => callback(), throwsAssertionError);
+  });
+
+  test('Removing an observe callback on a disposed layer does not throw', () {
+    final ContainerLayer root = ContainerLayer();
+    final VoidCallback callback = root.addCompositionCallback((_) { });
+    root.dispose();
+    expect(() => callback(), returnsNormally);
+  });
 }
 
 class FakeEngineLayer extends Fake implements EngineLayer {


### PR DESCRIPTION
The first added test passes with or without this patch, but was missing coverage.

The second added test fails without this patch. When a layer is disposed it clears its callbacks to avoid a potential memory retain.

I ran into this working on visibility_detector, which is trying to cancel its callback in a `RenderObject.dispose` method, which may end up firing _after_ the layer is disposed.