### PR TITLE
Fix DraggableScrollableSheet crash when switching out scrollables

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -631,7 +631,24 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
   @override
   void didUpdateWidget(covariant DraggableScrollableSheet oldWidget) {
     super.didUpdateWidget(oldWidget);
-    _replaceExtent();
+    if (_replacedExtent()
+      && widget.snap
+      && (widget.snap != oldWidget.snap || widget.snapSizes != oldWidget.snapSizes)
+      && _scrollController.hasClients
+      ) {
+      // Trigger a snap in case snap or snapSizes has changed and there is a
+      // scroll position currently attached. We put this in a post frame
+      // callback so that `build` can update `_extent.availablePixels` before
+      // this runs-we can't use the previous extent's available pixels as it may
+      // have changed when the widget was updated.
+      WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
+        for (int index = 0; index < _scrollController.positions.length; index++) {
+          final _DraggableScrollableSheetScrollPosition position =
+            _scrollController.positions.elementAt(index) as _DraggableScrollableSheetScrollPosition;
+          position.goBallistic(0);
+        }
+      });
+    }
   }
 
   @override
@@ -671,7 +688,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
     super.dispose();
   }
 
-  void _replaceExtent() {
+  bool _replacedExtent() {
     final _DraggableSheetExtent previousExtent = _extent;
     _extent.dispose();
     _extent = _extent.copyWith(
@@ -682,21 +699,17 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       initialSize: widget.initialChildSize,
       onSizeChanged: _setExtent,
     );
+    if (previousExtent == _extent) {
+      return false;
+    }
+
     // Modify the existing scroll controller instead of replacing it so that
     // developers listening to the controller do not have to rebuild their listeners.
     _scrollController.extent = _extent;
     // If an external facing controller was provided, let it know that the
     // extent has been replaced.
     widget.controller?._onExtentReplaced(previousExtent);
-    if (widget.snap) {
-      // Trigger a snap in case snap or snapSizes has changed. We put this in a
-      // post frame callback so that `build` can update `_extent.availablePixels`
-      // before this runs-we can't use the previous extent's available pixels as
-      // it may have changed when the widget was updated.
-      WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
-        _scrollController.position.goBallistic(0);
-      });
-    }
+    return true;
   }
 
   String _snapSizeErrorMessage(int invalidIndex) {

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -682,7 +682,6 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       initialSize: widget.initialChildSize,
       onSizeChanged: _setExtent,
     );
-
     // Modify the existing scroll controller instead of replacing it so that
     // developers listening to the controller do not have to rebuild their listeners.
     _scrollController.extent = _extent;
@@ -701,7 +700,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       WidgetsBinding.instance.addPostFrameCallback((Duration timeStamp) {
         for (int index = 0; index < _scrollController.positions.length; index++) {
           final _DraggableScrollableSheetScrollPosition position =
-          _scrollController.positions.elementAt(index) as _DraggableScrollableSheetScrollPosition;
+            _scrollController.positions.elementAt(index) as _DraggableScrollableSheetScrollPosition;
           position.goBallistic(0);
         }
       });

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -745,6 +745,58 @@ void main() {
     await tester.pumpAndSettle();
   }, variant: TargetPlatformVariant.all());
 
+  testWidgets('Transitioning between scrollable children sharing a scroll controller will not throw', (WidgetTester tester) async {
+    late StateSetter setState;
+    int s = 0;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: DraggableScrollableSheet(
+          initialChildSize: 0.25,
+          snap: true,
+          snapSizes: const <double>[0.25, 0.5, 1.0],
+          builder: (BuildContext context, ScrollController scrollController) {
+            return PrimaryScrollController(
+              controller: scrollController,
+              child: StatefulBuilder(
+                builder: (BuildContext context, StateSetter setter) {
+                  setState = setter;
+                  return AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 500),
+                    child: (s.isEven)
+                      ? ListView(
+                          children: List<Widget>.generate(
+                            50,
+                            (int index) => Text('ListView 1 - $index'),
+                          ),
+                        )
+                      : ListView(
+                          children: List<Widget>.generate(
+                            50,
+                            (int index) => Text('ListView 2 - $index'),
+                          ),
+                        ),
+                  );
+                },
+              ),
+            );
+          },
+        ),
+      )
+    ));
+
+    // Trigger the AnimatedSwitcher between ListViews
+    setState((){
+      s++;
+    });
+    await tester.pumpAndSettle();
+    // Trigger the AnimatedSwitcher between ListViews
+    setState((){
+      s++;
+    });
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('ScrollNotification correctly dispatched when flung without covering its container', (WidgetTester tester) async {
     final List<Type> notificationTypes = <Type>[];
     await tester.pumpWidget(boilerplateWidget(

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -746,55 +746,60 @@ void main() {
   }, variant: TargetPlatformVariant.all());
 
   testWidgets('Transitioning between scrollable children sharing a scroll controller will not throw', (WidgetTester tester) async {
-    late StateSetter setState;
     int s = 0;
-
     await tester.pumpWidget(MaterialApp(
-      home: Scaffold(
-        body: DraggableScrollableSheet(
-          initialChildSize: 0.25,
-          snap: true,
-          snapSizes: const <double>[0.25, 0.5, 1.0],
-          builder: (BuildContext context, ScrollController scrollController) {
-            return PrimaryScrollController(
-              controller: scrollController,
-              child: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setter) {
-                  setState = setter;
-                  return AnimatedSwitcher(
+      home: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return Scaffold(
+            body: DraggableScrollableSheet(
+              initialChildSize: 0.25,
+              snap: true,
+              snapSizes: const <double>[0.25, 0.5, 1.0],
+              builder: (BuildContext context, ScrollController scrollController) {
+                return PrimaryScrollController(
+                  controller: scrollController,
+                  child: AnimatedSwitcher(
                     duration: const Duration(milliseconds: 500),
                     child: (s.isEven)
                       ? ListView(
-                          children: List<Widget>.generate(
-                            50,
-                            (int index) => Text('ListView 1 - $index'),
+                        children: <Widget>[
+                          ElevatedButton(
+                            onPressed: () => setState(() => ++s),
+                            child: const Text('Switch to 2'),
                           ),
+                          Container(
+                            height: 400,
+                            color: Colors.blue,
+                          ),
+                        ],
+                      )
+                      : SingleChildScrollView(
+                        child: Column(
+                          children: <Widget>[
+                            ElevatedButton(
+                              onPressed: () => setState(() => ++s),
+                              child: const Text('Switch to 1'),
+                            ),
+                            Container(
+                              height: 400,
+                              color: Colors.blue,
+                            ),
+                          ],
                         )
-                      : ListView(
-                          children: List<Widget>.generate(
-                            50,
-                            (int index) => Text('ListView 2 - $index'),
-                          ),
-                        ),
-                  );
-                },
-              ),
-            );
-          },
-        ),
-      )
+                      ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
     ));
 
     // Trigger the AnimatedSwitcher between ListViews
-    setState((){
-      s++;
-    });
-    await tester.pumpAndSettle();
-    // Trigger the AnimatedSwitcher between ListViews
-    setState((){
-      s++;
-    });
-    await tester.pumpAndSettle();
+    await tester.tap(find.text('Switch to 2'));
+    await tester.pump();
+    // Completes without throwing
   });
 
   testWidgets('ScrollNotification correctly dispatched when flung without covering its container', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/105469

This accounts for when there is more than one position is attached to the scroll controller, and only triggers a snap when appropriate.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
