### PR TITLE
[flutter_tool] Pass --input-type to impellerc

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
@@ -5,7 +5,6 @@
 import 'package:process/process.dart';
 
 import '../../artifacts.dart';
-import '../../base/common.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../base/logger.dart';
@@ -43,17 +42,13 @@ class ShaderCompiler {
   ///
   /// All parameters are required.
   ///
-  /// If the input file is not a fragment shader, this returns false.
-  /// If the shader compiler subprocess fails, it will [throwToolExit].
-  /// Otherwise, it will return true.
+  /// If the shader compiler subprocess fails, it will print the stdout and
+  /// stderr to the log and throw a [ShaderCompilerException]. Otherwise, it
+  /// will return true.
   Future<bool> compileShader({
     required File input,
     required String outputPath,
   }) async {
-    if (!input.path.endsWith('.frag')) {
-      return false;
-    }
-
     final File impellerc = _fs.file(
       _artifacts.getHostArtifact(HostArtifact.impellerc),
     );
@@ -72,6 +67,7 @@ class ShaderCompiler {
       '--flutter-spirv',
       '--spirv=$outputPath',
       '--input=${input.path}',
+      '--input-type=frag',
     ];
     final Process impellercProcess = await _processManager.start(cmd);
     final int code = await impellercProcess.exitCode;

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -169,11 +169,25 @@ Future<void> writeBundle(
         // platform channels in the framework will URI encode these values,
         // and the native APIs will look for files this way.
         final File file = globals.fs.file(globals.fs.path.join(bundleDir.path, entry.key));
+        final AssetKind assetKind = entryKinds[entry.key] ?? AssetKind.regular;
         file.parent.createSync(recursive: true);
         final DevFSContent devFSContent = entry.value;
         if (devFSContent is DevFSFileContent) {
           final File input = devFSContent.file as File;
-          if (!await shaderCompiler.compileShader(input: input, outputPath: file.path)) {
+          bool doCopy = true;
+          switch (assetKind) {
+            case AssetKind.regular:
+              break;
+            case AssetKind.font:
+              break;
+            case AssetKind.shader:
+              doCopy = !await shaderCompiler.compileShader(
+                input: input,
+                outputPath: file.path,
+              );
+              break;
+          }
+          if (doCopy) {
             input.copySync(file.path);
           }
         } else {

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -444,6 +444,7 @@ flutter:
             '--flutter-spirv',
             '--spirv=$outputPath',
             '--input=/$shaderPath',
+            '--input-type=frag',
           ],
           onRun: () {
             fileSystem.file(outputPath).createSync(recursive: true);


### PR DESCRIPTION
Removes the requirement that shaders must end with the `.frag` extension.