### PR TITLE
Refactor TextSelectionGestureDetectorBuilderDelegate to not depend on RenderEditable's handleTapDown and handleSecondaryTapDown

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -85,13 +85,13 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
       switch (Theme.of(_state.context).platform) {
         case TargetPlatform.iOS:
         case TargetPlatform.macOS:
-          renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+          selectWordEdge(details.globalPosition, SelectionChangedCause.tap);
           break;
         case TargetPlatform.android:
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+          renderEditable.selectPositionAt(from: details.globalPosition, cause: SelectionChangedCause.tap);
           break;
       }
     }
@@ -101,7 +101,7 @@ class _SelectableTextSelectionGestureDetectorBuilder extends TextSelectionGestur
   @override
   void onSingleLongTapStart(LongPressStartDetails details) {
     if (delegate.selectionEnabled) {
-      renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+      renderEditable.selectWordsInRange(from: details.globalPosition, cause: SelectionChangedCause.longPress);
       Feedback.forLongPress(_state.context);
     }
   }

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -105,7 +105,7 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+          renderEditable.selectWordsInRange(from: details.globalPosition, cause: SelectionChangedCause.longPress);
           Feedback.forLongPress(_state.context);
           break;
       }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3018,7 +3018,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   /// Returns `false` if a toolbar couldn't be shown, such as when the toolbar
   /// is already shown, or when no text selection currently exists.
   @override
-  bool showToolbar() {
+  bool showToolbar([Offset? locationToDisplayToolbar]) {
     // Web is using native dom elements to enable clipboard functionality of the
     // toolbar: copy, paste, select, cut. It might also provide additional
     // functionality depending on the browser (such as translate). Due to this
@@ -3031,7 +3031,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       return false;
     }
     _clipboardStatus?.update();
-    _selectionOverlay!.showToolbar();
+    _selectionOverlay!.showToolbar(locationToDisplayToolbar);
     return true;
   }
 
@@ -3047,12 +3047,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   /// Toggles the visibility of the toolbar.
-  void toggleToolbar() {
+  void toggleToolbar([Offset? locationToDisplayToolbar]) {
     assert(_selectionOverlay != null);
     if (_selectionOverlay!.toolbarIsVisible) {
       hideToolbar();
     } else {
-      showToolbar();
+      showToolbar(locationToDisplayToolbar);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1454,7 +1454,7 @@ class TextSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onTapDown], which triggers this callback.
   @protected
   void onTapDown(TapDownDetails details) {
-    renderEditable.handleTapDown(details);
+    renderEditable.handleTapDown(details);//remove
     // The selection overlay should only be shown when the user is interacting
     // through a touch screen (via either a finger or a stylus). A mouse shouldn't
     // trigger the selection overlay.
@@ -1562,7 +1562,7 @@ class TextSelectionGestureDetectorBuilder {
             case PointerDeviceKind.stylus:
             case PointerDeviceKind.invertedStylus:
               // Precise devices should place the cursor at a precise position.
-              renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+              renderEditable.selectPositionAt(from: details.globalPosition, cause: SelectionChangedCause.tap);
               break;
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
@@ -1576,7 +1576,7 @@ class TextSelectionGestureDetectorBuilder {
         case TargetPlatform.fuchsia:
         case TargetPlatform.linux:
         case TargetPlatform.windows:
-          renderEditable.selectPosition(cause: SelectionChangedCause.tap);
+          renderEditable.selectPositionAt(from: details.globalPosition, cause: SelectionChangedCause.tap);
           break;
       }
     }
@@ -1702,7 +1702,7 @@ class TextSelectionGestureDetectorBuilder {
   @protected
   void onDoubleTapDown(TapDownDetails details) {
     if (delegate.selectionEnabled) {
-      renderEditable.selectWord(cause: SelectionChangedCause.tap);
+      renderEditable.selectWordsInRange(from: details.globalPosition, cause: SelectionChangedCause.tap);
       if (shouldShowSelectionToolbar) {
         editableText.showToolbar();
       }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -335,8 +335,8 @@ class TextSelectionOverlay {
   void hideHandles() => _selectionOverlay.hideHandles();
 
   /// {@macro flutter.widgets.SelectionOverlay.showToolbar}
-  void showToolbar() {
-    _updateSelectionOverlay();
+  void showToolbar([Offset? locationToDisplayToolbar]) {
+    _updateSelectionOverlay(locationToDisplayToolbar);
     _selectionOverlay.showToolbar();
   }
 
@@ -357,7 +357,7 @@ class TextSelectionOverlay {
     _updateSelectionOverlay();
   }
 
-  void _updateSelectionOverlay() {
+  void _updateSelectionOverlay([Offset? locationToDisplayToolbar]) {
     _selectionOverlay
       // Update selection handle metrics.
       ..startHandleType = _chooseType(
@@ -374,7 +374,7 @@ class TextSelectionOverlay {
       ..lineHeightAtEnd = _getEndGlyphHeight()
       // Update selection toolbar metrics.
       ..selectionEndPoints = renderObject.getEndpointsForSelection(_selection)
-      ..toolbarLocation = renderObject.lastSecondaryTapDownPosition;
+      ..toolbarLocation = locationToDisplayToolbar ?? renderObject.lastSecondaryTapDownPosition;
   }
 
   /// Causes the overlay to update its rendering.
@@ -1689,7 +1689,7 @@ class TextSelectionGestureDetectorBuilder {
         }
         if (shouldShowSelectionToolbar) {
           editableText.hideToolbar();
-          editableText.showToolbar();
+          editableText.showToolbar(details.globalPosition);
         }
         break;
       case TargetPlatform.android:
@@ -1699,7 +1699,7 @@ class TextSelectionGestureDetectorBuilder {
         if (!renderEditable.hasFocus) {
           renderEditable.selectPositionAt(from: details.globalPosition, cause: SelectionChangedCause.tap);
         }
-        editableText.toggleToolbar();
+        editableText.toggleToolbar(details.globalPosition);
         break;
     }
   }
@@ -1713,7 +1713,6 @@ class TextSelectionGestureDetectorBuilder {
   ///  * [onSecondaryTapUp], which is typically called after this.
   @protected
   void onSecondaryTapDown(TapDownDetails details) {
-    renderEditable.handleSecondaryTapDown(details);
     _shouldShowSelectionToolbar = true;
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1710,7 +1710,7 @@ class TextSelectionGestureDetectorBuilder {
   ///
   ///  * [TextSelectionGestureDetector.onSecondaryTapDown], which triggers this
   ///    callback.
-  ///  * [onSecondaryTap], which is typically called after this.
+  ///  * [onSecondaryTapUp], which is typically called after this.
   @protected
   void onSecondaryTapDown(TapDownDetails details) {
     renderEditable.handleSecondaryTapDown(details);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -3553,8 +3553,8 @@ void main() {
     final RenderEditable renderEditable =
       tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
 
-    await tester.tapAt(textOffsetToPosition(tester, 5));
-    renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    // await tester.longPressAt(textOffsetToPosition(tester, 5)); why doesn't this work?
+    renderEditable.selectWordsInRange(from: textOffsetToPosition(tester, 5), cause: SelectionChangedCause.longPress);
     await tester.pumpAndSettle();
 
     final List<Widget> transitions =

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -3553,7 +3553,6 @@ void main() {
     final RenderEditable renderEditable =
       tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
 
-    // await tester.longPressAt(textOffsetToPosition(tester, 5)); why doesn't this work?
     renderEditable.selectWordsInRange(from: textOffsetToPosition(tester, 5), cause: SelectionChangedCause.longPress);
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9387,10 +9387,6 @@ void main() {
       ),
     );
 
-    final EditableTextState state =
-      tester.state<EditableTextState>(find.byType(EditableText));
-    final RenderEditable renderEditable = state.renderEditable;
-
     await tester.longPressAt(const Offset(20, 10));
     await tester.pumpAndSettle();
 
@@ -9422,7 +9418,6 @@ void main() {
     final RenderEditable renderEditable =
       tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
 
-    // await tester.longPressAt(const Offset(20, 10)); why doesn't this work?
     renderEditable.selectWordsInRange(from: const Offset(20, 10), cause: SelectionChangedCause.longPress);
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -9391,8 +9391,7 @@ void main() {
       tester.state<EditableTextState>(find.byType(EditableText));
     final RenderEditable renderEditable = state.renderEditable;
 
-    await tester.tapAt(const Offset(20, 10));
-    renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    await tester.longPressAt(const Offset(20, 10));
     await tester.pumpAndSettle();
 
     final List<FadeTransition> transitions = find.descendant(
@@ -9423,8 +9422,8 @@ void main() {
     final RenderEditable renderEditable =
       tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
 
-    await tester.tapAt(const Offset(20, 10));
-    renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    // await tester.longPressAt(const Offset(20, 10)); why doesn't this work?
+    renderEditable.selectWordsInRange(from: const Offset(20, 10), cause: SelectionChangedCause.longPress);
     await tester.pumpAndSettle();
 
     final List<FadeTransition> transitions =

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -4220,10 +4220,6 @@ void main() {
       ),
     );
 
-    final EditableTextState state =
-    tester.state<EditableTextState>(find.byType(EditableText));
-    final RenderEditable renderEditable = state.renderEditable;
-
     await tester.longPressAt(const Offset(20, 10));
     await tester.pumpAndSettle();
 
@@ -4253,7 +4249,6 @@ void main() {
     final RenderEditable renderEditable =
         tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
 
-    // await tester.longPressAt(const Offset(20, 10)); Why doesn't this work?
     renderEditable.selectWordsInRange(from: const Offset(20, 10), cause: SelectionChangedCause.longPress);
     await tester.pumpAndSettle();
 

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -4224,8 +4224,7 @@ void main() {
     tester.state<EditableTextState>(find.byType(EditableText));
     final RenderEditable renderEditable = state.renderEditable;
 
-    await tester.tapAt(const Offset(20, 10));
-    renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    await tester.longPressAt(const Offset(20, 10));
     await tester.pumpAndSettle();
 
     final List<FadeTransition> transitions = find.descendant(
@@ -4254,8 +4253,8 @@ void main() {
     final RenderEditable renderEditable =
         tester.state<EditableTextState>(find.byType(EditableText)).renderEditable;
 
-    await tester.tapAt(const Offset(20, 10));
-    renderEditable.selectWord(cause: SelectionChangedCause.longPress);
+    // await tester.longPressAt(const Offset(20, 10)); Why doesn't this work?
+    renderEditable.selectWordsInRange(from: const Offset(20, 10), cause: SelectionChangedCause.longPress);
     await tester.pumpAndSettle();
 
     final List<Widget> transitions =

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -471,23 +471,23 @@ void main() {
     await gesture.down(globalCharLocation);
     await gesture.up();
     await tester.pump();
-    expect(renderEditable.selectWordCalled, isTrue);
+    expect(renderEditable.selectWordsInRangeCalled, isTrue);
 
     // Right clicking on a word within a selection shouldn't change the selection
-    renderEditable.selectWordCalled = false;
+    renderEditable.selectWordsInRangeCalled = false;
     renderEditable.selection = const TextSelection(baseOffset: 3, extentOffset: 20);
     await gesture.down(globalCharLocation);
     await gesture.up();
     await tester.pump();
-    expect(renderEditable.selectWordCalled, isFalse);
+    expect(renderEditable.selectWordsInRangeCalled, isFalse);
 
     // Right clicking on a word within a reverse (right-to-left) selection shouldn't change the selection
-    renderEditable.selectWordCalled = false;
+    renderEditable.selectWordsInRangeCalled = false;
     renderEditable.selection = const TextSelection(baseOffset: 20, extentOffset: 3);
     await gesture.down(globalCharLocation);
     await gesture.up();
     await tester.pump();
-    expect(renderEditable.selectWordCalled, isFalse);
+    expect(renderEditable.selectWordsInRangeCalled, isFalse);
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }),
   );
@@ -516,19 +516,19 @@ void main() {
     await gesture.down(globalCharLocation);
     await gesture.up();
     await tester.pump();
-    expect(renderEditable.selectWordCalled, isFalse);
-    expect(renderEditable.selectPositionCalled, isTrue);
+    expect(renderEditable.selectWordsInRangeCalled, isFalse);
+    expect(renderEditable.selectPositionAtCalled, isTrue);
 
     // Right clicking on a focused field with selection shouldn't change the
     // selection.
-    renderEditable.selectPositionCalled = false;
+    renderEditable.selectPositionAtCalled = false;
     renderEditable.selection = const TextSelection(baseOffset: 3, extentOffset: 20);
     renderEditable.hasFocus = true;
     await gesture.down(globalCharLocation);
     await gesture.up();
     await tester.pump();
-    expect(renderEditable.selectWordCalled, isFalse);
-    expect(renderEditable.selectPositionCalled, isFalse);
+    expect(renderEditable.selectWordsInRangeCalled, isFalse);
+    expect(renderEditable.selectPositionAtCalled, isFalse);
 
     // Right clicking on a focused field with a reverse (right to left)
     // selection shouldn't change the selection.
@@ -536,8 +536,8 @@ void main() {
     await gesture.down(globalCharLocation);
     await gesture.up();
     await tester.pump();
-    expect(renderEditable.selectWordCalled, isFalse);
-    expect(renderEditable.selectPositionCalled, isFalse);
+    expect(renderEditable.selectWordsInRangeCalled, isFalse);
+    expect(renderEditable.selectPositionAtCalled, isFalse);
   },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.fuchsia, TargetPlatform.linux, TargetPlatform.windows }),
   );
@@ -585,7 +585,7 @@ void main() {
     final FakeEditableTextState state = tester.state(find.byType(FakeEditableText));
     final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
     expect(state.showToolbarCalled, isTrue);
-    expect(renderEditable.selectWordCalled, isTrue);
+    expect(renderEditable.selectWordsInRangeCalled, isTrue);
   });
 
   testWidgets('test TextSelectionGestureDetectorBuilder forcePress enabled', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1339,13 +1339,13 @@ class FakeEditableTextState extends EditableTextState {
   RenderEditable get renderEditable => _editableKey.currentContext!.findRenderObject()! as RenderEditable;
 
   @override
-  bool showToolbar() {
+  bool showToolbar([Offset? locationToDisplayToolbar]) {
     showToolbarCalled = true;
     return true;
   }
 
   @override
-  void toggleToolbar() {
+  void toggleToolbar([Offset? locationToDisplayToolbar]) {
     return;
   }
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -558,7 +558,8 @@ void main() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        expect(renderEditable.selectWordEdgeCalled, isTrue);
+        expect(renderEditable.getPositionForPointIsCalled, isTrue);
+        expect(renderEditable.getWordBoundaryIsCalled, isTrue);
         break;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
@@ -1386,6 +1387,20 @@ class FakeRenderEditable extends RenderEditable {
       offset: 0,
     ),
   );
+
+  bool getPositionForPointIsCalled = false;
+  @override
+  TextPosition getPositionForPoint(Offset globalPosition) {
+    getPositionForPointIsCalled = true;
+    return super.getPositionForPoint(globalPosition);
+  }
+
+  bool getWordBoundaryIsCalled = false;
+  @override
+  TextRange getWordBoundary(TextPosition position) {
+    getWordBoundaryIsCalled = true;
+    return super.getWordBoundary(position);
+  }
 
   bool selectWordsInRangeCalled = false;
   @override


### PR DESCRIPTION
This change removes `TextSelectionGestureDetectorBuilderDelegate` dependance on `lastSecondaryTapDownPosition` and `lastTapDownPosition` stored in `RenderEditable`. This is in preparation of #101151 which will not rely on the gesture state stored in `RenderEditable`, rather solely use the `TapUpDetails/TapDownDetails` given by the `GestureRecognizers`.

As a result of not using `handleSecondaryTapDown` and `lastSecondaryTapDownPosition` we move the `onSecondaryTap` logic to `onSecondaryTapUp` which has access to `TapUpDetails` with the `globalPosition` we need to render the context menu at that specified location. `showToolbar` and `toggleToolbar` also now have an optional parameter to display the toolbar at a specified location, where as before they displayed it at `renderEditable.lastSecondaryTapDownPosition`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
