### PR TITLE
Create static plugin frameworks build ios-framework --static

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -80,6 +80,9 @@ class BuildIOSFrameworkCommand extends BuildSubCommand {
       ..addFlag('cocoapods',
         help: 'Produce a Flutter.podspec instead of an engine Flutter.xcframework (recommended if host app uses CocoaPods).',
       )
+      ..addFlag('static',
+        help: 'Build plugins as static frameworks. Link on, but do not embed these frameworks in the existing Xcode project.',
+      )
       ..addOption('output',
         abbr: 'o',
         valueHelp: 'path/to/directory/',
@@ -428,6 +431,8 @@ end
         'BITCODE_GENERATION_MODE=$bitcodeGenerationMode',
         'ONLY_ACTIVE_ARCH=NO', // No device targeted, so build all valid architectures.
         'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
+        if (boolArg('static') ?? false)
+          'MACH_O_TYPE=staticlib',
       ];
 
       RunResult buildPluginsResult = await globals.processUtils.run(
@@ -453,6 +458,8 @@ end
         'ENABLE_BITCODE=YES', // Support host apps with bitcode enabled.
         'ONLY_ACTIVE_ARCH=NO', // No device targeted, so build all valid architectures.
         'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
+        if (boolArg('static') ?? false)
+          'MACH_O_TYPE=staticlib',
       ];
 
       buildPluginsResult = await globals.processUtils.run(


### PR DESCRIPTION
Just the plugins part of https://github.com/flutter/flutter/issues/52217.  Build the plugin xcframeworks as static frameworks.  Flutter.xcframework and App.xcframework are still dylibs.

Previous behavior creates dylibs `dynamically linked shared library`:
```
$ flutter build ios-framework
$ $ file build/ios/framework/Debug/url_launcher_ios.xcframework/ios-arm64/url_launcher_ios.framework/url_launcher_ios
build/ios/framework/Debug/url_launcher_ios.xcframework/ios-arm64/url_launcher_ios.framework/url_launcher_ios: Mach-O 64-bit dynamically linked shared library arm64
```
With `--static` the plugins are `ar archive random library`
```
$ flutter build ios-framework --static
$ file build/ios/framework/Debug/url_launcher_ios.xcframework/ios-arm64/url_launcher_ios.framework/url_launcher_ios
build/ios/framework/Debug/url_launcher_ios.xcframework/ios-arm64/url_launcher_ios.framework/url_launcher_ios: current ar archive random library
```

I tested this manually by:
1. Adding a plugin `url_launcher:` to [the sample project pubspec](https://github.com/flutter/samples/blob/main/add_to_app/prebuilt_module/flutter_module/pubspec.yaml).
2. Adding a button that launches a URL to the [dart code](https://github.com/flutter/samples/blob/090c6f791b6703ee9107b80e7c533c14ea3a1f92/add_to_app/prebuilt_module/flutter_module/lib/main.dart#L82):
```dart
@override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Center(
        child: ElevatedButton(
          onPressed: () async {
            await launchUrl(Uri.parse('https://www.google.com'));
          },
          child: Text('Launch URL'),
        ),
      ),
    );
  }
```
3. Calling `GeneratedPluginRegistrant.register(with: self.flutterEngine!);` in [the AppDelegate](https://github.com/flutter/samples/blob/090c6f791b6703ee9107b80e7c533c14ea3a1f92/add_to_app/prebuilt_module/ios_using_prebuilt_module/IOSUsingPrebuiltModule/AppDelegate.swift#L17)
4. Linking (not embedding!) the static `url_launcher_ios` and `FlutterPluginRegistrant` xcframeworks
[in the Xcode project](https://github.com/flutter/samples/blob/090c6f791b6703ee9107b80e7c533c14ea3a1f92/add_to_app/prebuilt_module/ios_using_prebuilt_module/IOSUsingPrebuiltModule.xcodeproj/project.pbxproj#L46)
```
		F733C128283DD5C7005295FB /* url_launcher_ios.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = url_launcher_ios.xcframework; path = "Flutter/$(CONFIGURATION)/url_launcher_ios.xcframework"; sourceTree = "<group>"; };
		F733C12B283DD6C4005295FB /* FlutterPluginRegistrant.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = FlutterPluginRegistrant.xcframework; path = "Flutter/$(CONFIGURATION)/FlutterPluginRegistrant.xcframework"; sourceTree = "<group>"; };
```
```
			isa = PBXFrameworksBuildPhase;
			buildActionMask = 2147483647;
			files = (
				F733C12C283DD6C4005295FB /* FlutterPluginRegistrant.xcframework in Frameworks */,
				F77F88F1255396AD00309E51 /* App.xcframework in Frameworks */,
				F77F88F2255396AD00309E51 /* Flutter.xcframework in Frameworks */,
				F733C129283DD5C7005295FB /* url_launcher_ios.xcframework in Frameworks */,
			);
			runOnlyForDeploymentPostprocessing = 0;
```
etc.

Run the app, tap the button, the URL launches.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
