### PR TITLE
Fix `Scaffold` `setState` during locked framework due to open drawer

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2029,7 +2029,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   bool get isEndDrawerOpen => _endDrawerOpened.value;
 
   void _drawerOpenedCallback(bool isOpened) {
-    if (_drawerOpened.value != isOpened) {
+    if (_drawerOpened.value != isOpened && _drawerKey.currentState != null) {
       setState(() {
         _drawerOpened.value = isOpened;
       });
@@ -2038,7 +2038,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   }
 
   void _endDrawerOpenedCallback(bool isOpened) {
-    if (_endDrawerOpened.value != isOpened) {
+    if (_endDrawerOpened.value != isOpened && _endDrawerKey.currentState != null) {
       setState(() {
         _endDrawerOpened.value = isOpened;
       });

--- a/packages/flutter/test/material/drawer_test.dart
+++ b/packages/flutter/test/material/drawer_test.dart
@@ -422,6 +422,87 @@ void main() {
     expect(find.text('Drawer'), findsNothing);
   });
 
+  testWidgets('Disposing drawer does not crash if drawer is open and framework is locked', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/34978
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    tester.binding.window.physicalSizeTestValue = const Size(1800.0, 2400.0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OrientationBuilder(
+          builder: (BuildContext context, Orientation orientation) {
+            switch (orientation) {
+              case Orientation.portrait:
+                return Scaffold(
+                  drawer: const Text('drawer'),
+                  body: Container(),
+                );
+              case Orientation.landscape:
+                return Scaffold(
+                  appBar: AppBar(),
+                  body: Container(),
+                );
+            }
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('drawer'), findsNothing);
+
+    // Using a global key is a workaround for this issue.
+    final ScaffoldState portraitScaffoldState = tester.firstState(find.byType(Scaffold));
+    portraitScaffoldState.openDrawer();
+    await tester.pumpAndSettle();
+    expect(find.text('drawer'), findsOneWidget);
+
+    // Change the orientation and cause the drawer controller to be disposed
+    // while the framework is locked.
+    tester.binding.window.physicalSizeTestValue = const Size(2400.0, 1800.0);
+    await tester.pumpAndSettle();
+    expect(find.byType(BackButton), findsNothing);
+  });
+
+  testWidgets('Disposing endDrawer does not crash if endDrawer is open and framework is locked', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/34978
+    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
+    tester.binding.window.physicalSizeTestValue = const Size(1800.0, 2400.0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: OrientationBuilder(
+          builder: (BuildContext context, Orientation orientation) {
+            switch (orientation) {
+              case Orientation.portrait:
+                return Scaffold(
+                  endDrawer: const Text('endDrawer'),
+                  body: Container(),
+                );
+              case Orientation.landscape:
+                return Scaffold(
+                  appBar: AppBar(),
+                  body: Container(),
+                );
+            }
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('endDrawer'), findsNothing);
+
+    // Using a global key is a workaround for this issue.
+    final ScaffoldState portraitScaffoldState = tester.firstState(find.byType(Scaffold));
+    portraitScaffoldState.openEndDrawer();
+    await tester.pumpAndSettle();
+    expect(find.text('endDrawer'), findsOneWidget);
+
+    // Change the orientation and cause the drawer controller to be disposed
+    // while the framework is locked.
+    tester.binding.window.physicalSizeTestValue = const Size(2400.0, 1800.0);
+    await tester.pumpAndSettle();
+    expect(find.byType(BackButton), findsNothing);
+  });
 
   testWidgets('ScaffoldState close end drawer', (WidgetTester tester) async {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();


### PR DESCRIPTION
When the drawer is open and gets disposed during locked framework it still removes its controller history entry in `dispose`, leading to a `setState` response in `Scaffold` to close the drawer. This led to an exception and a broken `BackButton` in the `AppBar` in certain situations. 

This PR adds a check before the drawer and endDrawer opened callback `setState` to ensure that the drawer state still exists to avoid the issue. I considered adding it to a post-frame callback but it runs into the issue of the scaffold being disposed along with the drawer and then triggering setState for a disposed state.

Fixes https://github.com/flutter/flutter/issues/34978

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
