### PR TITLE
fix a Scaffold extendBodyBehindAppBar update bug

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -875,10 +875,6 @@ class _BodyBuilder extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!extendBody && !extendBodyBehindAppBar) {
-      return body;
-    }
-
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final _BodyBoxConstraints bodyConstraints = constraints as _BodyBoxConstraints;

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -11,6 +11,39 @@ import 'package:flutter_test/flutter_test.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
+  // Regression test for https://github.com/flutter/flutter/issues/103741
+  testWidgets('extendBodyBehindAppBar change should not cause the body widget lose state', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    Widget buildFrame({required bool extendBodyBehindAppBar}) {
+      return MediaQuery(
+        data: const MediaQueryData(),
+        child: Directionality(
+          textDirection: TextDirection.ltr,
+          child: Scaffold(
+            extendBodyBehindAppBar: extendBodyBehindAppBar,
+            resizeToAvoidBottomInset: false,
+            body: SingleChildScrollView(
+              controller: controller,
+              child: const FlutterLogo(
+                size: 1107,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(extendBodyBehindAppBar: true));
+    expect(controller.position.pixels, 0.0);
+
+    controller.jumpTo(100.0);
+    await tester.pump();
+    expect(controller.position.pixels, 100.0);
+
+    await tester.pumpWidget(buildFrame(extendBodyBehindAppBar: false));
+    expect(controller.position.pixels, 100.0);
+  });
+
   testWidgets('Scaffold drawer callback test', (WidgetTester tester) async {
     bool isDrawerOpen = false;
     bool isEndDrawerOpen = false;
@@ -2401,6 +2434,8 @@ void main() {
       '   ancestor was:\n'
       '     Builder\n'
       '   The ancestors of this widget were:\n'
+      '     MediaQuery\n'
+      '     LayoutBuilder\n'
       '     _BodyBuilder\n'
       '     MediaQuery\n'
       '     LayoutId-[<_ScaffoldSlot.body>]\n'

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -1269,11 +1269,9 @@ void main() {
     testWidgets('LayoutBuilder is only used for InteractiveViewer.builder', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: InteractiveViewer(
-                child: const SizedBox(width: 200.0, height: 200.0),
-              ),
+          home: Center(
+            child: InteractiveViewer(
+              child: const SizedBox(width: 200.0, height: 200.0),
             ),
           ),
         ),
@@ -1283,13 +1281,11 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: Center(
-              child: InteractiveViewer.builder(
-                builder: (BuildContext context, Quad viewport) {
-                  return const SizedBox(width: 200.0, height: 200.0);
-                },
-              ),
+          home: Center(
+            child: InteractiveViewer.builder(
+              builder: (BuildContext context, Quad viewport) {
+                return const SizedBox(width: 200.0, height: 200.0);
+              },
             ),
           ),
         ),

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -2360,37 +2360,35 @@ void main() {
   testWidgets('NestedScrollView works well when rebuilding during scheduleWarmUpFrame', (WidgetTester tester) async {
     bool? isScrolled;
     final Widget myApp = MaterialApp(
-      home: Scaffold(
-        body: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Focus(
-              onFocusChange: (_) => setState( (){} ),
-              child: NestedScrollView(
-                headerSliverBuilder: (BuildContext context, bool boxIsScrolled) {
-                  isScrolled = boxIsScrolled;
-                  return <Widget>[
-                    const SliverAppBar(
-                      expandedHeight: 200,
-                      title: Text('Test'),
+      home: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Focus(
+            onFocusChange: (_) => setState( (){} ),
+            child: NestedScrollView(
+              headerSliverBuilder: (BuildContext context, bool boxIsScrolled) {
+                isScrolled = boxIsScrolled;
+                return <Widget>[
+                  const SliverAppBar(
+                    expandedHeight: 200,
+                    title: Text('Test'),
+                  ),
+                ];
+              },
+              body: CustomScrollView(
+                slivers: <Widget>[
+                  SliverList(
+                    delegate: SliverChildBuilderDelegate(
+                          (BuildContext context, int index) {
+                        return const Text('');
+                      },
+                      childCount: 10,
                     ),
-                  ];
-                },
-                body: CustomScrollView(
-                  slivers: <Widget>[
-                    SliverList(
-                      delegate: SliverChildBuilderDelegate(
-                        (BuildContext context, int index) {
-                          return const Text('');
-                        },
-                        childCount: 10,
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/103741
Blocked by https://github.com/flutter/flutter/pull/104954
Blocked by #104998 

Insert or remove a widget middle of the tree will cause all of the sub-tree to be detached and cause the body sub-tree to lose its state. 
Two solutions,
1, Use a Global key
2, Keep the tree structure during configurations change

But I think the Global key is expensive.
