### PR TITLE
Restore Shortcuts.of and Shortcuts.maybeOf

### DIFF
--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -886,6 +886,52 @@ class Shortcuts extends StatefulWidget {
   /// unnecessarily with large default shortcut maps.
   final String? debugLabel;
 
+  /// Returns the [ShortcutManager] that most tightly encloses the given
+  /// [BuildContext].
+  ///
+  /// If no [Shortcuts] widget encloses the context given, will assert in debug
+  /// mode and throw an exception in release mode.
+  ///
+  /// See also:
+  ///
+  ///  * [maybeOf], which is similar to this function, but will return null if
+  ///    it doesn't find a [Shortcuts] ancestor.
+  static ShortcutManager of(BuildContext context) {
+    assert(context != null);
+    final _ShortcutsMarker? inherited = context.dependOnInheritedWidgetOfExactType<_ShortcutsMarker>();
+    assert(() {
+      if (inherited == null) {
+        throw FlutterError(
+          'Unable to find a $Shortcuts widget in the context.\n'
+              '$Shortcuts.of() was called with a context that does not contain a '
+              '$Shortcuts widget.\n'
+              'No $Shortcuts ancestor could be found starting from the context that was '
+              'passed to $Shortcuts.of().\n'
+              'The context used was:\n'
+              '  $context',
+        );
+      }
+      return true;
+    }());
+    return inherited!.manager;
+  }
+
+  /// Returns the [ShortcutManager] that most tightly encloses the given
+  /// [BuildContext].
+  ///
+  /// If no [Shortcuts] widget encloses the context given, will return null.
+  ///
+  /// See also:
+  ///
+  ///  * [of], which is similar to this function, but returns a non-nullable
+  ///    result, and will throw an exception if it doesn't find a [Shortcuts]
+  ///    ancestor.
+  static ShortcutManager? maybeOf(BuildContext context) {
+    assert(context != null);
+    final _ShortcutsMarker? inherited = context.dependOnInheritedWidgetOfExactType<_ShortcutsMarker>();
+    return inherited?.manager;
+  }
+
   @override
   State<Shortcuts> createState() => _ShortcutsState();
 

--- a/packages/flutter/lib/src/widgets/shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/shortcuts.dart
@@ -650,6 +650,7 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   ShortcutManager({
     Map<ShortcutActivator, Intent> shortcuts = const <ShortcutActivator, Intent>{},
     this.modal = false,
+    this.locked = false,
   })  : assert(shortcuts != null),
         _shortcuts = shortcuts;
 
@@ -666,6 +667,13 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   /// [KeyEventResult.ignored].
   final bool modal;
 
+  /// If this [ShortcutManager] was created by a [Shortcuts] widget, then the
+  /// list of shortcuts will be locked, and can't be changed.
+  ///
+  /// If the [shortcuts] setter is called when the manager is locked, it will
+  /// assert in debug mode.
+  final bool locked;
+
   /// Returns the shortcut map.
   ///
   /// When the map is changed, listeners to this manager will be notified.
@@ -675,7 +683,15 @@ class ShortcutManager with Diagnosticable, ChangeNotifier {
   Map<ShortcutActivator, Intent> _shortcuts = <ShortcutActivator, Intent>{};
   set shortcuts(Map<ShortcutActivator, Intent> value) {
     assert(value != null);
-    if (!mapEquals<ShortcutActivator, Intent>(_shortcuts, value)) {
+    assert(!locked, 'This $ShortcutManager is locked, meaning that it was probably '
+        'created by a Shortcuts widget, instead of being passed in to Shortcuts.manager, '
+        'and the shortcuts cannot be modified. If you want to check a manager to see its '
+        'locked status, check ShortcutManager.locked');
+    _setShortcuts(value);
+  }
+
+  void _setShortcuts(Map<ShortcutActivator, Intent> value) {
+      if (!mapEquals<ShortcutActivator, Intent>(_shortcuts, value)) {
       _shortcuts = value;
       _indexedShortcutsCache = null;
       notifyListeners();
@@ -859,7 +875,7 @@ class Shortcuts extends StatefulWidget {
   /// If this widget was created with [Shortcuts.manager], then
   /// [ShortcutManager.shortcuts] will be used as the source for shortcuts. If
   /// the unnamed constructor is used, this manager will be null, and a
-  /// default-constructed `ShortcutsManager` will be used.
+  /// default-constructed [ShortcutManager] will be used.
   final ShortcutManager? manager;
 
   /// {@template flutter.widgets.shortcuts.shortcuts}
@@ -957,8 +973,8 @@ class _ShortcutsState extends State<Shortcuts> {
   void initState() {
     super.initState();
     if (widget.manager == null) {
-      _internalManager = ShortcutManager();
-      _internalManager!.shortcuts = widget.shortcuts;
+      _internalManager = ShortcutManager(locked: true);
+      _internalManager!._setShortcuts(widget.shortcuts);
     }
   }
 
@@ -973,7 +989,7 @@ class _ShortcutsState extends State<Shortcuts> {
         _internalManager ??= ShortcutManager();
       }
     }
-    _internalManager?.shortcuts = widget.shortcuts;
+    _internalManager?._setShortcuts(widget.shortcuts);
   }
 
   KeyEventResult _handleOnKey(FocusNode node, RawKeyEvent event) {
@@ -1340,7 +1356,7 @@ class ShortcutRegistrar extends StatefulWidget {
 
 class _ShortcutRegistrarState extends State<ShortcutRegistrar> {
   final ShortcutRegistry registry = ShortcutRegistry();
-  final ShortcutManager manager = ShortcutManager();
+  final ShortcutManager manager = ShortcutManager(locked: true);
 
   @override
   void initState() {
@@ -1351,7 +1367,7 @@ class _ShortcutRegistrarState extends State<ShortcutRegistrar> {
   void _shortcutsChanged() {
     // This shouldn't need to update the widget, and avoids calling setState
     // during build phase.
-    manager.shortcuts = registry.shortcuts;
+    manager._setShortcuts(registry.shortcuts);
   }
 
   @override

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -558,6 +558,28 @@ void main() {
       expect(shortcuts.shortcuts, isNotNull);
       expect(shortcuts.shortcuts, equals(testShortcuts));
     });
+    testWidgets('Shortcuts.of and maybeOf find ShortcutManager', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      final TestShortcutManager testManager = TestShortcutManager(
+        pressedKeys,
+        shortcuts: <LogicalKeySet, Intent>{
+          LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
+        },
+      );      await tester.pumpWidget(
+        Shortcuts.manager(
+          manager: testManager,
+          child: Focus(
+            autofocus: true,
+            child: SizedBox(key: containerKey, width: 100, height: 100),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.maybeOf(containerKey.currentContext!), isNotNull);
+      expect(Shortcuts.maybeOf(containerKey.currentContext!), equals(testManager));
+      expect(Shortcuts.of(containerKey.currentContext!), equals(testManager));
+    });
     testWidgets('ShortcutManager handles shortcuts', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -580,6 +580,25 @@ void main() {
       expect(Shortcuts.maybeOf(containerKey.currentContext!), equals(testManager));
       expect(Shortcuts.of(containerKey.currentContext!), equals(testManager));
     });
+    testWidgets('Locked ShortcutManager asserts if shortcuts are modified', (WidgetTester tester) async {
+      final GlobalKey containerKey = GlobalKey();
+      final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];
+      await tester.pumpWidget(
+        Shortcuts(
+          shortcuts: <LogicalKeySet, Intent>{
+            LogicalKeySet(LogicalKeyboardKey.shift): const TestIntent(),
+          },
+          child: Focus(
+            autofocus: true,
+            child: SizedBox(key: containerKey, width: 100, height: 100),
+          ),
+        ),
+      );
+      await tester.pump();
+      expect(Shortcuts.maybeOf(containerKey.currentContext!), isNotNull);
+      expect(Shortcuts.of(containerKey.currentContext!).locked, isTrue);
+      expect(() => Shortcuts.of(containerKey.currentContext!).shortcuts = <LogicalKeySet, Intent>{}, throwsAssertionError);
+    });
     testWidgets('ShortcutManager handles shortcuts', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final List<LogicalKeyboardKey> pressedKeys = <LogicalKeyboardKey>[];


### PR DESCRIPTION
## Description

It turns out some people were [actually using this](https://github.com/superlistapp/super_editor/blob/main/super_editor/lib/src/default_editor/document_input_ime.dart#L358).  We removed it because we thought the API was poor enough that nobody would be using it, but I guess it's useful for something.

The reason we removed it was because if you try and set the `shortcuts` on the manager your retrieve this way, you definitely won't get what you expect: it will be overwritten on the next rebuild of the `Shortcuts` widget you attached it to. Also, we wanted to eliminate a bunch of `InheritedWidget`s from the tree, because they have a RAM cost.

However, looking up the manager and calling `handleKeyEvent` on it so that you can change the handling order of shortcut key events is a use case we hadn't considered, and since there's not really a good alternative way to do that, I'm going to add these back in.

## Tests
 - Reinstated tests to check for `of` and `maybeOf` functionality.