### PR TITLE
Modify calculation of dense button height when text scale is large

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1331,8 +1331,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // Similarly, we don't reduce the height of the button so much that its icon
   // would be clipped.
   double get _denseButtonHeight {
+    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
     final double fontSize = _textStyle!.fontSize ?? Theme.of(context).textTheme.subtitle1!.fontSize!;
-    return math.max(fontSize, math.max(widget.iconSize, _kDenseButtonHeight));
+    final double scaledFontSize = textScaleFactor * fontSize;
+    return math.max(scaledFontSize, math.max(widget.iconSize, _kDenseButtonHeight));
   }
 
   Color get _iconColor {

--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -27,10 +27,12 @@ const Duration _kDropdownMenuDuration = Duration(milliseconds: 300);
 const double _kMenuItemHeight = kMinInteractiveDimension;
 const double _kDenseButtonHeight = 24.0;
 const EdgeInsets _kMenuItemPadding = EdgeInsets.symmetric(horizontal: 16.0);
-const EdgeInsetsGeometry _kAlignedButtonPadding = EdgeInsetsDirectional.only(start: 16.0, end: 4.0);
+const EdgeInsetsGeometry _kAlignedButtonPadding =
+    EdgeInsetsDirectional.only(start: 16.0, end: 4.0);
 const EdgeInsets _kUnalignedButtonPadding = EdgeInsets.zero;
 const EdgeInsets _kAlignedMenuMargin = EdgeInsets.zero;
-const EdgeInsetsGeometry _kUnalignedMenuMargin = EdgeInsetsDirectional.only(start: 16.0, end: 24.0);
+const EdgeInsetsGeometry _kUnalignedMenuMargin =
+    EdgeInsetsDirectional.only(start: 16.0, end: 24.0);
 
 /// A builder to customize dropdown buttons.
 ///
@@ -45,15 +47,16 @@ class _DropdownMenuPainter extends CustomPainter {
     this.borderRadius,
     required this.resize,
     required this.getSelectedItemOffset,
-  }) : _painter = BoxDecoration(
-         // If you add an image here, you must provide a real
-         // configuration in the paint() function and you must provide some sort
-         // of onChanged callback here.
-         color: color,
-         borderRadius: borderRadius ?? const BorderRadius.all(Radius.circular(2.0)),
-         boxShadow: kElevationToShadow[elevation],
-       ).createBoxPainter(),
-       super(repaint: resize);
+  })  : _painter = BoxDecoration(
+          // If you add an image here, you must provide a real
+          // configuration in the paint() function and you must provide some sort
+          // of onChanged callback here.
+          color: color,
+          borderRadius:
+              borderRadius ?? const BorderRadius.all(Radius.circular(2.0)),
+          boxShadow: kElevationToShadow[elevation],
+        ).createBoxPainter(),
+        super(repaint: resize);
 
   final Color? color;
   final int? elevation;
@@ -67,27 +70,30 @@ class _DropdownMenuPainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     final double selectedItemOffset = getSelectedItemOffset();
     final Tween<double> top = Tween<double>(
-      begin: clampDouble(selectedItemOffset, 0.0, math.max(size.height - _kMenuItemHeight, 0.0)),
+      begin: clampDouble(selectedItemOffset, 0.0,
+          math.max(size.height - _kMenuItemHeight, 0.0)),
       end: 0.0,
     );
 
     final Tween<double> bottom = Tween<double>(
-      begin: clampDouble(top.begin! + _kMenuItemHeight, math.min(_kMenuItemHeight, size.height), size.height),
+      begin: clampDouble(top.begin! + _kMenuItemHeight,
+          math.min(_kMenuItemHeight, size.height), size.height),
       end: size.height,
     );
 
-    final Rect rect = Rect.fromLTRB(0.0, top.evaluate(resize), size.width, bottom.evaluate(resize));
+    final Rect rect = Rect.fromLTRB(
+        0.0, top.evaluate(resize), size.width, bottom.evaluate(resize));
 
     _painter.paint(canvas, rect.topLeft, ImageConfiguration(size: rect.size));
   }
 
   @override
   bool shouldRepaint(_DropdownMenuPainter oldPainter) {
-    return oldPainter.color != color
-        || oldPainter.elevation != elevation
-        || oldPainter.selectedIndex != selectedIndex
-        || oldPainter.borderRadius != borderRadius
-        || oldPainter.resize != resize;
+    return oldPainter.color != color ||
+        oldPainter.elevation != elevation ||
+        oldPainter.selectedIndex != selectedIndex ||
+        oldPainter.borderRadius != borderRadius ||
+        oldPainter.resize != resize;
   }
 }
 
@@ -111,10 +117,12 @@ class _DropdownMenuItemButton<T> extends StatefulWidget {
   final bool enableFeedback;
 
   @override
-  _DropdownMenuItemButtonState<T> createState() => _DropdownMenuItemButtonState<T>();
+  _DropdownMenuItemButtonState<T> createState() =>
+      _DropdownMenuItemButtonState<T>();
 }
 
-class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> {
+class _DropdownMenuItemButtonState<T>
+    extends State<_DropdownMenuItemButton<T>> {
   void _handleFocusChange(bool focused) {
     final bool inTraditionalMode;
     switch (FocusManager.instance.highlightMode) {
@@ -141,7 +149,8 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
   }
 
   void _handleOnTap() {
-    final DropdownMenuItem<T> dropdownMenuItem = widget.route.items[widget.itemIndex].item!;
+    final DropdownMenuItem<T> dropdownMenuItem =
+        widget.route.items[widget.itemIndex].item!;
 
     dropdownMenuItem.onTap?.call();
 
@@ -151,24 +160,31 @@ class _DropdownMenuItemButtonState<T> extends State<_DropdownMenuItemButton<T>> 
     );
   }
 
-  static const Map<ShortcutActivator, Intent> _webShortcuts = <ShortcutActivator, Intent>{
+  static const Map<ShortcutActivator, Intent> _webShortcuts =
+      <ShortcutActivator, Intent>{
     // On the web, up/down don't change focus, *except* in a <select>
     // element, which is what a dropdown emulates.
-    SingleActivator(LogicalKeyboardKey.arrowDown): DirectionalFocusIntent(TraversalDirection.down),
-    SingleActivator(LogicalKeyboardKey.arrowUp): DirectionalFocusIntent(TraversalDirection.up),
+    SingleActivator(LogicalKeyboardKey.arrowDown):
+        DirectionalFocusIntent(TraversalDirection.down),
+    SingleActivator(LogicalKeyboardKey.arrowUp):
+        DirectionalFocusIntent(TraversalDirection.up),
   };
 
   @override
   Widget build(BuildContext context) {
-    final DropdownMenuItem<T> dropdownMenuItem = widget.route.items[widget.itemIndex].item!;
+    final DropdownMenuItem<T> dropdownMenuItem =
+        widget.route.items[widget.itemIndex].item!;
     final CurvedAnimation opacity;
     final double unit = 0.5 / (widget.route.items.length + 1.5);
     if (widget.itemIndex == widget.route.selectedIndex) {
-      opacity = CurvedAnimation(parent: widget.route.animation!, curve: const Threshold(0.0));
+      opacity = CurvedAnimation(
+          parent: widget.route.animation!, curve: const Threshold(0.0));
     } else {
-      final double start = clampDouble(0.5 + (widget.itemIndex + 1) * unit, 0.0, 1.0);
+      final double start =
+          clampDouble(0.5 + (widget.itemIndex + 1) * unit, 0.0, 1.0);
       final double end = clampDouble(start + 1.5 * unit, 0.0, 1.0);
-      opacity = CurvedAnimation(parent: widget.route.animation!, curve: Interval(start, end));
+      opacity = CurvedAnimation(
+          parent: widget.route.animation!, curve: Interval(start, end));
     }
     Widget child = Container(
       padding: widget.padding,
@@ -254,7 +270,8 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
     // When the menu is dismissed we just fade the entire thing out
     // in the first 0.25s.
     assert(debugCheckHasMaterialLocalizations(context));
-    final MaterialLocalizations localizations = MaterialLocalizations.of(context);
+    final MaterialLocalizations localizations =
+        MaterialLocalizations.of(context);
     final _DropdownRoute<T> route = widget.route;
     final List<Widget> children = <Widget>[
       for (int itemIndex = 0; itemIndex < route.items.length; ++itemIndex)
@@ -266,7 +283,7 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           itemIndex: itemIndex,
           enableFeedback: widget.enableFeedback,
         ),
-      ];
+    ];
 
     return FadeTransition(
       opacity: _fadeOpacity,
@@ -288,9 +305,8 @@ class _DropdownMenuState<T> extends State<_DropdownMenu<T>> {
           label: localizations.popupMenuLabel,
           child: ClipRRect(
             borderRadius: widget.borderRadius ?? BorderRadius.zero,
-            clipBehavior: widget.borderRadius != null
-              ? Clip.antiAlias
-              : Clip.none,
+            clipBehavior:
+                widget.borderRadius != null ? Clip.antiAlias : Clip.none,
             child: Material(
               type: MaterialType.transparency,
               textStyle: route.style,
@@ -343,7 +359,8 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
     // the view height. This ensures a tappable area outside of the simple menu
     // with which to dismiss the menu.
     //   -- https://material.io/design/components/menus.html#usage
-    double maxHeight = math.max(0.0, constraints.maxHeight - 2 * _kMenuItemHeight);
+    double maxHeight =
+        math.max(0.0, constraints.maxHeight - 2 * _kMenuItemHeight);
     if (route.menuMaxHeight != null && route.menuMaxHeight! <= maxHeight) {
       maxHeight = route.menuMaxHeight!;
     }
@@ -359,7 +376,8 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
 
   @override
   Offset getPositionForChild(Size size, Size childSize) {
-    final _MenuLimits menuLimits = route.getMenuLimits(buttonRect, size.height, route.selectedIndex);
+    final _MenuLimits menuLimits =
+        route.getMenuLimits(buttonRect, size.height, route.selectedIndex);
 
     assert(() {
       final Rect container = Offset.zero & size;
@@ -388,7 +406,8 @@ class _DropdownMenuRouteLayout<T> extends SingleChildLayoutDelegate {
 
   @override
   bool shouldRelayout(_DropdownMenuRouteLayout<T> oldDelegate) {
-    return buttonRect != oldDelegate.buttonRect || textDirection != oldDelegate.textDirection;
+    return buttonRect != oldDelegate.buttonRect ||
+        textDirection != oldDelegate.textDirection;
   }
 }
 
@@ -403,8 +422,7 @@ class _DropdownRouteResult<T> {
 
   @override
   bool operator ==(Object other) {
-    return other is _DropdownRouteResult<T>
-        && other.result == result;
+    return other is _DropdownRouteResult<T> && other.result == result;
   }
 
   @override
@@ -434,8 +452,9 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     this.menuMaxHeight,
     required this.enableFeedback,
     this.borderRadius,
-  }) : assert(style != null),
-       itemHeights = List<double>.filled(items.length, itemHeight ?? kMinInteractiveDimension);
+  })  : assert(style != null),
+        itemHeights = List<double>.filled(
+            items.length, itemHeight ?? kMinInteractiveDimension);
 
   final List<_MenuItem<T>> items;
   final EdgeInsetsGeometry padding;
@@ -466,7 +485,8 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   final String? barrierLabel;
 
   @override
-  Widget buildPage(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+  Widget buildPage(BuildContext context, Animation<double> animation,
+      Animation<double> secondaryAnimation) {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         return _DropdownRoutePage<T>(
@@ -498,8 +518,8 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     if (items.isNotEmpty && index > 0) {
       assert(items.length == itemHeights.length);
       offset += itemHeights
-        .sublist(0, index)
-        .reduce((double total, double height) => total + height);
+          .sublist(0, index)
+          .reduce((double total, double height) => total + height);
     }
     return offset;
   }
@@ -508,7 +528,8 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
   // for the ListView that contains the menu items. The vertical center of the
   // selected item is aligned with the button's vertical center, as far as
   // that's possible given availableHeight.
-  _MenuLimits getMenuLimits(Rect buttonRect, double availableHeight, int index) {
+  _MenuLimits getMenuLimits(
+      Rect buttonRect, double availableHeight, int index) {
     double computedMaxHeight = availableHeight - 2.0 * _kMenuItemHeight;
     if (menuMaxHeight != null) {
       computedMaxHeight = math.min(computedMaxHeight, menuMaxHeight!);
@@ -522,12 +543,15 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
     // In this case, we want to change the menu limits to align with the top
     // or bottom edge of the button.
     final double topLimit = math.min(_kMenuItemHeight, buttonTop);
-    final double bottomLimit = math.max(availableHeight - _kMenuItemHeight, buttonBottom);
+    final double bottomLimit =
+        math.max(availableHeight - _kMenuItemHeight, buttonBottom);
 
-    double menuTop = (buttonTop - selectedItemOffset) - (itemHeights[selectedIndex] - buttonRect.height) / 2.0;
+    double menuTop = (buttonTop - selectedItemOffset) -
+        (itemHeights[selectedIndex] - buttonRect.height) / 2.0;
     double preferredMenuHeight = kMaterialListPadding.vertical;
     if (items.isNotEmpty) {
-      preferredMenuHeight += itemHeights.reduce((double total, double height) => total + height);
+      preferredMenuHeight +=
+          itemHeights.reduce((double total, double height) => total + height);
     }
 
     // If there are too many elements in the menu, we need to shrink it down
@@ -550,8 +574,11 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
       menuTop = menuBottom - menuHeight;
     }
 
-    if (menuBottom - itemHeights[selectedIndex] / 2.0 < buttonBottom - buttonRect.height / 2.0) {
-      menuBottom = buttonBottom - buttonRect.height / 2.0 + itemHeights[selectedIndex] / 2.0;
+    if (menuBottom - itemHeights[selectedIndex] / 2.0 <
+        buttonBottom - buttonRect.height / 2.0) {
+      menuBottom = buttonBottom -
+          buttonRect.height / 2.0 +
+          itemHeights[selectedIndex] / 2.0;
       menuTop = menuBottom - menuHeight;
     }
 
@@ -617,8 +644,10 @@ class _DropdownRoutePage<T> extends StatelessWidget {
     // Otherwise the initialScrollOffset is just a rough approximation based on
     // treating the items as if their heights were all equal to kMinInteractiveDimension.
     if (route.scrollController == null) {
-      final _MenuLimits menuLimits = route.getMenuLimits(buttonRect, constraints.maxHeight, selectedIndex);
-      route.scrollController = ScrollController(initialScrollOffset: menuLimits.scrollOffset);
+      final _MenuLimits menuLimits =
+          route.getMenuLimits(buttonRect, constraints.maxHeight, selectedIndex);
+      route.scrollController =
+          ScrollController(initialScrollOffset: menuLimits.scrollOffset);
     }
 
     final TextDirection? textDirection = Directionality.maybeOf(context);
@@ -664,7 +693,8 @@ class _MenuItem<T> extends SingleChildRenderObjectWidget {
     super.key,
     required this.onLayout,
     required this.item,
-  }) : assert(onLayout != null), super(child: item);
+  })  : assert(onLayout != null),
+        super(child: item);
 
   final ValueChanged<Size> onLayout;
   final DropdownMenuItem<T>? item;
@@ -675,13 +705,16 @@ class _MenuItem<T> extends SingleChildRenderObjectWidget {
   }
 
   @override
-  void updateRenderObject(BuildContext context, covariant _RenderMenuItem renderObject) {
+  void updateRenderObject(
+      BuildContext context, covariant _RenderMenuItem renderObject) {
     renderObject.onLayout = onLayout;
   }
 }
 
 class _RenderMenuItem extends RenderProxyBox {
-  _RenderMenuItem(this.onLayout, [RenderBox? child]) : assert(onLayout != null), super(child);
+  _RenderMenuItem(this.onLayout, [RenderBox? child])
+      : assert(onLayout != null),
+        super(child);
 
   ValueChanged<Size> onLayout;
 
@@ -780,7 +813,9 @@ class DropdownButtonHideUnderline extends InheritedWidget {
   /// Returns whether the underline of [DropdownButton] widgets should
   /// be hidden.
   static bool at(BuildContext context) {
-    return context.dependOnInheritedWidgetOfExactType<DropdownButtonHideUnderline>() != null;
+    return context.dependOnInheritedWidgetOfExactType<
+            DropdownButtonHideUnderline>() !=
+        null;
   }
 
   @override
@@ -887,24 +922,28 @@ class DropdownButton<T> extends StatefulWidget {
     this.borderRadius,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButtonFormField.
-  }) : assert(items == null || items.isEmpty || value == null ||
+  })  : assert(
+          items == null ||
+              items.isEmpty ||
+              value == null ||
               items.where((DropdownMenuItem<T> item) {
-                return item.value == value;
-              }).length == 1,
-                "There should be exactly one item with [DropdownButton]'s value: "
-                '$value. \n'
-                'Either zero or 2 or more [DropdownMenuItem]s were detected '
-                'with the same value',
-              ),
-       assert(elevation != null),
-       assert(iconSize != null),
-       assert(isDense != null),
-       assert(isExpanded != null),
-       assert(autofocus != null),
-       assert(itemHeight == null || itemHeight >=  kMinInteractiveDimension),
-       _inputDecoration = null,
-       _isEmpty = false,
-       _isFocused = false;
+                    return item.value == value;
+                  }).length ==
+                  1,
+          "There should be exactly one item with [DropdownButton]'s value: "
+          '$value. \n'
+          'Either zero or 2 or more [DropdownMenuItem]s were detected '
+          'with the same value',
+        ),
+        assert(elevation != null),
+        assert(iconSize != null),
+        assert(isDense != null),
+        assert(isExpanded != null),
+        assert(autofocus != null),
+        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
+        _inputDecoration = null,
+        _isEmpty = false,
+        _isFocused = false;
 
   DropdownButton._formField({
     super.key,
@@ -936,26 +975,30 @@ class DropdownButton<T> extends StatefulWidget {
     required InputDecoration inputDecoration,
     required bool isEmpty,
     required bool isFocused,
-  }) : assert(items == null || items.isEmpty || value == null ||
+  })  : assert(
+          items == null ||
+              items.isEmpty ||
+              value == null ||
               items.where((DropdownMenuItem<T> item) {
-                return item.value == value;
-              }).length == 1,
-                "There should be exactly one item with [DropdownButtonFormField]'s value: "
-                '$value. \n'
-                'Either zero or 2 or more [DropdownMenuItem]s were detected '
-                'with the same value',
-              ),
-       assert(elevation != null),
-       assert(iconSize != null),
-       assert(isDense != null),
-       assert(isExpanded != null),
-       assert(autofocus != null),
-       assert(itemHeight == null || itemHeight >=  kMinInteractiveDimension),
-       assert(isEmpty != null),
-       assert(isFocused != null),
-       _inputDecoration = inputDecoration,
-       _isEmpty = isEmpty,
-       _isFocused = isFocused;
+                    return item.value == value;
+                  }).length ==
+                  1,
+          "There should be exactly one item with [DropdownButtonFormField]'s value: "
+          '$value. \n'
+          'Either zero or 2 or more [DropdownMenuItem]s were detected '
+          'with the same value',
+        ),
+        assert(elevation != null),
+        assert(iconSize != null),
+        assert(isDense != null),
+        assert(isExpanded != null),
+        assert(autofocus != null),
+        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
+        assert(isEmpty != null),
+        assert(isFocused != null),
+        _inputDecoration = inputDecoration,
+        _isEmpty = isEmpty,
+        _isFocused = isFocused;
 
   /// The list of items the user can select.
   ///
@@ -1174,7 +1217,8 @@ class DropdownButton<T> extends StatefulWidget {
   State<DropdownButton<T>> createState() => _DropdownButtonState<T>();
 }
 
-class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindingObserver {
+class _DropdownButtonState<T> extends State<DropdownButton<T>>
+    with WidgetsBindingObserver {
   int? _selectedIndex;
   _DropdownRoute<T>? _dropdownRoute;
   Orientation? _lastOrientation;
@@ -1229,7 +1273,6 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-
   @override
   void didUpdateWidget(DropdownButton<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
@@ -1245,17 +1288,21 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   }
 
   void _updateSelectedIndex() {
-    if (widget.items == null
-        || widget.items!.isEmpty
-        || (widget.value == null &&
+    if (widget.items == null ||
+        widget.items!.isEmpty ||
+        (widget.value == null &&
             widget.items!
-                .where((DropdownMenuItem<T> item) => item.enabled && item.value == widget.value)
+                .where((DropdownMenuItem<T> item) =>
+                    item.enabled && item.value == widget.value)
                 .isEmpty)) {
       _selectedIndex = null;
       return;
     }
 
-    assert(widget.items!.where((DropdownMenuItem<T> item) => item.value == widget.value).length == 1);
+    assert(widget.items!
+            .where((DropdownMenuItem<T> item) => item.value == widget.value)
+            .length ==
+        1);
     for (int itemIndex = 0; itemIndex < widget.items!.length; itemIndex++) {
       if (widget.items![itemIndex].value == widget.value) {
         _selectedIndex = itemIndex;
@@ -1264,47 +1311,52 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-  TextStyle? get _textStyle => widget.style ?? Theme.of(context).textTheme.subtitle1;
+  TextStyle? get _textStyle =>
+      widget.style ?? Theme.of(context).textTheme.subtitle1;
 
   void _handleTap() {
     final TextDirection? textDirection = Directionality.maybeOf(context);
-    final EdgeInsetsGeometry menuMargin = ButtonTheme.of(context).alignedDropdown
-      ? _kAlignedMenuMargin
-      : _kUnalignedMenuMargin;
+    final EdgeInsetsGeometry menuMargin =
+        ButtonTheme.of(context).alignedDropdown
+            ? _kAlignedMenuMargin
+            : _kUnalignedMenuMargin;
 
     final List<_MenuItem<T>> menuItems = <_MenuItem<T>>[
-    for (int index = 0; index < widget.items!.length; index += 1)
-      _MenuItem<T>(
-        item: widget.items![index],
-        onLayout: (Size size) {
-          // If [_dropdownRoute] is null and onLayout is called, this means
-          // that performLayout was called on a _DropdownRoute that has not
-          // left the widget tree but is already on its way out.
-          //
-          // Since onLayout is used primarily to collect the desired heights
-          // of each menu item before laying them out, not having the _DropdownRoute
-          // collect each item's height to lay out is fine since the route is
-          // already on its way out.
-          if (_dropdownRoute == null) {
-            return;
-          }
+      for (int index = 0; index < widget.items!.length; index += 1)
+        _MenuItem<T>(
+          item: widget.items![index],
+          onLayout: (Size size) {
+            // If [_dropdownRoute] is null and onLayout is called, this means
+            // that performLayout was called on a _DropdownRoute that has not
+            // left the widget tree but is already on its way out.
+            //
+            // Since onLayout is used primarily to collect the desired heights
+            // of each menu item before laying them out, not having the _DropdownRoute
+            // collect each item's height to lay out is fine since the route is
+            // already on its way out.
+            if (_dropdownRoute == null) {
+              return;
+            }
 
-          _dropdownRoute!.itemHeights[index] = size.height;
-        },
-      ),
+            _dropdownRoute!.itemHeights[index] = size.height;
+          },
+        ),
     ];
 
     final NavigatorState navigator = Navigator.of(context);
     assert(_dropdownRoute == null);
     final RenderBox itemBox = context.findRenderObject()! as RenderBox;
-    final Rect itemRect = itemBox.localToGlobal(Offset.zero, ancestor: navigator.context.findRenderObject()) & itemBox.size;
+    final Rect itemRect = itemBox.localToGlobal(Offset.zero,
+            ancestor: navigator.context.findRenderObject()) &
+        itemBox.size;
     _dropdownRoute = _DropdownRoute<T>(
       items: menuItems,
       buttonRect: menuMargin.resolve(textDirection).inflateRect(itemRect),
       padding: _kMenuItemPadding.resolve(textDirection),
       selectedIndex: _selectedIndex ?? 0,
       elevation: widget.elevation,
-      capturedThemes: InheritedTheme.capture(from: context, to: navigator.context),
+      capturedThemes:
+          InheritedTheme.capture(from: context, to: navigator.context),
       style: _textStyle!,
       barrierLabel: MaterialLocalizations.of(context).modalBarrierDismissLabel,
       itemHeight: widget.itemHeight,
@@ -1315,7 +1367,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     );
 
     focusNode?.requestFocus();
-    navigator.push(_dropdownRoute!).then<void>((_DropdownRouteResult<T>? newValue) {
+    navigator
+        .push(_dropdownRoute!)
+        .then<void>((_DropdownRouteResult<T>? newValue) {
       _removeDropdownRoute();
       if (!mounted || newValue == null) {
         return;
@@ -1332,9 +1386,11 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // would be clipped.
   double get _denseButtonHeight {
     final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
-    final double fontSize = _textStyle!.fontSize ?? Theme.of(context).textTheme.subtitle1!.fontSize!;
+    final double fontSize = _textStyle!.fontSize ??
+        Theme.of(context).textTheme.subtitle1!.fontSize!;
     final double scaledFontSize = textScaleFactor * fontSize;
-    return math.max(scaledFontSize, math.max(widget.iconSize, _kDenseButtonHeight));
+    return math.max(
+        scaledFontSize, math.max(widget.iconSize, _kDenseButtonHeight));
   }
 
   Color get _iconColor {
@@ -1364,7 +1420,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
   }
 
-  bool get _enabled => widget.items != null && widget.items!.isNotEmpty && widget.onChanged != null;
+  bool get _enabled =>
+      widget.items != null &&
+      widget.items!.isNotEmpty &&
+      widget.onChanged != null;
 
   Orientation _getOrientation(BuildContext context) {
     Orientation? result = MediaQuery.maybeOf(context)?.orientation;
@@ -1372,7 +1431,9 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       // If there's no MediaQuery, then use the window aspect to determine
       // orientation.
       final Size size = WidgetsBinding.instance.window.physicalSize;
-      result = size.width > size.height ? Orientation.landscape : Orientation.portrait;
+      result = size.width > size.height
+          ? Orientation.landscape
+          : Orientation.portrait;
     }
     return result;
   }
@@ -1394,14 +1455,16 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     // otherwise, no explicit type adding items maybe trigger a crash/failure
     // when hint and selectedItemBuilder are provided.
     final List<Widget> items = widget.selectedItemBuilder == null
-      ? (widget.items != null ? List<Widget>.of(widget.items!) : <Widget>[])
-      : List<Widget>.of(widget.selectedItemBuilder!(context));
+        ? (widget.items != null ? List<Widget>.of(widget.items!) : <Widget>[])
+        : List<Widget>.of(widget.selectedItemBuilder!(context));
 
     int? hintIndex;
     if (widget.hint != null || (!_enabled && widget.disabledHint != null)) {
-      Widget displayedHint = _enabled ? widget.hint! : widget.disabledHint ?? widget.hint!;
+      Widget displayedHint =
+          _enabled ? widget.hint! : widget.disabledHint ?? widget.hint!;
       if (widget.selectedItemBuilder == null) {
-        displayedHint = _DropdownMenuItemContainer(alignment: widget.alignment, child: displayedHint);
+        displayedHint = _DropdownMenuItemContainer(
+            alignment: widget.alignment, child: displayedHint);
       }
 
       hintIndex = items.length;
@@ -1415,8 +1478,8 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     }
 
     final EdgeInsetsGeometry padding = ButtonTheme.of(context).alignedDropdown
-      ? _kAlignedButtonPadding
-      : _kUnalignedButtonPadding;
+        ? _kAlignedButtonPadding
+        : _kUnalignedButtonPadding;
 
     // If value is null (then _selectedIndex is null) then we
     // display the hint or nothing at all.
@@ -1427,18 +1490,24 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
       innerItemsWidget = IndexedStack(
         index: _selectedIndex ?? hintIndex,
         alignment: widget.alignment,
-        children: widget.isDense ? items : items.map((Widget item) {
-          return widget.itemHeight != null
-            ? SizedBox(height: widget.itemHeight, child: item)
-            : Column(mainAxisSize: MainAxisSize.min, children: <Widget>[item]);
-        }).toList(),
+        children: widget.isDense
+            ? items
+            : items.map((Widget item) {
+                return widget.itemHeight != null
+                    ? SizedBox(height: widget.itemHeight, child: item)
+                    : Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[item]);
+              }).toList(),
       );
     }
 
     const Icon defaultIcon = Icon(Icons.arrow_drop_down);
 
     Widget result = DefaultTextStyle(
-      style: _enabled ? _textStyle! : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
+      style: _enabled
+          ? _textStyle!
+          : _textStyle!.copyWith(color: Theme.of(context).disabledColor),
       child: Container(
         padding: padding.resolve(Directionality.of(context)),
         height: widget.isDense ? _denseButtonHeight : null,
@@ -1463,7 +1532,8 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
     );
 
     if (!DropdownButtonHideUnderline.at(context)) {
-      final double bottom = (widget.isDense || widget.itemHeight == null) ? 0.0 : 8.0;
+      final double bottom =
+          (widget.isDense || widget.itemHeight == null) ? 0.0 : 8.0;
       result = Stack(
         children: <Widget>[
           result,
@@ -1471,23 +1541,25 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
             left: 0.0,
             right: 0.0,
             bottom: bottom,
-            child: widget.underline ?? Container(
-              height: 1.0,
-              decoration: const BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(
-                    color: Color(0xFFBDBDBD),
-                    width: 0.0,
+            child: widget.underline ??
+                Container(
+                  height: 1.0,
+                  decoration: const BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(
+                        color: Color(0xFFBDBDBD),
+                        width: 0.0,
+                      ),
+                    ),
                   ),
                 ),
-              ),
-            ),
           ),
         ],
       );
     }
 
-    final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor>(
+    final MouseCursor effectiveMouseCursor =
+        MaterialStateProperty.resolveAs<MouseCursor>(
       MaterialStateMouseCursor.clickable,
       <MaterialState>{
         if (!_enabled) MaterialState.disabled,
@@ -1579,84 +1651,99 @@ class DropdownButtonFormField<T> extends FormField<T> {
     BorderRadius? borderRadius,
     // When adding new arguments, consider adding similar arguments to
     // DropdownButton.
-  }) : assert(items == null || items.isEmpty || value == null ||
+  })  : assert(
+          items == null ||
+              items.isEmpty ||
+              value == null ||
               items.where((DropdownMenuItem<T> item) {
-                return item.value == value;
-              }).length == 1,
-                "There should be exactly one item with [DropdownButton]'s value: "
-                '$value. \n'
-                'Either zero or 2 or more [DropdownMenuItem]s were detected '
-                'with the same value',
-              ),
-       assert(elevation != null),
-       assert(iconSize != null),
-       assert(isDense != null),
-       assert(isExpanded != null),
-       assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
-       assert(autofocus != null),
-       decoration = decoration ?? InputDecoration(focusColor: focusColor),
-       super(
-         initialValue: value,
-         autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
-         builder: (FormFieldState<T> field) {
-           final _DropdownButtonFormFieldState<T> state = field as _DropdownButtonFormFieldState<T>;
-           final InputDecoration decorationArg =  decoration ?? InputDecoration(focusColor: focusColor);
-           final InputDecoration effectiveDecoration = decorationArg.applyDefaults(
-             Theme.of(field.context).inputDecorationTheme,
-           );
+                    return item.value == value;
+                  }).length ==
+                  1,
+          "There should be exactly one item with [DropdownButton]'s value: "
+          '$value. \n'
+          'Either zero or 2 or more [DropdownMenuItem]s were detected '
+          'with the same value',
+        ),
+        assert(elevation != null),
+        assert(iconSize != null),
+        assert(isDense != null),
+        assert(isExpanded != null),
+        assert(itemHeight == null || itemHeight >= kMinInteractiveDimension),
+        assert(autofocus != null),
+        decoration = decoration ?? InputDecoration(focusColor: focusColor),
+        super(
+          initialValue: value,
+          autovalidateMode: autovalidateMode ?? AutovalidateMode.disabled,
+          builder: (FormFieldState<T> field) {
+            final _DropdownButtonFormFieldState<T> state =
+                field as _DropdownButtonFormFieldState<T>;
+            final InputDecoration decorationArg =
+                decoration ?? InputDecoration(focusColor: focusColor);
+            final InputDecoration effectiveDecoration =
+                decorationArg.applyDefaults(
+              Theme.of(field.context).inputDecorationTheme,
+            );
 
-           final bool showSelectedItem = items != null && items.where((DropdownMenuItem<T> item) => item.value == state.value).isNotEmpty;
-           bool isHintOrDisabledHintAvailable() {
-             final bool isDropdownDisabled = onChanged == null || (items == null || items.isEmpty);
-             if (isDropdownDisabled) {
-               return hint != null || disabledHint != null;
-             } else {
-               return hint != null;
-             }
-           }
-           final bool isEmpty = !showSelectedItem && !isHintOrDisabledHintAvailable();
+            final bool showSelectedItem = items != null &&
+                items
+                    .where(
+                        (DropdownMenuItem<T> item) => item.value == state.value)
+                    .isNotEmpty;
+            bool isHintOrDisabledHintAvailable() {
+              final bool isDropdownDisabled =
+                  onChanged == null || (items == null || items.isEmpty);
+              if (isDropdownDisabled) {
+                return hint != null || disabledHint != null;
+              } else {
+                return hint != null;
+              }
+            }
 
-           // An unfocusable Focus widget so that this widget can detect if its
-           // descendants have focus or not.
-           return Focus(
-             canRequestFocus: false,
-             skipTraversal: true,
-             child: Builder(builder: (BuildContext context) {
-               return DropdownButtonHideUnderline(
-                 child: DropdownButton<T>._formField(
-                   items: items,
-                   selectedItemBuilder: selectedItemBuilder,
-                   value: state.value,
-                   hint: hint,
-                   disabledHint: disabledHint,
-                   onChanged: onChanged == null ? null : state.didChange,
-                   onTap: onTap,
-                   elevation: elevation,
-                   style: style,
-                   icon: icon,
-                   iconDisabledColor: iconDisabledColor,
-                   iconEnabledColor: iconEnabledColor,
-                   iconSize: iconSize,
-                   isDense: isDense,
-                   isExpanded: isExpanded,
-                   itemHeight: itemHeight,
-                   focusColor: focusColor,
-                   focusNode: focusNode,
-                   autofocus: autofocus,
-                   dropdownColor: dropdownColor,
-                   menuMaxHeight: menuMaxHeight,
-                   enableFeedback: enableFeedback,
-                   alignment: alignment,
-                   borderRadius: borderRadius,
-                   inputDecoration: effectiveDecoration.copyWith(errorText: field.errorText),
-                   isEmpty: isEmpty,
-                   isFocused: Focus.of(context).hasFocus,
-                 ),
-               );
-             }),
-           );
-         },
-       );
+            final bool isEmpty =
+                !showSelectedItem && !isHintOrDisabledHintAvailable();
+
+            // An unfocusable Focus widget so that this widget can detect if its
+            // descendants have focus or not.
+            return Focus(
+              canRequestFocus: false,
+              skipTraversal: true,
+              child: Builder(builder: (BuildContext context) {
+                return DropdownButtonHideUnderline(
+                  child: DropdownButton<T>._formField(
+                    items: items,
+                    selectedItemBuilder: selectedItemBuilder,
+                    value: state.value,
+                    hint: hint,
+                    disabledHint: disabledHint,
+                    onChanged: onChanged == null ? null : state.didChange,
+                    onTap: onTap,
+                    elevation: elevation,
+                    style: style,
+                    icon: icon,
+                    iconDisabledColor: iconDisabledColor,
+                    iconEnabledColor: iconEnabledColor,
+                    iconSize: iconSize,
+                    isDense: isDense,
+                    isExpanded: isExpanded,
+                    itemHeight: itemHeight,
+                    focusColor: focusColor,
+                    focusNode: focusNode,
+                    autofocus: autofocus,
+                    dropdownColor: dropdownColor,
+                    menuMaxHeight: menuMaxHeight,
+                    enableFeedback: enableFeedback,
+                    alignment: alignment,
+                    borderRadius: borderRadius,
+                    inputDecoration: effectiveDecoration.copyWith(
+                        errorText: field.errorText),
+                    isEmpty: isEmpty,
+                    isFocused: Focus.of(context).hasFocus,
+                  ),
+                );
+              }),
+            );
+          },
+        );
 
   /// {@macro flutter.material.dropdownButton.onChanged}
   final ValueChanged<T?>? onChanged;
@@ -1675,11 +1762,11 @@ class DropdownButtonFormField<T> extends FormField<T> {
 }
 
 class _DropdownButtonFormFieldState<T> extends FormFieldState<T> {
-
   @override
   void didChange(T? value) {
     super.didChange(value);
-    final DropdownButtonFormField<T> dropdownButtonFormField = widget as DropdownButtonFormField<T>;
+    final DropdownButtonFormField<T> dropdownButtonFormField =
+        widget as DropdownButtonFormField<T>;
     assert(dropdownButtonFormField.onChanged != null);
     dropdownButtonFormField.onChanged!(value);
   }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -567,6 +567,37 @@ void main() {
     }
   });
 
+  testWidgets('DropdownButtonFormField with isDense:true does not clip large scale text', (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    const String value = 'two';
+
+    await tester.pumpWidget(
+      TestApp(
+        textDirection: TextDirection.ltr,
+        child: Material(
+          child: Center(
+            child: DropdownButtonFormField<String>(
+              key: buttonKey,
+              value: value,
+              onChanged: onChanged,
+              items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                return DropdownMenuItem<String>(
+                  key: ValueKey<String>(item),
+                  value: item,
+                  child: Text(item, key: ValueKey<String>('${item}Text'),
+                      textScaleFactor: 3.0, style: const(TextStyle(fontSize: 20.0))),
+                );
+              }).toList(),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box = tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    expect(box.size.height, 60.0);
+  });
+
   testWidgets('DropdownButtonFormField.isDense is true by default', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/46844
     final Key buttonKey = UniqueKey();

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -10,9 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 const List<String> menuItems = <String>['one', 'two', 'three', 'four'];
-void onChanged<T>(T _) { }
+void onChanged<T>(T _) {}
 final Type dropdownButtonType = DropdownButton<String>(
-  onChanged: (_) { },
+  onChanged: (_) {},
   items: const <DropdownMenuItem<String>>[],
 ).runtimeType;
 
@@ -90,7 +90,8 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: widget.mediaSize),
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
+            .copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(
@@ -127,12 +128,15 @@ class TestApp extends StatefulWidget {
 void verifyPaintedShadow(Finder customPaint, int elevation) {
   const Rect originalRectangle = Rect.fromLTRB(0.0, 0.0, 800, 208.0);
 
-  final List<BoxShadow> boxShadows = List<BoxShadow>.generate(3, (int index) => kElevationToShadow[elevation]![index]);
+  final List<BoxShadow> boxShadows = List<BoxShadow>.generate(
+      3, (int index) => kElevationToShadow[elevation]![index]);
   final List<RRect> rrects = List<RRect>.generate(3, (int index) {
     return RRect.fromRectAndRadius(
-      originalRectangle.shift(
-        boxShadows[index].offset,
-      ).inflate(boxShadows[index].spreadRadius),
+      originalRectangle
+          .shift(
+            boxShadows[index].offset,
+          )
+          .inflate(boxShadows[index].spreadRadius),
       const Radius.circular(2.0),
     );
   });
@@ -143,7 +147,8 @@ void verifyPaintedShadow(Finder customPaint, int elevation) {
       ..save()
       ..rrect(rrect: rrects[0], color: boxShadows[0].color, hasMaskFilter: true)
       ..rrect(rrect: rrects[1], color: boxShadows[1].color, hasMaskFilter: true)
-      ..rrect(rrect: rrects[2], color: boxShadows[2].color, hasMaskFilter: true),
+      ..rrect(
+          rrect: rrects[2], color: boxShadows[2].color, hasMaskFilter: true),
   );
 }
 
@@ -200,7 +205,8 @@ void main() {
     expect(hintEmptyLabel, oneValueLabel);
   });
 
-  testWidgets('label position test - show disabledHint: disable', (WidgetTester tester) async {
+  testWidgets('label position test - show disabledHint: disable',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -212,7 +218,8 @@ void main() {
               labelText: 'labelText',
             ),
             value: value,
-            onChanged: null, // this disables the menu and shows the disabledHint.
+            onChanged:
+                null, // this disables the menu and shows the disabledHint.
             disabledHint: const Text('disabledHint'),
             items: const <DropdownMenuItem<int?>>[
               DropdownMenuItem<int?>(
@@ -238,7 +245,8 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - show disabledHint: enable + null item', (WidgetTester tester) async {
+  testWidgets('label position test - show disabledHint: enable + null item',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -263,7 +271,8 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - show disabledHint: enable + empty item', (WidgetTester tester) async {
+  testWidgets('label position test - show disabledHint: enable + empty item',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -288,7 +297,8 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - show hint: enable + empty item', (WidgetTester tester) async {
+  testWidgets('label position test - show hint: enable + empty item',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -313,7 +323,9 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - no hint shown: enable + no selected + disabledHint', (WidgetTester tester) async {
+  testWidgets(
+      'label position test - no hint shown: enable + no selected + disabledHint',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -351,7 +363,9 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 24.0));
   });
 
-  testWidgets('label position test - show selected item: disabled + hint + disabledHint', (WidgetTester tester) async {
+  testWidgets(
+      'label position test - show selected item: disabled + hint + disabledHint',
+      (WidgetTester tester) async {
     const int value = 1;
 
     await tester.pumpWidget(
@@ -443,7 +457,8 @@ void main() {
     expect(nonEmptyLabel, nullValueLabel);
   });
 
-  testWidgets('DropdownButtonFormField with autovalidation test', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField with autovalidation test',
+      (WidgetTester tester) async {
     String? value = 'one';
     int validateCalled = 0;
 
@@ -492,7 +507,9 @@ void main() {
     expect(value, equals('three'));
   });
 
-  testWidgets('DropdownButtonFormField arrow icon aligns with the edge of button when expanded', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField arrow icon aligns with the edge of button when expanded',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
     // There shouldn't be overflow when expanded although list contains longer items.
@@ -527,7 +544,9 @@ void main() {
     );
   });
 
-  testWidgets('DropdownButtonFormField with isDense:true aligns selected menu item', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField with isDense:true aligns selected menu item',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
     await tester.pumpWidget(
@@ -548,57 +567,73 @@ void main() {
     // The selected dropdown item is both in menu we just popped up, and in
     // the IndexedStack contained by the dropdown button. Both of them should
     // have the same vertical center as the button.
-    final List<RenderBox> itemBoxes = tester.renderObjectList<RenderBox>(
-      find.byKey(const ValueKey<String>('two')),
-    ).toList();
+    final List<RenderBox> itemBoxes = tester
+        .renderObjectList<RenderBox>(
+          find.byKey(const ValueKey<String>('two')),
+        )
+        .toList();
     expect(itemBoxes.length, equals(2));
 
     // When isDense is true, the button's height is reduced. The menu items'
     // heights are not.
-    final List<double> itemBoxesHeight = itemBoxes.map<double>((RenderBox box) => box.size.height).toList();
+    final List<double> itemBoxesHeight =
+        itemBoxes.map<double>((RenderBox box) => box.size.height).toList();
     final double menuItemHeight = itemBoxesHeight.reduce(math.max);
     expect(menuItemHeight, greaterThanOrEqualTo(buttonBox.size.height));
 
     for (final RenderBox itemBox in itemBoxes) {
       expect(itemBox.attached, isTrue);
-      final Offset buttonBoxCenter = buttonBox.size.center(buttonBox.localToGlobal(Offset.zero));
-      final Offset itemBoxCenter = itemBox.size.center(itemBox.localToGlobal(Offset.zero));
+      final Offset buttonBoxCenter =
+          buttonBox.size.center(buttonBox.localToGlobal(Offset.zero));
+      final Offset itemBoxCenter =
+          itemBox.size.center(itemBox.localToGlobal(Offset.zero));
       expect(buttonBoxCenter.dy, equals(itemBoxCenter.dy));
     }
   });
 
-  testWidgets('DropdownButtonFormField with isDense:true does not clip large scale text', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField with isDense:true does not clip large scale text',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
     const String value = 'two';
 
     await tester.pumpWidget(
       TestApp(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: DropdownButtonFormField<String>(
-              key: buttonKey,
-              value: value,
-              onChanged: onChanged,
-              items: menuItems.map<DropdownMenuItem<String>>((String item) {
-                return DropdownMenuItem<String>(
-                  key: ValueKey<String>(item),
-                  value: item,
-                  child: Text(item, key: ValueKey<String>('${item}Text'),
-                      textScaleFactor: 3.0, style: const TextStyle(fontSize: 20.0)),
-                );
-              }).toList(),
+        child: Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaleFactor: 3.0),
+            child: Material(
+              child: Center(
+                child: DropdownButtonFormField<String>(
+                  key: buttonKey,
+                  value: value,
+                  onChanged: onChanged,
+                  isDense: true,
+                  items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                    return DropdownMenuItem<String>(
+                      key: ValueKey<String>(item),
+                      value: item,
+                      child: Text(item,
+                          key: ValueKey<String>('${item}Text'),
+                          style: const TextStyle(fontSize: 20.0)),
+                    );
+                  }).toList(),
+                ),
+              ),
             ),
           ),
         ),
       ),
     );
 
-    final RenderBox box = tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
-    expect(box.size.height, 60.0);
+    final RenderBox box =
+        tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    expect(box.size.height, 72.0);
   });
 
-  testWidgets('DropdownButtonFormField.isDense is true by default', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField.isDense is true by default',
+      (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/46844
     final Key buttonKey = UniqueKey();
     const String value = 'two';
@@ -625,11 +660,13 @@ void main() {
       ),
     );
 
-    final RenderBox box = tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    final RenderBox box =
+        tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
     expect(box.size.height, 48.0);
   });
 
-  testWidgets('DropdownButtonFormField - custom text style', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - custom text style',
+      (WidgetTester tester) async {
     const String value = 'foo';
     final UniqueKey itemKey = UniqueKey();
 
@@ -646,7 +683,7 @@ void main() {
                 child: const Text(value),
               ),
             ],
-            onChanged: (_) { },
+            onChanged: (_) {},
             style: const TextStyle(
               color: Colors.amber,
               fontSize: 20.0,
@@ -667,10 +704,12 @@ void main() {
     expect(richText.text.style!.fontSize, 20.0);
   });
 
-  testWidgets('DropdownButtonFormField - disabledHint displays when the items list is empty, when items is null', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - disabledHint displays when the items list is empty, when items is null',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items }) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -679,6 +718,7 @@ void main() {
         disabledHint: const Text('disabled'),
       );
     }
+
     // [disabledHint] should display when [items] is null
     await tester.pumpWidget(build());
     expect(find.text('enabled'), findsNothing);
@@ -696,7 +736,7 @@ void main() {
     (WidgetTester tester) async {
       final Key buttonKey = UniqueKey();
 
-      Widget build({ List<String>? items }) {
+      Widget build({List<String>? items}) {
         return buildFormFrame(
           items: items,
           buttonKey: buttonKey,
@@ -704,6 +744,7 @@ void main() {
           hint: const Text('hint used when disabled'),
         );
       }
+
       // [hint] should display when [items] is null and [disabledHint] is not defined
       await tester.pumpWidget(build());
       expect(find.text('hint used when disabled'), findsOneWidget);
@@ -714,10 +755,11 @@ void main() {
     },
   );
 
-  testWidgets('DropdownButtonFormField - disabledHint is null by default', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - disabledHint is null by default',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items }) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -725,6 +767,7 @@ void main() {
         hint: const Text('hint used when disabled'),
       );
     }
+
     // [hint] should display when [items] is null and [disabledHint] is not defined
     await tester.pumpWidget(build());
     expect(find.text('hint used when disabled'), findsOneWidget);
@@ -734,10 +777,11 @@ void main() {
     expect(find.text('hint used when disabled'), findsOneWidget);
   });
 
-  testWidgets('DropdownButtonFormField - disabledHint is null by default', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - disabledHint is null by default',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items }) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -745,6 +789,7 @@ void main() {
         hint: const Text('hint used when disabled'),
       );
     }
+
     // [hint] should display when [items] is null and [disabledHint] is not defined
     await tester.pumpWidget(build());
     expect(find.text('hint used when disabled'), findsOneWidget);
@@ -754,10 +799,12 @@ void main() {
     expect(find.text('hint used when disabled'), findsOneWidget);
   });
 
-  testWidgets('DropdownButtonFormField - disabledHint displays when onChanged is null', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - disabledHint displays when onChanged is null',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items, ValueChanged<String?>? onChanged }) {
+    Widget build({List<String>? items, ValueChanged<String?>? onChanged}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -767,15 +814,18 @@ void main() {
         disabledHint: const Text('disabled'),
       );
     }
+
     await tester.pumpWidget(build(items: menuItems));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
   });
 
-  testWidgets('DropdownButtonFormField - disabled hint should be of same size as enabled hint', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - disabled hint should be of same size as enabled hint',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items}) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -784,6 +834,7 @@ void main() {
         disabledHint: const Text('disabled'),
       );
     }
+
     await tester.pumpWidget(build());
     final RenderBox disabledHintBox = tester.renderObject<RenderBox>(
       find.byKey(buttonKey),
@@ -793,11 +844,13 @@ void main() {
     final RenderBox enabledHintBox = tester.renderObject<RenderBox>(
       find.byKey(buttonKey),
     );
-    expect(enabledHintBox.localToGlobal(Offset.zero), equals(disabledHintBox.localToGlobal(Offset.zero)));
+    expect(enabledHintBox.localToGlobal(Offset.zero),
+        equals(disabledHintBox.localToGlobal(Offset.zero)));
     expect(enabledHintBox.size, equals(disabledHintBox.size));
   });
 
-  testWidgets('DropdownButtonFormField - Custom icon size and colors', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - Custom icon size and colors',
+      (WidgetTester tester) async {
     final Key iconKey = UniqueKey();
     final Icon customIcon = Icon(Icons.assessment, key: iconKey);
 
@@ -814,7 +867,8 @@ void main() {
     expect(icon.size, const Size(30.0, 30.0));
 
     // test for enabled color
-    final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
+    final RichText enabledRichText =
+        tester.widget<RichText>(_iconRichText(iconKey));
     expect(enabledRichText.text.style!.color, Colors.pink);
 
     // test for disabled color
@@ -826,11 +880,13 @@ void main() {
       items: null,
     ));
 
-    final RichText disabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
+    final RichText disabledRichText =
+        tester.widget<RichText>(_iconRichText(iconKey));
     expect(disabledRichText.text.style!.color, Colors.orange);
   });
 
-  testWidgets('DropdownButtonFormField - default elevation', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - default elevation',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
     debugDisableShadows = false;
     await tester.pumpWidget(buildFormFrame(
@@ -840,17 +896,20 @@ void main() {
     await tester.tap(find.byKey(buttonKey));
     await tester.pumpAndSettle();
 
-    final Finder customPaint = find.ancestor(
-      of: find.text('one').last,
-      matching: find.byType(CustomPaint),
-    ).last;
+    final Finder customPaint = find
+        .ancestor(
+          of: find.text('one').last,
+          matching: find.byType(CustomPaint),
+        )
+        .last;
 
     // Verifying whether or not default elevation(i.e. 8) paints desired shadow
     verifyPaintedShadow(customPaint, 8);
     debugDisableShadows = true;
   });
 
-  testWidgets('DropdownButtonFormField - custom elevation', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - custom elevation',
+      (WidgetTester tester) async {
     debugDisableShadows = false;
     final Key buttonKeyOne = UniqueKey();
     final Key buttonKeyTwo = UniqueKey();
@@ -863,10 +922,12 @@ void main() {
     await tester.tap(find.byKey(buttonKeyOne));
     await tester.pumpAndSettle();
 
-    final Finder customPaintOne = find.ancestor(
-      of: find.text('one').last,
-      matching: find.byType(CustomPaint),
-    ).last;
+    final Finder customPaintOne = find
+        .ancestor(
+          of: find.text('one').last,
+          matching: find.byType(CustomPaint),
+        )
+        .last;
 
     verifyPaintedShadow(customPaintOne, 16);
     await tester.tap(find.text('one').last);
@@ -878,23 +939,30 @@ void main() {
     await tester.tap(find.byKey(buttonKeyTwo));
     await tester.pumpAndSettle();
 
-    final Finder customPaintTwo = find.ancestor(
-      of: find.text('one').last,
-      matching: find.byType(CustomPaint),
-    ).last;
+    final Finder customPaintTwo = find
+        .ancestor(
+          of: find.text('one').last,
+          matching: find.byType(CustomPaint),
+        )
+        .last;
 
     verifyPaintedShadow(customPaintTwo, 24);
     debugDisableShadows = true;
   });
 
-  testWidgets('DropdownButtonFormField does not allow duplicate item values', (WidgetTester tester) async {
-    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'c']
-      .map<DropdownMenuItem<String>>((String value) {
-        return DropdownMenuItem<String>(
-          value: value,
-          child: Text(value),
-        );
-      }).toList();
+  testWidgets('DropdownButtonFormField does not allow duplicate item values',
+      (WidgetTester tester) async {
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>[
+      'a',
+      'b',
+      'c',
+      'c'
+    ].map<DropdownMenuItem<String>>((String value) {
+      return DropdownMenuItem<String>(
+        value: value,
+        child: Text(value),
+      );
+    }).toList();
 
     await expectLater(
       () => tester.pumpWidget(
@@ -911,19 +979,26 @@ void main() {
       throwsA(isAssertionError.having(
         (AssertionError error) => error.toString(),
         '.toString()',
-        contains("There should be exactly one item with [DropdownButton]'s value"),
+        contains(
+            "There should be exactly one item with [DropdownButton]'s value"),
       )),
     );
   });
 
-  testWidgets('DropdownButtonFormField value should only appear in one menu item', (WidgetTester tester) async {
-    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'd']
-      .map<DropdownMenuItem<String>>((String value) {
-        return DropdownMenuItem<String>(
-          value: value,
-          child: Text(value),
-        );
-      }).toList();
+  testWidgets(
+      'DropdownButtonFormField value should only appear in one menu item',
+      (WidgetTester tester) async {
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>[
+      'a',
+      'b',
+      'c',
+      'd'
+    ].map<DropdownMenuItem<String>>((String value) {
+      return DropdownMenuItem<String>(
+        value: value,
+        child: Text(value),
+      );
+    }).toList();
 
     await expectLater(
       () => tester.pumpWidget(
@@ -940,12 +1015,15 @@ void main() {
       throwsA(isAssertionError.having(
         (AssertionError error) => error.toString(),
         '.toString()',
-        contains("There should be exactly one item with [DropdownButton]'s value"),
+        contains(
+            "There should be exactly one item with [DropdownButton]'s value"),
       )),
     );
   });
 
-  testWidgets('DropdownButtonFormField - selectedItemBuilder builds custom buttons', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - selectedItemBuilder builds custom buttons',
+      (WidgetTester tester) async {
     const List<String> items = <String>[
       'One',
       'Two',
@@ -960,7 +1038,8 @@ void main() {
             home: Scaffold(
               body: DropdownButtonFormField<String>(
                 value: selectedItem,
-                onChanged: (String? string) => setState(() => selectedItem = string),
+                onChanged: (String? string) =>
+                    setState(() => selectedItem = string),
                 selectedItemBuilder: (BuildContext context) {
                   int index = 0;
                   return items.map((String string) {
@@ -989,19 +1068,23 @@ void main() {
     expect(find.text('Two as an Arabic numeral: 2'), findsOneWidget);
   });
 
-  testWidgets('DropdownButton onTap callback is called when defined', (WidgetTester tester) async {
+  testWidgets('DropdownButton onTap callback is called when defined',
+      (WidgetTester tester) async {
     int dropdownButtonTapCounter = 0;
     String? value = 'one';
     void onChanged(String? newValue) {
       value = newValue;
     }
-    void onTap() { dropdownButtonTapCounter += 1; }
+
+    void onTap() {
+      dropdownButtonTapCounter += 1;
+    }
 
     Widget build() => buildFormFrame(
-      value: value,
-      onChanged: onChanged,
-      onTap: onTap,
-    );
+          value: value,
+          onChanged: onChanged,
+          onTap: onTap,
+        );
     await tester.pumpWidget(build());
 
     expect(dropdownButtonTapCounter, 0);
@@ -1035,7 +1118,8 @@ void main() {
     expect(dropdownButtonTapCounter, 2); // Should not change.
   });
 
-  testWidgets('DropdownButtonFormField should re-render if value param changes', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField should re-render if value param changes',
+      (WidgetTester tester) async {
     String currentValue = 'two';
 
     await tester.pumpWidget(
@@ -1081,7 +1165,8 @@ void main() {
     expect(find.text(currentValue), findsOneWidget);
   });
 
-  testWidgets('autovalidateMode is passed to super', (WidgetTester tester) async {
+  testWidgets('autovalidateMode is passed to super',
+      (WidgetTester tester) async {
     int validateCalled = 0;
 
     await tester.pumpWidget(
@@ -1110,20 +1195,24 @@ void main() {
     expect(validateCalled, 1);
   });
 
-  testWidgets('DropdownButtonFormField - Custom button alignment', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - Custom button alignment',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildFormFrame(
       buttonAlignment: AlignmentDirectional.center,
       items: <String>['one'],
       value: 'one',
     ));
 
-    final RenderBox buttonBox = tester.renderObject<RenderBox>(find.byType(IndexedStack));
+    final RenderBox buttonBox =
+        tester.renderObject<RenderBox>(find.byType(IndexedStack));
     final RenderBox selectedItemBox = tester.renderObject(find.text('one'));
 
     // Should be center-center aligned.
     expect(
-      buttonBox.localToGlobal(Offset(buttonBox.size.width / 2.0, buttonBox.size.height / 2.0)),
-      selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)),
+      buttonBox.localToGlobal(
+          Offset(buttonBox.size.width / 2.0, buttonBox.size.height / 2.0)),
+      selectedItemBox.localToGlobal(Offset(
+          selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)),
     );
   });
 }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -10,9 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 const List<String> menuItems = <String>['one', 'two', 'three', 'four'];
-void onChanged<T>(T _) { }
+void onChanged<T>(T _) {}
 final Type dropdownButtonType = DropdownButton<String>(
-  onChanged: (_) { },
+  onChanged: (_) {},
   items: const <DropdownMenuItem<String>>[],
 ).runtimeType;
 
@@ -90,7 +90,8 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: widget.mediaSize),
+        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
+            .copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(
@@ -127,12 +128,15 @@ class TestApp extends StatefulWidget {
 void verifyPaintedShadow(Finder customPaint, int elevation) {
   const Rect originalRectangle = Rect.fromLTRB(0.0, 0.0, 800, 208.0);
 
-  final List<BoxShadow> boxShadows = List<BoxShadow>.generate(3, (int index) => kElevationToShadow[elevation]![index]);
+  final List<BoxShadow> boxShadows = List<BoxShadow>.generate(
+      3, (int index) => kElevationToShadow[elevation]![index]);
   final List<RRect> rrects = List<RRect>.generate(3, (int index) {
     return RRect.fromRectAndRadius(
-      originalRectangle.shift(
-        boxShadows[index].offset,
-      ).inflate(boxShadows[index].spreadRadius),
+      originalRectangle
+          .shift(
+            boxShadows[index].offset,
+          )
+          .inflate(boxShadows[index].spreadRadius),
       const Radius.circular(2.0),
     );
   });
@@ -143,7 +147,8 @@ void verifyPaintedShadow(Finder customPaint, int elevation) {
       ..save()
       ..rrect(rrect: rrects[0], color: boxShadows[0].color, hasMaskFilter: true)
       ..rrect(rrect: rrects[1], color: boxShadows[1].color, hasMaskFilter: true)
-      ..rrect(rrect: rrects[2], color: boxShadows[2].color, hasMaskFilter: true),
+      ..rrect(
+          rrect: rrects[2], color: boxShadows[2].color, hasMaskFilter: true),
   );
 }
 
@@ -200,7 +205,8 @@ void main() {
     expect(hintEmptyLabel, oneValueLabel);
   });
 
-  testWidgets('label position test - show disabledHint: disable', (WidgetTester tester) async {
+  testWidgets('label position test - show disabledHint: disable',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -212,7 +218,8 @@ void main() {
               labelText: 'labelText',
             ),
             value: value,
-            onChanged: null, // this disables the menu and shows the disabledHint.
+            onChanged:
+                null, // this disables the menu and shows the disabledHint.
             disabledHint: const Text('disabledHint'),
             items: const <DropdownMenuItem<int?>>[
               DropdownMenuItem<int?>(
@@ -238,7 +245,8 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - show disabledHint: enable + null item', (WidgetTester tester) async {
+  testWidgets('label position test - show disabledHint: enable + null item',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -263,7 +271,8 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - show disabledHint: enable + empty item', (WidgetTester tester) async {
+  testWidgets('label position test - show disabledHint: enable + empty item',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -288,7 +297,8 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - show hint: enable + empty item', (WidgetTester tester) async {
+  testWidgets('label position test - show hint: enable + empty item',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -313,7 +323,9 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 12.0));
   });
 
-  testWidgets('label position test - no hint shown: enable + no selected + disabledHint', (WidgetTester tester) async {
+  testWidgets(
+      'label position test - no hint shown: enable + no selected + disabledHint',
+      (WidgetTester tester) async {
     int? value;
 
     await tester.pumpWidget(
@@ -351,7 +363,9 @@ void main() {
     expect(hintEmptyLabel, const Offset(0.0, 24.0));
   });
 
-  testWidgets('label position test - show selected item: disabled + hint + disabledHint', (WidgetTester tester) async {
+  testWidgets(
+      'label position test - show selected item: disabled + hint + disabledHint',
+      (WidgetTester tester) async {
     const int value = 1;
 
     await tester.pumpWidget(
@@ -443,7 +457,8 @@ void main() {
     expect(nonEmptyLabel, nullValueLabel);
   });
 
-  testWidgets('DropdownButtonFormField with autovalidation test', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField with autovalidation test',
+      (WidgetTester tester) async {
     String? value = 'one';
     int validateCalled = 0;
 
@@ -492,7 +507,9 @@ void main() {
     expect(value, equals('three'));
   });
 
-  testWidgets('DropdownButtonFormField arrow icon aligns with the edge of button when expanded', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField arrow icon aligns with the edge of button when expanded',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
     // There shouldn't be overflow when expanded although list contains longer items.
@@ -527,7 +544,9 @@ void main() {
     );
   });
 
-  testWidgets('DropdownButtonFormField with isDense:true aligns selected menu item', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField with isDense:true aligns selected menu item',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
     await tester.pumpWidget(
@@ -548,57 +567,73 @@ void main() {
     // The selected dropdown item is both in menu we just popped up, and in
     // the IndexedStack contained by the dropdown button. Both of them should
     // have the same vertical center as the button.
-    final List<RenderBox> itemBoxes = tester.renderObjectList<RenderBox>(
-      find.byKey(const ValueKey<String>('two')),
-    ).toList();
+    final List<RenderBox> itemBoxes = tester
+        .renderObjectList<RenderBox>(
+          find.byKey(const ValueKey<String>('two')),
+        )
+        .toList();
     expect(itemBoxes.length, equals(2));
 
     // When isDense is true, the button's height is reduced. The menu items'
     // heights are not.
-    final List<double> itemBoxesHeight = itemBoxes.map<double>((RenderBox box) => box.size.height).toList();
+    final List<double> itemBoxesHeight =
+        itemBoxes.map<double>((RenderBox box) => box.size.height).toList();
     final double menuItemHeight = itemBoxesHeight.reduce(math.max);
     expect(menuItemHeight, greaterThanOrEqualTo(buttonBox.size.height));
 
     for (final RenderBox itemBox in itemBoxes) {
       expect(itemBox.attached, isTrue);
-      final Offset buttonBoxCenter = buttonBox.size.center(buttonBox.localToGlobal(Offset.zero));
-      final Offset itemBoxCenter = itemBox.size.center(itemBox.localToGlobal(Offset.zero));
+      final Offset buttonBoxCenter =
+          buttonBox.size.center(buttonBox.localToGlobal(Offset.zero));
+      final Offset itemBoxCenter =
+          itemBox.size.center(itemBox.localToGlobal(Offset.zero));
       expect(buttonBoxCenter.dy, equals(itemBoxCenter.dy));
     }
   });
 
-  testWidgets('DropdownButtonFormField with isDense:true does not clip large scale text', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField with isDense:true does not clip large scale text',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
     const String value = 'two';
 
     await tester.pumpWidget(
       TestApp(
         textDirection: TextDirection.ltr,
-        child: Material(
-          child: Center(
-            child: DropdownButtonFormField<String>(
-              key: buttonKey,
-              value: value,
-              onChanged: onChanged,
-              items: menuItems.map<DropdownMenuItem<String>>((String item) {
-                return DropdownMenuItem<String>(
-                  key: ValueKey<String>(item),
-                  value: item,
-                  child: Text(item, key: ValueKey<String>('${item}Text'),
-                      textScaleFactor: 3.0, style: const(TextStyle(fontSize: 20.0))),
-                );
-              }).toList(),
+        child: Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaleFactor: 3.0),
+            child: Material(
+              child: Center(
+                child: DropdownButtonFormField<String>(
+                  key: buttonKey,
+                  value: value,
+                  onChanged: onChanged,
+                  isDense: true,
+                  items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                    return DropdownMenuItem<String>(
+                      key: ValueKey<String>(item),
+                      value: item,
+                      child: Text(item,
+                          key: ValueKey<String>('${item}Text'),
+                          style: const TextStyle(fontSize: 20.0)),
+                    );
+                  }).toList(),
+                ),
+              ),
             ),
           ),
         ),
       ),
     );
 
-    final RenderBox box = tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
-    expect(box.size.height, 60.0);
+    final RenderBox box =
+        tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    expect(box.size.height, 72.0);
   });
 
-  testWidgets('DropdownButtonFormField.isDense is true by default', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField.isDense is true by default',
+      (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/46844
     final Key buttonKey = UniqueKey();
     const String value = 'two';
@@ -625,11 +660,13 @@ void main() {
       ),
     );
 
-    final RenderBox box = tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    final RenderBox box =
+        tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
     expect(box.size.height, 48.0);
   });
 
-  testWidgets('DropdownButtonFormField - custom text style', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - custom text style',
+      (WidgetTester tester) async {
     const String value = 'foo';
     final UniqueKey itemKey = UniqueKey();
 
@@ -646,7 +683,7 @@ void main() {
                 child: const Text(value),
               ),
             ],
-            onChanged: (_) { },
+            onChanged: (_) {},
             style: const TextStyle(
               color: Colors.amber,
               fontSize: 20.0,
@@ -667,10 +704,12 @@ void main() {
     expect(richText.text.style!.fontSize, 20.0);
   });
 
-  testWidgets('DropdownButtonFormField - disabledHint displays when the items list is empty, when items is null', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - disabledHint displays when the items list is empty, when items is null',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items }) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -679,6 +718,7 @@ void main() {
         disabledHint: const Text('disabled'),
       );
     }
+
     // [disabledHint] should display when [items] is null
     await tester.pumpWidget(build());
     expect(find.text('enabled'), findsNothing);
@@ -696,7 +736,7 @@ void main() {
     (WidgetTester tester) async {
       final Key buttonKey = UniqueKey();
 
-      Widget build({ List<String>? items }) {
+      Widget build({List<String>? items}) {
         return buildFormFrame(
           items: items,
           buttonKey: buttonKey,
@@ -704,6 +744,7 @@ void main() {
           hint: const Text('hint used when disabled'),
         );
       }
+
       // [hint] should display when [items] is null and [disabledHint] is not defined
       await tester.pumpWidget(build());
       expect(find.text('hint used when disabled'), findsOneWidget);
@@ -714,10 +755,11 @@ void main() {
     },
   );
 
-  testWidgets('DropdownButtonFormField - disabledHint is null by default', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - disabledHint is null by default',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items }) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -725,6 +767,7 @@ void main() {
         hint: const Text('hint used when disabled'),
       );
     }
+
     // [hint] should display when [items] is null and [disabledHint] is not defined
     await tester.pumpWidget(build());
     expect(find.text('hint used when disabled'), findsOneWidget);
@@ -734,10 +777,11 @@ void main() {
     expect(find.text('hint used when disabled'), findsOneWidget);
   });
 
-  testWidgets('DropdownButtonFormField - disabledHint is null by default', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - disabledHint is null by default',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items }) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -745,6 +789,7 @@ void main() {
         hint: const Text('hint used when disabled'),
       );
     }
+
     // [hint] should display when [items] is null and [disabledHint] is not defined
     await tester.pumpWidget(build());
     expect(find.text('hint used when disabled'), findsOneWidget);
@@ -754,10 +799,12 @@ void main() {
     expect(find.text('hint used when disabled'), findsOneWidget);
   });
 
-  testWidgets('DropdownButtonFormField - disabledHint displays when onChanged is null', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - disabledHint displays when onChanged is null',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items, ValueChanged<String?>? onChanged }) {
+    Widget build({List<String>? items, ValueChanged<String?>? onChanged}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -767,15 +814,18 @@ void main() {
         disabledHint: const Text('disabled'),
       );
     }
+
     await tester.pumpWidget(build(items: menuItems));
     expect(find.text('enabled'), findsNothing);
     expect(find.text('disabled'), findsOneWidget);
   });
 
-  testWidgets('DropdownButtonFormField - disabled hint should be of same size as enabled hint', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - disabled hint should be of same size as enabled hint',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
 
-    Widget build({ List<String>? items}) {
+    Widget build({List<String>? items}) {
       return buildFormFrame(
         items: items,
         buttonKey: buttonKey,
@@ -784,6 +834,7 @@ void main() {
         disabledHint: const Text('disabled'),
       );
     }
+
     await tester.pumpWidget(build());
     final RenderBox disabledHintBox = tester.renderObject<RenderBox>(
       find.byKey(buttonKey),
@@ -793,11 +844,13 @@ void main() {
     final RenderBox enabledHintBox = tester.renderObject<RenderBox>(
       find.byKey(buttonKey),
     );
-    expect(enabledHintBox.localToGlobal(Offset.zero), equals(disabledHintBox.localToGlobal(Offset.zero)));
+    expect(enabledHintBox.localToGlobal(Offset.zero),
+        equals(disabledHintBox.localToGlobal(Offset.zero)));
     expect(enabledHintBox.size, equals(disabledHintBox.size));
   });
 
-  testWidgets('DropdownButtonFormField - Custom icon size and colors', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - Custom icon size and colors',
+      (WidgetTester tester) async {
     final Key iconKey = UniqueKey();
     final Icon customIcon = Icon(Icons.assessment, key: iconKey);
 
@@ -814,7 +867,8 @@ void main() {
     expect(icon.size, const Size(30.0, 30.0));
 
     // test for enabled color
-    final RichText enabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
+    final RichText enabledRichText =
+        tester.widget<RichText>(_iconRichText(iconKey));
     expect(enabledRichText.text.style!.color, Colors.pink);
 
     // test for disabled color
@@ -826,11 +880,13 @@ void main() {
       items: null,
     ));
 
-    final RichText disabledRichText = tester.widget<RichText>(_iconRichText(iconKey));
+    final RichText disabledRichText =
+        tester.widget<RichText>(_iconRichText(iconKey));
     expect(disabledRichText.text.style!.color, Colors.orange);
   });
 
-  testWidgets('DropdownButtonFormField - default elevation', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - default elevation',
+      (WidgetTester tester) async {
     final Key buttonKey = UniqueKey();
     debugDisableShadows = false;
     await tester.pumpWidget(buildFormFrame(
@@ -840,17 +896,20 @@ void main() {
     await tester.tap(find.byKey(buttonKey));
     await tester.pumpAndSettle();
 
-    final Finder customPaint = find.ancestor(
-      of: find.text('one').last,
-      matching: find.byType(CustomPaint),
-    ).last;
+    final Finder customPaint = find
+        .ancestor(
+          of: find.text('one').last,
+          matching: find.byType(CustomPaint),
+        )
+        .last;
 
     // Verifying whether or not default elevation(i.e. 8) paints desired shadow
     verifyPaintedShadow(customPaint, 8);
     debugDisableShadows = true;
   });
 
-  testWidgets('DropdownButtonFormField - custom elevation', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - custom elevation',
+      (WidgetTester tester) async {
     debugDisableShadows = false;
     final Key buttonKeyOne = UniqueKey();
     final Key buttonKeyTwo = UniqueKey();
@@ -863,10 +922,12 @@ void main() {
     await tester.tap(find.byKey(buttonKeyOne));
     await tester.pumpAndSettle();
 
-    final Finder customPaintOne = find.ancestor(
-      of: find.text('one').last,
-      matching: find.byType(CustomPaint),
-    ).last;
+    final Finder customPaintOne = find
+        .ancestor(
+          of: find.text('one').last,
+          matching: find.byType(CustomPaint),
+        )
+        .last;
 
     verifyPaintedShadow(customPaintOne, 16);
     await tester.tap(find.text('one').last);
@@ -878,23 +939,30 @@ void main() {
     await tester.tap(find.byKey(buttonKeyTwo));
     await tester.pumpAndSettle();
 
-    final Finder customPaintTwo = find.ancestor(
-      of: find.text('one').last,
-      matching: find.byType(CustomPaint),
-    ).last;
+    final Finder customPaintTwo = find
+        .ancestor(
+          of: find.text('one').last,
+          matching: find.byType(CustomPaint),
+        )
+        .last;
 
     verifyPaintedShadow(customPaintTwo, 24);
     debugDisableShadows = true;
   });
 
-  testWidgets('DropdownButtonFormField does not allow duplicate item values', (WidgetTester tester) async {
-    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'c']
-      .map<DropdownMenuItem<String>>((String value) {
-        return DropdownMenuItem<String>(
-          value: value,
-          child: Text(value),
-        );
-      }).toList();
+  testWidgets('DropdownButtonFormField does not allow duplicate item values',
+      (WidgetTester tester) async {
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>[
+      'a',
+      'b',
+      'c',
+      'c'
+    ].map<DropdownMenuItem<String>>((String value) {
+      return DropdownMenuItem<String>(
+        value: value,
+        child: Text(value),
+      );
+    }).toList();
 
     await expectLater(
       () => tester.pumpWidget(
@@ -911,19 +979,26 @@ void main() {
       throwsA(isAssertionError.having(
         (AssertionError error) => error.toString(),
         '.toString()',
-        contains("There should be exactly one item with [DropdownButton]'s value"),
+        contains(
+            "There should be exactly one item with [DropdownButton]'s value"),
       )),
     );
   });
 
-  testWidgets('DropdownButtonFormField value should only appear in one menu item', (WidgetTester tester) async {
-    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>['a', 'b', 'c', 'd']
-      .map<DropdownMenuItem<String>>((String value) {
-        return DropdownMenuItem<String>(
-          value: value,
-          child: Text(value),
-        );
-      }).toList();
+  testWidgets(
+      'DropdownButtonFormField value should only appear in one menu item',
+      (WidgetTester tester) async {
+    final List<DropdownMenuItem<String>> itemsWithDuplicateValues = <String>[
+      'a',
+      'b',
+      'c',
+      'd'
+    ].map<DropdownMenuItem<String>>((String value) {
+      return DropdownMenuItem<String>(
+        value: value,
+        child: Text(value),
+      );
+    }).toList();
 
     await expectLater(
       () => tester.pumpWidget(
@@ -940,12 +1015,15 @@ void main() {
       throwsA(isAssertionError.having(
         (AssertionError error) => error.toString(),
         '.toString()',
-        contains("There should be exactly one item with [DropdownButton]'s value"),
+        contains(
+            "There should be exactly one item with [DropdownButton]'s value"),
       )),
     );
   });
 
-  testWidgets('DropdownButtonFormField - selectedItemBuilder builds custom buttons', (WidgetTester tester) async {
+  testWidgets(
+      'DropdownButtonFormField - selectedItemBuilder builds custom buttons',
+      (WidgetTester tester) async {
     const List<String> items = <String>[
       'One',
       'Two',
@@ -960,7 +1038,8 @@ void main() {
             home: Scaffold(
               body: DropdownButtonFormField<String>(
                 value: selectedItem,
-                onChanged: (String? string) => setState(() => selectedItem = string),
+                onChanged: (String? string) =>
+                    setState(() => selectedItem = string),
                 selectedItemBuilder: (BuildContext context) {
                   int index = 0;
                   return items.map((String string) {
@@ -989,19 +1068,23 @@ void main() {
     expect(find.text('Two as an Arabic numeral: 2'), findsOneWidget);
   });
 
-  testWidgets('DropdownButton onTap callback is called when defined', (WidgetTester tester) async {
+  testWidgets('DropdownButton onTap callback is called when defined',
+      (WidgetTester tester) async {
     int dropdownButtonTapCounter = 0;
     String? value = 'one';
     void onChanged(String? newValue) {
       value = newValue;
     }
-    void onTap() { dropdownButtonTapCounter += 1; }
+
+    void onTap() {
+      dropdownButtonTapCounter += 1;
+    }
 
     Widget build() => buildFormFrame(
-      value: value,
-      onChanged: onChanged,
-      onTap: onTap,
-    );
+          value: value,
+          onChanged: onChanged,
+          onTap: onTap,
+        );
     await tester.pumpWidget(build());
 
     expect(dropdownButtonTapCounter, 0);
@@ -1035,7 +1118,8 @@ void main() {
     expect(dropdownButtonTapCounter, 2); // Should not change.
   });
 
-  testWidgets('DropdownButtonFormField should re-render if value param changes', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField should re-render if value param changes',
+      (WidgetTester tester) async {
     String currentValue = 'two';
 
     await tester.pumpWidget(
@@ -1081,7 +1165,8 @@ void main() {
     expect(find.text(currentValue), findsOneWidget);
   });
 
-  testWidgets('autovalidateMode is passed to super', (WidgetTester tester) async {
+  testWidgets('autovalidateMode is passed to super',
+      (WidgetTester tester) async {
     int validateCalled = 0;
 
     await tester.pumpWidget(
@@ -1110,20 +1195,24 @@ void main() {
     expect(validateCalled, 1);
   });
 
-  testWidgets('DropdownButtonFormField - Custom button alignment', (WidgetTester tester) async {
+  testWidgets('DropdownButtonFormField - Custom button alignment',
+      (WidgetTester tester) async {
     await tester.pumpWidget(buildFormFrame(
       buttonAlignment: AlignmentDirectional.center,
       items: <String>['one'],
       value: 'one',
     ));
 
-    final RenderBox buttonBox = tester.renderObject<RenderBox>(find.byType(IndexedStack));
+    final RenderBox buttonBox =
+        tester.renderObject<RenderBox>(find.byType(IndexedStack));
     final RenderBox selectedItemBox = tester.renderObject(find.text('one'));
 
     // Should be center-center aligned.
     expect(
-      buttonBox.localToGlobal(Offset(buttonBox.size.width / 2.0, buttonBox.size.height / 2.0)),
-      selectedItemBox.localToGlobal(Offset(selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)),
+      buttonBox.localToGlobal(
+          Offset(buttonBox.size.width / 2.0, buttonBox.size.height / 2.0)),
+      selectedItemBox.localToGlobal(Offset(
+          selectedItemBox.size.width / 2.0, selectedItemBox.size.height / 2.0)),
     );
   });
 }

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -585,7 +585,7 @@ void main() {
                   key: ValueKey<String>(item),
                   value: item,
                   child: Text(item, key: ValueKey<String>('${item}Text'),
-                      textScaleFactor: 3.0, style: const(TextStyle(fontSize: 20.0))),
+                      textScaleFactor: 3.0, style: const TextStyle(fontSize: 20.0)),
                 );
               }).toList(),
             ),


### PR DESCRIPTION
This PR fixes the problem where large scale text gets cut off in the dropdown button. The current calculation of height of the button only uses fontsize, but I scaled the fontsize according to text scale also.

Fixes #106359