### PR TITLE
Set selection on tap down for desktop platforms and tap up for mobile

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1465,13 +1465,21 @@ class TextSelectionGestureDetectorBuilder {
       || kind == PointerDeviceKind.stylus;
 
     // Handle shift + click selection if needed.
-    if (_isShiftPressed && renderEditable.selection?.baseOffset != null) {
-      _isShiftTapping = true;
-      switch (defaultTargetPlatform) {
-        case TargetPlatform.iOS:
-        case TargetPlatform.macOS:
-          // On these platforms, a shift-tapped unfocused field expands from 0,
-          // not from the previous selection.
+    final bool isShiftPressedValid = _isShiftPressed && renderEditable.selection?.baseOffset != null;
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+      case TargetPlatform.iOS:
+        // On mobile platforms the selection is set on tap up.
+        if (_isShiftTapping) {
+          _isShiftTapping = false;
+        }
+        break;
+      case TargetPlatform.macOS:
+        // On these platforms, a shift-tapped unfocused field expands from 0,
+        // not from the previous selection.
+        if (isShiftPressedValid) {
+          _isShiftTapping = true;
           final TextSelection? fromSelection = renderEditable.hasFocus
               ? null
               : const TextSelection.collapsed(offset: 0);
@@ -1480,14 +1488,33 @@ class TextSelectionGestureDetectorBuilder {
             SelectionChangedCause.tap,
             fromSelection,
           );
-          break;
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.windows:
+          return;
+        }
+        switch (details.kind) {
+          case PointerDeviceKind.mouse:
+          case PointerDeviceKind.trackpad:
+          case PointerDeviceKind.stylus:
+          case PointerDeviceKind.invertedStylus:
+          // Precise devices should place the cursor at a precise position.
+            renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+            break;
+          case PointerDeviceKind.touch:
+          case PointerDeviceKind.unknown:
+          // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
+          // of the word.
+            renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+            break;
+        }
+        break;
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        if (isShiftPressedValid) {
+          _isShiftTapping = true;
           _extendSelection(details.globalPosition, SelectionChangedCause.tap);
-          break;
-      }
+          return;
+        }
+        renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+        break;
     }
   }
 
@@ -1547,36 +1574,57 @@ class TextSelectionGestureDetectorBuilder {
   ///    this callback.
   @protected
   void onSingleTapUp(TapUpDetails details) {
-    if (_isShiftTapping) {
-      _isShiftTapping = false;
-      return;
-    }
-
     if (delegate.selectionEnabled) {
+      // Handle shift + click selection if needed.
+      final bool isShiftPressedValid = _isShiftPressed && renderEditable.selection?.baseOffset != null;
       switch (defaultTargetPlatform) {
-        case TargetPlatform.iOS:
+        case TargetPlatform.linux:
         case TargetPlatform.macOS:
+        case TargetPlatform.windows:
+          // On desktop platforms the selection is set on tap down.
+          if (_isShiftTapping) {
+            _isShiftTapping = false;
+          }
+          break;
+        case TargetPlatform.android:
+        case TargetPlatform.fuchsia:
+          if (isShiftPressedValid) {
+            _isShiftTapping = true;
+            _extendSelection(details.globalPosition, SelectionChangedCause.tap);
+            return;
+          }
+          renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+          break;
+        case TargetPlatform.iOS:
+          if (isShiftPressedValid) {
+            // On these platforms, a shift-tapped unfocused field expands from 0,
+            // not from the previous selection.
+            _isShiftTapping = true;
+            final TextSelection? fromSelection = renderEditable.hasFocus
+                ? null
+                : const TextSelection.collapsed(offset: 0);
+            _expandSelection(
+              details.globalPosition,
+              SelectionChangedCause.tap,
+              fromSelection,
+            );
+            return;
+          }
           switch (details.kind) {
             case PointerDeviceKind.mouse:
             case PointerDeviceKind.trackpad:
             case PointerDeviceKind.stylus:
             case PointerDeviceKind.invertedStylus:
-              // Precise devices should place the cursor at a precise position.
+            // Precise devices should place the cursor at a precise position.
               renderEditable.selectPosition(cause: SelectionChangedCause.tap);
               break;
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
-              // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
-              // of the word.
+            // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
+            // of the word.
               renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
               break;
           }
-          break;
-        case TargetPlatform.android:
-        case TargetPlatform.fuchsia:
-        case TargetPlatform.linux:
-        case TargetPlatform.windows:
-          renderEditable.selectPosition(cause: SelectionChangedCause.tap);
           break;
       }
     }
@@ -1591,7 +1639,7 @@ class TextSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onSingleTapCancel], which triggers
   ///    this callback.
   @protected
-  void onSingleTapCancel() {/* Subclass should override this method if needed. */}
+  void onSingleTapCancel() { /* Subclass should override this method if needed. */ }
 
   /// Handler for [TextSelectionGestureDetector.onSingleLongTapStart].
   ///

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1507,6 +1507,8 @@ class TextSelectionGestureDetectorBuilder {
           // of the word.
             renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
             break;
+          case null:
+            break;
         }
         break;
       case TargetPlatform.linux:

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1608,12 +1608,12 @@ class TextSelectionGestureDetectorBuilder {
             case PointerDeviceKind.trackpad:
             case PointerDeviceKind.stylus:
             case PointerDeviceKind.invertedStylus:
-            // Precise devices should place the cursor at a precise position.
+              // Precise devices should place the cursor at a precise position.
               renderEditable.selectPosition(cause: SelectionChangedCause.tap);
               break;
-            // On iOS/iPadOS a touch tap places the cursor at the edge of the word.
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
+              // On iOS/iPadOS a touch tap places the cursor at the edge of the word.
               renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
               break;
           }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1479,8 +1479,8 @@ class TextSelectionGestureDetectorBuilder {
         }
         break;
       case TargetPlatform.macOS:
-        // On these platforms, a shift-tapped unfocused field expands from 0,
-        // not from the previous selection.
+        // On macOS, a shift-tapped unfocused field expands from 0, not from the
+        // previous selection.
         if (isShiftPressedValid) {
           _isShiftTapping = true;
           final TextSelection? fromSelection = renderEditable.hasFocus
@@ -1501,10 +1501,9 @@ class TextSelectionGestureDetectorBuilder {
           // Precise devices should place the cursor at a precise position.
             renderEditable.selectPosition(cause: SelectionChangedCause.tap);
             break;
+          // On macOS a touch tap places the cursor at the edge of the word.
           case PointerDeviceKind.touch:
           case PointerDeviceKind.unknown:
-          // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
-          // of the word.
           case null:
             renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
             break;
@@ -1601,8 +1600,8 @@ class TextSelectionGestureDetectorBuilder {
           break;
         case TargetPlatform.iOS:
           if (isShiftPressedValid) {
-            // On these platforms, a shift-tapped unfocused field expands from 0,
-            // not from the previous selection.
+            // On iOS, a shift-tapped unfocused field expands from 0, not from
+            // the previous selection.
             _isShiftTapping = true;
             final TextSelection? fromSelection = renderEditable.hasFocus
                 ? null
@@ -1622,10 +1621,9 @@ class TextSelectionGestureDetectorBuilder {
             // Precise devices should place the cursor at a precise position.
               renderEditable.selectPosition(cause: SelectionChangedCause.tap);
               break;
+            // On iOS/iPadOS a touch tap places the cursor at the edge of the word.
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
-            // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
-            // of the word.
               renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
               break;
           }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1505,9 +1505,8 @@ class TextSelectionGestureDetectorBuilder {
           case PointerDeviceKind.unknown:
           // On macOS/iOS/iPadOS a touch tap places the cursor at the edge
           // of the word.
-            renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
-            break;
           case null:
+            renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
             break;
         }
         break;
@@ -1644,7 +1643,7 @@ class TextSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onSingleTapCancel], which triggers
   ///    this callback.
   @protected
-  void onSingleTapCancel() { /* Subclass should override this method if needed. */ }
+  void onSingleTapCancel() {/* Subclass should override this method if needed. */}
 
   /// Handler for [TextSelectionGestureDetector.onSingleLongTapStart].
   ///

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1454,6 +1454,9 @@ class TextSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onTapDown], which triggers this callback.
   @protected
   void onTapDown(TapDownDetails details) {
+    if (!delegate.selectionEnabled) {
+      return;
+    }
     renderEditable.handleTapDown(details);
     // The selection overlay should only be shown when the user is interacting
     // through a touch screen (via either a finger or a stylus). A mouse shouldn't

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1493,21 +1493,11 @@ class TextSelectionGestureDetectorBuilder {
           );
           return;
         }
-        switch (details.kind) {
-          case PointerDeviceKind.mouse:
-          case PointerDeviceKind.trackpad:
-          case PointerDeviceKind.stylus:
-          case PointerDeviceKind.invertedStylus:
-          // Precise devices should place the cursor at a precise position.
-            renderEditable.selectPosition(cause: SelectionChangedCause.tap);
-            break;
-          // On macOS a touch tap places the cursor at the edge of the word.
-          case PointerDeviceKind.touch:
-          case PointerDeviceKind.unknown:
-          case null:
-            renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
-            break;
-        }
+        // On macOS, a tap/click places the selection in a precise position.
+        // This differs from iOS/iPadOS, where if the gesture is done by a touch
+        // then the selection moves to the closest word edge, instead of a
+        // precise position.
+        renderEditable.selectPosition(cause: SelectionChangedCause.tap);
         break;
       case TargetPlatform.linux:
       case TargetPlatform.windows:

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1755,7 +1755,7 @@ void main() {
 
       // But don't trigger the toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
 
   testWidgets(
     'slow double tap does not trigger double tap',
@@ -1763,6 +1763,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
           home: Center(
@@ -1780,11 +1781,9 @@ void main() {
       await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
       await tester.pump();
 
-      // Plain collapsed selection.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+      // Place collapsed selection.
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 3);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 3);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -1893,6 +1892,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
           home: Center(
@@ -1911,10 +1911,9 @@ void main() {
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 8),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
+
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pumpAndSettle();
 
@@ -1979,6 +1978,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
           home: Center(
@@ -1994,23 +1994,22 @@ void main() {
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 8),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
+
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pump(const Duration(milliseconds: 500));
 
       await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
       await tester.pump();
 
-      // Plain collapsed selection at the edge of first word. In iOS 12, the
+      // Place collapsed selection at the edge of first word. In iOS 12, the
       // first tap after a double tap ends up putting the cursor at where
       // you tapped instead of the edge like every other single tap. This is
       // likely a bug in iOS 12 and not present in other versions.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+        TextSelection.collapsed(offset: isTargetPlatformMobile ? 7 : 6, affinity: TextAffinity.upstream),
       );
 
       // No toolbar.
@@ -2429,6 +2428,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
           home: Center(
@@ -2451,7 +2451,7 @@ void main() {
       // the toolbar.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
+        TextSelection.collapsed(offset: isTargetPlatformMobile ? 7 : 3, affinity: TextAffinity.upstream),
       );
 
       // The toolbar from the long press is now dismissed by the second tap.
@@ -2615,6 +2615,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
           home: Center(
@@ -2630,10 +2631,8 @@ void main() {
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor to the beginning of the second word.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 8),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -2656,6 +2655,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
           home: Center(
@@ -2674,10 +2674,8 @@ void main() {
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 8),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
       await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
       await tester.pumpAndSettle();
 
@@ -2752,7 +2750,7 @@ void main() {
         const TextSelection(baseOffset: 8, extentOffset: 12),
       );
       expect(find.byType(CupertinoButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(3));
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
 
   testWidgets('force press selects word', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
@@ -2798,6 +2796,7 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       CupertinoApp(
         home: Center(
@@ -2824,11 +2823,10 @@ void main() {
       ),
     );
     await gesture.up();
-    // Fall back to a single tap which selects the edge of the word.
-    expect(
-      controller.selection,
-      const TextSelection.collapsed(offset: 8),
-    );
+    // Fall back to a single tap which selects the edge of the word on iOS, and
+    // a precise position on macOS.
+    expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
+    expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
 
     await tester.pump();
     // Falling back to a single tap doesn't trigger a toolbar.
@@ -2839,6 +2837,7 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'abc def ghi',
     );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
 
     await tester.pumpWidget(
       CupertinoApp(
@@ -2860,7 +2859,7 @@ void main() {
     await tester.tapAt(ePos, pointer: 7);
     await tester.pump(const Duration(milliseconds: 50));
     expect(controller.selection.isCollapsed, isTrue);
-    expect(controller.selection.baseOffset, 4);
+    expect(controller.selection.baseOffset, isTargetPlatformMobile ? 4 : 5);
     await tester.tapAt(ePos, pointer: 7);
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 4);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2919,14 +2919,16 @@ void main() {
 
     final TestGesture gesture = await tester.startGesture(ePos, kind: PointerDeviceKind.mouse);
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 5));
+    expect(controller.selection.baseOffset, 5);
+    expect(controller.selection.extentOffset, 5);
 
     await gesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
 
     await gesture.down(gPos);
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 8));
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
   },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.macOS, TargetPlatform.windows })
   );
@@ -2958,11 +2960,13 @@ void main() {
 
     await gesture.down(gPos);
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 5));
+    expect(controller.selection.baseOffset, 5);
+    expect(controller.selection.extentOffset, 5);
 
     await gesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
-    expect(controller.selection, const TextSelection.collapsed(offset: 8));
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
 
     final TestGesture touchGesture = await tester.startGesture(ePos);
     await touchGesture.up();
@@ -2971,11 +2975,13 @@ void main() {
     await touchGesture.down(gPos);
     await tester.pumpAndSettle();
     // On iOS a tap to select, selects the word edge instead of the exact tap position.
-    expect(controller.selection, TextSelection.collapsed(offset: isTargetPlatformApple ? 4 : 5));
+    expect(controller.selection.baseOffset, isTargetPlatformApple ? 4 : 5);
+    expect(controller.selection.extentOffset, isTargetPlatformApple ? 4 : 5);
 
     await touchGesture.up();
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 8));
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
   },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.iOS })
   );

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1783,9 +1783,9 @@ void main() {
       await tester.tapAt(pos);
       await tester.pump();
 
-      // Place collapsed selection.
+      // Plain collapsed selection.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -1917,8 +1917,8 @@ void main() {
       await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
 
       await tester.tapAt(pPos);
       await tester.pumpAndSettle();
@@ -2003,8 +2003,8 @@ void main() {
       await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
 
       await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 500));
@@ -2012,12 +2012,12 @@ void main() {
       await tester.tapAt(ePos);
       await tester.pump();
 
-      // Place collapsed selection at the edge of first word. In iOS 12, the
+      // Plain collapsed selection at the edge of first word. In iOS 12, the
       // first tap after a double tap ends up putting the cursor at where
       // you tapped instead of the edge like every other single tap. This is
       // likely a bug in iOS 12 and not present in other versions.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -2458,8 +2458,8 @@ void main() {
 
       // We ended up moving the cursor to the edge of the same word and dismissed
       // the toolbar.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // The toolbar from the long press is now dismissed by the second tap.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -2641,8 +2641,8 @@ void main() {
       await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor to the beginning of the second word.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
       await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 500));
 
@@ -2687,8 +2687,8 @@ void main() {
       await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
       await tester.tapAt(pPos);
       await tester.pumpAndSettle();
 
@@ -2840,8 +2840,8 @@ void main() {
     await gesture.up();
     // Fall back to a single tap which selects the edge of the word on iOS, and
     // a precise position on macOS.
+    expect(controller.selection.isCollapsed, isTrue);
     expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
-    expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
 
     await tester.pump();
     // Falling back to a single tap doesn't trigger a toolbar.
@@ -2951,7 +2951,7 @@ void main() {
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 8);
   },
-      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.macOS, TargetPlatform.windows })
+      variant: TargetPlatformVariant.desktop(),
   );
 
   testWidgets('Selection updates on tap up (Mobile platforms)', (WidgetTester tester) async {
@@ -3007,7 +3007,7 @@ void main() {
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 8);
   },
-      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.iOS })
+      variant: TargetPlatformVariant.mobile(),
   );
 
   testWidgets('Can select text by dragging with a mouse', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -2929,6 +2929,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 8);
+
+    // This should do nothing. The selection is set on tap down on desktop platforms.
+    await gesture.up();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
   },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.macOS, TargetPlatform.windows })
   );
@@ -2971,10 +2976,13 @@ void main() {
     final TestGesture touchGesture = await tester.startGesture(ePos);
     await touchGesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
+    // On iOS, a tap to select, selects the word edge instead of the exact tap position.
+    expect(controller.selection.baseOffset, isTargetPlatformApple ? 4 : 5);
+    expect(controller.selection.extentOffset, isTargetPlatformApple ? 4 : 5);
 
+    // Selection should stay the same since it is set on tap up for mobile platforms.
     await touchGesture.down(gPos);
     await tester.pumpAndSettle();
-    // On iOS a tap to select, selects the word edge instead of the exact tap position.
     expect(controller.selection.baseOffset, isTargetPlatformApple ? 4 : 5);
     expect(controller.selection.extentOffset, isTargetPlatformApple ? 4 : 5);
 

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1763,6 +1763,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
@@ -1892,6 +1894,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
@@ -1978,6 +1982,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
@@ -2428,6 +2434,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
@@ -2615,6 +2623,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
@@ -2655,6 +2665,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         CupertinoApp(
@@ -2796,6 +2808,8 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    // On macOS, we select the precise position of the tap.
     final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       CupertinoApp(
@@ -2837,6 +2851,8 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'abc def ghi',
     );
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    // On macOS, we select the precise position of the tap.
     final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
 
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -5313,9 +5313,8 @@ void main() {
 
     // Expand the selection a bit.
     if (isTargetPlatformMobile) {
-      await gesture.down(textOffsetToPosition(tester, 23));
+      await gesture.down(textOffsetToPosition(tester, 24));
     }
-    await tester.pumpAndSettle();
     await gesture.moveTo(textOffsetToPosition(tester, 28));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
@@ -5410,7 +5409,6 @@ void main() {
           kind: PointerDeviceKind.mouse,
         );
     if (isTargetPlatformMobile) {
-      await tester.pump();
       await gesture.up();
     }
     await tester.pumpAndSettle();
@@ -5419,8 +5417,7 @@ void main() {
 
     // Expand the selection a bit.
     if (isTargetPlatformMobile) {
-      await gesture.down(textOffsetToPosition(tester, 23));
-      await tester.pump();
+      await gesture.down(textOffsetToPosition(tester, 24));
     }
     await gesture.moveTo(textOffsetToPosition(tester, 28));
     await tester.pumpAndSettle();
@@ -5523,7 +5520,7 @@ void main() {
 
     // Expand the selection a bit.
     if (isTargetPlatformMobile) {
-      await gesture.down(textOffsetToPosition(tester, 8));
+      await gesture.down(textOffsetToPosition(tester, 7));
     }
     await gesture.moveTo(textOffsetToPosition(tester, 5));
     await tester.pumpAndSettle();
@@ -5593,6 +5590,8 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.android
+        || defaultTargetPlatform == TargetPlatform.fuchsia;
     await tester.pumpWidget(
       CupertinoApp(
         home: Center(
@@ -5616,11 +5615,17 @@ void main() {
           pointer: 7,
           kind: PointerDeviceKind.mouse,
         );
+    if (isTargetPlatformMobile) {
+      await gesture.up();
+    }
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 8);
 
     // Expand the selection a bit.
+    if (isTargetPlatformMobile) {
+      await gesture.down(textOffsetToPosition(tester, 7));
+    }
     await gesture.moveTo(textOffsetToPosition(tester, 5));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 23);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1777,15 +1777,16 @@ void main() {
       );
 
       final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset pos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'.
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+      await tester.tapAt(pos);
       await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+      await tester.tapAt(pos);
       await tester.pump();
 
       // Place collapsed selection.
-      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 3);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 3);
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -1908,17 +1909,20 @@ void main() {
       );
 
       final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'.
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+
+      await tester.tapAt(ePos);
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
       expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pumpAndSettle();
 
       // Second tap selects the word around the cursor.
@@ -1996,27 +2000,27 @@ void main() {
       );
 
       final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
       expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(textFieldStart + const Offset(100.0, 5.0));
+      await tester.tapAt(ePos);
       await tester.pump();
 
       // Place collapsed selection at the edge of first word. In iOS 12, the
       // first tap after a double tap ends up putting the cursor at where
       // you tapped instead of the edge like every other single tap. This is
       // likely a bug in iOS 12 and not present in other versions.
-      expect(
-        controller.selection,
-        TextSelection.collapsed(offset: isTargetPlatformMobile ? 7 : 6, affinity: TextAffinity.upstream),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -2447,20 +2451,18 @@ void main() {
         ),
       );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
-      await tester.longPressAt(textFieldStart + const Offset(50.0, 5.0));
+      await tester.longPressAt(ePos);
       await tester.pump(const Duration(milliseconds: 50));
 
-      await tester.tapAt(textFieldStart + const Offset(50.0, 5.0));
+      await tester.tapAt(ePos);
       await tester.pump();
 
       // We ended up moving the cursor to the edge of the same word and dismissed
       // the toolbar.
-      expect(
-        controller.selection,
-        TextSelection.collapsed(offset: isTargetPlatformMobile ? 7 : 3, affinity: TextAffinity.upstream),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // The toolbar from the long press is now dismissed by the second tap.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -2636,23 +2638,24 @@ void main() {
         ),
       );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor to the beginning of the second word.
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
       expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.longPressAt(textFieldStart + const Offset(100.0, 5.0));
+      await tester.longPressAt(ePos);
       await tester.pumpAndSettle();
 
       // Plain collapsed selection at the exact tap position.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 6, affinity: TextAffinity.upstream),
+        const TextSelection.collapsed(offset: 6),
       );
 
       // Long press toolbar.
@@ -2678,17 +2681,18 @@ void main() {
         ),
       );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'
+      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'
 
-      await tester.longPressAt(textFieldStart + const Offset(50.0, 5.0));
+      await tester.longPressAt(wPos);
       await tester.pump(const Duration(milliseconds: 50));
 
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 8 : 9);
       expect(controller.selection.extentOffset, isTargetPlatformMobile ? 8 : 9);
-      await tester.tapAt(textFieldStart + const Offset(150.0, 5.0));
+      await tester.tapAt(pPos);
       await tester.pumpAndSettle();
 
       // Double tap selection.
@@ -2821,15 +2825,15 @@ void main() {
       ),
     );
 
-    final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
+    final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'
 
     final int pointerValue = tester.nextPointer;
     final TestGesture gesture = await tester.createGesture();
     await gesture.downWithCustomEvent(
-      textFieldStart + const Offset(150.0, 5.0),
+      pPos,
       PointerDownEvent(
         pointer: pointerValue,
-        position: textFieldStart + const Offset(150.0, 5.0),
+        position: pPos,
         // iPhone 6 and below report 0 across the board.
         pressure: 0,
         pressureMax: 0,

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1776,7 +1776,6 @@ void main() {
         ),
       );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
       final Offset pos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'.
 
       await tester.tapAt(pos);
@@ -1908,7 +1907,6 @@ void main() {
         ),
       );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
       final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'.
       final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
 
@@ -1999,7 +1997,6 @@ void main() {
         ),
       );
 
-      final Offset textFieldStart = tester.getTopLeft(find.byType(CupertinoTextField));
       final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
       final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 

--- a/packages/flutter/test/material/text_field_focus_test.dart
+++ b/packages/flutter/test/material/text_field_focus_test.dart
@@ -475,8 +475,6 @@ void main() {
 
     final TestGesture down1 = await tester.startGesture(tester.getCenter(find.byType(TextField).first), kind: PointerDeviceKind.mouse);
     await tester.pump();
-    await tester.pumpAndSettle();
-    await down1.up();
     await down1.removePointer();
 
     expect(focusNodeA.hasFocus, true);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -10955,106 +10955,11 @@ void main() {
     expect(controller.selection.extentOffset, 20);
   }, variant: TargetPlatformVariant.all());
 
-  testWidgets('can shift + tap + drag to select with a keyboard (MacOS)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard (Apple platforms)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
-    await tester.pumpWidget(
-      MaterialApp(
-        home:  Material(
-          child: Center(
-            child: TextField(controller: controller),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tapAt(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 8);
-
-    await tester.pump(kDoubleTapTimeout);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
-    final TestGesture gesture =
-        await tester.startGesture(
-          textOffsetToPosition(tester, 23),
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 23);
-
-    // Expand the selection a bit.
-    await gesture.moveTo(textOffsetToPosition(tester, 28));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 28);
-
-    // Move back to the original selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 23);
-
-    // Collapse the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 8);
-
-    // Invert the selection. The base jumps to the original extent.
-    await gesture.moveTo(textOffsetToPosition(tester, 7));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 7);
-
-    // Continuing to move in the inverted direction expands the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 4));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 4);
-
-    // Move back to the original base.
-    await gesture.moveTo(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 8);
-
-    // Continue to move past the original base, which will cause the selection
-    // to invert back to the original orientation.
-    await gesture.moveTo(textOffsetToPosition(tester, 9));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 9);
-
-    // Continuing to select in this direction selects just like it did
-    // originally.
-    await gesture.moveTo(textOffsetToPosition(tester, 24));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 24);
-
-    // Releasing the shift key has no effect; the selection continues as the
-    // mouse continues to move.
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 24);
-    await gesture.moveTo(textOffsetToPosition(tester, 26));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 26);
-
-    await gesture.up();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 26);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }));
-
-  testWidgets('can shift + tap + drag to select with a keyboard (iOS/iPadOS)', (WidgetTester tester) async {
-    final TextEditingController controller = TextEditingController(
-      text: 'Atwater Peel Sherbrooke Bonaventure',
-    );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       MaterialApp(
         home:  Material(
@@ -11078,13 +10983,17 @@ void main() {
       pointer: 7,
       kind: PointerDeviceKind.mouse,
     );
-    await gesture.up();
+    if (isTargetPlatformMobile) {
+      await gesture.up();
+    }
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 23);
 
     // Expand the selection a bit.
-    await gesture.down(textOffsetToPosition(tester, 23));
+    if (isTargetPlatformMobile) {
+      await gesture.down(textOffsetToPosition(tester, 23));
+    }
     await tester.pumpAndSettle();
     await gesture.moveTo(textOffsetToPosition(tester, 28));
     await tester.pumpAndSettle();
@@ -11148,12 +11057,14 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 26);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
-  testWidgets('can shift + tap + drag to select with a keyboard (Android, Fuchsia)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard (non-Apple platforms)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.android
+        || defaultTargetPlatform == TargetPlatform.fuchsia;
     await tester.pumpWidget(
       MaterialApp(
         home:  Material(
@@ -11177,13 +11088,17 @@ void main() {
           pointer: 7,
           kind: PointerDeviceKind.mouse,
         );
-    await gesture.up();
+    if (isTargetPlatformMobile) {
+      await gesture.up();
+    }
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 23);
 
     // Expand the selection a bit.
-    await gesture.down(textOffsetToPosition(tester, 23));
+    if (isTargetPlatformMobile) {
+      await gesture.down(textOffsetToPosition(tester, 23));
+    }
     await gesture.moveTo(textOffsetToPosition(tester, 28));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
@@ -11246,108 +11161,13 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 26);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
 
-  testWidgets('can shift + tap + drag to select with a keyboard (Linux, Windows)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard, reversed (Apple platforms)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
-    await tester.pumpWidget(
-      MaterialApp(
-        home:  Material(
-          child: Center(
-            child: TextField(controller: controller),
-          ),
-        ),
-      ),
-    );
-
-    await tester.tapAt(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 8);
-
-    await tester.pump(kDoubleTapTimeout);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
-    final TestGesture gesture =
-    await tester.startGesture(
-      textOffsetToPosition(tester, 23),
-      pointer: 7,
-      kind: PointerDeviceKind.mouse,
-    );
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 23);
-
-    // Expand the selection a bit.
-    await gesture.moveTo(textOffsetToPosition(tester, 28));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 28);
-
-    // Move back to the original selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 23);
-
-    // Collapse the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 8);
-
-    // Invert the selection. The original selection is not restored like on iOS
-    // and Mac.
-    await gesture.moveTo(textOffsetToPosition(tester, 7));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 7);
-
-    // Continuing to move in the inverted direction expands the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 4));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 4);
-
-    // Move back to the original base.
-    await gesture.moveTo(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 8);
-
-    // Continue to move past the original base.
-    await gesture.moveTo(textOffsetToPosition(tester, 9));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 9);
-
-    // Continuing to select in this direction selects just like it did
-    // originally.
-    await gesture.moveTo(textOffsetToPosition(tester, 24));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 24);
-
-    // Releasing the shift key has no effect; the selection continues as the
-    // mouse continues to move.
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 24);
-    await gesture.moveTo(textOffsetToPosition(tester, 26));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 26);
-
-    await gesture.up();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 26);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.windows }));
-
-  testWidgets('can shift + tap + drag to select with a keyboard, reversed (MacOS)', (WidgetTester tester) async {
-    final TextEditingController controller = TextEditingController(
-      text: 'Atwater Peel Sherbrooke Bonaventure',
-    );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       MaterialApp(
         home:  Material(
@@ -11366,16 +11186,22 @@ void main() {
     await tester.pump(kDoubleTapTimeout);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     final TestGesture gesture =
-        await tester.startGesture(
-          textOffsetToPosition(tester, 8),
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
+    await tester.startGesture(
+      textOffsetToPosition(tester, 8),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    if (isTargetPlatformMobile) {
+      await gesture.up();
+    }
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 8);
 
     // Expand the selection a bit.
+    if (isTargetPlatformMobile) {
+      await gesture.down(textOffsetToPosition(tester, 8));
+    }
     await gesture.moveTo(textOffsetToPosition(tester, 5));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 23);
@@ -11438,12 +11264,14 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 14);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
-  testWidgets('can shift + tap + drag to select with a keyboard, reversed (iOS)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard, reversed (non-Apple platforms)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.android
+        || defaultTargetPlatform == TargetPlatform.fuchsia;
     await tester.pumpWidget(
       MaterialApp(
         home:  Material(
@@ -11467,111 +11295,17 @@ void main() {
       pointer: 7,
       kind: PointerDeviceKind.mouse,
     );
-    await gesture.up();
+    if (isTargetPlatformMobile) {
+      await gesture.up();
+    }
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 8);
 
     // Expand the selection a bit.
-    await gesture.down(textOffsetToPosition(tester, 8));
-    await gesture.moveTo(textOffsetToPosition(tester, 5));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 5);
-
-    // Move back to the original selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 8);
-
-    // Collapse the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 23);
-
-    // Invert the selection. The base jumps to the original extent.
-    await gesture.moveTo(textOffsetToPosition(tester, 24));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 24);
-
-    // Continuing to move in the inverted direction expands the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 27));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 27);
-
-    // Move back to the original base.
-    await gesture.moveTo(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 8);
-    expect(controller.selection.extentOffset, 23);
-
-    // Continue to move past the original base, which will cause the selection
-    // to invert back to the original orientation.
-    await gesture.moveTo(textOffsetToPosition(tester, 22));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 22);
-
-    // Continuing to select in this direction selects just like it did
-    // originally.
-    await gesture.moveTo(textOffsetToPosition(tester, 16));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 16);
-
-    // Releasing the shift key has no effect; the selection continues as the
-    // mouse continues to move.
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 16);
-    await gesture.moveTo(textOffsetToPosition(tester, 14));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 14);
-
-    await gesture.up();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 14);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
-
-  testWidgets('can shift + tap + drag to select with a keyboard, reversed (Android, Fuchsia)', (WidgetTester tester) async {
-    final TextEditingController controller = TextEditingController(
-      text: 'Atwater Peel Sherbrooke Bonaventure',
-    );
-    await tester.pumpWidget(
-      MaterialApp(
-        home:  Material(
-          child: Center(
-            child: TextField(controller: controller),
-          ),
-        ),
-      ),
-    );
-
-    // Make a selection from right to left.
-    await tester.tapAt(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 23);
-    await tester.pump(kDoubleTapTimeout);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
-    final TestGesture gesture =
-    await tester.startGesture(
-      textOffsetToPosition(tester, 8),
-      pointer: 7,
-      kind: PointerDeviceKind.mouse,
-    );
-    await gesture.up();
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 8);
-
-    // Expand the selection a bit.
-    await gesture.down(textOffsetToPosition(tester, 8));
+    if (isTargetPlatformMobile) {
+      await gesture.down(textOffsetToPosition(tester, 8));
+    }
     await gesture.moveTo(textOffsetToPosition(tester, 5));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 23);
@@ -11634,103 +11368,7 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 14);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }));
-
-  testWidgets('can shift + tap + drag to select with a keyboard, reversed (Linux, Windows)', (WidgetTester tester) async {
-    final TextEditingController controller = TextEditingController(
-      text: 'Atwater Peel Sherbrooke Bonaventure',
-    );
-    await tester.pumpWidget(
-      MaterialApp(
-        home:  Material(
-          child: Center(
-            child: TextField(controller: controller),
-          ),
-        ),
-      ),
-    );
-
-    // Make a selection from right to left.
-    await tester.tapAt(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 23);
-    await tester.pump(kDoubleTapTimeout);
-    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
-    final TestGesture gesture =
-        await tester.startGesture(
-          textOffsetToPosition(tester, 8),
-          pointer: 7,
-          kind: PointerDeviceKind.mouse,
-        );
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 8);
-
-    // Expand the selection a bit.
-    await gesture.moveTo(textOffsetToPosition(tester, 5));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 5);
-
-    // Move back to the original selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 8));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 8);
-
-    // Collapse the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 23);
-
-    // Invert the selection. The selection is not restored like it would be on
-    // iOS and Mac.
-    await gesture.moveTo(textOffsetToPosition(tester, 24));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 24);
-
-    // Continuing to move in the inverted direction expands the selection.
-    await gesture.moveTo(textOffsetToPosition(tester, 27));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 27);
-
-    // Move back to the original base.
-    await gesture.moveTo(textOffsetToPosition(tester, 23));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 23);
-
-    // Continue to move past the original base.
-    await gesture.moveTo(textOffsetToPosition(tester, 22));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 22);
-
-    // Continuing to select in this direction selects just like it did
-    // originally.
-    await gesture.moveTo(textOffsetToPosition(tester, 16));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 16);
-
-    // Releasing the shift key has no effect; the selection continues as the
-    // mouse continues to move.
-    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 16);
-    await gesture.moveTo(textOffsetToPosition(tester, 14));
-    await tester.pumpAndSettle();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 14);
-
-    await gesture.up();
-    expect(controller.selection.baseOffset, 23);
-    expect(controller.selection.extentOffset, 14);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.windows }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
 
   // Regression test for https://github.com/flutter/flutter/issues/101587.
   testWidgets('Right clicking menu behavior', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -10955,7 +10955,7 @@ void main() {
     expect(controller.selection.extentOffset, 20);
   }, variant: TargetPlatformVariant.all());
 
-  testWidgets('can shift + tap + drag to select with a keyboard (Apple platforms)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard (MacOS)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
@@ -11049,7 +11049,105 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 26);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }));
+
+  testWidgets('can shift + tap + drag to select with a keyboard (iOS/iPadOS)', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(controller: controller),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
+
+    await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    final TestGesture gesture =
+    await tester.startGesture(
+      textOffsetToPosition(tester, 23),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 23);
+
+    // Expand the selection a bit.
+    await gesture.down(textOffsetToPosition(tester, 23));
+    await gesture.moveTo(textOffsetToPosition(tester, 28));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 28);
+
+    // Move back to the original selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 23);
+
+    // Collapse the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
+
+    // Invert the selection. The base jumps to the original extent.
+    await gesture.moveTo(textOffsetToPosition(tester, 7));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 7);
+
+    // Continuing to move in the inverted direction expands the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 4));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 4);
+
+    // Move back to the original base.
+    await gesture.moveTo(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 8);
+
+    // Continue to move past the original base, which will cause the selection
+    // to invert back to the original orientation.
+    await gesture.moveTo(textOffsetToPosition(tester, 9));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 9);
+
+    // Continuing to select in this direction selects just like it did
+    // originally.
+    await gesture.moveTo(textOffsetToPosition(tester, 24));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 24);
+
+    // Releasing the shift key has no effect; the selection continues as the
+    // mouse continues to move.
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 24);
+    await gesture.moveTo(textOffsetToPosition(tester, 26));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 26);
+
+    await gesture.up();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 26);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
 
   testWidgets('can shift + tap + drag to select with a keyboard (non-Apple platforms)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1964,7 +1964,7 @@ void main() {
     await tester.pumpAndSettle(kDoubleTapTimeout);
     expect(controller.selection, const TextSelection.collapsed(offset: 8));
 
-    final TestGesture touchGesture = await tester.startGesture(ePos, kind: PointerDeviceKind.touch);
+    final TestGesture touchGesture = await tester.startGesture(ePos);
     await touchGesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -908,6 +908,7 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       MaterialApp(
         home: Material(
@@ -933,7 +934,7 @@ void main() {
     // First tap moved the cursor.
     expect(
       controller.selection,
-      const TextSelection.collapsed(offset: 8),
+      TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
     );
     await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
     await tester.pump();
@@ -7203,7 +7204,7 @@ void main() {
       // But don't trigger the toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
   testWidgets(
@@ -7279,6 +7280,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -7298,11 +7300,9 @@ void main() {
       await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
       await tester.pump();
 
-      // Plain collapsed selection.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+      // Place collapsed selection.
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 3);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 3);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -7316,6 +7316,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -7340,7 +7341,7 @@ void main() {
       // First tap moved the cursor.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 8),
+        TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
       await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
       await tester.pumpAndSettle();
@@ -7772,6 +7773,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -7791,7 +7793,7 @@ void main() {
       // First tap moved the cursor.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 8),
+        TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
       await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
       await tester.pump(const Duration(milliseconds: 500));
@@ -7799,14 +7801,12 @@ void main() {
       await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
       await tester.pump();
 
-      // Plain collapsed selection at the edge of first word. In iOS 12, the
-      // first tap after a double tap ends up putting the cursor at where
+      // Place collapsed selection at the edge of first word on iOS. In iOS 12,
+      // the first tap after a double tap ends up putting the cursor at where
       // you tapped instead of the edge like every other single tap. This is
       // likely a bug in iOS 12 and not present in other versions.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -7889,6 +7889,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -7911,10 +7912,8 @@ void main() {
 
       // We ended up moving the cursor to the edge of the same word and dismissed
       // the toolbar.
-      expect(
-        controller.selection,
-        const TextSelection.collapsed(offset: 7, affinity: TextAffinity.upstream),
-      );
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 3);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 3);
 
       // Collapsed toolbar shows 2 buttons.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -8451,6 +8450,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -8470,7 +8470,7 @@ void main() {
       // First tap moved the cursor to the beginning of the second word.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 8),
+        TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
       await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
       await tester.pump(const Duration(milliseconds: 500));
@@ -8496,6 +8496,7 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -8522,7 +8523,7 @@ void main() {
       // First tap moved the cursor.
       expect(
         controller.selection,
-        const TextSelection.collapsed(offset: 8),
+        TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
       await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
       await tester.pumpAndSettle();
@@ -8661,7 +8662,7 @@ void main() {
       );
       expect(find.byType(CupertinoButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(3));
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
   testWidgets(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1940,7 +1940,7 @@ void main() {
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 8);
   },
-      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.macOS, TargetPlatform.windows })
+      variant: TargetPlatformVariant.desktop(),
   );
 
   testWidgets('Selection updates on tap up (Mobile platforms)', (WidgetTester tester) async {
@@ -1994,7 +1994,7 @@ void main() {
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 8);
   },
-      variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.iOS })
+      variant: TargetPlatformVariant.mobile(),
   );
 
   testWidgets('Can select text by dragging with a mouse', (WidgetTester tester) async {
@@ -7304,9 +7304,9 @@ void main() {
       await tester.tapAt(pos);
       await tester.pump();
 
-      // Place collapsed selection.
+      // Plain collapsed selection.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -7811,12 +7811,12 @@ void main() {
       await tester.tapAt(ePos);
       await tester.pump();
 
-      // Place collapsed selection at the edge of first word on iOS. In iOS 12,
+      // Plain collapsed selection at the edge of first word on iOS. In iOS 12,
       // the first tap after a double tap ends up putting the cursor at where
       // you tapped instead of the edge like every other single tap. This is
       // likely a bug in iOS 12 and not present in other versions.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -7924,8 +7924,8 @@ void main() {
 
       // We ended up moving the cursor to the edge of the same word and dismissed
       // the toolbar.
+      expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // Collapsed toolbar shows 2 buttons.
       expect(find.byType(CupertinoButton), findsNothing);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1087,12 +1087,12 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset pos = textOffsetToPosition(tester, 9); // Index of 'P|eel'
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pos);
       await tester.pump(const Duration(milliseconds: 50));
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pos);
       await tester.pump();
 
       // Selected text shows 'Copy', and not 'Paste', 'Cut', 'Select all'.
@@ -7297,16 +7297,16 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset pos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'.
 
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.tapAt(pos);
       await tester.pump(const Duration(milliseconds: 500));
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.tapAt(pos);
       await tester.pump();
 
       // Place collapsed selection.
-      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 3);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 3);
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // No toolbar.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -7336,20 +7336,21 @@ void main() {
       );
 
       final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset pos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
 
       // This tap just puts the cursor somewhere different than where the double
       // tap will occur to test that the double tap moves the existing cursor first.
       await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(
         controller.selection,
         TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pos);
       await tester.pumpAndSettle();
 
       // Second tap selects the word around the cursor.
@@ -7361,7 +7362,7 @@ void main() {
       // Selected text shows 3 toolbar buttons.
       expect(find.byType(CupertinoButton), isContextMenuProvidedByPlatform ? findsNothing : findsNWidgets(3));
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
   testWidgets(
@@ -7794,19 +7795,20 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(
         controller.selection,
         TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.tapAt(ePos);
       await tester.pump();
 
       // Place collapsed selection at the edge of first word on iOS. In iOS 12,
@@ -7912,18 +7914,18 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
-      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.longPressAt(ePos);
       await tester.pump(const Duration(milliseconds: 50));
 
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.tapAt(ePos);
       await tester.pump();
 
       // We ended up moving the cursor to the edge of the same word and dismissed
       // the toolbar.
-      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 3);
-      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 3);
+      expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
+      expect(controller.selection.extentOffset, isTargetPlatformMobile ? 7 : 6);
 
       // Collapsed toolbar shows 2 buttons.
       expect(find.byType(CupertinoButton), findsNothing);
@@ -8475,19 +8477,20 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'
+      final Offset ePos = textOffsetToPosition(tester, 6); // Index of 'Atwate|r'
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor to the beginning of the second word.
       expect(
         controller.selection,
         TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.longPressAt(textfieldStart + const Offset(100.0, 9.0));
+      await tester.longPressAt(ePos);
       await tester.pumpAndSettle();
 
       // Plain collapsed selection at the exact tap position.
@@ -8523,23 +8526,24 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'
+      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'
 
-      await tester.longPressAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.longPressAt(wPos);
       await tester.pump(const Duration(milliseconds: 50));
       expect(
         controller.selection,
         const TextSelection.collapsed(offset: 3),
       );
 
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(
         controller.selection,
         TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
-      await tester.tapAt(textfieldStart + const Offset(150.0, 9.0));
+      await tester.tapAt(pPos);
       await tester.pumpAndSettle();
 
       // Double tap selection.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11077,7 +11077,7 @@ void main() {
 
     // Expand the selection a bit.
     if (isTargetPlatformMobile) {
-      await gesture.down(textOffsetToPosition(tester, 23));
+      await gesture.down(textOffsetToPosition(tester, 24));
     }
     await tester.pumpAndSettle();
     await gesture.moveTo(textOffsetToPosition(tester, 28));
@@ -11285,7 +11285,7 @@ void main() {
 
     // Expand the selection a bit.
     if (isTargetPlatformMobile) {
-      await gesture.down(textOffsetToPosition(tester, 8));
+      await gesture.down(textOffsetToPosition(tester, 7));
     }
     await gesture.moveTo(textOffsetToPosition(tester, 5));
     await tester.pumpAndSettle();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7335,22 +7335,22 @@ void main() {
         ),
       );
 
-      final Offset textfieldStart = tester.getTopLeft(find.byType(TextField));
-      final Offset pos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
+      final Offset pPos = textOffsetToPosition(tester, 9); // Index of 'P|eel'.
+      final Offset wPos = textOffsetToPosition(tester, 3); // Index of 'Atw|ater'.
 
       // This tap just puts the cursor somewhere different than where the double
       // tap will occur to test that the double tap moves the existing cursor first.
-      await tester.tapAt(textfieldStart + const Offset(50.0, 9.0));
+      await tester.tapAt(wPos);
       await tester.pump(const Duration(milliseconds: 500));
 
-      await tester.tapAt(pos);
+      await tester.tapAt(pPos);
       await tester.pump(const Duration(milliseconds: 50));
       // First tap moved the cursor.
       expect(
         controller.selection,
         TextSelection.collapsed(offset: isTargetPlatformMobile ? 8 : 9),
       );
-      await tester.tapAt(pos);
+      await tester.tapAt(pPos);
       await tester.pumpAndSettle();
 
       // Second tap selects the word around the cursor.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1931,6 +1931,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 8);
+
+    // This should do nothing. The selection is set on tap down on desktop platforms.
+    await gesture.up();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
   },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.macOS, TargetPlatform.windows })
   );
@@ -1971,10 +1976,13 @@ void main() {
     final TestGesture touchGesture = await tester.startGesture(ePos);
     await touchGesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
+    // On iOS a tap to select, selects the word edge instead of the exact tap position.
+    expect(controller.selection.baseOffset, isTargetPlatformApple ? 4 : 5);
+    expect(controller.selection.extentOffset, isTargetPlatformApple ? 4 : 5);
 
+    // Selection should stay the same since it is set on tap up for mobile platforms.
     await touchGesture.down(gPos);
     await tester.pumpAndSettle();
-    // On iOS a tap to select, selects the word edge instead of the exact tap position.
     expect(controller.selection.baseOffset, isTargetPlatformApple ? 4 : 5);
     expect(controller.selection.extentOffset, isTargetPlatformApple ? 4 : 5);
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -10978,11 +10978,11 @@ void main() {
     await tester.pump(kDoubleTapTimeout);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     final TestGesture gesture =
-    await tester.startGesture(
-      textOffsetToPosition(tester, 23),
-      pointer: 7,
-      kind: PointerDeviceKind.mouse,
-    );
+        await tester.startGesture(
+          textOffsetToPosition(tester, 23),
+          pointer: 7,
+          kind: PointerDeviceKind.mouse,
+        );
     if (isTargetPlatformMobile) {
       await gesture.up();
     }
@@ -11186,11 +11186,11 @@ void main() {
     await tester.pump(kDoubleTapTimeout);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     final TestGesture gesture =
-    await tester.startGesture(
-      textOffsetToPosition(tester, 8),
-      pointer: 7,
-      kind: PointerDeviceKind.mouse,
-    );
+        await tester.startGesture(
+          textOffsetToPosition(tester, 8),
+          pointer: 7,
+          kind: PointerDeviceKind.mouse,
+        );
     if (isTargetPlatformMobile) {
       await gesture.up();
     }
@@ -11290,11 +11290,11 @@ void main() {
     await tester.pump(kDoubleTapTimeout);
     await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
     final TestGesture gesture =
-    await tester.startGesture(
-      textOffsetToPosition(tester, 8),
-      pointer: 7,
-      kind: PointerDeviceKind.mouse,
-    );
+        await tester.startGesture(
+          textOffsetToPosition(tester, 8),
+          pointer: 7,
+          kind: PointerDeviceKind.mouse,
+        );
     if (isTargetPlatformMobile) {
       await gesture.up();
     }

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11085,6 +11085,7 @@ void main() {
 
     // Expand the selection a bit.
     await gesture.down(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
     await gesture.moveTo(textOffsetToPosition(tester, 28));
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
@@ -11149,7 +11150,7 @@ void main() {
     expect(controller.selection.extentOffset, 26);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
 
-  testWidgets('can shift + tap + drag to select with a keyboard (non-Apple platforms)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard (Android, Fuchsia)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
@@ -11176,6 +11177,104 @@ void main() {
           pointer: 7,
           kind: PointerDeviceKind.mouse,
         );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 23);
+
+    // Expand the selection a bit.
+    await gesture.down(textOffsetToPosition(tester, 23));
+    await gesture.moveTo(textOffsetToPosition(tester, 28));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 28);
+
+    // Move back to the original selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 23);
+
+    // Collapse the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
+
+    // Invert the selection. The original selection is not restored like on iOS
+    // and Mac.
+    await gesture.moveTo(textOffsetToPosition(tester, 7));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 7);
+
+    // Continuing to move in the inverted direction expands the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 4));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 4);
+
+    // Move back to the original base.
+    await gesture.moveTo(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
+
+    // Continue to move past the original base.
+    await gesture.moveTo(textOffsetToPosition(tester, 9));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 9);
+
+    // Continuing to select in this direction selects just like it did
+    // originally.
+    await gesture.moveTo(textOffsetToPosition(tester, 24));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 24);
+
+    // Releasing the shift key has no effect; the selection continues as the
+    // mouse continues to move.
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 24);
+    await gesture.moveTo(textOffsetToPosition(tester, 26));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 26);
+
+    await gesture.up();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 26);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }));
+
+  testWidgets('can shift + tap + drag to select with a keyboard (Linux, Windows)', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(controller: controller),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
+
+    await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    final TestGesture gesture =
+    await tester.startGesture(
+      textOffsetToPosition(tester, 23),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
     await tester.pumpAndSettle();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 23);
@@ -11243,7 +11342,7 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 8);
     expect(controller.selection.extentOffset, 26);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux,  TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.windows }));
 
   testWidgets('can shift + tap + drag to select with a keyboard, reversed (Apple platforms)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11344,7 +11344,7 @@ void main() {
     expect(controller.selection.extentOffset, 26);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.windows }));
 
-  testWidgets('can shift + tap + drag to select with a keyboard, reversed (Apple platforms)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard, reversed (MacOS)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
@@ -11438,9 +11438,205 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 14);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.macOS }));
 
-  testWidgets('can shift + tap + drag to select with a keyboard, reversed (non-Apple platforms)', (WidgetTester tester) async {
+  testWidgets('can shift + tap + drag to select with a keyboard, reversed (iOS)', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(controller: controller),
+          ),
+        ),
+      ),
+    );
+
+    // Make a selection from right to left.
+    await tester.tapAt(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 23);
+    await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    final TestGesture gesture =
+    await tester.startGesture(
+      textOffsetToPosition(tester, 8),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 8);
+
+    // Expand the selection a bit.
+    await gesture.down(textOffsetToPosition(tester, 8));
+    await gesture.moveTo(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 5);
+
+    // Move back to the original selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 8);
+
+    // Collapse the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 23);
+
+    // Invert the selection. The base jumps to the original extent.
+    await gesture.moveTo(textOffsetToPosition(tester, 24));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 24);
+
+    // Continuing to move in the inverted direction expands the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 27));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 27);
+
+    // Move back to the original base.
+    await gesture.moveTo(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 23);
+
+    // Continue to move past the original base, which will cause the selection
+    // to invert back to the original orientation.
+    await gesture.moveTo(textOffsetToPosition(tester, 22));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 22);
+
+    // Continuing to select in this direction selects just like it did
+    // originally.
+    await gesture.moveTo(textOffsetToPosition(tester, 16));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 16);
+
+    // Releasing the shift key has no effect; the selection continues as the
+    // mouse continues to move.
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 16);
+    await gesture.moveTo(textOffsetToPosition(tester, 14));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 14);
+
+    await gesture.up();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 14);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
+
+  testWidgets('can shift + tap + drag to select with a keyboard, reversed (Android, Fuchsia)', (WidgetTester tester) async {
+    final TextEditingController controller = TextEditingController(
+      text: 'Atwater Peel Sherbrooke Bonaventure',
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home:  Material(
+          child: Center(
+            child: TextField(controller: controller),
+          ),
+        ),
+      ),
+    );
+
+    // Make a selection from right to left.
+    await tester.tapAt(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 23);
+    await tester.pump(kDoubleTapTimeout);
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shift);
+    final TestGesture gesture =
+    await tester.startGesture(
+      textOffsetToPosition(tester, 8),
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    await gesture.up();
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 8);
+
+    // Expand the selection a bit.
+    await gesture.down(textOffsetToPosition(tester, 8));
+    await gesture.moveTo(textOffsetToPosition(tester, 5));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 5);
+
+    // Move back to the original selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 8));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 8);
+
+    // Collapse the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 23);
+
+    // Invert the selection. The selection is not restored like it would be on
+    // iOS and Mac.
+    await gesture.moveTo(textOffsetToPosition(tester, 24));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 24);
+
+    // Continuing to move in the inverted direction expands the selection.
+    await gesture.moveTo(textOffsetToPosition(tester, 27));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 27);
+
+    // Move back to the original base.
+    await gesture.moveTo(textOffsetToPosition(tester, 23));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 23);
+
+    // Continue to move past the original base.
+    await gesture.moveTo(textOffsetToPosition(tester, 22));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 22);
+
+    // Continuing to select in this direction selects just like it did
+    // originally.
+    await gesture.moveTo(textOffsetToPosition(tester, 16));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 16);
+
+    // Releasing the shift key has no effect; the selection continues as the
+    // mouse continues to move.
+    await tester.sendKeyUpEvent(LogicalKeyboardKey.shift);
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 16);
+    await gesture.moveTo(textOffsetToPosition(tester, 14));
+    await tester.pumpAndSettle();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 14);
+
+    await gesture.up();
+    expect(controller.selection.baseOffset, 23);
+    expect(controller.selection.extentOffset, 14);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia }));
+
+  testWidgets('can shift + tap + drag to select with a keyboard, reversed (Linux, Windows)', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
@@ -11534,7 +11730,7 @@ void main() {
     await gesture.up();
     expect(controller.selection.baseOffset, 23);
     expect(controller.selection.extentOffset, 14);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux,  TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.windows }));
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.windows }));
 
   // Regression test for https://github.com/flutter/flutter/issues/101587.
   testWidgets('Right clicking menu behavior', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -908,6 +908,8 @@ void main() {
     final TextEditingController controller = TextEditingController(
       text: 'Atwater Peel Sherbrooke Bonaventure',
     );
+    // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+    // On macOS, we select the precise position of the tap.
     final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
     await tester.pumpWidget(
       MaterialApp(
@@ -7280,6 +7282,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
@@ -7316,6 +7320,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
@@ -7773,6 +7779,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
@@ -7889,6 +7897,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
@@ -8450,6 +8460,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(
@@ -8496,6 +8508,8 @@ void main() {
       final TextEditingController controller = TextEditingController(
         text: 'Atwater Peel Sherbrooke Bonaventure',
       );
+      // On iOS/iPadOS, during a tap we select the edge of the word closest to the tap.
+      // On macOS, we select the precise position of the tap.
       final bool isTargetPlatformMobile = defaultTargetPlatform == TargetPlatform.iOS;
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -1921,14 +1921,16 @@ void main() {
 
     final TestGesture gesture = await tester.startGesture(ePos, kind: PointerDeviceKind.mouse);
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 5));
+    expect(controller.selection.baseOffset, 5);
+    expect(controller.selection.extentOffset, 5);
 
     await gesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
 
     await gesture.down(gPos);
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 8));
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
   },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.linux, TargetPlatform.macOS, TargetPlatform.windows })
   );
@@ -1958,11 +1960,13 @@ void main() {
 
     await gesture.down(gPos);
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 5));
+    expect(controller.selection.baseOffset, 5);
+    expect(controller.selection.extentOffset, 5);
 
     await gesture.up();
     await tester.pumpAndSettle(kDoubleTapTimeout);
-    expect(controller.selection, const TextSelection.collapsed(offset: 8));
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
 
     final TestGesture touchGesture = await tester.startGesture(ePos);
     await touchGesture.up();
@@ -1971,11 +1975,13 @@ void main() {
     await touchGesture.down(gPos);
     await tester.pumpAndSettle();
     // On iOS a tap to select, selects the word edge instead of the exact tap position.
-    expect(controller.selection, TextSelection.collapsed(offset: isTargetPlatformApple ? 4 : 5));
+    expect(controller.selection.baseOffset, isTargetPlatformApple ? 4 : 5);
+    expect(controller.selection.extentOffset, isTargetPlatformApple ? 4 : 5);
 
     await touchGesture.up();
     await tester.pumpAndSettle();
-    expect(controller.selection, const TextSelection.collapsed(offset: 8));
+    expect(controller.selection.baseOffset, 8);
+    expect(controller.selection.extentOffset, 8);
   },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.iOS })
   );

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -557,9 +557,9 @@ void main() {
 
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
         expect(renderEditable.selectWordEdgeCalled, isTrue);
         break;
+      case TargetPlatform.macOS:
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:


### PR DESCRIPTION
On desktop platforms such as MacOS, Linux, Windows, and Web, the selection in an input field should be set during a tap down on the input field at a position.

On mobile platforms such as Android, Fuchsia, and iOS, the selection in an input field should be set during a tap up on the input field at a position.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
