### PR TITLE
feat: introduce environment variables for args

### DIFF
--- a/packages/flutter_tools/lib/src/runner/environment_variables.dart
+++ b/packages/flutter_tools/lib/src/runner/environment_variables.dart
@@ -1,0 +1,11 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+// this file contains the environment variables supported to configure Flutter
+// at runtime
+
+/// adjusts whether Flutter should run its version check when running the
+/// Flutter tool
+const String kFlutterVersionCheckName = 'FLUTTER_VERSION_CHECK';

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -19,6 +19,7 @@ import '../convert.dart';
 import '../globals.dart' as globals;
 import '../tester/flutter_tester.dart';
 import '../web/web_device.dart';
+import 'environment_variables.dart';
 
 class FlutterCommandRunner extends CommandRunner<void> {
   FlutterCommandRunner({ bool verboseHelp = false }) : super(
@@ -74,7 +75,8 @@ class FlutterCommandRunner extends CommandRunner<void> {
     argParser.addFlag('version-check',
         defaultsTo: true,
         hide: !verboseHelp,
-        help: 'Allow Flutter to check for updates when this command runs.');
+        help: 'Allow Flutter to check for updates when this command runs. '
+            'Can be set by $kFlutterVersionCheckName environment variable.');
     argParser.addFlag('suppress-analytics',
         negatable: false,
         help: 'Suppress analytics reporting when this command runs.');
@@ -247,13 +249,17 @@ class FlutterCommandRunner extends CommandRunner<void> {
         final bool redirectedCompletion = !globals.stdio.hasTerminal &&
             (topLevelResults.command?.name ?? '').endsWith('-completion');
         final bool isMachine = machineFlag || ci || redirectedCompletion;
+        final bool versionCheckEnvironment =
+            globals.platform.environment[kFlutterVersionCheckName] != 'false';
         final bool versionCheckFlag = topLevelResults['version-check'] as bool? ?? false;
         final bool explicitVersionCheckPassed = topLevelResults.wasParsed('version-check') && versionCheckFlag;
 
-        if (topLevelResults.command?.name != 'upgrade' &&
-            (explicitVersionCheckPassed || (versionCheckFlag && !isMachine))) {
-          await globals.flutterVersion.checkFlutterVersionFreshness();
-        }
+        await globals.flutterVersion.checkFlutterVersionFreshness(
+          isUpgradeCommand: topLevelResults.command?.name == 'upgrade',
+          versionCheckEnvironment: versionCheckEnvironment,
+          versionCheckFlag: explicitVersionCheckPassed,
+          isMachine: isMachine,
+        );
 
         // See if the user specified a specific device.
         final String? specifiedDeviceId = topLevelResults['device-id'] as String?;

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -240,7 +240,30 @@ class FlutterVersion {
   ///
   /// This function must run while [Cache.lock] is acquired because it reads and
   /// writes shared cache files.
-  Future<void> checkFlutterVersionFreshness() async {
+  ///
+  /// Based on the passed arguments, the method decides whether to perform
+  /// the version check or not.
+  ///
+  /// - [isUpgradeCommand]: whether the called command is the upgrade command
+  /// - [versionCheckEnvironment]: the environment variable about the version
+  ///                              check
+  /// - [versionCheckFlag]: whether the version check flag is explicitly passed
+  /// - [isMachine]: whether the tool runs in a machine-only environment like CI
+  Future<void> checkFlutterVersionFreshness({
+    bool isUpgradeCommand = false,
+    bool versionCheckEnvironment = true,
+    bool versionCheckFlag = false,
+    bool isMachine = false,
+  }) async {
+    // Don't perform update check in case it is disabled by environment
+    // unless it is explicitly overwritten
+    if (!versionCheckEnvironment && versionCheckFlag != true) {
+      return;
+    }
+    // Only perform check if sub-command is 'upgrade'
+    if (!isUpgradeCommand) {
+      return;
+    }
     // Don't perform update checks if we're not on an official channel.
     if (!kOfficialChannels.contains(channel)) {
       return;

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -292,5 +292,10 @@ class FakeFlutterVersion extends Fake implements FlutterVersion {
   void ensureVersionFile() {}
 
   @override
-  Future<void> checkFlutterVersionFreshness() async {}
+  Future<void> checkFlutterVersionFreshness({
+    bool isUpgradeCommand = false,
+    bool versionCheckEnvironment = true,
+    bool versionCheckFlag = false,
+    bool isMachine = false,
+  }) async {}
 }

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -378,7 +378,12 @@ class FakeFlutterVersion implements FlutterVersion {
   }
 
   @override
-  Future<void> checkFlutterVersionFreshness() async {
+  Future<void> checkFlutterVersionFreshness({
+    bool isUpgradeCommand = false,
+    bool versionCheckEnvironment = true,
+    bool versionCheckFlag = false,
+    bool isMachine = false,
+  }) async {
     _didCheckFlutterVersionFreshness = true;
   }
 


### PR DESCRIPTION
- adds fallack to environment variables the `--no-version-check` command line
      argument (FLUTTER_VERSION_CHECK)

Fixes: #107046

Signed-off-by: TheOneWithTheBraid <the-one@with-the-braid.cf>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
