### PR TITLE
plugin_ffi template test run ffigen

### DIFF
--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -20,6 +20,6 @@ jobs:
           channel: 'master' # This will be the last released version not the PR version
       - name: Install libclang-10-dev
         run: sudo apt-get install libclang-10-dev
-      - name: Build test dylib and bindings
-        working-directory: cd ./packages/flutter_tools/
+      - name: Run plugin_ffi ffigen test
+        working-directory: ./packages/flutter_tools/
         run: flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -20,6 +20,9 @@ jobs:
           channel: 'master' # This will be the last released version not the PR version
       - name: Install libclang-10-dev
         run: sudo apt-get install libclang-10-dev
+      - name: Run pub get in packages/flutter_tools/
+        working-directory: ./packages/flutter_tools/
+        run: flutter pub get
       - name: Run plugin_ffi ffigen test
         working-directory: ./packages/flutter_tools/
         run: flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -25,4 +25,4 @@ jobs:
         run: flutter pub get
       - name: Run plugin_ffi ffigen test
         working-directory: ./packages/flutter_tools/
-        run: flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen
+        run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -1,0 +1,24 @@
+name: Flutter Tools Test
+
+on:
+  # Run on PRs and pushes to the default branch.
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  PUB_ENVIRONMENT: bot.github
+
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'master' # This will be the last released version not the PR version
+      - name: Install libclang-10-dev
+        run: sudo apt-get install libclang-10-dev
+      - name: Build test dylib and bindings
+        run: flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -25,7 +25,7 @@ jobs:
         run: flutter pub get
       - name: Run plugin_ffi ffigen test
         working-directory: ./packages/flutter_tools/
-        run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen
+        run: flutter pub run test test/commands.shard/permeable/create_2_test.dart -n ffigen
 
   test-macos:
     runs-on: macos-latest
@@ -39,7 +39,7 @@ jobs:
         run: flutter pub get
       - name: Run plugin_ffi ffigen test
         working-directory: ./packages/flutter_tools/
-        run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen
+        run: flutter pub run test test/commands.shard/permeable/create_2_test.dart -n ffigen
 
   test-windows:
     runs-on: windows-latest
@@ -53,4 +53,4 @@ jobs:
         run: flutter pub get
       - name: Run plugin_ffi ffigen test
         working-directory: ./packages/flutter_tools/
-        run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen
+        run: flutter pub run test test/commands.shard/permeable/create_2_test.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -21,6 +21,5 @@ jobs:
       - name: Install libclang-10-dev
         run: sudo apt-get install libclang-10-dev
       - name: Build test dylib and bindings
-        run: |
-          cd packages/flutter_tools/
-          flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen
+        working-directory: cd ./packages/flutter_tools/
+        run: flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -21,4 +21,6 @@ jobs:
       - name: Install libclang-10-dev
         run: sudo apt-get install libclang-10-dev
       - name: Build test dylib and bindings
-        run: flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen
+        run: |
+          cd packages/flutter_tools/
+          flutter pub run test test/commands.shard/permeable/create_test.dart -n ffigen

--- a/.github/workflows/flutter-tools-test.yaml
+++ b/.github/workflows/flutter-tools-test.yaml
@@ -26,3 +26,31 @@ jobs:
       - name: Run plugin_ffi ffigen test
         working-directory: ./packages/flutter_tools/
         run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen
+
+  test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'master' # This will be the last released version not the PR version
+      - name: Run pub get in packages/flutter_tools/
+        working-directory: ./packages/flutter_tools/
+        run: flutter pub get
+      - name: Run plugin_ffi ffigen test
+        working-directory: ./packages/flutter_tools/
+        run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'master' # This will be the last released version not the PR version
+      - name: Run pub get in packages/flutter_tools/
+        working-directory: ./packages/flutter_tools/
+        run: flutter pub get
+      - name: Run plugin_ffi ffigen test
+        working-directory: ./packages/flutter_tools/
+        run: flutter pub run test test/commands.shard/permeable/create_test_2.dart -n ffigen

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -23,8 +23,11 @@ dependencies:
 
 dev_dependencies:
 {{#withFfiPluginHook}}
-  ffi: ^1.2.1
-  ffigen: ^5.0.1
+  ffi: ^2.0.0
+  ffigen:
+    git:
+      url: git@github.com:dart-lang/ffigen.git
+      ref: find-libclang-linux
 {{/withFfiPluginHook}}
   flutter_test:
     sdk: flutter

--- a/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
+++ b/packages/flutter_tools/templates/plugin_shared/pubspec.yaml.tmpl
@@ -24,10 +24,7 @@ dependencies:
 dev_dependencies:
 {{#withFfiPluginHook}}
   ffi: ^2.0.0
-  ffigen:
-    git:
-      url: git@github.com:dart-lang/ffigen.git
-      ref: find-libclang-linux
+  ffigen: ^6.0.1
 {{/withFfiPluginHook}}
   flutter_test:
     sdk: flutter

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -62,6 +62,11 @@ void main() {
     printOnFailure('pubspec.yaml contents:');
     printOnFailure(await projectDir.childFile('pubspec.yaml').readAsString());
 
+    final io.File template =
+        io.File('templates/plugin_shared/pubspec.yaml.tmpl');
+    printOnFailure('templates/plugin_shared/pubspec.yaml.tmpl contents:');
+    printOnFailure(await template.readAsString());
+
     final String generatedBindingsFromTemplate =
         (await generatedBindings.readAsString()).replaceAll('\r', '');
 

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -24,6 +24,9 @@ void main() {
 
   setUpAll(() async {
     Cache.disableLocking();
+
+    // GitHub actions do not have access to the full Flutter checkout with the
+    // cache folder, so we don't use `flutter_tools.snapshot`.
   });
 
   setUp(() {
@@ -52,18 +55,6 @@ void main() {
       projectDir.path,
     ]);
 
-    // // GitHub actions do not have access to the full Flutter checkout with the
-    // // cache folder, run from source via bin/ instead of with CommandRunner.
-    // await Process.run(
-    //   dart,
-    //   <String>[
-    //     'bin/flutter_tools.dart',
-    //     'create',
-    //     '--no-pub',
-    //     '--template=plugin_ffi',
-    //     projectDir.path,
-    //   ],
-    // );
     expect(projectDir.childFile('ffigen.yaml'), exists);
     final File generatedBindings = projectDir
         .childDirectory('lib')

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -56,6 +56,12 @@ void main() {
         .childFile('${projectDir.basename}_bindings_generated.dart');
     expect(generatedBindings, exists);
 
+    printOnFailure('projectDir.path:');
+    printOnFailure(projectDir.path);
+
+    printOnFailure('pubspec.yaml contents:');
+    printOnFailure(await projectDir.childFile('pubspec.yaml').readAsString());
+
     final String generatedBindingsFromTemplate =
         (await generatedBindings.readAsString()).replaceAll('\r', '');
 
@@ -69,7 +75,7 @@ void main() {
       ],
       workingDirectory: projectDir.path,
     );
-    printOnFailure('Results of running ffigen:');
+    printOnFailure('Results of running pub get:');
     printOnFailure(pubGetResult.stdout.toString());
     printOnFailure(pubGetResult.stderr.toString());
     expect(pubGetResult.exitCode, 0);

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -6,14 +6,17 @@
 
 import 'dart:io' as io;
 
+import 'package:args/command_runner.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/commands/create.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/test_flutter_command_runner.dart';
 
 void main() {
   Directory tempDir;
@@ -40,18 +43,27 @@ void main() {
     final String dart = io.Platform.resolvedExecutable;
     printOnFailure('dart: $dart');
 
-    // GitHub actions do not have access to the full Flutter checkout with the
-    // cache folder, run from source via bin/ instead of with CommandRunner.
-    await Process.run(
-      dart,
-      <String>[
-        'bin/flutter_tools.dart',
-        'create',
-        '--no-pub',
-        '--template=plugin_ffi',
-        projectDir.path,
-      ],
-    );
+    final CreateCommand command = CreateCommand();
+    final CommandRunner<void> runner = createTestCommandRunner(command);
+    await runner.run(<String>[
+      'create',
+      '--no-pub',
+      '--template=plugin_ffi',
+      projectDir.path,
+    ]);
+
+    // // GitHub actions do not have access to the full Flutter checkout with the
+    // // cache folder, run from source via bin/ instead of with CommandRunner.
+    // await Process.run(
+    //   dart,
+    //   <String>[
+    //     'bin/flutter_tools.dart',
+    //     'create',
+    //     '--no-pub',
+    //     '--template=plugin_ffi',
+    //     projectDir.path,
+    //   ],
+    // );
     expect(projectDir.childFile('ffigen.yaml'), exists);
     final File generatedBindings = projectDir
         .childDirectory('lib')

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -4,10 +4,11 @@
 
 // @dart = 2.8
 
+import 'dart:io' as io;
+
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
@@ -35,10 +36,10 @@ void main() {
   testUsingContext('create an FFI plugin, then run ffigen', () async {
     Cache.flutterRoot = '../..';
 
-    // GitHub actions do not have access to the full Flutter checkout with
-    // the cache folder, run from source via bin/ instead.
+    // GitHub actions do not have access to the full Flutter checkout with the
+    // cache folder, run from source via bin/ instead of with CommandRunner.
     await Process.run(
-      'flutter',
+      io.Platform.resolvedExecutable,
       <String>[
         'pub',
         'run',
@@ -61,7 +62,7 @@ void main() {
     await generatedBindings.delete();
 
     final ProcessResult pubGetResult = await Process.run(
-      'flutter',
+      io.Platform.resolvedExecutable,
       <String>[
         'pub',
         'get',
@@ -74,7 +75,7 @@ void main() {
     expect(pubGetResult.exitCode, 0);
 
     final ProcessResult ffigenResult = await Process.run(
-      'flutter',
+      io.Platform.resolvedExecutable,
       <String>[
         'pub',
         'run',

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -35,12 +35,10 @@ void main() {
   testUsingContext('create an FFI plugin, then run ffigen', () async {
     Cache.flutterRoot = '../..';
 
-    final String flutter =
-        const LocalPlatform().isWindows ? 'flutter.exe' : 'flutter';
     // GitHub actions do not have access to the full Flutter checkout with
     // the cache folder, run from source via bin/ instead.
     await Process.run(
-      flutter,
+      'flutter',
       <String>[
         'pub',
         'run',
@@ -63,7 +61,7 @@ void main() {
     await generatedBindings.delete();
 
     final ProcessResult pubGetResult = await Process.run(
-      flutter,
+      'flutter',
       <String>[
         'pub',
         'get',
@@ -76,7 +74,7 @@ void main() {
     expect(pubGetResult.exitCode, 0);
 
     final ProcessResult ffigenResult = await Process.run(
-      flutter,
+      'flutter',
       <String>[
         'pub',
         'run',

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -36,14 +36,16 @@ void main() {
   testUsingContext('create an FFI plugin, then run ffigen', () async {
     Cache.flutterRoot = '../..';
 
+    // Find the Flutter and Dart executable from the GitHub action.
+    final String dart = io.Platform.resolvedExecutable;
+    printOnFailure('dart: $dart');
+
     // GitHub actions do not have access to the full Flutter checkout with the
     // cache folder, run from source via bin/ instead of with CommandRunner.
     await Process.run(
-      io.Platform.resolvedExecutable,
+      dart,
       <String>[
-        'pub',
-        'run',
-        'flutter_tools',
+        'bin/flutter_tools.dart',
         'create',
         '--no-pub',
         '--template=plugin_ffi',
@@ -56,9 +58,7 @@ void main() {
         .childFile('${projectDir.basename}_bindings_generated.dart');
     expect(generatedBindings, exists);
 
-    printOnFailure('projectDir.path:');
-    printOnFailure(projectDir.path);
-
+    printOnFailure('projectDir.path: ${projectDir.path}');
     printOnFailure('pubspec.yaml contents:');
     printOnFailure(await projectDir.childFile('pubspec.yaml').readAsString());
 
@@ -68,7 +68,7 @@ void main() {
     await generatedBindings.delete();
 
     final ProcessResult pubGetResult = await Process.run(
-      io.Platform.resolvedExecutable,
+      dart,
       <String>[
         'pub',
         'get',
@@ -81,7 +81,7 @@ void main() {
     expect(pubGetResult.exitCode, 0);
 
     final ProcessResult ffigenResult = await Process.run(
-      io.Platform.resolvedExecutable,
+      dart,
       <String>[
         'pub',
         'run',

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -37,6 +37,8 @@ void main() {
 
     final String flutter =
         const LocalPlatform().isWindows ? 'flutter.exe' : 'flutter';
+    // GitHub actions do not have access to the full Flutter checkout with
+    // the cache folder, run from source via bin/ instead.
     await Process.run(
       flutter,
       <String>[

--- a/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_2_test.dart
@@ -57,7 +57,7 @@ void main() {
     expect(generatedBindings, exists);
 
     final String generatedBindingsFromTemplate =
-        await generatedBindings.readAsString();
+        (await generatedBindings.readAsString()).replaceAll('\r', '');
 
     await generatedBindings.delete();
 
@@ -91,7 +91,7 @@ void main() {
     expect(ffigenResult.exitCode, 0);
 
     final String generatedBindingsFromFfigen =
-        await generatedBindings.readAsString();
+        (await generatedBindings.readAsString()).replaceAll('\r', '');
 
     expect(generatedBindingsFromFfigen, generatedBindingsFromTemplate);
   });

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2870,7 +2870,7 @@ testUsingContext('create an FFI plugin, then run ffigen', () async {
     expect(generatedBindings, exists);
 
     final String generatedBindingsFromTemplate =
-        await generatedBindings.readAsString();
+        (await generatedBindings.readAsString()).replaceAll('\r', '');
 
     await generatedBindings.delete();
 
@@ -2906,7 +2906,7 @@ testUsingContext('create an FFI plugin, then run ffigen', () async {
     expect(ffigenResult.exitCode, 0);
 
     final String generatedBindingsFromFfigen =
-        await generatedBindings.readAsString();
+        (await generatedBindings.readAsString()).replaceAll('\r', '');
 
     expect(generatedBindingsFromFfigen, generatedBindingsFromTemplate);
   });

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -2874,8 +2874,10 @@ testUsingContext('create an FFI plugin, then run ffigen', () async {
 
     await generatedBindings.delete();
 
+    final String flutter =
+        const LocalPlatform().isWindows ? 'flutter.exe' : 'flutter';
     final ProcessResult pubGetResult = await Process.run(
-      'flutter',
+      flutter,
       <String>[
         'pub',
         'get',
@@ -2888,7 +2890,7 @@ testUsingContext('create an FFI plugin, then run ffigen', () async {
     expect(pubGetResult.exitCode, 0);
 
     final ProcessResult ffigenResult = await Process.run(
-      'flutter',
+      flutter,
       <String>[
         'pub',
         'run',

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test_2.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test_2.dart
@@ -1,0 +1,148 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:async';
+
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:process/process.dart';
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+const String frameworkRevision = '12345678';
+const String frameworkChannel = 'omega';
+
+// This needs to be created from the local platform due to re-entrant flutter calls made in this test.
+FakePlatform _kNoColorTerminalPlatform() =>
+    FakePlatform.fromPlatform(const LocalPlatform())
+      ..stdoutSupportsAnsi = false;
+
+final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
+  Platform: _kNoColorTerminalPlatform,
+};
+
+const String samplesIndexJson = '''
+[
+  { "id": "sample1" },
+  { "id": "sample2" }
+]''';
+
+void main() {
+  Directory tempDir;
+  Directory projectDir;
+
+  setUpAll(() async {
+    Cache.disableLocking();
+  });
+
+  setUp(() {
+    tempDir = globals.fs.systemTempDirectory
+        .createTempSync('flutter_tools_create_test.');
+    projectDir = tempDir.childDirectory('flutter_project');
+  });
+
+  tearDown(() {
+    tryToDelete(tempDir);
+  });
+
+  testUsingContext('create an FFI plugin, then run ffigen', () async {
+    Cache.flutterRoot = '../..';
+
+    final String flutter =
+        const LocalPlatform().isWindows ? 'flutter.exe' : 'flutter';
+    await Process.run(
+      flutter,
+      <String>[
+        'pub',
+        'run',
+        'flutter_tools',
+        'create',
+        '--no-pub',
+        '--template=plugin_ffi',
+        projectDir.path,
+      ],
+    );
+    expect(projectDir.childFile('ffigen.yaml'), exists);
+    final File generatedBindings = projectDir
+        .childDirectory('lib')
+        .childFile('${projectDir.basename}_bindings_generated.dart');
+    expect(generatedBindings, exists);
+
+    final String generatedBindingsFromTemplate =
+        await generatedBindings.readAsString();
+
+    await generatedBindings.delete();
+
+    final ProcessResult pubGetResult = await Process.run(
+      flutter,
+      <String>[
+        'pub',
+        'get',
+      ],
+      workingDirectory: projectDir.path,
+    );
+    printOnFailure('Results of running ffigen:');
+    printOnFailure(pubGetResult.stdout.toString());
+    printOnFailure(pubGetResult.stderr.toString());
+    expect(pubGetResult.exitCode, 0);
+
+    final ProcessResult ffigenResult = await Process.run(
+      flutter,
+      <String>[
+        'pub',
+        'run',
+        'ffigen',
+        '--config',
+        'ffigen.yaml',
+      ],
+      workingDirectory: projectDir.path,
+    );
+    printOnFailure('Results of running ffigen:');
+    printOnFailure(ffigenResult.stdout.toString());
+    printOnFailure(ffigenResult.stderr.toString());
+    expect(ffigenResult.exitCode, 0);
+
+    final String generatedBindingsFromFfigen =
+        await generatedBindings.readAsString();
+
+    expect(generatedBindingsFromFfigen, generatedBindingsFromTemplate);
+  });
+}
+
+/// A ProcessManager that invokes a real process manager, but keeps
+/// track of all commands sent to it.
+class LoggingProcessManager extends LocalProcessManager {
+  List<List<String>> commands = <List<String>>[];
+
+  @override
+  Future<Process> start(
+    List<Object> command, {
+    String workingDirectory,
+    Map<String, String> environment,
+    bool includeParentEnvironment = true,
+    bool runInShell = false,
+    ProcessStartMode mode = ProcessStartMode.normal,
+  }) {
+    commands.add(command.map((Object arg) => arg.toString()).toList());
+    return super.start(
+      command,
+      workingDirectory: workingDirectory,
+      environment: environment,
+      includeParentEnvironment: includeParentEnvironment,
+      runInShell: runInShell,
+      mode: mode,
+    );
+  }
+
+  void clear() {
+    commands.clear();
+  }
+}

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test_2.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test_2.dart
@@ -4,36 +4,15 @@
 
 // @dart = 2.8
 
-import 'dart:async';
-
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
-import 'package:process/process.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-
-const String frameworkRevision = '12345678';
-const String frameworkChannel = 'omega';
-
-// This needs to be created from the local platform due to re-entrant flutter calls made in this test.
-FakePlatform _kNoColorTerminalPlatform() =>
-    FakePlatform.fromPlatform(const LocalPlatform())
-      ..stdoutSupportsAnsi = false;
-
-final Map<Type, Generator> noColorTerminalOverride = <Type, Generator>{
-  Platform: _kNoColorTerminalPlatform,
-};
-
-const String samplesIndexJson = '''
-[
-  { "id": "sample1" },
-  { "id": "sample2" }
-]''';
 
 void main() {
   Directory tempDir;
@@ -115,34 +94,4 @@ void main() {
 
     expect(generatedBindingsFromFfigen, generatedBindingsFromTemplate);
   });
-}
-
-/// A ProcessManager that invokes a real process manager, but keeps
-/// track of all commands sent to it.
-class LoggingProcessManager extends LocalProcessManager {
-  List<List<String>> commands = <List<String>>[];
-
-  @override
-  Future<Process> start(
-    List<Object> command, {
-    String workingDirectory,
-    Map<String, String> environment,
-    bool includeParentEnvironment = true,
-    bool runInShell = false,
-    ProcessStartMode mode = ProcessStartMode.normal,
-  }) {
-    commands.add(command.map((Object arg) => arg.toString()).toList());
-    return super.start(
-      command,
-      workingDirectory: workingDirectory,
-      environment: environment,
-      includeParentEnvironment: includeParentEnvironment,
-      runInShell: runInShell,
-      mode: mode,
-    );
-  }
-
-  void clear() {
-    commands.clear();
-  }
 }


### PR DESCRIPTION
Run `ffigen` on the generated bindings of the plugin_ffi template to check that they are up to date.

* https://github.com/flutter/flutter/issues/105513

## Requirements

This requires `libclang` on the bots.

Creating this PR to see on which bots it fails.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
