### PR TITLE
Support for configuring environment variables using configuration file

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1107,7 +1107,7 @@ abstract class FlutterCommand extends Command<void> {
       dartDefines = updateDartDefines(dartDefines, stringArgDeprecated('web-renderer')!);
     }
 
-    return BuildInfo(buildMode,
+    BuildInfo buildInfo = BuildInfo(buildMode,
       argParser.options.containsKey('flavor')
         ? stringArgDeprecated('flavor')
         : null,
@@ -1143,6 +1143,8 @@ abstract class FlutterCommand extends Command<void> {
       assumeInitializeFromDillUpToDate: argParser.options.containsKey(FlutterOptions.kAssumeInitializeFromDillUpToDate)
           && boolArgDeprecated(FlutterOptions.kAssumeInitializeFromDillUpToDate),
     );
+    buildInfo.modifyDartDefines();
+    return buildInfo;
   }
 
   void setupApplicationPackages() {


### PR DESCRIPTION
Add a function: the developer configures a json file, which will read all the contents of the configuration into the corresponding variables and parameters，then you can use it in android and iOS projects with custom variables


1、Define  json file 


```
flutter build apk  --dart-define=CUSTOM_ENVIRONMENT_FILE=config.json 
```
for example: config.json  content
```
{
  "facebookAppId": "xxx",
  "versionName": "1.0.0",
  "label": "xxx xxx",
  "versionCode": 1,
  "android_applicationId": "com.xxx.br",
  "ios_bundle_identifier": "com.xxx.xxxx.nomodify",
  "googleAndroidApiKey": "xxxx",
  "googleAndroidAppId": "1:xxx:android:xxx",
  "googleAndroidMessagingSenderId": "xxx",
  "googleAndroidProjectId": "first-xxx",
  "googleAndroidStorageBucket": "first-xxx.xxx.com",
  "googleAndroidClientId": "xxx-xxxx.apps.googleusercontent.com",
  "googleIosClientId": "com.xxx.apps.xxx-xxx",
  "googleIosBundleId": "com.xxxx.br",
  "schemeHost": "first.xxx.com",
  "scheme": "xxxxx",
  "privacyProtocol": "https://xxxx.com/privacyProtocol.html",
  "teamsOfService": "https://xxx.com/teamsOfService.html",
  "androidChannel": "1OSH1PP64X",
  "iosChannel": "1J6C22IH91",
  "iosUploadCSymS": "false",
  "universalLinkDomain": "br.xxx.com"
}
```

2、Use environment in flutter

 You can get all json raw content:
```dart
var configRaw =
        const String.fromEnvironment("CUSTOM_ENVIRONMENT_FILE_RAW", defaultValue: "{}");
```
Or ,you can get field by 

```dart
var facebookAppId =
        const String.fromEnvironment("facebookAppId", defaultValue: "");
```

3、Android project 

file: `build.gradle`

```gradle

    buildTypes {
        release {
            manifestPlaceholders = [
                    faceBook_appId       : facebookAppId
            ]

            resValue "string", "facebook_app_id", facebookAppId

```

4、iOS project 
 
 file: `ios/Flutter/Generated.xcconfig`

```
  facebookAppId=xxx
  versionCode=1
  android_applicationId=com.xxx.br
  ios_bundle_identifier=com.xxx.xxxx.nomodify
 ……
```

 file: `ios/Flutter/flutter_export_environment.sh`

```shell
export "facebookAppId=xxx"
export "versionCode=1"
export "  android_applicationId=com.xxx.br"
export "ios_bundle_identifier=com.xxx.xxxx.nomodify"
……

```

You can use in Info.plist


```
	<key>CFBundleIdentifier</key>
	<string>$(ios_bundle_identifier)</string>
```
 
 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
