### PR TITLE
Revert "Make RenderSliverGrid more accurately report overflow"

### DIFF
--- a/packages/flutter/lib/src/rendering/sliver_grid.dart
+++ b/packages/flutter/lib/src/rendering/sliver_grid.dart
@@ -658,6 +658,7 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       leadingScrollOffset: leadingScrollOffset,
       trailingScrollOffset: trailingScrollOffset,
     );
+
     final double paintExtent = calculatePaintOffset(
       constraints,
       from: math.min(constraints.scrollOffset, leadingScrollOffset),
@@ -674,7 +675,8 @@ class RenderSliverGrid extends RenderSliverMultiBoxAdaptor {
       paintExtent: paintExtent,
       maxPaintExtent: estimatedTotalExtent,
       cacheExtent: cacheExtent,
-      hasVisualOverflow: estimatedTotalExtent > paintExtent || constraints.scrollOffset > 0.0 || constraints.overlap != 0.0,
+      // Conservative to avoid complexity.
+      hasVisualOverflow: true,
     );
 
     // We may have started the layout while scrolled to the end, which

--- a/packages/flutter/test/widgets/grid_view_test.dart
+++ b/packages/flutter/test/widgets/grid_view_test.dart
@@ -645,50 +645,13 @@ void main() {
     expect(counters[4], 2);
   });
 
-  testWidgets('GridView does not report visual overflow unnecessarily', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: GridView(
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
-          children: <Widget>[
-            Container(height: 200.0),
-          ],
-        ),
-      ),
-    );
-
-    // 1st, check that the render object has received the default clip behavior.
-    final RenderViewport renderObject = tester.allRenderObjects.whereType<RenderViewport>().first;
-    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
-
-    // The context will get Clip.none because there is no actual visual overflow.
-    final TestClipPaintingContext context = TestClipPaintingContext();
-    renderObject.paint(context, Offset.zero);
-    expect(context.clipBehavior, equals(Clip.none));
-  });
-
   testWidgets('GridView respects clipBehavior', (WidgetTester tester) async {
     await tester.pumpWidget(
       Directionality(
         textDirection: TextDirection.ltr,
         child: GridView(
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
-          children: <Widget>[
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-          ],
+          children: <Widget>[Container(height: 2000.0)],
         ),
       ),
     );
@@ -709,21 +672,7 @@ void main() {
         child: GridView(
           gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(crossAxisCount: 3),
           clipBehavior: Clip.antiAlias,
-          children: <Widget>[
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-            Container(height: 2000.0),
-          ],
+          children: <Widget>[Container(height: 2000.0)],
         ),
       ),
     );


### PR DESCRIPTION
Reverts flutter/flutter#104064

Caused bigger than expected golden changes internally.

@Piinks @jonahwilliams 