### PR TITLE
[flutter_tools] tool exit from flutter create when provided just a drive letter

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -132,9 +132,26 @@ abstract class CreateBase extends FlutterCommand {
     );
   }
 
+  /// Pattern for a Windows file system drive (e.g. "D:").
+  ///
+  /// `dart:io` does not recognize strings matching this pattern as absolute
+  /// paths, as they have no top level back-slash; however, users often specify
+  /// this
+  static final RegExp _kWindowsDrivePattern = RegExp(r'^[A-Z]:$');
+
   /// The output directory of the command.
   @protected
+  @visibleForTesting
   Directory get projectDir {
+    final String argProjectDir = argResults!.rest.first;
+    if (globals.platform.isWindows && _kWindowsDrivePattern.hasMatch(argProjectDir)) {
+      throwToolExit(
+        'You attempted to create a flutter project at the path "$argProjectDir", which is the name of a drive. This '
+        'is usually a mistake--you probably want to specify a containing directory, like "$argProjectDir\\app_name". '
+        'If you really want it at the drive root, re-run the command with the root directory after the drive, like '
+        '"$argProjectDir\\".',
+      );
+    }
     return globals.fs.directory(argResults!.rest.first);
   }
 

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -137,14 +137,15 @@ abstract class CreateBase extends FlutterCommand {
   /// `dart:io` does not recognize strings matching this pattern as absolute
   /// paths, as they have no top level back-slash; however, users often specify
   /// this
-  static final RegExp _kWindowsDrivePattern = RegExp(r'^[A-Z]:$');
+  @visibleForTesting
+  static final RegExp kWindowsDrivePattern = RegExp(r'^[a-zA-Z]:$');
 
   /// The output directory of the command.
   @protected
   @visibleForTesting
   Directory get projectDir {
     final String argProjectDir = argResults!.rest.first;
-    if (globals.platform.isWindows && _kWindowsDrivePattern.hasMatch(argProjectDir)) {
+    if (globals.platform.isWindows && kWindowsDrivePattern.hasMatch(argProjectDir)) {
       throwToolExit(
         'You attempted to create a flutter project at the path "$argProjectDir", which is the name of a drive. This '
         'is usually a mistake--you probably want to specify a containing directory, like "$argProjectDir\\app_name". '

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io' as io;
 
 import 'package:args/command_runner.dart';
 import 'package:file_testing/file_testing.dart';
@@ -112,6 +113,37 @@ void main() {
     final String identifier = CreateBase.createWindowsIdentifier('org', 'project');
     expect(Uuid.isValidUUID(fromString: identifier), isTrue);
   });
+
+  testUsingContext('tool exits on Windows if given a drive letter without a path', () async {
+    // Must use LocalFileSystem as it is dependent on dart:io handling of
+    // Windows paths, which the MemoryFileSystem does not implement
+    final Directory workingDir = globals.fs.directory(r'X:\path\to\working\dir');
+    // Must use [io.IOOverrides] as directory.absolute depends on Directory.current
+    // from dart:io.
+    await io.IOOverrides.runZoned<Future<void>>(
+      () async {
+        // Verify IOOverrides is working
+        expect(io.Directory.current, workingDir);
+        final CreateCommand command = CreateCommand();
+        final CommandRunner<void> runner = createTestCommandRunner(command);
+        const String driveName = 'X:';
+        await expectToolExitLater(
+          runner.run(<String>[
+            'create',
+            '--project-name',
+            'test_app',
+            '--offline',
+            driveName,
+          ]),
+          contains('You attempted to create a flutter project at the path "$driveName"'),
+        );
+      },
+      getCurrentDirectory: () => workingDir,
+    );
+  }, overrides: <Type, Generator>{
+    Logger: () => BufferLogger.test(),
+  }, skip: !io.Platform.isWindows // [intended] relies on Windows file system
+  );
 
   // Verify that we create a default project ('app') that is
   // well-formed.

--- a/packages/flutter_tools/test/general.shard/create_config_test.dart
+++ b/packages/flutter_tools/test/general.shard/create_config_test.dart
@@ -19,4 +19,13 @@ void main() {
 
     expect(isValidPackageName('Foo_bar'), false);
   });
+
+  test('kWindowsDrivePattern', () {
+    expect(CreateBase.kWindowsDrivePattern.hasMatch(r'D:\'), isFalse);
+    expect(CreateBase.kWindowsDrivePattern.hasMatch(r'z:\'), isFalse);
+    expect(CreateBase.kWindowsDrivePattern.hasMatch(r'\d:'), isFalse);
+    expect(CreateBase.kWindowsDrivePattern.hasMatch(r'ef:'), isFalse);
+    expect(CreateBase.kWindowsDrivePattern.hasMatch(r'D:'), isTrue);
+    expect(CreateBase.kWindowsDrivePattern.hasMatch(r'c:'), isTrue);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/104544

As described on the bug, the core problem is that `dart:io` does not consider `D:` an absolute path and thus treats it like a relative path and prepends it with the current working directory: https://github.com/dart-lang/sdk/blob/main/sdk/lib/io/file_system_entity.dart#L571.

Creating an app at the root of a drive is probably a user error anyway (they probably want it contained in a folder), so we tool exit with instructions on how to create it in a folder at the top level of the drive, or alternatively to specify `D:\` if they really want it at the root of the drive.