### PR TITLE
Extract ChangeNotifier.debugAssertNotDisposed as extension

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -119,36 +119,6 @@ class ChangeNotifier implements Listenable {
   int _reentrantlyRemovedListeners = 0;
   bool _debugDisposed = false;
 
-  /// Used by subclasses to assert that the [ChangeNotifier] has not yet been
-  /// disposed.
-  ///
-  /// {@tool snippet}
-  /// The `debugAssertNotDisposed` function should only be called inside of an
-  /// assert, as in this example.
-  ///
-  /// ```dart
-  /// class MyNotifier with ChangeNotifier {
-  ///   void doUpdate() {
-  ///     assert(debugAssertNotDisposed());
-  ///     // ...
-  ///   }
-  /// }
-  /// ```
-  /// {@end-tool}
-  @protected
-  bool debugAssertNotDisposed() {
-    assert(() {
-      if (_debugDisposed) {
-        throw FlutterError(
-          'A $runtimeType was used after being disposed.\n'
-          'Once you have called dispose() on a $runtimeType, it can no longer be used.',
-        );
-      }
-      return true;
-    }());
-    return true;
-  }
-
   /// Whether any listeners are currently registered.
   ///
   /// Clients should not depend on this value for their behavior, because having
@@ -393,6 +363,42 @@ class ChangeNotifier implements Listenable {
       _reentrantlyRemovedListeners = 0;
       _count = newLength;
     }
+  }
+}
+
+/// Used by subclasses to call assertions on the internal state of
+/// [ChangeNotifier]
+///
+/// This is a extension rather than a direct method, minimize the API footprint
+/// of subclasses implementing [ChangeNotifier].
+extension ChangeNotifierDisposeAssertion on ChangeNotifier {
+  /// Used by subclasses to assert that the [ChangeNotifier] has not yet been
+  /// disposed.
+  ///
+  /// {@tool snippet}
+  /// The `debugAssertNotDisposed` function should only be called inside of an
+  /// assert, as in this example.
+  ///
+  /// ```dart
+  /// class MyNotifier with ChangeNotifier {
+  ///   void doUpdate() {
+  ///     assert(debugAssertNotDisposed());
+  ///     // ...
+  ///   }
+  /// }
+  /// ```
+  /// {@end-tool}
+  bool debugAssertNotDisposed() {
+    assert(() {
+      if (_debugDisposed) {
+        throw FlutterError(
+          'A $runtimeType was used after being disposed.\n'
+          'Once you have called dispose() on a $runtimeType, it can no longer be used.',
+        );
+      }
+      return true;
+    }());
+    return true;
   }
 }
 

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -48,6 +48,54 @@ class Counter with ChangeNotifier {
   }
 }
 
+/// Minimal implementation of the [ChangeNotifier] interface
+class _CustomChangeNotifier implements ChangeNotifier {
+  final List<VoidCallback> listeners = <VoidCallback>[];
+
+  @override
+  void addListener(VoidCallback listener) {
+    listeners.add(listener);
+  }
+
+  @override
+  void removeListener(VoidCallback listener) {
+    listeners.remove(listener);
+  }
+
+  @override
+  void dispose() {
+    listeners.clear();
+  }
+
+  @override
+  bool get hasListeners => listeners.isNotEmpty;
+
+  @override
+  void notifyListeners() {
+    final List<void Function()> copy = listeners.reversed.toList();
+    for (final void Function() listener in copy) {
+      listener();
+    }
+  }
+}
+
+/// Counter example but only using the ChangeNotifier interface not the actual
+/// implementation
+class _CustomCounter with _CustomChangeNotifier {
+  int get value => _value;
+  int _value = 0;
+  set value(int value) {
+    if (_value != value) {
+      _value = value;
+      notifyListeners();
+    }
+  }
+
+  void notify() {
+    notifyListeners();
+  }
+}
+
 void main() {
   testWidgets('ChangeNotifier', (WidgetTester tester) async {
     final List<String> log = <String>[];
@@ -450,6 +498,20 @@ void main() {
     expect(notifications, 0);
     b.test();
     expect(b.result, isTrue);
+    expect(notifications, 1);
+  });
+
+  test('implementing ChangeNotifier', () {
+    // We document that this is a valid way to use this class.
+    final _CustomCounter counter = _CustomCounter();
+    int notifications = 0;
+    counter.addListener(() {
+      notifications += 1;
+    });
+    expect(counter.value, 0);
+
+    counter.value = 4;
+    expect(counter.value, 4);
     expect(notifications, 1);
   });
 


### PR DESCRIPTION
Making `debugAssertNotDisposed` an extension minimizes the API surface and makes it easier for subclasses to implement `ChangeNotifier`.

This method was recently made public (https://github.com/flutter/flutter/pull/103456), making it a breaking API change. 
It can be prevented by making the method an extension.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
