### PR TITLE
Pass app.started events to the DAP client + dart.debuggerUris for Profile mode

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/README.md
+++ b/packages/flutter_tools/lib/src/debug_adapters/README.md
@@ -70,6 +70,10 @@ Some custom requests are available for clients to call. Below are the Flutter-sp
 
 The debug adapter may emit several custom events that are useful to clients. Below are the Flutter-specific custom events, and the standard Dart DAP custom events are [documented here](https://github.com/dart-lang/sdk/blob/main/pkg/dds/tool/dap/README.md#custom-events).
 
+### `flutter.appStarted`
+
+This event is emitted when the application has started up. Unlike `dart.debuggerUris`, this event occurs even for `noDebug` launches or those that do not include a VM Service.
+
 ### `flutter.serviceExtensionStateChanged`
 
 When the value of a Flutter service extension changes, this event is emitted and includes the new value. Values are always encoded as strings, even if numeric/boolean.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -397,8 +397,25 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   /// Connects to the VM Service if the app.started event has fired, and a VM Service URI is available.
   void _connectDebuggerIfReady() {
     final Uri? serviceUri = _vmServiceUri;
+
     if (_receivedAppStarted && serviceUri != null) {
-      connectDebugger(serviceUri, resumeIfStarting: true);
+      if (enableDebugger) {
+        connectDebugger(serviceUri, resumeIfStarting: true);
+      } else {
+        // Usually, `connectDebugger` (in the base Dart adapter) will send this
+        // event when it connects a debugger. Since we're not connecting a
+        // debugger we send this ourselves, to allow clients to connect to the
+        // VM Service for things like starting DevTools, even if debugging is
+        // not available.
+        // TODO(dantup): Switch this to call `sendDebuggerUris()` on the base
+        //   adapter once rolled into Flutter.
+        sendEvent(
+          RawEventBody(<String, Object?>{
+            'vmServiceUri': serviceUri.toString(),
+          }),
+          eventType: 'dart.debuggerUris',
+        );
+      }
     }
   }
 
@@ -436,12 +453,6 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
 
   /// Handles the app.debugPort event from Flutter, connecting to the VM Service if everything else is ready.
   void _handleDebugPort(Map<String, Object?> params) {
-    // When running in noDebug mode, Flutter may still provide us a VM Service
-    // URI, but we will not connect it because we don't want to do any debugging.
-    if (!enableDebugger) {
-      return;
-    }
-
     // Capture the VM Service URL which we'll connect to when we get app.started.
     final String? wsUri = params['wsUri'] as String?;
     if (wsUri != null) {

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -412,6 +412,15 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   void _handleAppStarted() {
     appStartedCompleter.complete();
     _connectDebuggerIfReady();
+
+    // Send a custom event so the editor knows the app has started.
+    //
+    // This may be useful when there's no VM Service (for example Profile mode)
+    // but the editor still wants to know that startup has finished.
+    sendEvent(
+      RawEventBody(<String, Object?>{}),
+      eventType: 'flutter.appStarted',
+    );
   }
 
   /// Handles the daemon.connected event, recording the pid of the flutter_tools process.

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -302,6 +302,24 @@ void main() {
 
       await dap.client.terminate();
     });
+
+    testWithoutContext('provides appStarted events to the client', () async {
+      final BasicProject project = BasicProject();
+      await project.setUpIn(tempDir);
+
+      // Launch the app and wait for it to send a 'flutter.appStarted' event.
+      await Future.wait(<Future<void>>[
+        dap.client.event('flutter.appStarted'),
+        dap.client.start(
+          launch: () => dap.client.launch(
+            cwd: project.dir.path,
+            toolArgs: <String>['-d', 'flutter-tester'],
+          ),
+        ),
+      ], eagerError: true);
+
+      await dap.client.terminate();
+    });
   });
 
   group('attach', () {


### PR DESCRIPTION
This allows a DAP client to know when an app has finished launching even if there is no VM Service (such as noDebug runs) and also still get the VM Service URI in the case where the adapter doesn't connect to it itself (Profile mode - where we use VM Service for DevTools in the client, but don't provide any debugging). 

Fixes https://github.com/Dart-Code/Dart-Code/issues/3945 (with some client updates).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
