### PR TITLE
Added useMaterial3 parameters to the light, dark and fallback ThemeData constructors.

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -961,13 +961,19 @@ class ThemeData with Diagnosticable {
   ///
   /// This theme does not contain text geometry. Instead, it is expected that
   /// this theme is localized using text geometry using [ThemeData.localize].
-  factory ThemeData.light() => ThemeData(brightness: Brightness.light);
+  factory ThemeData.light({bool? useMaterial3}) => ThemeData(
+    brightness: Brightness.light,
+    useMaterial3: useMaterial3,
+  );
 
   /// A default dark theme with a teal secondary [ColorScheme] color.
   ///
   /// This theme does not contain text geometry. Instead, it is expected that
   /// this theme is localized using text geometry using [ThemeData.localize].
-  factory ThemeData.dark() => ThemeData(brightness: Brightness.dark);
+  factory ThemeData.dark({bool? useMaterial3}) => ThemeData(
+    brightness: Brightness.dark,
+    useMaterial3: useMaterial3,
+  );
 
   /// The default color theme. Same as [ThemeData.light].
   ///
@@ -978,7 +984,7 @@ class ThemeData with Diagnosticable {
   ///
   /// Most applications would use [Theme.of], which provides correct localized
   /// text geometry.
-  factory ThemeData.fallback() => ThemeData.light();
+  factory ThemeData.fallback({bool? useMaterial3}) => ThemeData.light(useMaterial3: useMaterial3);
 
   /// The overall theme brightness.
   ///

--- a/packages/flutter/test/material/theme_data_test.dart
+++ b/packages/flutter/test/material/theme_data_test.dart
@@ -125,6 +125,20 @@ void main() {
     expect(darkTheme.primaryTextTheme.headline6!.color, typography.white.headline6!.color);
   });
 
+  test('light, dark and fallback constructors support useMaterial3', () {
+    final ThemeData lightTheme = ThemeData.light(useMaterial3: true);
+    expect(lightTheme.useMaterial3, true);
+    expect(lightTheme.typography, Typography.material2021());
+
+    final ThemeData darkTheme = ThemeData.dark(useMaterial3: true);
+    expect(darkTheme.useMaterial3, true);
+    expect(darkTheme.typography, Typography.material2021());
+
+    final ThemeData fallbackTheme = ThemeData.light(useMaterial3: true);
+    expect(fallbackTheme.useMaterial3, true);
+    expect(fallbackTheme.typography, Typography.material2021());
+  });
+
   testWidgets('Defaults to MaterialTapTargetBehavior.padded on mobile platforms and MaterialTapTargetBehavior.shrinkWrap on desktop', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData(platform: defaultTargetPlatform);
     switch (defaultTargetPlatform) {


### PR DESCRIPTION
When setting `useMaterial3` to true with `ThemeData.copyWith`, it has no way of updating the defaults for `typography` and `splashFactory` as they were already set in the constructor. For applications that are using the `light`, `dark`, or `fallback` constructors for ThemeData, this PR provides `useMaterial3` parameters to each of them that allow them to have the appropriate Material 3 defaults for the typography and splash factories:

```dart
  MaterialApp(
     theme: ThemeData.light(useMaterial3: true).copyWith(...),
     // ...
   );
```

This will hopefully help with #105578.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
