### PR TITLE
Mark use of deprecated type.

### DIFF
--- a/packages/flutter/test/foundation/_compute_caller_unsound_null_safety_error.dart
+++ b/packages/flutter/test/foundation/_compute_caller_unsound_null_safety_error.dart
@@ -16,7 +16,7 @@ void main() async {
   try {
     await compute(throwNull, null);
   } catch (e) {
-    if (e is! NullThrownError) {
+    if (e is! NullThrownError) { // ignore: deprecated_member_use
       throw Exception('compute returned bad result');
     }
   }


### PR DESCRIPTION
`NullThrownError` will be deprecated Real Soon Now (https://dart-review.googlesource.com/c/sdk/+/248901) since it isn't needed in sound null-safe code, and therefore should go away when support is dropped for unsound/pre null-safe code.

Missed this use in prior PR.
