### PR TITLE
Fix `showSearch` query text field doesn't show toolbar initially when field is empty.

### DIFF
--- a/packages/flutter/lib/src/material/search.dart
+++ b/packages/flutter/lib/src/material/search.dart
@@ -263,7 +263,9 @@ abstract class SearchDelegate<T> {
   set query(String value) {
     assert(query != null);
     _queryTextController.text = value;
-    _queryTextController.selection = TextSelection.fromPosition(TextPosition(offset: _queryTextController.text.length));
+    if (_queryTextController.text.isNotEmpty) {
+      _queryTextController.selection = TextSelection.fromPosition(TextPosition(offset: _queryTextController.text.length));
+    }
   }
 
   /// Transition from the suggestions returned by [buildSuggestions] to the

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -918,7 +918,7 @@ void main() {
     await tester.tap(find.text('Paste'));
     await tester.pump();
     expect(textField.controller!.text.length, 15);
-  });
+  }, skip: kIsWeb);
 }
 
 class TestHomePage extends StatelessWidget {

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -883,6 +883,42 @@ void main() {
     expect(rootObserver.pushCount, 1);
     expect(localObserver.pushCount, 1);
   });
+
+  testWidgets('Query text field shows toolbar initially', (WidgetTester tester) async {
+    // This is a regression test for https://github.com/flutter/flutter/issues/95588
+
+    final _TestSearchDelegate delegate = _TestSearchDelegate();
+    final List<String> selectedResults = <String>[];
+
+    await tester.pumpWidget(TestHomePage(
+      delegate: delegate,
+      results: selectedResults,
+    ));
+
+    // Open search
+    await tester.tap(find.byTooltip('Search'));
+    await tester.pumpAndSettle();
+
+    final Finder textFieldFinder = find.byType(TextField);
+    final TextField textField = tester.widget<TextField>(textFieldFinder);
+    expect(textField.controller!.text.length, 0);
+
+    mockClipboard.handleMethodCall(const MethodCall(
+      'Clipboard.setData',
+      <String, dynamic>{
+        'text': 'pasteablestring',
+      },
+    ));
+
+    // Long press shows toolbar.
+    await tester.longPress(textFieldFinder);
+    await tester.pump();
+    expect(find.text('Paste'), findsOneWidget);
+
+    await tester.tap(find.text('Paste'));
+    await tester.pump();
+    expect(textField.controller!.text.length, 15);
+  });
 }
 
 class TestHomePage extends StatelessWidget {

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -895,7 +895,7 @@ void main() {
       results: selectedResults,
     ));
 
-    // Open search
+    // Open search.
     await tester.tap(find.byTooltip('Search'));
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/search_test.dart
+++ b/packages/flutter/test/material/search_test.dart
@@ -918,7 +918,7 @@ void main() {
     await tester.tap(find.text('Paste'));
     await tester.pump();
     expect(textField.controller!.text.length, 15);
-  }, skip: kIsWeb);
+  }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 }
 
 class TestHomePage extends StatelessWidget {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/95588

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
