### PR TITLE
Make flutter attach respect the `--dds-port` flag.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -428,6 +428,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
     final DebuggingOptions debuggingOptions = DebuggingOptions.enabled(
       buildInfo,
       enableDds: enableDds,
+      ddsPort: ddsPort,
       devToolsServerAddress: devToolsServerAddress,
     );
 

--- a/packages/flutter_tools/test/integration.shard/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_attach_test.dart
@@ -20,7 +20,6 @@ Future<int> getFreePort() async {
 }
 
 void main() {
-  late FlutterRunTestDriver flutterRun, flutterAttach;
   final BasicProject project = BasicProject();
   late Directory tempDir;
 
@@ -34,6 +33,7 @@ void main() {
   });
 
   group('DDS in flutter run', () {
+    late FlutterRunTestDriver flutterRun, flutterAttach;
     setUp(() {
       flutterRun = FlutterRunTestDriver(tempDir,    logPrefix: '   RUN  ');
       flutterAttach = FlutterRunTestDriver(
@@ -122,6 +122,7 @@ void main() {
   });
 
   group('DDS in flutter attach', () {
+    late FlutterRunTestDriver flutterRun, flutterAttach;
     setUp(() {
       flutterRun = FlutterRunTestDriver(
         tempDir,
@@ -131,7 +132,6 @@ void main() {
       flutterAttach = FlutterRunTestDriver(
         tempDir,
         logPrefix: 'ATTACH  ',
-        spawnDdsInstance: true,
       );
     });
 
@@ -146,7 +146,7 @@ void main() {
       await flutterRun.run(withDebugger: true);
       await flutterAttach.attach(
         flutterRun.vmServicePort!,
-        additionalCommandArgs: [
+        additionalCommandArgs: <String>[
           '--dds-port=$ddsPort',
         ],
       );

--- a/packages/flutter_tools/test/integration.shard/flutter_attach_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_attach_test.dart
@@ -3,12 +3,21 @@
 // found in the LICENSE file.
 
 import 'package:file/file.dart';
+import 'package:flutter_tools/src/base/io.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../src/common.dart';
 import 'test_data/basic_project.dart';
 import 'test_driver.dart';
 import 'test_utils.dart';
+
+Future<int> getFreePort() async {
+  int port = 0;
+  final ServerSocket serverSocket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  port = serverSocket.port;
+  await serverSocket.close();
+  return port;
+}
 
 void main() {
   late FlutterRunTestDriver flutterRun, flutterAttach;
@@ -18,89 +27,134 @@ void main() {
   setUp(() async {
     tempDir = createResolvedTempDirectorySync('attach_test.');
     await project.setUpIn(tempDir);
-    flutterRun = FlutterRunTestDriver(tempDir,    logPrefix: '   RUN  ');
-    flutterAttach = FlutterRunTestDriver(
-      tempDir,
-      logPrefix: 'ATTACH  ',
-      // Only one DDS instance can be connected to the VM service at a time.
-      // DDS can also only initialize if the VM service doesn't have any existing
-      // clients, so we'll just let _flutterRun be responsible for spawning DDS.
-      spawnDdsInstance: false,
-    );
   });
 
-  tearDown(() async {
-    await flutterAttach.detach();
-    await flutterRun.stop();
+  tearDown(() {
     tryToDelete(tempDir);
   });
 
-  testWithoutContext('can hot reload', () async {
-    await flutterRun.run(withDebugger: true);
-    await flutterAttach.attach(flutterRun.vmServicePort!);
-    await flutterAttach.hotReload();
+  group('DDS in flutter run', () {
+    setUp(() {
+      flutterRun = FlutterRunTestDriver(tempDir,    logPrefix: '   RUN  ');
+      flutterAttach = FlutterRunTestDriver(
+        tempDir,
+        logPrefix: 'ATTACH  ',
+        // Only one DDS instance can be connected to the VM service at a time.
+        // DDS can also only initialize if the VM service doesn't have any existing
+        // clients, so we'll just let _flutterRun be responsible for spawning DDS.
+        spawnDdsInstance: false,
+      );
+    });
+
+    tearDown(() async {
+      await flutterAttach.detach();
+      await flutterRun.stop();
+    });
+
+    testWithoutContext('can hot reload', () async {
+      await flutterRun.run(withDebugger: true);
+      await flutterAttach.attach(flutterRun.vmServicePort!);
+      await flutterAttach.hotReload();
+    });
+
+    testWithoutContext('can detach, reattach, hot reload', () async {
+      await flutterRun.run(withDebugger: true);
+      await flutterAttach.attach(flutterRun.vmServicePort!);
+      await flutterAttach.detach();
+      await flutterAttach.attach(flutterRun.vmServicePort!);
+      await flutterAttach.hotReload();
+    });
+
+    testWithoutContext('killing process behaves the same as detach ', () async {
+      await flutterRun.run(withDebugger: true);
+      await flutterAttach.attach(flutterRun.vmServicePort!);
+      await flutterAttach.quit();
+      flutterAttach = FlutterRunTestDriver(
+        tempDir,
+        logPrefix: 'ATTACH-2',
+        spawnDdsInstance: false,
+      );
+      await flutterAttach.attach(flutterRun.vmServicePort!);
+      await flutterAttach.hotReload();
+    });
+
+    testWithoutContext('sets activeDevToolsServerAddress extension', () async {
+      await flutterRun.run(
+        startPaused: true,
+        withDebugger: true,
+        additionalCommandArgs: <String>['--devtools-server-address', 'http://127.0.0.1:9105'],
+      );
+      await flutterRun.resume();
+      await pollForServiceExtensionValue<String>(
+        testDriver: flutterRun,
+        extension: 'ext.flutter.activeDevToolsServerAddress',
+        continuePollingValue: '',
+        matches: equals('http://127.0.0.1:9105'),
+      );
+      await pollForServiceExtensionValue<String>(
+        testDriver: flutterRun,
+        extension: 'ext.flutter.connectedVmServiceUri',
+        continuePollingValue: '',
+        matches: isNotEmpty,
+      );
+
+      final Response response = await flutterRun.callServiceExtension('ext.flutter.connectedVmServiceUri');
+      final String vmServiceUri = response.json!['value'] as String;
+
+      // Attach with a different DevTools server address.
+      await flutterAttach.attach(
+        flutterRun.vmServicePort!,
+        additionalCommandArgs: <String>['--devtools-server-address', 'http://127.0.0.1:9110'],
+      );
+      await pollForServiceExtensionValue<String>(
+        testDriver: flutterAttach,
+        extension: 'ext.flutter.activeDevToolsServerAddress',
+        continuePollingValue: '',
+        matches: equals('http://127.0.0.1:9110'),
+      );
+      await pollForServiceExtensionValue<String>(
+        testDriver: flutterRun,
+        extension: 'ext.flutter.connectedVmServiceUri',
+        continuePollingValue: '',
+        matches: equals(vmServiceUri),
+      );
+    });
   });
 
-  testWithoutContext('can detach, reattach, hot reload', () async {
-    await flutterRun.run(withDebugger: true);
-    await flutterAttach.attach(flutterRun.vmServicePort!);
-    await flutterAttach.detach();
-    await flutterAttach.attach(flutterRun.vmServicePort!);
-    await flutterAttach.hotReload();
-  });
+  group('DDS in flutter attach', () {
+    setUp(() {
+      flutterRun = FlutterRunTestDriver(
+        tempDir,
+        logPrefix: '   RUN  ',
+        spawnDdsInstance: false,
+      );
+      flutterAttach = FlutterRunTestDriver(
+        tempDir,
+        logPrefix: 'ATTACH  ',
+        spawnDdsInstance: true,
+      );
+    });
 
-  testWithoutContext('killing process behaves the same as detach ', () async {
-    await flutterRun.run(withDebugger: true);
-    await flutterAttach.attach(flutterRun.vmServicePort!);
-    await flutterAttach.quit();
-    flutterAttach = FlutterRunTestDriver(
-      tempDir,
-      logPrefix: 'ATTACH-2',
-      spawnDdsInstance: false,
-    );
-    await flutterAttach.attach(flutterRun.vmServicePort!);
-    await flutterAttach.hotReload();
-  });
+    tearDown(() async {
+      await flutterAttach.detach();
+      await flutterRun.stop();
+    });
 
-  testWithoutContext('sets activeDevToolsServerAddress extension', () async {
-    await flutterRun.run(
-      startPaused: true,
-      withDebugger: true,
-      additionalCommandArgs: <String>['--devtools-server-address', 'http://127.0.0.1:9105'],
-    );
-    await flutterRun.resume();
-    await pollForServiceExtensionValue<String>(
-      testDriver: flutterRun,
-      extension: 'ext.flutter.activeDevToolsServerAddress',
-      continuePollingValue: '',
-      matches: equals('http://127.0.0.1:9105'),
-    );
-    await pollForServiceExtensionValue<String>(
-      testDriver: flutterRun,
-      extension: 'ext.flutter.connectedVmServiceUri',
-      continuePollingValue: '',
-      matches: isNotEmpty,
-    );
+    testWithoutContext('uses the designated dds port', () async {
+      final int ddsPort = await getFreePort();
 
-    final Response response = await flutterRun.callServiceExtension('ext.flutter.connectedVmServiceUri');
-    final String vmServiceUri = response.json!['value'] as String;
+      await flutterRun.run(withDebugger: true);
+      await flutterAttach.attach(
+        flutterRun.vmServicePort!,
+        additionalCommandArgs: [
+          '--dds-port=$ddsPort',
+        ],
+      );
 
-    // Attach with a different DevTools server address.
-    await flutterAttach.attach(
-      flutterRun.vmServicePort!,
-      additionalCommandArgs: <String>['--devtools-server-address', 'http://127.0.0.1:9110'],
-    );
-    await pollForServiceExtensionValue<String>(
-      testDriver: flutterAttach,
-      extension: 'ext.flutter.activeDevToolsServerAddress',
-      continuePollingValue: '',
-      matches: equals('http://127.0.0.1:9110'),
-    );
-    await pollForServiceExtensionValue<String>(
-      testDriver: flutterRun,
-      extension: 'ext.flutter.connectedVmServiceUri',
-      continuePollingValue: '',
-      matches: equals(vmServiceUri),
-    );
+      final Response response = await flutterAttach.callServiceExtension('ext.flutter.connectedVmServiceUri');
+      final String vmServiceUriString = response.json!['value'] as String;
+      final Uri vmServiceUri = Uri.parse(vmServiceUriString);
+      expect(vmServiceUri.port, equals(ddsPort));
+    });
   });
 }


### PR DESCRIPTION
Flutter attach used to ignore the `--dds-port` flag.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
