### PR TITLE
Draft: Add option to throw exception when text overflows.

### DIFF
--- a/packages/flutter/lib/src/painting/text_painter.dart
+++ b/packages/flutter/lib/src/painting/text_painter.dart
@@ -37,6 +37,9 @@ enum TextOverflow {
 
   /// Render overflowing text outside of its container.
   visible,
+
+  /// Throw an exception if text overflows.
+  throwException,
 }
 
 /// Holds the [Size] and baseline required to represent the dimensions of

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -792,6 +792,8 @@ class RenderParagraph extends RenderBox
     final bool hasVisualOverflow = didOverflowWidth || didOverflowHeight;
     if (hasVisualOverflow) {
       switch (_overflow) {
+        case TextOverflow.throwException:
+          throw new Exception('Overflow: $didOverflowHeight $didOverflowWidth');
         case TextOverflow.visible:
           _needsClipping = false;
           _overflowShader = null;


### PR DESCRIPTION
Add an enum value in TextOverflow to specify that an exception should be thrown when text overflows.

This can be used in app testing to verify that strings are not overflowing (by asserting no exceptions are thrown). ~~It could also be used in app code to attempt to create a text widget and provide alternative text or behavior if there is an overflow.~~ (In my experimentation, it seems app code actually isn't able to catch the exception thrown in the rendering library)

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
