### PR TITLE
Refactoring the setPubRootDirectory tests

### DIFF
--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1446,8 +1446,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           );
         });
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
-    ); // [intended] Test requires --track-widget-creation flag.
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
+    );
 
     test('ext.flutter.inspector.disposeGroup', () async {
       final Object a = Object();
@@ -2194,8 +2194,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           },
         );
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
-    ); // [intended] Test requires --track-widget-creation flag.
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
+    );
 
     group(
       'ext.flutter.inspector.setPubRootDirectories extra args regression test',
@@ -2371,9 +2371,9 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           },
         );
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
-    ); // [intended] Test requires --track-widget-creation flag.
-
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
+    );
+    
     Map<Object, Object?> removeLastEvent(List<Map<Object, Object?>> events) {
       final Map<Object, Object?> event = events.removeLast();
       // Verify that the event is json encodable.

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2371,8 +2371,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           },
         );
       },
-    )
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
+    ); // [intended] Test requires --track-widget-creation flag.
 
     Map<Object, Object?> removeLastEvent(List<Map<Object, Object?>> events) {
       final Map<Object, Object?> event = events.removeLast();

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -23,7 +23,6 @@ import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:platform/platform.dart';
 
 import 'widget_inspector_test_utils.dart';
 
@@ -1447,8 +1446,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           );
         });
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
-    ); // [intended] Test requires --track-widget-creation flag.
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
+    );
 
     test('ext.flutter.inspector.disposeGroup', () async {
       final Object a = Object();
@@ -2372,8 +2371,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           },
         );
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
-    ); // [intended] Test requires --track-widget-creation flag.);
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.);
+    );
 
     Map<Object, Object?> removeLastEvent(List<Map<Object, Object?>> events) {
       final Map<Object, Object?> event = events.removeLast();

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1201,24 +1201,26 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(nodes[2].runtimeType, ErrorSpacer);
       expect(nodes[3].runtimeType, StringProperty);
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked());  // [intended] Test requires --track-widget-creation flag.
-    group('WidgetInspectorService', () {
 
-      group('setPubRootDirectories', ()  {
-        late final String pubRootTest; 
+    group(
+      'WidgetInspectorService',
+      () {
+        group('setPubRootDirectories', () {
+          late final String pubRootTest;
 
-        setUpAll(() {
-          pubRootTest = generateTestPubRootDirectory(service);
-        });
+          setUpAll(() {
+            pubRootTest = generateTestPubRootDirectory(service);
+          });
 
-        setUp((){
-          service.disposeAllGroups();
-          service.setPubRootDirectories(<String>[]);
-        });
+          setUp(() {
+            service.disposeAllGroups();
+            service.setPubRootDirectories(<String>[]);
+          });
 
-        testWidgets(
-          'does not have createdByLocalProject when there are no pubRootDirectories',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
+          testWidgets(
+            'does not have createdByLocalProject when there are no pubRootDirectories',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
                   children: const <Widget>[
@@ -1228,181 +1230,225 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
                   ],
                 ),
               );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
-            service.setSelection(elementA, 'my-group');
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
+              service.setSelection(elementA, 'my-group');
 
-            final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
-            final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
+              final Map<String, Object?> jsonObject =
+                  json.decode(service.getSelectedWidget(null, 'my-group'))
+                      as Map<String, Object?>;
+              final Map<String, Object?> creationLocation =
+                  jsonObject['creationLocation']! as Map<String, Object?>;
 
-            expect(creationLocation, isNotNull);
-            final String fileA = creationLocation['file']! as String;
-            expect(fileA, endsWith('widget_inspector_test.dart'));
-            expect(jsonObject, isNot(contains('createdByLocalProject')));
-          },
-        );
+              expect(creationLocation, isNotNull);
+              final String fileA = creationLocation['file']! as String;
+              expect(fileA, endsWith('widget_inspector_test.dart'));
+              expect(jsonObject, isNot(contains('createdByLocalProject')));
+            },
+          );
 
-        testWidgets(
-          'has createdByLocalProject when the element is part of the pubRootDirectory',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
+          testWidgets(
+            'has createdByLocalProject when the element is part of the pubRootDirectory',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
 
-            service.setPubRootDirectories(<String>[pubRootTest]);
-            
-            service.setSelection(elementA, 'my-group');
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-          },
-        );
+              service.setPubRootDirectories(<String>[pubRootTest]);
 
-        testWidgets(
-          'does not have createdByLocalProject when widget package directory is a suffix of a pubRootDirectory',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
-            service.setSelection(elementA, 'my-group');
+              service.setSelection(elementA, 'my-group');
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                contains('createdByLocalProject'),
+              );
+            },
+          );
 
-            service.setPubRootDirectories(<String>['/invalid/$pubRootTest']);
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
-          },
-        );
+          testWidgets(
+            'does not have createdByLocalProject when widget package directory is a suffix of a pubRootDirectory',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
+              service.setSelection(elementA, 'my-group');
 
-        testWidgets(
-          'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
-            service.setSelection(elementA, 'my-group');
+              service.setPubRootDirectories(<String>['/invalid/$pubRootTest']);
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                isNot(contains('createdByLocalProject')),
+              );
+            },
+          );
 
-            service.setPubRootDirectories(<String>['file://$pubRootTest']);
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-          },
-        );
+          testWidgets(
+            'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
+              service.setSelection(elementA, 'my-group');
 
-        testWidgets(
-          'does not have createdByLocalProject when thePubRootDirecty has a different suffix',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
-            service.setSelection(elementA, 'my-group');
+              service.setPubRootDirectories(<String>['file://$pubRootTest']);
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                contains('createdByLocalProject'),
+              );
+            },
+          );
 
-            service.setPubRootDirectories(<String>['$pubRootTest/different']);
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
-          },
-        );
+          testWidgets(
+            'does not have createdByLocalProject when thePubRootDirecty has a different suffix',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
+              service.setSelection(elementA, 'my-group');
 
-        testWidgets(
-          'has createdByLocalProject even if another pubRootDirectory does not match',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
-            service.setSelection(elementA, 'my-group');
+              service.setPubRootDirectories(<String>['$pubRootTest/different']);
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                isNot(contains('createdByLocalProject')),
+              );
+            },
+          );
 
-            service.setPubRootDirectories(<String>[
-              '/invalid/$pubRootTest',
-              pubRootTest,
-            ]);
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-          },
-        );
+          testWidgets(
+            'has createdByLocalProject even if another pubRootDirectory does not match',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
+              service.setSelection(elementA, 'my-group');
 
-        testWidgets(
-          'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
-          (WidgetTester tester) async {
-            final Widget widget = Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            );
-            await tester.pumpWidget(widget);
-            final Element elementA = find.text('a').evaluate().first;
-            final Element richText = find.descendant(
-              of: find.text('a'),
-              matching: find.byType(RichText),
-            ).evaluate().first;
-            service.setSelection(richText, 'my-group');
-            service.setPubRootDirectories(<String>[pubRootTest]);
-            
-            final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
-            expect(jsonObject, isNot(contains('createdByLocalProject')));
-            final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
-            expect(creationLocation, isNotNull);
-            // This RichText widget is created by the build method of the Text widget
-            // thus the creation location is in text.dart not basic.dart
-            final List<String> pathSegmentsFramework = Uri.parse(creationLocation['file']! as String).pathSegments;
-            expect(pathSegmentsFramework.join('/'), endsWith('/flutter/lib/src/widgets/text.dart'));
+              service.setPubRootDirectories(<String>[
+                '/invalid/$pubRootTest',
+                pubRootTest,
+              ]);
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                contains('createdByLocalProject'),
+              );
+            },
+          );
 
-            // Strip off /src/widgets/text.dart.
-            final String pubRootFramework = '/${pathSegmentsFramework.take(pathSegmentsFramework.length - 3).join('/')}';
-            service.setPubRootDirectories(<String>[pubRootFramework]);
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-            service.setSelection(elementA, 'my-group');
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
-            
-            service.setPubRootDirectories(<String>[pubRootFramework, pubRootTest]);
-            service.setSelection(elementA, 'my-group');
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-            service.setSelection(richText, 'my-group');
-            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-          },
-        );
-      });
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
+          testWidgets(
+            'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
+            (WidgetTester tester) async {
+              final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
+              await tester.pumpWidget(widget);
+              final Element elementA = find.text('a').evaluate().first;
+              final Element richText = find
+                  .descendant(
+                    of: find.text('a'),
+                    matching: find.byType(RichText),
+                  )
+                  .evaluate()
+                  .first;
+              service.setSelection(richText, 'my-group');
+              service.setPubRootDirectories(<String>[pubRootTest]);
+
+              final Map<String, Object?> jsonObject =
+                  json.decode(service.getSelectedWidget(null, 'my-group'))
+                      as Map<String, Object?>;
+              expect(jsonObject, isNot(contains('createdByLocalProject')));
+              final Map<String, Object?> creationLocation =
+                  jsonObject['creationLocation']! as Map<String, Object?>;
+              expect(creationLocation, isNotNull);
+              // This RichText widget is created by the build method of the Text widget
+              // thus the creation location is in text.dart not basic.dart
+              final List<String> pathSegmentsFramework =
+                  Uri.parse(creationLocation['file']! as String).pathSegments;
+              expect(
+                pathSegmentsFramework.join('/'),
+                endsWith('/flutter/lib/src/widgets/text.dart'),
+              );
+
+              // Strip off /src/widgets/text.dart.
+              final String pubRootFramework =
+                  '/${pathSegmentsFramework.take(pathSegmentsFramework.length - 3).join('/')}';
+              service.setPubRootDirectories(<String>[pubRootFramework]);
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                contains('createdByLocalProject'),
+              );
+              service.setSelection(elementA, 'my-group');
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                isNot(contains('createdByLocalProject')),
+              );
+
+              service
+                  .setPubRootDirectories(<String>[pubRootFramework, pubRootTest]);
+              service.setSelection(elementA, 'my-group');
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                contains('createdByLocalProject'),
+              );
+              service.setSelection(richText, 'my-group');
+              expect(
+                json.decode(service.getSelectedWidget(null, 'my-group')),
+                contains('createdByLocalProject'),
+              );
+            },
+          );
+        });
+      },
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
+    ); // [intended] Test requires --track-widget-creation flag.
 
     test('ext.flutter.inspector.disposeGroup', () async {
       final Object a = Object();
@@ -1884,317 +1930,450 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(columnA, equals(columnB));
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
 
-    group('ext.flutter.inspector.setPubRootDirectories group', () {
-      late final String pubRootTest; 
+    group(
+      'ext.flutter.inspector.setPubRootDirectories group',
+      () {
+        late final String pubRootTest;
 
-      setUpAll(() async {
-        pubRootTest = generateTestPubRootDirectory(service);
-      }); 
+        setUpAll(() async {
+          pubRootTest = generateTestPubRootDirectory(service);
+        });
 
-      testWidgets(
-        'has createdByLocalProject when the widget is in the pubRootDirectory',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            ),
-          );
-          
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
-
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': pubRootTest});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-        },
-      );
-
-      testWidgets(
-        'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
-              ),
-            ),
-          );
-          
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
-
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': '/invalid/$pubRootTest'});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
-        },
-      );
-
-      testWidgets(
-        'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
+        testWidgets(
+          'has createdByLocalProject when the widget is in the pubRootDirectory',
           (WidgetTester tester) async {
-          await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
               ),
-            ),
-          );
-          
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+            );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': 'file://$pubRootTest'});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-        },
-      );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
 
-      testWidgets(
-        'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': pubRootTest},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
               ),
-            ),
-          );
-          
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+              contains('createdByLocalProject'),
+            );
+          },
+        );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': '$pubRootTest/different'});
-        expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
-        },
-      );
-
-      testWidgets(
-        'has createdByLocalProject if at least one of the pubRootDirectories matches',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+        testWidgets(
+          'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
               ),
-            ),
-          );
-          
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+            );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{
-            'arg0': '/unrelated/$pubRootTest',
-            'arg1': 'file://$pubRootTest',
-          });
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
 
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject')); 
-        },
-      );
-
-      testWidgets(
-        'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
-        (WidgetTester tester) async {
-          await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': '/invalid/$pubRootTest'},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
               ),
-            ),
-          );
-          final Element elementA = find.text('a').evaluate().first;
+              isNot(contains('createdByLocalProject')),
+            );
+          },
+        );
 
-          // The RichText child of the Text widget is created by the core framework
-          // not the current package.
-          final Element richText = find.descendant(
-            of: find.text('a'),
-            matching: find.byType(RichText),
-          ).evaluate().first;
-          service.setSelection(richText, 'my-group');
-          service.setPubRootDirectories(<String>[pubRootTest]);
-          final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
-          expect(jsonObject, isNot(contains('createdByLocalProject')));
-          final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
-          expect(creationLocation, isNotNull);
-          // This RichText widget is created by the build method of the Text widget
-          // thus the creation location is in text.dart not basic.dart
-          final List<String> pathSegmentsFramework = Uri.parse(creationLocation['file']! as String).pathSegments;
-          expect(pathSegmentsFramework.join('/'), endsWith('/flutter/lib/src/widgets/text.dart'));
-
-          // Strip off /src/widgets/text.dart.
-          final String pubRootFramework = '/${pathSegmentsFramework.take(pathSegmentsFramework.length - 3).join('/')}';
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': pubRootFramework});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-          service.setSelection(elementA, 'my-group');
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
-
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': pubRootFramework, 'arg1': pubRootTest});
-          service.setSelection(elementA, 'my-group');
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-          service.setSelection(richText, 'my-group');
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-        },
-      );
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
-
-    group('ext.flutter.inspector.setPubRootDirectories extra args regression test', () {
-      // Ensure that passing the isolate id as an argument won't break
-      // setPubRootDirectories command.
-
-      late final String pubRootTest; 
-
-      setUpAll(() {
-        pubRootTest = generateTestPubRootDirectory(service);
-      });
-
-      testWidgets(
-        'has createdByLocalProject when the widget is in the pubRootDirectory',
-        (WidgetTester tester) async {
-           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+        testWidgets(
+          'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
               ),
-            ),
-          );
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+            );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': pubRootTest, 'isolateId': '34'});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-        },
-      );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
 
-      testWidgets(
-        'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
-        (WidgetTester tester) async {
-           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': 'file://$pubRootTest'},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
               ),
-            ),
-          );
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+              contains('createdByLocalProject'),
+            );
+          },
+        );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': '/invalid/$pubRootTest', 'isolateId': '34'});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
-        },
-      );
-
-      testWidgets(
-        'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
-        (WidgetTester tester) async {
-           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+        testWidgets(
+          'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
               ),
-            ),
-          );
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+            );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': 'file://$pubRootTest', 'isolateId': '34'});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-        },
-      );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
 
-      testWidgets(
-        'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
-        (WidgetTester tester) async {
-           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': '$pubRootTest/different'},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
               ),
-            ),
-          );
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+              isNot(contains('createdByLocalProject')),
+            );
+          },
+        );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{'arg0': '$pubRootTest/different', 'isolateId': '34'});
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
-        },
-      );
-
-      testWidgets(
-        'has createdByLocalProject if at least one of the pubRootDirectories matchesE',
-        (WidgetTester tester) async {
-           await tester.pumpWidget(
-            Directionality(
-              textDirection: TextDirection.ltr,
-              child: Stack(
-                children: const <Widget>[
-                  Text('a'),
-                  Text('b', textDirection: TextDirection.ltr),
-                  Text('c', textDirection: TextDirection.ltr),
-                ],
+        testWidgets(
+          'has createdByLocalProject if at least one of the pubRootDirectories matches',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
               ),
-            ),
-          );
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+            );
 
-          await service.testExtension('setPubRootDirectories', <String, String>{
-            'arg0': '/unrelated/$pubRootTest',
-            'isolateId': '34',
-            'arg1': 'file://$pubRootTest',
-          });
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
 
-          expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
-        },
-      );
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.);
+            await service.testExtension('setPubRootDirectories', <String, String>{
+              'arg0': '/unrelated/$pubRootTest',
+              'arg1': 'file://$pubRootTest',
+            });
+
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+          },
+        );
+
+        testWidgets(
+          'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ),
+            );
+            final Element elementA = find.text('a').evaluate().first;
+
+            // The RichText child of the Text widget is created by the core framework
+            // not the current package.
+            final Element richText = find
+                .descendant(
+                  of: find.text('a'),
+                  matching: find.byType(RichText),
+                )
+                .evaluate()
+                .first;
+            service.setSelection(richText, 'my-group');
+            service.setPubRootDirectories(<String>[pubRootTest]);
+            final Map<String, Object?> jsonObject =
+                json.decode(service.getSelectedWidget(null, 'my-group'))
+                    as Map<String, Object?>;
+            expect(jsonObject, isNot(contains('createdByLocalProject')));
+            final Map<String, Object?> creationLocation =
+                jsonObject['creationLocation']! as Map<String, Object?>;
+            expect(creationLocation, isNotNull);
+            // This RichText widget is created by the build method of the Text widget
+            // thus the creation location is in text.dart not basic.dart
+            final List<String> pathSegmentsFramework =
+                Uri.parse(creationLocation['file']! as String).pathSegments;
+            expect(
+              pathSegmentsFramework.join('/'),
+              endsWith('/flutter/lib/src/widgets/text.dart'),
+            );
+
+            // Strip off /src/widgets/text.dart.
+            final String pubRootFramework =
+                '/${pathSegmentsFramework.take(pathSegmentsFramework.length - 3).join('/')}';
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': pubRootFramework},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+            service.setSelection(elementA, 'my-group');
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              isNot(contains('createdByLocalProject')),
+            );
+
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': pubRootFramework, 'arg1': pubRootTest},
+            );
+            service.setSelection(elementA, 'my-group');
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+            service.setSelection(richText, 'my-group');
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+          },
+        );
+      },
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
+    ); // [intended] Test requires --track-widget-creation flag.
+
+    group(
+      'ext.flutter.inspector.setPubRootDirectories extra args regression test',
+      () {
+        // Ensure that passing the isolate id as an argument won't break
+        // setPubRootDirectories command.
+
+        late final String pubRootTest;
+
+        setUpAll(() {
+          pubRootTest = generateTestPubRootDirectory(service);
+        });
+
+        testWidgets(
+          'has createdByLocalProject when the widget is in the pubRootDirectory',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ),
+            );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
+
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': pubRootTest, 'isolateId': '34'},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+          },
+        );
+
+        testWidgets(
+          'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ),
+            );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
+
+            await service.testExtension('setPubRootDirectories', <String, String>{
+              'arg0': '/invalid/$pubRootTest',
+              'isolateId': '34'
+            });
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              isNot(contains('createdByLocalProject')),
+            );
+          },
+        );
+
+        testWidgets(
+          'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ),
+            );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
+
+            await service.testExtension(
+              'setPubRootDirectories',
+              <String, String>{'arg0': 'file://$pubRootTest', 'isolateId': '34'},
+            );
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+          },
+        );
+
+        testWidgets(
+          'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ),
+            );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
+
+            await service.testExtension('setPubRootDirectories', <String, String>{
+              'arg0': '$pubRootTest/different',
+              'isolateId': '34'
+            });
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              isNot(contains('createdByLocalProject')),
+            );
+          },
+        );
+
+        testWidgets(
+          'has createdByLocalProject if at least one of the pubRootDirectories matchesE',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(
+              Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              ),
+            );
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
+
+            await service.testExtension('setPubRootDirectories', <String, String>{
+              'arg0': '/unrelated/$pubRootTest',
+              'isolateId': '34',
+              'arg1': 'file://$pubRootTest',
+            });
+
+            expect(
+              await service.testExtension(
+                'getSelectedWidget',
+                <String, String>{'objectGroup': 'my-group'},
+              ),
+              contains('createdByLocalProject'),
+            );
+          },
+        );
+      },
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
+    ); // [intended] Test requires --track-widget-creation flag.);
 
     Map<Object, Object?> removeLastEvent(List<Map<Object, Object?>> events) {
       final Map<Object, Object?> event = events.removeLast();
@@ -3375,7 +3554,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     });
   }
 
-  static String generateTestPubRootDirectory(TestWidgetInspectorService service){
+  static String generateTestPubRootDirectory(TestWidgetInspectorService service) {
     final Map<String, Object?> jsonObject = const SizedBox().toDiagnosticsNode().toJsonMap(InspectorSerializationDelegate(service: service));
     final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
     expect(creationLocation, isNotNull);
@@ -3393,7 +3572,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
   }
 
   static void setupDefaultPubRootDirectory(TestWidgetInspectorService service) {
-    service.setPubRootDirectories(<String>[generateTestPubRootDirectory(service)]);
+    service
+        .setPubRootDirectories(<String>[generateTestPubRootDirectory(service)]);
   }
 }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1202,21 +1202,11 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(nodes[3].runtimeType, StringProperty);
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked());  // [intended] Test requires --track-widget-creation flag.
     group('WidgetInspectorService', () {
-      final widget = Directionality(
-          textDirection: TextDirection.ltr,
-          child: Stack(
-            children: const <Widget>[
-              Text('a'),
-              Text('b', textDirection: TextDirection.ltr),
-              Text('c', textDirection: TextDirection.ltr),
-            ],
-          ),
-        );
 
       group('setPubRootDirectories', ()  {
         late final String pubRootTest; 
         setUpAll(() {
-          pubRootTest = generateTestPubRootDirectory2(service);
+          pubRootTest = generateTestPubRootDirectory(service);
         });
 
         setUp((){
@@ -1227,6 +1217,16 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'does not have createdByLocalProject when there are no pubRootDirectories',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+                textDirection: TextDirection.ltr,
+                child: Stack(
+                  children: const <Widget>[
+                    Text('a'),
+                    Text('b', textDirection: TextDirection.ltr),
+                    Text('c', textDirection: TextDirection.ltr),
+                  ],
+                ),
+              );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
             service.setSelection(elementA, 'my-group');
@@ -1244,6 +1244,16 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'has createdByLocalProject when the element is part of the pubRootDirectory',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+              textDirection: TextDirection.ltr,
+              child: Stack(
+                children: const <Widget>[
+                  Text('a'),
+                  Text('b', textDirection: TextDirection.ltr),
+                  Text('c', textDirection: TextDirection.ltr),
+                ],
+              ),
+            );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
 
@@ -1257,12 +1267,21 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'does not have createdByLocalProject when widget package directory is a suffix of a pubRootDirectory',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+              textDirection: TextDirection.ltr,
+              child: Stack(
+                children: const <Widget>[
+                  Text('a'),
+                  Text('b', textDirection: TextDirection.ltr),
+                  Text('c', textDirection: TextDirection.ltr),
+                ],
+              ),
+            );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
             service.setSelection(elementA, 'my-group');
 
             service.setPubRootDirectories(<String>['/invalid/$pubRootTest']);
-
             expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
           },
         );
@@ -1270,6 +1289,16 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+              textDirection: TextDirection.ltr,
+              child: Stack(
+                children: const <Widget>[
+                  Text('a'),
+                  Text('b', textDirection: TextDirection.ltr),
+                  Text('c', textDirection: TextDirection.ltr),
+                ],
+              ),
+            );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
             service.setSelection(elementA, 'my-group');
@@ -1282,6 +1311,16 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'does not have createdByLocalProject when thePubRootDirecty has a different suffix',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+              textDirection: TextDirection.ltr,
+              child: Stack(
+                children: const <Widget>[
+                  Text('a'),
+                  Text('b', textDirection: TextDirection.ltr),
+                  Text('c', textDirection: TextDirection.ltr),
+                ],
+              ),
+            );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
             service.setSelection(elementA, 'my-group');
@@ -1294,6 +1333,16 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'has createdByLocalProject even if another pubRootDirectory does not match',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+              textDirection: TextDirection.ltr,
+              child: Stack(
+                children: const <Widget>[
+                  Text('a'),
+                  Text('b', textDirection: TextDirection.ltr),
+                  Text('c', textDirection: TextDirection.ltr),
+                ],
+              ),
+            );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
             service.setSelection(elementA, 'my-group');
@@ -1309,6 +1358,16 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
           (WidgetTester tester) async {
+            final Widget widget = Directionality(
+              textDirection: TextDirection.ltr,
+              child: Stack(
+                children: const <Widget>[
+                  Text('a'),
+                  Text('b', textDirection: TextDirection.ltr),
+                  Text('c', textDirection: TextDirection.ltr),
+                ],
+              ),
+            );
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
             final Element richText = find.descendant(
@@ -1342,8 +1401,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           },
         );
       });
-    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked());
-
+    }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked()); // [intended] Test requires --track-widget-creation flag.
 
     test('ext.flutter.inspector.disposeGroup', () async {
       final Object a = Object();
@@ -3135,7 +3193,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     });
   }
 
-  static String generateTestPubRootDirectory2(TestWidgetInspectorService service){
+  static String generateTestPubRootDirectory(TestWidgetInspectorService service){
     final Map<String, Object?> jsonObject = const SizedBox().toDiagnosticsNode().toJsonMap(InspectorSerializationDelegate(service: service));
     final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
     expect(creationLocation, isNotNull);
@@ -3153,9 +3211,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
   }
 
   static void setupDefaultPubRootDirectory(TestWidgetInspectorService service) {
-    final String pubRootTest = generateTestPubRootDirectory2(service);
-
-    service.setPubRootDirectories(<String>[pubRootTest]);
+    service.setPubRootDirectories(<String>[generateTestPubRootDirectory(service)]);
   }
 }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1220,7 +1220,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         });
 
         String testPubRootDirectory(WidgetTester tester, Element element){
-          final originalSelection = service.getSelectedWidget(null, 'my-group');
+          final String originalSelection = service.getSelectedWidget(null, 'my-group');
           service.setSelection(element, 'my-group');
 
           final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
@@ -1235,96 +1235,129 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           return pubRootTest;
         }
 
-        testWidgets('does not have createdByLocalProject when there are no pubRootDirectories',(WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          service.setSelection(elementA, 'my-group');
+        testWidgets(
+          'does not have createdByLocalProject when there are no pubRootDirectories',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            service.setSelection(elementA, 'my-group');
 
-          final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
-          final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
+            final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
+            final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
 
-          expect(creationLocation, isNotNull);
-          final String fileA = creationLocation['file']! as String;
-          expect(fileA, endsWith('widget_inspector_test.dart'));
-          expect(jsonObject, isNot(contains('createdByLocalProject')));
-        });
+            expect(creationLocation, isNotNull);
+            final String fileA = creationLocation['file']! as String;
+            expect(fileA, endsWith('widget_inspector_test.dart'));
+            expect(jsonObject, isNot(contains('createdByLocalProject')));
+          },
+        );
 
-        testWidgets('has createdByLocalProject when the element is part of the pubRootDirectory', (WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          final String pubRootTest = testPubRootDirectory(tester, elementA);
+        testWidgets(
+          'has createdByLocalProject when the element is part of the pubRootDirectory',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            final String pubRootTest = testPubRootDirectory(tester, elementA);
 
-          service.setPubRootDirectories(<String>[pubRootTest]);
-          
-          service.setSelection(elementA, 'my-group');
-          expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-        });
+            service.setPubRootDirectories(<String>[pubRootTest]);
+            
+            service.setSelection(elementA, 'my-group');
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
+          },
+        );
 
-        testWidgets('does not have createdByLocalProject when widget package directory is a suffix of a pubRootDirectory', (WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          final String pubRootTest = testPubRootDirectory(tester, elementA);
-          service.setSelection(elementA, 'my-group');
+        testWidgets(
+          'does not have createdByLocalProject when widget package directory is a suffix of a pubRootDirectory',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            final String pubRootTest = testPubRootDirectory(tester, elementA);
+            service.setSelection(elementA, 'my-group');
 
-          service.setPubRootDirectories(<String>['/invalid/$pubRootTest']);
+            service.setPubRootDirectories(<String>['/invalid/$pubRootTest']);
 
-          expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
-        });
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
+          },
+        );
 
-        testWidgets('has createdByLocalProject when the pubRootDirectory is prefixed with file://', (WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          final String pubRootTest = testPubRootDirectory(tester, elementA);
-          service.setSelection(elementA, 'my-group');
+        testWidgets(
+          'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            final String pubRootTest = testPubRootDirectory(tester, elementA);
+            service.setSelection(elementA, 'my-group');
 
-          service.setPubRootDirectories(<String>['file://$pubRootTest']);
-          expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-        });
+            service.setPubRootDirectories(<String>['file://$pubRootTest']);
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
+          },
+        );
 
-        testWidgets('does not have createdByLocalProject when thePubRootDirecty has a different suffix', (WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          final String pubRootTest = testPubRootDirectory(tester, elementA);
-          service.setSelection(elementA, 'my-group');
+        testWidgets(
+          'does not have createdByLocalProject when thePubRootDirecty has a different suffix',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            final String pubRootTest = testPubRootDirectory(tester, elementA);
+            service.setSelection(elementA, 'my-group');
 
-          service.setPubRootDirectories(<String>['$pubRootTest/different']);
-          expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
-        });
+            service.setPubRootDirectories(<String>['$pubRootTest/different']);
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
+          },
+        );
 
-        testWidgets('has createdByLocalProject even if another pubRootDirectory does not match', (WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          final String pubRootTest = testPubRootDirectory(tester, elementA);
-          service.setSelection(elementA, 'my-group');
+        testWidgets(
+          'has createdByLocalProject even if another pubRootDirectory does not match',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            final String pubRootTest = testPubRootDirectory(tester, elementA);
+            service.setSelection(elementA, 'my-group');
 
-          service.setPubRootDirectories(<String>[
-            '/invalid/$pubRootTest',
-            pubRootTest,
-          ]);
-          expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
-        });
+            service.setPubRootDirectories(<String>[
+              '/invalid/$pubRootTest',
+              pubRootTest,
+            ]);
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
+          },
+        );
 
-        testWidgets('widget is part of core framework and is the child of a widget in the package pubRootDirectories', (WidgetTester tester) async {
-          await tester.pumpWidget(widget);
-          final Element elementA = find.text('a').evaluate().first;
-          final String pubRootTest = testPubRootDirectory(tester, elementA);
-          final Element richText = find.descendant(
-            of: find.text('a'),
-            matching: find.byType(RichText),
-          ).evaluate().first;
+        testWidgets(
+          'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
+          (WidgetTester tester) async {
+            await tester.pumpWidget(widget);
+            final Element elementA = find.text('a').evaluate().first;
+            final String pubRootTest = testPubRootDirectory(tester, elementA);
+            final Element richText = find.descendant(
+              of: find.text('a'),
+              matching: find.byType(RichText),
+            ).evaluate().first;
+            service.setSelection(richText, 'my-group');
+            service.setPubRootDirectories(<String>[pubRootTest]);
+            
+            final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
+            expect(jsonObject, isNot(contains('createdByLocalProject')));
+            final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
+            expect(creationLocation, isNotNull);
+            // This RichText widget is created by the build method of the Text widget
+            // thus the creation location is in text.dart not basic.dart
+            final List<String> pathSegmentsFramework = Uri.parse(creationLocation['file']! as String).pathSegments;
+            expect(pathSegmentsFramework.join('/'), endsWith('/flutter/lib/src/widgets/text.dart'));
 
-          service.setSelection(richText, 'my-group');
-          service.setPubRootDirectories(<String>[pubRootTest]);
-
-          final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
-          expect(jsonObject, isNot(contains('createdByLocalProject')));
-          final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
-          expect(creationLocation, isNotNull);
-          // This RichText widget is created by the build method of the Text widget
-          // thus the creation location is in text.dart not basic.dart
-          final List<String> pathSegmentsFramework = Uri.parse(creationLocation['file']! as String).pathSegments;
-          expect(pathSegmentsFramework.join('/'), endsWith('/flutter/lib/src/widgets/text.dart'));
-        });
+            // Strip off /src/widgets/text.dart.
+            final String pubRootFramework = '/${pathSegmentsFramework.take(pathSegmentsFramework.length - 3).join('/')}';
+            service.setPubRootDirectories(<String>[pubRootFramework]);
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
+            service.setSelection(elementA, 'my-group');
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), isNot(contains('createdByLocalProject')));
+            
+            service.setPubRootDirectories(<String>[pubRootFramework, pubRootTest]);
+            service.setSelection(elementA, 'my-group');
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
+            service.setSelection(richText, 'my-group');
+            expect(json.decode(service.getSelectedWidget(null, 'my-group')), contains('createdByLocalProject'));
+          },
+        );
       });
     }, skip: !WidgetInspectorService.instance.isWidgetCreationTracked());
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1214,26 +1214,15 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         );
 
       group('setPubRootDirectories', ()  {
+        late final String pubRootTest; 
+        setUpAll(() {
+          pubRootTest = generateTestPubRootDirectory2(service);
+        });
+
         setUp((){
           service.disposeAllGroups();
           service.setPubRootDirectories(<String>[]);
         });
-
-        String testPubRootDirectory(WidgetTester tester, Element element){
-          final String originalSelection = service.getSelectedWidget(null, 'my-group');
-          service.setSelection(element, 'my-group');
-
-          final Map<String, Object?> jsonObject = json.decode(service.getSelectedWidget(null, 'my-group')) as Map<String, Object?>;
-          final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
-
-          final String fileA = creationLocation['file']! as String;
-          final List<String> segments = Uri.parse(fileA).pathSegments;
-          // Strip a couple subdirectories away to generate a plausible pub root
-          // directory.
-          final String pubRootTest = '/${segments.take(segments.length - 2).join('/')}';
-          service.setSelection(originalSelection, 'my-group');
-          return pubRootTest;
-        }
 
         testWidgets(
           'does not have createdByLocalProject when there are no pubRootDirectories',
@@ -1257,7 +1246,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           (WidgetTester tester) async {
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
-            final String pubRootTest = testPubRootDirectory(tester, elementA);
 
             service.setPubRootDirectories(<String>[pubRootTest]);
             
@@ -1271,7 +1259,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           (WidgetTester tester) async {
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
-            final String pubRootTest = testPubRootDirectory(tester, elementA);
             service.setSelection(elementA, 'my-group');
 
             service.setPubRootDirectories(<String>['/invalid/$pubRootTest']);
@@ -1285,7 +1272,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           (WidgetTester tester) async {
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
-            final String pubRootTest = testPubRootDirectory(tester, elementA);
             service.setSelection(elementA, 'my-group');
 
             service.setPubRootDirectories(<String>['file://$pubRootTest']);
@@ -1298,7 +1284,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           (WidgetTester tester) async {
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
-            final String pubRootTest = testPubRootDirectory(tester, elementA);
             service.setSelection(elementA, 'my-group');
 
             service.setPubRootDirectories(<String>['$pubRootTest/different']);
@@ -1311,7 +1296,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           (WidgetTester tester) async {
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
-            final String pubRootTest = testPubRootDirectory(tester, elementA);
             service.setSelection(elementA, 'my-group');
 
             service.setPubRootDirectories(<String>[
@@ -1327,7 +1311,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           (WidgetTester tester) async {
             await tester.pumpWidget(widget);
             final Element elementA = find.text('a').evaluate().first;
-            final String pubRootTest = testPubRootDirectory(tester, elementA);
             final Element richText = find.descendant(
               of: find.text('a'),
               matching: find.byType(RichText),
@@ -3152,7 +3135,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     });
   }
 
-  static void setupDefaultPubRootDirectory(TestWidgetInspectorService service) {
+  static String generateTestPubRootDirectory2(TestWidgetInspectorService service){
     final Map<String, Object?> jsonObject = const SizedBox().toDiagnosticsNode().toJsonMap(InspectorSerializationDelegate(service: service));
     final Map<String, Object?> creationLocation = jsonObject['creationLocation']! as Map<String, Object?>;
     expect(creationLocation, isNotNull);
@@ -3161,10 +3144,17 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     final List<String> segments = Uri
         .parse(file)
         .pathSegments;
-    final String pubRootTest = '/${segments.take(segments.length - 2).join('/')}';
 
     // Strip a couple subdirectories away to generate a plausible pub root
     // directory.
+    final String pubRootTest = '/${segments.take(segments.length - 2).join('/')}';
+
+    return pubRootTest;
+  }
+
+  static void setupDefaultPubRootDirectory(TestWidgetInspectorService service) {
+    final String pubRootTest = generateTestPubRootDirectory2(service);
+
     service.setPubRootDirectories(<String>[pubRootTest]);
   }
 }

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1446,8 +1446,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           );
         });
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
-    );
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(),
+    ); // [intended] Test requires --track-widget-creation flag.
 
     test('ext.flutter.inspector.disposeGroup', () async {
       final Object a = Object();
@@ -2371,8 +2371,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           },
         );
       },
-      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.);
-    );
+    )
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
 
     Map<Object, Object?> removeLastEvent(List<Map<Object, Object?>> events) {
       final Map<Object, Object?> event = events.removeLast();

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -2373,7 +2373,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       },
       skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
     );
-    
+
     Map<Object, Object?> removeLastEvent(List<Map<Object, Object?>> events) {
       final Map<Object, Object?> event = events.removeLast();
       // Verify that the event is json encodable.

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -1205,6 +1205,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
       group('setPubRootDirectories', ()  {
         late final String pubRootTest; 
+
         setUpAll(() {
           pubRootTest = generateTestPubRootDirectory(service);
         });
@@ -1885,8 +1886,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     group('ext.flutter.inspector.setPubRootDirectories group', () {
       late final String pubRootTest; 
+
       setUpAll(() async {
-        await service.testExtension('setPubRootDirectories', <String, String>{});
         pubRootTest = generateTestPubRootDirectory(service);
       }); 
 
@@ -1937,6 +1938,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
         },
       );
+
       testWidgets(
         'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
           (WidgetTester tester) async {
@@ -1960,6 +1962,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
         },
       );
+
       testWidgets(
         'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
         (WidgetTester tester) async {
@@ -1983,6 +1986,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
         },
       );
+
       testWidgets(
         'has createdByLocalProject if at least one of the pubRootDirectories matches',
         (WidgetTester tester) async {
@@ -2010,6 +2014,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject')); 
         },
       );
+
       testWidgets(
         'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
         (WidgetTester tester) async {
@@ -2063,6 +2068,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     group('ext.flutter.inspector.setPubRootDirectories extra args regression test', () {
       // Ensure that passing the isolate id as an argument won't break
       // setPubRootDirectories command.
+
       late final String pubRootTest; 
 
       setUpAll(() {
@@ -2091,6 +2097,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
         },
       );
+
       testWidgets(
         'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
         (WidgetTester tester) async {
@@ -2113,6 +2120,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
         },
       );
+
       testWidgets(
         'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
         (WidgetTester tester) async {
@@ -2135,6 +2143,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), contains('createdByLocalProject'));
         },
       );
+
       testWidgets(
         'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
         (WidgetTester tester) async {
@@ -2157,6 +2166,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           expect(await service.testExtension('getSelectedWidget', <String, String>{'objectGroup': 'my-group'}), isNot(contains('createdByLocalProject')));
         },
       );
+
       testWidgets(
         'has createdByLocalProject if at least one of the pubRootDirectories matchesE',
         (WidgetTester tester) async {


### PR DESCRIPTION
![](https://media.giphy.com/media/d2jioMTLON9bDogE/giphy.gif)

This is a small refactor to the specs that test `setPubRootDirectories` in the widget_inspector. These changes to the setPubRootTests will make the upcoming PR for https://github.com/flutter/flutter/issues/105730 a bit clearer, since the pubRoot tests will be modified to accommodate the new interactions.

In preparation for https://github.com/flutter/flutter/issues/105730


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
