### PR TITLE
Add backgroundBlendMode to ExpansionTile widget

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -64,6 +64,7 @@ class ExpansionTile extends StatefulWidget {
     this.childrenPadding,
     this.backgroundColor,
     this.collapsedBackgroundColor,
+    this.backgroundBlendMode,
     this.textColor,
     this.collapsedTextColor,
     this.iconColor,
@@ -128,6 +129,15 @@ class ExpansionTile extends StatefulWidget {
   /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
   ///   [ExpansionTileThemeData].
   final Color? collapsedBackgroundColor;
+
+  /// The blend mode applied to the [backgroundColor] or [collapsedBackgroundColor].
+  ///
+  /// If no [backgroundBlendMode] is provided then the default painting blend
+  /// mode is used.
+  ///
+  /// If no [backgroundColor] or [collapsedBackgroundColor] is provided then the blend mode
+  /// has no impact.
+  final BlendMode? backgroundBlendMode;
 
   /// A widget to display after the title.
   ///
@@ -366,6 +376,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     return Container(
       decoration: BoxDecoration(
         color: _backgroundColor.value ?? expansionTileTheme.backgroundColor ?? Colors.transparent,
+        backgroundBlendMode: widget.backgroundBlendMode,
         border: Border(
           top: BorderSide(color: borderSideColor),
           bottom: BorderSide(color: borderSideColor),


### PR DESCRIPTION
- Adds `backgroundBlendMode` property tot he `ExpansionTile` material widget.

- Fixes #107113

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
