### PR TITLE
[tool][web] Fix flutter.js in Safari 13

### DIFF
--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -27,14 +27,23 @@ _flutter.loader = null;
 (function() {
   "use strict";
   class FlutterLoader {
-    // TODO: Move the below methods to "#private" once supported by all the browsers
-    // we support. In the meantime, we use the "revealing module" pattern.
+    /**
+     * Creates a FlutterLoader, and initializes its instance methods.
+     */
+    constructor() {
+      // TODO: Move the below methods to "#private" once supported by all the browsers
+      // we support. In the meantime, we use the "revealing module" pattern.
 
-    // Watchdog to prevent injecting the main entrypoint multiple times.
-    _scriptLoaded = null;
+      // Watchdog to prevent injecting the main entrypoint multiple times.
+      this._scriptLoaded = null;
 
-    // Resolver for the pending promise returned by loadEntrypoint.
-    _didCreateEngineInitializerResolve = null;
+      // Resolver for the pending promise returned by loadEntrypoint.
+      this._didCreateEngineInitializerResolve = null;
+
+      // Called by Flutter web.
+      // Bound to `this` now, so "this" is preserved across JS <-> Flutter jumps.
+      this.didCreateEngineInitializer = this._didCreateEngineInitializer.bind(this);
+    }
 
     /**
      * Initializes the main.dart.js with/without serviceWorker.
@@ -51,19 +60,19 @@ _flutter.loader = null;
     }
 
     /**
-     * Resolves the promise created by loadEntrypoint. Called by Flutter.
-     * Needs to be weirdly bound like it is, so "this" is preserved across
-     * the JS <-> Flutter jumps.
+     * Resolves the promise created by loadEntrypoint.
+     * Called by Flutter through the public `didCreateEngineInitializer` method,
+     * which is bound to the correct instance of the FlutterLoader on the page.
      * @param {*} engineInitializer
      */
-    didCreateEngineInitializer = (function(engineInitializer) {
+    _didCreateEngineInitializer(engineInitializer) {
       if (typeof this._didCreateEngineInitializerResolve != "function") {
         console.warn("Do not call didCreateEngineInitializer by hand. Start with loadEntrypoint instead.");
       }
       this._didCreateEngineInitializerResolve(engineInitializer);
-      // Remove this method after it's done, so Flutter Web can hot restart.
+      // Remove the public method after it's done, so Flutter Web can hot restart.
       delete this.didCreateEngineInitializer;
-    }).bind(this);
+    }
 
     _loadEntrypoint(entrypointUrl) {
       if (!this._scriptLoaded) {
@@ -71,7 +80,11 @@ _flutter.loader = null;
           let scriptTag = document.createElement("script");
           scriptTag.src = entrypointUrl;
           scriptTag.type = "application/javascript";
-          this._didCreateEngineInitializerResolve = resolve; // Cache the resolve, so it can be called from Flutter.
+          // Cache the resolve, so it can be called from Flutter.
+          // Note: Flutter hot restart doesn't re-create this promise, so this
+          // can only be called once. Instead, we need to model this as a stream
+          // of `engineCreated` events coming from Flutter that are handled by JS.
+          this._didCreateEngineInitializerResolve = resolve;
           scriptTag.addEventListener("error", reject);
           document.body.append(scriptTag);
         });


### PR DESCRIPTION
The current version of `flutter.js` is using 'public class fields' ([docs](https://caniuse.com/mdn-javascript_classes_public_class_fields)) that weren't supported in Safari until v14.1.

This PR removes the public class field syntax, and uses instead a 'constructor' method to initialize public fields in the FlutterLoader class, which is more broadly supported ([docs](https://caniuse.com/mdn-javascript_classes_constructor)), importantly by Safari 13.

Fixes https://github.com/flutter/flutter/issues/104646

## Testing

Testing needs to be manual, because it's almost impossible to get Safari 13 on any updated device. An iOS simulator (or an old device) are required to use the affected browser.

This PR is now deployed here:

* https://dit-bootstrap-tests.web.app

Point Safari on an iOS Simulator on iOS 13 there to see that it loads. Compare with gallery.flutter.dev.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
