### PR TITLE
Allow key reparenting between slots in `SlottedMultiChildRenderObjectWidgetMixin`

### DIFF
--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -198,7 +198,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
   SlottedRenderObjectElement(SlottedMultiChildRenderObjectWidgetMixin<S> super.widget);
 
   final Map<S, Element> _slotToChild = <S, Element>{};
-  Map<GlobalKey, S> _globalKeyToSlot = <GlobalKey, S>{};
+  Map<Key, S> _keyToSlot = <Key, S>{};
 
   @override
   SlottedContainerRenderObjectMixin<S> get renderObject => super.renderObject as SlottedContainerRenderObjectMixin<S>;
@@ -240,24 +240,24 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
     }(), '${widget.runtimeType}.slots must not change.');
     assert(slottedMultiChildRenderObjectWidgetMixin.slots.toSet().length == slottedMultiChildRenderObjectWidgetMixin.slots.length, 'slots must be unique');
 
-    final Map<GlobalKey, S> oldGlobalKeyedSlots = _globalKeyToSlot;
-    _globalKeyToSlot = <GlobalKey, S>{};
+    final Map<Key, S> oldKeyedSlots = _keyToSlot;
+    _keyToSlot = <Key, S>{};
 
-    // New slots for children that are moved to a different slot by global key
+    // New slots for children that are moved to a different slot by key
     // reparenting. It shouldn't be updated in place because two children could
     // swap slots.
     final Map<S, Element> slotToKeyedChild = <S, Element>{};
 
-    // Process children that need to be moved to new slots because of global
-    // key reparenting first.
+    // Process children that need to be moved to new slots because of key
+    // reparenting first.
     for (final S slot in slottedMultiChildRenderObjectWidgetMixin.slots) {
       final Widget? widget = slottedMultiChildRenderObjectWidgetMixin.childForSlot(slot);
       final Key? newWidgetKey = widget?.key;
-      if (widget != null && newWidgetKey is GlobalKey) {
-        final S? oldSlot = oldGlobalKeyedSlots[newWidgetKey];
-        _globalKeyToSlot[newWidgetKey] = slot;
+      if (widget != null && newWidgetKey != null) {
+        final S? oldSlot = oldKeyedSlots[newWidgetKey];
+        _keyToSlot[newWidgetKey] = slot;
         if (oldSlot != null && oldSlot != slot) {
-          slotToKeyedChild[slot] = _updateSlotForGlobalKeyedChild(widget, oldSlot, slot);
+          slotToKeyedChild[slot] = _updateSlotForKeyedChild(widget, oldSlot, slot);
         }
       }
     }
@@ -271,7 +271,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
     }
   }
 
-  Element _updateSlotForGlobalKeyedChild(Widget widget, S oldSlot, S newSlot) {
+  Element _updateSlotForKeyedChild(Widget widget, S oldSlot, S newSlot) {
     final Element? oldChild = _slotToChild.remove(oldSlot);
     final Element? newChild = updateChild(oldChild, widget, newSlot);
     assert(newChild != null);

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -255,11 +255,10 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
       if (newWidgetKey != null) {
         assert(!_keyToSlot.containsKey(newWidgetKey));
         _keyToSlot[newWidgetKey] = slot;
-        final S oldSlot = oldKeyedSlots[newWidgetKey] ?? slot;
-        final Element? oldChild = _slotToChild.remove(oldSlot);
-        final Element newChild = updateChild(oldChild, widget, slot)!;
+        final S fromSlot = oldKeyedSlots[newWidgetKey] ?? slot;
+        final Element newChild = updateChild(_slotToChild.remove(fromSlot), widget, slot)!;
+        assert(!_slotToChild.containsKey(fromSlot));
         assert(!slotToKeyedChild.containsKey(slot));
-        assert(!_slotToChild.containsKey(slot));
         slotToKeyedChild[slot] = newChild;
       } else {
         // A unkeyed new widget shouldn't be used to update the child element

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -288,6 +288,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
     }
     oldSlotToChild.values.forEach(deactivateChild);
     assert(_debugDuplicateKeys(debugDuplicateKeys));
+    assert(_keyedChildren.values.every(_slotToChild.values.contains), '_keyedChildren ${_keyedChildren.values} should be a subset of ${_slotToChild.values}');
   }
 
   bool _debugDuplicateKeys(Map<Key, List<Element>>? debugDuplicateKeys) {

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -246,7 +246,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
     final Map<S, Element> oldSlotToChild = _slotToChild;
     _slotToChild = <S, Element>{};
 
-    Map<Key, List<Element>>? debugDuplicatedKeys;
+    Map<Key, List<Element>>? debugDuplicateKeys;
 
     for (final S slot in slottedMultiChildRenderObjectWidgetMixin.slots) {
       final Widget? widget = slottedMultiChildRenderObjectWidgetMixin.childForSlot(slot);
@@ -276,7 +276,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
           assert(() {
             final Element? existingElement = _keyedChildren[newWidgetKey];
             if (existingElement != null) {
-              (debugDuplicatedKeys ??= <Key, List<Element>>{})
+              (debugDuplicateKeys ??= <Key, List<Element>>{})
                 .putIfAbsent(newWidgetKey, () => <Element>[existingElement])
                 .add(newChild);
             }
@@ -287,20 +287,20 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
       }
     }
     oldSlotToChild.values.forEach(deactivateChild);
-    assert(_debugDuplicatedKeys(debugDuplicatedKeys));
+    assert(_debugDuplicateKeys(debugDuplicateKeys));
   }
 
-  bool _debugDuplicatedKeys(Map<Key, List<Element>>? debugDuplicatedKeys) {
-    if (debugDuplicatedKeys == null) {
+  bool _debugDuplicateKeys(Map<Key, List<Element>>? debugDuplicateKeys) {
+    if (debugDuplicateKeys == null) {
       return true;
     }
-    for (final MapEntry<Key, List<Element>> duplicatedKey in debugDuplicatedKeys.entries) {
+    for (final MapEntry<Key, List<Element>> duplicateKey in debugDuplicateKeys.entries) {
       throw FlutterError.fromParts(<DiagnosticsNode>[
         ErrorSummary('Multiple widgets used the same key in ${widget.runtimeType}.'),
         ErrorDescription(
-          'The key ${duplicatedKey.key} was used by multiple widgets. The parents of those widgets were:\n'
+          'The key ${duplicateKey.key} was used by multiple widgets. The parents of those widgets were:\n'
         ),
-        for (final Element element in duplicatedKey.value) ErrorDescription('  - $element\n'),
+        for (final Element element in duplicateKey.value) ErrorDescription('  - $element\n'),
         ErrorDescription(
           'A key can only be specified on one widget at a time in the same parent widget.',
         ),

--- a/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
@@ -139,9 +139,9 @@ void main() {
     expect(_RenderTest().publicNameForSlot(slot), slot.toString());
   });
 
-  testWidgets('global key reparenting', (WidgetTester tester) async {
-    final Widget widget1 = SizedBox(key: GlobalKey(debugLabel: 'smol'), height: 10, width: 10);
-    final Widget widget2 = SizedBox(key: GlobalKey(debugLabel: 'big'), height: 100, width: 100);
+  testWidgets('key reparenting', (WidgetTester tester) async {
+    const Widget widget1 = SizedBox(key: ValueKey<String>('smol'), height: 10, width: 10);
+    const Widget widget2 = SizedBox(key: ValueKey<String>('big'), height: 100, width: 100);
 
     await tester.pumpWidget(buildWidget(topLeft: widget1, bottomRight: widget2));
     final _RenderDiagonal renderObject = tester.renderObject(find.byType(_Diagonal));

--- a/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
@@ -139,6 +139,31 @@ void main() {
     expect(_RenderTest().publicNameForSlot(slot), slot.toString());
   });
 
+  testWidgets('global key reparenting', (WidgetTester tester) async {
+    final Widget widget1 = SizedBox(key: GlobalKey(debugLabel: 'smol'), height: 10, width: 10);
+    final Widget widget2 = SizedBox(key: GlobalKey(debugLabel: 'big'), height: 100, width: 100);
+
+    await tester.pumpWidget(buildWidget(topLeft: widget1, bottomRight: widget2));
+    final _RenderDiagonal renderObject = tester.renderObject(find.byType(_Diagonal));
+    expect(renderObject._topLeft!.size, const Size(10, 10));
+    expect(renderObject._bottomRight!.size, const Size(100, 100));
+
+    // Swapping.
+    await tester.pumpWidget(buildWidget(topLeft: widget2, bottomRight: widget1));
+    expect(renderObject._topLeft!.size, const Size(100, 100));
+    expect(renderObject._bottomRight!.size, const Size(10, 10));
+
+    // Moving + Deleting.
+    await tester.pumpWidget(buildWidget(bottomRight: widget2));
+    expect(renderObject._topLeft, null);
+    expect(renderObject._bottomRight!.size, const Size(100, 100));
+
+    // Moving.
+    await tester.pumpWidget(buildWidget(topLeft: widget2));
+    expect(renderObject._topLeft!.size, const Size(100, 100));
+    expect(renderObject._bottomRight, null);
+  });
+
   testWidgets('debugDescribeChildren', (WidgetTester tester) async {
     await tester.pumpWidget(buildWidget(
       topLeft: const SizedBox(

--- a/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
@@ -275,7 +275,7 @@ class _Diagonal extends RenderObjectWidget with SlottedMultiChildRenderObjectWid
   final Widget? nullSlot;
 
   @override
-  Iterable<_DiagonalSlot?> get slots => [null, ..._DiagonalSlot.values];
+  Iterable<_DiagonalSlot?> get slots => <_DiagonalSlot?>[null, ..._DiagonalSlot.values];
 
   @override
   Widget? childForSlot(_DiagonalSlot? slot) {

--- a/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
@@ -142,26 +142,67 @@ void main() {
   testWidgets('key reparenting', (WidgetTester tester) async {
     const Widget widget1 = SizedBox(key: ValueKey<String>('smol'), height: 10, width: 10);
     const Widget widget2 = SizedBox(key: ValueKey<String>('big'), height: 100, width: 100);
+    const Widget nullWidget = SizedBox(key: ValueKey<String>('null'), height: 50, width: 50);
 
-    await tester.pumpWidget(buildWidget(topLeft: widget1, bottomRight: widget2));
+    await tester.pumpWidget(buildWidget(topLeft: widget1, bottomRight: widget2, nullSlot: nullWidget));
     final _RenderDiagonal renderObject = tester.renderObject(find.byType(_Diagonal));
     expect(renderObject._topLeft!.size, const Size(10, 10));
     expect(renderObject._bottomRight!.size, const Size(100, 100));
+    expect(renderObject._nullSlot!.size, const Size(50, 50));
 
-    // Swapping.
-    await tester.pumpWidget(buildWidget(topLeft: widget2, bottomRight: widget1));
+    final Element widget1Element = tester.element(find.byWidget(widget1));
+    final Element widget2Element = tester.element(find.byWidget(widget2));
+    final Element nullWidgetElement = tester.element(find.byWidget(nullWidget));
+
+    // Swapping 1 and 2.
+    await tester.pumpWidget(buildWidget(topLeft: widget2, bottomRight: widget1, nullSlot: nullWidget));
     expect(renderObject._topLeft!.size, const Size(100, 100));
     expect(renderObject._bottomRight!.size, const Size(10, 10));
+    expect(renderObject._nullSlot!.size, const Size(50, 50));
+    expect(widget1Element, tester.element(find.byWidget(widget1)));
+    expect(widget2Element, tester.element(find.byWidget(widget2)));
+    expect(nullWidgetElement, tester.element(find.byWidget(nullWidget)));
+
+    // Shifting slots
+    await tester.pumpWidget(buildWidget(topLeft: nullWidget, bottomRight: widget2, nullSlot: widget1));
+    expect(renderObject._topLeft!.size, const Size(50, 50));
+    expect(renderObject._bottomRight!.size, const Size(100, 100));
+    expect(renderObject._nullSlot!.size, const Size(10, 10));
+    expect(widget1Element, tester.element(find.byWidget(widget1)));
+    expect(widget2Element, tester.element(find.byWidget(widget2)));
+    expect(nullWidgetElement, tester.element(find.byWidget(nullWidget)));
 
     // Moving + Deleting.
     await tester.pumpWidget(buildWidget(bottomRight: widget2));
     expect(renderObject._topLeft, null);
     expect(renderObject._bottomRight!.size, const Size(100, 100));
+    expect(renderObject._nullSlot, null);
+    expect(widget1Element.debugIsDefunct, isTrue);
+    expect(nullWidgetElement.debugIsDefunct, isTrue);
+    expect(widget2Element, tester.element(find.byWidget(widget2)));
 
     // Moving.
     await tester.pumpWidget(buildWidget(topLeft: widget2));
     expect(renderObject._topLeft!.size, const Size(100, 100));
     expect(renderObject._bottomRight, null);
+    expect(widget2Element, tester.element(find.byWidget(widget2)));
+  });
+
+  testWidgets('duplicated key error message', (WidgetTester tester) async {
+    const Widget widget1 = SizedBox(key: ValueKey<String>('widget 1'), height: 10, width: 10);
+    const Widget widget2 = SizedBox(key: ValueKey<String>('widget 1'), height: 100, width: 100);
+    const Widget widget3 = SizedBox(key: ValueKey<String>('widget 1'), height: 50, width: 50);
+
+    await tester.pumpWidget(buildWidget(topLeft: widget1, bottomRight: widget2, nullSlot: widget3));
+
+    expect((tester.takeException() as FlutterError).toString(), equalsIgnoringHashCodes(
+     'Multiple widgets used the same key in _Diagonal.\n'
+     "The key [<'widget 1'>] was used by multiple widgets. The parents of those widgets were:\n"
+     "  - SizedBox-[<'widget 1'>](width: 50.0, height: 50.0, renderObject: RenderConstrainedBox#00000 NEEDS-LAYOUT NEEDS-PAINT)\n"
+     "  - SizedBox-[<'widget 1'>](width: 10.0, height: 10.0, renderObject: RenderConstrainedBox#00000 NEEDS-LAYOUT NEEDS-PAINT)\n"
+     "  - SizedBox-[<'widget 1'>](width: 100.0, height: 100.0, renderObject: RenderConstrainedBox#a4685 NEEDS-LAYOUT NEEDS-PAINT)\n"
+     'A key can only be specified on one widget at a time in the same parent widget.'
+    ));
   });
 
   testWidgets('debugDescribeChildren', (WidgetTester tester) async {
@@ -203,7 +244,7 @@ _RenderDiagonal#00000 relayoutBoundary=up1
   });
 }
 
-Widget buildWidget({Widget? topLeft, Widget? bottomRight}) {
+Widget buildWidget({Widget? topLeft, Widget? bottomRight, Widget? nullSlot}) {
   return Directionality(
     textDirection: TextDirection.ltr,
     child: Align(
@@ -211,6 +252,7 @@ Widget buildWidget({Widget? topLeft, Widget? bottomRight}) {
       child: _Diagonal(
         topLeft: topLeft,
         bottomRight: bottomRight,
+        nullSlot: nullSlot,
       ),
     ),
   );
@@ -221,21 +263,25 @@ enum _DiagonalSlot {
   bottomRight,
 }
 
-class _Diagonal extends RenderObjectWidget with SlottedMultiChildRenderObjectWidgetMixin<_DiagonalSlot> {
+class _Diagonal extends RenderObjectWidget with SlottedMultiChildRenderObjectWidgetMixin<_DiagonalSlot?> {
   const _Diagonal({
     this.topLeft,
     this.bottomRight,
+    this.nullSlot,
   });
 
   final Widget? topLeft;
   final Widget? bottomRight;
+  final Widget? nullSlot;
 
   @override
-  Iterable<_DiagonalSlot> get slots => _DiagonalSlot.values;
+  Iterable<_DiagonalSlot?> get slots => [null, ..._DiagonalSlot.values];
 
   @override
-  Widget? childForSlot(_DiagonalSlot slot) {
+  Widget? childForSlot(_DiagonalSlot? slot) {
     switch (slot) {
+      case null:
+        return nullSlot;
       case _DiagonalSlot.topLeft:
         return topLeft;
       case _DiagonalSlot.bottomRight:
@@ -244,16 +290,17 @@ class _Diagonal extends RenderObjectWidget with SlottedMultiChildRenderObjectWid
   }
 
   @override
-  SlottedContainerRenderObjectMixin<_DiagonalSlot> createRenderObject(
+  SlottedContainerRenderObjectMixin<_DiagonalSlot?> createRenderObject(
     BuildContext context,
   ) {
     return _RenderDiagonal();
   }
 }
 
-class _RenderDiagonal extends RenderBox with SlottedContainerRenderObjectMixin<_DiagonalSlot> {
+class _RenderDiagonal extends RenderBox with SlottedContainerRenderObjectMixin<_DiagonalSlot?> {
   RenderBox? get _topLeft => childForSlot(_DiagonalSlot.topLeft);
   RenderBox? get _bottomRight => childForSlot(_DiagonalSlot.bottomRight);
+  RenderBox? get _nullSlot => childForSlot(null);
 
   @override
   void performLayout() {
@@ -276,9 +323,17 @@ class _RenderDiagonal extends RenderBox with SlottedContainerRenderObjectMixin<_
       bottomRightSize = _bottomRight!.size;
     }
 
+    Size nullSlotSize = Size.zero;
+    final RenderBox? nullSlot = _nullSlot;
+    if (nullSlot != null) {
+      nullSlot.layout(childConstraints, parentUsesSize: true);
+      _positionChild(nullSlot, Offset.zero);
+      nullSlotSize = nullSlot.size;
+    }
+
     size = constraints.constrain(Size(
-      topLeftSize.width + bottomRightSize.width,
-      topLeftSize.height + bottomRightSize.height,
+      topLeftSize.width + bottomRightSize.width + nullSlotSize.width,
+      topLeftSize.height + bottomRightSize.height + nullSlotSize.height,
     ));
   }
 

--- a/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
@@ -159,18 +159,18 @@ void main() {
     expect(renderObject._topLeft!.size, const Size(100, 100));
     expect(renderObject._bottomRight!.size, const Size(10, 10));
     expect(renderObject._nullSlot!.size, const Size(50, 50));
-    expect(widget1Element, tester.element(find.byWidget(widget1)));
-    expect(widget2Element, tester.element(find.byWidget(widget2)));
-    expect(nullWidgetElement, tester.element(find.byWidget(nullWidget)));
+    expect(widget1Element, same(tester.element(find.byWidget(widget1))));
+    expect(widget2Element, same(tester.element(find.byWidget(widget2))));
+    expect(nullWidgetElement, same(tester.element(find.byWidget(nullWidget))));
 
     // Shifting slots
     await tester.pumpWidget(buildWidget(topLeft: nullWidget, bottomRight: widget2, nullSlot: widget1));
     expect(renderObject._topLeft!.size, const Size(50, 50));
     expect(renderObject._bottomRight!.size, const Size(100, 100));
     expect(renderObject._nullSlot!.size, const Size(10, 10));
-    expect(widget1Element, tester.element(find.byWidget(widget1)));
-    expect(widget2Element, tester.element(find.byWidget(widget2)));
-    expect(nullWidgetElement, tester.element(find.byWidget(nullWidget)));
+    expect(widget1Element, same(tester.element(find.byWidget(widget1))));
+    expect(widget2Element, same(tester.element(find.byWidget(widget2))));
+    expect(nullWidgetElement, same(tester.element(find.byWidget(nullWidget))));
 
     // Moving + Deleting.
     await tester.pumpWidget(buildWidget(bottomRight: widget2));
@@ -179,13 +179,13 @@ void main() {
     expect(renderObject._nullSlot, null);
     expect(widget1Element.debugIsDefunct, isTrue);
     expect(nullWidgetElement.debugIsDefunct, isTrue);
-    expect(widget2Element, tester.element(find.byWidget(widget2)));
+    expect(widget2Element, same(tester.element(find.byWidget(widget2))));
 
     // Moving.
     await tester.pumpWidget(buildWidget(topLeft: widget2));
     expect(renderObject._topLeft!.size, const Size(100, 100));
     expect(renderObject._bottomRight, null);
-    expect(widget2Element, tester.element(find.byWidget(widget2)));
+    expect(widget2Element, same(tester.element(find.byWidget(widget2))));
   });
 
   testWidgets('duplicated key error message', (WidgetTester tester) async {


### PR DESCRIPTION
Extracted from https://github.com/flutter/flutter/pull/105430

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
