### PR TITLE
Fix SliverPadding geometry 

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_padding.dart
+++ b/packages/flutter/lib/src/rendering/sliver_padding.dart
@@ -119,10 +119,21 @@ abstract class RenderSliverEdgeInsetsPadding extends RenderSliver with RenderObj
     final double mainAxisPadding = this.mainAxisPadding;
     final double crossAxisPadding = this.crossAxisPadding;
     if (child == null) {
+      final double paintExtent = calculatePaintOffset(
+          constraints,
+          from: 0.0,
+          to: mainAxisPadding,
+      );
+      final double cacheExtent = calculateCacheOffset(
+          constraints,
+          from: 0.0,
+          to: mainAxisPadding,
+      );
       geometry = SliverGeometry(
         scrollExtent: mainAxisPadding,
-        paintExtent: math.min(mainAxisPadding, constraints.remainingPaintExtent),
+        paintExtent: math.min(paintExtent, constraints.remainingPaintExtent),
         maxPaintExtent: mainAxisPadding,
+        cacheExtent: cacheExtent,
       );
       return;
     }

--- a/packages/flutter/test/widgets/slivers_padding_test.dart
+++ b/packages/flutter/test/widgets/slivers_padding_test.dart
@@ -271,6 +271,34 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Offset.zero), const Offset(0.0, 200.0));
   });
 
+  testWidgets('SliverPadding with no child reports correct geometry as scroll offset changes', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/64506
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: CustomScrollView(
+          controller: controller,
+          slivers: const <Widget>[
+            SliverPadding(padding: EdgeInsets.all(100.0)),
+            SliverToBoxAdapter(child: SizedBox(width: 400.0, height: 400.0, child: Text('x'))),
+          ],
+        ),
+      ),
+    );
+    expect(tester.renderObject<RenderBox>(find.text('x')).localToGlobal(Offset.zero), const Offset(0.0, 200.0));
+    expect(
+      tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).geometry!.paintExtent,
+      200.0,
+    );
+    controller.jumpTo(50.0);
+    await tester.pump();
+    expect(
+      tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).geometry!.paintExtent,
+      150.0,
+    );
+  });
+
   testWidgets('Viewport+SliverPadding changing padding', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
@@ -366,7 +394,7 @@ void main() {
         ),
       ),
     );
-    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding)).afterPadding, 1.0);
+    expect(tester.renderObject<RenderSliverPadding>(find.byType(SliverPadding, skipOffstage: false)).afterPadding, 1.0);
   });
 
   testWidgets('SliverPadding propagates geometry offset corrections', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/64506

This fixes the SliverGeometry of SliverPadding when the child is null. Previous to this change, the geometry was not being updated to account for the scrollOffset changing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
