### PR TITLE
Remove asset mocking for tests

### DIFF
--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -7,14 +7,11 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:path/path.dart' as path;
 // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart' as test_package;
 
 import 'binding.dart';
-import 'deprecated.dart';
 
 /// Ensure the appropriate test binding is initialized.
 TestWidgetsFlutterBinding ensureInitialized([@visibleForTesting Map<String, String>? environment]) {

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -30,43 +30,6 @@ void setupHttpOverrides() {
   HttpOverrides.global = _MockHttpOverrides();
 }
 
-/// Setup mocking of platform assets if `UNIT_TEST_ASSETS` is defined.
-void mockFlutterAssets() {
-  if (!Platform.environment.containsKey('UNIT_TEST_ASSETS')) {
-    return;
-  }
-  final String assetFolderPath = Platform.environment['UNIT_TEST_ASSETS']!;
-  assert(Platform.environment['APP_NAME'] != null);
-  final String prefix =  'packages/${Platform.environment['APP_NAME']!}/';
-
-  /// Navigation related actions (pop, push, replace) broadcasts these actions via
-  /// platform messages.
-  SystemChannels.navigation.setMockMethodCallHandler((MethodCall methodCall) async {});
-
-  ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
-    assert(message != null);
-    String key = utf8.decode(message!.buffer.asUint8List());
-    File asset = File(path.join(assetFolderPath, key));
-
-    if (!asset.existsSync()) {
-      // For tests in package, it will load assets with its own package prefix.
-      // In this case, we do a best-effort look up.
-      if (!key.startsWith(prefix)) {
-        return null;
-      }
-
-      key = key.replaceFirst(prefix, '');
-      asset = File(path.join(assetFolderPath, key));
-      if (!asset.existsSync()) {
-        return null;
-      }
-    }
-
-    final Uint8List encoded = Uint8List.fromList(asset.readAsBytesSync());
-    return Future<ByteData>.value(encoded.buffer.asByteData());
-  });
-}
-
 /// Provides a default [HttpClient] which always returns empty 400 responses.
 ///
 /// If another [HttpClient] is provided using [HttpOverrides.runZoned], that will

--- a/packages/flutter_test/lib/src/_binding_web.dart
+++ b/packages/flutter_test/lib/src/_binding_web.dart
@@ -13,6 +13,3 @@ TestWidgetsFlutterBinding ensureInitialized([@visibleForTesting Map<String, Stri
 
 /// This method is a noop on the web.
 void setupHttpOverrides() { }
-
-/// This method is a noop on the web.
-void mockFlutterAssets() { }

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -983,7 +983,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   void initInstances() {
     super.initInstances();
     _instance = this;
-    binding.mockFlutterAssets();
   }
 
   /// The current [AutomatedTestWidgetsFlutterBinding], if one has been created.


### PR DESCRIPTION
Now that we've fixed the tester's asset loading, we should be able to remove the mocked asset channel.

See also:  https://github.com/flutter/flutter/pull/103667
