### PR TITLE
Skip `Mac_android run_release_test` in presubmit

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3119,6 +3119,7 @@ targets:
 
   - name: Mac_android run_release_test
     recipe: devicelab/devicelab_drone
+    presubmit: false
     runIf:
       - dev/**
     timeout: 60


### PR DESCRIPTION
Builder `Mac_android run_release_test` [has been very flaky](https://github.com/flutter/flutter/issues/105715) in pre-submit and affecting CQ workflows.

This PR skips the test in pre-submit.

Context: this builder was added to cover `Mac_android` test bed config in pre-submit: https://github.com/flutter/flutter/pull/96539. As of now, we have another builder `Mac_android entrypoint_dart_registrant` running with consistent success, it is safe to remove `Mac_android run_release_test` from pre-submit to unblock the workflow without sacrificing the coverage.