### PR TITLE
Add integration test for `flutter build windows`

### DIFF
--- a/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io' as io;
+
 import 'package:file/file.dart';
 import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/io.dart';
@@ -10,75 +12,72 @@ import '../src/common.dart';
 import 'test_utils.dart';
 
 void main() {
-  // Only run this test on Windows
-  if (!platform.isWindows) {
-    return;
-  }
-
   late Directory tempDir;
   late Directory projectRoot;
   late String flutterBin;
   late Directory releaseDir;
   late File exeFile;
 
-  setUpAll(() {
-    tempDir = createResolvedTempDirectorySync('build_windows_test.');
-    flutterBin = fileSystem.path.join(
-      getFlutterRoot(),
-      'bin',
-      'flutter',
-    );
-    processManager.runSync(<String>[flutterBin, 'config',
-      '--enable-windows-desktop',
-    ]);
+  group('flutter build windows command', () {
+    setUpAll(() {
+      tempDir = createResolvedTempDirectorySync('build_windows_test.');
+      flutterBin = fileSystem.path.join(
+        getFlutterRoot(),
+        'bin',
+        'flutter',
+      );
+      processManager.runSync(<String>[flutterBin, 'config',
+        '--enable-windows-desktop',
+      ]);
 
-    processManager.runSync(<String>[
-      flutterBin,
-      ...getLocalEngineArguments(),
-      'create',
-      'hello',
-    ], workingDirectory: tempDir.path);
+      processManager.runSync(<String>[
+        flutterBin,
+        ...getLocalEngineArguments(),
+        'create',
+        'hello',
+      ], workingDirectory: tempDir.path);
 
-    projectRoot = tempDir.childDirectory('hello');
+      projectRoot = tempDir.childDirectory('hello');
 
-    releaseDir = fileSystem.directory(fileSystem.path.join(
-      projectRoot.path,
-      'build',
-      'windows',
-      'runner',
-      'Release'
-    ));
+      releaseDir = fileSystem.directory(fileSystem.path.join(
+        projectRoot.path,
+        'build',
+        'windows',
+        'runner',
+        'Release',
+      ));
 
-    exeFile = fileSystem.file(fileSystem.path.join(
-      releaseDir.path,
-      'hello.exe'
-    ));
-  });
+      exeFile = fileSystem.file(fileSystem.path.join(
+        releaseDir.path,
+        'hello.exe',
+      ));
+    });
 
-  tearDownAll(() {
-    tryToDelete(tempDir);
-  });
+    tearDownAll(() {
+      tryToDelete(tempDir);
+    });
 
-  testWithoutContext('flutter build windows creates exe', () {
-    final ProcessResult result = processManager.runSync(<String>[
-      flutterBin,
-      ...getLocalEngineArguments(),
-      'build',
-      'windows',
-      '--no-pub',
-    ], workingDirectory: projectRoot.path);
+    testWithoutContext('flutter build windows creates exe', () {
+      final ProcessResult result = processManager.runSync(<String>[
+        flutterBin,
+        ...getLocalEngineArguments(),
+        'build',
+        'windows',
+        '--no-pub',
+      ], workingDirectory: projectRoot.path);
 
-    expect(result.exitCode, 0);
-    expect(releaseDir, exists);
-    expect(exeFile, exists);
+      expect(result.exitCode, 0);
+      expect(releaseDir, exists);
+      expect(exeFile, exists);
 
-    // Default exe has version 1.0.0
-    final String fileVersion = _getFileVersion(exeFile);
-    final String productVersion = _getProductVersion(exeFile);
+      // Default exe has version 1.0.0
+      final String fileVersion = _getFileVersion(exeFile);
+      final String productVersion = _getProductVersion(exeFile);
 
-    expect(fileVersion, equals('1.0.0.0'));
-    expect(productVersion, equals('1.0.0'));
-  });
+      expect(fileVersion, equals('1.0.0.0'));
+      expect(productVersion, equals('1.0.0'));
+    });
+  }, skip: io.Platform.isWindows);
 }
 
 String _getFileVersion(File file) {

--- a/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
@@ -77,7 +77,7 @@ void main() {
       expect(fileVersion, equals('1.0.0.0'));
       expect(productVersion, equals('1.0.0'));
     });
-  }, skip: io.Platform.isWindows);
+  }, skip: !io.Platform.isWindows);
 }
 
 String _getFileVersion(File file) {

--- a/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
@@ -77,7 +77,7 @@ void main() {
       expect(fileVersion, equals('1.0.0.0'));
       expect(productVersion, equals('1.0.0'));
     });
-  }, skip: !io.Platform.isWindows);
+  }, skip: !io.Platform.isWindows); // [intended] Windows integration build.
 }
 
 String _getFileVersion(File file) {

--- a/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_windows_test.dart
@@ -1,0 +1,117 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file/file.dart';
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  // Only run this test on Windows
+  if (!platform.isWindows) {
+    return;
+  }
+
+  late Directory tempDir;
+  late Directory projectRoot;
+  late String flutterBin;
+  late Directory releaseDir;
+  late File exeFile;
+
+  setUpAll(() {
+    tempDir = createResolvedTempDirectorySync('build_windows_test.');
+    flutterBin = fileSystem.path.join(
+      getFlutterRoot(),
+      'bin',
+      'flutter',
+    );
+    processManager.runSync(<String>[flutterBin, 'config',
+      '--enable-windows-desktop',
+    ]);
+
+    processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'create',
+      'hello',
+    ], workingDirectory: tempDir.path);
+
+    projectRoot = tempDir.childDirectory('hello');
+
+    releaseDir = fileSystem.directory(fileSystem.path.join(
+      projectRoot.path,
+      'build',
+      'windows',
+      'runner',
+      'Release'
+    ));
+
+    exeFile = fileSystem.file(fileSystem.path.join(
+      releaseDir.path,
+      'hello.exe'
+    ));
+  });
+
+  tearDownAll(() {
+    tryToDelete(tempDir);
+  });
+
+  testWithoutContext('flutter build windows creates exe', () {
+    final ProcessResult result = processManager.runSync(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'build',
+      'windows',
+      '--no-pub',
+    ], workingDirectory: projectRoot.path);
+
+    expect(result.exitCode, 0);
+    expect(releaseDir, exists);
+    expect(exeFile, exists);
+
+    // Default exe has version 1.0.0
+    final String fileVersion = _getFileVersion(exeFile);
+    final String productVersion = _getProductVersion(exeFile);
+
+    expect(fileVersion, equals('1.0.0.0'));
+    expect(productVersion, equals('1.0.0'));
+  });
+}
+
+String _getFileVersion(File file) {
+  // FileVersionInfo's FileVersion property excludes the private part,
+  // so this recreates the file version using the individual parts.
+  final ProcessResult result = Process.runSync(
+    'powershell.exe -command " '
+    '\$v = [System.Diagnostics.FileVersionInfo]::GetVersionInfo(\\"${file.path}\\"); '
+    r'Write-Output \"$($v.FileMajorPart).$($v.FileMinorPart).$($v.FileBuildPart).$($v.FilePrivatePart)\" '
+    '"',
+    <String>[]
+  );
+
+  if (result.exitCode != 0) {
+    throw Exception('GetVersionInfo failed.');
+  }
+
+  // Trim trailing new line.
+  final String output = result.stdout as String;
+  return output.trim();
+}
+
+String _getProductVersion(File file) {
+  final ProcessResult result = Process.runSync(
+    'powershell.exe -command "[System.Diagnostics.FileVersionInfo]::GetVersionInfo(\\"${file.path}\\").ProductVersion"',
+    <String>[]
+  );
+
+  if (result.exitCode != 0) {
+    throw Exception('GetVersionInfo failed.');
+  }
+
+  // Trim trailing new line.
+  final String output = result.stdout as String;
+  return output.trim();
+}


### PR DESCRIPTION
Add an integration test that verifies that `flutter build windows` produces the expected executable. In the future, this will be used to test that version information is properly stamped on the executable.

This solution uses PowerShell to read the executable's version information. I chose against using win32's version APIs as that requires adding `package:ffi` and [>100 lines of FFI boilerplate](https://github.com/loic-sharma/flutter/commit/387b076ecbb063c3116fbeafe62d4a29631a0f8a#diff-b361b1daccaf787194ba151fafc1bd31e508a65c22eb45c828947ea77b6f40eaR123-R237).

Part of https://github.com/flutter/flutter/issues/73652.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.