### PR TITLE
Fix existing DUPLICATE_IMPORT diagnostics.

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
-import '../android/android_builder.dart';
-import '../android/android_sdk.dart';
 import '../application_package.dart';
 import '../base/common.dart' show throwToolExit;
 import '../base/file_system.dart';
@@ -24,6 +22,7 @@ import '../project.dart';
 import '../protocol_discovery.dart';
 
 import 'android.dart';
+import 'android_builder.dart';
 import 'android_console.dart';
 import 'android_sdk.dart';
 import 'application_package.dart';

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -7,8 +7,6 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 
-import '../android/android_sdk.dart';
-import '../android/android_workflow.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -17,6 +15,7 @@ import '../convert.dart';
 import '../device.dart';
 import '../emulator.dart';
 import 'android_sdk.dart';
+import 'android_workflow.dart';
 
 class AndroidEmulators extends EmulatorDiscovery {
   AndroidEmulators({


### PR DESCRIPTION
We fixed https://github.com/dart-lang/sdk/issues/48987 in the [analyzer](https://dart-review.googlesource.com/c/sdk/+/244183), and need to fix pre-existing failures.