### PR TITLE
[framework] partial removal of forced compositing from opacity

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -883,15 +883,7 @@ class RenderOpacity extends RenderProxyBox {
        super(child);
 
   @override
-  bool get alwaysNeedsCompositing => child != null && (_alpha > 0);
-
-  @override
-  OffsetLayer updateCompositedLayer({required covariant OpacityLayer? oldLayer}) {
-    assert(_alpha != 255);
-    final OpacityLayer updatedLayer = oldLayer ?? OpacityLayer();
-    updatedLayer.alpha = _alpha;
-    return updatedLayer;
-  }
+  bool get alwaysNeedsCompositing => child != null && (_alpha > 0 && _alpha < 255);
 
   int _alpha;
 
@@ -949,19 +941,26 @@ class RenderOpacity extends RenderProxyBox {
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (child != null) {
-      if (_alpha == 0) {
-        // No need to keep the layer. We'll create a new one if necessary.
-        layer = null;
-        return;
-      }
-      assert(needsCompositing);
-      layer = context.pushOpacity(offset, _alpha, super.paint, oldLayer: layer as OpacityLayer?);
-      assert(() {
-        layer!.debugCreator = debugCreator;
-        return true;
-      }());
+    if (child == null) {
+      return;
     }
+    if (_alpha == 0) {
+      // No need to keep the layer. We'll create a new one if necessary.
+      layer = null;
+      return;
+    }
+    if (_alpha == 255) {
+      // No need to keep the layer. We'll create a new one if necessary.
+      layer = null;
+      return super.paint(context, offset);
+    }
+
+    assert(needsCompositing);
+    layer = context.pushOpacity(offset, _alpha, super.paint, oldLayer: layer as OpacityLayer?);
+    assert(() {
+      layer!.debugCreator = debugCreator;
+      return true;
+    }());
   }
 
   @override

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -240,8 +240,18 @@ void main() {
     expect(renderOpacity.needsCompositing, false);
   });
 
-  test('RenderOpacity does composite if it is opaque', () {
+  test('RenderOpacity does not composite if it is opaque', () {
     final RenderOpacity renderOpacity = RenderOpacity(
+      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+    );
+
+    layout(renderOpacity, phase: EnginePhase.composite);
+    expect(renderOpacity.needsCompositing, false);
+  });
+
+  test('RenderOpacity does composite if it is partially opaque', () {
+    final RenderOpacity renderOpacity = RenderOpacity(
+      opacity: 0.1,
       child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
     );
 

--- a/packages/flutter/test/widgets/debug_test.dart
+++ b/packages/flutter/test/widgets/debug_test.dart
@@ -285,7 +285,7 @@ void main() {
                   child: Placeholder(),
                 ),
                 const Opacity(
-                  opacity: 1.0,
+                  opacity: 0.9,
                   child: Placeholder(),
                 ),
                 ImageFiltered(


### PR DESCRIPTION
A simplified version of the previous removal attempt - this only removes forced compositing at fully opaque to match the behavior of the animated opacity layer.

https://github.com/flutter/flutter/issues/102179