### PR TITLE
Add `RelativeRect.fromDirectional` factory

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -56,6 +56,37 @@ class RelativeRect {
     );
   }
 
+  /// Creates a RelativeRect from horizontal position using `start` and `end`
+  /// rather than `left` and `right`.
+  ///
+  /// If `textDirection` is [TextDirection.rtl], then the `start` argument is
+  /// used for the [right] property and the `end` argument is used for the
+  /// [left] property. Otherwise, if `textDirection` is [TextDirection.ltr],
+  /// then the `start` argument is used for the [left] property and the `end`
+  /// argument is used for the [right] property.
+  factory RelativeRect.fromDirectional({
+    required TextDirection textDirection,
+    required double start,
+    required double top,
+    required double end,
+    required double bottom,
+  }) {
+    double left;
+    double right;
+    switch (textDirection) {
+      case TextDirection.rtl:
+        left = end;
+        right = start;
+        break;
+      case TextDirection.ltr:
+        left = start;
+        right = end;
+        break;
+    }
+
+    return RelativeRect.fromLTRB(left, top, right, bottom);
+  }
+
   /// A rect that covers the entire container.
   static const RelativeRect fill = RelativeRect.fromLTRB(0.0, 0.0, 0.0, 0.0);
 

--- a/packages/flutter/test/rendering/relative_rect_test.dart
+++ b/packages/flutter/test/rendering/relative_rect_test.dart
@@ -10,6 +10,24 @@ void main() {
     const RelativeRect r = RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
     expect(r, RelativeRect.fromSize(const Rect.fromLTWH(10.0, 20.0, 0.0, 0.0), const Size(40.0, 60.0)));
   });
+  test('RelativeRect.fromDirectional', () {
+    final RelativeRect r1 = RelativeRect.fromDirectional(
+      textDirection: TextDirection.ltr,
+      start: 10.0,
+      top: 20.0,
+      end: 30.0,
+      bottom: 40.0,
+    );
+    final RelativeRect r2 = RelativeRect.fromDirectional(
+      textDirection: TextDirection.rtl,
+      start: 10.0,
+      top: 20.0,
+      end: 30.0,
+      bottom: 40.0,
+    );
+    expect(r1, const RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0));
+    expect(r2, const RelativeRect.fromLTRB(30.0, 20.0, 10.0, 40.0));
+  });
   test('RelativeRect.shift', () {
     const RelativeRect r1 = RelativeRect.fromLTRB(10.0, 20.0, 30.0, 40.0);
     final RelativeRect r2 = r1.shift(const Offset(5.0, 50.0));


### PR DESCRIPTION
Added `fromDirectional` factory to `RelativeRect`.

When we need to consider both TextDirection.ltr and TextDirection.rtl, this will help us.

```
RelativeRect.fromDirectional(
    textDirection: textDirection,
    start: 10.0,
    top: 20.0,
    end: 30.0,
    bottom: 40.0,
);
```

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/107058

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
