### PR TITLE
Fix OutlineInputBorder with BorderRadius.zero is distorted

### DIFF
--- a/packages/flutter/lib/src/material/input_border.dart
+++ b/packages/flutter/lib/src/material/input_border.dart
@@ -439,44 +439,63 @@ class OutlineInputBorder extends InputBorder {
       scaledRRect.left,
       scaledRRect.bottom - scaledRRect.blRadiusY * 2.0,
       scaledRRect.blRadiusX * 2.0,
-      scaledRRect.blRadiusX * 2.0,
+      scaledRRect.blRadiusY * 2.0,
     );
 
     // This assumes that the radius is circular (x and y radius are equal).
     // Currently, BorderRadius only supports circular radii.
     const double cornerArcSweep = math.pi / 2.0;
-    final double tlCornerArcSweep = math.acos(
-      clampDouble(1 - start / scaledRRect.tlRadiusX, 0.0, 1.0),
-    );
+    final Path path = Path();
 
-    final Path path = Path()
-      ..addArc(tlCorner, math.pi, tlCornerArcSweep);
+    // Top left corner
+    if (scaledRRect.tlRadius != Radius.zero) {
+      final double tlCornerArcSweep = math.acos(clampDouble(1 - start / scaledRRect.tlRadiusX, 0.0, 1.0));
+      path.addArc(tlCorner, math.pi, tlCornerArcSweep);
+    } else {
+      // Because the path is painted with Paint.strokeCap = StrokeCap.butt, horizontal coordinate is moved
+      // to the left using borderSide.width / 2.
+      path.moveTo(scaledRRect.left - borderSide.width / 2, scaledRRect.top);
+    }
 
+    // Draw top border from top left corner to gap start.
     if (start > scaledRRect.tlRadiusX) {
       path.lineTo(scaledRRect.left + start, scaledRRect.top);
     }
 
+    // Draw top border from gap end to top right corner and draw top right corner.
     const double trCornerArcStart = (3 * math.pi) / 2.0;
     const double trCornerArcSweep = cornerArcSweep;
     if (start + extent < scaledRRect.width - scaledRRect.trRadiusX) {
       path.moveTo(scaledRRect.left + start + extent, scaledRRect.top);
       path.lineTo(scaledRRect.right - scaledRRect.trRadiusX, scaledRRect.top);
-      path.addArc(trCorner, trCornerArcStart, trCornerArcSweep);
+      if (scaledRRect.trRadius != Radius.zero) {
+        path.addArc(trCorner, trCornerArcStart, trCornerArcSweep);
+      }
     } else if (start + extent < scaledRRect.width) {
       final double dx = scaledRRect.width - (start + extent);
-      final double sweep = math.asin(
-        clampDouble(1 - dx / scaledRRect.trRadiusX, 0.0, 1.0),
-      );
+      final double sweep = math.asin(clampDouble(1 - dx / scaledRRect.trRadiusX, 0.0, 1.0));
       path.addArc(trCorner, trCornerArcStart + sweep, trCornerArcSweep - sweep);
     }
 
-    return path
-      ..moveTo(scaledRRect.right, scaledRRect.top + scaledRRect.trRadiusY)
-      ..lineTo(scaledRRect.right, scaledRRect.bottom - scaledRRect.brRadiusY)
-      ..addArc(brCorner, 0.0, cornerArcSweep)
-      ..lineTo(scaledRRect.left + scaledRRect.blRadiusX, scaledRRect.bottom)
-      ..addArc(blCorner, math.pi / 2.0, cornerArcSweep)
-      ..lineTo(scaledRRect.left, scaledRRect.top + scaledRRect.tlRadiusY);
+    // Draw right border and bottom right corner.
+    if (scaledRRect.brRadius != Radius.zero) {
+      path.moveTo(scaledRRect.right, scaledRRect.top + scaledRRect.trRadiusY);
+    }
+    path.lineTo(scaledRRect.right, scaledRRect.bottom - scaledRRect.brRadiusY);
+    if (scaledRRect.brRadius != Radius.zero) {
+      path.addArc(brCorner, 0.0, cornerArcSweep);
+    }
+
+    // Draw bottom border and bottom left corner.
+    path.lineTo(scaledRRect.left + scaledRRect.blRadiusX, scaledRRect.bottom);
+    if (scaledRRect.blRadius != Radius.zero) {
+      path.addArc(blCorner, math.pi / 2.0, cornerArcSweep);
+    }
+
+    // Draw left border
+    path.lineTo(scaledRRect.left, scaledRRect.top + scaledRRect.tlRadiusY);
+
+    return path;
   }
 
   /// Draw a rounded rectangle around [rect] using [borderRadius].


### PR DESCRIPTION
## Description

This PR fixes an `OutlineInputBorder` rendering bug. When `OutlineInputBorder.borderRadius` is `BorderRadius.zero` and the parent `InputDecorator.labelText` is set and shown on the border, the border is drawn using `Canvas.drawPath` and the path is distorted.

There were some miscalculations mainly related to using a temporary `RRect` with negative border radii.

This PR ~~adds a private `_clampRadius` method to clamp negative border radii and~~ builds the path without calling `Path.addArc` for corners with a zero border radius.
**_Edit_**: `RRect` radii clamping was added to the engine (see https://github.com/flutter/engine/pull/36062 and https://github.com/flutter/engine/pull/36106).

Before this PR (and **before** https://github.com/flutter/engine/pull/36062 + https://github.com/flutter/engine/pull/36106) : 
![before](https://user-images.githubusercontent.com/840911/176601440-69d2da20-8c9f-4ab0-aaaf-deb6aa7f69e7.png)

Before this PR (and **after** https://github.com/flutter/engine/pull/36062 + https://github.com/flutter/engine/pull/36106) : 
![image](https://user-images.githubusercontent.com/840911/190648414-9a7a0228-5cff-4211-ba0b-e8f197ce9a33.png)

After :
![after](https://user-images.githubusercontent.com/840911/176601431-3fb7b2d5-d2bf-4cd3-a631-a28f3394a8bd.png)


## Related Issue

Fixes https://github.com/flutter/flutter/issues/78855
Fixes https://github.com/flutter/flutter/issues/111086

## Tests

Adds 1 test.