### PR TITLE
more const immutable classes

### DIFF
--- a/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
@@ -19,6 +19,8 @@ enum _StockMenuItem { autorefresh, refresh, speedUp, speedDown }
 enum StockHomeTab { market, portfolio }
 
 class _NotImplementedDialog extends StatelessWidget {
+  const _NotImplementedDialog();
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
@@ -97,7 +99,7 @@ class StockHomeState extends State<StockHome> {
       case _StockMenuItem.refresh:
         showDialog<void>(
           context: context,
-          builder: (BuildContext context) => _NotImplementedDialog(),
+          builder: (BuildContext context) => const _NotImplementedDialog(),
         );
         break;
       case _StockMenuItem.speedUp:
@@ -303,7 +305,7 @@ class StockHomeState extends State<StockHome> {
   void _handleCreateCompany() {
     showModalBottomSheet<void>(
       context: context,
-      builder: (BuildContext context) => _CreateCompanySheet(),
+      builder: (BuildContext context) => const _CreateCompanySheet(),
     );
   }
 
@@ -339,6 +341,8 @@ class StockHomeState extends State<StockHome> {
 }
 
 class _CreateCompanySheet extends StatelessWidget {
+  const _CreateCompanySheet();
+
   @override
   Widget build(BuildContext context) {
     return Column(

--- a/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/slider_demo.dart
@@ -214,7 +214,7 @@ class _CustomValueIndicatorShape extends SliderComponentShape {
 class _SliderDemoState extends State<SliderDemo> {
   @override
   Widget build(BuildContext context) {
-    final List<ComponentDemoTabData> demos = <ComponentDemoTabData>[
+    const List<ComponentDemoTabData> demos = <ComponentDemoTabData>[
       ComponentDemoTabData(
         tabName: 'SINGLE',
         description: 'Sliders containing 1 thumb',
@@ -229,7 +229,7 @@ class _SliderDemoState extends State<SliderDemo> {
       ),
     ];
 
-    return TabbedComponentDemoScaffold(
+    return const TabbedComponentDemoScaffold(
       title: 'Sliders',
       demos: demos,
       isScrollable: false,
@@ -239,6 +239,8 @@ class _SliderDemoState extends State<SliderDemo> {
 }
 
 class _Sliders extends StatefulWidget {
+  const _Sliders();
+
   @override
   _SlidersState createState() => _SlidersState();
 }
@@ -357,6 +359,8 @@ class _SlidersState extends State<_Sliders> {
 }
 
 class _RangeSliders extends StatefulWidget {
+  const _RangeSliders();
+
   @override
   _RangeSlidersState createState() => _RangeSlidersState();
 }

--- a/examples/api/lib/material/material_state/material_state_mouse_cursor.0.dart
+++ b/examples/api/lib/material/material_state/material_state_mouse_cursor.0.dart
@@ -28,6 +28,8 @@ class MyApp extends StatelessWidget {
 }
 
 class ListTileCursor extends MaterialStateMouseCursor {
+  const ListTileCursor();
+
   @override
   MouseCursor resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
@@ -45,8 +47,8 @@ class MyStatelessWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      title: const Text('Disabled ListTile'),
+    return const ListTile(
+      title: Text('Disabled ListTile'),
       enabled: false,
       mouseCursor: ListTileCursor(),
     );

--- a/examples/api/lib/material/material_state/material_state_outlined_border.0.dart
+++ b/examples/api/lib/material/material_state/material_state_outlined_border.0.dart
@@ -24,6 +24,8 @@ class MyApp extends StatelessWidget {
 
 class SelectedBorder extends RoundedRectangleBorder
     implements MaterialStateOutlinedBorder {
+  const SelectedBorder();
+
   @override
   OutlinedBorder? resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.selected)) {
@@ -54,7 +56,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
             isSelected = value;
           });
         },
-        shape: SelectedBorder(),
+        shape: const SelectedBorder(),
       ),
     );
   }

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -19,13 +19,15 @@ class IVBuilderExampleApp extends StatelessWidget {
         appBar: AppBar(
           title: const Text('IV Builder Example'),
         ),
-        body: _IVBuilderExample(),
+        body: const _IVBuilderExample(),
       ),
     );
   }
 }
 
 class _IVBuilderExample extends StatefulWidget {
+  const _IVBuilderExample();
+
   @override
   State<_IVBuilderExample> createState() => _IVBuilderExampleState();
 }

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -1009,7 +1009,7 @@ enum _CupertinoTextSelectionToolbarItemsSlot {
 }
 
 class _NullElement extends Element {
-  _NullElement() : super(_NullWidget());
+  _NullElement() : super(const _NullWidget());
 
   static _NullElement instance = _NullElement();
 
@@ -1021,6 +1021,8 @@ class _NullElement extends Element {
 }
 
 class _NullWidget extends Widget {
+  const _NullWidget();
+
   @override
   Element createElement() => throw UnimplementedError();
 }

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1751,7 +1751,7 @@ class _CalendarDateRangePickerState extends State<_CalendarDateRangePicker> {
 
     return Column(
       children: <Widget>[
-        _DayHeaders(),
+        const _DayHeaders(),
         if (_showWeekBottomDivider) const Divider(height: 0),
         Expanded(
           child: _CalendarKeyboardNavigator(
@@ -1947,6 +1947,8 @@ class _FocusedDate extends InheritedWidget {
 
 
 class _DayHeaders extends StatelessWidget {
+  const _DayHeaders();
+
   /// Builds widgets showing abbreviated days of week. The first widget in the
   /// returned list corresponds to the first day of week for the current locale.
   ///

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1451,7 +1451,10 @@ class ButtonActivateIntent extends Intent {
 abstract class ActivateAction extends Action<ActivateIntent> { }
 
 /// An [Intent] that selects the currently focused control.
-class SelectIntent extends Intent { }
+class SelectIntent extends Intent {
+  /// Creates an intent that selects the currently focused control.
+  const SelectIntent();
+}
 
 /// An action that selects the currently focused control.
 ///

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -1919,7 +1919,7 @@ mixin WidgetInspectorService {
   ///
   /// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
   bool isWidgetCreationTracked() {
-    _widgetCreationTracked ??= _WidgetForTypeTests() is _HasCreationLocation;
+    _widgetCreationTracked ??= const _WidgetForTypeTests() is _HasCreationLocation;
     return _widgetCreationTracked!;
   }
 
@@ -2190,6 +2190,8 @@ class _ElementLocationStatsTracker {
 }
 
 class _WidgetForTypeTests extends Widget {
+  const _WidgetForTypeTests();
+
   @override
   Element createElement() => throw UnimplementedError();
 }

--- a/packages/flutter/test/animation/animations_test.dart
+++ b/packages/flutter/test/animation/animations_test.dart
@@ -8,6 +8,8 @@ import 'package:flutter_test/flutter_test.dart';
 import '../scheduler/scheduler_tester.dart';
 
 class BogusCurve extends Curve {
+  const BogusCurve();
+
   @override
   double transform(double t) => 100.0;
 }
@@ -234,7 +236,7 @@ void main() {
     final AnimationController controller = AnimationController(
       vsync: const TestVSync(),
     );
-    final CurvedAnimation curved = CurvedAnimation(parent: controller, curve: BogusCurve());
+    final CurvedAnimation curved = CurvedAnimation(parent: controller, curve: const BogusCurve());
     FlutterError? error;
     try {
       curved.value;

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -585,7 +585,7 @@ void main() {
 }
 
 class _NullElement extends Element {
-  _NullElement() : super(_NullWidget());
+  _NullElement() : super(const _NullWidget());
 
   static _NullElement instance = _NullElement();
 
@@ -597,6 +597,8 @@ class _NullElement extends Element {
 }
 
 class _NullWidget extends Widget {
+  const _NullWidget();
+
   @override
   Element createElement() => throw UnimplementedError();
 }

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -1233,7 +1233,7 @@ void main() {
 
   testWidgets('CupertinoDialogRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
-      CupertinoApp(
+      const CupertinoApp(
         restorationScopeId: 'app',
         home: _RestorableDialogTestWidget(),
       ),
@@ -1546,6 +1546,8 @@ Widget createAppWithCenteredButton(Widget child) {
 
 
 class _RestorableDialogTestWidget extends StatelessWidget {
+  const _RestorableDialogTestWidget();
+
   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
     return CupertinoDialogRoute<void>(
       context: context,

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1790,7 +1790,7 @@ void main() {
   });
 
   testWidgets('Popping routes should cancel down events', (WidgetTester tester) async {
-    await tester.pumpWidget(_TestPostRouteCancel());
+    await tester.pumpWidget(const _TestPostRouteCancel());
 
     final TestGesture gesture = await tester.createGesture();
     await gesture.down(tester.getCenter(find.text('PointerCancelEvents: 0')));
@@ -1861,7 +1861,7 @@ void main() {
 
   testWidgets('CupertinoModalPopupRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
-      CupertinoApp(
+      const CupertinoApp(
         restorationScopeId: 'app',
         home: _RestorableModalTestWidget(),
       ),
@@ -2249,6 +2249,8 @@ Widget buildNavigator({
 // Holding the 'Hold' button at the moment of popping will force the navigator to
 // cancel the down event, increasing the Home counter by 1.
 class _TestPostRouteCancel extends StatefulWidget {
+  const _TestPostRouteCancel();
+
   @override
   State<StatefulWidget> createState() => _TestPostRouteCancelState();
 }
@@ -2308,6 +2310,8 @@ class _TestPostRouteCancelState extends State<_TestPostRouteCancel> {
 }
 
 class _RestorableModalTestWidget extends StatelessWidget {
+  const _RestorableModalTestWidget();
+
   static Route<void> _modalBuilder(BuildContext context, Object? arguments) {
     return CupertinoModalPopupRoute<void>(
       builder: (BuildContext context) {

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -2212,7 +2212,7 @@ void main() {
 
   testWidgets('DialogRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      const MaterialApp(
         restorationScopeId: 'app',
         home: _RestorableDialogTestWidget(),
       ),
@@ -2294,6 +2294,8 @@ void main() {
 }
 
 class _RestorableDialogTestWidget extends StatelessWidget {
+  const _RestorableDialogTestWidget();
+
   static Route<Object?> _materialDialogBuilder(BuildContext context, Object? arguments) {
     return DialogRoute<void>(
       context: context,

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -167,7 +167,7 @@ void main() {
         // We create the geometry listener here, but it can only be set up
         // after it is pumped into the widget tree and a tester is
         // available.
-        geometryListener = _GeometryListener();
+        geometryListener = const _GeometryListener();
         geometry = null;
         listenerState = null;
         previousRect = null;
@@ -1516,6 +1516,8 @@ void main() {
 }
 
 class _GeometryListener extends StatefulWidget {
+  const _GeometryListener();
+
   @override
   State createState() => _GeometryListenerState();
 }

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -1236,7 +1236,7 @@ void main() {
             bottomNavigationBar: ConstrainedBox(
               key: key,
               constraints: const BoxConstraints.expand(height: 80.0),
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
             ),
       )));
 
@@ -1255,7 +1255,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: Scaffold(
             body: ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
             ),
       )));
 
@@ -1337,7 +1337,7 @@ void main() {
             body: Container(),
             floatingActionButton: FloatingActionButton(
               key: key,
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
               onPressed: () { },
             ),
       )));
@@ -1358,7 +1358,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: Scaffold(
             body: ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
             ),
       )));
 
@@ -1376,7 +1376,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: Scaffold(
             body: ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
             ),
       )));
 
@@ -1384,7 +1384,7 @@ void main() {
             body: Container(),
             floatingActionButton: FloatingActionButton(
               key: key,
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
               onPressed: () { },
             ),
       )));
@@ -1439,7 +1439,7 @@ void main() {
       await tester.pumpWidget(MaterialApp(home: Scaffold(
             body: ConstrainedBox(
               constraints: const BoxConstraints.expand(height: 80.0),
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
             ),
       )));
 
@@ -1452,7 +1452,7 @@ void main() {
             body: Container(),
             floatingActionButton: FloatingActionButton(
               key: key,
-              child: _GeometryListener(),
+              child: const _GeometryListener(),
               onPressed: () { },
             ),
       )));
@@ -2424,6 +2424,8 @@ void main() {
 }
 
 class _GeometryListener extends StatefulWidget {
+  const _GeometryListener();
+
   @override
   _GeometryListenerState createState() => _GeometryListenerState();
 }

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -15,7 +15,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: Navigator(
-            pages: <Page<void>>[_APage(), _BPage()],
+            pages: const <Page<void>>[_APage(), _BPage()],
             onPopPage: (Route<dynamic> route, dynamic result) {
               return false;
             },
@@ -551,6 +551,8 @@ void main() {
 }
 
 class _APage extends Page<void> {
+  const _APage();
+
   @override
   Route<void> createRoute(BuildContext context) => PageRouteBuilder<void>(
     settings: this,
@@ -559,6 +561,8 @@ class _APage extends Page<void> {
 }
 
 class _BPage extends Page<void> {
+  const _BPage();
+
   @override
   Route<void> createRoute(BuildContext context) => PageRouteBuilder<void>(
     settings: this,

--- a/packages/flutter/test/painting/border_rtl_test.dart
+++ b/packages/flutter/test/painting/border_rtl_test.dart
@@ -9,6 +9,8 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 class SillyBorder extends BoxBorder {
+  const SillyBorder();
+
   @override
   dynamic noSuchMethod(Invocation invocation) => null;
 }
@@ -53,7 +55,7 @@ void main() {
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithMagentaTop5, -1.0), const Border(top: BorderSide(color: Color(0xFFFFFF00), width: 5.0)));
     expect(BoxBorder.lerp(visualWithSides10, directionalWithSides10, -1.0), visualWithSides30);
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, -1.0), directionalWithYellowTop10);
-    expect(() => BoxBorder.lerp(SillyBorder(), const Border(), -1.0), throwsFlutterError);
+    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), -1.0), throwsFlutterError);
 
     expect(BoxBorder.lerp(null, null, 0.0), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 0.0), Border.all(width: 10.0));
@@ -65,7 +67,7 @@ void main() {
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithMagentaTop5, 0.0), const Border(top: BorderSide(color: Color(0xFFFFFF00), width: 5.0)));
     expect(BoxBorder.lerp(visualWithSides10, directionalWithSides10, 0.0), visualWithSides10);
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 0.0), directionalWithYellowTop5);
-    expect(() => BoxBorder.lerp(SillyBorder(), const Border(), 0.0), throwsFlutterError);
+    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 0.0), throwsFlutterError);
 
     expect(BoxBorder.lerp(null, null, 0.25), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 0.25), Border.all(width: 7.5));
@@ -77,7 +79,7 @@ void main() {
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithMagentaTop5, 0.25), Border(top: BorderSide(width: 5.0, color: Color.lerp(const Color(0xFFFFFF00), const Color(0xFFFF00FF), 0.25)!)));
     expect(BoxBorder.lerp(visualWithSides10, directionalWithSides10, 0.25), visualWithSides10At50);
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 0.25), visualWithYellowTop5At75 + directionalWithSides10At25);
-    expect(() => BoxBorder.lerp(SillyBorder(), const Border(), 0.25), throwsFlutterError);
+    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 0.25), throwsFlutterError);
 
     expect(BoxBorder.lerp(null, null, 0.75), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 0.75), Border.all(width: 2.5));
@@ -89,7 +91,7 @@ void main() {
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithMagentaTop5, 0.75), Border(top: BorderSide(width: 5.0, color: Color.lerp(const Color(0xFFFFFF00), const Color(0xFFFF00FF), 0.75)!)));
     expect(BoxBorder.lerp(visualWithSides10, directionalWithSides10, 0.75), directionalWithSides10At50);
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 0.75), visualWithYellowTop5At25 + directionalWithSides10At75);
-    expect(() => BoxBorder.lerp(SillyBorder(), const Border(), 0.75), throwsFlutterError);
+    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 0.75), throwsFlutterError);
 
     expect(BoxBorder.lerp(null, null, 1.0), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 1.0), Border.all(width: 0.0, style: BorderStyle.none));
@@ -101,7 +103,7 @@ void main() {
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithMagentaTop5, 1.0), visualWithMagentaTop5);
     expect(BoxBorder.lerp(visualWithSides10, directionalWithSides10, 1.0), directionalWithSides10);
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 1.0), directionalWithSides10);
-    expect(() => BoxBorder.lerp(SillyBorder(), const Border(), 1.0), throwsFlutterError);
+    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 1.0), throwsFlutterError);
 
     expect(BoxBorder.lerp(null, null, 2.0), null);
     expect(BoxBorder.lerp(Border.all(width: 10.0), null, 2.0), Border.all(width: 0.0, style: BorderStyle.none));
@@ -113,13 +115,13 @@ void main() {
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithMagentaTop5, 2.0), visualWithMagentaTop5);
     expect(BoxBorder.lerp(visualWithSides10, directionalWithSides10, 2.0), directionalWithSides30);
     expect(BoxBorder.lerp(visualWithYellowTop5, directionalWithSides10, 2.0), directionalWithSides20);
-    expect(() => BoxBorder.lerp(SillyBorder(), const Border(), 2.0), throwsFlutterError);
+    expect(() => BoxBorder.lerp(const SillyBorder(), const Border(), 2.0), throwsFlutterError);
   });
 
   test('BoxBorder.lerp throws correct FlutterError message', () {
     late FlutterError error;
     try {
-      BoxBorder.lerp(SillyBorder(), const Border(), 2.0);
+      BoxBorder.lerp(const SillyBorder(), const Border(), 2.0);
     } on FlutterError catch (e) {
       error = e;
     }

--- a/packages/flutter/test/widgets/layout_builder_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_test.dart
@@ -600,7 +600,7 @@ void main() {
             size: size,
             child: LayoutBuilder(builder: (BuildContext context, BoxConstraints constraints) {
               builderInvocationCount += 1;
-              return _LayoutSpy();
+              return const _LayoutSpy();
             }),
           ),
         ),
@@ -681,8 +681,8 @@ void main() {
                 final _RenderLayoutSpy spy = tester.renderObject(find.byType(_LayoutSpy));
                 childSize = spy.size;
               }
-              return ColoredBox(
-                color: const Color(0xffffffff),
+              return const ColoredBox(
+                color: Color(0xffffffff),
                 child: _LayoutSpy(),
               );
             }),
@@ -699,6 +699,8 @@ void main() {
 }
 
 class _LayoutSpy extends LeafRenderObjectWidget {
+  const _LayoutSpy();
+
   @override
   LeafRenderObjectElement createElement() => _LayoutSpyElement(this);
 

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -1032,7 +1032,7 @@ void main() {
   });
 
   testWidgets('detects pointer enter with closure arguments', (WidgetTester tester) async {
-    await tester.pumpWidget(_HoverClientWithClosures());
+    await tester.pumpWidget(const _HoverClientWithClosures());
     expect(find.text('not hovering'), findsOneWidget);
 
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
@@ -1896,6 +1896,8 @@ class _DelegatedPainter extends CustomPainter {
 }
 
 class _HoverClientWithClosures extends StatefulWidget {
+  const _HoverClientWithClosures();
+
   @override
   _HoverClientWithClosuresState createState() => _HoverClientWithClosuresState();
 }

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -1949,7 +1949,7 @@ void main() {
 
   testWidgets('RawDialogRoute is state restorable', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
+      const MaterialApp(
         restorationScopeId: 'app',
         home: _RestorableDialogTestWidget(),
       ),
@@ -2299,6 +2299,8 @@ class WidgetWithNoLocalHistoryState extends State<WidgetWithNoLocalHistory> {
 }
 
 class _RestorableDialogTestWidget extends StatelessWidget {
+  const _RestorableDialogTestWidget();
+
   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
     return RawDialogRoute<void>(
       pageBuilder: (

--- a/packages/flutter/test/widgets/ticker_provider_test.dart
+++ b/packages/flutter/test/widgets/ticker_provider_test.dart
@@ -67,7 +67,7 @@ void main() {
 
   group('TickerProviderStateMixin assertion control test', () {
     testWidgets('SingleTickerProviderStateMixin create multiple tickers', (WidgetTester tester) async {
-      final Widget widget = _SingleTickerCreateMultipleTicker();
+      const Widget widget = _SingleTickerCreateMultipleTicker();
       await tester.pumpWidget(widget);
       final dynamic exception = tester.takeException();
       expect(exception, isNotNull);
@@ -304,6 +304,8 @@ class _MultipleTickerTestState extends State<_MultipleTickerTest> with TickerPro
 }
 
 class _SingleTickerCreateMultipleTicker extends StatefulWidget {
+  const _SingleTickerCreateMultipleTicker();
+
   @override
   _SingleTickerCreateMultipleTickerState createState() => _SingleTickerCreateMultipleTickerState();
 }


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/58746 : immutable classes without explicit constructor are not catched by `prefer_const_constructors_in_immutables`. This PR fixes some of them.