### PR TITLE
added microbenchmark for loading assets

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/foundation/platform_asset_bundle.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/platform_asset_bundle.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/services.dart' show PlatformAssetBundle;
+import 'package:flutter/widgets.dart';
+
+import '../common.dart';
+
+const int _kBatchSize = 100;
+const int _kNumIterations = 100;
+
+void main() async {
+  assert(false,
+      "Don't run benchmarks in debug mode! Use 'flutter run --release'.");
+  final BenchmarkResultPrinter printer = BenchmarkResultPrinter();
+  WidgetsFlutterBinding.ensureInitialized();
+  final Stopwatch watch = Stopwatch();
+  final PlatformAssetBundle bundle = PlatformAssetBundle();
+
+  final List<double> values = <double>[];
+  for (int j = 0; j < _kNumIterations; ++j) {
+    double tally = 0;
+    watch.reset();
+    watch.start();
+    for (int i = 0; i < _kBatchSize; i += 1) {
+      tally += (await bundle.load(
+              'packages/flutter_gallery_assets/places/india_pondicherry_salt_farm.png'))
+          .lengthInBytes;
+    }
+    watch.stop();
+    values.add(watch.elapsedMicroseconds.toDouble() / _kBatchSize);
+    if (tally < 0.0) {
+      print("This shouldn't happen.");
+    }
+  }
+
+  printer.addResultStatistics(
+    description: 'PlatformAssetBundle.load 1MB',
+    values: values,
+    unit: 'us per iteration',
+    name: 'PlatformAssetBundle_load_1MB',
+  );
+
+  printer.printToStdout();
+}

--- a/dev/benchmarks/microbenchmarks/lib/foundation/platform_asset_bundle.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/platform_asset_bundle.dart
@@ -24,9 +24,10 @@ void main() async {
     watch.reset();
     watch.start();
     for (int i = 0; i < _kBatchSize; i += 1) {
-      tally += (await bundle.load(
-              'packages/flutter_gallery_assets/places/india_pondicherry_salt_farm.png'))
-          .lengthInBytes;
+      // Note: We don't load images like this.  PlatformAssetBundle is used for
+      // other assets (like Rive animations). We are using an image because it's
+      // conveniently sized and available for the test.
+      tally += (await bundle.load('packages/flutter_gallery_assets/places/india_pondicherry_salt_farm.png')).lengthInBytes;
     }
     watch.stop();
     values.add(watch.elapsedMicroseconds.toDouble() / _kBatchSize);

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -62,6 +62,7 @@ TaskFunction createMicrobenchmarkTask() {
       ...await runMicrobench('lib/foundation/all_elements_bench.dart'),
       ...await runMicrobench('lib/foundation/clamp.dart'),
       ...await runMicrobench('lib/foundation/change_notifier_bench.dart'),
+      ...await runMicrobench('lib/foundation/platform_asset_bundle.dart'),
       ...await runMicrobench('lib/foundation/standard_method_codec_bench.dart'),
       ...await runMicrobench('lib/foundation/standard_message_codec_bench.dart'),
       ...await runMicrobench('lib/foundation/timeline_bench.dart'),


### PR DESCRIPTION
A benchmark that will likely change for iOS if https://github.com/flutter/engine/pull/34018 lands or if https://github.com/dart-lang/sdk/issues/42785 is addressed.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
