### PR TITLE
[flutter_tools] print override storage warning to STDERR instead of STDOUT

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -520,7 +520,7 @@ class Cache {
     if (_hasWarnedAboutStorageOverride) {
       return;
     }
-    _logger.printStatus(
+    _logger.printError(
       'Flutter assets will be downloaded from $overrideUrl. Make sure you trust this source!',
       emphasis: true,
     );

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -319,6 +319,22 @@ void main() {
 
       expect(() => cache.storageBaseUrl, throwsToolExit());
     });
+
+    testWithoutContext('overridden storage base url prints warning to STDERR', () async {
+      final BufferLogger logger = BufferLogger.test();
+      const String baseUrl = 'https://storage.com';
+      final Cache cache = Cache.test(
+        platform: FakePlatform(environment: <String, String>{
+          'FLUTTER_STORAGE_BASE_URL': baseUrl,
+        }),
+        processManager: FakeProcessManager.any(),
+        logger: logger,
+      );
+
+      expect(cache.storageBaseUrl, baseUrl);
+      expect(logger.errorText, contains('Flutter assets will be downloaded from $baseUrl'));
+      expect(logger.statusText, isEmpty);
+    });
   });
 
   testWithoutContext('flattenNameSubdirs', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106069
Fixes https://github.com/flutter/flutter/issues/106070