### PR TITLE
Restore expectations for flutter_test/exception_handling_test

### DIFF
--- a/dev/automated_tests/flutter_test/exception_handling_expectation.txt
+++ b/dev/automated_tests/flutter_test/exception_handling_expectation.txt
@@ -46,6 +46,14 @@ Who lives, who dies, who tells your story\?
 When the exception was thrown, this was the stack:
 #[0-9]+ +main.<anonymous closure> \(.+[/\\]dev[/\\]automated_tests[/\\]flutter_test[/\\]exception_handling_test\.dart:16:5\)
 <<skip until matching line>>
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
+<<skip until matching line>>
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]binding.dart:[0-9]+:[0-9]+\)
+<<skip until matching line>>
+#[0-9]+ +.+ \(package:flutter_test[/\\]src[/\\]widget_tester\.dart:[0-9]+:[0-9]+\)
+<<skip until matching line>>
+^\(elided ([0-9]+|one) .+$
+<<skip until matching line>>
 The test description was:
 Exception handling in test harness - uncaught Future error
 ════════════════════════════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
This change restores expectations for `dev/automated_tests/flutter_test/exception_handling_test`. In addition to testing the real stack traces, this test also verifies `Chain` captured using `package:stack_trace`. Due to a bug in Dart SDK, `Chain` from `package:stack_trace` was sometimes truncated.

The bug was fixed (https://github.com/dart-lang/sdk/commit/e505ab1fd26be173f143484917a22a1e851e09f8) and the fix was rolled into Flutter, so now we can restore the test expectations.
