### PR TITLE
Merge dirty relayout boundaries after `RenderObject.invokeLayoutCallback`

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -927,6 +927,21 @@ class PipelineOwner {
     _rootNode?.attach(this);
   }
 
+  // Whether the current [flushLayout] call should pause to incorporate the
+  // [RenderObject]s in `_nodesNeedingLayout` into the current dirty list,
+  // before continuing to process dirty relayout boundaries.
+  //
+  // This flag is set to true when a [RenderObject.invokeLayoutCallback]
+  // returns, to avoid laying out dirty relayout boundaries in an incorrect
+  // order and causing them to be laid out more than once per frame. See
+  // layout_builder_mutations_test.dart for an example.
+  //
+  // The new dirty nodes are not immediately merged after a
+  // [RenderObject.invokeLayoutCallback] call because we may encounter multiple
+  // such calls while processing a single relayout boundary in [flushLayout].
+  // Batching new dirty nodes can reduce the number of merges [flushLayout]
+  // has to perform.
+  bool _shouldMergeDirtyNodes = false;
   List<RenderObject> _nodesNeedingLayout = <RenderObject>[];
 
   /// Whether this pipeline is currently in the layout phase.
@@ -967,16 +982,27 @@ class PipelineOwner {
       return true;
     }());
     try {
+      assert(!_shouldMergeDirtyNodes);
       while (_nodesNeedingLayout.isNotEmpty) {
         final List<RenderObject> dirtyNodes = _nodesNeedingLayout;
         _nodesNeedingLayout = <RenderObject>[];
-        for (final RenderObject node in dirtyNodes..sort((RenderObject a, RenderObject b) => a.depth - b.depth)) {
+        dirtyNodes.sort((RenderObject a, RenderObject b) => a.depth - b.depth);
+        for (int i = 0; i < dirtyNodes.length; i++) {
+          if (_shouldMergeDirtyNodes) {
+            _shouldMergeDirtyNodes = false;
+            if (_nodesNeedingLayout.isNotEmpty) {
+              _nodesNeedingLayout.addAll(dirtyNodes.getRange(i, dirtyNodes.length));
+              break;
+            }
+          }
+          final RenderObject node = dirtyNodes[i];
           if (node._needsLayout && node.owner == this) {
             node._layoutWithoutResize();
           }
         }
       }
     } finally {
+      _shouldMergeDirtyNodes = false;
       assert(() {
         _debugDoingLayout = false;
         return true;
@@ -1006,6 +1032,7 @@ class PipelineOwner {
     try {
       callback();
     } finally {
+      _shouldMergeDirtyNodes = true;
       assert(() {
         _debugAllowMutationsToDirtySubtrees = oldState!;
         return true;

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -982,8 +982,8 @@ class PipelineOwner {
       return true;
     }());
     try {
-      assert(!_shouldMergeDirtyNodes);
       while (_nodesNeedingLayout.isNotEmpty) {
+        assert(!_shouldMergeDirtyNodes);
         final List<RenderObject> dirtyNodes = _nodesNeedingLayout;
         _nodesNeedingLayout = <RenderObject>[];
         dirtyNodes.sort((RenderObject a, RenderObject b) => a.depth - b.depth);
@@ -1000,6 +1000,9 @@ class PipelineOwner {
             node._layoutWithoutResize();
           }
         }
+        // No need to merge dirty nodes generated from processing the last
+        // relayout boundary back.
+        _shouldMergeDirtyNodes = false;
       }
     } finally {
       _shouldMergeDirtyNodes = false;

--- a/packages/flutter/test/widgets/layout_builder_mutations_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_mutations_test.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/src/rendering/sliver.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/src/widgets/basic.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter/src/widgets/layout_builder.dart';
+import 'package:flutter/src/widgets/media_query.dart';
 import 'package:flutter/src/widgets/scroll_view.dart';
 import 'package:flutter/src/widgets/sliver_layout_builder.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -125,4 +127,84 @@ void main() {
 
     expect(tester.takeException(), null);
   });
+
+  testWidgets('LayoutBuilder does not layout twice', (WidgetTester tester) async {
+    // This widget marks itself dirty when the closest MediaQuery changes.
+    final _LayoutCount widget = _LayoutCount();
+    late StateSetter setState;
+    bool updated = false;
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setter) {
+            setState = setter;
+            return MediaQuery(
+              data: updated
+                ? const MediaQueryData(platformBrightness: Brightness.dark)
+                : const MediaQueryData(),
+              child: LayoutBuilder(
+                builder: (BuildContext context, BoxConstraints constraints) {
+                  return Center(
+                    child: SizedBox.square(
+                      dimension: 20,
+                      child: Center(
+                        child: SizedBox.square(
+                          dimension: updated ? 10 : 20,
+                          child: widget,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            );
+          }
+        ),
+      ),
+    );
+
+    assert(widget._renderObject.layoutCount == 1);
+    setState(() { updated = true; });
+
+    await tester.pump();
+    expect(widget._renderObject.layoutCount, 2);
+  });
+}
+
+class _LayoutCount extends LeafRenderObjectWidget {
+  late final _RenderLayoutCount _renderObject;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _renderObject = _RenderLayoutCount(MediaQuery.of(context));
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, _RenderLayoutCount renderObject) {
+    renderObject.mediaQuery = MediaQuery.of(context);
+  }
+}
+
+class _RenderLayoutCount extends RenderProxyBox {
+  _RenderLayoutCount(this._mediaQuery);
+  int layoutCount = 0;
+
+  MediaQueryData get mediaQuery => _mediaQuery;
+  MediaQueryData _mediaQuery;
+  set mediaQuery(MediaQueryData newValue) {
+    if (newValue != _mediaQuery) {
+      _mediaQuery = newValue;
+      markNeedsLayout();
+    }
+  }
+
+  @override
+  bool get sizedByParent => true;
+
+  @override
+  void performLayout() {
+    layoutCount += 1;
+  }
 }


### PR DESCRIPTION
An example where widget 3's subtree will be laid out twice in one frame:
```
InheritedWidget
  |
LayoutBuilder with an anonymous function as builder 
  |
Widget 1, which prevents incoming constraints from forcing a tree walk 
  |
Widget 2 which produces a relayout boundary
  |
Widget 3, which produces a relayout boundary, and also depends on the InheritedWidget to do layout correctly.
```
When the `InheritedWidget` changes, widget 3's render object will be marked as dirty so the initial dirty list will be:
`[RenderLayoutBuilder, RenderWidget3]`.

After `PipelineOwner.flushLayout` starts, the `LayoutBuilder` rebuilds, dirtying Widget 2 and causing it to produce different constraints for widget 3. But since 
`PipelineOwner.flushLayout` is already running so the list of dirty relayout boundaries is already locked. So `RenderWidget3` still gets to do layout before `RenderWidget2`, using outdated constraints.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
