### PR TITLE
Update `ListTile` and `ListTile` based widget docs for Material usage

### DIFF
--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -39,6 +39,30 @@ import 'theme_data.dart';
 /// [secondary] widget is placed on the opposite side. This maps to the
 /// [ListTile.leading] and [ListTile.trailing] properties of [ListTile].
 ///
+/// This widget requires a [Material] widget ancestor in the tree to paint
+/// itself on, which is typically provided by the app's [Scaffold].
+/// The [tileColor], and [selectedTileColor] are not painted by the
+/// [CheckboxListTile] itself but by the [Material] widget ancestor. An opaque
+/// widget, like `Container(color: Colors.white)`, is included in between
+/// the [CheckboxListTile] and its [Material] ancestor,then the opaque widget
+/// will obscure the [Material] widget and [CheckboxListTile] background
+/// [tileColor], etc. In this case, one can wrap a [Material] widget around
+/// the [CheckboxListTile], e.g.:
+///
+/// ```dart
+/// Container(
+///   color: Colors.green,
+///   child: Material(
+///     child: CheckboxListTile(
+///       tileColor: Colors.red,
+///       title: const Text('CheckboxListTile with red background'),
+///       value: true,
+///       onChanged:(bool? value) { },
+///     ),
+///   ),
+/// )
+/// ```
+///
 /// To show the [CheckboxListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -42,12 +42,9 @@ import 'theme_data.dart';
 /// This widget requires a [Material] widget ancestor in the tree to paint
 /// itself on, which is typically provided by the app's [Scaffold].
 /// The [tileColor], and [selectedTileColor] are not painted by the
-/// [CheckboxListTile] itself but by the [Material] widget ancestor. An opaque
-/// widget, like `Container(color: Colors.white)`, is included in between
-/// the [CheckboxListTile] and its [Material] ancestor,then the opaque widget
-/// will obscure the [Material] widget and [CheckboxListTile] background
-/// [tileColor], etc. In this case, one can wrap a [Material] widget around
-/// the [CheckboxListTile], e.g.:
+/// [CheckboxListTile] itself but by the [Material] widget ancestor.
+/// In this case, one can wrap a [Material] widget around the [CheckboxListTile],
+/// e.g.:
 ///
 /// ```dart
 /// Container(
@@ -63,7 +60,7 @@ import 'theme_data.dart';
 /// )
 /// ```
 ///
-/// ## Performance considerations when wrapping [Material] with [CheckboxListTile]
+/// ## Performance considerations when wrapping [CheckboxListTile] with [Material]
 ///
 /// Wrapping a large number of [CheckboxListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [CheckboxListTile]s that require it

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -46,6 +46,7 @@ import 'theme_data.dart';
 /// In this case, one can wrap a [Material] widget around the [CheckboxListTile],
 /// e.g.:
 ///
+/// {@tool snippet}
 /// ```dart
 /// Container(
 ///   color: Colors.green,
@@ -59,6 +60,7 @@ import 'theme_data.dart';
 ///   ),
 /// )
 /// ```
+/// {@end-tool}
 ///
 /// ## Performance considerations when wrapping [CheckboxListTile] with [Material]
 ///

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -63,7 +63,7 @@ import 'theme_data.dart';
 /// )
 /// ```
 ///
-/// ## Performance considerations when wrapping [Material] to [CheckboxListTile]
+/// ## Performance considerations when wrapping [Material] with [CheckboxListTile]
 ///
 /// Wrapping a large number of [CheckboxListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [CheckboxListTile]s that require it

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -63,6 +63,12 @@ import 'theme_data.dart';
 /// )
 /// ```
 ///
+/// ## Performance considerations when wrapping [Material] to [CheckboxListTile]
+///
+/// Wrapping a large number of [CheckboxListTile]s individually with [Material]s
+/// is expensive. Consider only wrapping the [CheckboxListTile]s that require it
+/// or include a common [Material] ancestor where possible.
+///
 /// To show the [CheckboxListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -109,6 +109,12 @@ enum ListTileControlAffinity {
 /// )
 /// ```
 ///
+/// ## Performance considerations when wrapping [Material] to [ListTile]
+///
+/// Wrapping a large number of [ListTile]s individually with [Material]s
+/// is expensive. Consider only wrapping the [ListTile]s that require it
+/// or include a common [Material] ancestor where possible.
+///
 /// {@tool snippet}
 ///
 /// This example uses a [ListView] to demonstrate different configurations of

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -87,16 +87,15 @@ enum ListTileControlAffinity {
 /// List tiles are typically used in [ListView]s, or arranged in [Column]s in
 /// [Drawer]s and [Card]s.
 ///
-/// One ancestor must be a [Material] widget and typically this is
-/// provided by the app's [Scaffold]. The [tileColor],
-/// [selectedTileColor], [focusColor], and [hoverColor] are not
-/// painted by the list tile itself but by the material widget
-/// ancestor. This generally has no effect. However, if an opaque
-/// widget, like `Container(color: Colors.white)`, is included in
-/// between the [ListTile] and its [Material] ancestor, then the
-/// opaque widget will obscure the material widget and its background
-/// [tileColor], etc. If this a problem, one can wrap a [Material]
-/// widget around the list tile, e.g.:
+/// This widget requires a [Material] widget ancestor in the tree to paint
+/// itself on, which is typically provided by the app's [Scaffold].
+/// The [tileColor], [selectedTileColor], [focusColor], and [hoverColor]
+/// are not painted by the [ListTile] itself but by the [Material] widget
+/// ancestor. An opaque widget, like `Container(color: Colors.white)`,
+/// is included in between the [ListTile] and its [Material] ancestor,
+/// then the opaque widget will obscure the [Material] widget and [ListTile]
+/// background [tileColor], etc. In this case, one can wrap a [Material]
+/// widget around the [ListTile], e.g.:
 ///
 /// ```dart
 /// Container(

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -94,6 +94,7 @@ enum ListTileControlAffinity {
 /// ancestor. In this case, one can wrap a [Material] widget around the
 /// [ListTile], e.g.:
 ///
+/// {@tool snippet}
 /// ```dart
 /// Container(
 ///   color: Colors.green,
@@ -105,6 +106,7 @@ enum ListTileControlAffinity {
 ///   ),
 /// )
 /// ```
+/// {@end-tool}
 ///
 /// ## Performance considerations when wrapping [ListTile] with [Material]
 ///

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -100,7 +100,7 @@ enum ListTileControlAffinity {
 ///   color: Colors.green,
 ///   child: const Material(
 ///     child: ListTile(
-///       title: const Text('ListTile with red background'),
+///       title: Text('ListTile with red background'),
 ///       tileColor: Colors.red,
 ///     ),
 ///   ),

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -91,11 +91,8 @@ enum ListTileControlAffinity {
 /// itself on, which is typically provided by the app's [Scaffold].
 /// The [tileColor], [selectedTileColor], [focusColor], and [hoverColor]
 /// are not painted by the [ListTile] itself but by the [Material] widget
-/// ancestor. An opaque widget, like `Container(color: Colors.white)`,
-/// is included in between the [ListTile] and its [Material] ancestor,
-/// then the opaque widget will obscure the [Material] widget and [ListTile]
-/// background [tileColor], etc. In this case, one can wrap a [Material]
-/// widget around the [ListTile], e.g.:
+/// ancestor. In this case, one can wrap a [Material] widget around the
+/// [ListTile], e.g.:
 ///
 /// ```dart
 /// Container(
@@ -109,7 +106,7 @@ enum ListTileControlAffinity {
 /// )
 /// ```
 ///
-/// ## Performance considerations when wrapping [Material] with [ListTile]
+/// ## Performance considerations when wrapping [ListTile] with [Material]
 ///
 /// Wrapping a large number of [ListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [ListTile]s that require it

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -98,7 +98,7 @@ enum ListTileControlAffinity {
 /// ```dart
 /// Container(
 ///   color: Colors.green,
-///   child: Material(
+///   child: const Material(
 ///     child: ListTile(
 ///       title: const Text('ListTile with red background'),
 ///       tileColor: Colors.red,

--- a/packages/flutter/lib/src/material/list_tile.dart
+++ b/packages/flutter/lib/src/material/list_tile.dart
@@ -109,7 +109,7 @@ enum ListTileControlAffinity {
 /// )
 /// ```
 ///
-/// ## Performance considerations when wrapping [Material] to [ListTile]
+/// ## Performance considerations when wrapping [Material] with [ListTile]
 ///
 /// Wrapping a large number of [ListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [ListTile]s that require it

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -65,7 +65,7 @@ import 'theme_data.dart';
 /// )
 /// ```
 ///
-/// ## Performance considerations when wrapping [Material] to [RadioListTile]
+/// ## Performance considerations when wrapping [Material] with [RadioListTile]
 ///
 /// Wrapping a large number of [RadioListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [RadioListTile]s that require it

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -12,6 +12,7 @@ import 'theme_data.dart';
 
 // Examples can assume:
 // void setState(VoidCallback fn) { }
+// enum Meridiem { am, pm }
 
 /// A [ListTile] with a [Radio]. In other words, a radio button with a label.
 ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -46,6 +46,7 @@ import 'theme_data.dart';
 /// [RadioListTile] itself but by the [Material] widget ancestor. In this
 /// case, one can wrap a [Material] widget around the [RadioListTile], e.g.:
 ///
+/// {@tool snippet}
 /// ```dart
 /// Container(
 ///   color: Colors.green,
@@ -60,6 +61,7 @@ import 'theme_data.dart';
 ///   ),
 /// )
 /// ```
+/// {@end-tool}
 ///
 /// ## Performance considerations when wrapping [RadioListTile] with [Material]
 ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -43,12 +43,8 @@ import 'theme_data.dart';
 /// This widget requires a [Material] widget ancestor in the tree to paint
 /// itself on, which is typically provided by the app's [Scaffold].
 /// The [tileColor], and [selectedTileColor] are not painted by the
-/// [RadioListTile] itself but by the [Material] widget ancestor. An opaque
-/// widget, like `Container(color: Colors.white)`, is included in between
-/// the [RadioListTile] and its [Material] ancestor,then the opaque widget
-/// will obscure the [Material] widget and [RadioListTile] background
-/// [tileColor], etc. In this case, one can wrap a [Material] widget around
-/// the [RadioListTile], e.g.:
+/// [RadioListTile] itself but by the [Material] widget ancestor. In this
+/// case, one can wrap a [Material] widget around the [RadioListTile], e.g.:
 ///
 /// ```dart
 /// Container(
@@ -65,7 +61,7 @@ import 'theme_data.dart';
 /// )
 /// ```
 ///
-/// ## Performance considerations when wrapping [Material] with [RadioListTile]
+/// ## Performance considerations when wrapping [RadioListTile] with [Material]
 ///
 /// Wrapping a large number of [RadioListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [RadioListTile]s that require it

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -40,6 +40,31 @@ import 'theme_data.dart';
 /// [secondary] widget is placed on the opposite side. This maps to the
 /// [ListTile.leading] and [ListTile.trailing] properties of [ListTile].
 ///
+/// This widget requires a [Material] widget ancestor in the tree to paint
+/// itself on, which is typically provided by the app's [Scaffold].
+/// The [tileColor], and [selectedTileColor] are not painted by the
+/// [RadioListTile] itself but by the [Material] widget ancestor. An opaque
+/// widget, like `Container(color: Colors.white)`, is included in between
+/// the [RadioListTile] and its [Material] ancestor,then the opaque widget
+/// will obscure the [Material] widget and [RadioListTile] background
+/// [tileColor], etc. In this case, one can wrap a [Material] widget around
+/// the [RadioListTile], e.g.:
+///
+/// ```dart
+/// Container(
+///   color: Colors.green,
+///   child: Material(
+///     child: RadioListTile<Meridiem>(
+///       tileColor: Colors.red,
+///       title: const Text('AM'),
+///       groupValue: Meridiem.am,
+///       value: Meridiem.am,
+///       onChanged:(Meridiem? value) { },
+///     ),
+///   ),
+/// )
+/// ```
+///
 /// To show the [RadioListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///

--- a/packages/flutter/lib/src/material/radio_list_tile.dart
+++ b/packages/flutter/lib/src/material/radio_list_tile.dart
@@ -65,6 +65,12 @@ import 'theme_data.dart';
 /// )
 /// ```
 ///
+/// ## Performance considerations when wrapping [Material] to [RadioListTile]
+///
+/// Wrapping a large number of [RadioListTile]s individually with [Material]s
+/// is expensive. Consider only wrapping the [RadioListTile]s that require it
+/// or include a common [Material] ancestor where possible.
+///
 /// To show the [RadioListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -12,7 +12,7 @@ import 'theme_data.dart';
 
 // Examples can assume:
 // void setState(VoidCallback fn) { }
-// bool _isSelected;
+// bool _isSelected = true;
 
 enum _SwitchListTileType { material, adaptive }
 
@@ -57,7 +57,7 @@ enum _SwitchListTileType { material, adaptive }
 /// ```dart
 /// Container(
 ///   color: Colors.green,
-///   child: Material(
+///   child: const Material(
 ///     child: SwitchListTile(
 ///       tileColor: Colors.red,
 ///       title: const Text('SwitchListTile with red background'),
@@ -245,6 +245,7 @@ class SwitchListTile extends StatelessWidget {
   /// [StatefulWidget] using the [State.setState] method, so that the parent
   /// gets rebuilt; for example:
   ///
+  /// {@tool snippet}
   /// ```dart
   /// SwitchListTile(
   ///   value: _isSelected,
@@ -253,9 +254,10 @@ class SwitchListTile extends StatelessWidget {
   ///       _isSelected = newValue;
   ///     });
   ///   },
-  ///   title: Text('Selection'),
+  ///   title: const Text('Selection'),
   /// )
   /// ```
+  /// {@end-tool}
   final ValueChanged<bool>? onChanged;
 
   /// The color to use when this switch is on.

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -70,6 +70,11 @@ enum _SwitchListTileType { material, adaptive }
 ///   ),
 /// )
 /// ```
+/// ## Performance considerations when wrapping [Material] to [SwitchListTile]
+///
+/// Wrapping a large number of [SwitchListTile]s individually with [Material]s
+/// is expensive. Consider only wrapping the [SwitchListTile]s that require it
+/// or include a common [Material] ancestor where possible.
 ///
 /// To show the [SwitchListTile] as disabled, pass null as the [onChanged]
 /// callback.

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -47,6 +47,30 @@ enum _SwitchListTileType { material, adaptive }
 /// in the [ListTile.trailing] slot) which can be changed using [controlAffinity].
 /// The [secondary] widget is placed in the [ListTile.leading] slot.
 ///
+/// This widget requires a [Material] widget ancestor in the tree to paint
+/// itself on, which is typically provided by the app's [Scaffold].
+/// The [tileColor], and [selectedTileColor] are not painted by the
+/// [SwitchListTile] itself but by the [Material] widget ancestor. An opaque
+/// widget, like `Container(color: Colors.white)`, is included in between
+/// the [SwitchListTile] and its [Material] ancestor,then the opaque widget
+/// will obscure the [Material] widget and [SwitchListTile] background
+/// [tileColor], etc. In this case, one can wrap a [Material] widget around
+/// the [SwitchListTile], e.g.:
+///
+/// ```dart
+/// Container(
+///   color: Colors.green,
+///   child: Material(
+///     child: SwitchListTile(
+///       tileColor: Colors.red,
+///       title: const Text('SwitchListTile with red background'),
+///       value: true,
+///       onChanged:(bool? value) { },
+///     ),
+///   ),
+/// )
+/// ```
+///
 /// To show the [SwitchListTile] as disabled, pass null as the [onChanged]
 /// callback.
 ///

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -70,7 +70,7 @@ enum _SwitchListTileType { material, adaptive }
 ///   ),
 /// )
 /// ```
-/// ## Performance considerations when wrapping [Material] to [SwitchListTile]
+/// ## Performance considerations when wrapping [Material] with [SwitchListTile]
 ///
 /// Wrapping a large number of [SwitchListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [SwitchListTile]s that require it

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -53,6 +53,7 @@ enum _SwitchListTileType { material, adaptive }
 /// [SwitchListTile] itself but by the [Material] widget ancestor. In this
 /// case, one can wrap a [Material] widget around the [SwitchListTile], e.g.:
 ///
+/// {@tool snippet}
 /// ```dart
 /// Container(
 ///   color: Colors.green,
@@ -66,6 +67,7 @@ enum _SwitchListTileType { material, adaptive }
 ///   ),
 /// )
 /// ```
+/// {@end-tool}
 ///
 /// ## Performance considerations when wrapping [SwitchListTile] with [Material]
 ///

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -50,12 +50,8 @@ enum _SwitchListTileType { material, adaptive }
 /// This widget requires a [Material] widget ancestor in the tree to paint
 /// itself on, which is typically provided by the app's [Scaffold].
 /// The [tileColor], and [selectedTileColor] are not painted by the
-/// [SwitchListTile] itself but by the [Material] widget ancestor. An opaque
-/// widget, like `Container(color: Colors.white)`, is included in between
-/// the [SwitchListTile] and its [Material] ancestor,then the opaque widget
-/// will obscure the [Material] widget and [SwitchListTile] background
-/// [tileColor], etc. In this case, one can wrap a [Material] widget around
-/// the [SwitchListTile], e.g.:
+/// [SwitchListTile] itself but by the [Material] widget ancestor. In this
+/// case, one can wrap a [Material] widget around the [SwitchListTile], e.g.:
 ///
 /// ```dart
 /// Container(
@@ -70,7 +66,8 @@ enum _SwitchListTileType { material, adaptive }
 ///   ),
 /// )
 /// ```
-/// ## Performance considerations when wrapping [Material] with [SwitchListTile]
+///
+/// ## Performance considerations when wrapping [SwitchListTile] with [Material]
 ///
 /// Wrapping a large number of [SwitchListTile]s individually with [Material]s
 /// is expensive. Consider only wrapping the [SwitchListTile]s that require it

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -57,7 +57,7 @@ enum _SwitchListTileType { material, adaptive }
 /// ```dart
 /// Container(
 ///   color: Colors.green,
-///   child: const Material(
+///   child: Material(
 ///     child: SwitchListTile(
 ///       tileColor: Colors.red,
 ///       title: const Text('SwitchListTile with red background'),


### PR DESCRIPTION
context: https://github.com/flutter/flutter/pull/102310

closes https://github.com/flutter/flutter/issues/105760
related https://github.com/flutter/flutter/pull/106955

This PR updated `ListTile` Material explanation and adds it to other ListTile based widgets such as `CheckboxListTile`, `RadioListTile`, and `SwitchListTile`
Instead of turning the ListTile doc explanation into the template, I'm reusing the `ListTile` doc with modifications along with a suitable code snippet.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
