### PR TITLE
[web] Fix JS crash when FF blocks service workers.

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -39,7 +39,7 @@ Future<void> main() async {
   await runWebServiceWorkerTestWithCachingResources(headless: false, testType: ServiceWorkerTestType.withoutFlutterJs);
   await runWebServiceWorkerTestWithCachingResources(headless: false, testType: ServiceWorkerTestType.withFlutterJs);
   await runWebServiceWorkerTestWithCachingResources(headless: false, testType: ServiceWorkerTestType.withFlutterJsShort);
-  await runWebServiceWorkerTestWithBlockedServiceWorkers(headless: true);
+  await runWebServiceWorkerTestWithBlockedServiceWorkers(headless: false);
 }
 
 Future<void> _setAppVersion(int version) async {

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1087,6 +1087,7 @@ Future<void> _runWebLongRunningTests() async {
     () => runWebServiceWorkerTestWithCachingResources(headless: true, testType: ServiceWorkerTestType.withoutFlutterJs),
     () => runWebServiceWorkerTestWithCachingResources(headless: true, testType: ServiceWorkerTestType.withFlutterJs),
     () => runWebServiceWorkerTestWithCachingResources(headless: true, testType: ServiceWorkerTestType.withFlutterJsShort),
+    () => runWebServiceWorkerTestWithBlockedServiceWorkers(headless: true),
     () => _runWebStackTraceTest('profile', 'lib/stack_trace.dart'),
     () => _runWebStackTraceTest('release', 'lib/stack_trace.dart'),
     () => _runWebStackTraceTest('profile', 'lib/framework_stack_trace.dart'),

--- a/dev/integration_tests/web/lib/service_worker_test_blocked_service_workers.dart
+++ b/dev/integration_tests/web/lib/service_worker_test_blocked_service_workers.dart
@@ -1,0 +1,10 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html' as html;
+Future<void> main() async {
+  const String response = 'CLOSE?version=1';
+  await html.HttpRequest.getString(response);
+  html.document.body?.appendHtml(response);
+}

--- a/dev/integration_tests/web/web/index_with_blocked_service_workers.html
+++ b/dev/integration_tests/web/web/index_with_blocked_service_workers.html
@@ -1,0 +1,48 @@
+<!DOCTYPE HTML>
+<!-- Copyright 2014 The Flutter Authors. All rights reserved.
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file. -->
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta content="IE=Edge" http-equiv="X-UA-Compatible">
+
+  <title>Web Test</title>
+  <!-- iOS meta tags & icons -->
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black">
+  <meta name="apple-mobile-web-app-title" content="Web Test">
+  <link rel="manifest" href="manifest.json">
+
+  <script>
+    // This is to break the serviceWorker registration, and make it throw a DOMException!
+    // Test for issue https://github.com/flutter/flutter/issues/103972
+    window.navigator.serviceWorker.register = (url) => {
+      console.error('Failed to register/update a ServiceWorker for scope ', url,
+          ': Storage access is restricted in this context due to user settings or private browsing mode.');
+      return Promise.reject(new DOMException('The operation is insecure.'));
+    }
+  </script>
+
+  <script>
+    // The value below is injected by flutter build, do not touch.
+    var serviceWorkerVersion = null;
+  </script>
+  <!-- This script adds the flutter initialization JS code -->
+  <script src="flutter.js" defer></script>
+</head>
+<body>
+  <script>
+    window.addEventListener('load', function(ev) {
+      // Download main.dart.js
+      _flutter.loader.loadEntrypoint({
+        serviceWorker: {
+          serviceWorkerVersion: serviceWorkerVersion,
+        }
+      }).then(function(engineInitializer) {
+        return engineInitializer.autoStart();
+      });
+    });
+  </script>
+</body>
+</html>

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -76,6 +76,7 @@ _flutter.loader = null;
 
     _loadEntrypoint(entrypointUrl) {
       if (!this._scriptLoaded) {
+        console.debug("Injecting <script> tag.");
         this._scriptLoaded = new Promise((resolve, reject) => {
           let scriptTag = document.createElement("script");
           scriptTag.src = entrypointUrl;
@@ -96,7 +97,7 @@ _flutter.loader = null;
     _waitForServiceWorkerActivation(serviceWorker, entrypointUrl) {
       if (!serviceWorker || serviceWorker.state == "activated") {
         if (!serviceWorker) {
-          console.warn("Cannot activate a null service worker. Falling back to plain <script> tag.");
+          console.warn("Cannot activate a null service worker.");
         } else {
           console.debug("Service worker already active.");
         }
@@ -114,7 +115,7 @@ _flutter.loader = null;
 
     _loadWithServiceWorker(entrypointUrl, serviceWorkerOptions) {
       if (!("serviceWorker" in navigator) || serviceWorkerOptions == null) {
-        console.warn("Service worker not supported (or configured). Falling back to plain <script> tag.", serviceWorkerOptions);
+        console.warn("Service worker not supported (or configured).", serviceWorkerOptions);
         return this._loadEntrypoint(entrypointUrl);
       }
 
@@ -158,7 +159,7 @@ _flutter.loader = null;
         timeout = new Promise((resolve, _) => {
           setTimeout(() => {
             if (!this._scriptLoaded) {
-              console.warn("Failed to load app from service worker. Falling back to plain <script> tag.");
+              console.warn("Loading from service worker timed out after", timeoutMillis, "milliseconds.");
               resolve(this._loadEntrypoint(entrypointUrl));
             }
           }, timeoutMillis);

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -145,6 +145,11 @@ _flutter.loader = null;
               console.debug("Loading app from service worker.");
               return this._loadEntrypoint(entrypointUrl);
             }
+          })
+          .catch((error) => {
+            // Some exception happened while registering/activating the service worker.
+            console.warn("Failed to register or activate service worker:", error);
+            return this._loadEntrypoint(entrypointUrl);
           });
 
       // Timeout race promise

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -160,7 +160,7 @@ _flutter.loader = null;
         });
       }
 
-      return Promise.race([loader, timeout]);
+      return Promise.any([loader, timeout]);
     }
   }
 

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -166,7 +166,7 @@ _flutter.loader = null;
         });
       }
 
-      return Promise.any([loader, timeout]);
+      return Promise.race([loader, timeout]);
     }
   }
 


### PR DESCRIPTION
When FF users enable the _"Delete cookies and site data when Firefox is closed"_ browser option, it has the side effect of **blocking service workers.** See [Bugzilla#1429714](https://bugzilla.mozilla.org/show_bug.cgi?id=1429714) ([and](https://bugzilla.mozilla.org/show_bug.cgi?id=1413615) [several](https://bugzilla.mozilla.org/show_bug.cgi?id=1552376) [others](https://bugzilla.mozilla.org/show_bug.cgi?id=1755167)).

When a Flutter app attempts to load in a browser configured like so, first the browser will log an error:

* **`Failed to register/update a ServiceWorker for scope 'https://domain': Storage access is restricted in this context due to user settings or private browsing mode.`**

And then **reject the `register` promise with a `DOMException: The operation is insecure.`** that goes unhandled into our `flutter.js` code.

The unhandled DOMException interrupts the JS bootstrap code, and the application stops loading, resulting in a white screen.

This PR handles this issue by `.catch`ing the rejected Promise from the service worker registration, then falling back to inject a script tag.

* Fixes https://github.com/flutter/flutter/issues/103972

### Testing

* Added an integration test to ensure that a Flutter Web app starts, even when the Service Workers are "blocked" (in the way that FF blocks them)
* Manually tested here with the actual browser: https://dit-bootstrap-tests.web.app

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
