### PR TITLE
Enable Windows platform_channel test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3994,7 +3994,6 @@ targets:
         ["devicelab", "hostonly"]
       task_name: platform_channel_sample_test_windows
     scheduler: luci
-    bringup: true
 
   - name: Windows plugin_dependencies_test
     recipe: devicelab/devicelab_drone

--- a/examples/platform_channel/lib/main.dart
+++ b/examples/platform_channel/lib/main.dart
@@ -28,8 +28,12 @@ class _PlatformChannelState extends State<PlatformChannel> {
     try {
       final int? result = await methodChannel.invokeMethod('getBatteryLevel');
       batteryLevel = 'Battery level: $result%.';
-    } on PlatformException {
-      batteryLevel = 'Failed to get battery level.';
+    } on PlatformException catch (e) {
+      if (e.code == 'NO_BATTERY') {
+        batteryLevel = 'No battery.';
+      } else {
+        batteryLevel = 'Failed to get battery level.';
+      }
     }
     setState(() {
       _batteryLevel = batteryLevel;

--- a/examples/platform_channel/test_driver/button_tap_test.dart
+++ b/examples/platform_channel/test_driver/button_tap_test.dart
@@ -31,7 +31,11 @@ void main() {
         batteryLevel = await driver.getText(batteryLevelLabel);
       }
 
-      expect(batteryLevel.contains('%'), isTrue);
+      // Allow either a battery percentage or "No battery" since it will vary
+      // by device; either indicates that a known response came from the host
+      // implementation.
+      expect(batteryLevel.contains('%') || batteryLevel.contains('No battery'),
+          isTrue);
     });
   });
 }


### PR DESCRIPTION
Fixes and enables the platform_channel integration test for Windows.

Because Windows devices don't necessarily have batteries, the Windows
implementation has been updated to return a specific error for cases
where there is no battery, and the example handles that error with
specific UI instead of a failure message.

The integration test has been updated to allow that response as a
valid response so that the test will pass on machines without
batteries.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
