### PR TITLE
Add `SeparatedSliverChildBuilderDelegate` and `SliverList.separated()` constructor

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
-
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 
@@ -1232,31 +1230,14 @@ class ListView extends BoxScrollView {
        assert(itemCount != null && itemCount >= 0),
        itemExtent = null,
        prototypeItem = null,
-       childrenDelegate = SliverChildBuilderDelegate(
-         (BuildContext context, int index) {
-           final int itemIndex = index ~/ 2;
-           final Widget widget;
-           if (index.isEven) {
-             widget = itemBuilder(context, itemIndex);
-           } else {
-             widget = separatorBuilder(context, itemIndex);
-             assert(() {
-               if (widget == null) {
-                 throw FlutterError('separatorBuilder cannot return null.');
-               }
-               return true;
-             }());
-           }
-           return widget;
-         },
+       childrenDelegate = SeparatedSliverChildBuilderDelegate(
          findChildIndexCallback: findChildIndexCallback,
-         childCount: _computeActualChildCount(itemCount),
+         itemCount: itemCount,
+         itemBuilder: itemBuilder,
+         separatorBuilder: separatorBuilder,
          addAutomaticKeepAlives: addAutomaticKeepAlives,
          addRepaintBoundaries: addRepaintBoundaries,
          addSemanticIndexes: addSemanticIndexes,
-         semanticIndexCallback: (Widget _, int index) {
-           return index.isEven ? index ~/ 2 : null;
-         },
        ),
        super(
          semanticChildCount: itemCount,
@@ -1439,11 +1420,6 @@ class ListView extends BoxScrollView {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(DoubleProperty('itemExtent', itemExtent, defaultValue: null));
-  }
-
-  // Helper method to compute the actual child count for the separated constructor.
-  static int _computeActualChildCount(int itemCount) {
-    return math.max(0, itemCount * 2 - 1);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -515,19 +515,19 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
 
 /// A delegate that supplies children for slivers using a builder callback,
 /// while also inserting separators between them.
-/// 
+///
 /// See also:
 ///
 ///  * [SliverChildBuilderDelegate], which is a delegate that uses a builder
 ///    callback to construct the children.
 ///  * [SliverList.separated], which is a [SliverList]
 ///    that uses this delegate to construct its children.
-/// 
+///
 /// {@tool snippet}
-/// 
+///
 /// This code sample shows how to use a `SliverList`
 /// that inserts separators between its children:
-/// 
+///
 /// ```dart
 /// CustomScrollView(
 ///   slivers: [
@@ -548,10 +548,10 @@ class SeparatedSliverChildBuilderDelegate extends SliverChildBuilderDelegate {
   /// Creates a delegate that supplies children for slivers using the given
   /// [itemBuilder] callback. The children are separated by separators,
   /// built using the given [separatorBuilder] callback.
-  /// 
+  ///
   /// The `itemBuilder` callback will be called with indices greater than
   /// or equal to zero and less than [itemCount].
-  /// 
+  ///
   /// Separators only appear between children built by the `itemBuilder`:
   /// The first separator appears after the first item
   /// and the last separator appears before the last item.
@@ -567,7 +567,7 @@ class SeparatedSliverChildBuilderDelegate extends SliverChildBuilderDelegate {
   /// providing a [findChildIndexCallback]. This allows the delegate to find the
   /// new index for a child that was previously located at a different index to
   /// attach the existing state to the [Widget] at its new location.
-  /// 
+  ///
   /// The `addAutomaticKeepAlives` argument corresponds to the
   /// [SliverChildBuilderDelegate.addAutomaticKeepAlives] property. The
   /// `addRepaintBoundaries` argument corresponds to the

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -586,19 +586,19 @@ class SeparatedSliverChildBuilderDelegate extends SliverChildBuilderDelegate {
   }): super(
     (BuildContext context, int index) {
       final int itemIndex = index ~/ 2;
-      final Widget widget;
       
       if (index.isEven) {
-        widget = itemBuilder(context, itemIndex);
-      } else {
-        widget = separatorBuilder(context, itemIndex);
-        assert(() {
-          if (widget == null) {
-            throw FlutterError('separatorBuilder cannot return null.');
-          }
-          return true;
-        }());
+        return itemBuilder(context, itemIndex);
       }
+
+      final Widget widget = separatorBuilder(context, itemIndex);
+        
+      assert(() {
+        if (widget == null) {
+          throw FlutterError('separatorBuilder cannot return null.');
+        }
+        return true;
+      }());
 
       return widget;
     },

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -586,13 +586,13 @@ class SeparatedSliverChildBuilderDelegate extends SliverChildBuilderDelegate {
   }): super(
     (BuildContext context, int index) {
       final int itemIndex = index ~/ 2;
-      
+
       if (index.isEven) {
         return itemBuilder(context, itemIndex);
       }
 
       final Widget widget = separatorBuilder(context, itemIndex);
-        
+
       assert(() {
         if (widget == null) {
           throw FlutterError('separatorBuilder cannot return null.');

--- a/packages/flutter/lib/src/widgets/sliver.dart
+++ b/packages/flutter/lib/src/widgets/sliver.dart
@@ -530,10 +530,10 @@ class SliverChildBuilderDelegate extends SliverChildDelegate {
 ///
 /// ```dart
 /// CustomScrollView(
-///   slivers: [
+///   slivers: <Widget>[
 ///     SliverList(
 ///       delegate: SeparatedSliverChildBuilderDelegate(
-///         (BuildContext context, int index){
+///         itemBuilder: (BuildContext context, int index){
 ///           return Text('item: $index');
 ///         },
 ///         itemCount: 10,

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -383,7 +383,7 @@ void main() {
             return const Divider();
           },
         ),
-      ); 
+      );
 
       expect(callbackTracker, equals(<String>['item 0']));
     }

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -333,6 +333,87 @@ void main() {
     expect(find.byKey(const Key('key0')), findsOneWidget);
     expect(find.byKey(const Key('key1')), findsOneWidget);
   });
+
+  testWidgets(
+    'SliverList with SeparatedSliverChildBuilderDelegate builds children correctly',
+    (WidgetTester tester) async {
+    const int itemCount = 2;
+
+    final List<String> callbackTracker = <String>[];
+
+    await tester.pumpWidget(
+      _buildSeparatedSliverList(
+        itemBuilder: (BuildContext context, int index){
+          callbackTracker.add('item $index');
+
+          return Text('item $index');
+        },
+        itemCount: itemCount,
+        separatorBuilder: (BuildContext context, int index) {
+          callbackTracker.add('divider $index');
+
+          return const Divider();
+        },
+      ),
+    );
+
+    expect(callbackTracker, equals(<String>['item 0', 'divider 0', 'item 1']));
+
+    callbackTracker.clear();
+  });
+
+  testWidgets(
+    'SliverList with SeparatedSliverChildBuilderDelegate and one child builds only the child',
+    (WidgetTester tester) async {
+      const int itemCount = 1;
+
+      final List<String> callbackTracker = <String>[];
+
+      await tester.pumpWidget(
+        _buildSeparatedSliverList(
+          itemBuilder: (BuildContext context, int index){
+            callbackTracker.add('item $index');
+
+            return Text('item $index');
+          },
+          itemCount: itemCount,
+          separatorBuilder: (BuildContext context, int index) {
+            callbackTracker.add('divider $index');
+
+            return const Divider();
+          },
+        ),
+      );     
+
+      expect(callbackTracker, equals(<String>['item 0']));
+    }
+  );
+
+  testWidgets(
+    'SliverList with SeparatedSliverChildBuilderDelegate and no children builds no children or separators',
+    (WidgetTester tester) async {
+      const int itemCount = 0;
+
+      final List<String> callbackTracker = <String>[];
+
+      await tester.pumpWidget(
+        _buildSeparatedSliverList(
+          itemBuilder: (BuildContext context, int index){
+            callbackTracker.add('item $index');
+
+            return Text('item $index');
+          },
+          itemCount: itemCount,
+          separatorBuilder: (BuildContext context, int index) {
+            callbackTracker.add('divider $index');
+
+            return const Divider();
+          },
+        ),
+      );
+  
+      expect(callbackTracker.isEmpty, true);
+  });
 }
 
 Widget _buildSliverListRenderWidgetChild(List<String> items) {
@@ -396,6 +477,30 @@ Widget _buildSliverList({
             ),
           ],
         ),
+      ),
+    ),
+  );
+}
+
+Widget _buildSeparatedSliverList({
+  required int itemCount,
+  required IndexedWidgetBuilder itemBuilder,
+  required IndexedWidgetBuilder separatorBuilder,
+}){
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: SizedBox(
+    height: 300,
+      child: CustomScrollView(
+        slivers: <Widget>[
+          SliverList(
+            delegate: SeparatedSliverChildBuilderDelegate(
+              itemBuilder: itemBuilder,
+              itemCount: itemCount,
+              separatorBuilder: separatorBuilder,
+            ),
+          ),
+        ],
       ),
     ),
   );

--- a/packages/flutter/test/widgets/sliver_list_test.dart
+++ b/packages/flutter/test/widgets/sliver_list_test.dart
@@ -383,7 +383,7 @@ void main() {
             return const Divider();
           },
         ),
-      );     
+      ); 
 
       expect(callbackTracker, equals(<String>['item 0']));
     }
@@ -411,7 +411,7 @@ void main() {
           },
         ),
       );
-  
+
       expect(callbackTracker.isEmpty, true);
   });
 }


### PR DESCRIPTION
This PR moves the builder delegate from `ListView.separated()` into its own class and adds a new constructor to `SliverList`, `SliverList.separated()`, which enables using similar functionality in a `CustomScrollView`.

*List which issues are fixed by this PR.*
https://github.com/flutter/flutter/issues/101418

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
