### PR TITLE
[Windows] Remove the usage of `SETLOCAL ENABLEDELAYEDEXPANSION` from bat scripts.

### DIFF
--- a/bin/dart.bat
+++ b/bin/dart.bat
@@ -11,7 +11,7 @@ REM work across all platforms!
 REM
 REM --------------------------------------------------------------------------
 
-SETLOCAL ENABLEDELAYEDEXPANSION
+SETLOCAL
 
 FOR %%i IN ("%~dp0..") DO SET FLUTTER_ROOT=%%~fi
 
@@ -23,6 +23,8 @@ SET cache_dir=%FLUTTER_ROOT%\bin\cache
 SET dart_sdk_path=%cache_dir%\dart-sdk
 SET dart=%dart_sdk_path%\bin\dart.exe
 
+SET exit_with_errorlevel=%FLUTTER_ROOT%/bin/internal/exit_with_errorlevel.bat
+
 REM Chaining the call to 'dart' and 'exit' with an ampersand ensures that
 REM Windows reads both commands into memory once before executing them. This
 REM avoids nasty errors that may otherwise occur when the dart command (e.g. as
@@ -31,4 +33,4 @@ REM
 REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
-"%dart%" %* & exit /B !ERRORLEVEL!
+"%dart%" %* & "%exit_with_errorlevel%"

--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -11,7 +11,7 @@ REM work across all platforms!
 REM
 REM --------------------------------------------------------------------------
 
-SETLOCAL ENABLEDELAYEDEXPANSION
+SETLOCAL
 
 REM To debug the tool, you can uncomment the following line to enable debug mode:
 REM SET FLUTTER_TOOL_ARGS="--enable-asserts %FLUTTER_TOOL_ARGS%"
@@ -43,6 +43,8 @@ SET snapshot_path=%cache_dir%\flutter_tools.snapshot
 SET dart_sdk_path=%cache_dir%\dart-sdk
 SET dart=%dart_sdk_path%\bin\dart.exe
 
+SET exit_with_errorlevel=%FLUTTER_ROOT%/bin/internal/exit_with_errorlevel.bat
+
 REM Chaining the call to 'dart' and 'exit' with an ampersand ensures that
 REM Windows reads both commands into memory once before executing them. This
 REM avoids nasty errors that may otherwise occur when the dart command (e.g. as
@@ -51,4 +53,4 @@ REM
 REM Do not use the CALL command in the next line to execute Dart. CALL causes
 REM Windows to re-read the line from disk after the CALL command has finished
 REM regardless of the ampersand chain.
-"%dart%" --disable-dart-dev --packages="%flutter_tools_dir%\.dart_tool\package_config.json" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & exit /B !ERRORLEVEL!
+"%dart%" --disable-dart-dev --packages="%flutter_tools_dir%\.dart_tool\package_config.json" %FLUTTER_TOOL_ARGS% "%snapshot_path%" %* & "%exit_with_errorlevel%"

--- a/bin/internal/exit_with_errorlevel.bat
+++ b/bin/internal/exit_with_errorlevel.bat
@@ -1,0 +1,13 @@
+@ECHO off
+REM Copyright 2014 The Flutter Authors. All rights reserved.
+REM Use of this source code is governed by a BSD-style license that can be
+REM found in the LICENSE file.
+
+REM A script to exit caller script with the last status code.
+REM This can be used with ampersand without `SETLOCAL ENABLEDELAYEDEXPANSION`.
+REM
+REM To use this script like `exit`, do not use with the CALL command.
+REM Without CALL, this script can exit caller script, but with CALL,
+REM this script returns back to caller and does not exit caller.
+
+exit /B %ERRORLEVEL%

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -11,7 +11,7 @@ REM work across all platforms!
 REM
 REM --------------------------------------------------------------------------
 
-SETLOCAL ENABLEDELAYEDEXPANSION
+SETLOCAL
 
 SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools
 SET cache_dir=%FLUTTER_ROOT%\bin\cache
@@ -84,11 +84,11 @@ GOTO :after_subroutine
   IF NOT EXIST "%engine_stamp%" GOTO do_sdk_update_and_snapshot
   SET /P dart_required_version=<"%engine_version_path%"
   SET /P dart_installed_version=<"%engine_stamp%"
-  IF !dart_required_version! NEQ !dart_installed_version! GOTO do_sdk_update_and_snapshot
+  IF %dart_required_version% NEQ %dart_installed_version% GOTO do_sdk_update_and_snapshot
   IF NOT EXIST "%snapshot_path%" GOTO do_snapshot
   IF NOT EXIST "%stamp_path%" GOTO do_snapshot
   SET /P stamp_value=<"%stamp_path%"
-  IF !stamp_value! NEQ !compilekey! GOTO do_snapshot
+  IF %stamp_value% NEQ %compilekey% GOTO do_snapshot
   SET pubspec_yaml_path=%flutter_tools_dir%\pubspec.yaml
   SET pubspec_lock_path=%flutter_tools_dir%\pubspec.lock
   FOR /F %%i IN ('DIR /B /O:D "%pubspec_yaml_path%" "%pubspec_lock_path%"') DO SET newer_file=%%i
@@ -104,7 +104,7 @@ GOTO :after_subroutine
     ECHO Checking Dart SDK version... 1>&2
     SET update_dart_bin=%FLUTTER_ROOT%\bin\internal\update_dart_sdk.ps1
     REM Escape apostrophes from the executable path
-    SET "update_dart_bin=!update_dart_bin:'=''!"
+    SET "update_dart_bin=%update_dart_bin:'=''%"
     REM PowerShell command must have exit code set in order to prevent all non-zero exit codes from being translated
     REM into 1. The exit code 2 is used to detect the case where the major version is incorrect and there should be
     REM no subsequent retries.

--- a/packages/flutter_tools/test/commands.shard/permeable/script_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/script_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// @dart = 2.8
+
+import 'dart:io';
+
+import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
+
+import '../../src/common.dart';
+import '../../src/context.dart';
+
+void main() {
+  setUpAll(() {
+    Cache.disableLocking();
+  });
+
+  testUsingContext('flutter command can receive `!`, avoiding expansion by cmd.exe', () async {
+    final String flutterBin = globals.fs.path.join(getFlutterRoot(), 'bin', 'flutter.bat');
+
+    final ProcessResult exec = await Process.run(
+      flutterBin,
+      <String>[
+        '!',
+      ],
+      workingDirectory: Cache.flutterRoot,
+    );
+    // If ENABLEDELAYEDEXPANSION is enabled, the argument `!` is removed,
+    // and flutter runs without any arguments.
+    expect(exec.exitCode, 64);
+    expect(exec.stderr, contains('Could not find a command named "!"'));
+  },
+  skip: !Platform.isWindows, // [intended] relies on Windows's cmd.exe
+  );
+}


### PR DESCRIPTION
On Windows, calling another script without `CALL` from bat script won't back to caller when callee exited. The callee can use last exit code. When the callee exits with exit code, the caller's caller can receive the code.

This PR replaces the usage of `SETLOCAL ENABLEDELAYEDEXPANSION` with this behavior.
This PR also replaces the usage of it which can be replaced by normal %~%.

Fixes flutter/flutter#26571.

No changes in the [flutter/tests] repo.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
