### PR TITLE
Search for local flutter engine in engine/src and src

### DIFF
--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -61,6 +61,9 @@ class LocalEngineLocator {
       engineSourcePath ??= _tryEnginePath(
         _fileSystem.path.join(_fileSystem.directory(_flutterRoot).parent.path, 'engine', 'src'),
       );
+      engineSourcePath ??= _tryEnginePath(
+        _fileSystem.path.join(_fileSystem.directory(_flutterRoot).parent.path, 'src'),
+      );
     }
 
     if (engineSourcePath != null && _tryEnginePath(engineSourcePath) == null) {


### PR DESCRIPTION
The search for a local flutter/engine checkout, and its build directory,
searches paths from FLUTTER_ENGINE, --local-engine-src-dir, the
pubspec.yaml, and [flutter]/../engine/src.

Add [flutter]/../src to this search, so a monorepo checkout
based on flutter/engine/DEPS can locate it.

Bug: https://github.com/dart-lang/sdk/issues/49163