### PR TITLE
use extension on Never pattern for namespaces

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
@@ -116,9 +116,7 @@ class BenchMouseRegionGridHover extends WidgetRecorder {
   }
 }
 
-class _UntilNextFrame {
-  _UntilNextFrame._();
-
+extension _UntilNextFrame on Never {
   static Completer<void>? _completer;
 
   static Future<void> wait() {

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_scroll.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_scroll.dart
@@ -88,9 +88,7 @@ class BenchMouseRegionGridScroll extends WidgetRecorder {
   }
 }
 
-class _UntilNextFrame {
-  _UntilNextFrame._();
-
+extension _UntilNextFrame on Never {
   static Completer<void>? _completer;
 
   static Future<void> wait() {

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_mixed_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_mixed_grid_hover.dart
@@ -138,9 +138,7 @@ class BenchMouseRegionMixedGridHover extends WidgetRecorder {
   }
 }
 
-class _UntilNextFrame {
-  _UntilNextFrame._();
-
+extension _UntilNextFrame on Never {
   static Completer<void>? _completer;
 
   static Future<void> wait() {

--- a/dev/integration_tests/flutter_gallery/lib/gallery/icons.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/icons.dart
@@ -4,11 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-class GalleryIcons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  GalleryIcons._();
-
+extension GalleryIcons on Never {
   static const IconData tooltip = IconData(0xe900, fontFamily: 'GalleryIcons');
   static const IconData text_fields_alt = IconData(0xe901, fontFamily: 'GalleryIcons');
   static const IconData tabs = IconData(0xe902, fontFamily: 'GalleryIcons');

--- a/dev/tools/gen_defaults/lib/typography_template.dart
+++ b/dev/tools/gen_defaults/lib/typography_template.dart
@@ -10,9 +10,7 @@ class TypographyTemplate extends TokenTemplate {
   @override
   String generate() => '''
 // Generated version ${tokens["version"]}
-class _M3Typography {
-  _M3Typography._();
-
+extension _M3Typography on Never {
   ${_textTheme('englishLike', 'alphabetic')}
 
   ${_textTheme('dense', 'ideographic')}

--- a/packages/flutter/lib/analysis_options_user.yaml
+++ b/packages/flutter/lib/analysis_options_user.yaml
@@ -33,7 +33,7 @@ linter:
     # - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses
     # - avoid_catching_errors
-    # - avoid_classes_with_only_static_members
+    - avoid_classes_with_only_static_members
     # - avoid_double_and_int_checks # only useful when targeting JS runtime
     # - avoid_dynamic_calls
     - avoid_empty_else

--- a/packages/flutter/lib/src/animation/curves.dart
+++ b/packages/flutter/lib/src/animation/curves.dart
@@ -1370,11 +1370,7 @@ class ElasticInOutCurve extends Curve {
 ///
 ///  * [Curve], the interface implemented by the constants available from the
 ///    [Curves] class.
-class Curves {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Curves._();
-
+extension Curves on Never {
   /// A linear animation curve.
   ///
   /// This is the identity map over the unit interval: its [Curve.transform]

--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -37,11 +37,7 @@ import 'theme.dart';
 /// ### Background Colors
 /// ![](https://flutter.github.io/assets-for-api-docs/assets/cupertino/cupertino_background_colors.png)
 ///
-class CupertinoColors {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  CupertinoColors._();
-
+extension CupertinoColors on Never {
   /// iOS 13's default blue color. Used to indicate active elements such as
   /// buttons, selected tabs and your own chat bubbles.
   ///

--- a/packages/flutter/lib/src/cupertino/icons.dart
+++ b/packages/flutter/lib/src/cupertino/icons.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 ///
 /// Icons are identified by their name as listed below.
 ///
-/// To use this class, make sure you add a dependency on `cupertino_icons` in your
+/// To use them, make sure you add a dependency on `cupertino_icons` in your
 /// project's `pubspec.yaml` file. This ensures that the CupertinoIcons font is
 /// included in your application. This font is used to display the icons. For example:
 ///
@@ -59,11 +59,7 @@ import 'package:flutter/widgets.dart';
 /// See also:
 ///
 ///  * [Icon], used to show these icons.
-class CupertinoIcons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  CupertinoIcons._();
-
+extension CupertinoIcons on Never {
   /// The icon font used for Cupertino icons.
   static const String iconFont = 'CupertinoIcons';
 

--- a/packages/flutter/lib/src/foundation/licenses.dart
+++ b/packages/flutter/lib/src/foundation/licenses.dart
@@ -291,11 +291,7 @@ class LicenseEntryWithLineBreaks extends LicenseEntry {
 ///    uses this API to select licenses to show.
 ///  * [AboutListTile], which is a widget that can be added to a [Drawer]. When
 ///    tapped it calls [showAboutDialog].
-class LicenseRegistry {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  LicenseRegistry._();
-
+extension LicenseRegistry on Never {
   static List<LicenseEntryCollector>? _collectors;
 
   /// Adds licenses to the registry.

--- a/packages/flutter/lib/src/foundation/unicode.dart
+++ b/packages/flutter/lib/src/foundation/unicode.dart
@@ -10,10 +10,7 @@
 ///
 ///  * <http://unicode.org/reports/tr9/>, which describes the Unicode
 ///    bidirectional text algorithm.
-class Unicode {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Unicode._();
+extension Unicode on Never {
   /// `U+202A LEFT-TO-RIGHT EMBEDDING`
   ///
   /// Treat the following text as embedded left-to-right.

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -37,11 +37,7 @@ int _synthesiseDownButtons(int buttons, PointerDeviceKind kind) {
 /// This takes [PointerDataPacket] objects, as received from the engine via
 /// [dart:ui.PlatformDispatcher.onPointerDataPacket], and converts them to
 /// [PointerEvent] objects.
-class PointerEventConverter {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  PointerEventConverter._();
-
+extension PointerEventConverter on Never {
   /// Expand the given packet of pointer data into a sequence of framework
   /// pointer events.
   ///

--- a/packages/flutter/lib/src/material/colors.dart
+++ b/packages/flutter/lib/src/material/colors.dart
@@ -190,11 +190,7 @@ class MaterialAccentColor extends ColorSwatch<int> {
 /// See also:
 ///
 ///  * Cookbook: [Use themes to share colors and font styles](https://flutter.dev/docs/cookbook/design/themes)
-class Colors {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Colors._();
-
+extension Colors on Never {
   /// Completely invisible.
   static const Color transparent = Color(0x00000000);
 

--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -7,11 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'material_localizations.dart';
 
 /// Utility functions for working with dates.
-class DateUtils {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  DateUtils._();
-
+extension DateUtils on Never {
   /// Returns a [DateTime] with the date of the original, but time set to
   /// midnight.
   static DateTime dateOnly(DateTime date) {

--- a/packages/flutter/lib/src/material/elevation_overlay.dart
+++ b/packages/flutter/lib/src/material/elevation_overlay.dart
@@ -8,13 +8,9 @@ import 'package:flutter/widgets.dart';
 
 import 'theme.dart';
 
-/// A utility class for dealing with the overlay color needed
+/// Utility functions for dealing with the overlay color needed
 /// to indicate elevation of surfaces.
-class ElevationOverlay {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  ElevationOverlay._();
-
+extension ElevationOverlay on Never {
   /// Applies a surface tint color to a given container color to indicate
   /// the level of its elevation.
   ///

--- a/packages/flutter/lib/src/material/feedback.dart
+++ b/packages/flutter/lib/src/material/feedback.dart
@@ -22,7 +22,7 @@ import 'theme.dart';
 /// Calling any of these methods is a no-op on iOS as actions on that platform
 /// typically don't provide haptic or acoustic feedback.
 ///
-/// All methods in this class are usually called from within a
+/// All those functions are usually called from within a
 /// [StatelessWidget.build] method or from a [State]'s methods as you have to
 /// provide a [BuildContext].
 ///
@@ -81,11 +81,7 @@ import 'theme.dart';
 /// }
 /// ```
 /// {@end-tool}
-class Feedback {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Feedback._();
-
+extension Feedback on Never {
   /// Provides platform-specific feedback for a tap.
   ///
   /// On Android the click system sound is played. On iOS this is a no-op.

--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -10,7 +10,7 @@ import 'package:flutter/widgets.dart';
 /// A set of platform-adaptive Material Design icons.
 ///
 /// Use [Icons.adaptive] to access a static instance of this class.
-class PlatformAdaptiveIcons implements Icons {
+class PlatformAdaptiveIcons {
   const PlatformAdaptiveIcons._();
 
   static bool _isCupertino() {
@@ -100,7 +100,7 @@ class PlatformAdaptiveIcons implements Icons {
 ///
 /// Search and find the perfect icon on the [Google Fonts](https://material.io/resources/icons) website.
 ///
-/// To use this class, make sure you set `uses-material-design: true` in your
+/// To use those icons, make sure you set `uses-material-design: true` in your
 /// project's `pubspec.yaml` file in the `flutter` section. This ensures that
 /// the Material Icons font is included in your application. This font is used to
 /// display the icons. For example:
@@ -148,11 +148,7 @@ class PlatformAdaptiveIcons implements Icons {
 ///  * [Icon]
 ///  * [IconButton]
 ///  * <https://material.io/resources/icons>
-class Icons {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Icons._();
-
+extension Icons on Never {
   /// A set of platform-adaptive Material Design icons.
   ///
   /// Provides a convenient way to show a certain set of platform-appropriate

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -736,9 +736,7 @@ class Typography with Diagnosticable {
 // database by the script dev/tools/gen_defaults/bin/gen_defaults.dart.
 
 // Generated version v0_101
-class _M3Typography {
-  _M3Typography._();
-
+extension _M3Typography on Never {
   static const TextTheme englishLike = TextTheme(
     displayLarge: TextStyle(debugLabel: 'englishLike displayLarge 2021', inherit: false, fontSize: 57.0, fontWeight: FontWeight.w400, letterSpacing: -0.25, height: 1.12, textBaseline: TextBaseline.alphabetic, leadingDistribution: TextLeadingDistribution.even),
     displayMedium: TextStyle(debugLabel: 'englishLike displayMedium 2021', inherit: false, fontSize: 45.0, fontWeight: FontWeight.w400, letterSpacing: 0.0, height: 1.16, textBaseline: TextBaseline.alphabetic, leadingDistribution: TextLeadingDistribution.even),

--- a/packages/flutter/lib/src/painting/matrix_utils.dart
+++ b/packages/flutter/lib/src/painting/matrix_utils.dart
@@ -8,11 +8,7 @@ import 'package:vector_math/vector_math_64.dart';
 import 'basic_types.dart';
 
 /// Utility functions for working with matrices.
-class MatrixUtils {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  MatrixUtils._();
-
+extension MatrixUtils on Never {
   /// Returns the given [transform] matrix as an [Offset], if the matrix is
   /// nothing but a 2D translation.
   ///

--- a/packages/flutter/lib/src/rendering/layout_helper.dart
+++ b/packages/flutter/lib/src/rendering/layout_helper.dart
@@ -17,11 +17,7 @@ typedef ChildLayouter = Size Function(RenderBox child, BoxConstraints constraint
 /// given set of [BoxConstraints].
 ///
 /// All of the functions adhere to the [ChildLayouter] signature.
-class ChildLayoutHelper {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  const ChildLayoutHelper._();
-
+extension ChildLayoutHelper on Never {
   /// Returns the [Size] that the [RenderBox] would have if it were to
   /// be laid out with the given [BoxConstraints].
   ///

--- a/packages/flutter/lib/src/rendering/selection.dart
+++ b/packages/flutter/lib/src/rendering/selection.dart
@@ -205,10 +205,8 @@ mixin SelectionRegistrant on Selectable {
   }
 }
 
-/// A utility class that provides useful methods for handling selection events.
-class SelectionUtils {
-  SelectionUtils._();
-
+/// Utility functions for handling selection events.
+extension SelectionUtils on Never {
   /// Determines [SelectionResult] purely based on the target rectangle.
   ///
   /// This method returns [SelectionResult.end] if the `point` is inside the

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -17,11 +17,7 @@ export 'dart:ui' show TextDirection;
 ///
 /// When possible, prefer using mechanisms like [Semantics] to implicitly
 /// trigger announcements over using this event.
-class SemanticsService {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SemanticsService._();
-
+extension SemanticsService on Never {
   /// Sends a semantic announcement.
   ///
   /// This should be used for announcement that are not seamlessly announced by

--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -10,11 +10,7 @@ import 'text_input.dart';
 /// Each hint is pre-defined on at least one supported platform. See their
 /// documentation for their availability on each platform, and the platform
 /// values each autofill hint corresponds to.
-class AutofillHints {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  AutofillHints._();
-
+extension AutofillHints on Never {
   /// The input field expects an address locality (city/town).
   ///
   /// This hint will be translated to the below values on different platforms:

--- a/packages/flutter/lib/src/services/clipboard.dart
+++ b/packages/flutter/lib/src/services/clipboard.dart
@@ -20,12 +20,8 @@ class ClipboardData {
   final String? text;
 }
 
-/// Utility methods for interacting with the system's clipboard.
-class Clipboard {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  Clipboard._();
-
+/// Utility functions for interacting with the system's clipboard.
+extension Clipboard on Never {
   // Constants for common [getData] [format] types.
 
   /// Plain text data format string.

--- a/packages/flutter/lib/src/services/deferred_component.dart
+++ b/packages/flutter/lib/src/services/deferred_component.dart
@@ -20,11 +20,7 @@ import 'system_channels.dart';
 /// Deferred components are currently an Android-only feature. The methods in
 /// this class are a no-op and all assets and dart code are already available
 /// without installation if called on other platforms.
-class DeferredComponent {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  DeferredComponent._();
-
+extension DeferredComponent on Never {
   // TODO(garyq): We should eventually expand this to install components by loadingUnitId
   // as well as componentName, but currently, loadingUnitId is opaque to the dart code
   // so this is not possible. The API has been left flexible to allow adding

--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -9,11 +9,7 @@ import 'system_channels.dart';
 ///
 /// This API is intentionally terse since it calls default platform behavior. It
 /// is not suitable for precise control of the system's haptic feedback module.
-class HapticFeedback {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  HapticFeedback._();
-
+extension HapticFeedback on Never {
   /// Provides vibration haptic feedback to the user for a short duration.
   ///
   /// On iOS devices that support haptic feedback, this uses the default system

--- a/packages/flutter/lib/src/services/mouse_cursor.dart
+++ b/packages/flutter/lib/src/services/mouse_cursor.dart
@@ -401,11 +401,7 @@ class SystemMouseCursor extends MouseCursor {
 /// The cursors should be named based on the cursors' use cases instead of their
 /// appearance, because different platforms might (although not commonly) use
 /// different shapes for the same use case.
-class SystemMouseCursors {
-  // This class only contains static members, and should not be instantiated or
-  // extended.
-  SystemMouseCursors._();
-
+extension SystemMouseCursors on Never {
   // The mapping in this class must be kept in sync with the following files in
   // the engine:
   //

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -8,11 +8,7 @@ import 'message_codecs.dart';
 import 'platform_channel.dart';
 
 /// Platform channels used by the Flutter system.
-class SystemChannels {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemChannels._();
-
+extension SystemChannels on Never {
   /// A JSON [MethodChannel] for navigation.
   ///
   /// The following incoming methods are defined for this channel (registered

--- a/packages/flutter/lib/src/services/system_chrome.dart
+++ b/packages/flutter/lib/src/services/system_chrome.dart
@@ -354,11 +354,7 @@ List<String> _stringify(List<dynamic> list) => <String>[
 
 /// Controls specific aspects of the operating system's graphical interface and
 /// how it interacts with the application.
-class SystemChrome {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemChrome._();
-
+extension SystemChrome on Never {
   /// Specifies the set of orientations the application interface can
   /// be displayed in.
   ///

--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -6,11 +6,7 @@
 import 'system_channels.dart';
 
 /// Controls specific aspects of the system navigation stack.
-class SystemNavigator {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemNavigator._();
-
+extension SystemNavigator on Never {
   /// Removes the topmost Flutter instance, presenting what was before
   /// it.
   ///

--- a/packages/flutter/lib/src/services/system_sound.dart
+++ b/packages/flutter/lib/src/services/system_sound.dart
@@ -26,11 +26,7 @@ enum SystemSoundType {
 
 /// Provides access to the library of short system specific sounds for common
 /// tasks.
-class SystemSound {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  SystemSound._();
-
+extension SystemSound on Never {
   /// Play the specified system sound. If that sound is not present on the
   /// system, the call is ignored.
   ///

--- a/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
+++ b/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
@@ -76,17 +76,13 @@ Future<PortForwarder> _dummyPortForwardingFunction(
   return _DummyPortForwarder(remotePort, remotePort);
 }
 
-/// Utility class for creating connections to the Fuchsia Device.
+/// Utility functions for creating connections to the Fuchsia Device.
 ///
 /// If executed on a host (non-Fuchsia device), behaves the same as running
 /// [FuchsiaRemoteConnection.connect] whereby the `FUCHSIA_REMOTE_URL` and
 /// `FUCHSIA_SSH_CONFIG` variables must be set. If run on a Fuchsia device, will
 /// connect locally without need for environment variables.
-class FuchsiaCompat {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  FuchsiaCompat._();
-
+extension FuchsiaCompat on Never {
   static void _init() {
     fuchsiaPortForwardingFunction = _dummyPortForwardingFunction;
   }

--- a/packages/flutter_test/lib/src/event_simulation.dart
+++ b/packages/flutter_test/lib/src/event_simulation.dart
@@ -36,14 +36,8 @@ String? _keyLabel(LogicalKeyboardKey key) {
   return null;
 }
 
-// ignore: avoid_classes_with_only_static_members
-/// A class that serves as a namespace for a bunch of keyboard-key generation
-/// utilities.
-class KeyEventSimulator {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  KeyEventSimulator._();
-
+/// Namespace for a bunch of keyboard-key generation utilities.
+extension KeyEventSimulator on Never {
   // Look up a synonym key, and just return the left version of it.
   static LogicalKeyboardKey _getKeySynonym(LogicalKeyboardKey origKey) {
     if (origKey == LogicalKeyboardKey.shift) {

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -12,11 +12,11 @@ class _AsyncScope {
   final Zone zone;
 }
 
-/// Utility class for all the async APIs in the `flutter_test` library.
+/// Utility functions for all the async APIs in the `flutter_test` library.
 ///
-/// This class provides checking for asynchronous APIs, allowing the library to
-/// verify that all the asynchronous APIs are properly `await`ed before calling
-/// another.
+/// This set of functions provides checking for asynchronous APIs, allowing the
+/// library to verify that all the asynchronous APIs are properly `await`ed
+/// before calling another.
 ///
 /// For example, it prevents this kind of code:
 ///
@@ -44,10 +44,7 @@ class _AsyncScope {
 ///   // ...
 /// });
 /// ```
-class TestAsyncUtils {
-  // This class is not meant to be instantiated or extended; this constructor
-  // prevents instantiation and extension.
-  TestAsyncUtils._();
+extension TestAsyncUtils on Never {
   static const String _className = 'TestAsyncUtils';
 
   static final List<_AsyncScope> _scopeStack = <_AsyncScope>[];


### PR DESCRIPTION
According to https://github.com/dart-lang/language/issues/2270#issuecomment-1144117060 using `extension Colors on Never { /* static members here. */ }` provides a namespace that can never be used for anything else. Thus it is impossible for instance to implement `Colors`.

This PR replaces classes only used as namespaces with this pattern.