### PR TITLE
Apply PrimaryScrollController updates to SingleChildScrollView

### DIFF
--- a/examples/api/lib/widgets/scroll_position/scroll_metrics_notification.0.dart
+++ b/examples/api/lib/widgets/scroll_position/scroll_metrics_notification.0.dart
@@ -46,6 +46,7 @@ class ScrollMetricsDemoState extends State<ScrollMetricsDemo> {
               height: windowSize,
               width: double.infinity,
               child: const SingleChildScrollView(
+                primary: true,
                 child: FlutterLogo(
                   size: 300.0,
                 ),

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -1079,6 +1079,7 @@ void main() {
                 isAlwaysShown: true,
                 controller: scrollController,
                 child: const SingleChildScrollView(
+                  primary: true,
                   child: SizedBox(width: 4000.0, height: 4000.0),
                 ),
               ),

--- a/packages/flutter/test/widgets/single_child_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/single_child_scroll_view_test.dart
@@ -34,6 +34,19 @@ class TestScrollController extends ScrollController {
   }
 }
 
+Widget primaryScrollControllerBoilerplate({ required Widget child, required ScrollController controller }) {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: MediaQuery(
+      data: const MediaQueryData(),
+      child: PrimaryScrollController(
+        controller: controller,
+        child: child,
+      ),
+    ),
+  );
+}
+
 void main() {
   testWidgets('SingleChildScrollView overflow and clipRect test', (WidgetTester tester) async {
     // the test widowSize is Size(800.0, 600.0)
@@ -210,22 +223,40 @@ void main() {
     ));
   });
 
-  testWidgets('Vertical SingleChildScrollViews are primary by default', (WidgetTester tester) async {
+  testWidgets('Vertical SingleChildScrollViews are not primary by default', (WidgetTester tester) async {
     const SingleChildScrollView view = SingleChildScrollView();
-    expect(view.primary, isTrue);
+    expect(view.primary, isNull);
   });
 
-  testWidgets('Horizontal SingleChildScrollViews are non-primary by default', (WidgetTester tester) async {
+  testWidgets('Horizontal SingleChildScrollViews are not primary by default', (WidgetTester tester) async {
     const SingleChildScrollView view = SingleChildScrollView(scrollDirection: Axis.horizontal);
-    expect(view.primary, isFalse);
+    expect(view.primary, isNull);
   });
 
-  testWidgets('SingleChildScrollViews with controllers are non-primary by default', (WidgetTester tester) async {
+  testWidgets('SingleChildScrollViews with controllers are not primary by default', (WidgetTester tester) async {
     final SingleChildScrollView view = SingleChildScrollView(
       controller: ScrollController(),
     );
-    expect(view.primary, isFalse);
+    expect(view.primary, isNull);
   });
+
+  testWidgets('Vertical SingleChildScrollViews use PrimaryScrollController by default on mobile', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: const SingleChildScrollView(),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isTrue);
+  }, variant: TargetPlatformVariant.mobile());
+
+  testWidgets("Vertical SingleChildScrollViews don't use PrimaryScrollController by default on desktop", (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(primaryScrollControllerBoilerplate(
+      child: const SingleChildScrollView(),
+      controller: controller,
+    ));
+    expect(controller.hasClients, isFalse);
+  }, variant: TargetPlatformVariant.desktop());
 
   testWidgets('Nested scrollables have a null PrimaryScrollController', (WidgetTester tester) async {
     const Key innerKey = Key('inner');


### PR DESCRIPTION
This applies the updates to PrimaryScrollController to SingleChildScrollView. It was left out in the original PR.

---

From original PR (#102099) for context:

This updates the PrimaryScrollController to not automatically attach to scroll views on desktop as it does on mobile platforms.
This behavior has caused a lot of issues for users developing desktop applications that have multiple parallel vertical ScrollViews.
This adds two parameters to PrimaryScrollController
- `automaticallyInheritForPlatforms`
  - specifies a set of TargetPlatforms that will engage automatic inheritance
- `scrollDirection`
  - This adds the ability to specify which axis the PrimaryScrollController should be inherited for.

Also adds static method `shouldInherit`, which uses the two properties above to determine if automatically inheriting the ScrollController is appropriate for the current configuration.

This design and other approaches is discussed at length in [this design document](https://docs.google.com/document/d/12OQx7h8UQzzAi0Kxh-saDC2dg7h2fghCCzwJ0ysPmZE/edit?usp=sharing&resourcekey=0-ATO-1Er3HO2HITm59I0IdA).

Fixes https://github.com/flutter/flutter/issues/100264
Related (among others):
- https://github.com/flutter/flutter/pull/100388
- #81152
- #86549
- #83671
- #82846
- #80664
- #79443
- #74372
- #71946
- #71682
- #70764
- #63359

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
](https://github.com/Piinks/flutter/pull/new/fixSingleChild)