### PR TITLE
Adding custom ellipsis text.

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -459,9 +459,7 @@ class TextPainter {
   /// After this is set, you must call [layout] before the next call to [paint].
   ///
   /// The higher layers of the system, such as the [Text] widget, represent
-  /// overflow effects using the [TextOverflow] enum. The
-  /// [TextOverflow.ellipsis] value corresponds to setting this property to
-  /// U+2026 HORIZONTAL ELLIPSIS (…).
+  /// overflow effects using the [TextOverflow] enum.
   String? get ellipsis => _ellipsis;
   String? _ellipsis;
   set ellipsis(String? value) {

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -499,6 +499,7 @@ class TextStyle with Diagnosticable {
     List<String>? fontFamilyFallback,
     String? package,
     this.overflow,
+    this.ellipsis,
   }) : fontFamily = package == null ? fontFamily : 'packages/$package/$fontFamily',
        _fontFamilyFallback = fontFamilyFallback,
        _package = package,
@@ -813,6 +814,10 @@ class TextStyle with Diagnosticable {
   /// How visual text overflow should be handled.
   final TextOverflow? overflow;
 
+  /// The string used to ellipsize text when
+  /// [overflow] is set to [TextOverflow.ellipsis].
+  final String? ellipsis;
+
   // Return the original value of fontFamily, without the additional
   // "packages/$_package/" prefix.
   String? get _fontFamily {
@@ -860,6 +865,7 @@ class TextStyle with Diagnosticable {
     List<String>? fontFamilyFallback,
     String? package,
     TextOverflow? overflow,
+    String? ellipsis,
   }) {
     assert(color == null || foreground == null, _kColorForegroundWarning);
     assert(backgroundColor == null || background == null, _kColorBackgroundWarning);
@@ -898,6 +904,7 @@ class TextStyle with Diagnosticable {
       fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
       package: package ?? _package,
       overflow: overflow ?? this.overflow,
+      ellipsis: ellipsis ?? this.ellipsis,
     );
   }
 
@@ -958,6 +965,7 @@ class TextStyle with Diagnosticable {
     List<ui.FontVariation>? fontVariations,
     String? package,
     TextOverflow? overflow,
+    String? ellipsis,
   }) {
     assert(fontSizeFactor != null);
     assert(fontSizeDelta != null);
@@ -1009,6 +1017,7 @@ class TextStyle with Diagnosticable {
       decorationStyle: decorationStyle ?? this.decorationStyle,
       decorationThickness: decorationThickness == null ? null : decorationThickness! * decorationThicknessFactor + decorationThicknessDelta,
       overflow: overflow ?? this.overflow,
+      ellipsis: ellipsis ?? this.ellipsis,
       package: package ?? _package,
       debugLabel: modifiedDebugLabel,
     );
@@ -1077,6 +1086,7 @@ class TextStyle with Diagnosticable {
       fontFamilyFallback: other._fontFamilyFallback,
       package: other._package,
       overflow: other.overflow,
+      ellipsis: other.ellipsis,
     );
   }
 
@@ -1143,6 +1153,7 @@ class TextStyle with Diagnosticable {
         fontFamilyFallback: t < 0.5 ? null : b._fontFamilyFallback,
         package: t < 0.5 ? null : b._package,
         overflow: t < 0.5 ? null : b.overflow,
+        ellipsis: t < 0.5 ? null : b.ellipsis,
       );
     }
 
@@ -1174,6 +1185,7 @@ class TextStyle with Diagnosticable {
         fontFamilyFallback: t < 0.5 ? a._fontFamilyFallback : null,
         package: t < 0.5 ? a._package : null,
         overflow: t < 0.5 ? a.overflow : null,
+        ellipsis: t < 0.5 ? a.ellipsis : null,
       );
     }
 
@@ -1274,6 +1286,7 @@ class TextStyle with Diagnosticable {
       fontFamilyFallback: t < 0.5 ? a._fontFamilyFallback : b._fontFamilyFallback,
       package: t < 0.5 ? a._package : b._package,
       overflow: t < 0.5 ? a.overflow : b.overflow,
+      ellipsis: t < 0.5 ? a.ellipsis : b.ellipsis,
     );
   }
 
@@ -1436,7 +1449,8 @@ class TextStyle with Diagnosticable {
         && other.fontFamily == fontFamily
         && listEquals(other.fontFamilyFallback, fontFamilyFallback)
         && other._package == _package
-        && other.overflow == overflow;
+        && other.overflow == overflow
+        && other.ellipsis == ellipsis;
   }
 
   @override
@@ -1475,6 +1489,7 @@ class TextStyle with Diagnosticable {
       decoration,
       decorationColor,
       fontHash,
+      ellipsis,
     );
   }
 
@@ -1552,5 +1567,6 @@ class TextStyle with Diagnosticable {
     }
 
     styles.add(EnumProperty<TextOverflow>('${prefix}overflow', overflow, defaultValue: null));
+    styles.add(StringProperty('${prefix}ellipsis', ellipsis, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -814,8 +814,10 @@ class TextStyle with Diagnosticable {
   /// How visual text overflow should be handled.
   final TextOverflow? overflow;
 
-  /// The string used to ellipsize text when
-  /// [overflow] is set to [TextOverflow.ellipsis].
+  /// The string used to ellipsize text when [overflow] is set to
+  /// [TextOverflow.ellipsis]. Otherwise it's ignored.
+  /// Defaults to U+2026 HORIZONTAL ELLIPSIS (…).
+  /// Cannot be empty String.
   final String? ellipsis;
 
   // Return the original value of fontFamily, without the additional

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -78,6 +78,7 @@ class RenderParagraph extends RenderBox
     required TextDirection textDirection,
     bool softWrap = true,
     TextOverflow overflow = TextOverflow.clip,
+    String? ellipsis,
     double textScaleFactor = 1.0,
     int? maxLines,
     Locale? locale,
@@ -105,7 +106,7 @@ class RenderParagraph extends RenderBox
          textDirection: textDirection,
          textScaleFactor: textScaleFactor,
          maxLines: maxLines,
-         ellipsis: overflow == TextOverflow.ellipsis ? _kEllipsis : null,
+         ellipsis: ellipsis ?? _kEllipsis,
          locale: locale,
          strutStyle: strutStyle,
          textWidthBasis: textWidthBasis,
@@ -332,7 +333,16 @@ class RenderParagraph extends RenderBox
       return;
     }
     _overflow = value;
-    _textPainter.ellipsis = value == TextOverflow.ellipsis ? _kEllipsis : null;
+    markNeedsLayout();
+  }
+
+  /// The ellipsis text when [overflow] is set to ellipsis.
+  String? get ellipsis => _textPainter.ellipsis;
+  set ellipsis(String? value) {
+    assert(value == null || value.isNotEmpty);
+    if (_textPainter.ellipsis == value)
+      return;
+    _textPainter.ellipsis = value;
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -73,7 +73,8 @@ class RenderParagraph extends RenderBox
   ///
   /// The [maxLines] property may be null (and indeed defaults to null), but if
   /// it is not null, it must be greater than zero.
-  RenderParagraph(InlineSpan text, {
+  RenderParagraph(
+    InlineSpan text, {
     TextAlign textAlign = TextAlign.start,
     required TextDirection textDirection,
     bool softWrap = true,
@@ -88,30 +89,32 @@ class RenderParagraph extends RenderBox
     List<RenderBox>? children,
     Color? selectionColor,
     SelectionRegistrar? registrar,
-  }) : assert(text != null),
-       assert(text.debugAssertIsValid()),
-       assert(textAlign != null),
-       assert(textDirection != null),
-       assert(softWrap != null),
-       assert(overflow != null),
-       assert(textScaleFactor != null),
-       assert(maxLines == null || maxLines > 0),
-       assert(textWidthBasis != null),
-       _softWrap = softWrap,
-       _overflow = overflow,
+  })  : assert(text != null),
+        assert(text.debugAssertIsValid()),
+        assert(textAlign != null),
+        assert(textDirection != null),
+        assert(softWrap != null),
+        assert(overflow != null),
+        assert(textScaleFactor != null),
+        assert(maxLines == null || maxLines > 0),
+        assert(textWidthBasis != null),
+        _softWrap = softWrap,
+        _overflow = overflow,
        _selectionColor = selectionColor,
-       _textPainter = TextPainter(
-         text: text,
-         textAlign: textAlign,
-         textDirection: textDirection,
-         textScaleFactor: textScaleFactor,
-         maxLines: maxLines,
-         ellipsis: ellipsis ?? _kEllipsis,
-         locale: locale,
-         strutStyle: strutStyle,
-         textWidthBasis: textWidthBasis,
-         textHeightBehavior: textHeightBehavior,
-       ) {
+        _textPainter = TextPainter(
+          text: text,
+          textAlign: textAlign,
+          textDirection: textDirection,
+          textScaleFactor: textScaleFactor,
+          maxLines: maxLines,
+          ellipsis: overflow == TextOverflow.ellipsis
+              ? (ellipsis ?? _kEllipsis)
+              : null,
+          locale: locale,
+          strutStyle: strutStyle,
+          textWidthBasis: textWidthBasis,
+          textHeightBehavior: textHeightBehavior,
+        ) {
     addAll(children);
     _extractPlaceholderSpans(text);
     this.registrar = registrar;
@@ -342,7 +345,8 @@ class RenderParagraph extends RenderBox
     assert(value == null || value.isNotEmpty);
     if (_textPainter.ellipsis == value)
       return;
-    _textPainter.ellipsis = value;
+    _textPainter.ellipsis =
+        overflow == TextOverflow.ellipsis ? (ellipsis ?? _kEllipsis) : null;
     markNeedsLayout();
   }
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5678,8 +5678,8 @@ class RichText extends MultiChildRenderObjectWidget {
   /// How visual overflow should be handled.
   final TextOverflow overflow;
 
-  /// The string used to ellipsize text when
-  /// [overflow] is set to [TextOverflow.ellipsis].
+  /// The string used to ellipsize text when [overflow] is set to
+  /// [TextOverflow.ellipsis]. Otherwise it's ignored.
   /// Defaults to U+2026 HORIZONTAL ELLIPSIS (…).
   /// Cannot be empty String.
   final String? ellipsis;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -5612,6 +5612,7 @@ class RichText extends MultiChildRenderObjectWidget {
     this.textDirection,
     this.softWrap = true,
     this.overflow = TextOverflow.clip,
+    this.ellipsis,
     this.textScaleFactor = 1.0,
     this.maxLines,
     this.locale,
@@ -5677,6 +5678,12 @@ class RichText extends MultiChildRenderObjectWidget {
   /// How visual overflow should be handled.
   final TextOverflow overflow;
 
+  /// The string used to ellipsize text when
+  /// [overflow] is set to [TextOverflow.ellipsis].
+  /// Defaults to U+2026 HORIZONTAL ELLIPSIS (…).
+  /// Cannot be empty String.
+  final String? ellipsis;
+
   /// The number of font pixels for each logical pixel.
   ///
   /// For example, if the text scale factor is 1.5, text will be 50% larger than
@@ -5731,6 +5738,7 @@ class RichText extends MultiChildRenderObjectWidget {
       textDirection: textDirection ?? Directionality.of(context),
       softWrap: softWrap,
       overflow: overflow,
+      ellipsis: ellipsis,
       textScaleFactor: textScaleFactor,
       maxLines: maxLines,
       strutStyle: strutStyle,
@@ -5751,6 +5759,7 @@ class RichText extends MultiChildRenderObjectWidget {
       ..textDirection = textDirection ?? Directionality.of(context)
       ..softWrap = softWrap
       ..overflow = overflow
+      ..ellipsis = ellipsis
       ..textScaleFactor = textScaleFactor
       ..maxLines = maxLines
       ..strutStyle = strutStyle
@@ -5768,6 +5777,7 @@ class RichText extends MultiChildRenderObjectWidget {
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
     properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: TextOverflow.clip));
+    properties.add(StringProperty('ellipsis', ellipsis, defaultValue: null));
     properties.add(DoubleProperty('textScaleFactor', textScaleFactor, defaultValue: 1.0));
     properties.add(IntProperty('maxLines', maxLines, ifNull: 'unlimited'));
     properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: TextWidthBasis.parent));

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -45,6 +45,7 @@ class DefaultTextStyle extends InheritedTheme {
     this.textAlign,
     this.softWrap = true,
     this.overflow = TextOverflow.clip,
+    this.ellipsis,
     this.maxLines,
     this.textWidthBasis = TextWidthBasis.parent,
     this.textHeightBehavior,
@@ -68,6 +69,7 @@ class DefaultTextStyle extends InheritedTheme {
       softWrap = true,
       maxLines = null,
       overflow = TextOverflow.clip,
+      ellipsis = null,
       textWidthBasis = TextWidthBasis.parent,
       textHeightBehavior = null,
       super(child: const _NullWidget());
@@ -94,6 +96,7 @@ class DefaultTextStyle extends InheritedTheme {
     TextAlign? textAlign,
     bool? softWrap,
     TextOverflow? overflow,
+    String? ellipsis,
     int? maxLines,
     TextWidthBasis? textWidthBasis,
     required Widget child,
@@ -108,6 +111,7 @@ class DefaultTextStyle extends InheritedTheme {
           textAlign: textAlign ?? parent.textAlign,
           softWrap: softWrap ?? parent.softWrap,
           overflow: overflow ?? parent.overflow,
+          ellipsis: ellipsis ?? parent.ellipsis,
           maxLines: maxLines ?? parent.maxLines,
           textWidthBasis: textWidthBasis ?? parent.textWidthBasis,
           child: child,
@@ -135,6 +139,10 @@ class DefaultTextStyle extends InheritedTheme {
   /// If [softWrap] is true or null, the glyph causing overflow, and those that follow,
   /// will not be rendered. Otherwise, it will be shown with the given overflow option.
   final TextOverflow overflow;
+
+  /// The string used to ellipsize text when
+  /// [overflow] is set to [TextOverflow.ellipsis].
+  final String? ellipsis;
 
   /// An optional maximum number of lines for the text to span, wrapping if necessary.
   /// If the text exceeds the given number of lines, it will be truncated according
@@ -175,6 +183,7 @@ class DefaultTextStyle extends InheritedTheme {
         textAlign != oldWidget.textAlign ||
         softWrap != oldWidget.softWrap ||
         overflow != oldWidget.overflow ||
+        ellipsis != oldWidget.ellipsis ||
         maxLines != oldWidget.maxLines ||
         textWidthBasis != oldWidget.textWidthBasis ||
         textHeightBehavior != oldWidget.textHeightBehavior;
@@ -187,6 +196,7 @@ class DefaultTextStyle extends InheritedTheme {
       textAlign: textAlign,
       softWrap: softWrap,
       overflow: overflow,
+      ellipsis: ellipsis,
       maxLines: maxLines,
       textWidthBasis: textWidthBasis,
       textHeightBehavior: textHeightBehavior,
@@ -201,6 +211,7 @@ class DefaultTextStyle extends InheritedTheme {
     properties.add(EnumProperty<TextAlign>('textAlign', textAlign, defaultValue: null));
     properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
     properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
+    properties.add(StringProperty('ellipsis', ellipsis, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, defaultValue: null));
     properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: TextWidthBasis.parent));
     properties.add(DiagnosticsProperty<ui.TextHeightBehavior>('textHeightBehavior', textHeightBehavior, defaultValue: null));
@@ -386,6 +397,7 @@ class Text extends StatelessWidget {
     this.locale,
     this.softWrap,
     this.overflow,
+    this.ellipsis,
     this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
@@ -418,6 +430,7 @@ class Text extends StatelessWidget {
     this.locale,
     this.softWrap,
     this.overflow,
+    this.ellipsis,
     this.textScaleFactor,
     this.maxLines,
     this.semanticsLabel,
@@ -487,6 +500,12 @@ class Text extends StatelessWidget {
   /// If this is null [TextStyle.overflow] will be used, otherwise the value
   /// from the nearest [DefaultTextStyle] ancestor will be used.
   final TextOverflow? overflow;
+
+  /// The string used to ellipsize text when
+  /// [overflow] is set to [TextOverflow.ellipsis].
+  /// Defaults to U+2026 HORIZONTAL ELLIPSIS (…).
+  /// Cannot be empty String.
+  final String? ellipsis;
 
   /// The number of font pixels for each logical pixel.
   ///
@@ -560,6 +579,7 @@ class Text extends StatelessWidget {
       locale: locale, // RichText uses Localizations.localeOf to obtain a default if this is null
       softWrap: softWrap ?? defaultTextStyle.softWrap,
       overflow: overflow ?? effectiveTextStyle?.overflow ?? defaultTextStyle.overflow,
+      ellipsis: ellipsis ?? effectiveTextStyle?.ellipsis,
       textScaleFactor: textScaleFactor ?? MediaQuery.textScaleFactorOf(context),
       maxLines: maxLines ?? defaultTextStyle.maxLines,
       strutStyle: strutStyle,
@@ -604,6 +624,7 @@ class Text extends StatelessWidget {
     properties.add(DiagnosticsProperty<Locale>('locale', locale, defaultValue: null));
     properties.add(FlagProperty('softWrap', value: softWrap, ifTrue: 'wrapping at box width', ifFalse: 'no wrapping except at line break characters', showName: true));
     properties.add(EnumProperty<TextOverflow>('overflow', overflow, defaultValue: null));
+    properties.add(StringProperty('ellipsis', ellipsis, defaultValue: null));
     properties.add(DoubleProperty('textScaleFactor', textScaleFactor, defaultValue: null));
     properties.add(IntProperty('maxLines', maxLines, defaultValue: null));
     properties.add(EnumProperty<TextWidthBasis>('textWidthBasis', textWidthBasis, defaultValue: null));

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -501,8 +501,8 @@ class Text extends StatelessWidget {
   /// from the nearest [DefaultTextStyle] ancestor will be used.
   final TextOverflow? overflow;
 
-  /// The string used to ellipsize text when
-  /// [overflow] is set to [TextOverflow.ellipsis].
+  /// The string used to ellipsize text when [overflow] is set to
+  /// [TextOverflow.ellipsis]. Otherwise it's ignored.
   /// Defaults to U+2026 HORIZONTAL ELLIPSIS (…).
   /// Cannot be empty String.
   final String? ellipsis;

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -802,6 +802,8 @@ class _TextStyleProxy implements TextStyle {
   List<ui.FontVariation>? get fontVariations => _delegate.fontVariations;
   @override
   TextOverflow? get overflow => _delegate.overflow;
+  @override
+  String? get ellipsis => _delegate.ellipsis;
 
   @override
   String toString({ DiagnosticLevel minLevel = DiagnosticLevel.info }) =>
@@ -845,6 +847,7 @@ class _TextStyleProxy implements TextStyle {
     List<ui.FontFeature>? fontFeatures,
     List<ui.FontVariation>? fontVariations,
     TextOverflow? overflow,
+    String? ellipsis,
     String? package,
   }) {
     throw UnimplementedError();
@@ -882,6 +885,7 @@ class _TextStyleProxy implements TextStyle {
     double? decorationThickness,
     String? debugLabel,
     TextOverflow? overflow,
+    String? ellipsis,
     String? package,
   }) {
     throw UnimplementedError();

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -1362,4 +1362,36 @@ void main() {
       matchesGoldenFile('text_golden.TextHeightBehavior.1.png'),
     );
   });
+
+  testWidgets('Custom ellipsis string', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Center(
+        child: RepaintBoundary(
+          child: Container(
+            width: 50.0,
+            height: 200.0,
+            decoration: const BoxDecoration(
+              color: Color(0xff00ff00),
+            ),
+            child: const Text(
+              'Long long long text that should be most definitely clipped as it is overflowing on max 2 lines.',
+              textDirection: TextDirection.ltr,
+              style: TextStyle(
+                fontSize: 10,
+                color: Color(0xffff0000),
+                overflow: TextOverflow.ellipsis,
+                ellipsis: '~~~>',
+              ),
+              maxLines: 2,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await expectLater(
+      find.byType(Container),
+      matchesGoldenFile('text_golden.Custom_ellipsis.1.png'),
+    );
+  });
 }


### PR DESCRIPTION
Addressing #26748. A small change that allows Text, TextStyle and RichText to take an ellipsis string which is used when overflow is TextOverflow.ellipsis in stead of the current _kEllipsis.

If overflow is ellipsis but the parameter is null we fall back to the constant, if it is provided we use that. Otherwise everything works the same so nothing should break. If ellipsis is not null but overflow is not ellipsis it is ignored.

![hello_world_isbvWQVHl5](https://user-images.githubusercontent.com/28347433/169673910-0cee7683-d18c-4d4a-bcdb-e3856280cc0c.png)

![hello_world_Jl4ZXslJBC](https://user-images.githubusercontent.com/28347433/169673913-92e248d7-4e5b-4733-9c41-a2b203ccb9cb.png)

