### PR TITLE
fix upcomming diagnostics after updates on use_build_context_synchronously

### DIFF
--- a/dev/integration_tests/android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/android_views/lib/motion_events_page.dart
@@ -172,8 +172,9 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
 
   Future<void> saveRecordedEvents(ByteData data, BuildContext context) async {
     if (await channel.invokeMethod<bool>('getStoragePermission') ?? false) {
-      showMessage(
-          context, 'External storage permissions are required to save events');
+      if (mounted) {
+        showMessage(context, 'External storage permissions are required to save events');
+      }
       return;
     }
     try {

--- a/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/motion_events_page.dart
@@ -154,8 +154,9 @@ class MotionEventsBodyState extends State<MotionEventsBody> {
 
   Future<void> saveRecordedEvents(ByteData data, BuildContext context) async {
     if (await channel.invokeMethod<bool>('getStoragePermission') != true) {
-      showMessage(
-          context, 'External storage permissions are required to save events');
+      if (mounted) {
+        showMessage(context, 'External storage permissions are required to save events');
+      }
       return;
     }
     try {


### PR DESCRIPTION
This PR fixes 2 upcoming diagnostics after [updates on use_build_context_synchronously](https://github.com/dart-lang/linter/pull/3458).