### PR TITLE
Enable arm64 module_test_ios and plugin_lint_mac in prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2706,7 +2706,6 @@ targets:
   - name: Mac_arm64_ios module_test_ios
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       tags: >
@@ -2765,7 +2764,6 @@ targets:
   - name: Mac_arm64_ios plugin_lint_mac
     recipe: devicelab/devicelab_drone
     presubmit: false
-    bringup: true
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/105636.

These two tests have been validated >50 runs without any flake.