### PR TITLE
Fixed AnimatedSwitcher chain produced duplicates

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 
 import 'basic.dart';
 import 'framework.dart';
@@ -222,6 +225,7 @@ class AnimatedSwitcher extends StatefulWidget {
   /// This is an [AnimatedSwitcherTransitionBuilder] function.
   static Widget defaultTransitionBuilder(Widget child, Animation<double> animation) {
     return FadeTransition(
+      key:child.key,
       opacity: animation,
       child: child,
     );
@@ -394,6 +398,6 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
   @override
   Widget build(BuildContext context) {
     _rebuildOutgoingWidgetsIfNeeded();
-    return widget.layoutBuilder(_currentEntry?.transition, _outgoingWidgets!);
+    return widget.layoutBuilder(_currentEntry?.transition, _outgoingWidgets!.where((Widget outgoing) => outgoing.key != _currentEntry?.transition.key).toSet().toList());
   }
 }

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -3,7 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
+
+import 'basic.dart';
+import 'framework.dart';
+import 'ticker_provider.dart';
+import 'transitions.dart';
 
 // Internal representation of a child that, now or in the past, was set on the
 // AnimatedSwitcher.child field, but is now in the process of

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -2,15 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
-import 'basic.dart';
-import 'framework.dart';
-import 'ticker_provider.dart';
-import 'transitions.dart';
 
 // Internal representation of a child that, now or in the past, was set on the
 // AnimatedSwitcher.child field, but is now in the process of

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -225,7 +225,7 @@ class AnimatedSwitcher extends StatefulWidget {
   /// This is an [AnimatedSwitcherTransitionBuilder] function.
   static Widget defaultTransitionBuilder(Widget child, Animation<double> animation) {
     return FadeTransition(
-      key:child.key,
+      key: ValueKey<Key?>(child.key),
       opacity: animation,
       child: child,
     );

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -415,6 +415,25 @@ void main() {
       );
     }
   });
+
+  testWidgets('AnimatedSwitcher does not duplicate animations if the same child is entered twice.', (WidgetTester tester) async {
+    Future<void> pumpChild(Widget child) async {
+      return tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: AnimatedSwitcher(
+            duration: const Duration(milliseconds: 1000),
+            child: child,
+          ),
+        ),
+      );
+    }
+    await pumpChild(const Text('1', key: Key('1')));
+    await pumpChild(const Text('2', key: Key('2')));
+    await pumpChild(const Text('1', key: Key('1')));
+    await tester.pump(const Duration(milliseconds: 1000));
+    expect(find.text('1'), findsOneWidget);
+  });
 }
 
 class StatefulTest extends StatefulWidget {
@@ -437,3 +456,4 @@ class StatefulTestState extends State<StatefulTest> {
   @override
   Widget build(BuildContext context) => Container();
 }
+

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -456,4 +456,3 @@ class StatefulTestState extends State<StatefulTest> {
   @override
   Widget build(BuildContext context) => Container();
 }
-


### PR DESCRIPTION
When the child of an AnimatedSwitcher went through rapid changes, there were times where the same widget would be in the display chain many times. For example if the AnimatedSwitcher's child goes from A->B->A then B is displayed once and A is displayed twice. This did not mesh so well when A was given a key as duplicate local keys are disallowed and this would cause problems with the rendering of AnimatedSwitcher.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.