### PR TITLE
Refactor add DateRangeController to date range picker

### DIFF
--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -245,3 +245,57 @@ class DateTimeRange {
   @override
   String toString() => '$start - $end';
 }
+
+/// Encapsulates a possible start and end [DateTime] that represent a range of dates.
+///
+/// The range may include the [start] and [end] dates. The [start] and [end] dates
+/// may be equal to indicate a date range of a single day.
+/// The [DateTimeRangeValue] is valid if [start] is not after [end]
+@immutable
+class DateTimeRangeValue {
+  /// Creates a date range for the given start and end [DateTime].
+  DateTimeRangeValue({
+    DateTime? start,
+    DateTime? end,
+  })  : assert((start == null && end == null) ||
+            (start != null && end == null) ||
+            (start != null && !end!.isBefore(start))),
+        start = start != null ? DateUtils.dateOnly(start) : null,
+        end = end != null ? DateUtils.dateOnly(end) : null;
+
+  /// Creates an empty date range where start and end are null.
+  const DateTimeRangeValue.empty()
+      : start = null,
+        end = null;
+
+  /// The start of the range of dates.
+  final DateTime? start;
+
+  /// The end of the range of dates.
+  final DateTime? end;
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType) {
+      return false;
+    }
+    return other is DateTimeRange && other.start == start && other.end == end;
+  }
+
+  @override
+  int get hashCode => Object.hash(start, end);
+
+  @override
+  String toString() => 'DateRangeValue($start - $end)';
+
+  /// Copies the DateTimeRangeValue with new start or/and end.
+  DateTimeRangeValue copyWith({
+    DateTime? start,
+    DateTime? end,
+  }) {
+    return DateTimeRangeValue(
+      start: start != null ? DateUtils.dateOnly(start) : this.start,
+      end: end != null ? DateUtils.dateOnly(end) : this.end,
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/date.dart
+++ b/packages/flutter/lib/src/material/date.dart
@@ -24,24 +24,22 @@ class DateUtils {
   /// See also:
   ///  * [dateOnly], which does the same thing for a single date.
   static DateTimeRange datesOnly(DateTimeRange range) {
-    return DateTimeRange(start: dateOnly(range.start), end: dateOnly(range.end));
+    return DateTimeRange(
+        start: dateOnly(range.start), end: dateOnly(range.end));
   }
 
   /// Returns true if the two [DateTime] objects have the same day, month, and
   /// year, or are both null.
   static bool isSameDay(DateTime? dateA, DateTime? dateB) {
-    return
-      dateA?.year == dateB?.year &&
-      dateA?.month == dateB?.month &&
-      dateA?.day == dateB?.day;
+    return dateA?.year == dateB?.year &&
+        dateA?.month == dateB?.month &&
+        dateA?.day == dateB?.day;
   }
 
   /// Returns true if the two [DateTime] objects have the same month and
   /// year, or are both null.
   static bool isSameMonth(DateTime? dateA, DateTime? dateB) {
-    return
-      dateA?.year == dateB?.year &&
-      dateA?.month == dateB?.month;
+    return dateA?.year == dateB?.year && dateA?.month == dateB?.month;
   }
 
   /// Determines the number of months between two [DateTime] objects.
@@ -55,7 +53,9 @@ class DateUtils {
   ///
   /// The value for `delta` would be `7`.
   static int monthDelta(DateTime startDate, DateTime endDate) {
-    return (endDate.year - startDate.year) * 12 + endDate.month - startDate.month;
+    return (endDate.year - startDate.year) * 12 +
+        endDate.month -
+        startDate.month;
   }
 
   /// Returns a [DateTime] that is [monthDate] with the added number
@@ -69,7 +69,7 @@ class DateUtils {
   ///
   /// `date` would be January 15, 2019.
   /// `futureDate` would be April 1, 2019 since it adds 3 months.
-  static  DateTime addMonthsToMonthDate(DateTime monthDate, int monthsToAdd) {
+  static DateTime addMonthsToMonthDate(DateTime monthDate, int monthsToAdd) {
     return DateTime(monthDate.year, monthDate.month + monthsToAdd);
   }
 
@@ -111,7 +111,8 @@ class DateUtils {
   ///   into the [MaterialLocalizations.narrowWeekdays] list.
   /// - [MaterialLocalizations.narrowWeekdays] list provides localized names of
   ///   days of week, always starting with Sunday and ending with Saturday.
-  static int firstDayOffset(int year, int month, MaterialLocalizations localizations) {
+  static int firstDayOffset(
+      int year, int month, MaterialLocalizations localizations) {
     // 0-based day of week for the month and year, with 0 representing Monday.
     final int weekdayFromMonday = DateTime(year, month).weekday - 1;
 
@@ -134,10 +135,24 @@ class DateUtils {
   /// 1582. It will not give valid results for dates prior to that time.
   static int getDaysInMonth(int year, int month) {
     if (month == DateTime.february) {
-      final bool isLeapYear = (year % 4 == 0) && (year % 100 != 0) || (year % 400 == 0);
+      final bool isLeapYear =
+          (year % 4 == 0) && (year % 100 != 0) || (year % 400 == 0);
       return isLeapYear ? 29 : 28;
     }
-    const List<int> daysInMonth = <int>[31, -1, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    const List<int> daysInMonth = <int>[
+      31,
+      -1,
+      31,
+      30,
+      31,
+      30,
+      31,
+      31,
+      30,
+      31,
+      30,
+      31
+    ];
     return daysInMonth[month - 1];
   }
 }
@@ -214,9 +229,9 @@ class DateTimeRange {
   DateTimeRange({
     required this.start,
     required this.end,
-  }) : assert(start != null),
-       assert(end != null),
-       assert(!start.isAfter(end));
+  })  : assert(start != null),
+        assert(end != null),
+        assert(!start.isAfter(end));
 
   /// The start of the range of dates.
   final DateTime start;
@@ -234,9 +249,7 @@ class DateTimeRange {
     if (other.runtimeType != runtimeType) {
       return false;
     }
-    return other is DateTimeRange
-      && other.start == start
-      && other.end == end;
+    return other is DateTimeRange && other.start == start && other.end == end;
   }
 
   @override
@@ -257,9 +270,12 @@ class DateTimeRangeValue {
   DateTimeRangeValue({
     DateTime? start,
     DateTime? end,
-  })  : assert((start == null && end == null) ||
-            (start != null && end == null) ||
-            (start != null && !end!.isBefore(start))),
+  })  : assert(
+            (start == null && end == null) 
+            || (start != null && end == null) 
+            || (start != null && end != null && !start.isAfter(end)),
+          '$start - $end is not a valid range',
+        ),
         start = start != null ? DateUtils.dateOnly(start) : null,
         end = end != null ? DateUtils.dateOnly(end) : null;
 

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -1134,16 +1134,6 @@ class DateRangeController extends ValueNotifier<DateTimeRangeValue> {
     return isCompleted && !date.isBefore(value.start!) && !date.isAfter(value.end!);
   }
 
-  /// Wether a possible date is a valid start for the range
-  bool verifyIsValidStart(DateTime? dateTime) => dateTime != null 
-    && verifyIsInAllowedRange(dateTime);
-
-  /// Wether a possible date is a valid end for the range
-  bool verifyIsValidEnd(DateTime? dateTime) => dateTime != null 
-    && verifyIsInAllowedRange(dateTime)
-    && start != null
-    && start!.isAfter(dateTime);
-
 }
 
 /// A Material-style date range picker dialog.
@@ -2752,6 +2742,22 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     _endController.text = endInputText;
   }
 
+  /// Synchronize the [DateRangeController] with the values in textFields
+  void _synchronizeRangeController() {
+    final DateTime? newStart = _parseDate(_startController.text);
+    final DateTime? newEnd = _parseDate(_endController.text);
+    final bool isValidStart = newStart != null && _controller.verifyIsInAllowedRange(newStart);
+    final bool isValidEnd = newEnd != null 
+      && isValidStart
+      && _controller.verifyIsInAllowedRange(newEnd)
+      && !newStart.isAfter(newEnd);
+
+    _controller.value = DateTimeRangeValue(
+      start: isValidStart ? newStart : null, 
+      end: isValidEnd ? newEnd : null,
+    );
+  }
+
   /// Validates that the text in the start and end fields represent a valid
   /// date range.
   ///
@@ -2759,7 +2765,6 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
   /// return false and display an appropriate error message under one of the
   /// text fields.
   bool validate() {
-    print('validate');
     final DateTime? startDate = _parseDate(_startController.text);
     final DateTime? endDate = _parseDate(_endController.text);
     String? startError = _validateInRange(startDate);
@@ -2799,24 +2804,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
     controller.value = selected;
   }
 
-  void _synchronizeRangeController() {
-    final DateTime? newStart = _parseDate(_startController.text);
-    final DateTime? newEnd = _parseDate(_endController.text);
-    final bool isValidStart = _controller.verifyIsValidStart(newStart);
-    if (!isValidStart) {
-      _controller.start = null;
-    } else {
-      _controller.start = newStart;
-    }
 
-    final bool isValidEnd = _controller.verifyIsValidEnd(newEnd);
-
-    if (!isValidEnd) {
-      _controller.end = null;
-    } else {
-      _controller.end = newEnd;
-    }
-  }
 
   void _onTextChanged() {
     _synchronizeRangeController();

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -2759,6 +2759,7 @@ class _InputDateRangePickerState extends State<_InputDateRangePicker> {
   /// return false and display an appropriate error message under one of the
   /// text fields.
   bool validate() {
+    print('validate');
     final DateTime? startDate = _parseDate(_startController.text);
     final DateTime? endDate = _parseDate(_endController.text);
     String? startError = _validateInRange(startDate);


### PR DESCRIPTION
This is preparation work needed to do this issue https://github.com/flutter/flutter/issues/104047

I refactored the internals of the date range picker to use a controller so in a future PR the `DayCell.onTap` can call this controller.

Basically instead of bubbling the onTap event, the controller is passed down the widget tree so the _MonthItem  can call it when the day is tapped. The idea is that once `DayItem` is implemented it will let this be possible:

```
showDateRangePicker(
   dayCellBuilder: (context, dateTime, controller) => DayCell(
      isSelectable: _isNotWednesday(dateTime) &&  _isAfterFirstDate(dateTime) && _isBeforeLastDate(dateTime) ,
      onTap: () => controller.push(dateTime),
      // ... other customization
   );
```
   
An alternative would have been to do something like `DateRangePicker.of(context).push(newDateTime)` but I felt like a controller fit better.

@darrenaustin 


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
