### PR TITLE
Updated positional parameter ordering for IndexedStack example

### DIFF
--- a/examples/api/lib/widgets/basic/indexed_stack.0.dart
+++ b/examples/api/lib/widgets/basic/indexed_stack.0.dart
@@ -72,7 +72,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                   }
                 });
               },
-              child: const Icon(key: Key('gesture1'), Icons.chevron_left),
+              child: const Icon(Icons.chevron_left, key: Key('gesture1')),
             ),
             Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -95,7 +95,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
                   }
                 });
               },
-              child: const Icon(key: Key('gesture2'), Icons.chevron_right),
+              child: const Icon(Icons.chevron_right, key: Key('gesture2')),
             ),
           ],
         )


### PR DESCRIPTION
Updated positional parameter ordering so that it compiles on DartPad.
Issue on DartPad is described here: https://github.com/dart-lang/dart-pad/issues/2308
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.