### PR TITLE
[flutter_tools] don't run pub_autoroller on release branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -136,6 +136,9 @@ targets:
     presubmit: false
     recipe: pub_autoroller/pub_autoroller
     timeout: 30
+    enabled_branches:
+      # Don't run this on release branches
+      - master
     properties:
       tags: >
         ["framework","hostonly"]


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/106371

It only makes sense to roll these on the default branch.