### PR TITLE
Refactor daemon to check for project's supported platforms

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -413,25 +413,26 @@ class DaemonDomain extends Domain {
     final List<String> result = <String>[];
     try {
       final FlutterProject flutterProject = FlutterProject.fromDirectory(globals.fs.directory(projectRoot));
-      if (featureFlags.isLinuxEnabled && flutterProject.linux.existsSync()) {
+      final supportedPlatforms = flutterProject.getSupportedPlatforms().toSet();
+      if (featureFlags.isLinuxEnabled && supportedPlatforms.contains(SupportedPlatform.linux)) {
         result.add('linux');
       }
-      if (featureFlags.isMacOSEnabled && flutterProject.macos.existsSync()) {
+      if (featureFlags.isMacOSEnabled && supportedPlatforms.contains(SupportedPlatform.macos)) {
         result.add('macos');
       }
-      if (featureFlags.isWindowsEnabled && flutterProject.windows.existsSync()) {
+      if (featureFlags.isWindowsEnabled && supportedPlatforms.contains(SupportedPlatform.windows)) {
         result.add('windows');
       }
-      if (featureFlags.isIOSEnabled && flutterProject.ios.existsSync()) {
+      if (featureFlags.isIOSEnabled && supportedPlatforms.contains(SupportedPlatform.ios)) {
         result.add('ios');
       }
-      if (featureFlags.isAndroidEnabled && flutterProject.android.existsSync()) {
+      if (featureFlags.isAndroidEnabled && supportedPlatforms.contains(SupportedPlatform.android)) {
         result.add('android');
       }
-      if (featureFlags.isWebEnabled && flutterProject.web.existsSync()) {
+      if (featureFlags.isWebEnabled && supportedPlatforms.contains(SupportedPlatform.web)) {
         result.add('web');
       }
-      if (featureFlags.isFuchsiaEnabled && flutterProject.fuchsia.existsSync()) {
+      if (featureFlags.isFuchsiaEnabled && supportedPlatforms.contains(SupportedPlatform.fuchsia)) {
         result.add('fuchsia');
       }
       if (featureFlags.areCustomDevicesEnabled) {

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -413,7 +413,7 @@ class DaemonDomain extends Domain {
     final List<String> result = <String>[];
     try {
       final FlutterProject flutterProject = FlutterProject.fromDirectory(globals.fs.directory(projectRoot));
-      final supportedPlatforms = flutterProject.getSupportedPlatforms().toSet();
+      final Set<SupportedPlatform> supportedPlatforms = flutterProject.getSupportedPlatforms().toSet();
       if (featureFlags.isLinuxEnabled && supportedPlatforms.contains(SupportedPlatform.linux)) {
         result.add('linux');
       }


### PR DESCRIPTION
We want to make it easier to provide information about supported platforms from the `FlutterProject` class to the daemon. This is to facilitate an internal change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above. (internal need)
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt]. (existing test checks the change)
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
