### PR TITLE
[tool][web] Create an early web plugin_registrant for dartpad.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -1106,6 +1106,11 @@ Future<void> refreshPluginsList(
 ///
 /// In the Web platform, `destination` can point to a real filesystem (`flutter build`)
 /// or an in-memory filesystem (`flutter run`).
+///
+/// This method is also used by [WebProject.ensureReadyForPlatformSpecificTooling]
+/// to inject a copy of the plugin registrant for web into .dart_tool/dartpad so
+/// dartpad can get the plugin registrant without needing to build the complete
+/// project. See: https://github.com/dart-lang/dart-services/pull/874
 Future<void> injectBuildTimePluginFiles(
   FlutterProject project, {
   required Directory destination,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -734,7 +734,20 @@ class WebProject extends FlutterProjectPlatform {
       .childDirectory('web')
       .childFile('index.html');
 
-  Future<void> ensureReadyForPlatformSpecificTooling() async {}
+  /// The .dart_tool/dartpad directory
+  Directory get dartpadToolDirectory => parent.directory
+      .childDirectory('.dart_tool')
+      .childDirectory('dartpad');
+
+  Future<void> ensureReadyForPlatformSpecificTooling() async {
+    /// Create .dart_tool/dartpad/web_plugin_registrant.dart.
+    /// See: https://github.com/dart-lang/dart-services/pull/874
+    await injectBuildTimePluginFiles(
+      parent,
+      destination: dartpadToolDirectory,
+      webPlatform: true,
+    );
+  }
 }
 
 /// The Fuchsia sub project.

--- a/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
@@ -112,7 +112,6 @@ void main() {
     await _createProject(projectDir, <String>[]);
     await _addDependency(projectDir, 'shared_preferences',
         version: '^2.0.0');
-
     // The plugin registrant for dartpad is created on flutter pub get.
     await _doFlutterPubGet(projectDir);
 


### PR DESCRIPTION
The `plugin_registrant.dart` for web used to be created on `flutter pub get`. This was changed to be created only upon build/run time, so the file didn't have to live in the users' working copy (and didn't need to be analyzed alongside user code), [here](https://github.com/flutter/flutter/pull/102185).

Making the `plugin_registrant.dart` ephemeral, however, broke the way that Dartpad compiles Flutter web apps quickly. [Read more](https://github.com/dart-lang/dart-services/pull/874#issuecomment-1168964745).

This PR adds a `web_plugin_registrant.dart` file in a known location (`.dart_tool/dartpad/`) at `flutter pub get` that Dartpad can use when bootstrapping their code.

The file is always generated, regardless of the app using web plugins or not. The contents are the same as for any Flutter web app.

Without plugins:

```dart
// Flutter web plugin registrant file.
//
// Generated file. Do not edit.
//

// ignore_for_file: type=lint

void registerPlugins() {}
```

With a bunch of plugins:

```dart
// Flutter web plugin registrant file.
//
// Generated file. Do not edit.
//

// ignore_for_file: type=lint

import 'package:camera_web/camera_web.dart';
import 'package:url_launcher_web/url_launcher_web.dart';
import 'package:video_player_web/video_player_web.dart';
import 'package:flutter_web_plugins/flutter_web_plugins.dart';

void registerPlugins([final Registrar? pluginRegistrar]) {
  final Registrar registrar = pluginRegistrar ?? webPluginRegistrar;
  CameraPlugin.registerWith(registrar);
  UrlLauncherPlugin.registerWith(registrar);
  VideoPlayerPlugin.registerWith(registrar);
  registrar.registerMessageHandler();
}
```


### Issues

* Fixes: https://github.com/flutter/flutter/issues/106765
* Unblocks: https://github.com/dart-lang/dart-services/pull/874 (or probably a newer version!)

### Tests

* Added a unit test to ensure the file is created in the expected location.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
