### PR TITLE
Do not schedule warm up frame before the device window size is communicated

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -59,7 +59,6 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   @override
   void initServiceExtensions() {
     super.initServiceExtensions();
-
     assert(() {
       // these service extensions only work in debug mode
       registerBoolServiceExtension(
@@ -215,7 +214,11 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
       _debugIsRenderViewInitialized = true;
       return true;
     }());
+    assert(!_hasDeviceMetrics);
     renderView = RenderView(configuration: createViewConfiguration(), window: window);
+    if (renderView.configuration.size != Size.zero) {
+      _hasDeviceMetrics = true;
+    }
     renderView.prepareInitialFrame();
   }
   bool _debugIsRenderViewInitialized = false;
@@ -247,6 +250,10 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   void handleMetricsChanged() {
     assert(renderView != null);
     renderView.configuration = createViewConfiguration();
+    if (!_hasDeviceMetrics && renderView.configuration.size != Size.zero) {
+      _hasDeviceMetrics = true;
+      scheduleWarmUpFrame();
+    }
     if (renderView.child != null) {
       scheduleForcedFrame();
     }
@@ -398,6 +405,10 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
 
   int _firstFrameDeferredCount = 0;
   bool _firstFrameSent = false;
+
+  @override
+  bool get isReadyForDoFrame => _hasDeviceMetrics;
+  bool _hasDeviceMetrics = false;
 
   /// Whether frames produced by [drawFrame] are sent to the engine.
   ///

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -59,6 +59,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   @override
   void initServiceExtensions() {
     super.initServiceExtensions();
+
     assert(() {
       // these service extensions only work in debug mode
       registerBoolServiceExtension(

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -735,6 +735,11 @@ mixin SchedulerBinding on BindingBase {
     }
   }
 
+  /// Whether ready for schedule a frame.
+  ///
+  /// Return true if the real [window] size is communicated.
+  bool get isReadyForDoFrame => true;
+
   /// Ensures callbacks for [PlatformDispatcher.onBeginFrame] and
   /// [PlatformDispatcher.onDrawFrame] are registered.
   @protected
@@ -864,7 +869,7 @@ mixin SchedulerBinding on BindingBase {
   ///
   /// Prefer [scheduleFrame] to update the display in normal operation.
   void scheduleWarmUpFrame() {
-    if (_warmUpFrame || schedulerPhase != SchedulerPhase.idle) {
+    if (_warmUpFrame || schedulerPhase != SchedulerPhase.idle || !isReadyForDoFrame) {
       return;
     }
 
@@ -1041,6 +1046,9 @@ mixin SchedulerBinding on BindingBase {
   /// statements printed during a frame from those printed between frames (e.g.
   /// in response to events or timers).
   void handleBeginFrame(Duration? rawTimeStamp) {
+    if (!isReadyForDoFrame) {
+      return;
+    }
     _frameTimelineTask?.start('Frame');
     _firstRawTimeStampInEpoch ??= rawTimeStamp;
     _currentFrameTimeStamp = _adjustForEpoch(rawTimeStamp ?? _lastRawTimeStamp);
@@ -1095,6 +1103,9 @@ mixin SchedulerBinding on BindingBase {
   /// See [handleBeginFrame] for a discussion about debugging hooks that may be
   /// useful when working with frame callbacks.
   void handleDrawFrame() {
+    if (!isReadyForDoFrame) {
+      return;
+    }
     assert(_schedulerPhase == SchedulerPhase.midFrameMicrotasks);
     _frameTimelineTask?.finish(); // end the "Animate" phase
     try {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1575,12 +1575,20 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
   }
 
   @override
+  bool get isReadyForDoFrame => _hasDeviceMetrics;
+
+  bool _hasDeviceMetrics = false;
+
+  @override
   void initRenderView() {
     renderView = _LiveTestRenderView(
       configuration: createViewConfiguration(),
       onNeedPaint: _handleViewNeedsPaint,
       window: window,
     );
+    if (renderView.configuration.size != Size.zero) {
+      _hasDeviceMetrics = true;
+    }
     renderView.prepareInitialFrame();
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/105302
Fixes https://github.com/flutter/flutter/issues/106858
Fixes https://github.com/flutter/flutter/issues/106797

As @jonahwilliams [points out](https://github.com/flutter/flutter/issues/105302#issuecomment-1146093300),
the real window size was notified after the warm-up frame, doing a frame at this time is unnecessary.