### PR TITLE
Remove duplicated key in _IconButtonM3

### DIFF
--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -497,7 +497,6 @@ class IconButton extends StatelessWidget {
         );
       }
       return _IconButtonM3(
-        key: key,
         style: adjustedStyle,
         onPressed: onPressed,
         autofocus: autofocus,
@@ -577,7 +576,6 @@ class IconButton extends StatelessWidget {
 
 class _IconButtonM3 extends ButtonStyleButton {
   const _IconButtonM3({
-    super.key,
     required super.onPressed,
     super.style,
     super.focusNode,

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -28,6 +28,22 @@ void main() {
     mockOnPressedFunction = MockOnPressedFunction();
   });
 
+  testWidgets('test icon is findable by key', (WidgetTester tester) async {
+    const ValueKey<String> key = ValueKey<String>('icon-button');
+    await tester.pumpWidget(
+      wrap(
+        useMaterial3: true,
+        child: IconButton(
+          key: key,
+          onPressed: () {},
+          icon: const Icon(Icons.link),
+        ),
+      ),
+    );
+
+    expect(find.byKey(key), findsOneWidget);
+  });
+
   testWidgets('test default icon buttons are sized up to 48', (WidgetTester tester) async {
     final bool material3 = theme.useMaterial3;
     await tester.pumpWidget(


### PR DESCRIPTION
This PR removes the key on _IconButtonM3 as it currently duplicates the parent key. As stated in that issue I'm under the impression that keys should not be reused, since this is not the first time I see this in the flutter repo maybe they are ? In any case, I just removed the duplication in the child widget.

Fixes #105554 



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [n/a] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
