### PR TITLE
Update parameters to the `styleFrom` button methods.

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/material/cards_demo.dart
@@ -247,7 +247,7 @@ class TravelDestinationContent extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final TextStyle titleStyle = theme.textTheme.headline5!.copyWith(color: Colors.white);
     final TextStyle descriptionStyle = theme.textTheme.subtitle1!;
-    final ButtonStyle textButtonStyle = TextButton.styleFrom(primary: Colors.amber.shade500);
+    final ButtonStyle textButtonStyle = TextButton.styleFrom(foregroundColor: Colors.amber.shade500);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/dev/integration_tests/flutter_gallery/lib/demo/shrine/shopping_cart.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/shrine/shopping_cart.dart
@@ -78,7 +78,7 @@ class _ShoppingCartPageState extends State<ShoppingCartPage> {
                   right: 16.0,
                   child: ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      primary: kShrinePink100,
+                      backgroundColor: kShrinePink100,
                       shape: const BeveledRectangleBorder(
                         borderRadius: BorderRadius.all(Radius.circular(7.0)),
                       ),

--- a/dev/integration_tests/flutter_gallery/lib/gallery/options.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/options.dart
@@ -177,7 +177,7 @@ class _TextButton extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     return TextButton(
       style: TextButton.styleFrom(
-        primary: theme.colorScheme.onPrimary,
+        foregroundColor: theme.colorScheme.onPrimary,
         textStyle: theme.textTheme.subtitle1,
         padding: EdgeInsets.zero,
       ),

--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -534,7 +534,7 @@ class _MyHomePageState extends State<MyHomePage> {
         label: _model.rtl ? 'زر مسطح' : 'Text Button',
         child: TextButton(
           style: TextButton.styleFrom(
-            primary: Colors.white,
+            foregroundColor: Colors.white,
             backgroundColor: m2Swatch[200]
           ),
           onPressed: _model.enable ? () {} : null,

--- a/dev/manual_tests/lib/text.dart
+++ b/dev/manual_tests/lib/text.dart
@@ -44,7 +44,7 @@ class _HomeState extends State<Home> {
               children: <Widget>[
                 TextButton(
                   style: TextButton.styleFrom(
-                    primary: Colors.white,
+                    foregroundColor: Colors.white,
                     backgroundColor: Colors.red.shade800,
                   ),
                   onPressed: () { Navigator.pushNamed(context, 'underlines'); },
@@ -52,7 +52,7 @@ class _HomeState extends State<Home> {
                 ),
                 TextButton(
                   style: TextButton.styleFrom(
-                    primary: Colors.white,
+                    foregroundColor: Colors.white,
                     backgroundColor: Colors.orange.shade700,
                   ),
                   onPressed: () { Navigator.pushNamed(context, 'fallback'); },
@@ -60,7 +60,7 @@ class _HomeState extends State<Home> {
                 ),
                 TextButton(
                   style: TextButton.styleFrom(
-                    primary: Colors.black,
+                    foregroundColor: Colors.black,
                     backgroundColor: Colors.yellow.shade700,
                   ),
                   onPressed: () { Navigator.pushNamed(context, 'bidi'); },
@@ -68,7 +68,7 @@ class _HomeState extends State<Home> {
                 ),
                 TextButton(
                   style: TextButton.styleFrom(
-                    primary: Colors.black,
+                    foregroundColor: Colors.black,
                     backgroundColor: Colors.green.shade400,
                   ),
                   onPressed: () { Navigator.pushNamed(context, 'fuzzer'); },
@@ -76,7 +76,7 @@ class _HomeState extends State<Home> {
                 ),
                 TextButton(
                   style: TextButton.styleFrom(
-                    primary: Colors.white,
+                    foregroundColor: Colors.white,
                     backgroundColor: Colors.blue.shade400,
                   ),
                   onPressed: () { Navigator.pushNamed(context, 'zalgo'); },
@@ -84,7 +84,7 @@ class _HomeState extends State<Home> {
                 ),
                 TextButton(
                   style: TextButton.styleFrom(
-                    primary: Colors.black,
+                    foregroundColor: Colors.black,
                     backgroundColor: Colors.purple.shade200,
                   ),
                   onPressed: () { Navigator.pushNamed(context, 'painting'); },
@@ -618,7 +618,7 @@ class _UnderlinesState extends State<Underlines> {
                   ),
                   TextButton(
                     style: TextButton.styleFrom(
-                      primary: Colors.white,
+                      foregroundColor: Colors.white,
                       backgroundColor: Colors.red,
                     ),
                     onPressed: _text == '' ? null : () {

--- a/examples/api/lib/material/app_bar/app_bar.2.dart
+++ b/examples/api/lib/material/app_bar/app_bar.2.dart
@@ -25,7 +25,7 @@ class AppBarExample extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ButtonStyle style = TextButton.styleFrom(
-      primary: Theme.of(context).colorScheme.onPrimary,
+      foregroundColor: Theme.of(context).colorScheme.onPrimary,
     );
     return Scaffold(
       appBar: AppBar(

--- a/examples/api/lib/material/button_style/button_style.0.dart
+++ b/examples/api/lib/material/button_style/button_style.0.dart
@@ -63,10 +63,8 @@ class ButtonTypesGroup extends StatelessWidget {
           // 'Filled' type.
           ElevatedButton(
             style: ElevatedButton.styleFrom(
-              // Foreground color
-              onPrimary: Theme.of(context).colorScheme.onPrimary,
-              // Background color
-              primary: Theme.of(context).colorScheme.primary,
+              foregroundColor: Theme.of(context).colorScheme.onPrimary,
+              backgroundColor: Theme.of(context).colorScheme.primary,
             ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
             onPressed: onPressed,
             child: const Text('Filled'),
@@ -76,10 +74,8 @@ class ButtonTypesGroup extends StatelessWidget {
           // 'Filled Tonal' type.
           ElevatedButton(
             style: ElevatedButton.styleFrom(
-              // Foreground color
-              onPrimary: Theme.of(context).colorScheme.onSecondaryContainer,
-              // Background color
-              primary: Theme.of(context).colorScheme.secondaryContainer,
+              foregroundColor: Theme.of(context).colorScheme.onSecondaryContainer,
+              backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
             ).copyWith(elevation: ButtonStyleButton.allOrNull(0.0)),
             onPressed: onPressed,
             child: const Text('Filled Tonal'),

--- a/examples/api/lib/material/navigation_bar/navigation_bar.0.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.0.dart
@@ -35,7 +35,7 @@ class RootPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final TextStyle headline5 = Theme.of(context).textTheme.headline5!;
     final ButtonStyle buttonStyle = ElevatedButton.styleFrom(
-      primary: destination.color,
+      backgroundColor: destination.color,
       visualDensity: VisualDensity.comfortable,
       padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
       textStyle: headline5,
@@ -125,7 +125,7 @@ class ListPage extends StatelessWidget {
   Widget build(BuildContext context) {
     const int itemCount = 50;
     final ButtonStyle buttonStyle = OutlinedButton.styleFrom(
-      primary: destination.color,
+      foregroundColor: destination.color,
       fixedSize: const Size.fromHeight(128),
       textStyle: Theme.of(context).textTheme.headline5,
     );

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -69,8 +69,8 @@ class MyStatelessWidget extends StatelessWidget {
                 ),
                 TextButton(
                   style: TextButton.styleFrom(
+                    foregroundColor: Colors.white,
                     padding: const EdgeInsets.all(16.0),
-                    primary: Colors.white,
                     textStyle: const TextStyle(fontSize: 20),
                   ),
                   onPressed: () {},

--- a/examples/api/lib/widgets/basic/absorb_pointer.0.dart
+++ b/examples/api/lib/widgets/basic/absorb_pointer.0.dart
@@ -49,7 +49,7 @@ class MyStatelessWidget extends StatelessWidget {
           child: AbsorbPointer(
             child: ElevatedButton(
               style: ElevatedButton.styleFrom(
-                primary: Colors.blue.shade200,
+                backgroundColor: Colors.blue.shade200,
               ),
               onPressed: () {},
               child: null,

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -17,7 +17,7 @@
 
 version: 1
 transforms:
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'ElevatedButton.styleFrom(primary)' to 'ElevatedButton.styleFrom(backgroundColor)'"
     date: 2022-05-27
     element:
@@ -39,7 +39,7 @@ transforms:
         kind: 'fragment'
         value: 'arguments[primary]'
 
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'ElevatedButton.styleFrom(onPrimary)' to 'ElevatedButton.styleFrom(foregroundColor)'"
     date: 2022-05-27
     element:
@@ -61,7 +61,7 @@ transforms:
         kind: 'fragment'
         value: 'arguments[onPrimary]'
 
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'ElevatedButton.styleFrom(onSurface)' to 'ElevatedButton.styleFrom(disabledForegroundColor)'"
     date: 2022-05-27
     element:
@@ -90,7 +90,7 @@ transforms:
        kind: 'fragment'
        value: 'arguments[onSurface]'
 
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'OutlinedButton.styleFrom(primary)' to 'OutlinedButton.styleFrom(foregroundColor)'"
     date: 2022-05-27
     element:
@@ -112,7 +112,7 @@ transforms:
         kind: 'fragment'
         value: 'arguments[primary]'
 
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'OutlinedButton.styleFrom(onSurface)' to 'OutlinedButton.styleFrom(disabledForeground)'"
     date: 2022-05-27
     element:
@@ -134,7 +134,7 @@ transforms:
         kind: 'fragment'
         value: 'arguments[onSurface]'
 
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'TextButton.styleFrom(primary)' to 'TextButton.styleFrom(foregroundColor)'"
     date: 2022-05-27
     element:
@@ -156,7 +156,7 @@ transforms:
         kind: 'fragment'
         value: 'arguments[primary]'
 
-  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  # Changes made in https://github.com/flutter/flutter/pull/105291
   - title: "Migrate 'TextButton.styleFrom(onSurface)' to 'TextButton.styleFrom(disabledForeground)'"
     date: 2022-05-27
     element:

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -17,6 +17,167 @@
 
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'ElevatedButton.styleFrom(primary)' to 'ElevatedButton.styleFrom(backgroundColor)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'ElevatedButton'
+    changes:
+      - kind: 'addParameter'
+        index: 1
+        name: 'backgroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% primary %}'
+          requiredIf: "primary != ''"
+      - kind: 'removeParameter'
+        name: 'primary'
+    variables:
+      primary:
+        kind: 'fragment'
+        value: 'arguments[primary]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'ElevatedButton.styleFrom(onPrimary)' to 'ElevatedButton.styleFrom(foregroundColor)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'ElevatedButton'
+    changes:
+      - kind: 'addParameter'
+        index: 0
+        name: 'foregroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% onPrimary %}'
+          requiredIf: "onPrimary != ''"
+      - kind: 'removeParameter'
+        name: 'onPrimary'
+    variables:
+      onPrimary:
+        kind: 'fragment'
+        value: 'arguments[onPrimary]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'ElevatedButton.styleFrom(onSurface)' to 'ElevatedButton.styleFrom(disabledForegroundColor)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'ElevatedButton'
+    changes:
+      - kind: 'addParameter'
+        index: 2
+        name: 'disabledForegroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% onSurface %}.withOpacity(0.38)'
+          requiredIf: "onSurface != ''"
+      - kind: 'addParameter'
+        index: 3
+        name: 'disabledBackgroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% onSurface %}.withOpacity(0.12)'
+          requiredIf: "onSurface != ''"
+      - kind: 'removeParameter'
+        name: 'onSurface'
+    variables:
+     onSurface:
+       kind: 'fragment'
+       value: 'arguments[onSurface]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'OutlinedButton.styleFrom(primary)' to 'OutlinedButton.styleFrom(foregroundColor)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'OutlinedButton'
+    changes:
+      - kind: 'addParameter'
+        index: 0
+        name: 'foregroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% primary %}'
+          requiredIf: "primary != ''"
+      - kind: 'removeParameter'
+        name: 'primary'
+    variables:
+      primary:
+        kind: 'fragment'
+        value: 'arguments[primary]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'OutlinedButton.styleFrom(onSurface)' to 'OutlinedButton.styleFrom(disabledForeground)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'OutlinedButton'
+    changes:
+      - kind: 'addParameter'
+        index: 2
+        name: 'disabledForegroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% onSurface %}.withOpacity(0.38)'
+          requiredIf: "onSurface != ''"
+      - kind: 'removeParameter'
+        name: 'onSurface'
+    variables:
+      onSurface:
+        kind: 'fragment'
+        value: 'arguments[onSurface]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'TextButton.styleFrom(primary)' to 'TextButton.styleFrom(foregroundColor)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'TextButton'
+    changes:
+      - kind: 'addParameter'
+        index: 0
+        name: 'foregroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% primary %}'
+          requiredIf: "primary != ''"
+      - kind: 'removeParameter'
+        name: 'primary'
+    variables:
+      primary:
+        kind: 'fragment'
+        value: 'arguments[primary]'
+
+  # Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  - title: "Migrate 'TextButton.styleFrom(onSurface)' to 'TextButton.styleFrom(disabledForeground)'"
+    date: 2022-05-27
+    element:
+      uris: [ 'material.dart' ]
+      method: 'styleFrom'
+      inClass: 'TextButton'
+    changes:
+      - kind: 'addParameter'
+        index: 2
+        name: 'disabledForegroundColor'
+        style: optional_named
+        argumentValue:
+          expression: '{% onSurface %}.withOpacity(0.38)'
+          requiredIf: "onSurface != ''"
+      - kind: 'removeParameter'
+        name: 'onSurface'
+    variables:
+      onSurface:
+        kind: 'fragment'
+        value: 'arguments[onSurface]'
+
   # Changes made in https://github.com/flutter/flutter/pull/100381
   - title: "Migrate 'TextSelectionOverlay.fadeDuration' to SelectionOverlay.fadeDuration"
     date: 2022-03-18

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -176,8 +176,8 @@ class ElevatedButton extends ButtonStyleButton {
     final Color? background = backgroundColor ?? primary;
     final Color? disabledBackground = disabledBackgroundColor ?? onSurface?.withOpacity(0.12);
     final MaterialStateProperty<Color?>? backgroundColorProp = (background == null && disabledBackground == null)
-        ? null
-        : _ElevatedButtonDefaultColor(background, disabledBackground);
+      ? null
+      : _ElevatedButtonDefaultColor(background, disabledBackground);
     final Color? foreground = foregroundColor ?? onPrimary;
     final Color? disabledForeground = disabledForegroundColor ?? onSurface?.withOpacity(0.38);
     final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)

--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -135,9 +135,10 @@ class ElevatedButton extends ButtonStyleButton {
   /// )
   /// ```
   static ButtonStyle styleFrom({
-    Color? primary,
-    Color? onPrimary,
-    Color? onSurface,
+    Color? foregroundColor,
+    Color? backgroundColor,
+    Color? disabledForegroundColor,
+    Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
     double? elevation,
@@ -156,16 +157,35 @@ class ElevatedButton extends ButtonStyleButton {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
+    @Deprecated(
+      'Use backgroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? primary,
+    @Deprecated(
+      'Use foregroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? onPrimary,
+    @Deprecated(
+      'Use disabledForegroundColor and disabledBackgroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? onSurface,
   }) {
-    final MaterialStateProperty<Color?>? backgroundColor = (onSurface == null && primary == null)
+    final Color? background = backgroundColor ?? primary;
+    final Color? disabledBackground = disabledBackgroundColor ?? onSurface?.withOpacity(0.12);
+    final MaterialStateProperty<Color?>? backgroundColorProp = (background == null && disabledBackground == null)
+        ? null
+        : _ElevatedButtonDefaultColor(background, disabledBackground);
+    final Color? foreground = foregroundColor ?? onPrimary;
+    final Color? disabledForeground = disabledForegroundColor ?? onSurface?.withOpacity(0.38);
+    final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
       ? null
-      : _ElevatedButtonDefaultBackground(primary, onSurface);
-    final MaterialStateProperty<Color?>? foregroundColor = (onSurface == null && onPrimary == null)
+      : _ElevatedButtonDefaultColor(foreground, disabledForeground);
+    final MaterialStateProperty<Color?>? overlayColor = (foreground == null)
       ? null
-      : _ElevatedButtonDefaultForeground(onPrimary, onSurface);
-    final MaterialStateProperty<Color?>? overlayColor = (onPrimary == null)
-      ? null
-      : _ElevatedButtonDefaultOverlay(onPrimary);
+      : _ElevatedButtonDefaultOverlay(foreground);
     final MaterialStateProperty<double>? elevationValue = (elevation == null)
       ? null
       : _ElevatedButtonDefaultElevation(elevation);
@@ -175,8 +195,8 @@ class ElevatedButton extends ButtonStyleButton {
 
     return ButtonStyle(
       textStyle: MaterialStatePropertyAll<TextStyle?>(textStyle),
-      backgroundColor: backgroundColor,
-      foregroundColor: foregroundColor,
+      backgroundColor: backgroundColorProp,
+      foregroundColor: foregroundColorProp,
       overlayColor: overlayColor,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
@@ -321,9 +341,10 @@ class ElevatedButton extends ButtonStyleButton {
     return Theme.of(context).useMaterial3
       ? _TokenDefaultsM3(context)
       : styleFrom(
-          primary: colorScheme.primary,
-          onPrimary: colorScheme.onPrimary,
-          onSurface: colorScheme.onSurface,
+          backgroundColor: colorScheme.primary,
+          foregroundColor: colorScheme.onPrimary,
+          disabledBackgroundColor: colorScheme.onSurface.withOpacity(0.12),
+          disabledForegroundColor: colorScheme.onSurface.withOpacity(0.38),
           shadowColor: theme.shadowColor,
           elevation: 2,
           textStyle: theme.textTheme.button,
@@ -360,50 +381,34 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
 }
 
 @immutable
-class _ElevatedButtonDefaultBackground extends MaterialStateProperty<Color?> with Diagnosticable {
-  _ElevatedButtonDefaultBackground(this.primary, this.onSurface);
+class _ElevatedButtonDefaultColor extends MaterialStateProperty<Color?> with Diagnosticable {
+  _ElevatedButtonDefaultColor(this.color, this.disabled);
 
-  final Color? primary;
-  final Color? onSurface;
-
-  @override
-  Color? resolve(Set<MaterialState> states) {
-    if (states.contains(MaterialState.disabled)) {
-      return onSurface?.withOpacity(0.12);
-    }
-    return primary;
-  }
-}
-
-@immutable
-class _ElevatedButtonDefaultForeground extends MaterialStateProperty<Color?> with Diagnosticable {
-  _ElevatedButtonDefaultForeground(this.onPrimary, this.onSurface);
-
-  final Color? onPrimary;
-  final Color? onSurface;
+  final Color? color;
+  final Color? disabled;
 
   @override
   Color? resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return onSurface?.withOpacity(0.38);
+      return disabled;
     }
-    return onPrimary;
+    return color;
   }
 }
 
 @immutable
 class _ElevatedButtonDefaultOverlay extends MaterialStateProperty<Color?> with Diagnosticable {
-  _ElevatedButtonDefaultOverlay(this.onPrimary);
+  _ElevatedButtonDefaultOverlay(this.overlay);
 
-  final Color onPrimary;
+  final Color overlay;
 
   @override
   Color? resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.hovered)) {
-      return onPrimary.withOpacity(0.08);
+      return overlay.withOpacity(0.08);
     }
     if (states.contains(MaterialState.focused) || states.contains(MaterialState.pressed)) {
-      return onPrimary.withOpacity(0.24);
+      return overlay.withOpacity(0.24);
     }
     return null;
   }

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -133,9 +133,10 @@ class OutlinedButton extends ButtonStyleButton {
   /// )
   /// ```
   static ButtonStyle styleFrom({
-    Color? primary,
-    Color? onSurface,
+    Color? foregroundColor,
     Color? backgroundColor,
+    Color? disabledForegroundColor,
+    Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
     double? elevation,
@@ -154,21 +155,36 @@ class OutlinedButton extends ButtonStyleButton {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
+    @Deprecated(
+      'Use foregroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? primary,
+    @Deprecated(
+      'Use disabledForegroundColor and disabledForegroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? onSurface,
   }) {
-    final MaterialStateProperty<Color?>? foregroundColor = (onSurface == null && primary == null)
+    final Color? foreground = foregroundColor ?? primary;
+    final Color? disabledForeground = disabledForegroundColor ?? onSurface?.withOpacity(0.38);
+    final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
       ? null
-      : _OutlinedButtonDefaultForeground(primary, onSurface);
-    final MaterialStateProperty<Color?>? overlayColor = (primary == null)
+      : _OutlinedButtonDefaultColor(foreground, disabledForeground);
+    final MaterialStateProperty<Color?>? backgroundColorProp = (backgroundColor == null && disabledBackgroundColor == null)
       ? null
-      : _OutlinedButtonDefaultOverlay(primary);
+      : _OutlinedButtonDefaultColor(backgroundColor, disabledBackgroundColor);
+    final MaterialStateProperty<Color?>? overlayColor = (foreground == null)
+      ? null
+      : _OutlinedButtonDefaultOverlay(foreground);
     final MaterialStateProperty<MouseCursor>? mouseCursor = (enabledMouseCursor == null && disabledMouseCursor == null)
       ? null
       : _OutlinedButtonDefaultMouseCursor(enabledMouseCursor!, disabledMouseCursor!);
 
     return ButtonStyle(
       textStyle: ButtonStyleButton.allOrNull<TextStyle>(textStyle),
-      foregroundColor: foregroundColor,
-      backgroundColor: ButtonStyleButton.allOrNull<Color>(backgroundColor),
+      foregroundColor: foregroundColorProp,
+      backgroundColor: backgroundColorProp,
       overlayColor: overlayColor,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
@@ -290,9 +306,10 @@ class OutlinedButton extends ButtonStyleButton {
     return Theme.of(context).useMaterial3
       ? _TokenDefaultsM3(context)
       : styleFrom(
-          primary: colorScheme.primary,
-          onSurface: colorScheme.onSurface,
+          foregroundColor: colorScheme.primary,
+          disabledForegroundColor: colorScheme.onSurface.withOpacity(0.38),
           backgroundColor: Colors.transparent,
+          disabledBackgroundColor: Colors.transparent,
           shadowColor: theme.shadowColor,
           elevation: 0,
           textStyle: theme.textTheme.button,
@@ -330,34 +347,34 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
 }
 
 @immutable
-class _OutlinedButtonDefaultForeground extends MaterialStateProperty<Color?>  with Diagnosticable {
-  _OutlinedButtonDefaultForeground(this.primary, this.onSurface);
+class _OutlinedButtonDefaultColor extends MaterialStateProperty<Color?>  with Diagnosticable {
+  _OutlinedButtonDefaultColor(this.color, this.disabled);
 
-  final Color? primary;
-  final Color? onSurface;
+  final Color? color;
+  final Color? disabled;
 
   @override
   Color? resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return onSurface?.withOpacity(0.38);
+      return disabled;
     }
-    return primary;
+    return color;
   }
 }
 
 @immutable
 class _OutlinedButtonDefaultOverlay extends MaterialStateProperty<Color?> with Diagnosticable {
-  _OutlinedButtonDefaultOverlay(this.primary);
+  _OutlinedButtonDefaultOverlay(this.foreground);
 
-  final Color primary;
+  final Color foreground;
 
   @override
   Color? resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.hovered)) {
-      return primary.withOpacity(0.04);
+      return foreground.withOpacity(0.04);
     }
     if (states.contains(MaterialState.focused) || states.contains(MaterialState.pressed)) {
-      return primary.withOpacity(0.12);
+      return foreground.withOpacity(0.12);
     }
     return null;
   }

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -173,7 +173,9 @@ class OutlinedButton extends ButtonStyleButton {
       : _OutlinedButtonDefaultColor(foreground, disabledForeground);
     final MaterialStateProperty<Color?>? backgroundColorProp = (backgroundColor == null && disabledBackgroundColor == null)
       ? null
-      : _OutlinedButtonDefaultColor(backgroundColor, disabledBackgroundColor);
+      : disabledBackgroundColor == null
+        ? ButtonStyleButton.allOrNull<Color?>(backgroundColor)
+        : _OutlinedButtonDefaultColor(backgroundColor, disabledBackgroundColor);
     final MaterialStateProperty<Color?>? overlayColor = (foreground == null)
       ? null
       : _OutlinedButtonDefaultOverlay(foreground);

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -177,14 +177,16 @@ class TextButton extends ButtonStyleButton {
     final Color? foreground = foregroundColor ?? primary;
     final Color? disabledForeground = disabledForegroundColor ?? onSurface?.withOpacity(0.38);
     final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
-        ? null
-        : _TextButtonDefaultColor(foreground, disabledForeground);
+      ? null
+      : _TextButtonDefaultColor(foreground, disabledForeground);
     final MaterialStateProperty<Color?>? backgroundColorProp = (backgroundColor == null && disabledBackgroundColor == null)
-        ? null
+      ? null
+      : disabledBackgroundColor == null
+        ? ButtonStyleButton.allOrNull<Color?>(backgroundColor)
         : _TextButtonDefaultColor(backgroundColor, disabledBackgroundColor);
     final MaterialStateProperty<Color?>? overlayColor = (foreground == null)
-        ? null
-        : _TextButtonDefaultOverlay(foreground);
+      ? null
+      : _TextButtonDefaultOverlay(foreground);
     final MaterialStateProperty<MouseCursor>? mouseCursor = (enabledMouseCursor == null && disabledMouseCursor == null)
       ? null
       : _TextButtonDefaultMouseCursor(enabledMouseCursor!, disabledMouseCursor!);

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -141,9 +141,10 @@ class TextButton extends ButtonStyleButton {
   /// )
   /// ```
   static ButtonStyle styleFrom({
-    Color? primary,
-    Color? onSurface,
+    Color? foregroundColor,
     Color? backgroundColor,
+    Color? disabledForegroundColor,
+    Color? disabledBackgroundColor,
     Color? shadowColor,
     Color? surfaceTintColor,
     double? elevation,
@@ -162,21 +163,36 @@ class TextButton extends ButtonStyleButton {
     bool? enableFeedback,
     AlignmentGeometry? alignment,
     InteractiveInkFeatureFactory? splashFactory,
+    @Deprecated(
+      'Use foregroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? primary,
+    @Deprecated(
+      'Use disabledForegroundColor and disabledForegroundColor instead. '
+      'This feature was deprecated after v3.1.0.'
+    )
+    Color? onSurface,
   }) {
-    final MaterialStateProperty<Color?>? foregroundColor = (onSurface == null && primary == null)
-      ? null
-      : _TextButtonDefaultForeground(primary, onSurface);
-    final MaterialStateProperty<Color?>? overlayColor = (primary == null)
-      ? null
-      : _TextButtonDefaultOverlay(primary);
+    final Color? foreground = foregroundColor ?? primary;
+    final Color? disabledForeground = disabledForegroundColor ?? onSurface?.withOpacity(0.38);
+    final MaterialStateProperty<Color?>? foregroundColorProp = (foreground == null && disabledForeground == null)
+        ? null
+        : _TextButtonDefaultColor(foreground, disabledForeground);
+    final MaterialStateProperty<Color?>? backgroundColorProp = (backgroundColor == null && disabledBackgroundColor == null)
+        ? null
+        : _TextButtonDefaultColor(backgroundColor, disabledBackgroundColor);
+    final MaterialStateProperty<Color?>? overlayColor = (foreground == null)
+        ? null
+        : _TextButtonDefaultOverlay(foreground);
     final MaterialStateProperty<MouseCursor>? mouseCursor = (enabledMouseCursor == null && disabledMouseCursor == null)
       ? null
       : _TextButtonDefaultMouseCursor(enabledMouseCursor!, disabledMouseCursor!);
 
     return ButtonStyle(
       textStyle: ButtonStyleButton.allOrNull<TextStyle>(textStyle),
-      backgroundColor: ButtonStyleButton.allOrNull<Color>(backgroundColor),
-      foregroundColor: foregroundColor,
+      foregroundColor: foregroundColorProp,
+      backgroundColor: backgroundColorProp,
       overlayColor: overlayColor,
       shadowColor: ButtonStyleButton.allOrNull<Color>(shadowColor),
       surfaceTintColor: ButtonStyleButton.allOrNull<Color>(surfaceTintColor),
@@ -311,9 +327,10 @@ class TextButton extends ButtonStyleButton {
     return Theme.of(context).useMaterial3
       ? _TokenDefaultsM3(context)
       : styleFrom(
-          primary: colorScheme.primary,
-          onSurface: colorScheme.onSurface,
+          foregroundColor: colorScheme.primary,
+          disabledForegroundColor: colorScheme.onSurface.withOpacity(0.38),
           backgroundColor: Colors.transparent,
+          disabledBackgroundColor: Colors.transparent,
           shadowColor: theme.shadowColor,
           elevation: 0,
           textStyle: theme.textTheme.button,
@@ -350,23 +367,23 @@ EdgeInsetsGeometry _scaledPadding(BuildContext context) {
 }
 
 @immutable
-class _TextButtonDefaultForeground extends MaterialStateProperty<Color?> {
-  _TextButtonDefaultForeground(this.primary, this.onSurface);
+class _TextButtonDefaultColor extends MaterialStateProperty<Color?> {
+  _TextButtonDefaultColor(this.color, this.disabled);
 
-  final Color? primary;
-  final Color? onSurface;
+  final Color? color;
+  final Color? disabled;
 
   @override
   Color? resolve(Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return onSurface?.withOpacity(0.38);
+      return disabled;
     }
-    return primary;
+    return color;
   }
 
   @override
   String toString() {
-    return '{disabled: ${onSurface?.withOpacity(0.38)}, otherwise: $primary}';
+    return '{disabled: $disabled, otherwise: $color}';
   }
 }
 

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -1600,6 +1600,30 @@ void main() {
     );
   });
 
+  testWidgets('ElevatedButton.styleFrom can be used to set foreground and background colors', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: Colors.purple,
+            ),
+            onPressed: () {},
+            child: const Text('button'),
+          ),
+        ),
+      ),
+    );
+
+    final Material material = tester.widget<Material>(find.descendant(
+      of: find.byType(ElevatedButton),
+      matching: find.byType(Material),
+    ));
+    expect(material.color, Colors.purple);
+    expect(material.textStyle!.color, Colors.white);
+  });
+
   testWidgets('ElevatedButton statesController', (WidgetTester tester) async {
     int count = 0;
     void valueChanged() {

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1718,6 +1718,30 @@ void main() {
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
   });
 
+  testWidgets('OutlinedButton.styleFrom can be used to set foreground and background colors', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: OutlinedButton(
+            style: OutlinedButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: Colors.purple,
+            ),
+            onPressed: () {},
+            child: const Text('button'),
+          ),
+        ),
+      ),
+    );
+
+    final Material material = tester.widget<Material>(find.descendant(
+      of: find.byType(OutlinedButton),
+      matching: find.byType(Material),
+    ));
+    expect(material.color, Colors.purple);
+    expect(material.textStyle!.color, Colors.white);
+  });
+
   testWidgets('OutlinedButton statesController', (WidgetTester tester) async {
     int count = 0;
     void valueChanged() {

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -1525,6 +1525,30 @@ void main() {
     expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.basic);
   });
 
+  testWidgets('TextButton.styleFrom can be used to set foreground and background colors', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TextButton(
+            style: TextButton.styleFrom(
+              foregroundColor: Colors.white,
+              backgroundColor: Colors.purple,
+            ),
+            onPressed: () {},
+            child: const Text('button'),
+          ),
+        ),
+      ),
+    );
+
+    final Material material = tester.widget<Material>(find.descendant(
+      of: find.byType(TextButton),
+      matching: find.byType(Material),
+    ));
+    expect(material.color, Colors.purple);
+    expect(material.textStyle!.color, Colors.white);
+  });
+
   testWidgets('TextButton statesController', (WidgetTester tester) async {
     int count = 0;
     void valueChanged() {

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -554,4 +554,19 @@ void main() {
 
   // Change made in https://github.com/flutter/flutter/pull/100381
   TextSelectionOverlay.fadeDuration;
+
+  // Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  ButtonStyle elevationButtonStyle = ElevatedButton.styleFrom(
+    primary: Colors.blue,
+    onPrimary: Colors.white,
+    onSurface: Colors.grey,
+  );
+  ButtonStyle outlinedButtonStyle = OutlinedButton.styleFrom(
+    primary: Colors.blue,
+    onSurface: Colors.grey,
+  );
+  ButtonStyle textButtonStyle = TextButton.styleFrom(
+    primary: Colors.blue,
+    onSurface: Colors.grey,
+  );
 }

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -555,7 +555,7 @@ void main() {
   // Change made in https://github.com/flutter/flutter/pull/100381
   TextSelectionOverlay.fadeDuration;
 
-  // Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  // Changes made in https://github.com/flutter/flutter/pull/105291
   ButtonStyle elevationButtonStyle = ElevatedButton.styleFrom(
     primary: Colors.blue,
     onPrimary: Colors.white,

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -528,7 +528,7 @@ void main() {
   // Change made in https://github.com/flutter/flutter/pull/100381
   SelectionOverlay.fadeDuration;
 
-  // Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  // Changes made in https://github.com/flutter/flutter/pull/105291
   ButtonStyle elevationButtonStyle = ElevatedButton.styleFrom(
     foregroundColor: Colors.white, backgroundColor: Colors.blue, disabledForegroundColor: Colors.grey.withOpacity(0.38), disabledBackgroundColor: Colors.grey.withOpacity(0.12),
   );

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -527,4 +527,15 @@ void main() {
 
   // Change made in https://github.com/flutter/flutter/pull/100381
   SelectionOverlay.fadeDuration;
+
+  // Changes made in https://github.com/flutter/flutter/pull/XXXXX
+  ButtonStyle elevationButtonStyle = ElevatedButton.styleFrom(
+    foregroundColor: Colors.white, backgroundColor: Colors.blue, disabledForegroundColor: Colors.grey.withOpacity(0.38), disabledBackgroundColor: Colors.grey.withOpacity(0.12),
+  );
+  ButtonStyle outlinedButtonStyle = OutlinedButton.styleFrom(
+    foregroundColor: Colors.blue, disabledForegroundColor: Colors.grey.withOpacity(0.38),
+  );
+  ButtonStyle textButtonStyle = TextButton.styleFrom(
+    foregroundColor: Colors.blue, disabledForegroundColor: Colors.grey.withOpacity(0.38),
+  );
 }

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -765,7 +765,7 @@ void main() {
         backgroundColor: Colors.white,
         body: ElevatedButton(
           style: ElevatedButton.styleFrom(
-            primary: const Color(0xFFFBBC04),
+            backgroundColor: const Color(0xFFFBBC04),
             elevation: 0,
           ),
           onPressed: () {},

--- a/packages/flutter_test/test/accessibility_window_test.dart
+++ b/packages/flutter_test/test/accessibility_window_test.dart
@@ -13,8 +13,8 @@ void main() {
     final Widget invalidButton = ElevatedButton(
       onPressed: () {},
       style: ElevatedButton.styleFrom(
-        primary: Colors.orangeAccent, // background fill color
-        onPrimary: Colors.orange, // text foreground color
+        foregroundColor: Colors.orange,
+        backgroundColor: Colors.orangeAccent,
       ),
       child: const Text('Button'),
     );
@@ -31,8 +31,8 @@ void main() {
     final Widget invalidButton = ElevatedButton(
       onPressed: () {},
       style: ElevatedButton.styleFrom(
-        primary: Colors.orangeAccent, // background fill color
-        onPrimary: Colors.orange, // text foreground color
+        foregroundColor: Colors.orange,
+        backgroundColor: Colors.orangeAccent,
       ),
       child: const Text('Button'),
     );


### PR DESCRIPTION
To make the common button `.styleFrom` methods a little easier to use, this PR adds the following parameters to each of `ElevatedButton.styleFrom`, `OutlinedButton.styleFrom` and `TextButton.styleFrom`:

```dart
    Color? foregroundColor,
    Color? backgroundColor,
    Color? disabledForegroundColor,
    Color? disabledBackgroundColor,
```

If given they will be used to construct foreground and background MaterialStateProperty colors for the style. These replace `primary`, `onPrimary`, and `onSurface` which are deprecated. 

To update your apps to use these new parameters you can either use the quick fix feature of your IDE, or use [Flutter Fix](https://docs.flutter.dev/development/tools/flutter-fix) to apply the given fixes to your entire project. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
