### PR TITLE
Export public API types from gestures/*.dart library

### DIFF
--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -19,6 +19,16 @@ import 'pointer_router.dart';
 import 'pointer_signal_resolver.dart';
 import 'resampler.dart';
 
+export 'dart:ui' show Offset;
+
+export 'package:flutter/foundation.dart' show DiagnosticsNode, InformationCollector;
+
+export 'arena.dart' show GestureArenaManager;
+export 'events.dart' show PointerEvent;
+export 'hit_test.dart' show HitTestEntry, HitTestTarget, HitTestResult;
+export 'pointer_router.dart' show PointerRouter;
+export 'pointer_signal_resolver.dart' show PointerSignalResolver;
+
 typedef _HandleSampleTimeChangedCallback = void Function();
 
 /// Class that implements clock used for sampling.

--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -7,6 +7,10 @@ import 'dart:ui' as ui show PointerData, PointerChange, PointerSignalKind;
 
 import 'events.dart';
 
+export 'dart:ui' show PointerData;
+
+export 'events.dart' show PointerEvent;
+
 // Add `kPrimaryButton` to [buttons] when a pointer of certain devices is down.
 //
 // TODO(tongmu): This patch is supposed to be done by embedders. Patching it

--- a/packages/flutter/lib/src/gestures/drag.dart
+++ b/packages/flutter/lib/src/gestures/drag.dart
@@ -2,8 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 import 'drag_details.dart';
+
+export 'drag_details.dart' show DragEndDetails, DragUpdateDetails;
 
 /// Interface for objects that receive updates about drags.
 ///

--- a/packages/flutter/lib/src/gestures/drag_details.dart
+++ b/packages/flutter/lib/src/gestures/drag_details.dart
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-import 'dart:ui' show Offset, PointerDeviceKind;
-
 import 'package:flutter/foundation.dart';
 
 import 'velocity_tracker.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'velocity_tracker.dart' show Velocity;
 
 /// Details object for callbacks that use [GestureDragDownCallback].
 ///

--- a/packages/flutter/lib/src/gestures/eager.dart
+++ b/packages/flutter/lib/src/gestures/eager.dart
@@ -2,10 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-import 'arena.dart';
-import 'events.dart';
 import 'recognizer.dart';
+
+export 'dart:ui' show PointerDeviceKind;
+
+export 'events.dart' show PointerDownEvent, PointerEvent;
 
 /// A gesture recognizer that eagerly claims victory in all gesture arenas.
 ///

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -13,6 +13,11 @@ import 'gesture_settings.dart';
 
 export 'dart:ui' show Offset, PointerDeviceKind;
 
+export 'package:flutter/foundation.dart' show DiagnosticPropertiesBuilder;
+export 'package:vector_math/vector_math_64.dart' show Matrix4;
+
+export 'gesture_settings.dart' show DeviceGestureSettings;
+
 /// The bit of [PointerEvent.buttons] that corresponds to a cross-device
 /// behavior of "primary operation".
 ///

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -3,9 +3,13 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart' show clampDouble;
-import 'arena.dart';
+
 import 'events.dart';
 import 'recognizer.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'events.dart' show PointerDownEvent, PointerEvent;
 
 enum _ForceState {
   // No pointer has touched down and the detector is ready for a pointer down to occur.

--- a/packages/flutter/lib/src/gestures/gesture_settings.dart
+++ b/packages/flutter/lib/src/gestures/gesture_settings.dart
@@ -3,7 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui;
+
 import 'package:flutter/foundation.dart';
+
+export 'dart:ui' show FlutterView;
 
 /// The device specific gesture settings scaled into logical pixels.
 ///

--- a/packages/flutter/lib/src/gestures/hit_test.dart
+++ b/packages/flutter/lib/src/gestures/hit_test.dart
@@ -8,6 +8,12 @@ import 'package:vector_math/vector_math_64.dart';
 
 import 'events.dart';
 
+export 'dart:ui' show Offset;
+
+export 'package:vector_math/vector_math_64.dart' show Matrix4;
+
+export 'events.dart' show PointerEvent;
+
 /// An object that can hit-test pointers.
 abstract class HitTestable {
   // This class is intended to be used as an interface, and should not be

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -2,12 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-import 'arena.dart';
 import 'constants.dart';
 import 'events.dart';
 import 'recognizer.dart';
 import 'velocity_tracker.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'arena.dart' show GestureDisposition;
+export 'events.dart' show PointerDownEvent, PointerEvent;
+export 'velocity_tracker.dart' show Velocity;
 
 /// Callback signature for [LongPressGestureRecognizer.onLongPressDown].
 ///

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -3,14 +3,22 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:vector_math/vector_math_64.dart';
 
-import 'arena.dart';
 import 'constants.dart';
 import 'drag_details.dart';
 import 'events.dart';
 import 'recognizer.dart';
 import 'velocity_tracker.dart';
+
+export 'dart:ui' show PointerDeviceKind;
+
+export 'package:flutter/foundation.dart' show DiagnosticPropertiesBuilder;
+
+export 'drag.dart' show DragEndDetails, DragUpdateDetails;
+export 'drag_details.dart' show DragDownDetails, DragStartDetails, DragUpdateDetails, GestureDragDownCallback, GestureDragStartCallback, GestureDragUpdateCallback;
+export 'events.dart' show PointerDownEvent, PointerEvent, PointerPanZoomStartEvent;
+export 'recognizer.dart' show DragStartBehavior;
+export 'velocity_tracker.dart' show VelocityEstimate, VelocityTracker;
 
 enum _DragState {
   ready,

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -13,9 +13,15 @@ import 'constants.dart';
 import 'drag.dart';
 import 'drag_details.dart';
 import 'events.dart';
-import 'gesture_settings.dart';
 import 'recognizer.dart';
 import 'velocity_tracker.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'arena.dart' show GestureDisposition;
+export 'drag.dart' show Drag;
+export 'events.dart' show PointerDownEvent;
+export 'gesture_settings.dart' show DeviceGestureSettings;
 
 /// Signature for when [MultiDragGestureRecognizer] recognizes the start of a drag gesture.
 typedef GestureMultiDragStartCallback = Drag? Function(Offset position);

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -3,16 +3,19 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'arena.dart';
 import 'binding.dart';
 import 'constants.dart';
 import 'events.dart';
-import 'gesture_settings.dart';
 import 'pointer_router.dart';
 import 'recognizer.dart';
 import 'tap.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'events.dart' show PointerDownEvent;
+export 'tap.dart' show GestureTapCancelCallback, GestureTapDownCallback, TapDownDetails, TapUpDetails;
 
 /// Signature for callback when the user has tapped the screen at the same
 /// location twice in quick succession.

--- a/packages/flutter/lib/src/gestures/pointer_router.dart
+++ b/packages/flutter/lib/src/gestures/pointer_router.dart
@@ -4,9 +4,12 @@
 
 
 import 'package:flutter/foundation.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'events.dart';
+
+export 'package:vector_math/vector_math_64.dart' show Matrix4;
+
+export 'events.dart' show PointerEvent;
 
 /// A callback that receives a [PointerEvent]
 typedef PointerRoute = void Function(PointerEvent event);

--- a/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
+++ b/packages/flutter/lib/src/gestures/pointer_signal_resolver.dart
@@ -6,6 +6,8 @@ import 'package:flutter/foundation.dart';
 
 import 'events.dart';
 
+export 'events.dart' show PointerSignalEvent;
+
 /// The callback to register with a [PointerSignalResolver] to express
 /// interest in a pointer signal event.
 typedef PointerSignalResolvedCallback = void Function(PointerSignalEvent event);

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -7,17 +7,23 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/foundation.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'arena.dart';
 import 'binding.dart';
 import 'constants.dart';
 import 'debug.dart';
 import 'events.dart';
-import 'gesture_settings.dart';
 import 'pointer_router.dart';
 import 'team.dart';
 
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'package:flutter/foundation.dart' show DiagnosticPropertiesBuilder;
+export 'package:vector_math/vector_math_64.dart' show Matrix4;
+
+export 'arena.dart' show GestureDisposition;
+export 'events.dart' show PointerDownEvent, PointerEvent, PointerPanZoomStartEvent;
+export 'gesture_settings.dart' show DeviceGestureSettings;
 export 'pointer_router.dart' show PointerRouter;
 
 /// Generic signature for callbacks passed to

--- a/packages/flutter/lib/src/gestures/resampler.dart
+++ b/packages/flutter/lib/src/gestures/resampler.dart
@@ -6,6 +6,8 @@ import 'dart:collection';
 
 import 'events.dart';
 
+export 'events.dart' show PointerEvent;
+
 /// A callback used by [PointerEventResampler.sample] and
 /// [PointerEventResampler.stop] to process a resampled `event`.
 typedef HandleEventCallback = void Function(PointerEvent event);

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -4,13 +4,17 @@
 
 import 'dart:math' as math;
 
-import 'package:vector_math/vector_math_64.dart';
-
-import 'arena.dart';
 import 'constants.dart';
 import 'events.dart';
 import 'recognizer.dart';
 import 'velocity_tracker.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'events.dart' show PointerDownEvent, PointerEvent, PointerPanZoomStartEvent;
+export 'recognizer.dart' show DragStartBehavior;
+export 'velocity_tracker.dart' show Velocity;
+
 
 /// The possible states of a [ScaleGestureRecognizer].
 enum _ScaleState {

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -4,12 +4,19 @@
 
 
 import 'package:flutter/foundation.dart';
-import 'package:vector_math/vector_math_64.dart' show Matrix4;
 
 import 'arena.dart';
 import 'constants.dart';
 import 'events.dart';
 import 'recognizer.dart';
+
+export 'dart:ui' show Offset, PointerDeviceKind;
+
+export 'package:flutter/foundation.dart' show DiagnosticPropertiesBuilder;
+export 'package:vector_math/vector_math_64.dart' show Matrix4;
+
+export 'arena.dart' show GestureDisposition;
+export 'events.dart' show PointerCancelEvent, PointerDownEvent, PointerEvent, PointerUpEvent;
 
 /// Details for [GestureTapDownCallback], such as position.
 ///

--- a/packages/flutter/lib/src/gestures/team.dart
+++ b/packages/flutter/lib/src/gestures/team.dart
@@ -6,6 +6,8 @@
 import 'arena.dart';
 import 'binding.dart';
 
+export 'arena.dart' show GestureArenaEntry, GestureArenaMember;
+
 class _CombiningGestureArenaEntry implements GestureArenaEntry {
   _CombiningGestureArenaEntry(this._combiner, this._member);
 

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -8,7 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'events.dart';
 import 'lsq_solver.dart';
 
-export 'dart:ui' show Offset;
+export 'dart:ui' show Offset, PointerDeviceKind;
 
 /// A velocity in two dimensions.
 @immutable

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -11,7 +11,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'box.dart';
 import 'custom_paint.dart';

--- a/packages/flutter/lib/src/rendering/mouse_tracker.dart
+++ b/packages/flutter/lib/src/rendering/mouse_tracker.dart
@@ -14,8 +14,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/services.dart';
 
-import 'package:vector_math/vector_math_64.dart' show Matrix4;
-
 import 'object.dart';
 
 export 'package:flutter/services.dart' show

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -10,7 +10,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
 import 'package:flutter/semantics.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'debug.dart';
 import 'layer.dart';

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -10,8 +10,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 
-import 'package:vector_math/vector_math_64.dart';
-
 import 'box.dart';
 import 'debug.dart';
 import 'layer.dart';

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -10,8 +10,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 
-import 'package:vector_math/vector_math_64.dart';
-
 import 'box.dart';
 import 'layer.dart';
 import 'layout_helper.dart';

--- a/packages/flutter/lib/src/rendering/sliver.dart
+++ b/packages/flutter/lib/src/rendering/sliver.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 import 'box.dart';
 import 'debug.dart';

--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -8,7 +8,9 @@ import 'package:flutter/foundation.dart';
 
 import 'binding.dart';
 
-export 'package:flutter/foundation.dart' show DiagnosticsNode, VoidCallback;
+export 'dart:ui' show VoidCallback;
+
+export 'package:flutter/foundation.dart' show DiagnosticsNode;
 
 /// Signature for the callback passed to the [Ticker] class's constructor.
 ///

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/gestures.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
 

--- a/packages/flutter/test/gestures/hit_test_test.dart
+++ b/packages/flutter/test/gestures/hit_test_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 void main() {
   test('wrapped HitTestResult gets HitTestEntry added to wrapping HitTestResult', () async {

--- a/packages/flutter/test/gestures/pointer_router_test.dart
+++ b/packages/flutter/test/gestures/pointer_router_test.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 void main() {
   test('Should route pointers', () {

--- a/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
+++ b/packages/flutter/test/gestures/pointer_signal_resolver_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:vector_math/vector_math_64.dart';
 
 class TestPointerSignalListener {
   TestPointerSignalListener(this.event);


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/58731 this PR exports public API types from gestures/*.dart library.

Before this PR the namespace export by gesture.dart was (outside of gesture):
* `export 'dart:ui' show Offset, PointerDeviceKind;`

After this PR:
* `export 'dart:ui' show FlutterView, Offset, PointerDeviceKind;`
* `export 'package:flutter/foundation.dart' show DiagnosticsNode, DiagnosticPropertiesBuilder, InformationCollector;`
* `export 'package:vector_math/vector_math_64.dart' show Matrix4;`