### PR TITLE
[flutter_releases] Removing minor iOS version filter value from ci.yaml (#105059)

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -129,7 +129,7 @@ platform_properties:
         ]
       os: Mac-12
       cpu: x86
-      device_os: iOS-15.1
+      device_os: iOS-15
       xcode: 13a233
   windows:
     properties:


### PR DESCRIPTION
Post-submit is failing on the latest stable hotfix for ios as there's no Mac 12 - ios15.1 bots available