### PR TITLE
custom tooltip support added in appbar back button

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -195,6 +195,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
     this.toolbarTextStyle,
     this.titleTextStyle,
     this.systemOverlayStyle,
+    this.tooltip,
   }) : assert(automaticallyImplyLeading != null),
        assert(elevation == null || elevation >= 0.0),
        assert(primary != null),
@@ -754,6 +755,13 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   ///  * [SystemChrome.setSystemUIOverlayStyle]
   final SystemUiOverlayStyle? systemOverlayStyle;
 
+  /// {@template flutter.material.appbar.tooltip}
+  /// Defines the tooltip of [backButton] icon.
+  ///
+  /// By default, the value of `tooltip` is [backButtonTooltip] specified in the [MaterialLocalizations]
+  /// {@endtemplate}
+  final String? tooltip;
+
   bool _getEffectiveCenterTitle(ThemeData theme) {
     bool platformCenter() {
       assert(theme.platform != null);
@@ -938,7 +946,7 @@ class _AppBarState extends State<AppBar> {
         );
       } else {
         if (!hasEndDrawer && canPop)
-          leading = useCloseButton ? const CloseButton() : const BackButton();
+          leading = useCloseButton ? const CloseButton() : BackButton(tooltip: widget.tooltip);
       }
     }
     if (leading != null) {

--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -74,7 +74,7 @@ class BackButtonIcon extends StatelessWidget {
 class BackButton extends StatelessWidget {
   /// Creates an [IconButton] with the appropriate "back" icon for the current
   /// target platform.
-  const BackButton({ Key? key, this.color, this.onPressed }) : super(key: key);
+  const BackButton({ Key? key, this.color, this.onPressed, this.tooltip }) : super(key: key);
 
   /// The color to use for the icon.
   ///
@@ -92,13 +92,18 @@ class BackButton extends StatelessWidget {
   /// Defaults to null.
   final VoidCallback? onPressed;
 
+  /// The tooltip to use for back button icon.
+  ///
+  /// Defaults to the value of [backButtonTooltip] specified in the [MaterialLocalizations]
+  final String? tooltip;
+
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
     return IconButton(
       icon: const BackButtonIcon(),
       color: color,
-      tooltip: MaterialLocalizations.of(context).backButtonTooltip,
+      tooltip: tooltip ?? MaterialLocalizations.of(context).backButtonTooltip,
       onPressed: () {
         if (onPressed != null) {
           onPressed!();


### PR DESCRIPTION
This PR implements the feature request of issue#106814.

issue#106814


With this feature added, now user can added custom tooltip message on back icon button in Appbar.
If no tooltip is provided the default behaviour remains same as previous.