### PR TITLE
Update README to respect GitHub site theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1 align="center">
     <picture>
       <source media="(prefers-color-scheme: dark)" srcset="https://storage.googleapis.com/cms-storage-bucket/6e19fee6b47b36ca613f.png">
-      <img alt="The Flutter logo" src="https://storage.googleapis.com/cms-storage-bucket/c823e53b3a1a7b0d36a9.png">
+      <img alt="Flutter" src="https://storage.googleapis.com/cms-storage-bucket/c823e53b3a1a7b0d36a9.png">
     </picture>
   </h1>
 </a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-# [![Flutter logo][]][flutter.dev]
+<a href="https://flutter.dev/">
+  <h1 align="center">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://storage.googleapis.com/cms-storage-bucket/6e19fee6b47b36ca613f.png">
+      <img alt="The Flutter logo" src="https://storage.googleapis.com/cms-storage-bucket/c823e53b3a1a7b0d36a9.png">
+    </picture>
+  </h1>
+</a>
 
 [![Build Status - Cirrus][]][Build status]
 [![Discord badge][]][Discord instructions]
@@ -85,7 +92,6 @@ Flutter is a fully open-source project, and we welcome contributions.
 Information on how to get started can be found in our
 [contributor guide](CONTRIBUTING.md).
 
-[Flutter logo]: https://github.com/flutter/website/blob/archived-master/src/_assets/image/flutter-lockup-bg.jpg?raw=true
 [flutter.dev]: https://flutter.dev
 [Build Status - Cirrus]: https://api.cirrus-ci.com/github/flutter/flutter.svg
 [Build status]: https://cirrus-ci.com/github/flutter/flutter/master


### PR DESCRIPTION
GitHub recently added support for specifying an alternate appearance when the site is using a dark theme [(see the changelog)](https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/). I've implemented this here with download links from https://flutter.dev/brand.

Before:
<img width="924" alt="before" src="https://user-images.githubusercontent.com/13630061/171543234-7c6315e0-686d-47ee-8367-382b31367529.png">

After:
<img width="919" alt="after" src="https://user-images.githubusercontent.com/13630061/171543256-2025e72f-5133-49b2-96fa-6aca432f6e3f.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

Requesting test exemption @Hixie 
