### PR TITLE
Fix PageView throws Null check error

### DIFF
--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -463,6 +463,20 @@ class _PagePosition extends ScrollPositionWithSingleContext implements PageMetri
   }
 
   @override
+  void absorb(ScrollPosition other) {
+    super.absorb(other);
+    assert(_cachedPage == null);
+
+    if (other is! _PagePosition) {
+      return;
+    }
+
+    if (other._cachedPage != null) {
+      _cachedPage = other._cachedPage;
+    }
+  }
+
+  @override
   bool applyContentDimensions(double minScrollExtent, double maxScrollExtent) {
     final double newMinScrollExtent = minScrollExtent + _initialPageOffset;
     return super.applyContentDimensions(

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -133,6 +133,45 @@ void main() {
     expect(find.text('Illinois'), findsOneWidget);
   });
 
+  testWidgets('_PagePosition.applyViewportDimension should not throw', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/101007
+    final PageController controller = PageController(
+      initialPage: 1,
+    );
+
+    // Set the starting viewportDimension to 0.0
+    await tester.binding.setSurfaceSize(Size.zero);
+    final MediaQueryData mediaQueryData = MediaQueryData.fromWindow(tester.binding.window);
+
+    Widget build(Size size) {
+      return MediaQuery(
+        data: mediaQueryData.copyWith(size: size),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Center(
+            child: SizedBox.expand(
+              child: PageView(
+                controller: controller,
+                onPageChanged: (int page) { },
+                children: kStates.map<Widget>((String state) => Text(state)).toList(),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(Size.zero));
+    const Size surfaceSize = Size(500,400);
+    await tester.binding.setSurfaceSize(surfaceSize);
+    await tester.pumpWidget(build(surfaceSize));
+
+    expect(tester.takeException(), isNull);
+
+    // Reset TestWidgetsFlutterBinding surfaceSize
+    await tester.binding.setSurfaceSize(null);
+  });
+
   testWidgets('PageController cannot return page while unattached',
       (WidgetTester tester) async {
     final PageController controller = PageController();


### PR DESCRIPTION
## Description

This PR fixes a null check error in `PageView`.

The null check was added by the following PR : https://github.com/flutter/flutter/pull/65015

Flutter 3.0 is the first stable release where the null check error surfaces.
It surfaces due to the following PR : https://github.com/flutter/flutter/pull/97971
which added a call to `MediaQuery` in `SrollableState.didChangeDependencies` ([line 462](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/scrollable.dart#L460)) :

```dart
  @override
  void didChangeDependencies() {
    _mediaQueryData = MediaQuery.maybeOf(context);
    _updatePosition();
    super.didChangeDependencies();
  }
```
During startup, especially in release mode, `MediaQuery.of(context).size` might return (0,0). The size will be updated when the native platform reports the actual resolution (several milliseconds later). This seems to be by design for performance reasons (see https://github.com/flutter/flutter/issues/25827#issuecomment-571804641).

For `PageView`, it means that the Viewport dimensions are updated during startup which was not expected with the previous code.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/101007

## Tests

Adds 1 test.