### PR TITLE
Revert "Removing minor ios version value for device_os property"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -86,7 +86,7 @@ platform_properties:
         ]
       os: Mac-12
       cpu: x86
-      device_os: iOS-15
+      device_os: iOS-15.1
       xcode: 13a233
   mac_arm64_ios:
     properties:
@@ -98,7 +98,7 @@ platform_properties:
         ]
       os: Mac-12
       cpu: arm64
-      device_os: iOS-15
+      device_os: iOS-15.1
       xcode: 13a233
   windows:
     properties:


### PR DESCRIPTION
Reverts flutter/flutter#104835

Issue with incompatible xcode version and ios 15.5 is causing failures. 

https://github.com/flutter/flutter/issues/104852 should fix the issue. Reverting this so that we can test without fear of tree closures.