### PR TITLE
Dropdown height large scale text fix

### DIFF
--- a/packages/flutter/lib/src/material/dropdown.dart
+++ b/packages/flutter/lib/src/material/dropdown.dart
@@ -1331,8 +1331,10 @@ class _DropdownButtonState<T> extends State<DropdownButton<T>> with WidgetsBindi
   // Similarly, we don't reduce the height of the button so much that its icon
   // would be clipped.
   double get _denseButtonHeight {
+    final double textScaleFactor = MediaQuery.of(context).textScaleFactor;
     final double fontSize = _textStyle!.fontSize ?? Theme.of(context).textTheme.subtitle1!.fontSize!;
-    return math.max(fontSize, math.max(widget.iconSize, _kDenseButtonHeight));
+    final double scaledFontSize = textScaleFactor * fontSize;
+    return math.max(scaledFontSize, math.max(widget.iconSize, _kDenseButtonHeight));
   }
 
   Color get _iconColor {

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -567,6 +567,45 @@ void main() {
     }
   });
 
+  testWidgets('DropdownButtonFormField with isDense:true does not clip large scale text',
+      (WidgetTester tester) async {
+    final Key buttonKey = UniqueKey();
+    const String value = 'two';
+
+    await tester.pumpWidget(
+      TestApp(
+        textDirection: TextDirection.ltr,
+        child: Builder(
+          builder: (BuildContext context) => MediaQuery(
+            data: MediaQuery.of(context).copyWith(textScaleFactor: 3.0),
+            child: Material(
+              child: Center(
+                child: DropdownButtonFormField<String>(
+                  key: buttonKey,
+                  value: value,
+                  onChanged: onChanged,
+                  items: menuItems.map<DropdownMenuItem<String>>((String item) {
+                    return DropdownMenuItem<String>(
+                      key: ValueKey<String>(item),
+                      value: item,
+                      child: Text(item,
+                          key: ValueKey<String>('${item}Text'),
+                          style: const TextStyle(fontSize: 20.0)),
+                    );
+                  }).toList(),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final RenderBox box =
+    tester.renderObject<RenderBox>(find.byType(dropdownButtonType));
+    expect(box.size.height, 72.0);
+  });
+
   testWidgets('DropdownButtonFormField.isDense is true by default', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/46844
     final Key buttonKey = UniqueKey();


### PR DESCRIPTION
This PR fixes the problem where large scale text gets cut off in the dropdown button. The current calculation of height of the button only uses fontSize, which does not reflect the actual size of the text when a text scale factor of more than 1.0 is specified. 

To fix this problem, I scaled the fontSize according to text scale, before using this new text size to calculate the button height.

Fixes https://github.com/flutter/flutter/issues/106359