### PR TITLE
[fuchsia] Change format of ffx call to debug spam.

### DIFF
--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -482,7 +482,7 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
 
   @override
   Future<List<String>> discoverDevices() async {
-    final List<String> output = (await eval(_ffx, <String>['target', 'list', '--format', 's']))
+    final List<String> output = (await eval(_ffx, <String>['target', 'list', '-f', 's']))
       .trim()
       .split('\n');
 
@@ -505,7 +505,7 @@ class FuchsiaDeviceDiscovery implements DeviceDiscovery {
           <String>[
             'target',
             'list',
-            '--format',
+            '-f',
             'a',
             deviceId,
           ]

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_ffx.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_ffx.dart
@@ -57,7 +57,9 @@ class FuchsiaFfx {
         ...<String>['-T', '${timeout.inSeconds}'],
       'target',
       'list',
-      '--format',
+      // TODO(akbiggs): Revert -f back to --format once we've verified that
+      // analytics spam is coming from here.
+      '-f',
       's',
     ];
     final RunResult result = await _processUtils.run(command);
@@ -84,7 +86,7 @@ class FuchsiaFfx {
       ffx.path,
       'target',
       'list',
-      '--format',
+      '-f',
       'a',
       deviceName,
     ];

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_ffx_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_ffx_test.dart
@@ -45,7 +45,7 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, 'target', 'list', '--format', 's'],
+          command: <String>[ffx.path, 'target', 'list', '-f', 's'],
           stderr: 'No devices found.',
         ),
       ]);
@@ -66,7 +66,7 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, 'target', 'list', '--format', 's'],
+          command: <String>[ffx.path, 'target', 'list', '-f', 's'],
           exitCode: 1,
           stderr: 'unexpected error',
         ),
@@ -88,7 +88,7 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, 'target', 'list', '--format', 's'],
+          command: <String>[ffx.path, 'target', 'list', '-f', 's'],
           stdout: 'device1\ndevice2',
         ),
       ]);
@@ -109,7 +109,7 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, '-T', '2', 'target', 'list', '--format', 's'],
+          command: <String>[ffx.path, '-T', '2', 'target', 'list', '-f', 's'],
           stdout: 'device1',
         ),
       ]);
@@ -143,7 +143,14 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, 'target', 'list', '--format', 'a', 'unknown-device'],
+          command: <String>[
+            ffx.path,
+            'target',
+            'list',
+            '-f',
+            'a',
+            'unknown-device'
+          ],
           exitCode: 2,
           stderr: 'No devices found.',
         ),
@@ -165,7 +172,14 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, 'target', 'list', '--format', 'a', 'error-device'],
+          command: <String>[
+            ffx.path,
+            'target',
+            'list',
+            '-f',
+            'a',
+            'error-device'
+          ],
           exitCode: 1,
           stderr: 'unexpected error',
         ),
@@ -187,7 +201,14 @@ void main() {
       final ProcessManager processManager =
           FakeProcessManager.list(<FakeCommand>[
         FakeCommand(
-          command: <String>[ffx.path, 'target', 'list', '--format', 'a', 'known-device'],
+          command: <String>[
+            ffx.path,
+            'target',
+            'list',
+            '-f',
+            'a',
+            'known-device'
+          ],
           stdout: '1234-1234-1234-1234',
         ),
       ]);


### PR DESCRIPTION
Fuchsia is seeing a large amount of
ffx analytics spam with the command
`ffx -T 30 target list --format s`. We
suspect it is coming from this file but are
not 100% sure. We are changing the format of this
call to verify that the spammed command also
changes in our analytics.