### PR TITLE
[WIP] Let Android logs respect flutter --verbose flag

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -781,6 +781,7 @@ class AndroidDevice extends Device {
       return _logReader ??= await AdbLogReader.createLogReader(
         this,
         _processManager,
+        isVerbose: _logger.isVerbose,
       );
     }
   }
@@ -1018,6 +1019,7 @@ class AdbLogReader extends DeviceLogReader {
     AndroidDevice device,
     ProcessManager processManager, {
     bool includePastLogs = false,
+    bool isVerbose = false,
   }) async {
     // logcat -T is not supported on Android releases before Lollipop.
     const int kLollipopVersionCode = 21;
@@ -1038,11 +1040,12 @@ class AdbLogReader extends DeviceLogReader {
       'time',
     ];
 
-    // If past logs are included then filter for 'flutter' logs only.
-    if (includePastLogs) {
+    // Filter for 'flutter' logs only unless the --verbose flag is presented.
+    if (!isVerbose || includePastLogs) {
       args.addAll(<String>['-s', 'flutter']);
-    } else if (apiVersion != null && apiVersion >= kLollipopVersionCode) {
-      // Otherwise, filter for logs appearing past the present.
+    }
+    // Filter for logs appearing past the present.
+    if (!includePastLogs && apiVersion != null && apiVersion >= kLollipopVersionCode) {
       // '-T 0` means the timestamp of the logcat command invocation.
       final String? lastLogcatTimestamp = await device.lastLogcatTimestamp();
       args.addAll(<String>[


### PR DESCRIPTION
Default Android log reader doesn't filter logcat records. On large codebases, it generates a lot of noise on `futter run`. This PR reverts default behaviour to filtering Android logs by "flutter" string with the ability to see all logs if the `--verbose` flag is passed to the `flutter` command-line tool.  

### Related issues:

https://github.com/flutter/flutter/issues/50808, #104268

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
