### PR TITLE
`SelectionArea` vibration feedback on Android when selection changes

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -10,6 +10,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
+import 'package:flutter/services.dart';
 
 import 'box.dart';
 import 'debug.dart';
@@ -1283,6 +1284,9 @@ class _SelectableFragment with Selectable, ChangeNotifier {
   TextPosition? _textSelectionStart;
   TextPosition? _textSelectionEnd;
 
+  int _previousTextSelectionEndOffset = -1;
+  int _previousTextSelectionStartOffset = -1;
+
   LayerLink? _startHandleLayerLink;
   LayerLink? _endHandleLayerLink;
 
@@ -1423,9 +1427,21 @@ class _SelectableFragment with Selectable, ChangeNotifier {
 
   void _setSelectionPosition(TextPosition? position, {required bool isEnd}) {
     if (isEnd) {
+      if(position != null && position.offset != _previousTextSelectionEndOffset) {
+        HapticFeedback.selectionClick();
+      }
       _textSelectionEnd = position;
+      if (_textSelectionEnd != null) {
+        _previousTextSelectionEndOffset = _textSelectionEnd!.offset;
+      }
     } else {
+      if(position != null && position.offset != _previousTextSelectionStartOffset) {
+        HapticFeedback.selectionClick();
+      }
       _textSelectionStart = position;
+      if (_textSelectionStart != null) {
+        _previousTextSelectionStartOffset = _textSelectionStart!.offset;
+      }
     }
   }
 
@@ -1461,6 +1477,9 @@ class _SelectableFragment with Selectable, ChangeNotifier {
     }
     _textSelectionStart = start;
     _textSelectionEnd = end;
+    _previousTextSelectionStartOffset = start.offset;
+    _previousTextSelectionEndOffset = end.offset;
+    HapticFeedback.mediumImpact();
     return SelectionResult.end;
   }
 

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1208,6 +1208,60 @@ void main() {
     skip: kIsWeb, // [intended] Web uses its native context menu.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.android }),
   );
+
+  testWidgets('dragging handle or selecting word triggers haptic feedback on Android', (WidgetTester tester) async {
+    final List<MethodCall> log = <MethodCall>[];
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, (MethodCall methodCall) async {
+      log.add(methodCall);
+      return null;
+    });
+    addTearDown(() {
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.platform, mockClipboard.handleMethodCall);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectableRegion(
+          focusNode: FocusNode(),
+          selectionControls: materialTextSelectionControls,
+          child: const Text('How are you?'),
+        ),
+      ),
+    );
+
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you?'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 6)); // at the 'r'
+    addTearDown(gesture.removePointer);
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 500));
+    // `are` is selected.
+    expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 7));
+    expect(
+      log.last,
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.mediumImpact'),
+    );
+
+    final int lastLogLength = log.length;
+    final List<TextBox> boxes = paragraph.getBoxesForSelection(paragraph.selections[0]);
+    expect(boxes.length, 1);
+    final Offset handlePos = globalize(boxes[0].toRect().bottomRight, paragraph);
+    await gesture.down(handlePos);
+    final Offset endPos = Offset(textOffsetToPosition(paragraph, 8).dx, handlePos.dy);
+
+    // Select 1 more character by dragging end handle to trigger feedback.
+    await gesture.moveTo(endPos);
+    expect(paragraph.selections[0], const TextSelection(baseOffset: 4, extentOffset: 8));
+    expect(
+      log.last,
+      isMethodCall('HapticFeedback.vibrate', arguments: 'HapticFeedbackType.selectionClick'),
+    );
+    expect(log.length, lastLogLength + 1);
+    await gesture.up();
+  },
+    skip: kIsWeb, // [intended] Vibration is not handled on web.
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }),
+  );
 }
 
 class SelectionSpy extends LeafRenderObjectWidget {


### PR DESCRIPTION
Vibrate on Android when `SelectionArea` changes selection by dragging handles or choosing word with long-press.

Fixes https://github.com/flutter/flutter/issues/104551

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
