### PR TITLE
Reland "Hide text selection toolbar when dragging handles on mobile"

### DIFF
--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -3426,6 +3426,11 @@ void main() {
     expect(controller.selection.extentOffset, 50);
 
     if (!isContextMenuProvidedByPlatform) {
+      if (defaultTargetPlatform == TargetPlatform.android) {
+        // There should be a delay before the toolbar is shown again on Android.
+        expect(find.text('Cut'), findsNothing);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
       await tester.tap(find.text('Cut'));
       await tester.pump();
       expect(controller.selection.isCollapsed, true);

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -1232,7 +1232,12 @@ void main() {
     await gesture.moveTo(newHandlePos);
     await tester.pump();
     await gesture.up();
-    await tester.pump();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      // There should be a delay before the toolbar is shown again on Android.
+      expect(find.text('Cut'), findsNothing);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    await tester.pumpAndSettle();
 
     expect(controller.selection.baseOffset, 5);
     expect(controller.selection.extentOffset, 50);

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1278,6 +1278,8 @@ void main() {
       await gesture2.up();
       await tester.pump(const Duration(milliseconds: 20));
       expect(endDragEndDetails, isNotNull);
+
+      selectionOverlay.dispose();
     });
   });
 


### PR DESCRIPTION
Relands https://github.com/flutter/flutter/pull/104274

Fixes https://github.com/flutter/flutter/issues/62193
