### PR TITLE
Fix `selectableDayPredicate` is called after selecting a date in the input mode

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -519,7 +519,9 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
                   firstDate: widget.firstDate,
                   lastDate: widget.lastDate,
                   onDateSubmitted: _handleDateChanged,
-                  onDateSaved: _handleDateChanged,
+                  onDateSaved: (DateTime savedDate) {
+                    _selectedDate.value = savedDate;
+                  },
                   selectableDayPredicate: widget.selectableDayPredicate,
                   errorFormatText: widget.errorFormatText,
                   errorInvalidText: widget.errorInvalidText,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -802,6 +802,58 @@ void main() {
         expect(find.text(errorInvalidText!), findsOneWidget);
       });
     });
+
+    testWidgets('selectableDayPredicate is not called after selecting a date', (WidgetTester tester) async {
+      final List<String> logs = <String>[];
+
+      Widget buildFrame(TextDirection textDirection) {
+        return MaterialApp(
+          home: Material(
+            child: Center(
+              child: Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    child: const Text('X'),
+                    onPressed: () async {
+                      final Future<DateTime?> pickedDate = showDatePicker(
+                        context: context,
+                        initialDate: DateTime(2016, DateTime.january, 15),
+                        firstDate:DateTime(2001),
+                        lastDate: DateTime(2031, DateTime.december, 31),
+                        initialEntryMode: DatePickerEntryMode.input,
+                        selectableDayPredicate: (DateTime day) {
+                          logs.add('selectableDayPredicate called');
+                          return true;
+                        },
+                        builder: (BuildContext context, Widget? child) {
+                          return Directionality(
+                            textDirection: textDirection,
+                            child: child ?? const SizedBox(),
+                          );
+                        },
+                      );
+                      logs.add('${await pickedDate}');
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      }
+
+      await tester.pumpWidget(buildFrame(TextDirection.ltr));
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+      expect(logs.last, 'selectableDayPredicate called');
+
+      // Test picked date is the last log entry.
+      await tester.tap(find.text('OK'));
+      await tester.pumpAndSettle();
+      expect(logs.last, '2016-01-15 00:00:00.000');
+
+      logs.clear();
+    });
   });
 
   group('Semantics', () {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/105223

### Before
```console
flutter: selectableDayPredicate called.
flutter: Picked date: 2022-06-08 00:00:00.000
flutter: selectableDayPredicate called.
```

### After
```console
flutter: selectableDayPredicate called.
flutter: Picked date: 2022-06-08 00:00:00.000
```

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key, this.dark = true, this.useMaterial3 = true});

  final bool dark;
  final bool useMaterial3;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      themeMode: dark ? ThemeMode.dark : ThemeMode.light,
      theme: ThemeData(
        useMaterial3: useMaterial3,
        brightness: Brightness.light,
        colorSchemeSeed: const Color(0xff6750a4),
      ),
      darkTheme: ThemeData(
        useMaterial3: useMaterial3,
        brightness: Brightness.dark,
        colorSchemeSeed: const Color(0xff6750a4),
      ),
      home: const DatePickerSample(),
    );
  }
}

class DatePickerSample extends StatelessWidget {
  const DatePickerSample({super.key});

  Future<DateTime?> _showDatePicker(BuildContext context) async {
    final Future<DateTime?> pickedDate = showDatePicker(
      context: context,
      initialDate: DateTime.now(),
      firstDate: DateTime(2021),
      lastDate: DateTime(2030),
      initialEntryMode: DatePickerEntryMode.input,
      selectableDayPredicate: (DateTime day) {
        print('selectableDayPredicate called.');
        return true;
      },
    );
    print('Picked date: ${await pickedDate}');

    return pickedDate;
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('DatePicker Sample'),
      ),
      body: Center(
        child: ElevatedButton(
          onPressed: () async => _showDatePicker(context),
          child: const Text('Open DatePicker'),
        ),
      ),
    );
  }
}

``` 
	
</details>


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
