### PR TITLE
Hide `SelectableRegion` text selection toolbar when orientation changes

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -16,6 +16,7 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
+import 'media_query.dart';
 import 'overlay.dart';
 import 'selection_container.dart';
 import 'text_editing_intents.dart';
@@ -212,6 +213,8 @@ class _SelectableRegionState extends State<SelectableRegion> with TextSelectionD
   bool get _hasSelectionOverlayGeometry => _selectionDelegate.value.startSelectionPoint != null
                                         || _selectionDelegate.value.endSelectionPoint != null;
 
+  Orientation? _lastOrientation;
+
   @override
   void initState() {
     super.initState();
@@ -226,6 +229,33 @@ class _SelectableRegionState extends State<SelectableRegion> with TextSelectionD
         instance.onSecondaryTapDown = _handleRightClickDown;
       },
     );
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.iOS:
+        break;
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.linux:
+      case TargetPlatform.macOS:
+      case TargetPlatform.windows:
+        return;
+    }
+
+    // Hide the text selection toolbar on mobile when orientation changes.
+    final Orientation orientation = MediaQuery.of(context).orientation;
+    if (_lastOrientation == null) {
+      _lastOrientation = orientation;
+      return;
+    }
+    if (orientation != _lastOrientation) {
+      _lastOrientation = orientation;
+      hideToolbar(defaultTargetPlatform == TargetPlatform.android);
+    }
   }
 
   @override
@@ -699,7 +729,7 @@ class _SelectableRegionState extends State<SelectableRegion> with TextSelectionD
   void hideToolbar([bool hideHandles = true]) {
     _selectionOverlay?.hideToolbar();
     if (hideHandles) {
-      _selectionOverlay?.hideToolbar();
+      _selectionOverlay?.hideHandles();
     }
   }
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1044,7 +1044,7 @@ void main() {
     }, skip: kIsWeb); // [intended] Web uses its native context menu.
   });
 
-  testWidgets('toolbar hidden on mobile when orientation changes', (WidgetTester tester) async {
+  testWidgets('toolbar is hidden on mobile when orientation changes', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: SelectableRegion(


### PR DESCRIPTION
Hide the `SelectableRegion` text selection toolbar on Android and iOS when orientation changes by keeping track of the previous orientation in `didChangeDependencies`. Hide text selection handles as well on Android to match native project behavior.

This also fixes the wrong method call in `hideToolbar`.

Fixes https://github.com/flutter/flutter/issues/104816

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat