### PR TITLE
Enable skipped test for Dart URI logs from DWDS

### DIFF
--- a/packages/flutter_tools/test/web.shard/output_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/output_web_test.dart
@@ -90,6 +90,5 @@ void main() {
     await start();
     await flutter.stop();
     expect(containsDartUriWarning, isFalse);
-    // TODO(elliette): Enable for DWDS >13.1.0, https://github.com/flutter/flutter/issues/101639
-  }, skip: true); // [intended] enable for DWDS >13.1.0
+  });
 }


### PR DESCRIPTION
Enables the test checking for Dart URI warning messages in the logs from DWDS.

Now that DWDS is `>13.1.0`, this test should be enabled to catch any regressions to https://github.com/flutter/flutter/issues/101639.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
