### PR TITLE
Use AppBar.systemOverlayStyle to style system navigation bar

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -879,7 +879,13 @@ class _AppBarState extends State<AppBar> {
     final SystemUiOverlayStyle style = brightness == Brightness.dark
       ? SystemUiOverlayStyle.light
       : SystemUiOverlayStyle.dark;
-    return style.copyWith(statusBarColor: backgroundColor);
+    // For backward compatibility, create an overlay style without system navigation bar settings.
+    return SystemUiOverlayStyle(
+      statusBarColor: backgroundColor,
+      statusBarBrightness: style.statusBarBrightness,
+      statusBarIconBrightness: style.statusBarIconBrightness,
+      systemStatusBarContrastEnforced: style.systemStatusBarContrastEnforced,
+    );
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -323,7 +323,10 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     }
 
     // If both are not null, the upper provides the status bar properties and the lower provides
-    // the system navigation bar properties.
+    // the system navigation bar properties. This is done for advanced use cases where a widget
+    // on the top (for instance an app bar) will create an annotated region to set the status bar
+    // style and another widget on the bottom will create an annotated region to set the system
+    // navigation bar style.
     if (upperOverlayStyle != null && lowerOverlayStyle != null) {
       final SystemUiOverlayStyle overlayStyle = SystemUiOverlayStyle(
         statusBarBrightness: upperOverlayStyle.statusBarBrightness,
@@ -338,8 +341,10 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
       SystemChrome.setSystemUIOverlayStyle(overlayStyle);
       return;
     }
-    // If only one of upper or bottom overlay style is not null, it provides all properties
-    // System navigation bar should be set only in Android.
+    // If only one of the upper or the lower overlay style is not null, it provides all properties.
+    // This is done for developer convenience as it allows setting both status bar style and
+    // navigation bar style using only one annotated region layer (for instance the one
+    // automatically created by an [AppBar]).
     final bool isAndroid = defaultTargetPlatform == TargetPlatform.android;
     final SystemUiOverlayStyle definedOverlayStyle = (upperOverlayStyle ?? lowerOverlayStyle)!;
     final SystemUiOverlayStyle overlayStyle = SystemUiOverlayStyle(

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -558,7 +558,8 @@ class SystemChrome {
   /// it can be hit-tested by the framework. On every frame, the framework will
   /// hit-test and select the annotated region it finds under the status and
   /// navigation bar and synthesize them into a single style. This can be used
-  /// to configure the system styles when an app bar is not used.
+  /// to configure the system styles when an app bar is not used. When an app
+  /// bar is used an annotated region is automatically created.
   ///
   /// {@tool sample}
   /// The following example creates a widget that changes the status bar color

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -559,7 +559,12 @@ class SystemChrome {
   /// hit-test and select the annotated region it finds under the status and
   /// navigation bar and synthesize them into a single style. This can be used
   /// to configure the system styles when an app bar is not used. When an app
-  /// bar is used an annotated region is automatically created.
+  /// bar is used, apps should not enclose the app bar in an annotated region
+  /// because one is automatically created. If an app bar is used and the app
+  /// bar is enclosed in an annotated region, the app bar overlay style supercedes
+  /// the status bar properties defined in the enclosing annotated region overlay
+  /// style and the enclosing annotated region overlay style supercedes the app bar
+  /// overlay style navigation bar properties.
   ///
   /// {@tool sample}
   /// The following example creates a widget that changes the status bar color

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2421,6 +2421,56 @@ void main() {
     }
   });
 
+  testWidgets('Default status bar color', (WidgetTester tester) async {
+    Future<void> pumpBoilerplate({required bool useMaterial3, required bool backwardsCompatibility}) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          key: GlobalKey(),
+          theme: ThemeData.light().copyWith(
+            useMaterial3: useMaterial3,
+            appBarTheme: AppBarTheme(
+              backwardsCompatibility: backwardsCompatibility,
+            ),
+          ),
+          home: Scaffold(
+            appBar: AppBar(
+              title: const Text('title'),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await pumpBoilerplate(useMaterial3: false, backwardsCompatibility: false);
+    expect(SystemChrome.latestStyle!.statusBarColor, null);
+    await pumpBoilerplate(useMaterial3: false, backwardsCompatibility: true);
+    expect(SystemChrome.latestStyle!.statusBarColor, null);
+    await pumpBoilerplate(useMaterial3: true, backwardsCompatibility: false);
+    expect(SystemChrome.latestStyle!.statusBarColor, Colors.transparent);
+    await pumpBoilerplate(useMaterial3: true, backwardsCompatibility: true);
+    expect(SystemChrome.latestStyle!.statusBarColor, null);
+  });
+
+  testWidgets('AppBar systemOverlayStyle is use to style status bar and navigation bar', (WidgetTester tester) async {
+    final SystemUiOverlayStyle systemOverlayStyle = SystemUiOverlayStyle.light.copyWith(
+      statusBarColor: Colors.red,
+      systemNavigationBarColor: Colors.green,
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text('test'),
+            systemOverlayStyle: systemOverlayStyle,
+          ),
+        ),
+      ),
+    );
+
+    expect(SystemChrome.latestStyle!.statusBarColor, Colors.red);
+    expect(SystemChrome.latestStyle!.systemNavigationBarColor, Colors.green);
+  });
+
   testWidgets('Changing SliverAppBar snap from true to false', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/17598
     const double appBarHeight = 256.0;

--- a/packages/flutter/test/rendering/view_chrome_style_test.dart
+++ b/packages/flutter/test/rendering/view_chrome_style_test.dart
@@ -228,6 +228,72 @@ void main() {
         variant: TargetPlatformVariant.only(TargetPlatform.android),
       );
     });
+
+    testWidgets('Top AnnotatedRegion provides status bar overlay style and bottom AnnotatedRegion provides navigation bar overlay style', (WidgetTester tester) async {
+      setupTestDevice();
+      await tester.pumpWidget(
+        Column(children: const <Widget>[
+          Expanded(child: AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              systemNavigationBarColor: Colors.blue,
+              statusBarColor: Colors.blue
+            ),
+            child: SizedBox.expand(),
+          )),
+          Expanded(child: AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              systemNavigationBarColor: Colors.green,
+              statusBarColor: Colors.green,
+            ),
+            child: SizedBox.expand(),
+          )),
+        ]),
+      );
+      await tester.pumpAndSettle();
+
+      expect(SystemChrome.latestStyle?.statusBarColor, Colors.blue);
+      expect(SystemChrome.latestStyle?.systemNavigationBarColor, Colors.green);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+    testWidgets('Top only AnnotatedRegion provides status bar and navigation bar style properties', (WidgetTester tester) async {
+      setupTestDevice();
+      await tester.pumpWidget(
+        Column(children: const <Widget>[
+          Expanded(child: AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              systemNavigationBarColor: Colors.blue,
+              statusBarColor: Colors.blue
+            ),
+            child: SizedBox.expand(),
+          )),
+          Expanded(child: SizedBox.expand()),
+        ]),
+      );
+      await tester.pumpAndSettle();
+
+      expect(SystemChrome.latestStyle?.statusBarColor, Colors.blue);
+      expect(SystemChrome.latestStyle?.systemNavigationBarColor, Colors.blue);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+    testWidgets('Bottom only AnnotatedRegion provides status bar and navigation bar style properties', (WidgetTester tester) async {
+      setupTestDevice();
+      await tester.pumpWidget(
+        Column(children: const <Widget>[
+          Expanded(child: SizedBox.expand()),
+          Expanded(child: AnnotatedRegion<SystemUiOverlayStyle>(
+            value: SystemUiOverlayStyle(
+              systemNavigationBarColor: Colors.green,
+              statusBarColor: Colors.green
+            ),
+            child: SizedBox.expand(),
+          )),
+        ]),
+      );
+      await tester.pumpAndSettle();
+
+      expect(SystemChrome.latestStyle?.statusBarColor, Colors.green);
+      expect(SystemChrome.latestStyle?.systemNavigationBarColor, Colors.green);
+    }, variant: TargetPlatformVariant.only(TargetPlatform.android));
   });
 }
 


### PR DESCRIPTION
## Description

`AppBar.systemOverlayStyle` exposes properties to set system navigation bar style.
Those properties are not applied because the `AnnotatedRegion` created by an AppBar is on the top of the screen and RenderView does not use the annotated region on the top to style the system navigation bar.

To set the system navigation bar style, Flutter developers should create a second AnnotatedRegion on the bottom of the screen. This is not intuitive as system navigation properties are available when setting `AppBar.systemOverlayStyle` and this is not convenient, as explained [<ins>in this comment</ins>](https://github.com/flutter/flutter/issues/100027#issuecomment-1077697819).

This PR updates how `RenderView` creates a system overlay style.
Before, it looked up for a top annotated region to style the status bar and a bottom annotated region to style the system navigation bar.
After, if only one of the top or the bottom annotated region is found, it will be used to style the status bar and the system navigation bar. If both are found, it will work as before.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/104410

## Tests

Adds 1 test in material/app_bar_test.dart
Adds 3 tests in rendering/view_chrome_style_test.dart
