### PR TITLE
[flutter_tools] refactor stringsArg

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1557,10 +1557,7 @@ abstract class FlutterCommand extends Command<void> {
 
   /// Gets the parsed command-line option named [name] as `List<String>`.
   List<String> stringsArg(String name) {
-    if (!argParser.options.containsKey(name)) {
-      return <String>[];
-    }
-    return argResults![name] as List<String>;
+    return argResults![name]! as List<String>? ?? <String>[];
   }
 }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1556,7 +1556,12 @@ abstract class FlutterCommand extends Command<void> {
   int? intArg(String name) => argResults?[name] as int?;
 
   /// Gets the parsed command-line option named [name] as `List<String>`.
-  List<String> stringsArg(String name) => argResults?[name] as List<String>? ?? <String>[];
+  List<String> stringsArg(String name) {
+    if (!argParser.options.containsKey(name)) {
+      return <String>[];
+    }
+    return argResults![name] as List<String>;
+  }
 }
 
 /// A mixin which applies an implementation of [requiredArtifacts] that only

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -80,7 +80,8 @@ void main() {
         }
     );
     final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
-    command.argParser.addMultiOption('key',
+    command.argParser.addMultiOption(
+      'key',
       allowed: <String>['a', 'b', 'c'],
     );
     // argResults will be null at this point, if attempt to read them is made,

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -72,6 +72,29 @@ void main() {
     expect(command.stringArgDeprecated('key'), 'value');
     expect(() => command.stringArgDeprecated('empty'), throwsA(const TypeMatcher<ArgumentError>()));
   });
+
+  testUsingContext('List<String> safe argResults', () async {
+    final DummyFlutterCommand command = DummyFlutterCommand(
+        commandFunction: () async {
+          return const FlutterCommandResult(ExitStatus.success);
+        }
+    );
+    final FlutterCommandRunner runner = FlutterCommandRunner(verboseHelp: true);
+    command.argParser.addMultiOption('key',
+      allowed: <String>['a', 'b', 'c'],
+    );
+    // argResults will be null at this point, if attempt to read them is made,
+    // exception `Null check operator used on a null value` would be thrown
+    expect(() => command.stringsArg('key'), throwsA(const TypeMatcher<TypeError>()));
+
+    runner.addCommand(command);
+    await runner.run(<String>['dummy', '--key', 'a']);
+
+    expect(command.stringsArg('key'), <String>['a']);
+    expect(command.stringsArg('empty'), <String>[]);
+    await runner.run(<String>['dummy', '--key', 'a', '--key', 'b']);
+    expect(command.stringsArg('key'), <String>['a', 'b']);
+  });
 }
 
 void verifyCommandRunner(CommandRunner<Object> runner) {

--- a/packages/flutter_tools/test/general.shard/args_test.dart
+++ b/packages/flutter_tools/test/general.shard/args_test.dart
@@ -85,16 +85,22 @@ void main() {
       allowed: <String>['a', 'b', 'c'],
     );
     // argResults will be null at this point, if attempt to read them is made,
-    // exception `Null check operator used on a null value` would be thrown
+    // exception `Null check operator used on a null value` would be thrown.
     expect(() => command.stringsArg('key'), throwsA(const TypeMatcher<TypeError>()));
 
     runner.addCommand(command);
     await runner.run(<String>['dummy', '--key', 'a']);
 
+    // throws error when trying to parse non-existent key.
+    expect(() => command.stringsArg('empty'),throwsA(const TypeMatcher<ArgumentError>()));
+
     expect(command.stringsArg('key'), <String>['a']);
-    expect(command.stringsArg('empty'), <String>[]);
+
     await runner.run(<String>['dummy', '--key', 'a', '--key', 'b']);
     expect(command.stringsArg('key'), <String>['a', 'b']);
+
+    await runner.run(<String>['dummy']);
+    expect(command.stringsArg('key'), <String>[]);
   });
 }
 


### PR DESCRIPTION
Update stringsArg function.

part of #101595

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
