### PR TITLE
Add build-after-edit benchmark

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1334,11 +1334,11 @@ class CompileTest {
         ...compileSecondDebug,
       };
 
-      final mainDart = File(testDirectory + "/lib/main.dart");
+      final File mainDart = File('$testDirectory/lib/main.dart');
       if (mainDart.existsSync()) {
-        final bytes = mainDart.readAsBytesSync();
+        final List<int> bytes = mainDart.readAsBytesSync();
         // "Touch" the file
-        mainDart.writeAsStringSync(" ", mode: FileMode.append, flush: true);
+        mainDart.writeAsStringSync(' ', mode: FileMode.append, flush: true);
         // Build after "edit" without clean should be faster than first build
         final Map<String, dynamic> compileAfterEditDebug = await _compileDebug(
           clean: false,
@@ -1347,7 +1347,7 @@ class CompileTest {
         metrics.addAll(compileAfterEditDebug);
         // Revert the changes
         mainDart.writeAsBytesSync(bytes, flush: true);
-      };
+      }
 
       return TaskResult.success(metrics, benchmarkScoreKeys: metrics.keys.toList());
     });

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1328,6 +1328,7 @@ class CompileTest {
         clean: false,
         metricKey: 'debug_second_compile_millis',
       );
+
       final Map<String, dynamic> metrics = <String, dynamic>{
         ...compileRelease,
         ...compileDebug,

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1328,11 +1328,25 @@ class CompileTest {
         clean: false,
         metricKey: 'debug_second_compile_millis',
       );
-
       final Map<String, dynamic> metrics = <String, dynamic>{
         ...compileRelease,
         ...compileDebug,
         ...compileSecondDebug,
+      };
+
+      final mainDart = File(testDirectory + "/lib/main.dart");
+      if (mainDart.existsSync()) {
+        final bytes = mainDart.readAsBytesSync();
+        // "Touch" the file
+        mainDart.writeAsStringSync(" ", mode: FileMode.append, flush: true);
+        // Build after "edit" without clean should be faster than first build
+        final Map<String, dynamic> compileAfterEditDebug = await _compileDebug(
+          clean: false,
+          metricKey: 'debug_compile_after_edit_millis',
+        );
+        metrics.addAll(compileAfterEditDebug);
+        // Revert the changes
+        mainDart.writeAsBytesSync(bytes, flush: true);
       };
 
       return TaskResult.success(metrics, benchmarkScoreKeys: metrics.keys.toList());


### PR DESCRIPTION
This adds new compile benchmark that measures performance of repeated build after edit.

This captures potential for performance improvements identified in https://github.com/flutter/flutter/issues/107183.