### PR TITLE
Fixes a bug when dragging selection handle sends events in wrong coor…

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -984,7 +984,7 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
   /// Gets the list of selectables this delegate is managing.
   List<Selectable> selectables = <Selectable>[];
 
-  /// The amount of additional pixel added to the selection handle drawable
+  /// The number of additional pixels added to the selection handle drawable
   /// area.
   ///
   /// Selection handles that are outside of the drawable area will be hidden.
@@ -1318,12 +1318,9 @@ abstract class MultiSelectableSelectionContainerDelegate extends SelectionContai
     LayerLink? effectiveStartHandle = _startHandleLayer;
     LayerLink? effectiveEndHandle = _endHandleLayer;
     if (effectiveStartHandle != null || effectiveEndHandle != null) {
-      final Rect drawableArea = Rect.fromLTWH(
-        0 - _kSelectionHandleDrawableAreaPadding,
-        0 - _kSelectionHandleDrawableAreaPadding,
-        containerSize.width + 2 * _kSelectionHandleDrawableAreaPadding,
-        containerSize.height + 2 * _kSelectionHandleDrawableAreaPadding,
-      );
+      final Rect drawableArea = Rect
+        .fromLTWH(0, 0, containerSize.width, containerSize.height)
+        .inflate(_kSelectionHandleDrawableAreaPadding);
       final bool hideStartHandle = value.startSelectionPoint == null || !drawableArea.contains(value.startSelectionPoint!.localPosition);
       final bool hideEndHandle = value.endSelectionPoint == null || !drawableArea.contains(value.endSelectionPoint!.localPosition);
       effectiveStartHandle = hideStartHandle ? null : _startHandleLayer;

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -71,6 +71,34 @@ void main() {
       await gesture.up();
     }, skip: kIsWeb); // https://github.com/flutter/flutter/issues/102410.
 
+    testWidgets('can draw handles when they are at rect boundaries', (WidgetTester tester) async {
+      final UniqueKey spy = UniqueKey();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Column(
+            children: <Widget>[
+              const Text('How are you?'),
+              SelectableRegion(
+                focusNode: FocusNode(),
+                selectionControls: materialTextSelectionControls,
+                child: SelectAllWidget(key: spy, child: const SizedBox(width: 100, height: 100)),
+              ),
+              const Text('Fine, thank you.'),
+            ],
+          ),
+        ),
+      );
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(spy))); // at the 'a'
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pump();
+
+      final RenderSelectAll renderSpy = tester.renderObject<RenderSelectAll>(find.byKey(spy));
+      expect(renderSpy.startHandle, isNotNull);
+      expect(renderSpy.endHandle, isNotNull);
+    });
+
     testWidgets('touch does not accept drag', (WidgetTester tester) async {
       final UniqueKey spy = UniqueKey();
       await tester.pumpWidget(
@@ -739,44 +767,73 @@ void main() {
       await gesture.up();
     });
 
-    testWidgets('can drag end selection handle', (WidgetTester tester) async {
+    testWidgets('can drag end handle when not covering entire screen', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/104620.
       await tester.pumpWidget(
         MaterialApp(
-          home: SelectableRegion(
-            focusNode: FocusNode(),
-            selectionControls: materialTextSelectionControls,
-            child: Column(
-              children: const <Widget>[
-                Text('How are you?'),
-                Text('Good, and you?'),
-                Text('Fine, thank you.'),
-              ],
-            ),
+          home: Column(
+            children: <Widget>[
+              const Text('How are you?'),
+              SelectableRegion(
+                focusNode: FocusNode(),
+                selectionControls: materialTextSelectionControls,
+                child: const Text('Good, and you?'),
+              ),
+              const Text('Fine, thank you.'),
+            ],
           ),
         ),
       );
-      final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
-      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 6)); // at the 'r'
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 7)); // at the 'a'
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();
       await tester.pump(const Duration(milliseconds: 500));
-      expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
-      final List<TextBox> boxes = paragraph1.getBoxesForSelection(paragraph1.selections[0]);
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 6, extentOffset: 9));
+      final List<TextBox> boxes = paragraph2.getBoxesForSelection(paragraph2.selections[0]);
       expect(boxes.length, 1);
 
-      final Offset handlePos = globalize(boxes[0].toRect().bottomRight, paragraph1);
+      final Offset handlePos = globalize(boxes[0].toRect().bottomRight, paragraph2);
       await gesture.down(handlePos);
-      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
-      await gesture.moveTo(textOffsetToPosition(paragraph2, 5) + Offset(0, paragraph2.size.height / 2));
-      expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 12));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 5));
 
-      final RenderParagraph paragraph3 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Fine, thank you.'), matching: find.byType(RichText)));
-      await gesture.moveTo(textOffsetToPosition(paragraph3, 6) + Offset(0, paragraph3.size.height / 2));
-      expect(paragraph1.selections[0], const TextSelection(baseOffset: 4, extentOffset: 12));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 14));
-      expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 11) + Offset(0, paragraph2.size.height / 2));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 6, extentOffset: 11));
+      await gesture.up();
+    });
+
+    testWidgets('can drag start handle when not covering entire screen', (WidgetTester tester) async {
+      // Regression test for https://github.com/flutter/flutter/issues/104620.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Column(
+            children: <Widget>[
+              const Text('How are you?'),
+              SelectableRegion(
+                focusNode: FocusNode(),
+                selectionControls: materialTextSelectionControls,
+                child: const Text('Good, and you?'),
+              ),
+              const Text('Fine, thank you.'),
+            ],
+          ),
+        ),
+      );
+      final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+      final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 7)); // at the 'a'
+      addTearDown(gesture.removePointer);
+      await tester.pump(const Duration(milliseconds: 500));
+      await gesture.up();
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 6, extentOffset: 9));
+      final List<TextBox> boxes = paragraph2.getBoxesForSelection(paragraph2.selections[0]);
+      expect(boxes.length, 1);
+
+      final Offset handlePos = globalize(boxes[0].toRect().bottomLeft, paragraph2);
+      await gesture.down(handlePos);
+
+      await gesture.moveTo(textOffsetToPosition(paragraph2, 11) + Offset(0, paragraph2.size.height / 2));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 11, extentOffset: 9));
       await gesture.up();
     });
 
@@ -971,7 +1028,7 @@ void main() {
 
 class SelectionSpy extends LeafRenderObjectWidget {
   const SelectionSpy({
-  super.key,
+    super.key,
   });
 
   @override
@@ -1040,4 +1097,95 @@ class RenderSelectionSpy extends RenderProxyBox
 
   @override
   void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) { }
+}
+
+class SelectAllWidget extends SingleChildRenderObjectWidget {
+  const SelectAllWidget({
+    super.key,
+    super.child,
+  });
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return RenderSelectAll(
+      SelectionContainer.maybeOf(context),
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant RenderObject renderObject) { }
+}
+
+class RenderSelectAll extends RenderProxyBox
+    with Selectable, SelectionRegistrant {
+  RenderSelectAll(
+    SelectionRegistrar? registrar,
+  ) {
+    this.registrar = registrar;
+  }
+
+  final Set<VoidCallback> listeners = <VoidCallback>{};
+  LayerLink? startHandle;
+  LayerLink? endHandle;
+
+  @override
+  void addListener(VoidCallback listener) => listeners.add(listener);
+
+  @override
+  void removeListener(VoidCallback listener) => listeners.remove(listener);
+
+  @override
+  SelectionResult dispatchSelectionEvent(SelectionEvent event) {
+    value = SelectionGeometry(
+      hasContent: true,
+      status: SelectionStatus.uncollapsed,
+      startSelectionPoint: SelectionPoint(
+        localPosition: Offset(0, size.height),
+        lineHeight: 0.0,
+        handleType: TextSelectionHandleType.left,
+      ),
+      endSelectionPoint: SelectionPoint(
+        localPosition: Offset(size.width, size.height),
+        lineHeight: 0.0,
+        handleType: TextSelectionHandleType.left,
+      ),
+    );
+    return SelectionResult.end;
+  }
+
+  @override
+  SelectedContent? getSelectedContent() {
+    return const SelectedContent(plainText: 'content');
+  }
+
+  @override
+  SelectionGeometry get value => _value;
+  SelectionGeometry _value = SelectionGeometry(
+    hasContent: true,
+    status: SelectionStatus.uncollapsed,
+    startSelectionPoint: const SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+    endSelectionPoint: const SelectionPoint(
+      localPosition: Offset.zero,
+      lineHeight: 0.0,
+      handleType: TextSelectionHandleType.left,
+    ),
+  );
+  set value(SelectionGeometry other) {
+    if (other == _value)
+      return;
+    _value = other;
+    for (final VoidCallback callback in listeners) {
+      callback();
+    }
+  }
+
+  @override
+  void pushHandleLayers(LayerLink? startHandle, LayerLink? endHandle) {
+    this.startHandle = startHandle;
+    this.endHandle = endHandle;
+  }
 }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -88,7 +88,7 @@ void main() {
           ),
         ),
       );
-      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(spy))); // at the 'a'
+      final TestGesture gesture = await tester.startGesture(tester.getCenter(find.byKey(spy)));
       addTearDown(gesture.removePointer);
       await tester.pump(const Duration(milliseconds: 500));
       await gesture.up();


### PR DESCRIPTION
…dinates system

fixes https://github.com/flutter/flutter/issues/104620

This pr fixes two issue:
1. select handle drag use wrong coordinates
2. select handles at the rect boundary were hidden by selection container.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
