### PR TITLE
Expose ExpansionTileState

### DIFF
--- a/examples/api/lib/material/expansion_tile/expansion_tile.of.0.dart
+++ b/examples/api/lib/material/expansion_tile/expansion_tile.of.0.dart
@@ -22,7 +22,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
         body: const ExpansionTile(
           title: Text('ExpansionTile'),
-          children: [
+          children: <Widget>[
             MyExpansionTileBody(),
           ],
         ),

--- a/examples/api/lib/material/expansion_tile/expansion_tile.of.0.dart
+++ b/examples/api/lib/material/expansion_tile/expansion_tile.of.0.dart
@@ -1,0 +1,48 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for Scaffold.of
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Code Sample for ExpansionTile.of.',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: Scaffold(
+        body: const ExpansionTile(
+          title: Text('ExpansionTile'),
+          children: [
+            MyExpansionTileBody(),
+          ],
+        ),
+        appBar: AppBar(title: const Text('ExpansionTile.of Example')),
+      ),
+      color: Colors.white,
+    );
+  }
+}
+
+class MyExpansionTileBody extends StatelessWidget {
+  const MyExpansionTileBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      child: const Text('COLLAPSE TILE'),
+      onPressed: () {
+        ExpansionTile.of(context).collapse();
+      },
+    );
+  }
+}

--- a/examples/api/lib/material/expansion_tile/expansion_tile.of.1.dart
+++ b/examples/api/lib/material/expansion_tile/expansion_tile.of.1.dart
@@ -1,0 +1,45 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for Scaffold.of
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  // This widget is the root of your application.
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Code Sample for ExpansionTile.of.',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: Scaffold(
+        body: ExpansionTile(
+          title: const Text('ExpansionTile'),
+          children: <Widget>[
+            Builder(
+              // Create an inner BuildContext so that the onPressed methods
+              // can refer to the ExpansionTile with ExpansionTile.of().
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  child: const Text('COLLAPSE TILE'),
+                  onPressed: () {
+                    ExpansionTile.of(context).collapse();
+                  },
+                );
+              },
+            ),
+          ],
+        ),
+        appBar: AppBar(title: const Text('ExpansionTile.of Example')),
+      ),
+      color: Colors.white,
+    );
+  }
+}

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -446,8 +446,8 @@ class ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderS
   ///
   /// See also:
   ///
-  ///  * [ExpansionTile.expand], which expands the [ExpansionTile].
-  ///  * [ExpansionTile.collapse], which collapses the [ExpansionTile].
+  ///  * [expand], which expands the [ExpansionTile].
+  ///  * [collapse], which collapses the [ExpansionTile].
   bool get isExpanded => _isExpanded;
 
   /// Expands the current [ExpansionTile].
@@ -463,7 +463,8 @@ class ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderS
   ///
   /// See also:
   ///
-  ///  * [ExpansionTile.collapse], which collapses the [ExpansionTile].
+  ///  * [collapse], which collapses the tile.
+  ///  * [isExpanded] to check whether the tile is expanded.
   void expand() {
     if (!_isExpanded) {
       _toggleExpansion();
@@ -483,7 +484,8 @@ class ExpansionTileState extends State<ExpansionTile> with SingleTickerProviderS
   ///
   /// See also:
   ///
-  ///  * [ExpansionTile.expand], which expands the [ExpansionTile].
+  ///  * [expand], which expands the tile.
+  ///  * [isExpanded] to check whether the tile is expanded.
   void collapse() {
     if (_isExpanded) {
       _toggleExpansion();


### PR DESCRIPTION
Allows to programmatically expand or collapse an ExpansionTile
Fixes #60387

Example usage:
```dart
class MyApp extends StatefulWidget {
  const MyApp({super.key});

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  final GlobalKey<ExpansionTileState> _expansionTileKey = GlobalKey<ExpansionTileState>();

  @override
  Widget build(BuildContext context) {
    return Column(
      children: <Widget>[
        ExpansionTile(
          key: _expansionTileKey,
          title: const Text('Collapsible menu'),
          children: const <Widget>[
            Text('Menu'),
          ],
        ),
        ElevatedButton(
          onPressed: () {
            ExpansionTileState expansionTile = _expansionTileKey.currentState!;
            if (expansionTile.isExpanded) {
              expansionTile.collapse();
            } else {
              expansionTile.expand();
            }
          },
          child: const Text('TOGGLE MENU'),
        )
      ],
    );
  }
}

```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
