### PR TITLE
Fix plugin_ffi bindings regen command and bump ffigen

### DIFF
--- a/packages/flutter_tools/templates/plugin_ffi/ffigen.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/ffigen.yaml.tmpl
@@ -1,9 +1,9 @@
-# Run with `dart run ffigen --config ffigen.yaml`.
+# Run with `flutter pub run ffigen --config ffigen.yaml`.
 name: {{pluginDartClass}}Bindings
 description: |
   Bindings for `src/{{projectName}}.h`.
 
-  Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
+  Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
 output: 'lib/{{projectName}}_bindings_generated.dart'
 headers:
   entry-points:

--- a/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/lib/projectName_bindings_generated.dart.tmpl
@@ -9,7 +9,7 @@ import 'dart:ffi' as ffi;
 
 /// Bindings for `src/{{projectName}}.h`.
 ///
-/// Regenerate bindings with `dart run ffigen --config ffigen.yaml`.
+/// Regenerate bindings with `flutter pub run ffigen --config ffigen.yaml`.
 ///
 class {{pluginDartClass}}Bindings {
   /// Holds the symbol lookup function.
@@ -48,9 +48,9 @@ class {{pluginDartClass}}Bindings {
 
   /// A longer lived native function, which occupies the thread calling it.
   ///
-  /// Calling these kind of native functions in the main isolate will
-  /// block Dart execution and cause dropped frames in Flutter applications.
-  /// Consider calling such native functions from a separate isolate.
+  /// Do not call these kind of native functions in the main isolate. They will
+  /// block Dart execution. This will cause dropped frames in Flutter applications.
+  /// Instead, call these native functions on a separate isolate.
   int sum_long_running(
     int a,
     int b,

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -23,8 +23,8 @@ dependencies:
 
 dev_dependencies:
 {{#withFfiPluginHook}}
-  ffi: ^1.1.2
-  ffigen: ^4.1.2
+  ffi: ^1.2.1
+  ffigen: ^5.0.1
 {{/withFfiPluginHook}}
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Fix FFI plugin template:

* `dart run ffigen` -> `flutter pub run ffigen`
* Bump `package:ffigen` to include
  * https://github.com/dart-lang/ffigen/pull/389

Issues addressed:

* https://github.com/flutter/flutter/issues/104681

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
