### PR TITLE
Add constraintsBuilder to showModalBottomSheet()

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -674,6 +674,9 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 /// The [constraints] parameter can be used to provide a fixed constraint to the 
 /// bottom sheet. If the constraint for the bottom sheet should be a flexible constraint
 /// consider using the [constraintsBuilder] instead.
+/// 
+/// If both `constraints` and `constraintsBuilder` are specified, 
+/// the result of calling `constraintsBuilder` is used.
 ///
 /// The optional [backgroundColor], [elevation], [shape], [clipBehavior]
 /// and [transitionAnimationController] parameters can be passed in to customize

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -36,7 +36,7 @@ typedef BottomSheetDragEndHandler = void Function(
 });
 
 /// A callback that builds the flexible constraints for a modal bottom sheet.
-/// 
+///
 /// This callback provides the incoming layout constraints
 /// so that a modal bottom sheet can provide its child with a flexible constraint.
 typedef BottomSheetConstraintBuilder = BoxConstraints Function(
@@ -670,12 +670,12 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 ///
 /// The [enableDrag] parameter specifies whether the bottom sheet can be
 /// dragged up and down and dismissed by swiping downwards.
-/// 
-/// The [constraints] parameter can be used to provide a fixed constraint to the 
+///
+/// The [constraints] parameter can be used to provide a fixed constraint to the
 /// bottom sheet. If the constraint for the bottom sheet should be a flexible constraint
 /// consider using the [constraintsBuilder] instead.
-/// 
-/// If both `constraints` and `constraintsBuilder` are specified, 
+///
+/// If both `constraints` and `constraintsBuilder` are specified,
 /// the result of calling `constraintsBuilder` is used.
 ///
 /// The optional [backgroundColor], [elevation], [shape], [clipBehavior]

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -1649,6 +1649,161 @@ void main() {
       );
     });
 
+    testWidgets(
+      'passing no constraintsBuilder falls back to using constraints for showModalBottomSheet',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return Center(
+                    child: ElevatedButton(
+                      child: const Text('Press me'),
+                      onPressed: () {
+                        showModalBottomSheet<void>(
+                          context: context,
+                          builder: (BuildContext context) => const Text('BottomSheet'),
+                          constraints: const BoxConstraints(maxWidth: 100),
+                        );
+                      },
+                    ),
+                  );
+                }
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('BottomSheet'), findsNothing);
+        await tester.tap(find.text('Press me'));
+        await tester.pumpAndSettle();
+        expect(find.text('BottomSheet'), findsOneWidget);
+
+        expect(
+          tester.getRect(find.text('BottomSheet')),
+          const Rect.fromLTRB(350, 572, 450, 600),
+        );
+    });
+
+    testWidgets(
+      'passing only constraintsBuilder uses builder constraints for showModalBottomSheet',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return Center(
+                    child: ElevatedButton(
+                      child: const Text('Press me'),
+                      onPressed: () {
+                        showModalBottomSheet<void>(
+                          context: context,
+                          builder: (BuildContext context) => const Text('BottomSheet'),
+                          constraintsBuilder: (BoxConstraints constraints) {
+                            return BoxConstraints(
+                              maxWidth: constraints.maxWidth / 2,
+                            );
+                          }
+                        );
+                      },
+                    ),
+                  );
+                }
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('BottomSheet'), findsNothing);
+        await tester.tap(find.text('Press me'));
+        await tester.pumpAndSettle();
+        expect(find.text('BottomSheet'), findsOneWidget);
+
+        expect(
+          tester.getRect(find.text('BottomSheet')),
+          const Rect.fromLTRB(323, 586, 477, 600),
+        );
+    });
+
+    testWidgets(
+      'passing both constraintsBuilder and constraints uses builder constraints for showModalBottomSheet',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return Center(
+                    child: ElevatedButton(
+                      child: const Text('Press me'),
+                      onPressed: () {
+                        showModalBottomSheet<void>(
+                          context: context,
+                          builder: (BuildContext context) => const Text('BottomSheet'),
+                          constraints: const BoxConstraints(maxWidth: 100),
+                          constraintsBuilder: (BoxConstraints constraints) {
+                            return BoxConstraints(
+                              maxWidth: constraints.maxWidth / 2,
+                            );
+                          }
+                        );
+                      },
+                    ),
+                  );
+                }
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('BottomSheet'), findsNothing);
+        await tester.tap(find.text('Press me'));
+        await tester.pumpAndSettle();
+        expect(find.text('BottomSheet'), findsOneWidget);
+
+        expect(
+          tester.getRect(find.text('BottomSheet')),
+          const Rect.fromLTRB(323, 586, 477, 600),
+        );
+    });
+
+    testWidgets(
+      'passing neither constraintsBuilder or constraints uses no constraints for showModalBottomSheet',
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (BuildContext context) {
+                  return Center(
+                    child: ElevatedButton(
+                      child: const Text('Press me'),
+                      onPressed: () {
+                        showModalBottomSheet<void>(
+                          context: context,
+                          builder: (BuildContext context) => const Text('BottomSheet'),
+                        );
+                      },
+                    ),
+                  );
+                }
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('BottomSheet'), findsNothing);
+        await tester.tap(find.text('Press me'));
+        await tester.pumpAndSettle();
+        expect(find.text('BottomSheet'), findsOneWidget);
+
+        expect(
+          tester.getRect(find.text('BottomSheet')),
+          const Rect.fromLTRB(0, 586, 800, 600),
+        );
+    });
   });
 }
 


### PR DESCRIPTION
This PR adds a `constraintsBuilder` argument to showModalBottomSheet() that allows for a more flexible constraint than the fixed `constraint` argument.

*List which issues are fixed by this PR.*
https://github.com/flutter/flutter/issues/100066

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

TODO: figure out what's up with the tests (I don't trust the results)