### PR TITLE
move "Linux packages_autoroller" to prod pool

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -133,7 +133,6 @@ targets:
       validation_name: Analyze
 
   - name: Linux packages_autoroller
-    bringup: true
     presubmit: false
     recipe: pub_autoroller/pub_autoroller
     timeout: 30


### PR DESCRIPTION
Follow-up to https://github.com/flutter/flutter/pull/106711

Part of https://github.com/flutter/flutter/issues/106371

Staging builds (which this ran in because bringup: true) do not have access to secrets, and thus this builder was an infra failure every time: https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20packages_autoroller/3/overview. The only way to validate this is working is by running it in prod. I will monitor the tree after this merges (I am on the framework tree gardener rotation this week).