### PR TITLE
Mark use of `BidirectionalIterator` as deprecated.

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -186,6 +186,11 @@ class VerticalCaretMovementRun extends Iterator<TextPosition> {
     return true;
   }
 
+  /// Move back to the previous element.
+  ///
+  /// Returns `true` and updates [current] if successful. Returns `false`
+  /// and updates [current] to an implementation defined state if there is no
+  /// previous element
   bool movePrevious() {
     assert(isValid);
     if (_currentLine <= 0) {

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -112,7 +112,9 @@ class TextSelectionPoint {
 /// the [VerticalCaretMovementRun] must not be used. The [isValid] property must
 /// be checked before calling [movePrevious] and [moveNext], or accessing
 /// [current].
-class VerticalCaretMovementRun extends BidirectionalIterator<TextPosition> {
+class VerticalCaretMovementRun
+    // ignore: deprecated_member_use
+    extends BidirectionalIterator<TextPosition> {
   VerticalCaretMovementRun._(
     this._editable,
     this._lineMetrics,

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -112,9 +112,7 @@ class TextSelectionPoint {
 /// the [VerticalCaretMovementRun] must not be used. The [isValid] property must
 /// be checked before calling [movePrevious] and [moveNext], or accessing
 /// [current].
-class VerticalCaretMovementRun
-    // ignore: deprecated_member_use
-    extends BidirectionalIterator<TextPosition> {
+class VerticalCaretMovementRun extends Iterator<TextPosition> {
   VerticalCaretMovementRun._(
     this._editable,
     this._lineMetrics,
@@ -188,7 +186,6 @@ class VerticalCaretMovementRun
     return true;
   }
 
-  @override
   bool movePrevious() {
     assert(isValid);
     if (_currentLine <= 0) {


### PR DESCRIPTION
Marks the one use of `BidirectionalIterator` in the repo to ignore the class becoming deprecated.

We are deprecating the interface in the Dart SDK (https://dart-review.googlesource.com/c/sdk/+/249486) because it simply doesn't carry its own weight. 
There is no existing use of the interface as an abstraction (no function expecting a `BidirectionalIterator`). This shows that it's not an abstraction the people *need*. Individual classes can have a `movePrevious` without them needing a common super-interface.

Almost every class which currently implement `BidirectionalIterator` (and there are very few of those) also extend the interface with more methods, so users will be using the objects at that subclass type instead. 
This is the case here, everyone uses `VerticalCaretMovementRun`, nobody ever casts it to `BidirectionalIterator`. It doesn't *matter* that it implements `BidirectionalIterator`. 

Some classes which can move a cursor in both directions choose a different name than `movePrevious` instead. 
And because of the above, that also doesn't ever matter.

There are very few uses at all, and they are not necessary. The interface will go away, and nobody will be poorer for it.

I'd actually recommend, instead this change, to just make the class extend `Iterable` directly and drop `@override` from `movePrevious`. It's technically a breaking change, because the class is no longer assignable to `BidirectionalIterator`, but nobody ever does that anyway. But I'll let you decide when to do that (as long as it's before we remove the interface).

