### PR TITLE
[ci.yaml] Remove google testing postsubmit target

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4178,11 +4178,3 @@ targets:
         ["devicelab", "android", "windows"]
       task_name: windows_chrome_dev_mode
     scheduler: luci
-
-  - name: google_test
-    bringup: true
-    presubmit: false
-    scheduler: google_internal
-    properties:
-      tags: >
-          ["framework", "hostonly", "shard"]

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -257,4 +257,3 @@
 # skp_generator @Hixie
 # test_ownership @keyonghan
 # verify_binaries_codesigned @christopherfujino @flutter/releases
-# google_test @renyou


### PR DESCRIPTION
There's too many differences between the internal CI systems and LUCI. For the time being, this won't give a good signal as most commits break the internal tests in some way.

b/213452020

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
