### PR TITLE
Fix to InkSparkle rendering with a non-grayscale splash color

### DIFF
--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -359,8 +359,8 @@ class InkSparkle extends InteractiveInkFeature {
   Vector4 _colorToVector4(Color color) {
     return Vector4(
         color.red / 255.0,
-        color.blue / 255.0,
         color.green / 255.0,
+        color.blue / 255.0,
         color.alpha / 255.0,
       );
   }

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -108,9 +108,27 @@ void main() {
   },
     skip: kIsWeb, // [intended] SPIR-V shaders are not yet supported for web.
   );
+
+  testWidgets('InkSparkle renders with correct colors', (WidgetTester tester) async {
+    await _runTest(tester, 'colored_sparkle', 0.6, color: const Color(0xffccaa88));
+  },
+    skip: kIsWeb, // [intended] SPIR-V shaders are not yet supported for web.
+  );
+
+  testWidgets('InkSparkle renders with correct colors', (WidgetTester tester) async {
+    await _runTest(tester, 'green_sparkle', 0.2, color: const Color(0xff44cc44));
+  },
+    skip: kIsWeb, // [intended] SPIR-V shaders are not yet supported for web.
+  );
+
+  testWidgets('InkSparkle renders with correct colors', (WidgetTester tester) async {
+    await _runTest(tester, 'purple_sparkle', 0.8, color: const Color(0xffcc88ff));
+  },
+    skip: kIsWeb, // [intended] SPIR-V shaders are not yet supported for web.
+  );
 }
 
-Future<void> _runTest(WidgetTester tester, String positionName, double distanceFromTopLeft) async {
+Future<void> _runTest(WidgetTester tester, String positionName, double distanceFromTopLeft, {Color? color}) async {
   final Key repaintKey = UniqueKey();
   final Key buttonKey = UniqueKey();
 
@@ -121,7 +139,12 @@ Future<void> _runTest(WidgetTester tester, String positionName, double distanceF
           key: repaintKey,
           child: ElevatedButton(
             key: buttonKey,
-            style: ElevatedButton.styleFrom(splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory),
+            style: color == null ?
+              ElevatedButton.styleFrom(splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory) :
+              ButtonStyle(
+                splashFactory: InkSparkle.constantTurbulenceSeedSplashFactory,
+                overlayColor: MaterialStateProperty.all<Color>(color),
+              ),
             child: const Text('Sparkle!'),
             onPressed: () { },
           ),


### PR DESCRIPTION
InkSparke's colors are incorrect: The colors are converted into Vector4 in RBG order, not RGB. As a result, a red splashColor produces a red splash as expected, but a blue splashColor makes a green splash and a green splashColor a blue one.

Fixes #104312.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
