### PR TITLE
Themeable Switch thumb images (active/inactive)

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -303,9 +303,9 @@ class Switch extends StatelessWidget {
   ///   onChanged: (_) => true,
   ///   thumbImage: MaterialStateProperty.resolveWith<ImageProvider>((Set<MaterialState> states) {
   ///     if (states.contains(MaterialState.disabled)) {
-  ///       return MemoryImage(Uint8List.fromList(bytes));
+  ///       return MemoryImage(Uint8List.fromList(<int>[1, 2]));
   ///     }
-  ///     return MemoryImage(Uint8List.fromList(otherBytes));
+  ///     return MemoryImage(Uint8List.fromList(<int>[3, 4]));
   ///   }),
   /// )
   /// ```

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -93,6 +93,7 @@ class Switch extends StatelessWidget {
     this.inactiveThumbImage,
     this.onInactiveThumbImageError,
     this.thumbColor,
+    this.thumbImage,
     this.trackColor,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -137,6 +138,7 @@ class Switch extends StatelessWidget {
     this.onInactiveThumbImageError,
     this.materialTapTargetSize,
     this.thumbColor,
+    this.thumbImage,
     this.trackColor,
     this.dragStartBehavior = DragStartBehavior.start,
     this.mouseCursor,
@@ -280,6 +282,41 @@ class Switch extends StatelessWidget {
   /// | Selected | [ThemeData.toggleableActiveColor] | [ThemeData.toggleableActiveColor] |
   /// | Disabled | `Colors.grey.shade400`            | `Colors.grey.shade800`            |
   final MaterialStateProperty<Color?>? thumbColor;
+
+  /// {@template flutter.material.switch.thumbImage}
+  /// The image of this [Switch]'s thumb.
+  ///
+  /// Resolved in the following states:
+  ///  * [MaterialState.selected].
+  ///  * [MaterialState.hovered].
+  ///  * [MaterialState.focused].
+  ///  * [MaterialState.disabled].
+  ///
+  /// {@tool snippet}
+  /// This example resolves the [thumbImage] based on the current
+  /// [MaterialState] of the [Switch], providing a different [ImageProvider] when it is
+  /// [MaterialState.disabled].
+  ///
+  /// ```dart
+  /// Switch(
+  ///   value: true,
+  ///   onChanged: (_) => true,
+  ///   thumbColor: MaterialStateProperty.resolveWith<ImageProvider>((Set<MaterialState> states) {
+  ///     if (states.contains(MaterialState.disabled)) {
+  ///       return Colors.orange.withOpacity(.48);
+  ///     }
+  ///     return Colors.orange;
+  ///   }),
+  /// )
+  /// ```
+  /// {@end-tool}
+  /// {@endtemplate}
+  ///
+  /// If null, then the value of [activeThumbImage] is used in the selected
+  /// state and [inactiveThumbImage] in the default state. If that is also null,
+  /// then the value of [SwitchThemeData.thumbImage] is used. If that is also
+  /// null, then it defaults to null
+  final MaterialStateProperty<ImageProvider?>? thumbImage;
 
   /// {@template flutter.material.switch.trackColor}
   /// The color of this [Switch]'s track.
@@ -465,6 +502,7 @@ class Switch extends StatelessWidget {
       inactiveThumbImage: inactiveThumbImage,
       onInactiveThumbImageError: onInactiveThumbImageError,
       thumbColor: thumbColor,
+      thumbImage: thumbImage,
       trackColor: trackColor,
       materialTapTargetSize: materialTapTargetSize,
       dragStartBehavior: dragStartBehavior,
@@ -523,6 +561,7 @@ class _MaterialSwitch extends StatefulWidget {
     this.inactiveThumbImage,
     this.onInactiveThumbImageError,
     this.thumbColor,
+    this.thumbImage,
     this.trackColor,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -548,6 +587,7 @@ class _MaterialSwitch extends StatefulWidget {
   final ImageProvider? inactiveThumbImage;
   final ImageErrorListener? onInactiveThumbImageError;
   final MaterialStateProperty<Color?>? thumbColor;
+  final MaterialStateProperty<ImageProvider?>? thumbImage;
   final MaterialStateProperty<Color?>? trackColor;
   final MaterialTapTargetSize? materialTapTargetSize;
   final DragStartBehavior dragStartBehavior;
@@ -633,6 +673,18 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
         return widget.activeTrackColor;
       }
       return widget.inactiveTrackColor;
+    });
+  }
+
+  MaterialStateProperty<ImageProvider?> get _widgetThumbImage {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.disabled)) {
+        return widget.inactiveThumbImage;
+      }
+      if (states.contains(MaterialState.selected)) {
+        return widget.activeThumbImage;
+      }
+      return widget.inactiveThumbImage;
     });
   }
 
@@ -734,7 +786,12 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
       ?? _widgetTrackColor.resolve(inactiveStates)
       ?? switchTheme.trackColor?.resolve(inactiveStates)
       ?? _defaultTrackColor.resolve(inactiveStates);
-
+    final ImageProvider? effectiveActiveThumbImage = widget.thumbImage?.resolve(activeStates)
+        ?? _widgetThumbImage.resolve(activeStates)
+        ?? switchTheme.thumbImage?.resolve(activeStates);
+    final ImageProvider? effectiveInactiveThumbImage = widget.thumbImage?.resolve(inactiveStates)
+        ?? _widgetThumbImage.resolve(inactiveStates)
+        ?? switchTheme.thumbImage?.resolve(inactiveStates);
     final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
     final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
       ?? widget.focusColor
@@ -791,9 +848,9 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
             ..isHovered = states.contains(MaterialState.hovered)
             ..activeColor = effectiveActiveThumbColor
             ..inactiveColor = effectiveInactiveThumbColor
-            ..activeThumbImage = widget.activeThumbImage ?? switchTheme.activeThumbImage
+            ..activeThumbImage = effectiveActiveThumbImage
             ..onActiveThumbImageError = widget.onActiveThumbImageError
-            ..inactiveThumbImage = widget.inactiveThumbImage ?? switchTheme.inactiveThumbImage
+            ..inactiveThumbImage = effectiveInactiveThumbImage
             ..onInactiveThumbImageError = widget.onInactiveThumbImageError
             ..activeTrackColor = effectiveActiveTrackColor
             ..inactiveTrackColor = effectiveInactiveTrackColor

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -220,6 +220,8 @@ class Switch extends StatelessWidget {
 
   /// An image to use on the thumb of this switch when the switch is on.
   ///
+  /// Defaults to the image described in the Material design specification.
+  ///
   /// Ignored if this switch is created with [Switch.adaptive].
   final ImageProvider? activeThumbImage;
 
@@ -228,6 +230,8 @@ class Switch extends StatelessWidget {
   final ImageErrorListener? onActiveThumbImageError;
 
   /// An image to use on the thumb of this switch when the switch is off.
+  ///
+  /// Defaults to the image described in the Material design specification.
   ///
   /// Ignored if this switch is created with [Switch.adaptive].
   final ImageProvider? inactiveThumbImage;
@@ -787,9 +791,9 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
             ..isHovered = states.contains(MaterialState.hovered)
             ..activeColor = effectiveActiveThumbColor
             ..inactiveColor = effectiveInactiveThumbColor
-            ..activeThumbImage = widget.activeThumbImage
+            ..activeThumbImage = widget.activeThumbImage ?? switchTheme.activeThumbImage
             ..onActiveThumbImageError = widget.onActiveThumbImageError
-            ..inactiveThumbImage = widget.inactiveThumbImage
+            ..inactiveThumbImage = widget.inactiveThumbImage ?? switchTheme.inactiveThumbImage
             ..onInactiveThumbImageError = widget.onInactiveThumbImageError
             ..activeTrackColor = effectiveActiveTrackColor
             ..inactiveTrackColor = effectiveInactiveTrackColor

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -301,11 +301,11 @@ class Switch extends StatelessWidget {
   /// Switch(
   ///   value: true,
   ///   onChanged: (_) => true,
-  ///   thumbColor: MaterialStateProperty.resolveWith<ImageProvider>((Set<MaterialState> states) {
+  ///   thumbImage: MaterialStateProperty.resolveWith<ImageProvider>((Set<MaterialState> states) {
   ///     if (states.contains(MaterialState.disabled)) {
-  ///       return Colors.orange.withOpacity(.48);
+  ///       return MemoryImage(Uint8List.fromList(bytes));
   ///     }
-  ///     return Colors.orange;
+  ///     return MemoryImage(Uint8List.fromList(otherBytes));
   ///   }),
   /// )
   /// ```

--- a/packages/flutter/lib/src/material/switch_theme.dart
+++ b/packages/flutter/lib/src/material/switch_theme.dart
@@ -35,6 +35,8 @@ class SwitchThemeData with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.switchTheme].
   const SwitchThemeData({
     this.thumbColor,
+    this.activeThumbImage,
+    this.inactiveThumbImage,
     this.trackColor,
     this.materialTapTargetSize,
     this.mouseCursor,
@@ -46,6 +48,16 @@ class SwitchThemeData with Diagnosticable {
   ///
   /// If specified, overrides the default value of [Switch.thumbColor].
   final MaterialStateProperty<Color?>? thumbColor;
+
+  /// {@macro flutter.material.switch.activeThumbImage}
+  ///
+  /// If specified, overrides the default value of [Switch.activeThumbImage].
+  final ImageProvider? activeThumbImage;
+
+  /// {@macro flutter.material.switch.inactiveThumbImage}
+  ///
+  /// If specified, overrides the default value of [Switch.inactiveThumbImage].
+  final ImageProvider? inactiveThumbImage;
 
   /// {@macro flutter.material.switch.trackColor}
   ///
@@ -77,6 +89,8 @@ class SwitchThemeData with Diagnosticable {
   /// new values.
   SwitchThemeData copyWith({
     MaterialStateProperty<Color?>? thumbColor,
+    ImageProvider? activeThumbImage,
+    ImageProvider? inactiveThumbImage,
     MaterialStateProperty<Color?>? trackColor,
     MaterialTapTargetSize? materialTapTargetSize,
     MaterialStateProperty<MouseCursor?>? mouseCursor,
@@ -85,6 +99,8 @@ class SwitchThemeData with Diagnosticable {
   }) {
     return SwitchThemeData(
       thumbColor: thumbColor ?? this.thumbColor,
+      activeThumbImage: activeThumbImage ?? this.activeThumbImage,
+      inactiveThumbImage: inactiveThumbImage ?? this.inactiveThumbImage,
       trackColor: trackColor ?? this.trackColor,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
       mouseCursor: mouseCursor ?? this.mouseCursor,
@@ -99,6 +115,8 @@ class SwitchThemeData with Diagnosticable {
   static SwitchThemeData lerp(SwitchThemeData? a, SwitchThemeData? b, double t) {
     return SwitchThemeData(
       thumbColor: MaterialStateProperty.lerp<Color?>(a?.thumbColor, b?.thumbColor, t, Color.lerp),
+      activeThumbImage: t < 0.5 ? a?.activeThumbImage : b?.activeThumbImage,
+      inactiveThumbImage: t < 0.5 ? a?.inactiveThumbImage : b?.inactiveThumbImage,
       trackColor: MaterialStateProperty.lerp<Color?>(a?.trackColor, b?.trackColor, t, Color.lerp),
       materialTapTargetSize: t < 0.5 ? a?.materialTapTargetSize : b?.materialTapTargetSize,
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
@@ -110,6 +128,8 @@ class SwitchThemeData with Diagnosticable {
   @override
   int get hashCode => Object.hash(
     thumbColor,
+    activeThumbImage,
+    inactiveThumbImage,
     trackColor,
     materialTapTargetSize,
     mouseCursor,
@@ -127,6 +147,8 @@ class SwitchThemeData with Diagnosticable {
     }
     return other is SwitchThemeData
       && other.thumbColor == thumbColor
+      && other.activeThumbImage == activeThumbImage
+      && other.inactiveThumbImage == inactiveThumbImage
       && other.trackColor == trackColor
       && other.materialTapTargetSize == materialTapTargetSize
       && other.mouseCursor == mouseCursor

--- a/packages/flutter/lib/src/material/switch_theme.dart
+++ b/packages/flutter/lib/src/material/switch_theme.dart
@@ -35,8 +35,7 @@ class SwitchThemeData with Diagnosticable {
   /// Creates a theme that can be used for [ThemeData.switchTheme].
   const SwitchThemeData({
     this.thumbColor,
-    this.activeThumbImage,
-    this.inactiveThumbImage,
+    this.thumbImage,
     this.trackColor,
     this.materialTapTargetSize,
     this.mouseCursor,
@@ -49,15 +48,10 @@ class SwitchThemeData with Diagnosticable {
   /// If specified, overrides the default value of [Switch.thumbColor].
   final MaterialStateProperty<Color?>? thumbColor;
 
-  /// {@macro flutter.material.switch.activeThumbImage}
+  /// {@macro flutter.material.switch.thumbImage}
   ///
-  /// If specified, overrides the default value of [Switch.activeThumbImage].
-  final ImageProvider? activeThumbImage;
-
-  /// {@macro flutter.material.switch.inactiveThumbImage}
-  ///
-  /// If specified, overrides the default value of [Switch.inactiveThumbImage].
-  final ImageProvider? inactiveThumbImage;
+  /// If specified, overrides the default value of [Switch.thumbImage].
+  final MaterialStateProperty<ImageProvider?>? thumbImage;
 
   /// {@macro flutter.material.switch.trackColor}
   ///
@@ -89,8 +83,7 @@ class SwitchThemeData with Diagnosticable {
   /// new values.
   SwitchThemeData copyWith({
     MaterialStateProperty<Color?>? thumbColor,
-    ImageProvider? activeThumbImage,
-    ImageProvider? inactiveThumbImage,
+    MaterialStateProperty<ImageProvider?>? thumbImage,
     MaterialStateProperty<Color?>? trackColor,
     MaterialTapTargetSize? materialTapTargetSize,
     MaterialStateProperty<MouseCursor?>? mouseCursor,
@@ -99,8 +92,7 @@ class SwitchThemeData with Diagnosticable {
   }) {
     return SwitchThemeData(
       thumbColor: thumbColor ?? this.thumbColor,
-      activeThumbImage: activeThumbImage ?? this.activeThumbImage,
-      inactiveThumbImage: inactiveThumbImage ?? this.inactiveThumbImage,
+      thumbImage: thumbImage,
       trackColor: trackColor ?? this.trackColor,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
       mouseCursor: mouseCursor ?? this.mouseCursor,
@@ -115,8 +107,7 @@ class SwitchThemeData with Diagnosticable {
   static SwitchThemeData lerp(SwitchThemeData? a, SwitchThemeData? b, double t) {
     return SwitchThemeData(
       thumbColor: MaterialStateProperty.lerp<Color?>(a?.thumbColor, b?.thumbColor, t, Color.lerp),
-      activeThumbImage: t < 0.5 ? a?.activeThumbImage : b?.activeThumbImage,
-      inactiveThumbImage: t < 0.5 ? a?.inactiveThumbImage : b?.inactiveThumbImage,
+      thumbImage: t < 0.5 ? a?.thumbImage : b?.thumbImage,
       trackColor: MaterialStateProperty.lerp<Color?>(a?.trackColor, b?.trackColor, t, Color.lerp),
       materialTapTargetSize: t < 0.5 ? a?.materialTapTargetSize : b?.materialTapTargetSize,
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
@@ -128,8 +119,7 @@ class SwitchThemeData with Diagnosticable {
   @override
   int get hashCode => Object.hash(
     thumbColor,
-    activeThumbImage,
-    inactiveThumbImage,
+    thumbImage,
     trackColor,
     materialTapTargetSize,
     mouseCursor,
@@ -147,8 +137,7 @@ class SwitchThemeData with Diagnosticable {
     }
     return other is SwitchThemeData
       && other.thumbColor == thumbColor
-      && other.activeThumbImage == activeThumbImage
-      && other.inactiveThumbImage == inactiveThumbImage
+      && other.thumbImage == thumbImage
       && other.trackColor == trackColor
       && other.materialTapTargetSize == materialTapTargetSize
       && other.mouseCursor == mouseCursor
@@ -160,6 +149,7 @@ class SwitchThemeData with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('thumbColor', thumbColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<ImageProvider?>>('thumbImage', thumbImage, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('trackColor', trackColor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('mouseCursor', mouseCursor, defaultValue: null));

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../image_data.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
@@ -18,8 +20,7 @@ void main() {
   test('SwitchThemeData defaults', () {
     const SwitchThemeData themeData = SwitchThemeData();
     expect(themeData.thumbColor, null);
-    expect(themeData.activeThumbImage, null);
-    expect(themeData.inactiveThumbImage, null);
+    expect(themeData.thumbImage, null);
     expect(themeData.trackColor, null);
     expect(themeData.mouseCursor, null);
     expect(themeData.materialTapTargetSize, null);
@@ -28,8 +29,7 @@ void main() {
 
     const SwitchTheme theme = SwitchTheme(data: SwitchThemeData(), child: SizedBox());
     expect(theme.data.thumbColor, null);
-    expect(theme.data.activeThumbImage, null);
-    expect(theme.data.inactiveThumbImage, null);
+    expect(themeData.thumbImage, null);
     expect(theme.data.trackColor, null);
     expect(theme.data.mouseCursor, null);
     expect(theme.data.materialTapTargetSize, null);
@@ -50,13 +50,15 @@ void main() {
   });
 
   testWidgets('SwitchThemeData implements debugFillProperties', (WidgetTester tester) async {
+    final Uint8List thumbImageBytes = Uint8List.fromList(kBlueRectPng);
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    const SwitchThemeData(
-      thumbColor: MaterialStatePropertyAll<Color>(Color(0xfffffff0)),
-      trackColor: MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
-      mouseCursor: MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.click),
+    SwitchThemeData(
+      thumbColor: const MaterialStatePropertyAll<Color>(Color(0xfffffff0)),
+      thumbImage: MaterialStatePropertyAll<ImageProvider>(MemoryImage(thumbImageBytes)),
+      trackColor: const MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
+      mouseCursor: const MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.click),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
+      overlayColor: const MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
       splashRadius: 1.0,
     ).debugFillProperties(builder);
 
@@ -66,11 +68,12 @@ void main() {
       .toList();
 
     expect(description[0], 'thumbColor: MaterialStatePropertyAll(Color(0xfffffff0))');
-    expect(description[1], 'trackColor: MaterialStatePropertyAll(Color(0xfffffff1))');
-    expect(description[2], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
-    expect(description[3], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
-    expect(description[4], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff2))');
-    expect(description[5], 'splashRadius: 1.0');
+    expect(description[1], 'thumbImage: MaterialStatePropertyAll(MemoryImage(Uint8List#${shortHash(thumbImageBytes)}, scale: 1.0))');
+    expect(description[2], 'trackColor: MaterialStatePropertyAll(Color(0xfffffff1))');
+    expect(description[3], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
+    expect(description[4], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
+    expect(description[5], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff2))');
+    expect(description[6], 'splashRadius: 1.0');
   });
 
   testWidgets('Switch is themeable', (WidgetTester tester) async {
@@ -78,6 +81,8 @@ void main() {
 
     const Color defaultThumbColor = Color(0xfffffff0);
     const Color selectedThumbColor = Color(0xfffffff1);
+    final ImageProvider defaultThumbImage = MemoryImage(Uint8List.fromList(kBlueRectPng));
+    final ImageProvider selectedThumbImage = MemoryImage(Uint8List.fromList(kTransparentImage));
     const Color defaultTrackColor = Color(0xfffffff2);
     const Color selectedTrackColor = Color(0xfffffff3);
     const MouseCursor mouseCursor = SystemMouseCursors.text;
@@ -95,6 +100,12 @@ void main() {
                 return selectedThumbColor;
               }
               return defaultThumbColor;
+            }),
+            thumbImage: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return selectedThumbImage;
+              }
+              return defaultThumbImage;
             }),
             trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
@@ -141,6 +152,7 @@ void main() {
     );
     // Size from MaterialTapTargetSize.shrinkWrap.
     expect(tester.getSize(find.byType(Switch)), const Size(59.0, 40.0));
+    // TODO(kirolous-nashaat): verify that defaultThumbImage is used.
 
     // Selected switch.
     await tester.pumpWidget(buildSwitch(selected: true));
@@ -154,6 +166,7 @@ void main() {
         ..circle()
         ..circle(color: selectedThumbColor),
     );
+    // TODO(kirolous-nashaat): verify that selectedThumbImage is used.
 
     // Switch with hover.
     await tester.pumpWidget(buildSwitch());
@@ -173,6 +186,8 @@ void main() {
 
     const Color themeDefaultThumbColor = Color(0xfffffff0);
     const Color themeSelectedThumbColor = Color(0xfffffff1);
+    final ImageProvider themeDefaultThumbImage = MemoryImage(Uint8List.fromList(kBlueRectPng));
+    final ImageProvider themeSelectedThumbImage = MemoryImage(Uint8List.fromList(kTransparentImage));
     const Color themeDefaultTrackColor = Color(0xfffffff2);
     const Color themeSelectedTrackColor = Color(0xfffffff3);
     const MouseCursor themeMouseCursor = SystemMouseCursors.click;
@@ -200,6 +215,12 @@ void main() {
                 return themeSelectedThumbColor;
               }
               return themeDefaultThumbColor;
+            }),
+            thumbImage: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return themeSelectedThumbImage;
+              }
+              return themeDefaultThumbImage;
             }),
             trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
@@ -262,6 +283,7 @@ void main() {
     );
     // Size from MaterialTapTargetSize.shrinkWrap.
     expect(tester.getSize(find.byType(Switch)), const Size(59.0, 40.0));
+    // TODO(kirolous-nashaat): verify that themeDefaultThumbImage is used.
 
     // Selected switch.
     await tester.pumpWidget(buildSwitch(selected: true));
@@ -275,6 +297,7 @@ void main() {
         ..circle()
         ..circle(color: selectedThumbColor),
     );
+    // TODO(kirolous-nashaat): verify that themeSelectedThumbImage is used.
 
     // Switch with hover.
     await tester.pumpWidget(buildSwitch());
@@ -294,11 +317,15 @@ void main() {
 
     const Color themeDefaultThumbColor = Color(0xfffffff0);
     const Color themeSelectedThumbColor = Color(0xfffffff1);
+    final ImageProvider themeDefaultThumbImage = MemoryImage(Uint8List.fromList(kBlueRectPng));
+    final ImageProvider themeSelectedThumbImage = MemoryImage(Uint8List.fromList(kTransparentImage));
     const Color themeDefaultTrackColor = Color(0xfffffff2);
     const Color themeSelectedTrackColor = Color(0xfffffff3);
 
     const Color defaultThumbColor = Color(0xffffff0f);
     const Color selectedThumbColor = Color(0xffffff1f);
+    final ImageProvider defaultThumbImage = MemoryImage(Uint8List.fromList(kBlueSquarePng));
+    final ImageProvider selectedThumbImage = MemoryImage(Uint8List.fromList(kBlueSquarePng));
     const Color defaultTrackColor = Color(0xffffff2f);
     const Color selectedTrackColor = Color(0xffffff3f);
 
@@ -311,6 +338,12 @@ void main() {
                 return themeSelectedThumbColor;
               }
               return themeDefaultThumbColor;
+            }),
+            thumbImage: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return themeSelectedThumbImage;
+              }
+              return themeDefaultThumbImage;
             }),
             trackColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
               if (states.contains(MaterialState.selected)) {
@@ -327,6 +360,8 @@ void main() {
             autofocus: autofocus,
             activeColor: selectedThumbColor,
             inactiveThumbColor: defaultThumbColor,
+            activeThumbImage: selectedThumbImage,
+            inactiveThumbImage: defaultThumbImage,
             activeTrackColor: selectedTrackColor,
             inactiveTrackColor: defaultTrackColor,
           ),
@@ -346,6 +381,7 @@ void main() {
         ..circle()
         ..circle(color: defaultThumbColor),
     );
+    // TODO(kirolous-nashaat): verify that defaultThumbImage is used.
 
     // Selected switch.
     await tester.pumpWidget(buildSwitch(selected: true));
@@ -359,6 +395,7 @@ void main() {
         ..circle()
         ..circle(color: selectedThumbColor),
     );
+    // TODO(kirolous-nashaat): verify that selectedThumbImage is used.
   });
 
   testWidgets('Switch theme overlay color resolves in active/pressed states', (WidgetTester tester) async {
@@ -426,23 +463,28 @@ void main() {
 
   testWidgets('Local SwitchTheme can override global SwitchTheme', (WidgetTester tester) async {
     const Color globalThemeThumbColor = Color(0xfffffff1);
+    final ImageProvider globalThemeThumbImage = MemoryImage(Uint8List.fromList(kBlueRectPng));
     const Color globalThemeTrackColor = Color(0xfffffff2);
+
     const Color localThemeThumbColor = Color(0xffff0000);
+    final ImageProvider localThemeThumbImage = MemoryImage(Uint8List.fromList(kTransparentImage));
     const Color localThemeTrackColor = Color(0xffff0000);
 
     Widget buildSwitch({bool selected = false, bool autofocus = false}) {
       return MaterialApp(
         theme: ThemeData(
-          switchTheme: const SwitchThemeData(
-            thumbColor: MaterialStatePropertyAll<Color>(globalThemeThumbColor),
-            trackColor: MaterialStatePropertyAll<Color>(globalThemeTrackColor),
+          switchTheme: SwitchThemeData(
+            thumbColor: const MaterialStatePropertyAll<Color>(globalThemeThumbColor),
+            thumbImage: MaterialStatePropertyAll<ImageProvider>(globalThemeThumbImage),
+            trackColor: const MaterialStatePropertyAll<Color>(globalThemeTrackColor),
           ),
         ),
         home: Scaffold(
           body: SwitchTheme(
-            data: const SwitchThemeData(
-              thumbColor: MaterialStatePropertyAll<Color>(localThemeThumbColor),
-              trackColor: MaterialStatePropertyAll<Color>(localThemeTrackColor),
+            data: SwitchThemeData(
+              thumbColor: const MaterialStatePropertyAll<Color>(localThemeThumbColor),
+              thumbImage: MaterialStatePropertyAll<ImageProvider>(localThemeThumbImage),
+              trackColor: const MaterialStatePropertyAll<Color>(localThemeTrackColor),
             ),
             child: Switch(
               value: selected,
@@ -465,6 +507,7 @@ void main() {
         ..circle()
         ..circle(color: localThemeThumbColor),
     );
+    // TODO(kirolous-nashaat): verify that localThemeThumbImage is used.
   });
 }
 

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -18,6 +18,8 @@ void main() {
   test('SwitchThemeData defaults', () {
     const SwitchThemeData themeData = SwitchThemeData();
     expect(themeData.thumbColor, null);
+    expect(themeData.activeThumbImage, null);
+    expect(themeData.inactiveThumbImage, null);
     expect(themeData.trackColor, null);
     expect(themeData.mouseCursor, null);
     expect(themeData.materialTapTargetSize, null);
@@ -26,6 +28,8 @@ void main() {
 
     const SwitchTheme theme = SwitchTheme(data: SwitchThemeData(), child: SizedBox());
     expect(theme.data.thumbColor, null);
+    expect(theme.data.activeThumbImage, null);
+    expect(theme.data.inactiveThumbImage, null);
     expect(theme.data.trackColor, null);
     expect(theme.data.mouseCursor, null);
     expect(theme.data.materialTapTargetSize, null);


### PR DESCRIPTION
Adding `SwitchThemeData.activeThumbImage` & `SwitchThemeData.inactiveThumbImage`

Fixes [#81564](https://github.com/flutter/flutter/issues/81564) 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
