### PR TITLE
Updated the analyze.dart deprecation check to only look for beta branch versions.

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -495,6 +495,16 @@ Future<void> verifyDeprecations(String workingDirectory, { int minimumMatches = 
             throw 'Incomplete deprecation notice.';
           versionMatch = _deprecationVersionPattern.firstMatch(lines[lineNumber]);
         } while (versionMatch == null);
+        final int major = int.parse(versionMatch.namedGroup('major')!);
+        final int minor = int.parse(versionMatch.namedGroup('minor')!);
+        final int patch = int.parse(versionMatch.namedGroup('patch')!);
+        final bool hasBuild = versionMatch.namedGroup('build') != null;
+        // There was a beta release that was mistakenly labeled 3.1.0 without a build.
+        final bool specialBeta = major == 3 && minor == 1 && patch == 0;
+        if (!specialBeta && (major > 1 || (major == 1 && minor >= 20))) {
+          if (!hasBuild)
+            throw 'Deprecation notice does not accurately indicate a dev branch version number; please see https://flutter.dev/docs/development/tools/sdk/releases to find the latest dev build version number.';
+        }
         if (!message.endsWith('.') && !message.endsWith('!') && !message.endsWith('?'))
           throw 'Deprecation notice should be a grammatically correct sentence and end with a period.';
         if (!lines[lineNumber].startsWith("$indent  '"))

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -503,7 +503,7 @@ Future<void> verifyDeprecations(String workingDirectory, { int minimumMatches = 
         final bool specialBeta = major == 3 && minor == 1 && patch == 0;
         if (!specialBeta && (major > 1 || (major == 1 && minor >= 20))) {
           if (!hasBuild)
-            throw 'Deprecation notice does not accurately indicate a dev branch version number; please see https://flutter.dev/docs/development/tools/sdk/releases to find the latest dev build version number.';
+            throw 'Deprecation notice does not accurately indicate a beta branch version number; please see https://flutter.dev/docs/development/tools/sdk/releases to find the latest beta build version number.';
         }
         if (!message.endsWith('.') && !message.endsWith('!') && !message.endsWith('?'))
           throw 'Deprecation notice should be a grammatically correct sentence and end with a period.';

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -368,7 +368,7 @@ Future<void> verifyNoSyncAsyncStar(String workingDirectory, {int minimumMatches 
 
 final RegExp _findGoldenTestPattern = RegExp(r'matchesGoldenFile\(');
 final RegExp _findGoldenDefinitionPattern = RegExp(r'matchesGoldenFile\(Object');
-final RegExp _leadingComment = RegExp(r'\/\/');
+final RegExp _leadingComment = RegExp(r'//');
 final RegExp _goldenTagPattern1 = RegExp(r'@Tags\(');
 final RegExp _goldenTagPattern2 = RegExp(r"'reduced-test-set'");
 
@@ -435,7 +435,7 @@ Future<void> verifyGoldenTags(String workingDirectory, { int minimumMatches = 20
 final RegExp _findDeprecationPattern = RegExp(r'@[Dd]eprecated');
 final RegExp _deprecationPattern1 = RegExp(r'^( *)@Deprecated\($'); // flutter_ignore: deprecation_syntax (see analyze.dart)
 final RegExp _deprecationPattern2 = RegExp(r"^ *'(.+) '$");
-final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v([0-9]+)\.([0-9]+)\.([0-9]+)(\-[0-9]+\.[0-9]+\.pre)?\.',?$");
+final RegExp _deprecationPattern3 = RegExp(r"^ *'This feature was deprecated after v(\d+)\.(\d+)\.(\d+)(-\d+\.\d+\.pre)?\.',?$");
 final RegExp _deprecationPattern4 = RegExp(r'^ *\)$');
 
 /// Some deprecation notices are special, for example they're used to annotate members that
@@ -446,7 +446,7 @@ final RegExp _deprecationPattern4 = RegExp(r'^ *\)$');
 const String _ignoreDeprecation = ' // flutter_ignore: deprecation_syntax (see analyze.dart)';
 
 /// Some deprecation notices are exempt for historical reasons. They must have an issue listed.
-final RegExp _legacyDeprecation = RegExp(r' // flutter_ignore: deprecation_syntax, https://github.com/flutter/flutter/issues/[0-9]+$');
+final RegExp _legacyDeprecation = RegExp(r' // flutter_ignore: deprecation_syntax, https://github.com/flutter/flutter/issues/\d+$');
 
 Future<void> verifyDeprecations(String workingDirectory, { int minimumMatches = 2000 }) async {
   final List<String> errors = <String>[];
@@ -495,13 +495,6 @@ Future<void> verifyDeprecations(String workingDirectory, { int minimumMatches = 
             throw 'Incomplete deprecation notice.';
           match3 = _deprecationPattern3.firstMatch(lines[lineNumber]);
         } while (match3 == null);
-        final int v1 = int.parse(match3[1]!);
-        final int v2 = int.parse(match3[2]!);
-        final bool hasV4 = match3[4] != null;
-        if (v1 > 1 || (v1 == 1 && v2 >= 20)) {
-          if (!hasV4)
-            throw 'Deprecation notice does not accurately indicate a dev branch version number; please see https://flutter.dev/docs/development/tools/sdk/releases to find the latest dev build version number.';
-        }
         if (!message!.endsWith('.') && !message.endsWith('!') && !message.endsWith('?'))
           throw 'Deprecation notice should be a grammatically correct sentence and end with a period.';
         if (!lines[lineNumber].startsWith("$indent  '"))
@@ -637,7 +630,7 @@ class _TestSkipLinesVisitor<T> extends RecursiveAstVisitor<T> {
 
 final RegExp _skipTestCommentPattern = RegExp(r'//(.*)$');
 const Pattern _skipTestIntentionalPattern = '[intended]';
-final Pattern _skipTestTrackingBugPattern = RegExp(r'https+?://github.com/.*/issues/[0-9]+');
+final Pattern _skipTestTrackingBugPattern = RegExp(r'https+?://github.com/.*/issues/\d+');
 
 Future<void> verifySkipTestComments(String workingDirectory) async {
   final List<String> errors = <String>[];
@@ -1721,7 +1714,7 @@ Future<void> _checkConsumerDependencies() async {
 }
 
 const String _kDebugOnlyAnnotation = '@_debugOnly';
-final RegExp _nullInitializedField = RegExp(r'kDebugMode \? [\w\<\> ,{}()]+ : null;');
+final RegExp _nullInitializedField = RegExp(r'kDebugMode \? [\w<> ,{}()]+ : null;');
 
 Future<void> verifyNullInitializedDebugExpensiveFields(String workingDirectory, {int minimumMatches = 400}) async {
   final String flutterLib = path.join(workingDirectory, 'packages', 'flutter', 'lib');

--- a/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
@@ -66,19 +66,19 @@ void test11() { }
 void test12() { }
 
 @Deprecated(
-  'Version number test (should fail). '
+  'Version number test (should pass). '
   'This feature was deprecated after v1.20.0.'
 )
 void test13() { }
 
 @Deprecated(
-  'Version number test (should fail). '
+  'Version number test (should pass). '
   'This feature was deprecated after v1.21.0.'
 )
 void test14() { }
 
 @Deprecated(
-  'Version number test (should fail). '
+  'Version number test (should pass). '
   'This feature was deprecated after v3.1.0.'
 )
 void test15() { }

--- a/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/deprecation.dart
@@ -66,19 +66,19 @@ void test11() { }
 void test12() { }
 
 @Deprecated(
-  'Version number test (should pass). '
+  'Version number test (should fail). '
   'This feature was deprecated after v1.20.0.'
 )
 void test13() { }
 
 @Deprecated(
-  'Version number test (should pass). '
+  'Version number test (should fail). '
   'This feature was deprecated after v1.21.0.'
 )
 void test14() { }
 
 @Deprecated(
-  'Version number test (should pass). '
+  'Version number test (special beta should pass). '
   'This feature was deprecated after v3.1.0.'
 )
 void test15() { }

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -53,9 +53,6 @@ void main() {
         'test/analyze-test-input/root/packages/foo/deprecation.dart:41: Deprecation notice does not match required pattern.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:48: End of deprecation notice does not match required pattern.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:51: Unexpected deprecation notice indent.',
-        'test/analyze-test-input/root/packages/foo/deprecation.dart:70: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
-        'test/analyze-test-input/root/packages/foo/deprecation.dart:76: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
-        'test/analyze-test-input/root/packages/foo/deprecation.dart:82: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:99: Deprecation notice does not match required pattern. You might have used double quotes (") for the string instead of single quotes (\').',
       ]
       .map((String line) {

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -53,8 +53,8 @@ void main() {
         'test/analyze-test-input/root/packages/foo/deprecation.dart:41: Deprecation notice does not match required pattern.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:48: End of deprecation notice does not match required pattern.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:51: Unexpected deprecation notice indent.',
-        'test/analyze-test-input/root/packages/foo/deprecation.dart:70: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
-        'test/analyze-test-input/root/packages/foo/deprecation.dart:76: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
+        'test/analyze-test-input/root/packages/foo/deprecation.dart:70: Deprecation notice does not accurately indicate a beta branch version number; please see RELEASES_URL to find the latest beta build version number.',
+        'test/analyze-test-input/root/packages/foo/deprecation.dart:76: Deprecation notice does not accurately indicate a beta branch version number; please see RELEASES_URL to find the latest beta build version number.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:99: Deprecation notice does not match required pattern. You might have used double quotes (") for the string instead of single quotes (\').',
       ]
       .map((String line) {

--- a/dev/bots/test/analyze_test.dart
+++ b/dev/bots/test/analyze_test.dart
@@ -53,6 +53,8 @@ void main() {
         'test/analyze-test-input/root/packages/foo/deprecation.dart:41: Deprecation notice does not match required pattern.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:48: End of deprecation notice does not match required pattern.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:51: Unexpected deprecation notice indent.',
+        'test/analyze-test-input/root/packages/foo/deprecation.dart:70: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
+        'test/analyze-test-input/root/packages/foo/deprecation.dart:76: Deprecation notice does not accurately indicate a dev branch version number; please see RELEASES_URL to find the latest dev build version number.',
         'test/analyze-test-input/root/packages/foo/deprecation.dart:99: Deprecation notice does not match required pattern. You might have used double quotes (") for the string instead of single quotes (\').',
       ]
       .map((String line) {


### PR DESCRIPTION
The current analyzer bot script looks for dev versions in the deprecated warnings. As we no longer have dev releases this PR updates the check to only look for beta version numbers (i.e. vX.X.X).

This also cleans up some lint warnings for some of the regexp raw strings.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
