### PR TITLE
Cupertino date picker fix for minDate, maxDate when using minuteInterval

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -977,8 +977,8 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       }
 
       if (fromDate.minute != newDate.minute) {
-        final positionDouble = newDate.minute ~/ widget.minuteInterval;
-        final position = minCheck ? positionDouble.ceil() : positionDouble.floor();
+        final double positionDouble = newDate.minute / widget.minuteInterval;
+        final int position = minCheck ? positionDouble.ceil() : positionDouble.floor();
         _animateColumnControllerToItem(minuteController, position);
       }
     });

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -977,7 +977,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       }
 
       if (fromDate.minute != newDate.minute) {
-        _animateColumnControllerToItem(minuteController, newDate.minute);
+        _animateColumnControllerToItem(minuteController, newDate.minute ~/ widget.minuteInterval);
       }
     });
   }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -946,11 +946,11 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
     if (minCheck || maxCheck) {
       // We have minCheck === !maxCheck.
       final DateTime targetDate = minCheck ? widget.minimumDate! : widget.maximumDate!;
-      _scrollToDate(targetDate, selectedDate);
+      _scrollToDate(targetDate, selectedDate, minCheck);
     }
   }
 
-  void _scrollToDate(DateTime newDate, DateTime fromDate) {
+  void _scrollToDate(DateTime newDate, DateTime fromDate, bool minCheck) {
     assert(newDate != null);
     SchedulerBinding.instance.addPostFrameCallback((Duration timestamp) {
       if (fromDate.year != newDate.year || fromDate.month != newDate.month || fromDate.day != newDate.day) {
@@ -977,7 +977,9 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       }
 
       if (fromDate.minute != newDate.minute) {
-        _animateColumnControllerToItem(minuteController, (newDate.minute / widget.minuteInterval).ceil());
+        final positionDouble = newDate.minute ~/ widget.minuteInterval;
+        final position = minCheck ? positionDouble.ceil() : positionDouble.floor();
+        _animateColumnControllerToItem(minuteController, position);
       }
     });
   }

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -977,7 +977,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       }
 
       if (fromDate.minute != newDate.minute) {
-        _animateColumnControllerToItem(minuteController, newDate.minute ~/ widget.minuteInterval);
+        _animateColumnControllerToItem(minuteController, (newDate.minute / widget.minuteInterval).ceil());
       }
     });
   }

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1628,8 +1628,8 @@ void main() {
       ),
     );
 
+    // Drag picker minutes to min date
     await tester.drag(find.text('40'), const Offset(0.0, 32.0), touchSlopY: 0.0, warnIfMissed: false);
-    await tester.pump(); // Once to trigger the post frame animate call.
     await tester.pumpAndSettle();
 
     // Returns to min date.
@@ -1638,8 +1638,8 @@ void main() {
       DateTime(2022, 6, 14, 3, 35),
     );
 
+    // Drag picker minutes to max date
     await tester.drag(find.text('50'), const Offset(0.0, -64.0), touchSlopY: 0.0, warnIfMissed: false);
-    await tester.pump(); // Once to trigger the post frame animate call.
     await tester.pumpAndSettle();
 
     // Returns to max date.

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -1601,6 +1601,53 @@ void main() {
     // Text style should not return unresolved color.
     expect(paragraph.text.style!.color.toString().contains('UNRESOLVED'), isFalse);
   });
+
+  testWidgets('TimerPicker minDate - maxDate with minuteInterval', (WidgetTester tester) async {
+    late DateTime date;
+    final DateTime minimum = DateTime(2022, 6, 14, 3, 31);
+    final DateTime initial = DateTime(2022, 6, 14, 3, 40);
+    final DateTime maximum = DateTime(2022, 6, 14, 3, 49);
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: Center(
+          child: SizedBox(
+            height: 400.0,
+            width: 400.0,
+            child: CupertinoDatePicker(
+              initialDateTime: initial,
+              minimumDate: minimum,
+              maximumDate: maximum,
+              minuteInterval: 5,
+              use24hFormat: true,
+              onDateTimeChanged: (DateTime newDate) {
+                date = newDate;
+              },
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.drag(find.text('40'), const Offset(0.0, 32.0), touchSlopY: 0.0, warnIfMissed: false);
+    await tester.pump(); // Once to trigger the post frame animate call.
+    await tester.pumpAndSettle();
+
+    // Returns to min date.
+    expect(
+      date,
+      DateTime(2022, 6, 14, 3, 35),
+    );
+
+    await tester.drag(find.text('50'), const Offset(0.0, -64.0), touchSlopY: 0.0, warnIfMissed: false);
+    await tester.pump(); // Once to trigger the post frame animate call.
+    await tester.pumpAndSettle();
+
+    // Returns to max date.
+    expect(
+      date,
+      DateTime(2022, 6, 14, 3, 45),
+    );
+  });
 }
 
 Widget _buildPicker({


### PR DESCRIPTION
The Cupertino date picker does not calculate the position of the min-max value correctly when using minuteInterval.

Fixing https://github.com/flutter/flutter/issues/97010

Need help to complete this pr as I have not done anything similar in the past

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
