### PR TITLE
[flutter_tools] flutter daemon handles a closed stdout IOSink

### DIFF
--- a/packages/flutter_tools/lib/src/daemon.dart
+++ b/packages/flutter_tools/lib/src/daemon.dart
@@ -219,6 +219,10 @@ class DaemonStreams {
       if (binary != null) {
         _outputSink.add(binary);
       }
+    } on StateError catch (error) {
+      _logger.printError('Failed to write daemon command response: $error');
+      // Failed to send, close the connection
+      _outputSink.close();
     } on IOException catch (error) {
       _logger.printError('Failed to write daemon command response: $error');
       // Failed to send, close the connection

--- a/packages/flutter_tools/test/general.shard/daemon_test.dart
+++ b/packages/flutter_tools/test/general.shard/daemon_test.dart
@@ -364,6 +364,20 @@ void main() {
       await daemonStreams.dispose();
       expect(outputStream.isClosed, true);
     });
+
+    testWithoutContext('handles sending to a closed sink', () async {
+      // Unless the stream is listened to, the call to .close() will never
+      // complete
+      outputStream.stream.listen((List<int> _) {});
+      await outputStream.sink.close();
+      daemonStreams.send(testCommand);
+      expect(
+        bufferLogger.errorText,
+        contains(
+          'Failed to write daemon command response: Bad state: Cannot add event after closing',
+        ),
+      );
+    });
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/99367

In the stacktrace from crash logging, the `IOSink` is coming from STDOUT.