### PR TITLE
Support string compileSdkVersion for preview android SDKs

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -458,7 +458,10 @@ class FlutterPlugin implements Plugin<Project> {
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
         project.afterEvaluate {
-            int projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
+            int projectCompileSdkVersion = Integer.MAX_VALUE // Default to zero if using a preview version as all plugins must be using a lower API version
+            if (project.android.compileSdkVersion.substring(8).isInteger()) {
+                projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
+            }
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -461,7 +461,7 @@ class FlutterPlugin implements Plugin<Project> {
             int projectCompileSdkVersion = Integer.MAX_VALUE // Default to int max if using a preview version to skip the sdk check.
             if (project.android.compileSdkVersion.substring(8).isInteger()) { // Stable versions use ints, legacy preview uses string.
                 projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
-            }gi
+            }
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -458,10 +458,10 @@ class FlutterPlugin implements Plugin<Project> {
     /** Prints error message and fix for any plugin compileSdkVersion or ndkVersion that are higher than the project. */
     private void detectLowCompileSdkVersionOrNdkVersion() {
         project.afterEvaluate {
-            int projectCompileSdkVersion = Integer.MAX_VALUE // Default to zero if using a preview version as all plugins must be using a lower API version
-            if (project.android.compileSdkVersion.substring(8).isInteger()) {
+            int projectCompileSdkVersion = Integer.MAX_VALUE // Default to int max if using a preview version to skip the sdk check.
+            if (project.android.compileSdkVersion.substring(8).isInteger()) { // Stable versions use ints, legacy preview uses string.
                 projectCompileSdkVersion = project.android.compileSdkVersion.substring(8) as int
-            }
+            }gi
             int maxPluginCompileSdkVersion = projectCompileSdkVersion
             String ndkVersionIfUnspecified = "21.1.6352462" /* The default for AGP 4.1.0 used in old templates. */
             String projectNdkVersion = project.android.ndkVersion ?: ndkVersionIfUnspecified

--- a/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
@@ -88,10 +88,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.buildtest"
-        // You can update the following values to match your application needs.
-        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
@@ -100,8 +97,6 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
     }

--- a/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 
@@ -117,8 +116,7 @@ dependencies {
         'apk',
         '--debug',
       ], workingDirectory: exampleAppDir.path);
-      print(result.stdout);
-      print(result.stderr);
+      expect(result.stdout, contains('Built build/app/outputs/flutter-apk/app-debug.apk.'));
       expect(exampleAppDir.childDirectory('build')
         .childDirectory('app')
         .childDirectory('outputs')

--- a/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
@@ -1,0 +1,135 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Directory tempDir;
+  late String flutterBin;
+  late Directory exampleAppDir;
+
+  setUp(() async {
+    tempDir = createResolvedTempDirectorySync('flutter_plugin_test.');
+    flutterBin = fileSystem.path.join(
+      getFlutterRoot(),
+      'bin',
+      'flutter',
+    );
+    exampleAppDir = tempDir.childDirectory('aaa').childDirectory('example');
+
+    processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'create',
+      '--template=plugin',
+      '--platforms=android',
+      'aaa',
+    ], workingDirectory: tempDir.path);
+  });
+
+  tearDown(() async {
+    tryToDelete(tempDir);
+  });
+
+  test(
+    'build succeeds targeting string compileSdkVersion',
+    () async {
+      final File buildGradleFile = exampleAppDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
+      // write a build.gradle with compileSdkVersion as `Tiramisu` which is a string preview version
+      buildGradleFile.writeAsStringSync(r'''
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file('local.properties')
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
+def flutterRoot = localProperties.getProperty('flutter.sdk')
+if (flutterRoot == null) {
+    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+}
+
+def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+if (flutterVersionCode == null) {
+    flutterVersionCode = '1'
+}
+
+def flutterVersionName = localProperties.getProperty('flutter.versionName')
+if (flutterVersionName == null) {
+    flutterVersionName = '1.0'
+}
+
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+
+android {
+    compileSdkVersion "android-Tiramisu"
+    ndkVersion flutter.ndkVersion
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+
+    defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId "com.example.buildtest"
+        // You can update the following values to match your application needs.
+        // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-build-configuration.
+        minSdkVersion flutter.minSdkVersion
+        targetSdkVersion flutter.targetSdkVersion
+        versionCode flutterVersionCode.toInteger()
+        versionName flutterVersionName
+    }
+
+    buildTypes {
+        release {
+            // TODO: Add your own signing config for the release build.
+            // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig signingConfigs.debug
+        }
+    }
+}
+
+flutter {
+    source '../..'
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}
+''', flush: true);
+      final ProcessResult result = await processManager.run(<String>[
+        flutterBin,
+        ...getLocalEngineArguments(),
+        'build',
+        'apk',
+        '--debug',
+      ], workingDirectory: exampleAppDir.path);
+      print(result.stdout);
+      print(result.stderr);
+      expect(exampleAppDir.childDirectory('build')
+        .childDirectory('app')
+        .childDirectory('outputs')
+        .childDirectory('apk')
+        .childDirectory('debug')
+        .childFile('app-debug.apk').existsSync(), true);
+    },
+  );
+}

--- a/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_preview_sdk.dart
@@ -41,7 +41,10 @@ void main() {
     () async {
       final File buildGradleFile = exampleAppDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
       // write a build.gradle with compileSdkVersion as `android-Tiramisu` which is a string preview version
-      buildGradleFile.writeAsStringSync(buildGradleFile.readAsStringSync().replaceFirst('compileSdkVersion flutter.compileSdkVersion', 'compileSdkVersion "android-Tiramisu"'), flush: true);
+      buildGradleFile.writeAsStringSync(
+        buildGradleFile.readAsStringSync().replaceFirst('compileSdkVersion flutter.compileSdkVersion', 'compileSdkVersion "android-Tiramisu"'),
+        flush: true
+      );
       expect(buildGradleFile.readAsStringSync(), contains('compileSdkVersion "android-Tiramisu"'));
 
       final ProcessResult result = await processManager.run(<String>[
@@ -66,7 +69,10 @@ void main() {
     () async {
       final File buildGradleFile = exampleAppDir.childDirectory('android').childDirectory('app').childFile('build.gradle');
       // write a build.gradle with compileSdkPreview as `Tiramisu` which is a string preview version
-      buildGradleFile.writeAsStringSync(buildGradleFile.readAsStringSync().replaceFirst('compileSdkVersion flutter.compileSdkVersion', 'compileSdkPreview "Tiramisu"'), flush: true);
+      buildGradleFile.writeAsStringSync(
+        buildGradleFile.readAsStringSync().replaceFirst('compileSdkVersion flutter.compileSdkVersion', 'compileSdkPreview "Tiramisu"'),
+        flush: true
+      );
       expect(buildGradleFile.readAsStringSync(), contains('compileSdkPreview "Tiramisu"'));
 
       final ProcessResult result = await processManager.run(<String>[


### PR DESCRIPTION
Resolves https://github.com/flutter/flutter/issues/104170

Loosely based off of https://github.com/flutter/flutter/pull/104172 but a little less strict due to gradle being able to capture invalid values. Still goes through the ndk check while sdk check will always pass.