### PR TITLE
Migrate `IconButton` to Material 3 - Part 2

### DIFF
--- a/dev/tools/gen_defaults/lib/icon_button_template.dart
+++ b/dev/tools/gen_defaults/lib/icon_button_template.dart
@@ -35,12 +35,26 @@ class _TokenDefaultsM3 extends ButtonStyle {
       if (states.contains(MaterialState.disabled)) {
         return ${componentColor('md.comp.icon-button.disabled.icon')};
       }
+      if (states.contains(MaterialState.selected)) {
+        return ${componentColor('md.comp.icon-button.selected.icon')};
+      }
       return ${componentColor('md.comp.icon-button.unselected.icon')};
     });
 
  @override
   MaterialStateProperty<Color?>? get overlayColor =>
     MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.hovered)) {
+          return ${componentColor('md.comp.icon-button.selected.hover.state-layer')};
+        }
+        if (states.contains(MaterialState.focused)) {
+          return ${componentColor('md.comp.icon-button.selected.focus.state-layer')};
+        }
+        if (states.contains(MaterialState.pressed)) {
+          return ${componentColor('md.comp.icon-button.selected.pressed.state-layer')};
+        }
+      }
       if (states.contains(MaterialState.hovered)) {
         return ${componentColor('md.comp.icon-button.unselected.hover.state-layer')};
       }

--- a/examples/api/lib/material/icon_button/icon_button.3.dart
+++ b/examples/api/lib/material/icon_button/icon_button.3.dart
@@ -190,4 +190,3 @@ ButtonStyle disabledOutlinedButtonStyle(bool selected, ColorScheme colors) {
     side: selected ? null : BorderSide(color: colors.outline.withOpacity(0.12)),
   );
 }
-

--- a/examples/api/lib/material/icon_button/icon_button.3.dart
+++ b/examples/api/lib/material/icon_button/icon_button.3.dart
@@ -1,0 +1,259 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for IconButton with toggle feature
+
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const IconButtonsApp());
+}
+
+class IconButtonsApp extends StatelessWidget {
+  const IconButtonsApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(
+        colorSchemeSeed: const Color(0xff6750a4),
+        useMaterial3: true,
+        // Desktop and web platforms have a compact visual density by default.
+        // To see buttons with circular background on desktop/web, the "visualDensity"
+        // needs to be set to "VisualDensity.standard".
+        visualDensity: VisualDensity.standard,
+      ),
+      title: 'Icon Button Types',
+      home: Scaffold(
+        body: Column(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: const <Widget>[
+            StandardIconButtons(),
+            FilledIconButtons(),
+            FilledTonalIconButtons(),
+            OutlinedIconButtons(),
+          ]
+        ),
+      ),
+    );
+  }
+}
+
+class StandardIconButtons extends StatefulWidget {
+  const StandardIconButtons({super.key});
+
+  @override
+  State<StandardIconButtons> createState() => _StandardIconButtonsState();
+}
+
+class _StandardIconButtonsState extends State<StandardIconButtons> {
+  bool selected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          IconButton(
+            isSelected: selected,
+            onPressed: () {
+              setState(() {
+                selected = !selected;
+              });
+            },
+            selectedIcon: const Icon(Icons.settings),
+            icon: const Icon(Icons.settings_outlined),
+          ),
+          const SizedBox(width: 10),
+          IconButton(
+            isSelected: selected,
+            onPressed: null,
+            selectedIcon: const Icon(Icons.settings),
+            icon: const Icon(Icons.settings_outlined),
+          ),
+        ]
+      ),
+    );
+  }
+}
+
+// Use a standard IconButton with specific style to implement the
+// 'Filled' toggle button.
+class FilledIconButtons extends StatefulWidget {
+  const FilledIconButtons({super.key});
+
+  @override
+  State<FilledIconButtons> createState() => _FilledIconButtonsState();
+}
+
+class _FilledIconButtonsState extends State<FilledIconButtons> {
+  bool selected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          IconButton(
+            isSelected: selected,
+            icon: const Icon(Icons.settings_outlined),
+            selectedIcon: const Icon(Icons.settings),
+            onPressed: () {
+              setState(() {
+                selected = !selected;
+              });
+            },
+            style: IconButton.styleFrom(
+              foregroundColor: selected ? colors.onPrimary : colors.primary,
+              backgroundColor: selected ? colors.primary : colors.surfaceVariant,
+              hoverColor: selected ? colors.onPrimary.withOpacity(0.08) : colors.primary.withOpacity(0.08),
+              focusColor: selected ? colors.onPrimary.withOpacity(0.12) : colors.primary.withOpacity(0.12),
+              highlightColor: selected ? colors.onPrimary.withOpacity(0.12) : colors.primary.withOpacity(0.12),
+            )
+          ),
+          const SizedBox(width: 10),
+          IconButton(
+              isSelected: selected,
+              icon: const Icon(Icons.settings_outlined),
+              selectedIcon: const Icon(Icons.settings),
+              onPressed: null,
+              style: IconButton.styleFrom(
+                disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+                disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
+              )
+          ),
+        ]
+      ),
+    );
+  }
+}
+
+// Use a standard IconButton with specific style to implement the
+// 'Filled Tonal' toggle button.
+class FilledTonalIconButtons extends StatefulWidget {
+  const FilledTonalIconButtons({super.key});
+
+  @override
+  State<FilledTonalIconButtons> createState() => _FilledTonalIconButtonsState();
+}
+
+class _FilledTonalIconButtonsState extends State<FilledTonalIconButtons> {
+  bool selected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            IconButton(
+              isSelected: selected,
+              icon: const Icon(Icons.settings_outlined),
+              selectedIcon: const Icon(Icons.settings),
+              onPressed: () {
+                setState(() {
+                  selected = !selected;
+                });
+              },
+              style: IconButton.styleFrom(
+                foregroundColor: selected ? colors.onSecondaryContainer : colors.onSurfaceVariant,
+                backgroundColor: selected ?  colors.secondaryContainer : colors.surfaceVariant,
+                hoverColor: selected ? colors.onSecondaryContainer.withOpacity(0.08) : colors.onSurfaceVariant.withOpacity(0.08),
+                focusColor: selected ? colors.onSecondaryContainer.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
+                highlightColor: selected ? colors.onSecondaryContainer.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
+              ),
+            ),
+            const SizedBox(width: 10),
+            IconButton(
+              isSelected: selected,
+              icon: const Icon(Icons.settings_outlined),
+              selectedIcon: const Icon(Icons.settings),
+              onPressed: null,
+              style: IconButton.styleFrom(
+                disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+                disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
+              ),
+            ),
+          ]
+      ),
+    );
+  }
+}
+
+class OutlinedIconButtons extends StatefulWidget {
+  const OutlinedIconButtons({super.key});
+
+  @override
+  State<OutlinedIconButtons> createState() => _OutlinedIconButtonsState();
+}
+
+// Use a standard IconButton with specific style to implement the
+// 'Outlined' toggle button.
+class _OutlinedIconButtonsState extends State<OutlinedIconButtons> {
+  bool selected = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          IconButton(
+            isSelected: selected,
+            icon: const Icon(Icons.settings_outlined),
+            selectedIcon: const Icon(Icons.settings),
+            onPressed: () {
+              setState(() {
+                selected = !selected;
+              });
+            },
+            style: IconButton.styleFrom(
+              backgroundColor: selected ? colors.inverseSurface : null,
+              hoverColor: selected ? colors.onInverseSurface.withOpacity(0.08) : colors.onSurfaceVariant.withOpacity(0.08),
+              focusColor: selected ? colors.onInverseSurface.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
+              highlightColor: selected ? colors.onInverseSurface.withOpacity(0.12) : colors.onSurface.withOpacity(0.12),
+              side: BorderSide(color: colors.outline),
+            ).copyWith(
+              foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+                if (states.contains(MaterialState.selected)) {
+                  return colors.onInverseSurface;
+                }
+                if (states.contains(MaterialState.pressed)) {
+                  return colors.onSurface;
+                }
+                return null;
+              }),
+            ),
+          ),
+          const SizedBox(width: 10),
+          IconButton(
+            isSelected: selected,
+            icon: const Icon(Icons.settings_outlined),
+            selectedIcon: const Icon(Icons.settings),
+            onPressed: null,
+            style: IconButton.styleFrom(
+              disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+              disabledBackgroundColor: selected ? colors.onSurface.withOpacity(0.12) : null,
+              side: selected ? null : BorderSide(color: colors.outline.withOpacity(0.12)),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+

--- a/examples/api/lib/material/icon_button/icon_button.3.dart
+++ b/examples/api/lib/material/icon_button/icon_button.3.dart
@@ -255,5 +255,3 @@ class _OutlinedIconButtonsState extends State<OutlinedIconButtons> {
     );
   }
 }
-
-

--- a/examples/api/lib/material/icon_button/icon_button.3.dart
+++ b/examples/api/lib/material/icon_button/icon_button.3.dart
@@ -7,11 +7,11 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(const IconButtonsApp());
+  runApp(const IconButtonToggleApp());
 }
 
-class IconButtonsApp extends StatelessWidget {
-  const IconButtonsApp({super.key});
+class IconButtonToggleApp extends StatelessWidget {
+  const IconButtonToggleApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -25,54 +25,63 @@ class IconButtonsApp extends StatelessWidget {
         visualDensity: VisualDensity.standard,
       ),
       title: 'Icon Button Types',
-      home: Scaffold(
-        body: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: const <Widget>[
-            StandardIconButtons(),
-            FilledIconButtons(),
-            FilledTonalIconButtons(),
-            OutlinedIconButtons(),
-          ]
-        ),
+      home: const Scaffold(
+        body: DemoIconToggleButtons(),
       ),
     );
   }
 }
 
-class StandardIconButtons extends StatefulWidget {
-  const StandardIconButtons({super.key});
+class DemoIconToggleButtons extends StatefulWidget {
+  const DemoIconToggleButtons({super.key});
 
   @override
-  State<StandardIconButtons> createState() => _StandardIconButtonsState();
+  State<DemoIconToggleButtons> createState() => _DemoIconToggleButtonsState();
 }
 
-class _StandardIconButtonsState extends State<StandardIconButtons> {
-  bool selected = false;
-
+class _DemoIconToggleButtonsState extends State<DemoIconToggleButtons> {
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: <Widget>[
-          IconButton(
-            isSelected: selected,
-            onPressed: () {
-              setState(() {
-                selected = !selected;
-              });
-            },
-            selectedIcon: const Icon(Icons.settings),
-            icon: const Icon(Icons.settings_outlined),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            // Standard IconButton
+            children: const <Widget>[
+              DemoIconToggleButton(isEnabled: true),
+              SizedBox(width: 10),
+              DemoIconToggleButton(isEnabled: false),
+            ]
           ),
-          const SizedBox(width: 10),
-          IconButton(
-            isSelected: selected,
-            onPressed: null,
-            selectedIcon: const Icon(Icons.settings),
-            icon: const Icon(Icons.settings_outlined),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const <Widget>[
+              // Filled IconButton
+              DemoIconToggleButton(isEnabled: true, getDefaultStyle: enabledFilledButtonStyle,),
+              SizedBox(width: 10),
+              DemoIconToggleButton(isEnabled: false, getDefaultStyle: disabledFilledButtonStyle,)
+            ]
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const <Widget>[
+              // Filled Tonal IconButton
+              DemoIconToggleButton(isEnabled: true, getDefaultStyle: enabledFilledTonalButtonStyle,),
+              SizedBox(width: 10),
+              DemoIconToggleButton(isEnabled: false, getDefaultStyle: disabledFilledTonalButtonStyle,),
+            ]
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const <Widget>[
+              // Outlined IconButton
+              DemoIconToggleButton(isEnabled: true, getDefaultStyle: enabledOutlinedButtonStyle,),
+              SizedBox(width: 10),
+              DemoIconToggleButton(isEnabled: false, getDefaultStyle: disabledOutlinedButtonStyle,),
+            ]
           ),
         ]
       ),
@@ -80,178 +89,105 @@ class _StandardIconButtonsState extends State<StandardIconButtons> {
   }
 }
 
-// Use a standard IconButton with specific style to implement the
-// 'Filled' toggle button.
-class FilledIconButtons extends StatefulWidget {
-  const FilledIconButtons({super.key});
+class DemoIconToggleButton extends StatefulWidget {
+  const DemoIconToggleButton({required this.isEnabled, this.getDefaultStyle, super.key});
+
+  final bool isEnabled;
+  final ButtonStyle? Function(bool, ColorScheme)? getDefaultStyle;
 
   @override
-  State<FilledIconButtons> createState() => _FilledIconButtonsState();
+  State<DemoIconToggleButton> createState() => _DemoIconToggleButtonState();
 }
 
-class _FilledIconButtonsState extends State<FilledIconButtons> {
+class _DemoIconToggleButtonState extends State<DemoIconToggleButton> {
   bool selected = false;
 
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
+    final VoidCallback? onPressed = widget.isEnabled
+      ? () {
+        setState(() {
+          selected = !selected;
+        });
+      }
+      : null;
+    ButtonStyle? style;
+    if (widget.getDefaultStyle != null) {
+      style = widget.getDefaultStyle!(selected, colors);
+    }
 
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          IconButton(
-            isSelected: selected,
-            icon: const Icon(Icons.settings_outlined),
-            selectedIcon: const Icon(Icons.settings),
-            onPressed: () {
-              setState(() {
-                selected = !selected;
-              });
-            },
-            style: IconButton.styleFrom(
-              foregroundColor: selected ? colors.onPrimary : colors.primary,
-              backgroundColor: selected ? colors.primary : colors.surfaceVariant,
-              hoverColor: selected ? colors.onPrimary.withOpacity(0.08) : colors.primary.withOpacity(0.08),
-              focusColor: selected ? colors.onPrimary.withOpacity(0.12) : colors.primary.withOpacity(0.12),
-              highlightColor: selected ? colors.onPrimary.withOpacity(0.12) : colors.primary.withOpacity(0.12),
-            )
-          ),
-          const SizedBox(width: 10),
-          IconButton(
-              isSelected: selected,
-              icon: const Icon(Icons.settings_outlined),
-              selectedIcon: const Icon(Icons.settings),
-              onPressed: null,
-              style: IconButton.styleFrom(
-                disabledForegroundColor: colors.onSurface.withOpacity(0.38),
-                disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
-              )
-          ),
-        ]
-      ),
+    return IconButton(
+      isSelected: selected,
+      icon: const Icon(Icons.settings_outlined),
+      selectedIcon: const Icon(Icons.settings),
+      onPressed: onPressed,
+      style: style,
     );
   }
 }
 
-// Use a standard IconButton with specific style to implement the
-// 'Filled Tonal' toggle button.
-class FilledTonalIconButtons extends StatefulWidget {
-  const FilledTonalIconButtons({super.key});
-
-  @override
-  State<FilledTonalIconButtons> createState() => _FilledTonalIconButtonsState();
+ButtonStyle enabledFilledButtonStyle(bool selected, ColorScheme colors) {
+  return IconButton.styleFrom(
+    foregroundColor: selected ? colors.onPrimary : colors.primary,
+    backgroundColor: selected ? colors.primary : colors.surfaceVariant,
+    disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+    disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
+    hoverColor: selected ? colors.onPrimary.withOpacity(0.08) : colors.primary.withOpacity(0.08),
+    focusColor: selected ? colors.onPrimary.withOpacity(0.12) : colors.primary.withOpacity(0.12),
+    highlightColor: selected ? colors.onPrimary.withOpacity(0.12) : colors.primary.withOpacity(0.12),
+  );
 }
 
-class _FilledTonalIconButtonsState extends State<FilledTonalIconButtons> {
-  bool selected = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final ColorScheme colors = Theme.of(context).colorScheme;
-
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            IconButton(
-              isSelected: selected,
-              icon: const Icon(Icons.settings_outlined),
-              selectedIcon: const Icon(Icons.settings),
-              onPressed: () {
-                setState(() {
-                  selected = !selected;
-                });
-              },
-              style: IconButton.styleFrom(
-                foregroundColor: selected ? colors.onSecondaryContainer : colors.onSurfaceVariant,
-                backgroundColor: selected ?  colors.secondaryContainer : colors.surfaceVariant,
-                hoverColor: selected ? colors.onSecondaryContainer.withOpacity(0.08) : colors.onSurfaceVariant.withOpacity(0.08),
-                focusColor: selected ? colors.onSecondaryContainer.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
-                highlightColor: selected ? colors.onSecondaryContainer.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
-              ),
-            ),
-            const SizedBox(width: 10),
-            IconButton(
-              isSelected: selected,
-              icon: const Icon(Icons.settings_outlined),
-              selectedIcon: const Icon(Icons.settings),
-              onPressed: null,
-              style: IconButton.styleFrom(
-                disabledForegroundColor: colors.onSurface.withOpacity(0.38),
-                disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
-              ),
-            ),
-          ]
-      ),
-    );
-  }
+ButtonStyle disabledFilledButtonStyle(bool selected, ColorScheme colors) {
+  return IconButton.styleFrom(
+    disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+    disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
+  );
 }
 
-class OutlinedIconButtons extends StatefulWidget {
-  const OutlinedIconButtons({super.key});
-
-  @override
-  State<OutlinedIconButtons> createState() => _OutlinedIconButtonsState();
+ButtonStyle enabledFilledTonalButtonStyle(bool selected, ColorScheme colors) {
+  return IconButton.styleFrom(
+    foregroundColor: selected ? colors.onSecondaryContainer : colors.onSurfaceVariant,
+    backgroundColor: selected ?  colors.secondaryContainer : colors.surfaceVariant,
+    hoverColor: selected ? colors.onSecondaryContainer.withOpacity(0.08) : colors.onSurfaceVariant.withOpacity(0.08),
+    focusColor: selected ? colors.onSecondaryContainer.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
+    highlightColor: selected ? colors.onSecondaryContainer.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
+  );
 }
 
-// Use a standard IconButton with specific style to implement the
-// 'Outlined' toggle button.
-class _OutlinedIconButtonsState extends State<OutlinedIconButtons> {
-  bool selected = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final ColorScheme colors = Theme.of(context).colorScheme;
-
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          IconButton(
-            isSelected: selected,
-            icon: const Icon(Icons.settings_outlined),
-            selectedIcon: const Icon(Icons.settings),
-            onPressed: () {
-              setState(() {
-                selected = !selected;
-              });
-            },
-            style: IconButton.styleFrom(
-              backgroundColor: selected ? colors.inverseSurface : null,
-              hoverColor: selected ? colors.onInverseSurface.withOpacity(0.08) : colors.onSurfaceVariant.withOpacity(0.08),
-              focusColor: selected ? colors.onInverseSurface.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
-              highlightColor: selected ? colors.onInverseSurface.withOpacity(0.12) : colors.onSurface.withOpacity(0.12),
-              side: BorderSide(color: colors.outline),
-            ).copyWith(
-              foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-                if (states.contains(MaterialState.selected)) {
-                  return colors.onInverseSurface;
-                }
-                if (states.contains(MaterialState.pressed)) {
-                  return colors.onSurface;
-                }
-                return null;
-              }),
-            ),
-          ),
-          const SizedBox(width: 10),
-          IconButton(
-            isSelected: selected,
-            icon: const Icon(Icons.settings_outlined),
-            selectedIcon: const Icon(Icons.settings),
-            onPressed: null,
-            style: IconButton.styleFrom(
-              disabledForegroundColor: colors.onSurface.withOpacity(0.38),
-              disabledBackgroundColor: selected ? colors.onSurface.withOpacity(0.12) : null,
-              side: selected ? null : BorderSide(color: colors.outline.withOpacity(0.12)),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
+ButtonStyle disabledFilledTonalButtonStyle(bool selected, ColorScheme colors) {
+  return IconButton.styleFrom(
+    disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+    disabledBackgroundColor: colors.onSurface.withOpacity(0.12),
+  );
 }
+
+ButtonStyle enabledOutlinedButtonStyle(bool selected, ColorScheme colors) {
+  return IconButton.styleFrom(
+    backgroundColor: selected ? colors.inverseSurface : null,
+    hoverColor: selected ? colors.onInverseSurface.withOpacity(0.08) : colors.onSurfaceVariant.withOpacity(0.08),
+    focusColor: selected ? colors.onInverseSurface.withOpacity(0.12) : colors.onSurfaceVariant.withOpacity(0.12),
+    highlightColor: selected ? colors.onInverseSurface.withOpacity(0.12) : colors.onSurface.withOpacity(0.12),
+    side: BorderSide(color: colors.outline),
+  ).copyWith(
+    foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return colors.onInverseSurface;
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return colors.onSurface;
+      }
+      return null;
+    }),
+  );
+}
+
+ButtonStyle disabledOutlinedButtonStyle(bool selected, ColorScheme colors) {
+  return IconButton.styleFrom(
+    disabledForegroundColor: colors.onSurface.withOpacity(0.38),
+    disabledBackgroundColor: selected ? colors.onSurface.withOpacity(0.12) : null,
+    side: selected ? null : BorderSide(color: colors.outline.withOpacity(0.12)),
+  );
+}
+

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -108,7 +108,6 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// If [isSelected] is null it will behave as a normal button. If [isSelected] is not
 /// null then it will behave as a toggle button. If [isSelected] is true then it will
 /// show [selectedIcon], if it false it will show the normal [icon].
-/// Pressing the button will toggle the state.
 ///
 /// {@tool dartpad}
 /// This sample shows creation of [IconButton] widgets for standard, filled,

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -101,11 +101,24 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// The default [IconButton] is the standard type, and contained icon buttons can be produced
 /// by configuring the [IconButton] widget's properties.
 ///
+/// If [isSelected] is not null, [IconButton] is turned into a toggle button. In
+/// other words, the icon button will show a selected status if [isSelected] is
+/// set to true, and it will show an unselected status if [isSelected] is set to
+/// false.
+///
 /// {@tool dartpad}
 /// This sample shows creation of [IconButton] widgets for standard, filled,
 /// filled tonal and outlined types, as described in: https://m3.material.io/components/icon-buttons/overview
 ///
 /// ** See code in examples/api/lib/material/icon_button/icon_button.2.dart **
+/// {@end-tool}
+///
+/// {@tool dartpad}
+/// This sample shows creation of [IconButton] widgets with toggle feature for
+/// standard, filled, filled tonal and outlined types, as described
+/// in: https://m3.material.io/components/icon-buttons/overview
+///
+/// ** See code in examples/api/lib/material/icon_button/icon_button.3.dart **
 /// {@end-tool}
 ///
 /// See also:
@@ -151,6 +164,8 @@ class IconButton extends StatelessWidget {
     this.enableFeedback = true,
     this.constraints,
     this.style,
+    this.isSelected,
+    this.selectedIcon,
     required this.icon,
   }) : assert(padding != null),
        assert(alignment != null),
@@ -218,12 +233,34 @@ class IconButton extends StatelessWidget {
   /// See [Icon], [ImageIcon].
   final Widget icon;
 
-  /// The color for the button's icon when it has the input focus.
+  /// The color for the button when it has the input focus.
+  ///
+  /// If [ThemeData.useMaterial3] is set to true, this [focusColor] will be mapped
+  /// to be the [ButtonStyle.overlayColor] in focused state. Therefore, using
+  /// a color with an opacity value would be recommended. For example, one could
+  /// customize the [focusColor] below:
+  ///
+  /// ```dart
+  /// IconButton(
+  ///   focusColor: Colors.orange.withOpacity(0.3),
+  /// )
+  /// ```
   ///
   /// Defaults to [ThemeData.focusColor] of the ambient theme.
   final Color? focusColor;
 
-  /// The color for the button's icon when a pointer is hovering over it.
+  /// The color for the button when a pointer is hovering over it.
+  ///
+  /// If [ThemeData.useMaterial3] is set to true, this [hoverColor] will be mapped
+  /// to be the [ButtonStyle.overlayColor] in hovered state. Therefore, using
+  /// a color with an opacity value would be recommended. For example, one could
+  /// customize the [hoverColor] below:
+  ///
+  /// ```dart
+  /// IconButton(
+  ///   hoverColor: Colors.orange.withOpacity(0.3),
+  /// )
+  /// ```
   ///
   /// Defaults to [ThemeData.hoverColor] of the ambient theme.
   final Color? hoverColor;
@@ -249,7 +286,9 @@ class IconButton extends StatelessWidget {
   /// fill the button area if the touch is held for long enough time. If the splash
   /// color has transparency then the highlight and button color will show through.
   ///
-  /// If [ThemeData.useMaterial3] is set to true, this will not be used.
+  /// If [ThemeData.useMaterial3] is set to true, this will not be used. Use
+  /// [highlightColor] instead to show the overlay color of the button when the button
+  /// is in the pressed state.
   ///
   /// Defaults to the Theme's splash color, [ThemeData.splashColor].
   final Color? splashColor;
@@ -258,6 +297,17 @@ class IconButton extends StatelessWidget {
   /// state. The highlight color is represented as a solid color that is overlaid over the
   /// button color (if any). If the highlight color has transparency, the button color
   /// will show through. The highlight fades in quickly as the button is held down.
+  ///
+  /// If [ThemeData.useMaterial3] is set to true, this [highlightColor] will be mapped
+  /// to be the [ButtonStyle.overlayColor] in pressed state. Therefore, using
+  /// a color with an opacity value would be recommended. For example, one could
+  /// customize the [highlightColor] below:
+  ///
+  /// ```dart
+  /// IconButton(
+  ///   highlightColor: Colors.orange.withOpacity(0.3),
+  /// )
+  /// ```
   ///
   /// Defaults to the Theme's highlight color, [ThemeData.highlightColor].
   final Color? highlightColor;
@@ -340,6 +390,29 @@ class IconButton extends StatelessWidget {
   ///
   /// Null by default.
   final ButtonStyle? style;
+
+  /// The optional selection state of the icon button.
+  ///
+  /// If this property is null, the button will be a non-toggle button; otherwise,
+  /// the button will be a toggle button with the corresponding selection state.
+  ///
+  /// This property is only used for Material 3 [IconButton].
+  final bool? isSelected;
+
+  /// The optional icon to display inside the button when [isSelected] is true.
+  ///
+  /// The [Icon.size] and [Icon.color] of the icon is configured automatically
+  /// based on the [iconSize] and [color] properties of _this_ widget using an
+  /// [IconTheme] and therefore should not be explicitly given in the icon
+  /// widget.
+  ///
+  /// This property can be null. The original icon will be used for both selected
+  /// and unselected status if it is null.
+  ///
+  /// This property is only used for Material 3 [IconButton].
+  ///
+  /// See [Icon], [ImageIcon].
+  final Widget? selectedIcon;
 
   /// A static convenience method that constructs an icon button
   /// [ButtonStyle] given simple values. This method is only used for Material 3.
@@ -484,11 +557,16 @@ class IconButton extends StatelessWidget {
         adjustedStyle = style!.merge(adjustedStyle);
       }
 
+      Widget adjustedIcon = icon;
+      if (isSelected != null && isSelected! && selectedIcon != null) {
+        adjustedIcon = selectedIcon!;
+      }
+
       Widget iconButton = IconTheme.merge(
         data: IconThemeData(
           size: effectiveIconSize,
         ),
-        child: icon,
+        child: adjustedIcon,
       );
       if (tooltip != null) {
         iconButton = Tooltip(
@@ -496,11 +574,13 @@ class IconButton extends StatelessWidget {
           child: iconButton,
         );
       }
-      return _IconButtonM3(
+
+      return _SelectableIconButton(
         style: adjustedStyle,
         onPressed: onPressed,
         autofocus: autofocus,
         focusNode: focusNode,
+        isSelected: isSelected,
         child: iconButton,
       );
     }
@@ -574,12 +654,73 @@ class IconButton extends StatelessWidget {
   }
 }
 
+class _SelectableIconButton extends StatefulWidget {
+  const _SelectableIconButton({
+    this.isSelected,
+    this.style,
+    this.focusNode,
+    required this.autofocus,
+    required this.onPressed,
+    required this.child,
+  });
+
+  final bool? isSelected;
+  final ButtonStyle? style;
+  final FocusNode? focusNode;
+  final bool autofocus;
+  final VoidCallback? onPressed;
+  final Widget child;
+
+  @override
+  State<_SelectableIconButton> createState() => _SelectableIconButtonState();
+}
+
+class _SelectableIconButtonState extends State<_SelectableIconButton> {
+  late final MaterialStatesController statesController;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.isSelected == null) {
+      statesController = MaterialStatesController();
+    } else {
+      statesController = MaterialStatesController(<MaterialState>{
+        if (widget.isSelected!) MaterialState.selected
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(_SelectableIconButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isSelected == null) {
+      return;
+    }
+    if (widget.isSelected != oldWidget.isSelected) {
+      statesController.update(MaterialState.selected, widget.isSelected!);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _IconButtonM3(
+      statesController: statesController,
+      style: widget.style,
+      autofocus: widget.autofocus,
+      focusNode: widget.focusNode,
+      onPressed: widget.onPressed,
+      child: widget.child,
+    );
+  }
+}
+
 class _IconButtonM3 extends ButtonStyleButton {
   const _IconButtonM3({
     required super.onPressed,
     super.style,
     super.focusNode,
     super.autofocus = false,
+    super.statesController,
     required Widget super.child,
   }) : super(
       onLongPress: null,
@@ -596,8 +737,12 @@ class _IconButtonM3 extends ButtonStyleButton {
   /// * `backgroundColor` - transparent
   /// * `foregroundColor`
   ///   * disabled - Theme.colorScheme.onSurface(0.38)
+  ///   * selected - Theme.colorScheme.primary
   ///   * others - Theme.colorScheme.onSurfaceVariant
   /// * `overlayColor`
+  ///   * selected
+  ///      * hovered - Theme.colorScheme.primary(0.08)
+  ///      * focused or pressed - Theme.colorScheme.primary(0.12)
   ///   * hovered or focused - Theme.colorScheme.onSurfaceVariant(0.08)
   ///   * pressed - Theme.colorScheme.onSurfaceVariant(0.12)
   ///   * others - null
@@ -684,14 +829,25 @@ class _IconButtonDefaultOverlay extends MaterialStateProperty<Color?> {
 
   @override
   Color? resolve(Set<MaterialState> states) {
+    if (states.contains(MaterialState.selected)) {
+      if (states.contains(MaterialState.pressed)) {
+        return highlightColor ?? foregroundColor?.withOpacity(0.12);
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return hoverColor ?? foregroundColor?.withOpacity(0.08);
+      }
+      if (states.contains(MaterialState.focused)) {
+        return focusColor ?? foregroundColor?.withOpacity(0.12);
+      }
+    }
+    if (states.contains(MaterialState.pressed)) {
+      return highlightColor ?? foregroundColor?.withOpacity(0.12);
+    }
     if (states.contains(MaterialState.hovered)) {
       return hoverColor ?? foregroundColor?.withOpacity(0.08);
     }
     if (states.contains(MaterialState.focused)) {
       return focusColor ?? foregroundColor?.withOpacity(0.08);
-    }
-    if (states.contains(MaterialState.pressed)) {
-      return highlightColor ?? foregroundColor?.withOpacity(0.12);
     }
     return null;
   }
@@ -748,12 +904,26 @@ class _TokenDefaultsM3 extends ButtonStyle {
       if (states.contains(MaterialState.disabled)) {
         return _colors.onSurface.withOpacity(0.38);
       }
+      if (states.contains(MaterialState.selected)) {
+        return _colors.primary;
+      }
       return _colors.onSurfaceVariant;
     });
 
  @override
   MaterialStateProperty<Color?>? get overlayColor =>
     MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.hovered)) {
+          return _colors.primary.withOpacity(0.08);
+        }
+        if (states.contains(MaterialState.focused)) {
+          return _colors.primary.withOpacity(0.12);
+        }
+        if (states.contains(MaterialState.pressed)) {
+          return _colors.primary.withOpacity(0.12);
+        }
+      }
       if (states.contains(MaterialState.hovered)) {
         return _colors.onSurfaceVariant.withOpacity(0.08);
       }

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -1142,8 +1142,7 @@ void main() {
               body: Center(
                 child: IconButton(
                   style: ButtonStyle(
-                    foregroundColor: MaterialStateProperty.resolveWith<Color>(
-                        getIconColor),
+                    foregroundColor: MaterialStateProperty.resolveWith<Color>(getIconColor),
                   ),
                   isSelected: isSelected,
                   onPressed: () {
@@ -1517,22 +1516,22 @@ void main() {
   testWidgets('The original icon is used for selected and unselected status when selectedIcon is null' , (WidgetTester tester) async {
     bool isSelected = false;
     await tester.pumpWidget(
-        MaterialApp(
-            theme: ThemeData.from(colorScheme: const ColorScheme.light(), useMaterial3: true),
-            home: StatefulBuilder(
-                builder: (BuildContext context, StateSetter setState) {
-                  return IconButton(
-                    isSelected: isSelected,
-                    icon: const Icon(Icons.account_box),
-                    onPressed: (){
-                      setState(() {
-                        isSelected = !isSelected;
-                      });
-                    },
-                  );
-                }
-            )
+      MaterialApp(
+        theme: ThemeData.from(colorScheme: const ColorScheme.light(), useMaterial3: true),
+        home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return IconButton(
+              isSelected: isSelected,
+              icon: const Icon(Icons.account_box),
+              onPressed: (){
+                setState(() {
+                  isSelected = !isSelected;
+                });
+              },
+            );
+          }
         )
+      )
     );
 
     final Finder button = find.byType(IconButton);


### PR DESCRIPTION
resolves https://github.com/flutter/flutter/issues/103528

<img width="643" alt="Screen Shot 2022-06-22 at 12 26 16 PM" src="https://user-images.githubusercontent.com/36861262/175120346-5cb695f3-fcee-4a74-b2d0-b8eafa2716bb.png">
<img width="646" alt="Screen Shot 2022-06-22 at 12 27 09 PM" src="https://user-images.githubusercontent.com/36861262/175120360-85860133-3fc0-4313-879b-4b2a0e69a089.png">

This PR is the second part of the `IconButton` migration. In this PR, a `IconButton` can be turned into a "toggle button" by using `isSelected` parameter.

The boolean `isSelected` is a new parameter in `IconButton` class. The button will be non-toggle button by default if `isSelected` is not set; otherwise, the button will show the selection state based on the value of `isSelected`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.