### PR TITLE
Pass URI converter from context to DDS

### DIFF
--- a/packages/flutter_tools/lib/src/base/dds.dart
+++ b/packages/flutter_tools/lib/src/base/dds.dart
@@ -8,6 +8,7 @@ import 'package:dds/dds.dart' as dds;
 import 'package:meta/meta.dart';
 
 import 'common.dart';
+import 'context.dart';
 import 'io.dart' as io;
 import 'logger.dart';
 
@@ -18,6 +19,7 @@ Future<dds.DartDevelopmentService> Function(
   bool ipv6,
   Uri? serviceUri,
   List<String> cachedUserTags,
+  dds.UriConverter? uriConverter,
 }) ddsLauncherCallback = dds.DartDevelopmentService.startDartDevelopmentService;
 
 /// Helper class to launch a [dds.DartDevelopmentService]. Allows for us to
@@ -56,6 +58,7 @@ class DartDevelopmentService {
           ipv6: ipv6 ?? false,
           // Enables caching of CPU samples collected during application startup.
           cachedUserTags: cacheStartupProfile ? const <String>['AppStartUp'] : const <String>[],
+          uriConverter: context.get<dds.UriConverter>(),
         );
       unawaited(_ddsInstance?.done.whenComplete(() {
         if (!_completer.isCompleted) {

--- a/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
+++ b/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
@@ -16,7 +16,7 @@ class SdkWebConfigurationProvider extends SdkConfigurationProvider {
   SdkWebConfigurationProvider(this._artifacts);
 
   final Artifacts _artifacts;
-  late SdkConfiguration _configuration;
+  SdkConfiguration _configuration;
 
   /// Create and validate configuration matching the default SDK layout.
   /// Create configuration matching the default SDK layout.

--- a/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
+++ b/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
@@ -16,7 +16,7 @@ class SdkWebConfigurationProvider extends SdkConfigurationProvider {
   SdkWebConfigurationProvider(this._artifacts);
 
   final Artifacts _artifacts;
-  SdkConfiguration? _configuration;
+  late SdkConfiguration _configuration;
 
   /// Create and validate configuration matching the default SDK layout.
   /// Create configuration matching the default SDK layout.

--- a/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
+++ b/packages/flutter_tools/lib/src/isolated/sdk_web_configuration.dart
@@ -16,7 +16,7 @@ class SdkWebConfigurationProvider extends SdkConfigurationProvider {
   SdkWebConfigurationProvider(this._artifacts);
 
   final Artifacts _artifacts;
-  SdkConfiguration _configuration;
+  SdkConfiguration? _configuration;
 
   /// Create and validate configuration matching the default SDK layout.
   /// Create configuration matching the default SDK layout.


### PR DESCRIPTION
We want to be able to pass in a URI converter that maps from package URIs to local file paths for internal purposes. 

Related to https://github.com/dart-lang/sdk/issues/48435#

~A few things I'm not sure about:~
- ~I need to update versions of multiple packages, but some have a comment about autogenerating versions, e.g. `dds_service_extensions: 1.3.1 # THIS LINE IS AUTOGENERATED - TO UPDATE USE "flutter update-packages --force-upgrade"`. This doesn't work for me, and pubspec is just updated manually right now so I can access the changes from DDS that I need. @christopherfujino can you advise here?~
- ~I need help from @annagrin on how to change `SdkWebConfigurationProvider` correctly to be compatible with updated DWDS~

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
