### PR TITLE
Stop using `FallThroughError`.

### DIFF
--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -780,7 +780,7 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
         pingSuccessRegex: null
       );
     } else {
-      throw FallThroughError();
+      throw UnsupportedError('Unsupported operating system');
     }
 
     final bool apply = await askApplyConfig(
@@ -809,7 +809,7 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
     if (boolArgDeprecated(_kSsh) == true) {
       return runInteractivelySsh();
     }
-    throw FallThroughError();
+    throw UnsupportedError('Unknown run mode');
   }
 }
 

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device_config.dart
@@ -138,7 +138,7 @@ class CustomDeviceConfig {
       platform = archString == null
         ? null
         : getTargetPlatformForName(archString);
-    } on FallThroughError {
+    } on UnsupportedError {
       throw const CustomDeviceRevivalException.fromDescriptions(
         _kPlatform,
         'null or one of linux-arm64, linux-x64'
@@ -300,7 +300,7 @@ class CustomDeviceConfig {
     if (platform.isLinux || platform.isMacOS) {
       return exampleUnix;
     }
-    throw FallThroughError();
+    throw UnsupportedError('Unsupported operating system');
   }
 
   final String id;

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -323,7 +323,7 @@ CustomDevicesCommand createCustomDevicesCommand({
       hostPlatform: platform.isLinux ? HostPlatform.linux_x64
         : platform.isWindows ? HostPlatform.windows_x64
         : platform.isMacOS ? HostPlatform.darwin_x64
-        : throw FallThroughError()
+        : throw UnsupportedError('Unsupported operating system')
     ),
     terminal: terminal != null
       ? terminal(platform)


### PR DESCRIPTION
Stop using `FallThroughError` as a general error representing an "unknown case".

The `FallThroughError` class was used in Dart 1 to report a `switch` case reaching its end (because Dart does not support case fall-through like, e.g., C). It was not intended for any other use.
With Dart 2, the class stopped being used because flow analysis made it a compile-time error to be able to reach the end of a switch case.
The class is planned to be removed in Dart 3.0. It's about to be deprecated. That deprecation makes test fail in this repository.

There are uses of `FallThroughError` in flutter_tools where it represents an "unsupported case". 
The recommended error to use for that is `UnsupportedError`, and this PR changes to using that.

(No open issue, but in-progress CL https://dart-review.googlesource.com/c/sdk/+/247384 will be blocked on occurrences of `FallThroughError` here.)
