### PR TITLE
Fix TabController throws build scheduled during frame error

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1495,15 +1495,13 @@ class _TabBarViewState extends State<TabBarView> {
     }
 
     final Duration duration = _controller!.animationDuration;
-
-    if (duration == Duration.zero) {
-      _pageController.jumpToPage(_currentIndex!);
-      return Future<void>.value();
-    }
-
     final int previousIndex = _controller!.previousIndex;
 
     if ((_currentIndex! - previousIndex).abs() == 1) {
+      if (duration == Duration.zero) {
+        _pageController.jumpToPage(_currentIndex!);
+        return Future<void>.value();
+      }
       _warpUnderwayCount += 1;
       await _pageController.animateToPage(_currentIndex!, duration: duration, curve: Curves.ease);
       _warpUnderwayCount -= 1;
@@ -1524,6 +1522,11 @@ class _TabBarViewState extends State<TabBarView> {
       _childrenWithKey[previousIndex] = temp;
     });
     _pageController.jumpToPage(initialPage);
+
+    if (duration == Duration.zero) {
+      _pageController.jumpToPage(_currentIndex!);
+      return Future<void>.value();
+    }
 
     await _pageController.animateToPage(_currentIndex!, duration: duration, curve: Curves.ease);
     if (!mounted) {


### PR DESCRIPTION
## Description

This PR fixes an exception (`Build scheduled during frame`) thrown when `TabController.index` is updated and `TabController.animationDuration` is set to `Duration.zero`.
See this comment  https://github.com/flutter/flutter/issues/102600#issuecomment-1112679636 for a reproducible code sample.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/102600

## Tests

Adds 1 test.