### PR TITLE
PointerEvent asserts device kinds

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -216,7 +216,6 @@ class PointerEventConverter {
                   return PointerPanZoomStartEvent(
                     timeStamp: timeStamp,
                     pointer: datum.pointerIdentifier,
-                    kind: kind,
                     device: datum.device,
                     position: position,
                     embedderId: datum.embedderId,
@@ -230,7 +229,6 @@ class PointerEventConverter {
                   return PointerPanZoomUpdateEvent(
                     timeStamp: timeStamp,
                     pointer: datum.pointerIdentifier,
-                    kind: kind,
                     device: datum.device,
                     position: position,
                     pan: pan,
@@ -244,7 +242,6 @@ class PointerEventConverter {
                   return PointerPanZoomEndEvent(
                     timeStamp: timeStamp,
                     pointer: datum.pointerIdentifier,
-                    kind: kind,
                     device: datum.device,
                     position: position,
                     embedderId: datum.embedderId,

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1035,7 +1035,8 @@ class PointerHoverEvent extends PointerEvent with _PointerEventDescription, _Cop
     super.tilt,
     super.synthesized,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          down: false,
          pressure: 0.0,
        );
@@ -1153,7 +1154,8 @@ class PointerEnterEvent extends PointerEvent with _PointerEventDescription, _Cop
     super.down,
     super.synthesized,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          pressure: 0.0,
        );
 
@@ -1297,7 +1299,8 @@ class PointerExitEvent extends PointerEvent with _PointerEventDescription, _Copy
     super.down,
     super.synthesized,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          pressure: 0.0,
        );
 
@@ -1432,7 +1435,8 @@ class PointerDownEvent extends PointerEvent with _PointerEventDescription, _Copy
     super.orientation,
     super.tilt,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          down: true,
          distance: 0.0,
        );
@@ -1548,7 +1552,8 @@ class PointerMoveEvent extends PointerEvent with _PointerEventDescription, _Copy
     super.platformData,
     super.synthesized,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          down: true,
          distance: 0.0,
        );
@@ -1662,7 +1667,8 @@ class PointerUpEvent extends PointerEvent with _PointerEventDescription, _CopyPo
     super.orientation,
     super.tilt,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          down: false,
        );
 
@@ -1711,7 +1717,7 @@ abstract class PointerSignalEvent extends PointerEvent {
     super.device,
     super.position,
     super.embedderId,
-  });
+  }) : assert(kind != PointerDeviceKind.trackpad);
 }
 
 mixin _CopyPointerScrollEvent on PointerEvent {
@@ -1849,9 +1855,9 @@ mixin _CopyPointerPanZoomStartEvent on PointerEvent {
     bool? synthesized,
     int? embedderId,
   }) {
+    assert(kind == null || kind == PointerDeviceKind.trackpad);
     return PointerPanZoomStartEvent(
       timeStamp: timeStamp ?? this.timeStamp,
-      kind: kind ?? this.kind,
       device: device ?? this.device,
       position: position ?? this.position,
       embedderId: embedderId ?? this.embedderId,
@@ -1871,19 +1877,18 @@ class PointerPanZoomStartEvent extends PointerEvent with _PointerEventDescriptio
   /// All of the arguments must be non-null.
   const PointerPanZoomStartEvent({
     super.timeStamp,
-    super.kind = PointerDeviceKind.mouse,
     super.device,
     super.pointer,
     super.position,
     super.embedderId,
     super.synthesized,
   }) : assert(timeStamp != null),
-       assert(kind != null),
        assert(device != null),
        assert(pointer != null),
        assert(position != null),
        assert(embedderId != null),
-       assert(synthesized != null);
+       assert(synthesized != null),
+       super(kind: PointerDeviceKind.trackpad);
 
   @override
   PointerPanZoomStartEvent transformed(Matrix4? transform) {
@@ -1953,9 +1958,9 @@ mixin _CopyPointerPanZoomUpdateEvent on PointerEvent {
     double? scale,
     double? rotation,
   }) {
+    assert(kind == null || kind == PointerDeviceKind.trackpad);
     return PointerPanZoomUpdateEvent(
       timeStamp: timeStamp ?? this.timeStamp,
-      kind: kind ?? this.kind,
       device: device ?? this.device,
       position: position ?? this.position,
       embedderId: embedderId ?? this.embedderId,
@@ -1979,7 +1984,6 @@ class PointerPanZoomUpdateEvent extends PointerEvent with _PointerEventDescripti
   /// All of the arguments must be non-null.
   const PointerPanZoomUpdateEvent({
     super.timeStamp,
-    super.kind = PointerDeviceKind.mouse,
     super.device,
     super.pointer,
     super.position,
@@ -1990,7 +1994,6 @@ class PointerPanZoomUpdateEvent extends PointerEvent with _PointerEventDescripti
     this.rotation = 0.0,
     super.synthesized,
   }) : assert(timeStamp != null),
-       assert(kind != null),
        assert(device != null),
        assert(pointer != null),
        assert(position != null),
@@ -1999,7 +2002,9 @@ class PointerPanZoomUpdateEvent extends PointerEvent with _PointerEventDescripti
        assert(panDelta != null),
        assert(scale != null),
        assert(rotation != null),
-       assert(synthesized != null);
+       assert(synthesized != null),
+       super(kind: PointerDeviceKind.trackpad);
+
   @override
   final Offset pan;
   @override
@@ -2085,9 +2090,9 @@ mixin _CopyPointerPanZoomEndEvent on PointerEvent {
     bool? synthesized,
     int? embedderId,
   }) {
+    assert(kind == null || kind == PointerDeviceKind.trackpad);
     return PointerPanZoomEndEvent(
       timeStamp: timeStamp ?? this.timeStamp,
-      kind: kind ?? this.kind,
       device: device ?? this.device,
       position: position ?? this.position,
       embedderId: embedderId ?? this.embedderId,
@@ -2107,19 +2112,18 @@ class PointerPanZoomEndEvent extends PointerEvent with _PointerEventDescription,
   /// All of the arguments must be non-null.
   const PointerPanZoomEndEvent({
     super.timeStamp,
-    super.kind = PointerDeviceKind.mouse,
     super.device,
     super.pointer,
     super.position,
     super.embedderId,
     super.synthesized,
   }) : assert(timeStamp != null),
-       assert(kind != null),
        assert(device != null),
        assert(pointer != null),
        assert(position != null),
        assert(embedderId != null),
-       assert(synthesized != null);
+       assert(synthesized != null),
+       super(kind: PointerDeviceKind.trackpad);
 
   @override
   PointerPanZoomEndEvent transformed(Matrix4? transform) {
@@ -2224,7 +2228,8 @@ class PointerCancelEvent extends PointerEvent with _PointerEventDescription, _Co
     super.orientation,
     super.tilt,
     super.embedderId,
-  }) : super(
+  }) : assert(kind != PointerDeviceKind.trackpad),
+       super(
          down: false,
          pressure: 0.0,
        );

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1035,7 +1035,9 @@ class PointerHoverEvent extends PointerEvent with _PointerEventDescription, _Cop
     super.tilt,
     super.synthesized,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : // Dart doesn't support comparing enums with == in const contexts yet.
+       // https://github.com/dart-lang/language/issues/1811
+       assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          down: false,
          pressure: 0.0,
@@ -1154,7 +1156,7 @@ class PointerEnterEvent extends PointerEvent with _PointerEventDescription, _Cop
     super.down,
     super.synthesized,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          pressure: 0.0,
        );
@@ -1299,7 +1301,7 @@ class PointerExitEvent extends PointerEvent with _PointerEventDescription, _Copy
     super.down,
     super.synthesized,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          pressure: 0.0,
        );
@@ -1435,7 +1437,7 @@ class PointerDownEvent extends PointerEvent with _PointerEventDescription, _Copy
     super.orientation,
     super.tilt,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          down: true,
          distance: 0.0,
@@ -1552,7 +1554,7 @@ class PointerMoveEvent extends PointerEvent with _PointerEventDescription, _Copy
     super.platformData,
     super.synthesized,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          down: true,
          distance: 0.0,
@@ -1667,7 +1669,7 @@ class PointerUpEvent extends PointerEvent with _PointerEventDescription, _CopyPo
     super.orientation,
     super.tilt,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          down: false,
        );
@@ -1717,7 +1719,7 @@ abstract class PointerSignalEvent extends PointerEvent {
     super.device,
     super.position,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad);
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad));
 }
 
 mixin _CopyPointerScrollEvent on PointerEvent {
@@ -1855,7 +1857,7 @@ mixin _CopyPointerPanZoomStartEvent on PointerEvent {
     bool? synthesized,
     int? embedderId,
   }) {
-    assert(kind == null || kind == PointerDeviceKind.trackpad);
+    assert(kind == null || identical(kind, PointerDeviceKind.trackpad));
     return PointerPanZoomStartEvent(
       timeStamp: timeStamp ?? this.timeStamp,
       device: device ?? this.device,
@@ -1958,7 +1960,7 @@ mixin _CopyPointerPanZoomUpdateEvent on PointerEvent {
     double? scale,
     double? rotation,
   }) {
-    assert(kind == null || kind == PointerDeviceKind.trackpad);
+    assert(kind == null || identical(kind, PointerDeviceKind.trackpad));
     return PointerPanZoomUpdateEvent(
       timeStamp: timeStamp ?? this.timeStamp,
       device: device ?? this.device,
@@ -2090,7 +2092,7 @@ mixin _CopyPointerPanZoomEndEvent on PointerEvent {
     bool? synthesized,
     int? embedderId,
   }) {
-    assert(kind == null || kind == PointerDeviceKind.trackpad);
+    assert(kind == null || identical(kind, PointerDeviceKind.trackpad));
     return PointerPanZoomEndEvent(
       timeStamp: timeStamp ?? this.timeStamp,
       device: device ?? this.device,
@@ -2228,7 +2230,7 @@ class PointerCancelEvent extends PointerEvent with _PointerEventDescription, _Co
     super.orientation,
     super.tilt,
     super.embedderId,
-  }) : assert(kind != PointerDeviceKind.trackpad),
+  }) : assert(!identical(kind, PointerDeviceKind.trackpad)),
        super(
          down: false,
          pressure: 0.0,

--- a/packages/flutter/test/gestures/drag_test.dart
+++ b/packages/flutter/test/gestures/drag_test.dart
@@ -1507,7 +1507,7 @@ void main() {
       didEndPan = true;
     };
 
-    final TestPointer pointer = TestPointer(2);
+    final TestPointer pointer = TestPointer(2, PointerDeviceKind.trackpad);
     final PointerPanZoomStartEvent start = pointer.panZoomStart(const Offset(10.0, 10.0));
     pan.addPointerPanZoom(start);
     competingPan.addPointerPanZoom(start);
@@ -1564,7 +1564,7 @@ void main() {
       didEndPan = true;
     };
 
-    final TestPointer panZoomPointer = TestPointer(2);
+    final TestPointer panZoomPointer = TestPointer(2, PointerDeviceKind.trackpad);
     final TestPointer touchPointer = TestPointer(3);
     final PointerPanZoomStartEvent start = panZoomPointer.panZoomStart(const Offset(10.0, 10.0));
     pan.addPointerPanZoom(start);
@@ -1641,7 +1641,7 @@ testGesture('Touch drags should allow pointer pan/zooms to join them', (GestureT
       didEndPan = true;
     };
 
-    final TestPointer panZoomPointer = TestPointer(2);
+    final TestPointer panZoomPointer = TestPointer(2, PointerDeviceKind.trackpad);
     final TestPointer touchPointer = TestPointer(3);
     final PointerDownEvent touchDown = touchPointer.down(const Offset(20.0, 20.0));
     pan.addPointer(touchDown);

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -732,7 +732,7 @@ void main() {
       didEndScale = true;
     };
 
-    final TestPointer pointer1 = TestPointer(2);
+    final TestPointer pointer1 = TestPointer(2, PointerDeviceKind.trackpad);
 
     final PointerPanZoomStartEvent start = pointer1.panZoomStart(Offset.zero);
     scale.addPointerPanZoom(start);
@@ -836,7 +836,7 @@ void main() {
 
     final TestPointer touchPointer1 = TestPointer(2);
     final TestPointer touchPointer2 = TestPointer(3);
-    final TestPointer panZoomPointer = TestPointer(4);
+    final TestPointer panZoomPointer = TestPointer(4, PointerDeviceKind.trackpad);
 
     final PointerPanZoomStartEvent panZoomStart = panZoomPointer.panZoomStart(Offset.zero);
     scale.addPointerPanZoom(panZoomStart);
@@ -985,7 +985,7 @@ void main() {
     drag.onStart = (DragStartDetails details) { log.add('drag-start'); };
     drag.onEnd = (DragEndDetails details) { log.add('drag-end'); };
 
-    final TestPointer pointer1 = TestPointer(2);
+    final TestPointer pointer1 = TestPointer(2, PointerDeviceKind.trackpad);
 
     final PointerPanZoomStartEvent down = pointer1.panZoomStart(const Offset(10.0, 10.0));
     scale.addPointerPanZoom(down);
@@ -1004,7 +1004,7 @@ void main() {
     expect(log, equals(<String>['scale-start', 'scale-update']));
     log.clear();
 
-    final TestPointer pointer2 = TestPointer(3);
+    final TestPointer pointer2 = TestPointer(3, PointerDeviceKind.trackpad);
     final PointerPanZoomStartEvent down2 = pointer2.panZoomStart(const Offset(10.0, 20.0));
     scale.addPointerPanZoom(down2);
     drag.addPointerPanZoom(down2);
@@ -1033,7 +1033,7 @@ void main() {
     // TODO(ianh): https://github.com/flutter/flutter/issues/11384
     // In this case, we move fast, so that the scale wins. If we moved slowly,
     // the horizontal drag would win, since it was added first.
-    final TestPointer pointer3 = TestPointer(4);
+    final TestPointer pointer3 = TestPointer(4, PointerDeviceKind.trackpad);
     final PointerPanZoomStartEvent down3 = pointer3.panZoomStart(const Offset(30.0, 30.0));
     scale.addPointerPanZoom(down3);
     drag.addPointerPanZoom(down3);
@@ -1084,7 +1084,7 @@ void main() {
       didEndScale = true;
     };
 
-    final TestPointer pointer1 = TestPointer(2);
+    final TestPointer pointer1 = TestPointer(2, PointerDeviceKind.trackpad);
 
     final PointerPanZoomStartEvent start = pointer1.panZoomStart(Offset.zero);
     scale.addPointerPanZoom(start);

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -314,12 +314,12 @@ class TestPointer {
     Duration timeStamp = Duration.zero
   }) {
     assert(!isPanZoomActive);
+    assert(kind == PointerDeviceKind.trackpad);
     _location = location;
     _pan = Offset.zero;
     _isPanZoomActive = true;
     return PointerPanZoomStartEvent(
       timeStamp: timeStamp,
-      kind: kind,
       device: _device,
       pointer: pointer,
       position: location,
@@ -341,12 +341,12 @@ class TestPointer {
     Duration timeStamp = Duration.zero,
   }) {
     assert(isPanZoomActive);
+    assert(kind == PointerDeviceKind.trackpad);
     _location = location;
     final Offset panDelta = pan - _pan!;
     _pan = pan;
     return PointerPanZoomUpdateEvent(
       timeStamp: timeStamp,
-      kind: kind,
       device: _device,
       pointer: pointer,
       position: location,
@@ -366,11 +366,11 @@ class TestPointer {
     Duration timeStamp = Duration.zero
   }) {
     assert(isPanZoomActive);
+    assert(kind == PointerDeviceKind.trackpad);
     _isPanZoomActive = false;
     _pan = null;
     return PointerPanZoomEndEvent(
       timeStamp: timeStamp,
-      kind: kind,
       device: _device,
       pointer: pointer,
       position: location!,


### PR DESCRIPTION
The new pointer event types added in https://github.com/flutter/flutter/pull/89944 allows only the `PointerDeviceKind.trackpad` kind, while the other event types allows any kinds but `PointerDeviceKind.trackpad`. This PR enforces it with assertions.

As a direct result, several occasions are fixed where trackpad gestures were simulated on non-trackpad pointers.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
