### PR TITLE
exports public API types from scheduler/*.dart

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -13,7 +13,10 @@ import 'package:flutter/foundation.dart';
 import 'debug.dart';
 import 'priority.dart';
 
-export 'dart:ui' show AppLifecycleState, VoidCallback, FrameTiming;
+export 'dart:developer' show Flow;
+export 'dart:ui' show AppLifecycleState, FrameTiming, TimingsCallback, VoidCallback;
+
+export 'priority.dart' show Priority;
 
 /// Slows down animations by this factor to help in development.
 double get timeDilation => _timeDilation;

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -8,6 +8,8 @@ import 'package:flutter/foundation.dart';
 
 import 'binding.dart';
 
+export 'package:flutter/foundation.dart' show DiagnosticsNode, VoidCallback;
+
 /// Signature for the callback passed to the [Ticker] class's constructor.
 ///
 /// The argument is the time that the object had spent enabled so far


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/58731 this PR exports public API types from scheduler/*.dart library.