### PR TITLE
Chip theme cleanup

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1094,10 +1094,6 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
     );
   }
 
-  static const double _defaultElevation = 0.0;
-  static const double _defaultPressElevation = 8.0;
-  static const Color _defaultShadowColor = Colors.black;
-
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
@@ -1128,37 +1124,31 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
 
     final double elevation = widget.elevation
       ?? chipTheme.elevation
-      ?? theme.chipTheme.elevation
-      ?? _defaultElevation;
+      ?? chipDefaults.elevation!;
     final double pressElevation = widget.pressElevation
       ?? chipTheme.pressElevation
-      ?? theme.chipTheme.pressElevation
-      ?? _defaultPressElevation;
+      ?? chipDefaults.pressElevation!;
     final Color shadowColor = widget.shadowColor
       ?? chipTheme.shadowColor
-      ?? theme.chipTheme.shadowColor
-      ?? _defaultShadowColor;
+      ?? chipDefaults.shadowColor!;
     final Color selectedShadowColor = widget.selectedShadowColor
       ?? chipTheme.selectedShadowColor
-      ?? theme.chipTheme.selectedShadowColor
-      ?? _defaultShadowColor;
+      ?? chipDefaults.selectedShadowColor!;
     final Color? checkmarkColor = widget.checkmarkColor
       ?? chipTheme.checkmarkColor
-      ?? theme.chipTheme.checkmarkColor;
+      ?? chipDefaults.checkmarkColor;
     final bool showCheckmark = widget.showCheckmark
       ?? chipTheme.showCheckmark
-      ?? theme.chipTheme.showCheckmark
-      ?? true;
+      ?? chipDefaults.showCheckmark!;
     final EdgeInsetsGeometry padding = widget.padding
       ?? chipTheme.padding
-      ?? theme.chipTheme.padding
       ?? chipDefaults.padding!;
+    // Widget's label style is merged with this below.
     final TextStyle labelStyle = chipTheme.labelStyle
-      ?? theme.chipTheme.labelStyle
       ?? chipDefaults.labelStyle!;
     final EdgeInsetsGeometry labelPadding = widget.labelPadding
       ?? chipTheme.labelPadding
-      ?? theme.chipTheme.labelPadding
+      ?? chipDefaults.labelPadding
       ?? defaultLabelPadding;
 
     final TextStyle effectiveLabelStyle = labelStyle.merge(widget.labelStyle);

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -256,10 +256,15 @@ class ChipThemeData with Diagnosticable {
       disabledColor: disabledColor,
       selectedColor: selectedColor,
       secondarySelectedColor: secondarySelectedColor,
+      shadowColor: Colors.black,
+      selectedShadowColor: Colors.black,
+      showCheckmark: true,
       padding: padding,
       labelStyle: labelStyle,
       secondaryLabelStyle: secondaryLabelStyle,
       brightness: brightness,
+      elevation: 0.0,
+      pressElevation: 8.0,
     );
   }
 
@@ -420,6 +425,7 @@ class ChipThemeData with Diagnosticable {
     Color? secondarySelectedColor,
     Color? shadowColor,
     Color? selectedShadowColor,
+    bool? showCheckmark,
     Color? checkmarkColor,
     EdgeInsetsGeometry? labelPadding,
     EdgeInsetsGeometry? padding,
@@ -439,6 +445,7 @@ class ChipThemeData with Diagnosticable {
       secondarySelectedColor: secondarySelectedColor ?? this.secondarySelectedColor,
       shadowColor: shadowColor ?? this.shadowColor,
       selectedShadowColor: selectedShadowColor ?? this.selectedShadowColor,
+      showCheckmark: showCheckmark ?? this.showCheckmark,
       checkmarkColor: checkmarkColor ?? this.checkmarkColor,
       labelPadding: labelPadding ?? this.labelPadding,
       padding: padding ?? this.padding,
@@ -470,6 +477,7 @@ class ChipThemeData with Diagnosticable {
       secondarySelectedColor: Color.lerp(a?.secondarySelectedColor, b?.secondarySelectedColor, t),
       shadowColor: Color.lerp(a?.shadowColor, b?.shadowColor, t),
       selectedShadowColor: Color.lerp(a?.selectedShadowColor, b?.selectedShadowColor, t),
+      showCheckmark: t < 0.5 ? a?.showCheckmark ?? true : b?.showCheckmark ?? true,
       checkmarkColor: Color.lerp(a?.checkmarkColor, b?.checkmarkColor, t),
       labelPadding: EdgeInsetsGeometry.lerp(a?.labelPadding, b?.labelPadding, t),
       padding: EdgeInsetsGeometry.lerp(a?.padding, b?.padding, t),
@@ -514,6 +522,7 @@ class ChipThemeData with Diagnosticable {
     secondarySelectedColor,
     shadowColor,
     selectedShadowColor,
+    showCheckmark,
     checkmarkColor,
     labelPadding,
     padding,
@@ -542,6 +551,7 @@ class ChipThemeData with Diagnosticable {
         && other.secondarySelectedColor == secondarySelectedColor
         && other.shadowColor == shadowColor
         && other.selectedShadowColor == selectedShadowColor
+        && other.showCheckmark == showCheckmark
         && other.checkmarkColor == checkmarkColor
         && other.labelPadding == labelPadding
         && other.padding == padding
@@ -564,6 +574,7 @@ class ChipThemeData with Diagnosticable {
     properties.add(ColorProperty('secondarySelectedColor', secondarySelectedColor, defaultValue: null));
     properties.add(ColorProperty('shadowColor', shadowColor, defaultValue: null));
     properties.add(ColorProperty('selectedShadowColor', selectedShadowColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<bool>('showCheckmark', showCheckmark, defaultValue: null));
     properties.add(ColorProperty('checkMarkColor', checkmarkColor, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('labelPadding', labelPadding, defaultValue: null));
     properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding, defaultValue: null));

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -112,6 +112,7 @@ void main() {
       'secondarySelectedColor: Color(0xfffffff4)',
       'shadowColor: Color(0xfffffff5)',
       'selectedShadowColor: Color(0xfffffff6)',
+      'showCheckmark: true',
       'checkMarkColor: Color(0xfffffff7)',
       'labelPadding: EdgeInsets.all(1.0)',
       'padding: EdgeInsets.all(2.0)',
@@ -268,25 +269,54 @@ void main() {
   });
 
   testWidgets('ChipTheme.fromDefaults', (WidgetTester tester) async {
+    const TextStyle labelStyle = TextStyle();
     ChipThemeData chipTheme = ChipThemeData.fromDefaults(
       brightness: Brightness.light,
       secondaryColor: Colors.red,
-      labelStyle: const TextStyle(),
+      labelStyle: labelStyle,
     );
-    expect(chipTheme.backgroundColor, equals(Colors.black.withAlpha(0x1f)));
-    expect(chipTheme.selectedColor, equals(Colors.black.withAlpha(0x3d)));
-    expect(chipTheme.secondarySelectedColor, equals(Colors.red.withAlpha(0x3d)));
-    expect(chipTheme.deleteIconColor, equals(Colors.black.withAlpha(0xde)));
+    expect(chipTheme.backgroundColor, Colors.black.withAlpha(0x1f));
+    expect(chipTheme.deleteIconColor, Colors.black.withAlpha(0xde));
+    expect(chipTheme.disabledColor, Colors.black.withAlpha(0x0c));
+    expect(chipTheme.selectedColor, Colors.black.withAlpha(0x3d));
+    expect(chipTheme.secondarySelectedColor, Colors.red.withAlpha(0x3d));
+    expect(chipTheme.shadowColor, Colors.black);
+    expect(chipTheme.selectedShadowColor, Colors.black);
+    expect(chipTheme.showCheckmark, true);
+    expect(chipTheme.checkmarkColor, null);
+    expect(chipTheme.labelPadding, null);
+    expect(chipTheme.padding, const EdgeInsets.all(4.0));
+    expect(chipTheme.side, null);
+    expect(chipTheme.shape, null);
+    expect(chipTheme.labelStyle, labelStyle.copyWith(color: Colors.black.withAlpha(0xde)));
+    expect(chipTheme.secondaryLabelStyle, labelStyle.copyWith(color: Colors.red.withAlpha(0xde)));
+    expect(chipTheme.brightness, Brightness.light);
+    expect(chipTheme.elevation, 0.0);
+    expect(chipTheme.pressElevation, 8.0);
 
     chipTheme = ChipThemeData.fromDefaults(
       brightness: Brightness.dark,
       secondaryColor: Colors.tealAccent[200]!,
       labelStyle: const TextStyle(),
     );
-    expect(chipTheme.backgroundColor, equals(Colors.white.withAlpha(0x1f)));
-    expect(chipTheme.selectedColor, equals(Colors.white.withAlpha(0x3d)));
-    expect(chipTheme.secondarySelectedColor, equals(Colors.tealAccent[200]!.withAlpha(0x3d)));
-    expect(chipTheme.deleteIconColor, equals(Colors.white.withAlpha(0xde)));
+    expect(chipTheme.backgroundColor, Colors.white.withAlpha(0x1f));
+    expect(chipTheme.deleteIconColor, Colors.white.withAlpha(0xde));
+    expect(chipTheme.disabledColor, Colors.white.withAlpha(0x0c));
+    expect(chipTheme.selectedColor, Colors.white.withAlpha(0x3d));
+    expect(chipTheme.secondarySelectedColor, Colors.tealAccent[200]!.withAlpha(0x3d));
+    expect(chipTheme.shadowColor, Colors.black);
+    expect(chipTheme.selectedShadowColor, Colors.black);
+    expect(chipTheme.showCheckmark, true);
+    expect(chipTheme.checkmarkColor, null);
+    expect(chipTheme.labelPadding, null);
+    expect(chipTheme.padding, const EdgeInsets.all(4.0));
+    expect(chipTheme.side, null);
+    expect(chipTheme.shape, null);
+    expect(chipTheme.labelStyle, labelStyle.copyWith(color: Colors.white.withAlpha(0xde)));
+    expect(chipTheme.secondaryLabelStyle, labelStyle.copyWith(color: Colors.tealAccent[200]!.withAlpha(0xde)));
+    expect(chipTheme.brightness, Brightness.dark);
+    expect(chipTheme.elevation, 0.0);
+    expect(chipTheme.pressElevation, 8.0);
   });
 
 
@@ -366,6 +396,7 @@ void main() {
       pressElevation: 4.0,
       shadowColor: Colors.black,
       selectedShadowColor: Colors.black,
+      showCheckmark: false,
       checkmarkColor: Colors.black,
     );
     final ChipThemeData chipThemeWhite = ChipThemeData.fromDefaults(
@@ -381,6 +412,7 @@ void main() {
       pressElevation: 10.0,
       shadowColor: Colors.white,
       selectedShadowColor: Colors.white,
+      showCheckmark: true,
       checkmarkColor: Colors.white,
     );
 
@@ -393,6 +425,7 @@ void main() {
     expect(lerp.secondarySelectedColor, equals(middleGrey.withAlpha(0x3d)));
     expect(lerp.shadowColor, equals(middleGrey));
     expect(lerp.selectedShadowColor, equals(middleGrey));
+    expect(lerp.showCheckmark, equals(true));
     expect(lerp.labelPadding, equals(const EdgeInsets.all(4.0)));
     expect(lerp.padding, equals(const EdgeInsets.all(3.0)));
     expect(lerp.side!.color, equals(middleGrey));
@@ -414,6 +447,7 @@ void main() {
     expect(lerpANull25.secondarySelectedColor, equals(Colors.white.withAlpha(0x0f)));
     expect(lerpANull25.shadowColor, equals(Colors.white.withAlpha(0x40)));
     expect(lerpANull25.selectedShadowColor, equals(Colors.white.withAlpha(0x40)));
+    expect(lerpANull25.showCheckmark, equals(true));
     expect(lerpANull25.labelPadding, equals(const EdgeInsets.only(top: 2.0, bottom: 2.0)));
     expect(lerpANull25.padding, equals(const EdgeInsets.all(0.5)));
     expect(lerpANull25.side!.color, equals(Colors.white.withAlpha(0x3f)));
@@ -433,6 +467,7 @@ void main() {
     expect(lerpANull75.secondarySelectedColor, equals(Colors.white.withAlpha(0x2e)));
     expect(lerpANull75.shadowColor, equals(Colors.white.withAlpha(0xbf)));
     expect(lerpANull75.selectedShadowColor, equals(Colors.white.withAlpha(0xbf)));
+    expect(lerpANull75.showCheckmark, equals(true));
     expect(lerpANull75.labelPadding, equals(const EdgeInsets.only(top: 6.0, bottom: 6.0)));
     expect(lerpANull75.padding, equals(const EdgeInsets.all(1.5)));
     expect(lerpANull75.side!.color, equals(Colors.white.withAlpha(0xbf)));
@@ -452,6 +487,7 @@ void main() {
     expect(lerpBNull25.secondarySelectedColor, equals(Colors.black.withAlpha(0x2e)));
     expect(lerpBNull25.shadowColor, equals(Colors.black.withAlpha(0xbf)));
     expect(lerpBNull25.selectedShadowColor, equals(Colors.black.withAlpha(0xbf)));
+    expect(lerpBNull25.showCheckmark, equals(false));
     expect(lerpBNull25.labelPadding, equals(const EdgeInsets.only(left: 6.0, right: 6.0)));
     expect(lerpBNull25.padding, equals(const EdgeInsets.all(3.0)));
     expect(lerpBNull25.side!.color, equals(Colors.black.withAlpha(0x3f)));
@@ -471,6 +507,7 @@ void main() {
     expect(lerpBNull75.secondarySelectedColor, equals(Colors.black.withAlpha(0x0f)));
     expect(lerpBNull75.shadowColor, equals(Colors.black.withAlpha(0x40)));
     expect(lerpBNull75.selectedShadowColor, equals(Colors.black.withAlpha(0x40)));
+    expect(lerpBNull75.showCheckmark, equals(true));
     expect(lerpBNull75.labelPadding, equals(const EdgeInsets.only(left: 2.0, right: 2.0)));
     expect(lerpBNull75.padding, equals(const EdgeInsets.all(1.0)));
     expect(lerpBNull75.side!.color, equals(Colors.black.withAlpha(0xbf)));


### PR DESCRIPTION
Various small cleanups of the Chip theme:

- `ChipThemeData.showCheckmark` was missing from several of the standard theme APIs (like `copyWith`).
- Added more properties to `ChipTheme.fromDefaults`.
- Improved the tests for `ChipThemeData`.
- Removed checking `ThemeData.chipTheme` in the build method as it is already handled by `ChipTheme.of()`.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
