### PR TITLE
Added option for Platform Channel statistics and Timeline events

### DIFF
--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -21,7 +21,7 @@ KeyDataTransitMode? debugKeyEventSimulatorTransitModeOverride;
 /// excluded).
 ///
 /// The statistics include the total bytes transmitted and the average number of
-/// bytes per invocation in the last quantum.  "Up" means in the direction of
+/// bytes per invocation in the last quantum. "Up" means in the direction of
 /// Flutter to the host platform, "down" is the host platform to flutter.
 bool debugProfilePlatformChannels = false;
 

--- a/packages/flutter/lib/src/services/debug.dart
+++ b/packages/flutter/lib/src/services/debug.dart
@@ -13,6 +13,18 @@ import 'hardware_keyboard.dart';
 /// of their extent of support for keyboard API.
 KeyDataTransitMode? debugKeyEventSimulatorTransitModeOverride;
 
+/// Profile and print statistics on Platform Channel usage.
+///
+/// When this is is true statistics about the usage of Platform Channels will be
+/// printed out periodically to the console and Timeline events will show the
+/// time between sending and receiving a message (encoding and decoding time
+/// excluded).
+///
+/// The statistics include the total bytes transmitted and the average number of
+/// bytes per invocation in the last quantum.  "Up" means in the direction of
+/// Flutter to the host platform, "down" is the host platform to flutter.
+bool debugProfilePlatformChannels = false;
+
 /// Returns true if none of the widget library debug variables have been changed.
 ///
 /// This function is used by the test framework to ensure that debug variables
@@ -22,6 +34,9 @@ KeyDataTransitMode? debugKeyEventSimulatorTransitModeOverride;
 bool debugAssertAllServicesVarsUnset(String reason) {
   assert(() {
     if (debugKeyEventSimulatorTransitModeOverride != null) {
+      throw FlutterError(reason);
+    }
+    if (debugProfilePlatformChannels) {
       throw FlutterError(reason);
     }
     return true;


### PR DESCRIPTION
When `debugProfilePlatformChannels` is true there will be Timeline events representing the time between sending a message and getting the result from the host platform.  Also, every second there will be bandwidth information printed to the console for the platform channels.

issue: https://github.com/flutter/flutter/issues/102189

example log:
```
flutter: Platform Channel Stats:
flutter:   (name:"flutter/platform#SystemChrome.setSystemUIOverlayStyle" type:"OptionalMethodChannel" codec:"JSONMethodCodec" upBytes:359 upBytes_avg:359.0 downBytes:6 downBytes_avg:6.0)
flutter:   (name:"flutter/platform#SystemChrome.setApplicationSwitcherDescription" type:"OptionalMethodChannel" codec:"JSONMethodCodec" upBytes:117 upBytes_avg:117.0 downBytes:6 downBytes_avg:6.0)
flutter:   (name:"flutter/navigation#routeInformationUpdated" type:"OptionalMethodChannel" codec:"JSONMethodCodec" upBytes:89 upBytes_avg:89.0 downBytes:0 downBytes_avg:0.0)
flutter:   (name:"flutter/navigation#selectSingleEntryHistory" type:"OptionalMethodChannel" codec:"JSONMethodCodec" upBytes:49 upBytes_avg:49.0 downBytes:0 downBytes_avg:0.0)
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
