### PR TITLE
Remove `RenderAligningShiftedBox.mixin` (no longer needed)

### DIFF
--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -54,9 +54,9 @@ class _OverflowRegionData {
 /// class MyRenderObject extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin {
 ///   MyRenderObject({
 ///     AlignmentGeometry alignment = Alignment.center,
-///     TextDirection? textDirection,
+///     required TextDirection? textDirection,
 ///     RenderBox? child,
-///   }) : super.mixin(alignment, textDirection, child);
+///   });
 ///
 ///   late Rect _containerRect;
 ///   late Rect _childRect;

--- a/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
+++ b/packages/flutter/lib/src/rendering/debug_overflow_indicator.dart
@@ -53,9 +53,9 @@ class _OverflowRegionData {
 /// ```dart
 /// class MyRenderObject extends RenderAligningShiftedBox with DebugOverflowIndicatorMixin {
 ///   MyRenderObject({
-///     AlignmentGeometry alignment = Alignment.center,
-///     required TextDirection? textDirection,
-///     RenderBox? child,
+///     super.alignment = Alignment.center,
+///     required super.textDirection,
+///     super.child,
 ///   });
 ///
 ///   late Rect _containerRect;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -291,12 +291,6 @@ abstract class RenderAligningShiftedBox extends RenderShiftedBox {
        _textDirection = textDirection,
        super(child);
 
-  /// A constructor to be used only when the extending class also has a mixin.
-  // TODO(gspencer): Remove this constructor once https://github.com/dart-lang/sdk/issues/31543 is fixed.
-  @protected
-  RenderAligningShiftedBox.mixin(AlignmentGeometry alignment, TextDirection? textDirection, RenderBox? child)
-    : this(alignment: alignment, textDirection: textDirection, child: child);
-
   Alignment? _resolvedAlignment;
 
   void _resolve() {
@@ -708,16 +702,15 @@ class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugO
   /// The [alignment] and [clipBehavior] must not be null.
   RenderConstraintsTransformBox({
     required AlignmentGeometry alignment,
-    required TextDirection? textDirection,
+    required super.textDirection,
     required BoxConstraintsTransform constraintsTransform,
-    RenderBox? child,
+    super.child,
     Clip clipBehavior = Clip.none,
   }) : assert(alignment != null),
        assert(clipBehavior != null),
        assert(constraintsTransform != null),
        _constraintsTransform = constraintsTransform,
-       _clipBehavior = clipBehavior,
-       super.mixin(alignment, textDirection, child);
+       _clipBehavior = clipBehavior;
 
   /// {@macro flutter.widgets.constraintsTransform}
   BoxConstraintsTransform get constraintsTransform => _constraintsTransform;

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -701,7 +701,7 @@ class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugO
   ///
   /// The [alignment] and [clipBehavior] must not be null.
   RenderConstraintsTransformBox({
-    required AlignmentGeometry alignment,
+    required super.alignment,
     required super.textDirection,
     required BoxConstraintsTransform constraintsTransform,
     super.child,


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/84260

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
