### PR TITLE
Implement 'reversed' parameter for Flex

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4464,9 +4464,6 @@ class Flex extends MultiChildRenderObjectWidget {
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
 
-  @override
-  List<Widget> get children => reversed ? super.children.reversed.toList() : super.children;
-
   bool get _needTextDirection {
     assert(direction != null);
     switch (direction) {

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -4360,6 +4360,7 @@ class Flex extends MultiChildRenderObjectWidget {
     this.textBaseline, // NO DEFAULT: we don't know what the text's baseline should be
     this.clipBehavior = Clip.none,
     super.children,
+    super.reversed,
   }) : assert(direction != null),
        assert(mainAxisAlignment != null),
        assert(mainAxisSize != null),
@@ -4462,6 +4463,9 @@ class Flex extends MultiChildRenderObjectWidget {
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;
+
+  @override
+  List<Widget> get children => reversed ? super.children.reversed.toList() : super.children;
 
   bool get _needTextDirection {
     assert(direction != null);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1807,7 +1807,7 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   ///
   /// The [children] argument must not be null and must not contain any null
   /// objects.
-  MultiChildRenderObjectWidget({ super.key, this.children = const <Widget>[] })
+  MultiChildRenderObjectWidget({ super.key, this.children = const <Widget>[], this.reversed = false })
     : assert(children != null) {
     assert(() {
       for (int index = 0; index < children.length; index++) {
@@ -1881,6 +1881,17 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   /// }
   /// ```
   final List<Widget> children;
+
+  // Each subwidget that want to use reversed needs to implement this for itself
+  // This could most likely be accomplished more conveniently.
+  // @override
+  // Widget get children => reversed ? super.children.reversed.toList() : super.children;
+
+  /// If the childrens order should be reversed. 
+  ///
+  /// This makes it possible to replicate the behavior of
+  /// `flex-direction: row-reverse` and `flex-direction: column-reverse` 
+  final bool reversed;
 
   @override
   MultiChildRenderObjectElement createElement() => MultiChildRenderObjectElement(this);

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1802,6 +1802,7 @@ abstract class SingleChildRenderObjectWidget extends RenderObjectWidget {
 ///  * [SlottedMultiChildRenderObjectWidgetMixin], which configures a
 ///    [RenderObject] that instead of having a single list of children organizes
 ///    its children in named slots.
+// ignore: must_be_immutable
 abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   /// Initializes fields for subclasses.
   ///
@@ -1821,6 +1822,8 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
       }
       return true;
     }()); // https://github.com/dart-lang/sdk/issues/29276
+
+    children = reversed ? children.reversed.toList() : children;
   }
 
   /// The widgets below this widget in the tree.
@@ -1880,12 +1883,7 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   ///   }
   /// }
   /// ```
-  final List<Widget> children;
-
-  // Each subwidget that want to use reversed needs to implement this for itself
-  // This could most likely be accomplished more conveniently.
-  // @override
-  // Widget get children => reversed ? super.children.reversed.toList() : super.children;
+  List<Widget> children;
 
   /// If the childrens order should be reversed.
   ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1802,7 +1802,6 @@ abstract class SingleChildRenderObjectWidget extends RenderObjectWidget {
 ///  * [SlottedMultiChildRenderObjectWidgetMixin], which configures a
 ///    [RenderObject] that instead of having a single list of children organizes
 ///    its children in named slots.
-
 abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   /// Initializes fields for subclasses.
   ///
@@ -1814,19 +1813,19 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
     this.reversed = false
     }): children = reversed ? children.reversed.toList() : children,
         assert(children != null) {
-        assert(() {
-          for (int index = 0; index < children.length; index++) {
-            // TODO(a14n): remove this check to have a lot more const widget
-            if (children[index] == null) {
-              throw FlutterError(
-                "$runtimeType's children must not contain any null values, "
-                'but a null value was found at index $index',
-              );
+          assert(() {
+            for (int index = 0; index < children.length; index++) {
+              // TODO(a14n): remove this check to have a lot more const widget
+              if (children[index] == null) {
+                throw FlutterError(
+                  "$runtimeType's children must not contain any null values, "
+                  'but a null value was found at index $index',
+                );
+              }
             }
-          }
-          return true;
-        }()); // https://github.com/dart-lang/sdk/issues/29276
-  }
+            return true;
+          }()); // https://github.com/dart-lang/sdk/issues/29276
+        }
 
   /// The widgets below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1802,28 +1802,30 @@ abstract class SingleChildRenderObjectWidget extends RenderObjectWidget {
 ///  * [SlottedMultiChildRenderObjectWidgetMixin], which configures a
 ///    [RenderObject] that instead of having a single list of children organizes
 ///    its children in named slots.
-// ignore: must_be_immutable
+
 abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   /// Initializes fields for subclasses.
   ///
   /// The [children] argument must not be null and must not contain any null
   /// objects.
-  MultiChildRenderObjectWidget({ super.key, this.children = const <Widget>[], this.reversed = false })
-    : assert(children != null) {
-    assert(() {
-      for (int index = 0; index < children.length; index++) {
-        // TODO(a14n): remove this check to have a lot more const widget
-        if (children[index] == null) {
-          throw FlutterError(
-            "$runtimeType's children must not contain any null values, "
-            'but a null value was found at index $index',
-          );
-        }
-      }
-      return true;
-    }()); // https://github.com/dart-lang/sdk/issues/29276
-
-    children = reversed ? children.reversed.toList() : children;
+  MultiChildRenderObjectWidget({
+    super.key,
+    List<Widget> children = const <Widget>[],
+    this.reversed = false
+    }): children = reversed ? children.reversed.toList() : children,
+        assert(children != null) {
+        assert(() {
+          for (int index = 0; index < children.length; index++) {
+            // TODO(a14n): remove this check to have a lot more const widget
+            if (children[index] == null) {
+              throw FlutterError(
+                "$runtimeType's children must not contain any null values, "
+                'but a null value was found at index $index',
+              );
+            }
+          }
+          return true;
+        }()); // https://github.com/dart-lang/sdk/issues/29276
   }
 
   /// The widgets below this widget in the tree.
@@ -1883,7 +1885,7 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   ///   }
   /// }
   /// ```
-  List<Widget> children;
+  final List<Widget> children;
 
   /// If the childrens order should be reversed.
   ///

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1887,10 +1887,10 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   // @override
   // Widget get children => reversed ? super.children.reversed.toList() : super.children;
 
-  /// If the childrens order should be reversed. 
+  /// If the childrens order should be reversed.
   ///
   /// This makes it possible to replicate the behavior of
-  /// `flex-direction: row-reverse` and `flex-direction: column-reverse` 
+  /// `flex-direction: row-reverse` and `flex-direction: column-reverse`
   final bool reversed;
 
   @override

--- a/packages/flutter/test/widgets/flex_test.dart
+++ b/packages/flutter/test/widgets/flex_test.dart
@@ -141,4 +141,37 @@ void main() {
     await tester.pumpWidget(Flex(direction: Axis.vertical, clipBehavior: Clip.antiAlias));
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
+
+  testWidgets('Successfully reverses children', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Flex(
+        direction: Axis.vertical,
+        reversed: true,
+        children: <Widget>[
+          Container(
+            key: const Key('FlexChildKey1'),
+          ),
+          Container(
+            key: const Key('FlexChildKey2'),
+          ),
+          Container(
+            key: const Key('FlexChildKey3'),
+          ),
+        ],
+      ),
+    );
+
+    // Get the elements with "FlexChildKey" in their key
+    final List<String> widgetOrderList = <String>[];
+    for (final Widget element in tester.allWidgets) {
+      if (element.key.toString().contains('FlexChildKey')) {
+        widgetOrderList.add(element.key.toString());
+      }
+    }
+
+    expect(
+      widgetOrderList,
+      equals(<String>["[<'FlexChildKey3'>]", "[<'FlexChildKey2'>]", "[<'FlexChildKey1'>]"])
+    );
+  });
 }


### PR DESCRIPTION
This pull request implements the "reversed" parameter for the Flex widget and can be enabled for other widgets extending `MultiChildRenderObjectWidget`.  This makes it possible to easily replicate css's features `flex-direction: row-reverse` and `flex-direction: column-reverse`.

### Here is an example scenario where this feature can be useful.
This is how you would do it **without** this feature. It is not ergonomic if you want a clean code structure. And if you are going to have multiple lists of children that should be reversed, it would be a mess.

```dart
import "package:flutter/material.dart";

// Without this feature
class TestPage extends StatelessWidget {
  const TestPage({
    super.key,
    this.dividerFirst = false,
  });

  /// If the divider should be on top instead of bottom (default)
  final bool dividerFirst;

  @override
  Widget build(context) {
    const List<Widget> children = [
      Divider(
        color: Color(0xFFFF0000),
        thickness: 1.5,
      ),
      SizedBox(height: 50),
      Text("Hello world")
    ];

    return Center(
      child: Flex(
        direction: Axis.vertical,
        children: dividerFirst ? children : children.reversed.toList(),
      ),
    );
  }
}

```
With this feature however. It would look something along the lines of this:
```dart
import "package:flutter/material.dart";

// With feature
class TestPage extends StatelessWidget {
  const TestPage({
    super.key,
    this.dividerFirst = false,
  });

  /// If the divider should be on top instead of bottom (default)
  final bool dividerFirst;

  @override
  Widget build(context) {
   return Center(
      child: Flex(
        direction: Axis.vertical,
        reversed: !dividerFirst,
        children: const [
          Divider(
            color: Color(0xFFFF0000),
            thickness: 1.5,
          ),
          SizedBox(height: 50),
          Text("Hello world")
        ],
      ),
    );
  }
}
```

### Resolves
- #54821
