### PR TITLE
[flutter_tools] Improve emulator error based on machine architecture

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1290,6 +1290,7 @@ class EmulatorDomain extends Domain {
     androidSdk: globals.androidSdk,
     processManager: globals.processManager,
     androidWorkflow: androidWorkflow,
+    operatingSystemUtils: globals.os,
   );
 
   Future<List<Map<String, dynamic>>> getEmulators([ Map<String, dynamic> args ]) async {

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -221,6 +221,7 @@ Future<T> runInContext<T>(
         logger: globals.logger,
         fileSystem: globals.fs,
         androidWorkflow: androidWorkflow,
+        operatingSystemUtils: globals.os,
       ),
       FeatureFlags: () => FlutterFeatureFlags(
         flutterVersion: globals.flutterVersion,


### PR DESCRIPTION
- Improving emulator error message based on machine architecture 
- Update the android emulator image from 27 to 31

#105544 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

