### PR TITLE
[tool] Add tests for FakeProcessManager

### DIFF
--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -158,6 +158,8 @@ class FakeProcess implements io.Process {
     } else if (outputFollowsExit) {
       // Wait for the process to exit before emitting stderr.
       this.stderr = Stream<List<int>>.fromFuture(this.exitCode.then((_) {
+        // Return a Future so stderr isn't immediately available to those who
+        // await exitCode, but is available asynchronously later.
         return Future<List<int>>(() => _stderr);
       }));
     } else {
@@ -169,6 +171,8 @@ class FakeProcess implements io.Process {
     } else if (outputFollowsExit) {
       // Wait for the process to exit before emitting stdout.
       this.stdout = Stream<List<int>>.fromFuture(this.exitCode.then((_) {
+        // Return a Future so stdout isn't immediately available to those who
+        // await exitCode, but is available asynchronously later.
         return Future<List<int>>(() => _stdout);
       }));
     } else {


### PR DESCRIPTION
Adds tests that verify the behaviour of stderr, stdout of processes
launched via FakeProcessManager.

Specifically:
* Verifies that stderr, stdout are not emitted immediately after process
  exit if outputFollowsExit is true. They must be emitted at least one
  turn through the event loop later.
* Verifies that ProcessResult.stderr, stdout have the type documented
  according to the encoding passted to Process.run/runSync:
  * List<int> if null is passed as the encoding.
  * String (in the default system encoding) if no encoding is specified.
  * String (in the specified encoding) if an encoding is specified.

This is additional testing relating to refactoring landed in:
https://github.com/flutter/flutter/pull/103947

Issue: https://github.com/flutter/flutter/issues/102451

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
