### PR TITLE
[flutter_tools] add shuffle to hermetic run_tests

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -4,12 +4,6 @@
 
 // @dart = 2.8
 
-// TODO(gspencergoog): Remove this tag once this test's state leaks/test
-// dependencies have been fixed.
-// https://github.com/flutter/flutter/issues/85160
-// Fails with "flutter test --test-randomize-ordering-seed=1000"
-@Tags(<String>['no-shuffle'])
-
 import 'dart:async';
 
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -431,7 +431,7 @@ void main() {
         expect(usage.commands, contains(
           TestUsageCommand('run', parameters: CustomDimensions.fromMap(<String, String>{
             'cd3': 'false', 'cd4': 'ios', 'cd22': 'iOS 13',
-            'cd23': 'debug', 'cd18': 'false', 'cd15': 'swift', 'cd31': 'false',
+            'cd23': 'debug', 'cd18': 'false', 'cd15': 'swift', 'cd31': 'true',
             'cd56': 'false',
           })
         )));
@@ -441,6 +441,7 @@ void main() {
         DeviceManager: () => mockDeviceManager,
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
+        Stdio: () => FakeStdio()..stdout,
         Usage: () => usage,
       });
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -405,7 +405,6 @@ void main() {
         Usage: () => usage,
       });
 
-
       testUsingContext('passes device target platform to usage', () async {
         final RunCommand command = RunCommand();
         final FakeDevice mockDevice = FakeDevice(sdkNameAndVersion: 'iOS 13')
@@ -441,7 +440,7 @@ void main() {
         DeviceManager: () => mockDeviceManager,
         FileSystem: () => fs,
         ProcessManager: () => FakeProcessManager.any(),
-        Stdio: () => FakeStdio()..stdout,
+        Stdio: () => FakeStdio(),
         Usage: () => usage,
       });
 

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -222,9 +222,10 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
 
 /// A Stdio that collects stdout and supports simulated stdin.
 class FakeStdio extends Stdio {
-  final MemoryStdout _stdout = MemoryStdout();
+  final MemoryStdout _stdout = MemoryStdout()..terminalColumns = 80;
   final MemoryIOSink _stderr = MemoryIOSink();
-  final StreamController<List<int>> _stdin = StreamController<List<int>>();
+  //final StreamController<List<int>> _stdin = StreamController<List<int>>();
+  final FakeStdin _stdin = FakeStdin();
 
   @override
   MemoryStdout get stdout => _stdout;
@@ -233,14 +234,45 @@ class FakeStdio extends Stdio {
   MemoryIOSink get stderr => _stderr;
 
   @override
-  Stream<List<int>> get stdin => _stdin.stream;
+  Stream<List<int>> get stdin => _stdin;
 
   void simulateStdin(String line) {
-    _stdin.add(utf8.encode('$line\n'));
+    _stdin.controller.add(utf8.encode('$line\n'));
   }
+
+  @override
+  bool stdinHasTerminal = true;
 
   List<String> get writtenToStdout => _stdout.writes.map<String>(_stdout.encoding.decode).toList();
   List<String> get writtenToStderr => _stderr.writes.map<String>(_stderr.encoding.decode).toList();
+}
+
+class FakeStdin extends Fake implements Stdin {
+  final StreamController<List<int>> controller = StreamController<List<int>>();
+
+  @override
+  bool echoMode = true;
+
+  @override
+  bool echoNewlineMode = true;
+
+  @override
+  bool lineMode = true;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return controller.stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
 }
 
 class FakePlistParser implements PlistParser {

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -259,6 +259,11 @@ class FakeStdin extends Fake implements Stdin {
   bool lineMode = true;
 
   @override
+  Stream<S> transform<S>(StreamTransformer<List<int>, S> transformer) {
+    return controller.stream.transform(transformer);
+  }
+
+  @override
   StreamSubscription<List<int>> listen(
     void Function(List<int> event)? onData, {
     Function? onError,

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -224,7 +224,6 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
 class FakeStdio extends Stdio {
   final MemoryStdout _stdout = MemoryStdout()..terminalColumns = 80;
   final MemoryIOSink _stderr = MemoryIOSink();
-  //final StreamController<List<int>> _stdin = StreamController<List<int>>();
   final FakeStdin _stdin = FakeStdin();
 
   @override

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -240,7 +240,7 @@ class FakeStdio extends Stdio {
   }
 
   @override
-  bool stdinHasTerminal = true;
+  bool hasTerminal = true;
 
   List<String> get writtenToStdout => _stdout.writes.map<String>(_stdout.encoding.decode).toList();
   List<String> get writtenToStderr => _stderr.writes.map<String>(_stderr.encoding.decode).toList();


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/85160

Note, the fix to allowing shuffle was actually lifting Cache.disableLocking() to the top level scope in https://github.com/flutter/flutter/pull/105283/files#diff-38f3e3415d9806f22a78060fafb3206d1a006f74631fac04e7a680a64e06ccf0R52, however, I didn't actually disable shuffle in that PR because many other tests in that file were failing locally. The code changes in this PR are just to remove the local terminal from the test code, so that the tests are more hermetic (and all pass for me locally now).