### PR TITLE
[Reland]: Fix `StretchingOverscrollIndicator` clipping and add `clipBehavior` parameter

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -819,6 +819,7 @@ class MaterialScrollBehavior extends ScrollBehavior {
           case AndroidOverscrollIndicator.stretch:
             return StretchingOverscrollIndicator(
               axisDirection: details.direction,
+              clipBehavior: details.clipBehavior ?? Clip.hardEdge,
               child: child,
             );
           case AndroidOverscrollIndicator.glow:

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -653,9 +653,11 @@ class StretchingOverscrollIndicator extends StatefulWidget {
     super.key,
     required this.axisDirection,
     this.notificationPredicate = defaultScrollNotificationPredicate,
+    this.clipBehavior = Clip.hardEdge,
     this.child,
   }) : assert(axisDirection != null),
-       assert(notificationPredicate != null);
+       assert(notificationPredicate != null),
+       assert(clipBehavior != null);
 
   /// {@macro flutter.overscroll.axisDirection}
   final AxisDirection axisDirection;
@@ -665,6 +667,11 @@ class StretchingOverscrollIndicator extends StatefulWidget {
 
   /// {@macro flutter.overscroll.notificationPredicate}
   final ScrollNotificationPredicate notificationPredicate;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  final Clip clipBehavior;
 
   /// The widget below this widget in the tree.
   ///
@@ -806,7 +813,8 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
           // screen, overflow from transforming the viewport is irrelevant.
           return ClipRect(
             clipBehavior: stretch != 0.0 && viewportDimension != mainAxisSize
-              ? Clip.hardEdge : Clip.none,
+              ? widget.clipBehavior
+              : Clip.none,
             child: transform,
           );
         },

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -425,6 +425,7 @@ abstract class ScrollView extends StatelessWidget {
       viewportBuilder: (BuildContext context, ViewportOffset offset) {
         return buildViewport(context, offset, axisDirection, slivers);
       },
+      clipBehavior: clipBehavior,
     );
 
     final Widget scrollableResult = effectivePrimary && scrollController != null

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1328,7 +1328,7 @@ class ScrollableDetails {
 
   /// The direction in which this widget scrolls.
   ///
-  /// Defaults to null.
+  /// Cannot be null.
   final AxisDirection direction;
 
   /// A [ScrollController] that can be used to control the position of the
@@ -1342,7 +1342,7 @@ class ScrollableDetails {
   ///
   /// This can be used by [MaterialScrollBehavior] to clip [StretchingOverscrollIndicator].
   ///
-  /// Cannot be null.
+  /// Defaults to null.
   final Clip? clipBehavior;
 }
 

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -96,6 +96,7 @@ class Scrollable extends StatefulWidget {
     this.dragStartBehavior = DragStartBehavior.start,
     this.restorationId,
     this.scrollBehavior,
+    this.clipBehavior = Clip.hardEdge,
   }) : assert(axisDirection != null),
        assert(dragStartBehavior != null),
        assert(viewportBuilder != null),
@@ -259,6 +260,14 @@ class Scrollable extends StatefulWidget {
   /// followed by [scrollBehavior], and then the inherited ancestor
   /// [ScrollBehavior].
   final ScrollBehavior? scrollBehavior;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// Defaults to [Clip.hardEdge].
+  ///
+  /// Rather than clipping [Scrollable], this is passed to decorators in
+  /// [ScrollableDetails].
+  final Clip clipBehavior;
 
   /// The axis along which the scroll view scrolls.
   ///
@@ -796,6 +805,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
     final ScrollableDetails details = ScrollableDetails(
       direction: widget.axisDirection,
       controller: _effectiveScrollController,
+      clipBehavior: widget.clipBehavior,
     );
 
     result = _configuration.buildScrollbar(
@@ -811,7 +821,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         state: this,
         position: position,
         registrar: registrar,
-        child: result
+        child: result,
       );
     }
 
@@ -1312,6 +1322,7 @@ class ScrollableDetails {
   const ScrollableDetails({
     required this.direction,
     required this.controller,
+    this.clipBehavior,
   });
 
   /// The direction in which this widget scrolls.
@@ -1325,6 +1336,13 @@ class ScrollableDetails {
   /// This can be used by [ScrollBehavior] to apply a [Scrollbar] to the associated
   /// [Scrollable].
   final ScrollController controller;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// This can be used by [MaterialScrollBehavior] to clip [StretchingOverscrollIndicator].
+  ///
+  /// Cannot be null.
+  final Clip? clipBehavior;
 }
 
 /// With [_ScrollSemantics] certain child [SemanticsNode]s can be

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -265,8 +265,9 @@ class Scrollable extends StatefulWidget {
   ///
   /// Defaults to [Clip.hardEdge].
   ///
-  /// Rather than clipping [Scrollable], this is passed to decorators in
-  /// [ScrollableDetails].
+  /// This is passed to decorators in [ScrollableDetails], and does not directly affect
+  /// clipping of the [Scrollable]. This reflects the same [Clip] that is provided
+  /// to [ScrollView.clipBehavior] and is supplied to the [Viewport].
   final Clip clipBehavior;
 
   /// The axis along which the scroll view scrolls.
@@ -1327,7 +1328,7 @@ class ScrollableDetails {
 
   /// The direction in which this widget scrolls.
   ///
-  /// Cannot be null.
+  /// Defaults to null.
   final AxisDirection direction;
 
   /// A [ScrollController] that can be used to control the position of the

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -454,6 +454,70 @@ void main() {
     await tester.pumpAndSettle();
   });
 
+  testWidgets('clipBehavior parameter updates overscroll clipping behavior', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/103491
+
+    Widget buildFrame(Clip clipBehavior) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(size: Size(800.0, 600.0)),
+          child: ScrollConfiguration(
+            behavior: const ScrollBehavior().copyWith(overscroll: false),
+            child: Column(
+              children: <Widget>[
+                StretchingOverscrollIndicator(
+                  axisDirection: AxisDirection.down,
+                  clipBehavior: clipBehavior,
+                  child: SizedBox(
+                    height: 300,
+                    child: ListView.builder(
+                      itemCount: 20,
+                      itemBuilder: (BuildContext context, int index){
+                        return Padding(
+                          padding: const EdgeInsets.all(10.0),
+                          child: Text('Index $index'),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+                Opacity(
+                  opacity: 0.5,
+                  child: Container(
+                    color: const Color(0xD0FF0000),
+                    height: 100,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildFrame(Clip.none));
+
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, 51.0);
+    RenderClipRect renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Currently not clipping
+    expect(renderClip.clipBehavior, equals(Clip.none));
+
+    final TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('Index 1')));
+    // Overscroll the start.
+    await gesture.moveBy(const Offset(0.0, 200.0));
+    await tester.pumpAndSettle();
+    expect(find.text('Index 1'), findsOneWidget);
+    expect(tester.getCenter(find.text('Index 1')).dy, greaterThan(0));
+    renderClip = tester.allRenderObjects.whereType<RenderClipRect>().first;
+    // Now clipping
+    expect(renderClip.clipBehavior, equals(Clip.none));
+
+    await gesture.up();
+    await tester.pumpAndSettle();
+  });
+
   testWidgets('Stretch limit', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/99264
     await tester.pumpWidget(


### PR DESCRIPTION
Reland  https://github.com/flutter/flutter/pull/105303 with minor tweaks.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
