### PR TITLE
[tool] Migrate off deprecated coverage parameters

### DIFF
--- a/packages/flutter_tools/bin/fuchsia_tester.dart
+++ b/packages/flutter_tools/bin/fuchsia_tester.dart
@@ -164,7 +164,7 @@ Future<void> run(List<String> args) async {
       } else {
         globals.fs.currentDirectory = testDirectory;
       }
-      if (!collector.collectCoverageData(argResults[_kOptionCoveragePath] as String, coverageDirectory: coverageDirectory)) {
+      if (!await collector.collectCoverageData(argResults[_kOptionCoveragePath] as String, coverageDirectory: coverageDirectory)) {
         throwToolExit('Failed to collect coverage data');
       }
     }

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -461,7 +461,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     );
 
     if (collector != null) {
-      final bool collectionResult = collector.collectCoverageData(
+      final bool collectionResult = await collector.collectCoverageData(
         stringArgDeprecated('coverage-path'),
         mergeCoverageData: boolArgDeprecated('merge-coverage'),
       );

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -92,9 +92,7 @@ class CoverageCollector extends TestWatcher {
     _logMessage('($observatoryUri): collected coverage data; merging...');
     _addHitmap(await coverage.HitMap.parseJson(
       data['coverage'] as List<Map<String, dynamic>>,
-      // TODO(cbracken): https://github.com/flutter/flutter/issues/103830
-      // Replace with packagePath: packageDirectory
-      packagesPath: packagesPath, // ignore: deprecated_member_use
+      packagePath: packageDirectory,
       checkIgnoredLines: true,
     ));
     _logMessage('($observatoryUri): done merging coverage data into global coverage map.');
@@ -137,9 +135,7 @@ class CoverageCollector extends TestWatcher {
     _logMessage('Merging coverage data...');
     _addHitmap(await coverage.HitMap.parseJson(
       data['coverage'] as List<Map<String, dynamic>>,
-      // TODO(cbracken): https://github.com/flutter/flutter/issues/103830
-      // Replace with packagePath: packageDirectory
-      packagesPath: packagesPath, // ignore: deprecated_member_use
+      packagePath: packageDirectory,
       checkIgnoredLines: true,
     ));
     _logMessage('Done merging coverage data into global coverage map.');
@@ -149,19 +145,16 @@ class CoverageCollector extends TestWatcher {
   ///
   /// This will not start any collection tasks. It us up to the caller of to
   /// call [collectCoverage] for each process first.
-  String finalizeCoverage({
+  Future<String> finalizeCoverage({
     String Function(Map<String, coverage.HitMap> hitmap) formatter,
     coverage.Resolver resolver,
     Directory coverageDirectory,
-  }) {
+  }) async {
     if (_globalHitmap == null) {
       return null;
     }
     if (formatter == null) {
-      // TODO(cbracken): https://github.com/flutter/flutter/issues/103830
-      // Replace with: resolver ??= await coverage.Resolver.create(packagesPath: packagesPath);
-      // ignore: deprecated_member_use
-      resolver ??= coverage.Resolver(packagesPath: packagesPath);
+      resolver ??= await coverage.Resolver.create(packagesPath: packagesPath);
       final String packagePath = globals.fs.currentDirectory.path;
       final List<String> reportOn = coverageDirectory == null
           ? <String>[globals.fs.path.join(packagePath, 'lib')]
@@ -174,8 +167,8 @@ class CoverageCollector extends TestWatcher {
     return result;
   }
 
-  bool collectCoverageData(String coveragePath, { bool mergeCoverageData = false, Directory coverageDirectory }) {
-    final String coverageData = finalizeCoverage(
+  Future<bool> collectCoverageData(String coveragePath, { bool mergeCoverageData = false, Directory coverageDirectory }) async {
+    final String coverageData = await finalizeCoverage(
       coverageDirectory: coverageDirectory,
     );
     _logMessage('coverage information collection complete');


### PR DESCRIPTION
In https://github.com/flutter/flutter/pull/103771, we rolled
dependencies in Flutter, which triggered an update of package:coverage
to v1.3.1. The new version includes
https://github.com/dart-lang/coverage/pull/370 in which two deprecations
landed:

* The `Resolver` default constructor was deprecated and replaced with
  the `Resolver.create` static factory method, which unfortunately
  happens to be async.
* The `packagesPath` parameter to `HitMap.parseJson`, which takes the
  path to the `.packages` file of the package for which coverage is to
  be collected, was deprecated. This parameter was replaced with
  `packagePath` in https://github.com/dart-lang/coverage/pull/370 which
  was part of the overall deprecation of the .packages file in Dart
  itself https://github.com/dart-lang/sdk/issues/48272. The overall goal
  being that end-user code shouldn't need to know about implementation
  details such as whether dependency information is stored in a
  .packages file or a package_info.json file, but rather use the
  package_config package to obtain the package metadata and perform
  other functions such as resolving its dependencies to filesystem
  paths. packagesPath was replaced by packagePath, which takes the path
  to the package directory itself. Internally, package:coverage then
  uses package_config to do the rest of the package/script URI
  resolution to filesystem paths.

This migrates off the deprecated `packagesPath` parameter to the
replacement `packagePath` paramter.

No test since this simply migrates off a deprecated parameter and onto its
replacement; the goal is to maintain identical behaviour.

Issue: https://github.com/flutter/flutter/issues/103830


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
