### PR TITLE
Put shaders under a 'shaders' section in the manifest

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -88,6 +88,9 @@ Future<Depfile> copyAssets(
     if (skslBundle != null)
       kSkSLShaderBundlePath: skslBundle,
   };
+  final Map<String, AssetKind> entryKinds = <String, AssetKind>{
+    ...assetBundle.entryKinds,
+  };
 
   await Future.wait<void>(
     assetEntries.entries.map<Future<void>>((MapEntry<String, DevFSContent> entry) async {
@@ -100,19 +103,31 @@ Future<Depfile> copyAssets(
         // and the native APIs will look for files this way.
         final File file = environment.fileSystem.file(
           environment.fileSystem.path.join(outputDirectory.path, entry.key));
+        final AssetKind assetKind = entryKinds[entry.key] ?? AssetKind.regular;
         outputs.add(file);
         file.parent.createSync(recursive: true);
         final DevFSContent content = entry.value;
         if (content is DevFSFileContent && content.file is File) {
           inputs.add(content.file as File);
-          if (!await iconTreeShaker.subsetFont(
-            input: content.file as File,
-            outputPath: file.path,
-            relativePath: entry.key,
-          ) && !await shaderCompiler.compileShader(
-            input: content.file as File,
-            outputPath: file.path,
-          )) {
+          bool doCopy = true;
+          switch (assetKind) {
+            case AssetKind.regular:
+              break;
+            case AssetKind.font:
+              doCopy = !await iconTreeShaker.subsetFont(
+                input: content.file as File,
+                outputPath: file.path,
+                relativePath: entry.key,
+              );
+              break;
+            case AssetKind.shader:
+              doCopy = !await shaderCompiler.compileShader(
+                input: content.file as File,
+                outputPath: file.path,
+              );
+              break;
+          }
+          if (doCopy) {
             await (content.file as File).copy(file.path);
           }
         } else {
@@ -127,8 +142,8 @@ Future<Depfile> copyAssets(
   // The assets are included in assetBundle.entries as a normal asset when
   // building as debug.
   if (environment.defines[kDeferredComponents] == 'true' && buildMode != null) {
-    await Future.wait<void>(
-      assetBundle.deferredComponentsEntries.entries.map<Future<void>>((MapEntry<String, Map<String, DevFSContent>> componentEntries) async {
+    await Future.wait<void>(assetBundle.deferredComponentsEntries.entries.map<Future<void>>(
+      (MapEntry<String, Map<String, DevFSContent>> componentEntries) async {
         final Directory componentOutputDir =
             environment.projectDir
                 .childDirectory('build')

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -134,6 +134,7 @@ Future<AssetBundle?> buildAssets({
 Future<void> writeBundle(
   Directory bundleDir,
   Map<String, DevFSContent> assetEntries,
+  Map<String, AssetKind> entryKinds,
   { Logger? loggerOverride }
 ) async {
   loggerOverride ??= globals.logger;

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -477,7 +477,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     }
     if (_needRebuild(assetBundle.entries)) {
       await writeBundle(globals.fs.directory(globals.fs.path.join('build', 'unit_test_assets')),
-          assetBundle.entries);
+          assetBundle.entries, assetBundle.entryKinds);
     }
   }
 

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -370,6 +370,33 @@ class FlutterManifest {
     return fonts;
   }
 
+
+  late final List<Uri> shaders = _extractShaders();
+
+  List<Uri> _extractShaders() {
+    if (!_flutterDescriptor.containsKey('shaders')) {
+      return <Uri>[];
+    }
+
+    final List<Object?>? shaders = _flutterDescriptor['shaders'] as List<Object?>?;
+    if (shaders == null) {
+      return const <Uri>[];
+    }
+    final List<Uri> results = <Uri>[];
+    for (final Object? shader in shaders) {
+      if (shader is! String || shader == null || shader == '') {
+        _logger.printError('Shader manifest contains a null or empty uri.');
+        continue;
+      }
+      try {
+        results.add(Uri(pathSegments: shader.split('/')));
+      } on FormatException {
+        _logger.printError('Shader manifest contains invalid uri: $shader.');
+      }
+    }
+    return results;
+  }
+
   /// Whether a synthetic flutter_gen package should be generated.
   ///
   /// This can be provided to the [Pub] interface to inject a new entry
@@ -498,7 +525,17 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         break;
       case 'assets':
         if (yamlValue is! YamlList) {
-
+          errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
+        } else if (yamlValue.isEmpty) {
+          break;
+        } else if (yamlValue[0] is! String) {
+          errors.add(
+            'Expected "$yamlKey" to be a list of strings, but the first element is $yamlValue (${yamlValue.runtimeType}).',
+          );
+        }
+        break;
+      case 'shaders':
+        if (yamlValue is! YamlList) {
           errors.add('Expected "$yamlKey" to be a list, but got $yamlValue (${yamlValue.runtimeType}).');
         } else if (yamlValue.isEmpty) {
           break;

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_build.dart
@@ -124,9 +124,10 @@ Future<void> _buildAssets(
     throwToolExit('Unable to find assets.', exitCode: 1);
   }
 
-  final Map<String, DevFSContent> assetEntries =
-      Map<String, DevFSContent>.of(assets.entries);
-  await writeBundle(globals.fs.directory(assetDir), assetEntries);
+  final Map<String, DevFSContent> assetEntries = Map<String, DevFSContent>.of(
+    assets.entries,
+  );
+  await writeBundle(globals.fs.directory(assetDir), assetEntries, assets.entryKinds);
 
   final String appName = fuchsiaProject.project.manifest.appName;
   final String outDir = getFuchsiaBuildDirectory();

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -843,6 +843,7 @@ class WebDevFS implements DevFS {
         await writeBundle(
           globals.fs.directory(getAssetBuildDirectory()),
           bundle.entries,
+          bundle.entryKinds,
         );
       }
     }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -308,7 +308,12 @@ flutter:
       ..createSync();
     handler.addError(directory, FileSystemOp.delete, const FileSystemException('Expected Error Text'));
 
-    await writeBundle(directory, <String, DevFSContent>{}, loggerOverride: testLogger);
+    await writeBundle(
+      directory,
+      <String, DevFSContent>{},
+      <String, AssetKind>{},
+      loggerOverride: testLogger,
+    );
 
     expect(testLogger.warningText, contains('Expected Error Text'));
   });
@@ -415,14 +420,19 @@ flutter:
         ..writeAsStringSync(r'''
   name: example
   flutter:
-    assets:
+    shaders:
       - assets/shader.frag
   ''');
       final AssetBundle bundle = AssetBundleFactory.instance.createBundle();
 
       expect(await bundle.build(packagesPath: '.packages'), 0);
 
-      await writeBundle(output, bundle.entries, loggerOverride: testLogger);
+      await writeBundle(
+        output,
+        bundle.entries,
+        bundle.entryKinds,
+        loggerOverride: testLogger,
+      );
 
     }, overrides: <Type, Generator>{
       Artifacts: () => artifacts,

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -633,6 +633,9 @@ class FakeBundle extends AssetBundle {
   Map<String, DevFSContent> get entries => <String, DevFSContent>{};
 
   @override
+  Map<String, AssetKind> get entryKinds => <String, AssetKind>{};
+
+  @override
   List<File> get inputFiles => <File>[];
 
   @override


### PR DESCRIPTION
This is a step towards no longer identifying shaders that need compilation by way of the `.frag` extension.