### PR TITLE
Remove destinations length hard limit in NavigationRail widget

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -68,7 +68,7 @@ import 'theme.dart';
 class NavigationRail extends StatefulWidget {
   /// Creates a Material Design navigation rail.
   ///
-  /// The value of [destinations] must be a list of two or more
+  /// The value of [destinations] must be a list of zero or more
   /// [NavigationRailDestination] values.
   ///
   /// If [elevation] is specified, it must be non-negative.
@@ -164,7 +164,7 @@ class NavigationRail extends StatefulWidget {
   /// Defines the appearance of the button items that are arrayed within the
   /// navigation rail.
   ///
-  /// The value must be a list of two or more [NavigationRailDestination]
+  /// The value must be a list of zero or more [NavigationRailDestination]
   /// values.
   final List<NavigationRailDestination> destinations;
 

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -108,7 +108,7 @@ class NavigationRail extends StatefulWidget {
     this.minExtendedWidth,
     this.useIndicator,
     this.indicatorColor,
-  }) :  assert(destinations != null && destinations.length >= 2),
+  }) :  assert(destinations != null && destinations.length >= 0),
         assert(selectedIndex == null || (0 <= selectedIndex && selectedIndex < destinations.length)),
         assert(elevation == null || elevation > 0),
         assert(minWidth == null || minWidth > 0),

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -170,7 +170,7 @@ void main() {
     );
 
     final RenderBox leading = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(0));
-    expect(leading.localToGlobal(Offset.zero), Offset((80 - leading.size.width) / 2, 8.0));
+    expect(leading.localToGlobal(Offset.zero), const Offset(0, 8.0));
   });
 
   testWidgets('Renders wider for a destination with a long label - [labelType]=all', (WidgetTester tester) async {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -158,7 +158,7 @@ void main() {
     final RenderBox renderBox = tester.renderObject(find.byType(NavigationRail));
     expect(renderBox.size.width, 80.0);
   });
-  
+
   testWidgets('No destinations', (WidgetTester tester) async {
     await _pumpNavigationRail(
       tester,

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -159,7 +159,7 @@ void main() {
     expect(renderBox.size.width, 80.0);
   });
 
-  testWidgets('No destinations', (WidgetTester tester) async {
+  testWidgets('Leading spacing is correct with 0 destinations', (WidgetTester tester) async {
     await _pumpNavigationRail(
       tester,
       navigationRail: NavigationRail(
@@ -2766,6 +2766,21 @@ void main() {
 
       final RenderBox renderBox = tester.renderObject(find.byType(NavigationRail));
       expect(renderBox.size.width, 72.0);
+    });
+
+    testWidgets('Leading spacing is correct with 0 destinations', (WidgetTester tester) async {
+      await _pumpNavigationRail(
+        tester,
+        useMaterial3: false,
+        navigationRail: NavigationRail(
+          selectedIndex: null,
+          leading: FloatingActionButton(onPressed: () { }),
+          destinations: const <NavigationRailDestination>[],
+        ),
+      );
+
+      final RenderBox leading = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(0));
+      expect(leading.localToGlobal(Offset.zero), const Offset(0, 8.0));
     });
 
     testWidgets('Destination spacing is correct - [labelType]=none (default), [textScaleFactor]=1.0 (default)', (WidgetTester tester) async {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -158,6 +158,20 @@ void main() {
     final RenderBox renderBox = tester.renderObject(find.byType(NavigationRail));
     expect(renderBox.size.width, 80.0);
   });
+  
+  testWidgets('No destinations', (WidgetTester tester) async {
+    await _pumpNavigationRail(
+      tester,
+      navigationRail: NavigationRail(
+        selectedIndex: null,
+        leading: FloatingActionButton(onPressed: () { }),
+        destinations: const <NavigationRailDestination>[],
+      ),
+    );
+
+    final RenderBox leading = tester.renderObject<RenderBox>(find.byType(FloatingActionButton).at(0));
+    expect(leading.localToGlobal(Offset.zero), Offset((80 - leading.size.width) / 2, 8.0));
+  });
 
   testWidgets('Renders wider for a destination with a long label - [labelType]=all', (WidgetTester tester) async {
     await _pumpNavigationRail(


### PR DESCRIPTION
Remove destinations length hard limit in NavigationRail.

- Resolve https://github.com/flutter/flutter/issues/58367
- Related https://github.com/flutter/flutter/issues/104913

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
