### PR TITLE
Fix Cupertino route long animation on back gesture

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -740,7 +740,7 @@ class _CupertinoBackGestureController<T> {
     //
     // This curve has been determined through rigorously eyeballing native iOS
     // animations.
-    const Curve animationCurve = Curves.easeOut;
+    const Curve animationCurve = Cubic(0.2, 1.0, 0.75, 1.0);
     final bool animateForward;
 
     // If the user releases the page before mid screen with sufficient velocity,

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -19,7 +19,7 @@ const double _kMinFlingVelocity = 1.0; // Screen widths per second.
 
 // An eyeballed value for the maximum time it takes for a page to animate forward
 // if the user releases a page mid swipe.
-const int _kMaxDroppedSwipePageForwardAnimationTime = 800; // Milliseconds.
+const int _kMaxDroppedSwipePageForwardAnimationTime = 300; // Milliseconds.
 
 // The maximum time for a page to get reset to it's original position if the
 // user releases a page mid swipe.
@@ -740,7 +740,7 @@ class _CupertinoBackGestureController<T> {
     //
     // This curve has been determined through rigorously eyeballing native iOS
     // animations.
-    const Curve animationCurve = Curves.fastLinearToSlowEaseIn;
+    const Curve animationCurve = Curves.easeOut;
     final bool animateForward;
 
     // If the user releases the page before mid screen with sufficient velocity,


### PR DESCRIPTION
Screen is not clickable for some time after swiping back. (~300-600ms)

Issue #92978

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

