### PR TITLE
Ignore context import warning in tool tests that only need `late`s

### DIFF
--- a/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_studio_validator.dart';
 import 'package:flutter_tools/src/base/config.dart';
@@ -15,6 +13,7 @@ import 'package:flutter_tools/src/doctor_validator.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../src/context.dart';
 
 const String home = '/home/me';
@@ -24,8 +23,8 @@ final Platform linuxPlatform = FakePlatform(
 );
 
 void main() {
-  FileSystem fileSystem;
-  FakeProcessManager fakeProcessManager;
+  late FileSystem fileSystem;
+  late FakeProcessManager fakeProcessManager;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();

--- a/packages/flutter_tools/test/general.shard/android/deferred_components_prebuild_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/deferred_components_prebuild_validator_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/deferred_components_prebuild_validator.dart';
 import 'package:flutter_tools/src/android/deferred_components_validator.dart';
@@ -13,14 +11,15 @@ import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 
 import '../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../src/context.dart';
 
 void main() {
-  FileSystem fileSystem;
-  BufferLogger logger;
-  Directory projectDir;
-  Platform platform;
-  Directory flutterRootDir;
+  late FileSystem fileSystem;
+  late BufferLogger logger;
+  late Directory projectDir;
+  late Platform platform;
+  late Directory flutterRootDir;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();

--- a/packages/flutter_tools/test/general.shard/android/multidex_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/multidex_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/multidex.dart';
@@ -11,6 +9,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../src/context.dart';
 
 void main() {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/android_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -17,14 +15,15 @@ import 'package:flutter_tools/src/build_system/targets/android.dart';
 import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 import '../../../src/fake_process_manager.dart';
 
 void main() {
-  FakeProcessManager processManager;
-  FileSystem fileSystem;
-  Artifacts artifacts;
-  Logger logger;
+  late FakeProcessManager processManager;
+  late FileSystem fileSystem;
+  late Artifacts artifacts;
+  late Logger logger;
 
   setUp(() {
     logger = BufferLogger.test();

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -17,6 +15,7 @@ import 'package:flutter_tools/src/build_system/targets/ios.dart';
 import 'package:flutter_tools/src/compile.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 import '../../../src/fake_process_manager.dart';
 
@@ -26,12 +25,12 @@ const String kAssemblyAot = '--snapshot_kind=app-aot-assembly';
 
 final Platform macPlatform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{});
 void main() {
-  FakeProcessManager processManager;
-  Environment androidEnvironment;
-  Environment iosEnvironment;
-  Artifacts artifacts;
-  FileSystem fileSystem;
-  Logger logger;
+  late FakeProcessManager processManager;
+  late Environment androidEnvironment;
+  late Environment iosEnvironment;
+  late Artifacts artifacts;
+  late FileSystem fileSystem;
+  late Logger logger;
 
   setUp(() {
     processManager = FakeProcessManager.empty();

--- a/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/dart_plugin_registrant_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 // TODO(gspencergoog): Remove this tag once this test's state leaks/test
 // dependencies have been fixed.
 // https://github.com/flutter/flutter/issues/85160
@@ -20,6 +18,7 @@ import 'package:flutter_tools/src/build_system/targets/dart_plugin_registrant.da
 import 'package:flutter_tools/src/project.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 
 const String _kEmptyPubspecFile = '''

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -16,6 +14,7 @@ import 'package:flutter_tools/src/build_system/targets/ios.dart';
 import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 
 final Platform macPlatform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{});
@@ -39,11 +38,11 @@ const List<String> _kSharedConfig = <String>[
 ];
 
 void main() {
-  Environment environment;
-  FileSystem fileSystem;
-  FakeProcessManager processManager;
-  Artifacts artifacts;
-  BufferLogger logger;
+  late Environment environment;
+  late FileSystem fileSystem;
+  late FakeProcessManager processManager;
+  late Artifacts artifacts;
+  late BufferLogger logger;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -323,13 +322,13 @@ void main() {
   });
 
   group('copies Flutter.framework', () {
-    Directory outputDir;
-    File binary;
-    FakeCommand copyPhysicalFrameworkCommand;
-    FakeCommand lipoCommandNonFatResult;
-    FakeCommand lipoVerifyArm64Command;
-    FakeCommand bitcodeStripCommand;
-    FakeCommand adHocCodesignCommand;
+    late Directory outputDir;
+    late File binary;
+    late FakeCommand copyPhysicalFrameworkCommand;
+    late FakeCommand lipoCommandNonFatResult;
+    late FakeCommand lipoVerifyArm64Command;
+    late FakeCommand bitcodeStripCommand;
+    late FakeCommand adHocCodesignCommand;
 
     setUp(() {
       final FileSystem fileSystem = MemoryFileSystem.test();

--- a/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/linux_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -16,6 +14,7 @@ import 'package:flutter_tools/src/build_system/targets/linux.dart';
 import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 
 void main() {
@@ -90,7 +89,7 @@ void main() {
   });
 
   // Only required for the test below that still depends on the context.
-  FileSystem fileSystem;
+  late FileSystem fileSystem;
   setUp(() {
     fileSystem = MemoryFileSystem.test();
   });

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -15,20 +13,21 @@ import 'package:flutter_tools/src/build_system/targets/macos.dart';
 import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 import '../../../src/fake_process_manager.dart';
 
 void main() {
-  Environment environment;
-  FileSystem fileSystem;
-  Artifacts artifacts;
-  FakeProcessManager processManager;
-  File binary;
-  BufferLogger logger;
-  FakeCommand copyFrameworkCommand;
-  FakeCommand lipoInfoNonFatCommand;
-  FakeCommand lipoInfoFatCommand;
-  FakeCommand lipoVerifyX86_64Command;
+  late Environment environment;
+  late FileSystem fileSystem;
+  late Artifacts artifacts;
+  late FakeProcessManager processManager;
+  late File binary;
+  late BufferLogger logger;
+  late FakeCommand copyFrameworkCommand;
+  late FakeCommand lipoInfoNonFatCommand;
+  late FakeCommand lipoInfoFatCommand;
+  late FakeCommand lipoVerifyX86_64Command;
 
   setUp(() {
     processManager = FakeProcessManager.empty();

--- a/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/windows_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/artifacts.dart';
@@ -17,6 +15,7 @@ import 'package:flutter_tools/src/build_system/targets/windows.dart';
 import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../../src/context.dart';
 
 void main() {
@@ -120,7 +119,7 @@ void main() {
   });
 
   // AssetBundleFactory still uses context injection
-  FileSystem fileSystem;
+  late FileSystem fileSystem;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test(style: FileSystemStyle.windows);

--- a/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
+++ b/packages/flutter_tools/test/general.shard/bundle_builder_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/config.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -15,6 +13,7 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/project.dart';
 
 import '../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../src/context.dart';
 import '../src/test_build_system.dart';
 
@@ -71,7 +70,7 @@ void main() {
     final String mainPath = globals.fs.path.join('lib', 'main.dart');
     const String assetDirPath = 'example';
     const String depfilePath = 'example.d';
-    Environment env;
+    late Environment env;
     final BuildSystem buildSystem = TestBuildSystem.all(
       BuildResult(success: true),
       (Target target, Environment environment) {

--- a/packages/flutter_tools/test/general.shard/create_config_test.dart
+++ b/packages/flutter_tools/test/general.shard/create_config_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:flutter_tools/src/commands/create_base.dart';
 
 import '../src/common.dart';

--- a/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
+++ b/packages/flutter_tools/test/general.shard/fuchsia/fuchsia_pm_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/fuchsia/fuchsia_pm.dart';
@@ -11,14 +9,15 @@ import 'package:flutter_tools/src/fuchsia/fuchsia_sdk.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 
 void main() {
   group('FuchsiaPM', () {
-    File pm;
-    FakeProcessManager fakeProcessManager;
-    FakeFuchsiaArtifacts fakeFuchsiaArtifacts;
+    late File pm;
+    late FakeProcessManager fakeProcessManager;
+    late FakeFuchsiaArtifacts fakeFuchsiaArtifacts;
 
     setUp(() {
       pm = MemoryFileSystem.test().file('pm');

--- a/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_device_project_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
@@ -18,11 +16,12 @@ import 'package:flutter_tools/src/ios/mac.dart';
 import 'package:flutter_tools/src/project.dart';
 
 import '../../src/common.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import '../../src/context.dart';
 
 // FlutterProject still depends on context.
 void main() {
-  FileSystem fileSystem;
+  late FileSystem fileSystem;
 
   // This setup is required to inject the context.
   setUp(() {

--- a/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_file_invalidator_test.dart
@@ -2,14 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/multi_root_file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/convert.dart';
+// ignore: import_of_legacy_library_into_null_safe
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:package_config/package_config.dart';
 

--- a/packages/flutter_tools/test/general.shard/web/migrations/scrub_generated_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/migrations/scrub_generated_plugin_registrant_test.dart
@@ -2,15 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart = 2.8
-
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/build_system/build_system.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build.dart';
 
-import '../../../src/context.dart'; // legacy
+// ignore: import_of_legacy_library_into_null_safe
+import '../../../src/context.dart';
 import '../../../src/test_build_system.dart';
 import '../../../src/test_flutter_command_runner.dart'; // legacy
 
@@ -22,13 +21,13 @@ void main() {
 
   group('ScrubGeneratedPluginRegistrant', () {
     // The files this migration deals with
-    File gitignore;
-    File registrant;
+    late File gitignore;
+    late File registrant;
 
     // Environment overrides
-    FileSystem fileSystem;
-    ProcessManager processManager;
-    BuildSystem buildSystem;
+    late FileSystem fileSystem;
+    late ProcessManager processManager;
+    late BuildSystem buildSystem;
 
     setUp(() {
       // Prepare environment overrides


### PR DESCRIPTION
Migrate some test files to null safety after ignoring null unsafe `context.dart`.  The only other changes to these tests was the addition of `late`.

Part of https://github.com/flutter/flutter/issues/71511

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
