### PR TITLE
Do not show diagnostic warning for disconnected iOS devices

### DIFF
--- a/packages/flutter_tools/lib/src/macos/xcdevice.dart
+++ b/packages/flutter_tools/lib/src/macos/xcdevice.dart
@@ -354,7 +354,10 @@ class XCDevice {
     return error is Map<String, Object?> ? error : null;
   }
 
-  static int? _errorCode(Map<String, Object?> errorProperties) {
+  static int? _errorCode(Map<String, Object?>? errorProperties) {
+    if (errorProperties == null) {
+      return null;
+    }
     final Object? code = errorProperties['code'];
     return code is int ? code : null;
   }
@@ -521,6 +524,14 @@ class XCDevice {
       final Map<String, Object?>? errorProperties = _errorProperties(deviceProperties);
       final String? errorMessage = _parseErrorMessage(errorProperties);
       if (errorMessage != null) {
+        final int? code = _errorCode(errorProperties);
+        // Error -13: iPhone is not connected. Xcode will continue when iPhone is connected.
+        // This error is confusing since the device is not connected and maybe has not been connected
+        // for a long time. Avoid showing it.
+        if (code == -13 && errorMessage.contains('not connected')) {
+          continue;
+        }
+
         diagnostics.add(errorMessage);
       }
     }

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -828,11 +828,12 @@ void main() {
 
           final List<String> errors = await xcdevice.getDiagnostics();
           expect(errors, hasLength(4));
-          // Does not contain "Xcode will continue when iPad is connected."
+
           expect(errors[0], 'Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
           expect(errors[1], 'Error: iPhone is not paired with your computer.');
           expect(errors[2], 'Error: Xcode pairing error. (code -13)');
           expect(errors[3], 'Error: iPhone is busy: Preparing debugger support for iPhone. Xcode will continue when iPhone is finished. (code -10)');
+          expect(errors, isNot(contains('Xcode will continue')));
           expect(fakeProcessManager.hasRemainingExpectations, isFalse);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -788,6 +788,35 @@ void main() {
       "recoverySuggestion" : "Xcode will continue when iPhone is finished.",
       "domain" : "com.apple.platform.iphoneos"
     }
+  },
+  {
+    "modelCode" : "iPad8,5",
+    "simulator" : false,
+    "modelName" : "iPad Pro (12.9-inch) (3rd generation)",
+    "error" : {
+      "code" : -13,
+      "failureReason" : "",
+      "underlyingErrors" : [
+        {
+          "code" : 4,
+          "failureReason" : "",
+          "description" : "iPad is locked.",
+          "recoverySuggestion" : "To use iPad with Xcode, unlock it.",
+          "domain" : "DVTDeviceIneligibilityErrorDomain"
+        }
+      ],
+      "description" : "iPad is not connected",
+      "recoverySuggestion" : "Xcode will continue when iPad is connected.",
+      "domain" : "com.apple.platform.iphoneos"
+    },
+    "operatingSystemVersion" : "15.6 (19G5027e)",
+    "identifier" : "00008027-0019253601068123",
+    "platform" : "com.apple.platform.iphoneos",
+    "architecture" : "arm64e",
+    "interface" : "usb",
+    "available" : false,
+    "name" : "iPad",
+    "modelUTI" : "com.apple.ipad-pro-12point9-1"
   }
 ]
 ''';
@@ -799,6 +828,7 @@ void main() {
 
           final List<String> errors = await xcdevice.getDiagnostics();
           expect(errors, hasLength(4));
+          // Does not contain "Xcode will continue when iPad is connected."
           expect(errors[0], 'Error: iPhone is not paired with your computer. To use iPhone with Xcode, unlock it and choose to trust this computer when prompted. (code -9)');
           expect(errors[1], 'Error: iPhone is not paired with your computer.');
           expect(errors[2], 'Error: Xcode pairing error. (code -13)');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/105970

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
