### PR TITLE
Allow DoNothingIntent and DoNothingAndStopPropagationIntent to be used in a const environment

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1343,7 +1343,8 @@ class VoidCallbackAction extends Action<VoidCallbackIntent> {
 class DoNothingIntent extends Intent {
   /// Creates a const [DoNothingIntent].
   ///
-  /// If you want to use [DoNothingIntent] as a constant, use [instance].
+  /// If you want to use [DoNothingIntent] in a const environment, use
+  /// [instance].
   factory DoNothingIntent() => instance;
 
   // Make DoNothingIntent constructor private so it can't be subclassed.
@@ -1376,8 +1377,8 @@ class DoNothingIntent extends Intent {
 class DoNothingAndStopPropagationIntent extends Intent {
   /// Creates a const [DoNothingAndStopPropagationIntent].
   ///
-  /// If you want to use [DoNothingAndStopPropagationIntent] as a constant,
-  /// use [instance].
+  /// If you want to use [DoNothingAndStopPropagationIntent] in a const
+  /// environment, use [instance].
   factory DoNothingAndStopPropagationIntent() => instance;
 
   // Make DoNothingAndStopPropagationIntent constructor private so it can't be subclassed.

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1342,19 +1342,10 @@ class VoidCallbackAction extends Action<VoidCallbackIntent> {
 ///    handlers in the focus chain.
 class DoNothingIntent extends Intent {
   /// Creates a const [DoNothingIntent].
-  ///
-  /// If you want to use [DoNothingIntent] in a const environment, use
-  /// [instance].
-  factory DoNothingIntent() => instance;
+  const factory DoNothingIntent() = DoNothingIntent._;
 
   // Make DoNothingIntent constructor private so it can't be subclassed.
   const DoNothingIntent._();
-
-  /// A const [DoNothingIntent].
-  ///
-  /// This is identical to the factory constructor, only that [instance] is
-  /// allowed in a const enviroment.
-  static const DoNothingIntent instance = DoNothingIntent._();
 }
 
 /// An [Intent] that is bound to a [DoNothingAction], but, in addition to not
@@ -1376,19 +1367,10 @@ class DoNothingIntent extends Intent {
 ///  * [DoNothingIntent], a similar intent that will handle the key event.
 class DoNothingAndStopPropagationIntent extends Intent {
   /// Creates a const [DoNothingAndStopPropagationIntent].
-  ///
-  /// If you want to use [DoNothingAndStopPropagationIntent] in a const
-  /// environment, use [instance].
-  factory DoNothingAndStopPropagationIntent() => instance;
+  const factory DoNothingAndStopPropagationIntent() = DoNothingAndStopPropagationIntent._;
 
   // Make DoNothingAndStopPropagationIntent constructor private so it can't be subclassed.
   const DoNothingAndStopPropagationIntent._();
-
-  /// A const [DoNothingAndStopPropagationIntent].
-  ///
-  /// This is identical to the factory constructor, only that [instance] is
-  /// allowed in a const enviroment.
-  static const DoNothingAndStopPropagationIntent instance = DoNothingAndStopPropagationIntent._();
 }
 
 /// An [Action] that doesn't perform any action when invoked.

--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1342,10 +1342,18 @@ class VoidCallbackAction extends Action<VoidCallbackIntent> {
 ///    handlers in the focus chain.
 class DoNothingIntent extends Intent {
   /// Creates a const [DoNothingIntent].
-  factory DoNothingIntent() => const DoNothingIntent._();
+  ///
+  /// If you want to use [DoNothingIntent] as a constant, use [instance].
+  factory DoNothingIntent() => instance;
 
   // Make DoNothingIntent constructor private so it can't be subclassed.
   const DoNothingIntent._();
+
+  /// A const [DoNothingIntent].
+  ///
+  /// This is identical to the factory constructor, only that [instance] is
+  /// allowed in a const enviroment.
+  static const DoNothingIntent instance = DoNothingIntent._();
 }
 
 /// An [Intent] that is bound to a [DoNothingAction], but, in addition to not
@@ -1367,10 +1375,19 @@ class DoNothingIntent extends Intent {
 ///  * [DoNothingIntent], a similar intent that will handle the key event.
 class DoNothingAndStopPropagationIntent extends Intent {
   /// Creates a const [DoNothingAndStopPropagationIntent].
-  factory DoNothingAndStopPropagationIntent() => const DoNothingAndStopPropagationIntent._();
+  ///
+  /// If you want to use [DoNothingAndStopPropagationIntent] as a constant,
+  /// use [instance].
+  factory DoNothingAndStopPropagationIntent() => instance;
 
   // Make DoNothingAndStopPropagationIntent constructor private so it can't be subclassed.
   const DoNothingAndStopPropagationIntent._();
+
+  /// A const [DoNothingAndStopPropagationIntent].
+  ///
+  /// This is identical to the factory constructor, only that [instance] is
+  /// allowed in a const enviroment.
+  static const DoNothingAndStopPropagationIntent instance = DoNothingAndStopPropagationIntent._();
 }
 
 /// An [Action] that doesn't perform any action when invoked.

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -120,7 +120,7 @@ void main() {
       await tester.pump();
       final Object? result = Actions.maybeInvoke(
         containerKey.currentContext!,
-        DoNothingIntent(),
+        const DoNothingIntent(),
       );
       expect(result, isNull);
       expect(invoked, isFalse);
@@ -146,7 +146,7 @@ void main() {
       await tester.pump();
       final Object? result = Actions.maybeInvoke(
         containerKey.currentContext!,
-        DoNothingIntent(),
+        const DoNothingIntent(),
       );
       expect(result, isNull);
       expect(invoked, isFalse);

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1710,8 +1710,8 @@ void main() {
 
     testWidgets('using a disposed token asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
-      final ShortcutRegistryEntry token = registry.addAll(<ShortcutActivator, Intent>{
-        const SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
+      final ShortcutRegistryEntry token = registry.addAll(const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent.instance,
       });
       token.dispose();
       expect(() {token.replaceAll(<ShortcutActivator, Intent>{}); }, throwsFlutterError);
@@ -1719,8 +1719,8 @@ void main() {
 
     testWidgets('setting duplicate bindings asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
-      final ShortcutRegistryEntry token = registry.addAll(<ShortcutActivator, Intent>{
-        const SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
+      final ShortcutRegistryEntry token = registry.addAll(const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent.instance,
       });
       expect(() {
         final ShortcutRegistryEntry token2 = registry.addAll(const <ShortcutActivator, Intent>{

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -871,7 +871,7 @@ void main() {
                 },
                 child: Shortcuts(
                   shortcuts: <LogicalKeySet, Intent>{
-                    LogicalKeySet(LogicalKeyboardKey.keyA): DoNothingAndStopPropagationIntent(),
+                    LogicalKeySet(LogicalKeyboardKey.keyA): const DoNothingAndStopPropagationIntent(),
                   },
                   child: TextField(key: textFieldKey, autofocus: true),
                 ),

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1711,7 +1711,7 @@ void main() {
     testWidgets('using a disposed token asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
       final ShortcutRegistryEntry token = registry.addAll(const <ShortcutActivator, Intent>{
-        SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent.instance,
+        SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
       });
       token.dispose();
       expect(() {token.replaceAll(<ShortcutActivator, Intent>{}); }, throwsFlutterError);
@@ -1720,7 +1720,7 @@ void main() {
     testWidgets('setting duplicate bindings asserts', (WidgetTester tester) async {
       final ShortcutRegistry registry = ShortcutRegistry();
       final ShortcutRegistryEntry token = registry.addAll(const <ShortcutActivator, Intent>{
-        SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent.instance,
+        SingleActivator(LogicalKeyboardKey.keyA): DoNothingIntent(),
       });
       expect(() {
         final ShortcutRegistryEntry token2 = registry.addAll(const <ShortcutActivator, Intent>{


### PR DESCRIPTION
This PR makes the factory constructors of `DoNothingIntent` and `DoNothingAndStopPropagationIntent` const.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
