### PR TITLE
Fix issues running integration tests through DAP debug adapter

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -25,14 +25,23 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     required this.fileSystem,
     required this.platform,
     super.ipv6,
-    super.enableDds,
+    bool enableDds = true,
     super.enableAuthCodes,
     super.logger,
-  });
+  })  : _enableDds = enableDds,
+        // Always disable in the DAP layer as it's handled in the spawned
+        // 'flutter' process.
+        super(enableDds: false);
 
   FileSystem fileSystem;
   Platform platform;
   Process? _process;
+
+  /// Whether DDS should be enabled in the Flutter process.
+  ///
+  /// We never enable DDS in the DAP process for Flutter, so this value is not
+  /// the same as what is passed to the base class, which is always provided 'false'.
+  final bool _enableDds;
 
   @override
   final FlutterLaunchRequestArguments Function(Map<String, Object?> obj)
@@ -136,6 +145,7 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     final List<String> toolArgs = <String>[
       'attach',
       '--machine',
+      if (!_enableDds) '--no-dds',
       if (vmServiceUri != null)
       ...<String>['--debug-uri', vmServiceUri],
     ];
@@ -249,6 +259,7 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     final List<String> toolArgs = <String>[
       'run',
       '--machine',
+      if (!_enableDds) '--no-dds',
       if (enableDebugger) '--start-paused',
       // Structured errors are enabled by default, but since we don't connect
       // the VM Service for noDebug, we need to disable them so that error text

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -25,14 +25,23 @@ class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArgum
     required this.fileSystem,
     required this.platform,
     super.ipv6,
-    super.enableDds,
+    bool enableDds = true,
     super.enableAuthCodes,
     super.logger,
-  });
+  })  : _enableDds = enableDds,
+        // Always disable in the DAP layer as it's handled in the spawned
+        // 'flutter' process.
+        super(enableDds: false);
 
   FileSystem fileSystem;
   Platform platform;
   Process? _process;
+
+  /// Whether DDS should be enabled in the Flutter process.
+  ///
+  /// We never enable DDS in the DAP process for Flutter, so this value is not
+  /// the same as what is passed to the base class, which is always provided 'false'.
+  final bool _enableDds;
 
   @override
   final FlutterLaunchRequestArguments Function(Map<String, Object?> obj)
@@ -78,6 +87,22 @@ class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArgum
     terminatePids(ProcessSignal.sigkill);
   }
 
+  /// Whether or not the user requested debugging be enabled.
+  ///
+  /// For debugging to be enabled, the user must have chosen "Debug" (and not
+  /// "Run") in the editor (which maps to the DAP `noDebug` field).
+  bool get enableDebugger {
+    final DartCommonLaunchAttachRequestArguments args = this.args;
+    if (args is FlutterLaunchRequestArguments) {
+      // Invert DAP's noDebug flag, treating it as false (so _do_ debug) if not
+      // provided.
+      return !(args.noDebug ?? false);
+    }
+
+    // Otherwise (attach), always debug.
+    return true;
+  }
+
   /// Called by [launchRequest] to request that we actually start the tests to be run/debugged.
   ///
   /// For debugging, this should start paused, connect to the VM Service, set
@@ -86,12 +111,13 @@ class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArgum
   Future<void> launchImpl() async {
     final FlutterLaunchRequestArguments args = this.args as FlutterLaunchRequestArguments;
 
-    final bool debug = !(args.noDebug ?? false);
+    final bool debug = enableDebugger;
     final String? program = args.program;
 
     final List<String> toolArgs = <String>[
       'test',
       '--machine',
+      if (!_enableDds) '--no-dds',
       if (debug) '--start-paused',
     ];
 
@@ -207,8 +233,9 @@ class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArgum
   /// Handles the test.processStarted event from Flutter that provides the VM Service URL.
   void _handleTestStartedProcess(Map<String, Object?> params) {
     final String? vmServiceUriString = params['observatoryUri'] as String?;
-    // For no-debug mode, this event is still sent, but has a null URI.
-    if (vmServiceUriString == null) {
+    // For no-debug mode, this event may be still sent so ignore it if we know
+    // we're not debugging, or its URI is null.
+    if (!enableDebugger || vmServiceUriString == null) {
       return;
     }
     final Uri vmServiceUri = Uri.parse(vmServiceUriString);

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
@@ -18,7 +18,6 @@ void main() {
   late DapTestSession dap;
   late DapTestClient client;
   late TestsProject project;
-  List<String>? toolArgs;
 
   setUpAll(() {
     Cache.flutterRoot = getFlutterRoot();
@@ -35,7 +34,7 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  void standardTests() {
+  void standardTests({List<String>? toolArgs}) {
     test('can run in debug mode', () async {
       // Collect output and test events while running the script.
       final TestEvents outputEvents = await client.collectTestOutput(
@@ -113,7 +112,6 @@ void main() {
 
   group('widget tests', () {
     setUp(() async {
-      toolArgs = null;
       project = TestsProject();
       await project.setUpIn(tempDir);
     });
@@ -122,13 +120,14 @@ void main() {
   });
 
   group('integration tests', () {
+    const List<String> toolArgs = <String>['-d', 'flutter-tester'];
+
     setUp(() async {
-      toolArgs = <String>['-d', 'flutter-tester'];
       project = IntegrationTestsProject();
       await project.setUpIn(tempDir);
     });
 
-    standardTests();
+    standardTests(toolArgs: toolArgs);
   });
 }
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_adapter_test.dart
@@ -7,6 +7,7 @@ import 'package:file/file.dart';
 import 'package:flutter_tools/src/cache.dart';
 
 import '../../src/common.dart';
+import '../test_data/integration_tests_project.dart';
 import '../test_data/tests_project.dart';
 import '../test_utils.dart';
 import 'test_client.dart';
@@ -15,6 +16,9 @@ import 'test_support.dart';
 void main() {
   late Directory tempDir;
   late DapTestSession dap;
+  late DapTestClient client;
+  late TestsProject project;
+  List<String>? toolArgs;
 
   setUpAll(() {
     Cache.flutterRoot = getFlutterRoot();
@@ -23,6 +27,7 @@ void main() {
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('flutter_test_adapter_test.');
     dap = await DapTestSession.setUp(additionalArgs: <String>['--test']);
+    client = dap.client;
   });
 
   tearDown(() async {
@@ -30,45 +35,40 @@ void main() {
     tryToDelete(tempDir);
   });
 
-  test('can run in debug mode', () async {
-    final DapTestClient client = dap.client;
-    final TestsProject project = TestsProject();
-    await project.setUpIn(tempDir);
+  void standardTests() {
+    test('can run in debug mode', () async {
+      // Collect output and test events while running the script.
+      final TestEvents outputEvents = await client.collectTestOutput(
+        launch: () => client.launch(
+          program: project.testFilePath,
+          cwd: project.dir.path,
+          toolArgs: toolArgs,
+        ),
+      );
 
-    // Collect output and test events while running the script.
-    final TestEvents outputEvents = await client.collectTestOutput(
-      launch: () => client.launch(
-        program: project.testFilePath,
-        cwd: project.dir.path,
-      ),
-    );
+      // Check the printed output shows that the run finished, and it's exit
+      // code (which is 1 due to the failing test).
+      final String output = outputEvents.output.map((OutputEventBody e) => e.output).join();
+      expectLines(
+        output,
+        <Object>[
+          startsWith('Connecting to VM Service at'),
+          ..._testsProjectExpectedOutput,
+        ],
+        allowExtras: true, // Allow for printed call stack etc.
+      );
 
-    // Check the printed output shows that the run finished, and it's exit
-    // code (which is 1 due to the failing test).
-    final String output = outputEvents.output.map((OutputEventBody e) => e.output).join();
-    expectLines(
-      output,
-      <Object>[
-        startsWith('Connecting to VM Service at'),
-        ..._testsProjectExpectedOutput,
-      ],
-      allowExtras: true, // Allow for printed call stack etc.
-    );
-
-    _expectStandardTestsProjectResults(outputEvents);
-  });
+      _expectStandardTestsProjectResults(outputEvents);
+    });
 
   test('can run in noDebug mode', () async {
-    final DapTestClient client = dap.client;
-    final TestsProject project = TestsProject();
-    await project.setUpIn(tempDir);
-
     // Collect output and test events while running the script.
     final TestEvents outputEvents = await client.collectTestOutput(
       launch: () => client.launch(
         program: project.testFilePath,
         noDebug: true,
         cwd: project.dir.path,
+        toolArgs: toolArgs,
       ),
     );
 
@@ -85,21 +85,18 @@ void main() {
   });
 
   test('can run a single test', () async {
-    final DapTestClient client = dap.client;
-    final TestsProject project = TestsProject();
-    await project.setUpIn(tempDir);
-
     // Collect output and test events while running the script.
     final TestEvents outputEvents = await client.collectTestOutput(
       launch: () => client.launch(
         program: project.testFilePath,
         noDebug: true,
         cwd: project.dir.path,
-        // It's up to the calling IDE to pass the correct args for 'dart test'
-        // if it wants to run a subset of tests.
-        args: <String>[
+        // It's up to the calling IDE to pass the correct args for
+        // 'flutter test' if it wants to run a subset of tests.
+        toolArgs: <String>[
           '--plain-name',
           'can pass',
+          ...?toolArgs,
         ],
       ),
     );
@@ -111,6 +108,27 @@ void main() {
 
     expect(testsNames, contains('Flutter tests can pass'));
     expect(testsNames, isNot(contains('Flutter tests can fail')));
+  });
+ }
+
+  group('widget tests', () {
+    setUp(() async {
+      toolArgs = null;
+      project = TestsProject();
+      await project.setUpIn(tempDir);
+    });
+
+    standardTests();
+  });
+
+  group('integration tests', () {
+    setUp(() async {
+      toolArgs = <String>['-d', 'flutter-tester'];
+      project = IntegrationTestsProject();
+      await project.setUpIn(tempDir);
+    });
+
+    standardTests();
   });
 }
 
@@ -137,8 +155,9 @@ final List<Object> _testsProjectExpectedOutput = <Object>[
 void _expectStandardTestsProjectResults(TestEvents events) {
   // Check we received all expected test events passed through from
   // package:test.
-  final List<Object> eventNames =
-      events.testNotifications.map((Map<String, Object?> e) => e['type']!).toList();
+  final List<Object> eventNames = events.testNotifications
+      .map((Map<String, Object?> e) => e['type']!)
+      .toList();
 
   // start/done should always be first/last.
   expect(eventNames.first, equals('start'));

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_server.dart
@@ -36,6 +36,7 @@ class InProcessDapTestServer extends DapTestServer {
       // Simulate flags based on the args to aid testing.
       enableDds: !args.contains('--no-dds'),
       ipv6: args.contains('--ipv6'),
+      test: args.contains('--test'),
     );
   }
 

--- a/packages/flutter_tools/test/integration.shard/test_data/integration_tests_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/integration_tests_project.dart
@@ -1,0 +1,68 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+
+import '../test_utils.dart';
+import 'project.dart';
+import 'tests_project.dart';
+
+class IntegrationTestsProject extends Project implements TestsProject {
+  @override
+  final String pubspec = '''
+  name: test
+  environment:
+    sdk: '>=2.12.0-0 <3.0.0'
+
+  dependencies:
+    flutter:
+      sdk: flutter
+
+  dev_dependencies:
+    integration_test:
+      sdk: flutter
+    flutter_test:
+      sdk: flutter
+  ''';
+
+  @override
+  String get main => '// Unused';
+
+  @override
+  final String testContent = r'''
+  import 'package:flutter_test/flutter_test.dart';
+  import 'package:integration_test/integration_test.dart';
+
+  void main() {
+    group('Flutter tests', () {
+      testWidgets('can pass', (WidgetTester tester) async {
+        expect(true, isTrue); // BREAKPOINT
+      });
+      testWidgets('can fail', (WidgetTester tester) async {
+        expect(true, isFalse);
+      });
+    });
+  }
+  ''';
+
+  @override
+  Future<void> setUpIn(Directory dir) {
+    this.dir = dir;
+    writeFile(testFilePath, testContent);
+    return super.setUpIn(dir);
+  }
+
+  @override
+  String get testFilePath => fileSystem.path.join(dir.path, 'integration_test', 'app_test.dart');
+
+  @override
+  Uri get breakpointUri => throw UnimplementedError();
+
+  @override
+  Uri get breakpointAppUri => throw UnimplementedError();
+
+  @override
+  int get breakpointLine => throw UnimplementedError();
+}


### PR DESCRIPTION
These adapters were incorrectly trying to connect a DDS instance even when Flutter would create its own, which caused issues when running integration tests through the test DAP. This change disables DDS in the DAP layer and leaves it to Flutter (although it will pass along `--no-dds` to Flutter if provided to the DAP process to allow it to still be disabled there if required) + adds explicit tests for integration tests (that require this change to pass).

Also fixes an issue where we would unnecessarily connect the VM Service for tests even in 'noDebug' mode because the assumption that 'vmServiceUri' would be `null` in the `test.startedProcess` event when not using `--start-paused` is no longer correct.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
