### PR TITLE
Reclaim image resources more aggressively when evicted from ImageCache

### DIFF
--- a/packages/flutter/lib/src/painting/image_cache.dart
+++ b/packages/flutter/lib/src/painting/image_cache.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:developer';
 
 import 'package:flutter/foundation.dart';
@@ -621,7 +622,7 @@ abstract class _CachedImageBase {
     assert(handle != null);
     // Give any interested parties a chance to listen to the stream before we
     // potentially dispose it.
-    SchedulerBinding.instance.addPostFrameCallback((Duration timeStamp) {
+    scheduleMicrotask(() {
       assert(handle != null);
       handle?.dispose();
       handle = null;


### PR DESCRIPTION
From #102140, when an applications loads a lot of large images in a ListView, it will easily crash due to OOM, despite the size limit in ImageCache. This can be fixed by disposing of the unneeded `ImageStreamCompleter` more aggressively.

An example project to reproduce this issue

- Run `flutter create hello_world`, and change the contents of main.dart to https://gist.github.com/Yeatse/5b1837083aefafbc87df301fa2bdb28f
- Launch this app in profile mode from an iOS device, tap 'Show Image List', and swipe the list quickly.

Before this fix:
Memory used by this app grows rapidly and finally it will crash.
<img width="720" alt="before fix" src="https://user-images.githubusercontent.com/6036532/170038554-baf78026-f114-43bb-a241-0692fd79a98e.png">


With this fix:
Memory is reclaimed as soon as the image goes out of the screen.
<img width="720" alt="after fix" src="https://user-images.githubusercontent.com/6036532/170038832-8af50e90-a818-49e6-b6d8-8b6a85877feb.png">


related issue: #102140

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
