### PR TITLE
Fix/cursor height

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -255,6 +255,7 @@ class CupertinoTextField extends StatefulWidget {
     this.enabled,
     this.cursorWidth = 2.0,
     this.cursorHeight,
+    this.fixedCursorHeight = false,
     this.cursorRadius = const Radius.circular(2.0),
     this.cursorColor,
     this.selectionHeightStyle = ui.BoxHeightStyle.tight,
@@ -415,6 +416,7 @@ class CupertinoTextField extends StatefulWidget {
     this.enabled,
     this.cursorWidth = 2.0,
     this.cursorHeight,
+    this.fixedCursorHeight = false,
     this.cursorRadius = const Radius.circular(2.0),
     this.cursorColor,
     this.selectionHeightStyle = ui.BoxHeightStyle.tight,
@@ -708,6 +710,9 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.cursorHeight}
   final double? cursorHeight;
 
+  /// {@macro flutter.widgets.editableText.fixedCursorHeight}
+  final bool fixedCursorHeight;
+
   /// {@macro flutter.widgets.editableText.cursorRadius}
   final Radius cursorRadius;
 
@@ -809,6 +814,7 @@ class CupertinoTextField extends StatefulWidget {
     properties.add(EnumProperty<MaxLengthEnforcement>('maxLengthEnforcement', maxLengthEnforcement, defaultValue: null));
     properties.add(DoubleProperty('cursorWidth', cursorWidth, defaultValue: 2.0));
     properties.add(DoubleProperty('cursorHeight', cursorHeight, defaultValue: null));
+    properties.add(DiagnosticsProperty<bool>('fixedCursorHeight', fixedCursorHeight, defaultValue: false));
     properties.add(DiagnosticsProperty<Radius>('cursorRadius', cursorRadius, defaultValue: null));
     properties.add(createCupertinoColorProperty('cursorColor', cursorColor, defaultValue: null));
     properties.add(FlagProperty('selectionEnabled', value: selectionEnabled, defaultValue: true, ifFalse: 'selection disabled'));
@@ -1267,6 +1273,7 @@ class _CupertinoTextFieldState extends State<CupertinoTextField> with Restoratio
             rendererIgnoresPointer: true,
             cursorWidth: widget.cursorWidth,
             cursorHeight: widget.cursorHeight,
+            fixedCursorHeight: widget.fixedCursorHeight,
             cursorRadius: widget.cursorRadius,
             cursorColor: cursorColor,
             cursorOpacityAnimates: true,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -310,6 +310,7 @@ class TextField extends StatefulWidget {
     this.enabled,
     this.cursorWidth = 2.0,
     this.cursorHeight,
+    this.fixedCursorHeight = false,
     this.cursorRadius,
     this.cursorColor,
     this.selectionHeightStyle = ui.BoxHeightStyle.tight,
@@ -606,6 +607,9 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.cursorHeight}
   final double? cursorHeight;
 
+  /// {@macro flutter.widgets.editableText.fixedCursorHeight}
+  final bool? fixedCursorHeight;
+
   /// {@macro flutter.widgets.editableText.cursorRadius}
   final Radius? cursorRadius;
 
@@ -797,6 +801,7 @@ class TextField extends StatefulWidget {
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(DoubleProperty('cursorWidth', cursorWidth, defaultValue: 2.0));
     properties.add(DoubleProperty('cursorHeight', cursorHeight, defaultValue: null));
+    properties.add(DiagnosticsProperty<bool>('fixedCursorHeight', fixedCursorHeight, defaultValue: false));
     properties.add(DiagnosticsProperty<Radius>('cursorRadius', cursorRadius, defaultValue: null));
     properties.add(ColorProperty('cursorColor', cursorColor, defaultValue: null));
     properties.add(DiagnosticsProperty<Brightness>('keyboardAppearance', keyboardAppearance, defaultValue: null));
@@ -1258,6 +1263,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           mouseCursor: MouseCursor.defer, // TextField will handle the cursor
           cursorWidth: widget.cursorWidth,
           cursorHeight: widget.cursorHeight,
+          fixedCursorHeight: widget.fixedCursorHeight,
           cursorRadius: cursorRadius,
           cursorColor: cursorColor,
           selectionHeightStyle: widget.selectionHeightStyle,

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -608,7 +608,7 @@ class TextField extends StatefulWidget {
   final double? cursorHeight;
 
   /// {@macro flutter.widgets.editableText.fixedCursorHeight}
-  final bool? fixedCursorHeight;
+  final bool fixedCursorHeight;
 
   /// {@macro flutter.widgets.editableText.cursorRadius}
   final Radius? cursorRadius;

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -310,6 +310,7 @@ class TextField extends StatefulWidget {
     this.enabled,
     this.cursorWidth = 2.0,
     this.cursorHeight,
+    this.fixedCursorHeight = false,
     this.cursorRadius,
     this.cursorColor,
     this.selectionHeightStyle = ui.BoxHeightStyle.tight,
@@ -606,6 +607,9 @@ class TextField extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.cursorHeight}
   final double? cursorHeight;
 
+  /// {@macro flutter.widgets.editableText.fixedCursorHeight}
+  final bool fixedCursorHeight;
+
   /// {@macro flutter.widgets.editableText.cursorRadius}
   final Radius? cursorRadius;
 
@@ -797,6 +801,7 @@ class TextField extends StatefulWidget {
     properties.add(EnumProperty<TextDirection>('textDirection', textDirection, defaultValue: null));
     properties.add(DoubleProperty('cursorWidth', cursorWidth, defaultValue: 2.0));
     properties.add(DoubleProperty('cursorHeight', cursorHeight, defaultValue: null));
+    properties.add(DiagnosticsProperty<bool>('fixedCursorHeight', fixedCursorHeight, defaultValue: false));
     properties.add(DiagnosticsProperty<Radius>('cursorRadius', cursorRadius, defaultValue: null));
     properties.add(ColorProperty('cursorColor', cursorColor, defaultValue: null));
     properties.add(DiagnosticsProperty<Brightness>('keyboardAppearance', keyboardAppearance, defaultValue: null));
@@ -1258,6 +1263,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
           mouseCursor: MouseCursor.defer, // TextField will handle the cursor
           cursorWidth: widget.cursorWidth,
           cursorHeight: widget.cursorHeight,
+          fixedCursorHeight: widget.fixedCursorHeight,
           cursorRadius: cursorRadius,
           cursorColor: cursorColor,
           selectionHeightStyle: widget.selectionHeightStyle,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1083,10 +1083,6 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// {@endtemplate}
   bool get fixedCursorHeight => _fixedCursorHeight;
   bool _fixedCursorHeight = false;
-  set fixedCursorHeight(bool value) {
-    if (_fixedCursorHeight == value) return;
-    _fixedCursorHeight = value;
-  }
 
   /// {@template flutter.rendering.RenderEditable.paintCursorAboveText}
   /// If the cursor should be painted on top of the text or underneath it.

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -265,6 +265,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     Locale? locale,
     double cursorWidth = 1.0,
     double? cursorHeight,
+    bool fixedCursorHeight = false,
     Radius? cursorRadius,
     bool paintCursorAboveText = false,
     Offset cursorOffset = Offset.zero,
@@ -329,6 +330,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
        _offset = offset,
        _cursorWidth = cursorWidth,
        _cursorHeight = cursorHeight,
+       _fixedCursorHeight = fixedCursorHeight,
        _paintCursorOnTop = paintCursorAboveText,
        _enableInteractiveSelection = enableInteractiveSelection,
        _devicePixelRatio = devicePixelRatio,
@@ -1073,6 +1075,18 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     }
     _cursorHeight = value;
     markNeedsLayout();
+  }
+
+  /// {@template flutter.rendering.RenderEditable.fixedCursorHeight}
+  /// If the cursor height should be fixed.
+  ///
+  /// {@endtemplate}
+  bool get fixedCursorHeight => _fixedCursorHeight;
+  bool _fixedCursorHeight;
+
+  set fixedCursorHeight(bool value) {
+    if (_fixedCursorHeight == value) return;
+    _fixedCursorHeight = value;
   }
 
   /// {@template flutter.rendering.RenderEditable.paintCursorAboveText}
@@ -2944,6 +2958,14 @@ class _FloatingCursorPainter extends RenderEditablePainter {
     }
 
     caretRect = caretRect.shift(renderEditable._paintOffset);
+
+    //If fixed cursorHeight, caretRect top bottom will fixed
+    if (renderEditable.fixedCursorHeight != null &&
+        renderEditable.fixedCursorHeight) {
+      caretRect = Rect.fromLTRB(caretRect.left, 0.0, caretRect.right,
+          renderEditable.cursorHeight + 2.0);
+    }
+
     final Rect integralRect = caretRect.shift(renderEditable._snapToPhysicalPixel(caretRect.topLeft));
 
     if (shouldPaint) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3464,6 +3464,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
                         rendererIgnoresPointer: widget.rendererIgnoresPointer,
                         cursorWidth: widget.cursorWidth,
                         cursorHeight: widget.cursorHeight,
+                        fixedCursorHeight: widget.fixedCursorHeight,
                         cursorRadius: widget.cursorRadius,
                         cursorOffset: widget.cursorOffset ?? Offset.zero,
                         selectionHeightStyle: widget.selectionHeightStyle,
@@ -3567,6 +3568,7 @@ class _Editable extends MultiChildRenderObjectWidget {
     this.rendererIgnoresPointer = false,
     required this.cursorWidth,
     this.cursorHeight,
+    this.fixedCursorHeight = false,
     this.cursorRadius,
     required this.cursorOffset,
     required this.paintCursorAboveText,
@@ -3623,6 +3625,7 @@ class _Editable extends MultiChildRenderObjectWidget {
   final bool rendererIgnoresPointer;
   final double cursorWidth;
   final double? cursorHeight;
+  final bool fixedCursorHeight;
   final Radius? cursorRadius;
   final Offset cursorOffset;
   final bool paintCursorAboveText;
@@ -3666,6 +3669,7 @@ class _Editable extends MultiChildRenderObjectWidget {
       textWidthBasis: textWidthBasis,
       cursorWidth: cursorWidth,
       cursorHeight: cursorHeight,
+      fixedCursorHeight: fixedCursorHeight,
       cursorRadius: cursorRadius,
       cursorOffset: cursorOffset,
       paintCursorAboveText: paintCursorAboveText,

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -532,6 +532,7 @@ class EditableText extends StatefulWidget {
     this.rendererIgnoresPointer = false,
     this.cursorWidth = 2.0,
     this.cursorHeight,
+    this.fixedCursorHeight = false,
     this.cursorRadius,
     this.cursorOpacityAnimates = false,
     this.cursorOffset,
@@ -1175,6 +1176,13 @@ class EditableText extends StatefulWidget {
   /// If this property is null, [RenderEditable.preferredLineHeight] will be used.
   /// {@endtemplate}
   final double? cursorHeight;
+
+  /// {@template flutter.widgets.editableText.fixedCursorHeight}
+  /// How tall the cursor will be.
+  ///
+  /// If this property is null, [RenderEditable.preferredLineHeight] will be used.
+  /// {@endtemplate}
+  final bool? fixedCursorHeight;
 
   /// {@template flutter.widgets.editableText.cursorRadius}
   /// How rounded the corners of the cursor should be.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1182,7 +1182,7 @@ class EditableText extends StatefulWidget {
   ///
   /// If this property is null, [RenderEditable.preferredLineHeight] will be used.
   /// {@endtemplate}
-  final bool? fixedCursorHeight;
+  final bool fixedCursorHeight;
 
   /// {@template flutter.widgets.editableText.cursorRadius}
   /// How rounded the corners of the cursor should be.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -699,6 +699,7 @@ void main() {
     expect(textField.cursorWidth, 2.0);
     expect(textField.cursorHeight, null);
     expect(textField.cursorRadius, null);
+    expect(textField.fixedCursorHeight, false);
   });
 
   testWidgets('cursor has expected radius value', (WidgetTester tester) async {
@@ -9033,6 +9034,7 @@ void main() {
       enabled: false,
       cursorWidth: 1.0,
       cursorHeight: 1.0,
+      fixedCursorHeight: true,
       cursorRadius: Radius.zero,
       cursorColor: Color(0xff00ff00),
       keyboardAppearance: Brightness.dark,
@@ -9061,6 +9063,7 @@ void main() {
       'textDirection: ltr',
       'cursorWidth: 1.0',
       'cursorHeight: 1.0',
+      'fixedCursorHeight: true',
       'cursorRadius: Radius.circular(0.0)',
       'cursorColor: Color(0xff00ff00)',
       'keyboardAppearance: Brightness.dark',

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -258,6 +258,7 @@ void main() {
     expect(editableText.textAlign, TextAlign.start);
     expect(editableText.cursorWidth, 2.0);
     expect(editableText.cursorHeight, isNull);
+    expect(editableText.fixedCursorHeight, false);
     expect(editableText.textHeightBehavior, isNull);
   });
 


### PR DESCRIPTION
## sorry
my first pr and mistake here:

[https://github.com/flutter/flutter/pull/96212](url) 
[https://github.com/flutter/flutter/pull/105885](url) 
[https://github.com/flutter/flutter/pull/105884](url) 

please close pr, thank you;


## issues
[https://github.com/flutter/flutter/issues/92080](url)

On the IOS platform
it is not entered by default : renderEidtable._caretPrototype = Rect.fromLTRB(0.0, 0.0, 2.0, 21.0)

_caretPrototype calculated value from : _caretPrototype = Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight + 2)

```
 void _computeCaretPrototype() {
    assert(defaultTargetPlatform != null);
    switch (defaultTargetPlatform) {
      case TargetPlatform.iOS:
      case TargetPlatform.macOS:
        _caretPrototype = Rect.fromLTWH(0.0, 0.0, cursorWidth, cursorHeight + 2);
        break;
      case TargetPlatform.android:
      case TargetPlatform.fuchsia:
      case TargetPlatform.linux:
      case TargetPlatform.windows:
        _caretPrototype = Rect.fromLTWH(0.0, _kCaretHeightOffset, cursorWidth, cursorHeight - 2.0 * _kCaretHeightOffset);
        break;
    }
  }
```

Execute the code to the following image ： caretRect = Rect.fromLTRB(-1.0, 0.0, 1.0, 21.0)

![undefined](https://camo.githubusercontent.com/161a3d78089f4ec91f7bcbcfba2685513a7d0648d43670114efd32943b6d24d7/68747470733a2f2f696d672e616c6963646e2e636f6d2f696d6765787472612f69342f4f31434e3031436839753175314963656a7268364b76705f2121363030303030303030303931342d322d7470732d313630342d3235382e706e67) 


When input enters some text, Execute the code to the following image ： caretRect = Rect.fromLTRB(6.4, -1.0, 8.4, 20.0)

![undefined](https://camo.githubusercontent.com/26cc45089f20b2d12ba07868fbc538d7fc6692583a0acad7b34f07725f0e3c71/68747470733a2f2f696d672e616c6963646e2e636f6d2f696d6765787472612f69342f4f31434e3031344e4e425a31315176754a5568506e63385f2121363030303030303030323033392d322d7470732d313731302d3231322e706e67) 

When no text is entered ： cursorHeight = 21.0 - 0.0 = 21.0 ；

When entering text ： cursorHeight = 20.0 - （-1.0） = 21.0 ；

On the Android platform
it is not entered by default : renderEidtable._caretPrototype = Rect.fromLTRB(0.0, 2.0, 2.0, 17.0)

Execute the code to the following image ： caretRect = Rect.fromLTRB(0.0, 2.0, 2.0, 17.0)

![undefined](https://camo.githubusercontent.com/75570ede3f1479ea86eaa20d193482d8f8af43bd106183e922fb453f710d34fe/68747470733a2f2f696d672e616c6963646e2e636f6d2f696d6765787472612f69342f4f31434e303171566a674951316b6e766a4370577146695f2121363030303030303030343732392d322d7470732d313534342d3231302e706e67) 

When input enters some text, Execute the code to the following image ：caretRect = Rect.fromLTRB(9.0, 0.3, 11.0, 19.0)

![undefined](https://camo.githubusercontent.com/d033ac58983f7d2326ceda4b2e21ebd37870327ae9cefd7584fa74e7de8d625b/68747470733a2f2f696d672e616c6963646e2e636f6d2f696d6765787472612f69342f4f31434e3031477a3467676e317a42657278536754556c5f2121363030303030303030363637362d322d7470732d313735322d3231382e706e67) 

When no text is entered ：cursorHeight = 17.0 - 2.0 = 15.0 ；

When entering text ： cursorHeight = 19.0 - 0.3 = 18.7 ；

## Solution
Whether the cursor height is fixed by setting a marker bit ： fixedCursorHeight；

Refer to the top / bottom of the default cursor area of iOS platform, reset caretrect to fix cursorHeight;

```
   caretRect = caretRect.shift(renderEditable._paintOffset);

    //If fixed cursorHeight, caretRect top bottom will fixed
    if (renderEditable.fixedCursorHeight != null && renderEditable.fixedCursorHeight) {
      caretRect = Rect.fromLTRB(caretRect.left, 0.0, caretRect.right, renderEditable.cursorHeight + 2.0);
    }

    final Rect integralRect = caretRect.shift(renderEditable._snapToPhysicalPixel(caretRect.topLeft));
```

