### PR TITLE
Ignore invalid description in vswhere.exe JSON output

### DIFF
--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -316,13 +316,14 @@ class VisualStudio {
     late List<dynamic> result;
     late FormatException error;
     try {
-      // vswhere.exe is known to encode its output incorrectly, resulting in
-      // invalid JSON in the description property when interpreted as UTF-8.
-      // First, try to decode without any pre-processing.
-      // See: https://github.com/flutter/flutter/issues/106601
+      // Some versions of vswhere.exe are known to encode their output incorrectly,
+      // resulting in invalid JSON in the 'description' property when interpreted
+      // as UTF-8. First, try to decode without any pre-processing.
       try {
         result = json.decode(vswhereJson) as List<dynamic>;
       } on FormatException catch (e) {
+        // If that fails, remove the 'description' property and try again.
+        // See: https://github.com/flutter/flutter/issues/106601
         error = e;
         vswhereJson = vswhereJson.replaceFirst(_vswhereDescriptionProperty, '');
 

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -322,10 +322,13 @@ class VisualStudio {
       try {
         result = json.decode(vswhereJson) as List<dynamic>;
       } on FormatException catch (e) {
-        // Decoding without pre-processing failed. Retry after removing the
-        // unused description property.
+        // See: https://github.com/flutter/flutter/issues/106601
         error = e;
         vswhereJson = vswhereJson.replaceFirst(_vswhereDescriptionProperty, '');
+
+        _logger.printTrace('Decoding vswhere.exe JSON output failed. $error'
+          'Retrying after removing the unused description property:\n$vswhereJson');
+
         result = json.decode(vswhereJson) as List<dynamic>;
       }
     } on FormatException {

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -317,12 +317,12 @@ class VisualStudio {
     late FormatException error;
     try {
       // vswhere.exe is known to encode its output incorrectly, resulting in
-      // malformed JSON in the description property when interpreted as UTF-8.
+      // invalid JSON in the description property when interpreted as UTF-8.
       // First, try to decode without any pre-processing.
+      // See: https://github.com/flutter/flutter/issues/106601
       try {
         result = json.decode(vswhereJson) as List<dynamic>;
       } on FormatException catch (e) {
-        // See: https://github.com/flutter/flutter/issues/106601
         error = e;
         vswhereJson = vswhereJson.replaceFirst(_vswhereDescriptionProperty, '');
 

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -326,7 +326,7 @@ class VisualStudio {
         error = e;
         vswhereJson = vswhereJson.replaceFirst(_vswhereDescriptionProperty, '');
 
-        _logger.printTrace('Decoding vswhere.exe JSON output failed. $error'
+        _logger.printTrace('Failed to decode vswhere.exe JSON output. $error'
           'Retrying after removing the unused description property:\n$vswhereJson');
 
         result = json.decode(vswhereJson) as List<dynamic>;

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -313,29 +313,29 @@ class VisualStudio {
   }
 
   List<Map<String, dynamic>>? _tryDecodeVswhereJson(String vswhereJson) {
-    late List<dynamic> result;
-    late FormatException error;
+    List<dynamic>? result;
+    FormatException? originalError;
     try {
       // Some versions of vswhere.exe are known to encode their output incorrectly,
       // resulting in invalid JSON in the 'description' property when interpreted
       // as UTF-8. First, try to decode without any pre-processing.
       try {
         result = json.decode(vswhereJson) as List<dynamic>;
-      } on FormatException catch (e) {
+      } on FormatException catch (error) {
         // If that fails, remove the 'description' property and try again.
         // See: https://github.com/flutter/flutter/issues/106601
-        error = e;
         vswhereJson = vswhereJson.replaceFirst(_vswhereDescriptionProperty, '');
 
         _logger.printTrace('Failed to decode vswhere.exe JSON output. $error'
           'Retrying after removing the unused description property:\n$vswhereJson');
 
+        originalError = error;
         result = json.decode(vswhereJson) as List<dynamic>;
       }
     } on FormatException {
       // Removing the description property didn't help.
       // Report the original decoding error on the unprocessed JSON.
-      _logger.printWarning('Warning: Unexpected vswhere.exe JSON output. $error'
+      _logger.printWarning('Warning: Unexpected vswhere.exe JSON output. $originalError'
         'To see the full JSON, run flutter doctor -vv.');
       return null;
     }

--- a/packages/flutter_tools/lib/src/windows/visual_studio.dart
+++ b/packages/flutter_tools/lib/src/windows/visual_studio.dart
@@ -32,7 +32,7 @@ class VisualStudio {
   final Logger _logger;
 
   /// Matches the description property from the vswhere.exe JSON output.
-  final RegExp _vswhereDescriptionProperty = RegExp(r'\s*"description":\s*".*"\s*,?');
+  final RegExp _vswhereDescriptionProperty = RegExp(r'\s*"description"\s*:\s*".*"\s*,?');
 
   /// True if Visual Studio installation was found.
   ///

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -92,6 +92,23 @@ const Map<String, dynamic> _missingStatusResponse = <String, dynamic>{
   },
 };
 
+const String _malformedDescriptionResponse = r'''
+[
+  {
+    "installationPath": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2017\\Community",
+    "displayName": "Visual Studio Community 2019",
+    "description": "This description has too many "quotes",
+    "installationVersion": "16.2.29306.81",
+    "isRebootRequired": false,
+    "isComplete": true,
+    "isPrerelease": false,
+    "catalog": {
+      "productDisplayVersion": "16.2.5"
+    }
+  }
+]
+''';
+
 // Arguments for a vswhere query to search for an installation with the
 // requirements.
 const List<String> _requirements = <String>[
@@ -124,7 +141,7 @@ void setMockVswhereResponse(
   fileSystem.file(vswherePath).createSync(recursive: true);
   fileSystem.file(cmakePath).createSync(recursive: true);
   final String finalResponse = responseOverride
-    ?? (response != null ? json.encode(<Map<String, dynamic>>[response]) : '');
+    ?? (response != null ? json.encode(<Map<String, dynamic>>[response]) : '[]');
   final List<String> requirementArguments = requiredComponents == null
     ? <String>[]
     : <String>['-requires', ...requiredComponents];
@@ -323,7 +340,7 @@ VisualStudioFixture setUpVisualStudio() {
     logger: logger,
     processManager: processManager,
   );
-  return VisualStudioFixture(visualStudio, fileSystem, processManager);
+  return VisualStudioFixture(visualStudio, fileSystem, processManager, logger);
 }
 
 // Set all vswhere query with the required components return null.
@@ -717,7 +734,7 @@ void main() {
       expect(visualStudio.fullVersion, equals('16.2.29306.81'));
     });
 
-    testWithoutContext('cmakePath returns null when VS is present but when vswhere returns invalid JSON', () {
+    testWithoutContext('Warns when VS is present but vswhere returns invalid JSON', () {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 
@@ -729,7 +746,19 @@ void main() {
         fixture.processManager,
       );
 
+      expect(visualStudio.isInstalled, isFalse);
+      expect(visualStudio.isComplete, isFalse);
+      expect(visualStudio.isLaunchable, isFalse);
+      expect(visualStudio.isPrerelease, isFalse);
+      expect(visualStudio.isRebootRequired, isFalse);
+      expect(visualStudio.hasNecessaryComponents, isFalse);
+      expect(visualStudio.displayName, isNull);
+      expect(visualStudio.displayVersion, isNull);
+      expect(visualStudio.installLocation, isNull);
+      expect(visualStudio.fullVersion, isNull);
       expect(visualStudio.cmakePath, isNull);
+
+      expect(fixture.logger.warningText, contains('Warning: unexpected vswhere.exe output'));
     });
 
     testWithoutContext('Everything returns good values when VS is present with all components', () {
@@ -941,6 +970,26 @@ void main() {
       expect(visualStudio.cmakeGenerator, equals('Visual Studio 16 2019'));
       expect(visualStudio.displayVersion, equals('\u{FFFD}'));
     });
+
+    testWithoutContext('Ignores malformed JSON in description property', () {
+      setMockVswhereResponse(
+        fixture.fileSystem,
+        fixture.processManager,
+        _requirements,
+        <String>['-version', '16'],
+        null,
+        _malformedDescriptionResponse,
+      );
+
+      expect(visualStudio.isInstalled, true);
+      expect(visualStudio.isAtLeastMinimumVersion, true);
+      expect(visualStudio.hasNecessaryComponents, true);
+      expect(visualStudio.cmakePath, equals(cmakePath));
+      expect(visualStudio.cmakeGenerator, equals('Visual Studio 16 2019'));
+      expect(visualStudio.displayVersion, equals('16.2.5'));
+
+      expect(fixture.logger.warningText, isEmpty);
+    });
   });
 
   group(VswhereDetails, () {
@@ -1037,9 +1086,10 @@ void main() {
 }
 
 class VisualStudioFixture {
-  VisualStudioFixture(this.visualStudio, this.fileSystem, this.processManager);
+  VisualStudioFixture(this.visualStudio, this.fileSystem, this.processManager, this.logger);
 
   final VisualStudio visualStudio;
   final FileSystem fileSystem;
   final FakeProcessManager processManager;
+  final BufferLogger logger;
 }

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -734,7 +734,7 @@ void main() {
       expect(visualStudio.fullVersion, equals('16.2.29306.81'));
     });
 
-    testWithoutContext('Warns when VS is present but vswhere returns invalid JSON', () {
+    testWithoutContext('Warns and returns no installation when VS is present but vswhere returns invalid JSON', () {
       final VisualStudioFixture fixture = setUpVisualStudio();
       final VisualStudio visualStudio = fixture.visualStudio;
 

--- a/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows/visual_studio_test.dart
@@ -758,7 +758,7 @@ void main() {
       expect(visualStudio.fullVersion, isNull);
       expect(visualStudio.cmakePath, isNull);
 
-      expect(fixture.logger.warningText, contains('Warning: unexpected vswhere.exe output'));
+      expect(fixture.logger.warningText, contains('Warning: Unexpected vswhere.exe JSON output'));
     });
 
     testWithoutContext('Everything returns good values when VS is present with all components', () {


### PR DESCRIPTION
The `flutter doctor` command uses `vswhere.exe` to verify the Visual Studio installation. This `vswhere.exe` is known to encode its output incorrectly. This is problematic as the `description` property is localized, and in certain languages this results in invalid JSON due to the incorrect encoding.

This change introduces a fallback to our `vswhere.exe` output parsing logic: if parsing JSON fails, remove the `description` property and retry parsing the JSON.

This fix was also tested on the outputs provided here: https://github.com/flutter/flutter/issues/106601#issuecomment-1170138123

Addresses https://github.com/flutter/flutter/issues/106601.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
