### PR TITLE
Fix to InkSparke's colors (RGB, not RBG).

### DIFF
--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -349,8 +349,8 @@ class InkSparkle extends InteractiveInkFeature {
   Vector4 _colorToVector4(Color color) {
     return Vector4(
         color.red / 255.0,
-        color.blue / 255.0,
         color.green / 255.0,
+        color.blue / 255.0,
         color.alpha / 255.0,
       );
   }

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -115,7 +115,10 @@ Future<void> _runTest(WidgetTester tester, String positionName, double distanceF
           key: repaintKey,
           child: ElevatedButton(
             key: buttonKey,
-            style: ElevatedButton.styleFrom(splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory),
+            style: ButtonStyle(
+              splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory,
+              overlayColor: MaterialStateProperty.all<Color>(const Color(0xffccaa88)),
+            ),
             child: const Text('Sparkle!'),
             onPressed: () { },
           ),


### PR DESCRIPTION
InkSparke's colors are incorrect: The colors are converted into Vector4 in RBG order, not RGB. As a result, a red splashColor produces a red splash as expected, but a blue splashColor makes a green splash and a green splashColor a blue one.

Fixes #104312.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
