### PR TITLE
Add labelWidget property to BottomNavigationBarItem

### DIFF
--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -265,7 +265,7 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
       Expanded(
         child: Center(child: active ? item.activeIcon : item.icon),
       ),
-      if (item.label != null) Text(item.label!),
+      if (item.labelWidget != null || item.label != null) item.labelWidget ?? Text(item.label!),
     ];
   }
 

--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -187,8 +187,8 @@ class BottomNavigationBar extends StatefulWidget {
   }) : assert(items != null),
        assert(items.length >= 2),
        assert(
-        items.every((BottomNavigationBarItem item) => item.label != null),
-        'Every item must have a non-null label',
+        items.every((BottomNavigationBarItem item) => item.label != null || item.labelWidget != null),
+        'Every item must have a non-null label or a non-null labelWidget',
        ),
        assert(0 <= currentIndex && currentIndex < items.length),
        assert(elevation == null || elevation >= 0.0),
@@ -698,7 +698,7 @@ class _Label extends StatelessWidget {
           ),
         ),
         alignment: Alignment.bottomCenter,
-        child: Text(item.label!),
+        child: item.labelWidget ?? Text(item.label!),
       ),
     );
 

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -25,6 +25,7 @@ class BottomNavigationBarItem {
   const BottomNavigationBarItem({
     required this.icon,
     this.label,
+    this.labelWidget,
     Widget? activeIcon,
     this.backgroundColor,
     this.tooltip,
@@ -63,8 +64,13 @@ class BottomNavigationBarItem {
 
   /// The text label for this [BottomNavigationBarItem].
   ///
-  /// This will be used to create a [Text] widget to put in the bottom navigation bar.
+  /// This will be used to create a [Text] widget to put in the bottom navigation bar and
+  /// to initialize the tooltip label if [tooltip] is null.
   final String? label;
+
+  /// An optional widget that will be displayed in place of the default [Text]
+  /// widget containing the [label] if provided.
+  final Widget? labelWidget;
 
   /// The color of the background radial animation for material [BottomNavigationBar].
   ///

--- a/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
+++ b/packages/flutter/test/cupertino/bottom_tab_bar_test.dart
@@ -80,8 +80,7 @@ Future<void> main() async {
     expect(actualActive.text.style!.color, const Color(0xFF123456));
   });
 
-
-  testWidgets('BottomNavigationBar.label will create a text widget', (WidgetTester tester) async {
+  testWidgets('BottomNavigationBarItem.label will create a text widget', (WidgetTester tester) async {
     await pumpWidgetWithBoilerplate(tester, MediaQuery(
       data: const MediaQueryData(),
       child: CupertinoTabBar(
@@ -101,6 +100,29 @@ Future<void> main() async {
 
     expect(find.text('Tab 1'), findsOneWidget);
     expect(find.text('Tab 2'), findsOneWidget);
+  });
+
+  testWidgets('BottomNavigationBarItem.labelWidget replaces label if provided', (WidgetTester tester) async {
+    await pumpWidgetWithBoilerplate(tester, MediaQuery(
+      data: const MediaQueryData(),
+      child: CupertinoTabBar(
+        items: <BottomNavigationBarItem>[
+          BottomNavigationBarItem(
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            label: 'Tab 1',
+            labelWidget: const Text('Custom Tab 1'),
+          ),
+          BottomNavigationBarItem(
+            icon: ImageIcon(MemoryImage(Uint8List.fromList(kTransparentImage))),
+            label: 'Tab 2',
+          ),
+        ],
+        currentIndex: 1,
+      ),
+    ));
+
+    expect(find.text('Tab 1'), findsNothing);
+    expect(find.text('Custom Tab 1'), findsOneWidget);
   });
 
   testWidgets('Active and inactive colors dark mode', (WidgetTester tester) async {

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -144,25 +144,25 @@ void main() {
     const TextStyle unselectedTextStyle = TextStyle(fontWeight: FontWeight.w600, fontSize: 12.0);
 
     await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            bottomNavigationBar: BottomNavigationBar(
-              type: BottomNavigationBarType.fixed,
-              selectedLabelStyle: selectedTextStyle,
-              unselectedLabelStyle: unselectedTextStyle,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.ac_unit),
-                  label: 'AC',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.access_alarm),
-                  label: 'Alarm',
-                ),
-              ],
-            ),
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            selectedLabelStyle: selectedTextStyle,
+            unselectedLabelStyle: unselectedTextStyle,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                label: 'AC',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                label: 'Alarm',
+              ),
+            ],
           ),
         ),
+      ),
     );
 
     final TextStyle selectedFontStyle = tester.renderObject<RenderParagraph>(find.text('AC')).text.style!;
@@ -183,27 +183,27 @@ void main() {
     const double unselectedFontSize = 11.0;
 
     await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            bottomNavigationBar: BottomNavigationBar(
-              type: BottomNavigationBarType.fixed,
-              selectedLabelStyle: selectedTextStyle,
-              unselectedLabelStyle: unselectedTextStyle,
-              selectedFontSize: selectedFontSize,
-              unselectedFontSize: unselectedFontSize,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.ac_unit),
-                  label: 'AC',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.access_alarm),
-                  label: 'Alarm',
-                ),
-              ],
-            ),
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            selectedLabelStyle: selectedTextStyle,
+            unselectedLabelStyle: unselectedTextStyle,
+            selectedFontSize: selectedFontSize,
+            unselectedFontSize: unselectedFontSize,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                label: 'AC',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                label: 'Alarm',
+              ),
+            ],
           ),
         ),
+      ),
     );
 
     final TextStyle selectedFontStyle = tester.renderObject<RenderParagraph>(find.text('AC')).text.style!;
@@ -337,28 +337,28 @@ void main() {
     const IconThemeData unselectedIconTheme = IconThemeData(size: unselectedIconSize);
 
     await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            bottomNavigationBar: BottomNavigationBar(
-              type: BottomNavigationBarType.fixed,
-              showSelectedLabels: true,
-              showUnselectedLabels: false,
-              selectedFontSize: selectedFontSize,
-              selectedIconTheme: selectedIconTheme,
-              unselectedIconTheme: unselectedIconTheme,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.ac_unit),
-                  label: 'AC',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.access_alarm),
-                  label: 'Alarm',
-                ),
-              ],
-            ),
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            showSelectedLabels: true,
+            showUnselectedLabels: false,
+            selectedFontSize: selectedFontSize,
+            selectedIconTheme: selectedIconTheme,
+            unselectedIconTheme: unselectedIconTheme,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                label: 'AC',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                label: 'Alarm',
+              ),
+            ],
           ),
         ),
+      ),
     );
 
     final EdgeInsets selectedItemPadding = _itemPadding(tester, Icons.ac_unit);
@@ -377,28 +377,28 @@ void main() {
     const IconThemeData unselectedIconTheme = IconThemeData(size: unselectedIconSize);
 
     await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            bottomNavigationBar: BottomNavigationBar(
-              type: BottomNavigationBarType.fixed,
-              showSelectedLabels: false,
-              showUnselectedLabels: false,
-              selectedFontSize: selectedFontSize,
-              selectedIconTheme: selectedIconTheme,
-              unselectedIconTheme: unselectedIconTheme,
-              items: const <BottomNavigationBarItem>[
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.ac_unit),
-                  label: 'AC',
-                ),
-                BottomNavigationBarItem(
-                  icon: Icon(Icons.access_alarm),
-                  label: 'Alarm',
-                ),
-              ],
-            ),
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            showSelectedLabels: false,
+            showUnselectedLabels: false,
+            selectedFontSize: selectedFontSize,
+            selectedIconTheme: selectedIconTheme,
+            unselectedIconTheme: unselectedIconTheme,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                label: 'AC',
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                label: 'Alarm',
+              ),
+            ],
           ),
         ),
+      ),
     );
 
     final EdgeInsets selectedItemPadding = _itemPadding(tester, Icons.ac_unit);
@@ -495,7 +495,6 @@ void main() {
     expect(findOpacity, findsNothing);
     expect(findFadeTransition, findsNothing);
   });
-
 
   testWidgets('Shifting BottomNavigationBar custom font size, color', (WidgetTester tester) async {
     const Color primaryColor = Colors.black;
@@ -1369,6 +1368,104 @@ void main() {
 
     expect(find.byKey(filled), findsNothing);
     expect(find.byKey(stroked), findsOneWidget);
+  });
+
+  testWidgets('BottomNavigationBar item labelWidget replaces label if defined', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                label: 'AC',
+                labelWidget: Padding(
+                  padding: EdgeInsets.all(4.0),
+                  child: Text('Custom AC'),
+                )
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                label: 'Alarm',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('AC'), findsNothing);
+    expect(find.text('Custom AC'), findsOneWidget);
+  });
+
+  testWidgets('BottomNavigationBar item label is not required when labelWidget is provided', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                labelWidget: Padding(
+                  padding: EdgeInsets.all(4.0),
+                  child: Text('Custom AC'),
+                )
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                labelWidget: Text('Custom Alarm'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Custom AC'), findsOneWidget);
+    expect(find.text('Custom Alarm'), findsOneWidget);
+  });
+
+  testWidgets('BottomNavigationBar item labelWidget inherits selected and unselected font styles and font size', (WidgetTester tester) async {
+    const TextStyle selectedTextStyle = TextStyle(fontSize: 18.0);
+    const TextStyle unselectedTextStyle = TextStyle(fontSize: 12.0);
+    const double selectedFontSize = 17.0;
+    const double unselectedFontSize = 11.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: BottomNavigationBar(
+            type: BottomNavigationBarType.fixed,
+            selectedLabelStyle: selectedTextStyle,
+            unselectedLabelStyle: unselectedTextStyle,
+            selectedFontSize: selectedFontSize,
+            unselectedFontSize: unselectedFontSize,
+            items: const <BottomNavigationBarItem>[
+              BottomNavigationBarItem(
+                icon: Icon(Icons.ac_unit),
+                labelWidget: Text('Custom AC')
+              ),
+              BottomNavigationBarItem(
+                icon: Icon(Icons.access_alarm),
+                labelWidget: Text('Alarm'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Custom AC'), findsOneWidget);
+    expect(find.text('Alarm'), findsOneWidget);
+
+    final TextStyle selectedFontStyle = tester.renderObject<RenderParagraph>(find.text('Custom AC')).text.style!;
+    expect(selectedFontStyle.fontSize, equals(selectedTextStyle.fontSize));
+    expect(
+      tester.firstWidget<Transform>(find.ancestor(of: find.text('Alarm'), matching: find.byType(Transform))).transform,
+      equals(Matrix4.diagonal3(Vector3.all(unselectedTextStyle.fontSize! / selectedTextStyle.fontSize!))),
+    );
   });
 
   testWidgets('BottomNavigationBar.fixed semantics', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR adds a `labelWidget` property to `BottomNavigationBarItem`.
Motivation : https://github.com/flutter/flutter/issues/104234#issuecomment-1138946867
Implementation inspiration : https://github.com/flutter/flutter/pull/104673

## Related Issue

Fixes https://github.com/flutter/flutter/issues/104234

## Tests

Adds 4 tests.