### PR TITLE
Fixed issue with Hero Animations and BoxScrollViews in Scaffolds

### DIFF
--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -1003,8 +1003,7 @@ class HeroController extends NavigatorObserver {
     BuildContext toHeroContext,
   ) {
     final Hero toHero = toHeroContext.widget as Hero;
-      return toHero.child;
-
+    
     final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(toHeroContext);
     final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(fromHeroContext);
 

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -1003,6 +1003,7 @@ class HeroController extends NavigatorObserver {
     BuildContext toHeroContext,
   ) {
     final Hero toHero = toHeroContext.widget as Hero;
+      return toHero.child;
 
     final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(toHeroContext);
     final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(fromHeroContext);

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -136,13 +136,16 @@ enum HeroFlightDirection {
 /// To make the animations look good, it's critical that the widget tree for the
 /// hero in both locations be essentially identical. The widget of the *target*
 /// is, by default, used to do the transition: when going from route A to route
-/// B, route B's hero's widget is placed over route A's hero's widget. However,
-/// if the hero uses information from InheritedWidgets, and the inherited data
-/// are different between the starting tree and the target tree, there will be
-/// an ugly jumping animation unless that data is properly interpolated. By
-/// default, Hero interpolates MediaQuery's paddings. If your hero uses custom
-/// InheritedWidgets and displays jumping animation, try to provide custom
-/// in-flight transition using flightShuttleBuilder.
+/// B, route B's hero's widget is placed over route A's hero's widget. Additionally,
+/// if the [Hero] subtree changes appearance based on an InheritedWidget in route A
+/// or route B (such as MediaQuery or Theme), and the inherited data are different
+/// between the starting tree and the target tree, there will be a discontinuity
+/// in the animation unless that data is properly interpolated. For example if
+/// both routes provide MediaQuery but with different paddings, you may see
+/// jumps/gaps. The default [flightShuttleBuilder] interpolates [MediaQuery]'s
+/// paddings. If your [Hero] widget uses custom [InheritedWidget]s and displays
+/// a discontinuity in the animation, try to provide custom in-flight transition
+/// using [flightShuttleBuilder].
 ///
 /// By default, both route A and route B's heroes are hidden while the
 /// transitioning widget is animating in-flight above the 2 routes.

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -136,20 +136,13 @@ enum HeroFlightDirection {
 /// To make the animations look good, it's critical that the widget tree for the
 /// hero in both locations be essentially identical. The widget of the *target*
 /// is, by default, used to do the transition: when going from route A to route
-/// B, route B's hero's widget is placed over route A's hero's widget. If a
-/// [flightShuttleBuilder] is supplied, its output widget is shown during the
-/// flight transition instead.
-///
-/// The flightShuttleBulder tree uses [InheritedWidget]s from the route the Hero
-/// animation starts from. If the widget tree in [flightShuttleBuilder] changes
-/// its geometry/appearance based on [InheritedWidget]s that are above the Hero
-/// widget tree, for example if both routes provide [MediaQuery] but with
-/// different paddings, you may see jumps/gaps. If you experience this problem,
-/// wrap the current flightShuttleBulder in an [InheritedWidget] (and
-/// potentially interpolate the value provided by the inherited widget using the
-/// animation parameter). The default [flightShuttleBuilder] is wrapped in a
-/// [MediaQuery] widget if only one navigator has padding or both navigator's
-/// [MediaQuery]'s provide different paddings.
+/// B, route B's hero's widget is placed over route A's hero's widget. However,
+/// if the hero uses information from InheritedWidgets, and the inherited data
+/// are different between the starting tree and the target tree, there will be
+/// an ugly jumping animation unless that data is properly interpolated. By
+/// default, Hero interpolates MediaQuery's paddings. If your hero uses custom
+/// InheritedWidgets and displays jumping animation, try to provide custom
+/// in-flight transition using flightShuttleBuilder.
 ///
 /// By default, both route A and route B's heroes are hidden while the
 /// transitioning widget is animating in-flight above the 2 routes.
@@ -219,18 +212,6 @@ class Hero extends StatefulWidget {
   final Widget child;
 
   /// Optional override to supply a widget that's shown during the hero's flight.
-  ///
-  /// If overriding note the flightShuttleBulder tree uses [InheritedWidget]s 
-  /// from the route the Hero animation starts from. If the widget tree in 
-  /// [flightShuttleBuilder] changes its geometry/appearance based on 
-  /// [InheritedWidget]s that are above the Hero widget tree, for example if both
-  /// routes provide [MediaQuery] but with different paddings, you may see 
-  /// jumps/gaps. If you experience this problem, wrap the current 
-  /// flightShuttleBulder in an [InheritedWidget] (and potentially interpolate
-  /// the value provided by the inherited widget using the animation parameter).
-  /// The default [flightShuttleBuilder] is wrapped in a [MediaQuery] widget if
-  /// only one navigator has padding or both navigator's [MediaQuery]'s provide
-  /// different paddings.
   ///
   /// This in-flight widget can depend on the route transition's animation as
   /// well as the incoming and outgoing routes' [Hero] descendants' widgets and

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -1003,7 +1003,7 @@ class HeroController extends NavigatorObserver {
     BuildContext toHeroContext,
   ) {
     final Hero toHero = toHeroContext.widget as Hero;
-    
+
     final MediaQueryData? toMediaQueryData = MediaQuery.maybeOf(toHeroContext);
     final MediaQueryData? fromMediaQueryData = MediaQuery.maybeOf(fromHeroContext);
 

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -3,11 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-
 import 'basic.dart';
 import 'binding.dart';
 import 'framework.dart';
+import 'media_query.dart';
 import 'navigator.dart';
 import 'overlay.dart';
 import 'pages.dart';

--- a/packages/flutter/lib/src/widgets/heroes.dart
+++ b/packages/flutter/lib/src/widgets/heroes.dart
@@ -137,15 +137,14 @@ enum HeroFlightDirection {
 /// hero in both locations be essentially identical. The widget of the *target*
 /// is, by default, used to do the transition: when going from route A to route
 /// B, route B's hero's widget is placed over route A's hero's widget. Additionally,
-/// if the [Hero] subtree changes appearance based on an InheritedWidget in route A
-/// or route B (such as MediaQuery or Theme), and the inherited data are different
-/// between the starting tree and the target tree, there will be a discontinuity
-/// in the animation unless that data is properly interpolated. For example if
-/// both routes provide MediaQuery but with different paddings, you may see
-/// jumps/gaps. The default [flightShuttleBuilder] interpolates [MediaQuery]'s
-/// paddings. If your [Hero] widget uses custom [InheritedWidget]s and displays
-/// a discontinuity in the animation, try to provide custom in-flight transition
-/// using [flightShuttleBuilder].
+/// if the [Hero] subtree changes appearance based on an [InheritedWidget] (such
+/// as [MediaQuery] or [Theme]), then the hero animation may have discontinuity
+/// at the start or the end of the animation because route A and route B provides
+/// different such [InheritedWidget]s. Consider providing a custom [flightShuttleBuilder]
+/// to ensure smooth transitions. The default [flightShuttleBuilder] interpolates
+/// [MediaQuery]'s paddings. If your [Hero] widget uses custom [InheritedWidget]s
+/// and displays a discontinuity in the animation, try to provide custom in-flight
+/// transition using [flightShuttleBuilder].
 ///
 /// By default, both route A and route B's heroes are hidden while the
 /// transitioning widget is animating in-flight above the 2 routes.

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui;
+import 'dart:ui' show WindowPadding;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -11,7 +12,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../painting/image_test_utils.dart' show TestImageProvider;
-import '../rendering/view_chrome_style_test.dart';
 
 Future<ui.Image> createTestImage() {
   final ui.Paint paint = ui.Paint()
@@ -183,6 +183,25 @@ class MyStatefulWidgetState extends State<MyStatefulWidget> {
   @override
   Widget build(BuildContext context) => Text(widget.value);
 }
+
+class FakeWindowPadding implements WindowPadding {
+  const FakeWindowPadding({
+    this.left = 0.0,
+    this.top = 0.0,
+    this.right = 0.0,
+    this.bottom = 0.0,
+  });
+
+  @override
+  final double left;
+  @override
+  final double top;
+  @override
+  final double right;
+  @override
+  final double bottom;
+}
+
 
 Future<void> main() async {
   final ui.Image testImage = await createTestImage();
@@ -3074,9 +3093,8 @@ Future<void> main() async {
     await tester.pumpAndSettle();
     expect(tester.takeException(), isNull);
   });
-
   testWidgets('smooth transition between different incoming data', (WidgetTester tester) async {
-    final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
+      final GlobalKey<NavigatorState> navigatorKey = GlobalKey();
       const Key imageKey1 = Key('image1');
       const Key imageKey2 = Key('image2');
       final TestImageProvider imageProvider = TestImageProvider(testImage);

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3112,7 +3112,7 @@ Future<void> main() async {
               child: GridView.count(
                 crossAxisCount: 3,
                 shrinkWrap: true,
-                children: [
+                children: <Widget>[
                   Image(image: imageProvider, key: imageKey1),
                 ],
               ),
@@ -3129,7 +3129,7 @@ Future<void> main() async {
               child: GridView.count(
                 crossAxisCount: 3,
                 shrinkWrap: true,
-                children: [
+                children: <Widget>[
                   Image(image: imageProvider, key: imageKey2),
                 ],
               ),

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3081,8 +3081,8 @@ Future<void> main() async {
       const Key imageKey2 = Key('image2');
       final TestImageProvider imageProvider = TestImageProvider(testImage);
       final TestWidgetsFlutterBinding testBinding = tester.binding;
-      
-      testBinding.window.paddingTestValue = const FakeWindowPadding(top:50);
+
+      testBinding.window.paddingTestValue = const FakeWindowPadding(top: 50);
 
       await tester.pumpWidget(
         MaterialApp(
@@ -3090,33 +3090,32 @@ Future<void> main() async {
           home: Scaffold(
             appBar: AppBar(title: const Text('test')),
             body: Hero(
-            tag: 'imageHero',
-            child: GridView.count(
-              crossAxisCount: 3,
-              shrinkWrap: true,
-              children: [
-                Image(image: imageProvider, key: imageKey1),
-              ],
+              tag: 'imageHero',
+              child: GridView.count(
+                crossAxisCount: 3,
+                shrinkWrap: true,
+                children: [
+                  Image(image: imageProvider, key: imageKey1),
+                ],
+              ),
             ),
-          ),
           ),
         ),
       );
 
       final MaterialPageRoute<void> route2 = MaterialPageRoute<void>(
         builder: (BuildContext context) {
-          return 
-          Scaffold(
+          return Scaffold(
             body: Hero(
-            tag: 'imageHero',
-            child: GridView.count(
-              crossAxisCount: 3,
-              shrinkWrap: true,
-              children: [
-                Image(image: imageProvider, key: imageKey2),
-              ],
+              tag: 'imageHero',
+              child: GridView.count(
+                crossAxisCount: 3,
+                shrinkWrap: true,
+                children: [
+                  Image(image: imageProvider, key: imageKey2),
+                ],
+              ),
             ),
-          ),
           );
         },
       );

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3155,8 +3155,6 @@ Future<void> main() async {
       expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
       await tester.pumpAndSettle();
       expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
-
-      testBinding.window.clearAllTestValues();
     },
   );
 }

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3155,6 +3155,8 @@ Future<void> main() async {
       expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
       await tester.pumpAndSettle();
       expect(tester.getTopLeft(find.byType(Image)).dy, moreOrLessEquals(forwardRest, epsilon: 0.1));
+
+      testBinding.window.clearAllTestValues();
     },
   );
 }


### PR DESCRIPTION
Fixed an issue where a jump would happen with Hero animations on mobile when the Hero child was a BoxScrollView and the destination page had a Scaffold with different layout (difference in AppBar, etc).

#99084
Before:
https://user-images.githubusercontent.com/16466991/172736468-d81b7e5a-8bb7-4627-bac6-2632b1e89a74.mov

After:
https://user-images.githubusercontent.com/16466991/172736486-93f08372-e8a0-4d12-b8a1-06ee791cc015.mov

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.