### PR TITLE
Ignore uses of soon-to-be deprecated `NullThrownError`.

### DIFF
--- a/packages/flutter/lib/src/foundation/assertions.dart
+++ b/packages/flutter/lib/src/foundation/assertions.dart
@@ -395,8 +395,7 @@ class FlutterErrorDetails with Diagnosticable {
   /// subsequently be reported using [FlutterError.onError].
   ///
   /// The [exception] must not be null; other arguments can be left to
-  /// their default values. (`throw null` results in a
-  /// [NullThrownError] exception.)
+  /// their default values.
   const FlutterErrorDetails({
     required this.exception,
     this.stack,
@@ -671,7 +670,7 @@ class FlutterErrorDetails with Diagnosticable {
     super.debugFillProperties(properties);
     final DiagnosticsNode verb = ErrorDescription('thrown${ context != null ? ErrorDescription(" $context") : ""}');
     final Diagnosticable? diagnosticable = _exceptionToDiagnosticable();
-    if (exception is NullThrownError) {
+    if (exception is NullThrownError) { // ignore: deprecated_member_use
       properties.add(ErrorDescription('The null value was $verb.'));
     } else if (exception is num) {
       properties.add(ErrorDescription('The number $exception was $verb.'));

--- a/packages/flutter/test/foundation/assertions_test.dart
+++ b/packages/flutter/test/foundation/assertions_test.dart
@@ -60,7 +60,7 @@ void main() {
     );
     expect(
       FlutterErrorDetails(
-        exception: NullThrownError(),
+        exception: NullThrownError(), // ignore: deprecated_member_use
         library: 'LIBRARY',
         context: ErrorDescription('CONTEXTING'),
         informationCollector: () sync* {
@@ -113,6 +113,7 @@ void main() {
       '═════════════════════════════════════════════════════════════════\n',
     );
     expect(
+      // ignore: deprecated_member_use
       FlutterErrorDetails(exception: NullThrownError()).toString(),
       '══╡ EXCEPTION CAUGHT BY FLUTTER FRAMEWORK ╞══════════════════════\n'
       'The null value was thrown.\n'


### PR DESCRIPTION
The `NullThrownError` is not used in null safe Dart,
and is planned to go away when pre-null-safety code stops being supported.
The error class will soon be deprecated.

The deprecation recommends using `TypeError` instead, because that is what should be thrown in null-safe code if you do `throw (null as dynamic)`, because `null` cannot be down-cast from `dynamic` to `Object`.
