### PR TITLE
Scroll inertia cancel [framework]

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -259,9 +259,15 @@ class PointerEventConverter {
                 scrollDelta: scrollDelta,
                 embedderId: datum.embedderId,
               );
+            case ui.PointerSignalKind.scrollInertiaCancel:
+              return PointerScrollInertiaCancelEvent(
+                timeStamp: timeStamp,
+                kind: kind,
+                device: datum.device,
+                position: position,
+                embedderId: datum.embedderId,
+              );
             case ui.PointerSignalKind.unknown:
-            default: // ignore: no_default_cases, to allow adding a new [PointerSignalKind]
-                     // TODO(moffatman): Remove after landing https://github.com/flutter/engine/pull/34402
               // This branch should already have 'unknown' filtered out, but
               // we don't want to return anything or miss if someone adds a new
               // enumeration to PointerSignalKind.

--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1831,6 +1831,91 @@ class _TransformedPointerScrollEvent extends _TransformedPointerEvent with _Copy
   }
 }
 
+mixin _CopyPointerScrollInertiaCancelEvent on PointerEvent {
+  @override
+  PointerScrollInertiaCancelEvent copyWith({
+    Duration? timeStamp,
+    int? pointer,
+    PointerDeviceKind? kind,
+    int? device,
+    Offset? position,
+    Offset? delta,
+    int? buttons,
+    bool? obscured,
+    double? pressure,
+    double? pressureMin,
+    double? pressureMax,
+    double? distance,
+    double? distanceMax,
+    double? size,
+    double? radiusMajor,
+    double? radiusMinor,
+    double? radiusMin,
+    double? radiusMax,
+    double? orientation,
+    double? tilt,
+    bool? synthesized,
+    int? embedderId,
+  }) {
+    return PointerScrollInertiaCancelEvent(
+      timeStamp: timeStamp ?? this.timeStamp,
+      kind: kind ?? this.kind,
+      device: device ?? this.device,
+      position: position ?? this.position,
+      embedderId: embedderId ?? this.embedderId,
+    ).transformed(transform);
+  }
+}
+
+/// The pointer issued a scroll-inertia cancel event.
+///
+/// Touching the trackpad immediately after a scroll is an example of an event
+/// that would create a [PointerScrollInertiaCancelEvent].
+///
+/// See also:
+///
+///  * [Listener.onPointerSignal], which allows callers to be notified of these
+///    events in a widget tree.
+///  * [PointerSignalResolver], which provides an opt-in mechanism whereby
+///    participating agents may disambiguate an event's target.
+class PointerScrollInertiaCancelEvent extends PointerSignalEvent with _PointerEventDescription, _CopyPointerScrollInertiaCancelEvent {
+  /// Creates a pointer scroll-inertia cancel event.
+  ///
+  /// All of the arguments must be non-null.
+  const PointerScrollInertiaCancelEvent({
+    super.timeStamp,
+    super.kind,
+    super.device,
+    super.position,
+    super.embedderId,
+  }) : assert(timeStamp != null),
+       assert(kind != null),
+       assert(device != null),
+       assert(position != null);
+
+  @override
+  PointerScrollInertiaCancelEvent transformed(Matrix4? transform) {
+    if (transform == null || transform == this.transform) {
+      return this;
+    }
+    return _TransformedPointerScrollInertiaCancelEvent(original as PointerScrollInertiaCancelEvent? ?? this, transform);
+  }
+}
+
+class _TransformedPointerScrollInertiaCancelEvent extends _TransformedPointerEvent with _CopyPointerScrollInertiaCancelEvent implements PointerScrollInertiaCancelEvent {
+  _TransformedPointerScrollInertiaCancelEvent(this.original, this.transform)
+    : assert(original != null), assert(transform != null);
+
+  @override
+  final PointerScrollInertiaCancelEvent original;
+
+  @override
+  final Matrix4 transform;
+
+  @override
+  PointerScrollInertiaCancelEvent transformed(Matrix4? transform) => original.transformed(transform);
+}
+
 mixin _CopyPointerPanZoomStartEvent on PointerEvent {
   @override
   PointerPanZoomStartEvent copyWith({

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -732,6 +732,10 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         GestureBinding.instance.pointerSignalResolver.register(event, _handlePointerScroll);
       }
     }
+    else if (event is PointerScrollInertiaCancelEvent) {
+      position.jumpTo(position.pixels);
+      // Don't use pointer signal resolver, all hit-tested scrollables should stop
+    }
   }
 
   void _handlePointerScroll(PointerEvent event) {

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -731,10 +731,9 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
       if (delta != 0.0 && targetScrollOffset != position.pixels) {
         GestureBinding.instance.pointerSignalResolver.register(event, _handlePointerScroll);
       }
-    }
-    else if (event is PointerScrollInertiaCancelEvent) {
+    } else if (event is PointerScrollInertiaCancelEvent) {
       position.jumpTo(position.pixels);
-      // Don't use pointer signal resolver, all hit-tested scrollables should stop
+      // Don't use the pointer signal resolver, all hit-tested scrollables should stop.
     }
   }
 

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1436,7 +1436,7 @@ void main() {
     await tester.pump(); // trigger fling
     expect(getScrollOffset(tester), dragOffset);
     await tester.pump(const Duration(seconds: 5));
-    final double withoutCancelResult = getScrollOffset(tester);
+    expect(getScrollOffset(tester), closeTo(380.2303, 0.0001));
     resetScrollOffset(tester);
 
     // Now cancel partway into the inertia.
@@ -1450,12 +1450,9 @@ void main() {
     testPointer.hover(tester.getCenter(find.byType(Scrollable)));
     await tester.sendEventToBinding(testPointer.scrollInertiaCancel());
     await tester.pump();
-    final double atCancelResult = getScrollOffset(tester);
+    expect(getScrollOffset(tester), closeTo(333.2944, 0.0001));
     await tester.pump(const Duration(milliseconds: 4800)); // Add up to the same 5 seconds as before.
-    final double withCancelResult = getScrollOffset(tester);
-
-    expect(withCancelResult, lessThan(withoutCancelResult)); // Inertia was stopped before reaching full distance
-    expect(withCancelResult, atCancelResult); // Scroll position remains as it was when inertia cancel event occured.
+    expect(getScrollOffset(tester), closeTo(333.2944, 0.0001));
   });
 }
 

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1429,17 +1429,6 @@ void main() {
   });
 
   testWidgets('Scroll inertia cancel event', (WidgetTester tester) async {
-    // First try without cancelling.
-    await pumpTest(tester, null);
-    await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 1000.0);
-    expect(getScrollOffset(tester), dragOffset);
-    await tester.pump(); // trigger fling
-    expect(getScrollOffset(tester), dragOffset);
-    await tester.pump(const Duration(seconds: 5));
-    expect(getScrollOffset(tester), closeTo(380.2303, 0.0001));
-    resetScrollOffset(tester);
-
-    // Now cancel partway into the inertia.
     await pumpTest(tester, null);
     await tester.fling(find.byType(Scrollable), const Offset(0.0, -dragOffset), 1000.0);
     expect(getScrollOffset(tester), dragOffset);
@@ -1447,11 +1436,11 @@ void main() {
     expect(getScrollOffset(tester), dragOffset);
     await tester.pump(const Duration(milliseconds: 200));
     final TestPointer testPointer = TestPointer(1, ui.PointerDeviceKind.mouse);
-    testPointer.hover(tester.getCenter(find.byType(Scrollable)));
-    await tester.sendEventToBinding(testPointer.scrollInertiaCancel());
+    await tester.sendEventToBinding(testPointer.hover(tester.getCenter(find.byType(Scrollable))));
+    await tester.sendEventToBinding(testPointer.scrollInertiaCancel()); // Cancel partway through.
     await tester.pump();
     expect(getScrollOffset(tester), closeTo(333.2944, 0.0001));
-    await tester.pump(const Duration(milliseconds: 4800)); // Add up to the same 5 seconds as before.
+    await tester.pump(const Duration(milliseconds: 4800));
     expect(getScrollOffset(tester), closeTo(333.2944, 0.0001));
   });
 }

--- a/packages/flutter_test/lib/src/test_pointer.dart
+++ b/packages/flutter_test/lib/src/test_pointer.dart
@@ -304,6 +304,23 @@ class TestPointer {
     );
   }
 
+  /// Create a [PointerScrollInertiaCancelEvent] (e.g., user resting their finger on the trackpad).
+  ///
+  /// By default, the time stamp on the event is [Duration.zero]. You can give a
+  /// specific time stamp by passing the `timeStamp` argument.
+  PointerScrollInertiaCancelEvent scrollInertiaCancel({
+    Duration timeStamp = Duration.zero,
+  }) {
+    assert(kind != PointerDeviceKind.touch, "Touch pointers can't generate pointer signal events");
+    assert(location != null);
+    return PointerScrollInertiaCancelEvent(
+      timeStamp: timeStamp,
+      kind: kind,
+      device: _device,
+      position: location!
+    );
+  }
+
   /// Create a [PointerPanZoomStartEvent] (e.g., trackpad scroll; not scroll wheel
   /// or finger-drag scroll) with the given delta.
   ///


### PR DESCRIPTION
It's expected behaviour on some platforms that scroll inertia/momentum animations will stop when a finger is rested on the trackpad. This PR reacts to a new kind of pointer signal event (`PointerSignalKind.scrollInertiaCancel`) to convey that message. 

Framework prep PR: #106906

Engine PR [1/4]: https://github.com/flutter/engine/pull/34402

Part of #106979

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
