### PR TITLE
[DataTable]: Add `builder` to `DataCell`

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -308,12 +308,6 @@ class DataCell {
   ///
   /// When the builder is implemented, the customized widget will be displayed.
   ///
-  /// {@tool dartpad}
-  /// This sample shows a [DataTable] with a customized [DataRow] for calorie numbers.
-  ///
-  /// ** See code in examples/api/lib/material/data_table/data_table.builder.0.dart **
-  /// {@end-tool}
-  ///
   /// If this callback is null, the widget provided to [DataCell]'s [child] will be
   /// displayed.
   final DataCellBuilder? builder;

--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -831,13 +831,7 @@ class DataTable extends StatelessWidget {
       label = Expanded(child: builder != null ? builder(context, label) : label);
       label = Row(
         textDirection: numeric ? TextDirection.rtl : null,
-        children: <Widget>[
-          if (builder != null)
-            builder(context, label)
-          else
-           label,
-          icon,
-        ],
+        children: <Widget>[ if (builder != null) builder(context, label) else label, icon ],
       );
     }
 
@@ -857,11 +851,12 @@ class DataTable extends StatelessWidget {
         style: effectiveDataTextStyle.copyWith(
           color: placeholder ? effectiveDataTextStyle.color!.withOpacity(0.6) : null,
         ),
-        child: DropdownButtonHideUnderline(
-          child: builder != null ? builder(context, label) : label,
-        ),
+        child: DropdownButtonHideUnderline(child: builder != null ? builder(context, label) : label),
       ),
     );
+    if (builder != null) {
+      return label;
+    }
     if (onTap != null ||
         onDoubleTap != null ||
         onLongPress != null ||

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1895,4 +1895,73 @@ void main() {
     // Go without crashes.
 
   });
+
+  testWidgets('DataCell builder', (WidgetTester tester) async {
+    const String greenText = '159';
+    const String redText = '305';
+
+    BoxDecoration getBoxDecoration(String text) {
+      return tester.widget<DecoratedBox>(
+        find.widgetWithText(DecoratedBox, text),
+      ).decoration as BoxDecoration;
+    }
+
+    Widget buildTable() {
+      return DataTable(
+        columns: const <DataColumn>[
+          DataColumn(
+            label: Text('Name'),
+          ),
+          DataColumn(
+            label: Text('Calories'),
+            numeric: true,
+          ),
+        ],
+        rows: kDesserts.map<DataRow>((Dessert dessert) {
+          return DataRow(
+            key: ValueKey<String>(dessert.name),
+            cells: <DataCell>[
+              DataCell(
+                Text(dessert.name),
+              ),
+              DataCell(
+                Text('${dessert.calories}'),
+                builder: (BuildContext context, Widget child) {
+                  if (dessert.calories > 300) {
+                    return Container(
+                      padding: const EdgeInsets.all(4.0),
+                      decoration: BoxDecoration(
+                        color: Colors.red,
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
+                      child: child,
+                    );
+                  } else {
+                    return Container(
+                      padding: const EdgeInsets.all(4.0),
+                      decoration: BoxDecoration(
+                        color: Colors.green,
+                        borderRadius: BorderRadius.circular(8.0),
+                      ),
+                      child: child,
+                    );
+                  }
+                },
+              ),
+            ],
+          );
+        }).toList(),
+      );
+    }
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(child: buildTable()),
+    ));
+
+    expect(find.text(greenText), findsOneWidget);
+    expect(find.text(redText), findsOneWidget);
+
+    expect(getBoxDecoration(greenText).color, Colors.green);
+    expect(getBoxDecoration(redText).color, Colors.red);
+  });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/105015

### Description

This PR adds a `builder` callback to `DataCell` so that `DataCell`'s child can be wrapped with other widgets such as `Container` or `Actions`.

<details> 
<summary>minimal code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key, this.dark = false, this.useMaterial3 = true});

  final bool dark;
  final bool useMaterial3;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      themeMode: dark ? ThemeMode.dark : ThemeMode.light,
      theme: ThemeData(
        useMaterial3: useMaterial3,
        brightness: Brightness.light,
        colorSchemeSeed: const Color(0xff6750a4),
      ),
      darkTheme: ThemeData(
        useMaterial3: useMaterial3,
        brightness: Brightness.dark,
        colorSchemeSeed: const Color(0xff6750a4),
      ),
      home: const Example(),
    );
  }
}

class Example extends StatelessWidget {
  const Example({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('DataRow.builder sample'),
      ),
      body: SingleChildScrollView(
        child: DataTable(
          columns: const <DataColumn>[
            DataColumn(
              label: Text('Name'),
            ),
            DataColumn(
              label: Text('Calories'),
              numeric: true,
            ),
          ],
          rows: kDesserts.map<DataRow>((Dessert dessert) {
            return DataRow(
              key: ValueKey<String>(dessert.name),
              cells: <DataCell>[
                DataCell(
                  Text(dessert.name),
                ),
                DataCell(
                  Text(
                    '${dessert.calories}',
                    style: const TextStyle(color: Colors.white),
                  ),
                  builder: (BuildContext context, Widget child) {
                    if (dessert.calories >= 200 && dessert.calories <= 300) {
                      return Container(
                        padding: const EdgeInsets.all(4.0),
                        decoration: BoxDecoration(
                          color: Colors.amber,
                          borderRadius: BorderRadius.circular(8.0),
                        ),
                        child: child,
                      );
                    } else if (dessert.calories > 300) {
                      return Container(
                        padding: const EdgeInsets.all(4.0),
                        decoration: BoxDecoration(
                          color: Colors.red,
                          borderRadius: BorderRadius.circular(8.0),
                        ),
                        child: child,
                      );
                    } else {
                      return Container(
                        padding: const EdgeInsets.all(4.0),
                        decoration: BoxDecoration(
                          color: Colors.green,
                          borderRadius: BorderRadius.circular(8.0),
                        ),
                        child: child,
                      );
                    }
                  },
                ),
              ],
            );
          }).toList(),
        ),
      ),
    );
  }
}

class Dessert {
  Dessert(this.name, this.calories, this.fat, this.carbs, this.protein,
      this.sodium, this.calcium, this.iron);

  final String name;
  final int calories;
  final double fat;
  final int carbs;
  final double protein;
  final int sodium;
  final int calcium;
  final int iron;
}

final List<Dessert> kDesserts = <Dessert>[
  Dessert('Frozen yogurt', 159, 6.0, 24, 4.0, 87, 14, 1),
  Dessert('Ice cream sandwich', 237, 9.0, 37, 4.3, 129, 8, 1),
  Dessert('Eclair', 262, 16.0, 24, 6.0, 337, 6, 7),
  Dessert('Cupcake', 305, 3.7, 67, 4.3, 413, 3, 8),
  Dessert('Gingerbread', 356, 16.0, 49, 3.9, 327, 7, 16),
  Dessert('Jelly bean', 375, 0.0, 94, 0.0, 50, 0, 0),
  Dessert('Lollipop', 392, 0.2, 98, 0.0, 38, 0, 2),
  Dessert('Honeycomb', 408, 3.2, 87, 6.5, 562, 0, 45),
  Dessert('Donut', 452, 25.0, 51, 4.9, 326, 2, 22),
  Dessert('KitKat', 518, 26.0, 65, 7.0, 54, 12, 6),
];

``` 
	
</details>

![Screenshot 2022-06-15 at 17 05 49](https://user-images.githubusercontent.com/48603081/173847368-1330134b-ab67-4296-ab9b-30016668fd0e.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
