### PR TITLE
Make the cursor no longer blinking when move, as same as the effect of iOS platform.

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2185,8 +2185,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           _onFloatingCursorResetTick();
         }
         // Stop cursor blinking and making it visable.
-        _stopCursorTimer(resetCharTicks: false);
-        _cursorBlinkOpacityController!.value = 1.0;
+        _stopCursorBlink(resetCharTicks: false);
+        _cursorBlinkOpacityController.value = 1.0;
         // We want to send in points that are centered around a (0,0) origin, so
         // we cache the position.
         _pointOffsetOrigin = point.offset;
@@ -2208,7 +2208,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         break;
       case FloatingCursorDragState.End:
         // Resume cursor blinking
-        _startCursorTimer();
+        _startCursorBlink();
         // We skip animation if no update has happened.
         if (_lastTextPosition != null && _lastBoundedOffset != null) {
           _floatingCursorResetController!.value = 0.0;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2187,7 +2187,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         // Stop cursor blinking and making it visable.
         _stopCursorTimer();
         _cursorBlinkOpacityController!.value = 1.0;
-        
         // We want to send in points that are centered around a (0,0) origin, so
         // we cache the position.
         _pointOffsetOrigin = point.offset;
@@ -2210,7 +2209,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       case FloatingCursorDragState.End:
         // Resume cursor blinking
         _startCursorTimer();
-        
         // We skip animation if no update has happened.
         if (_lastTextPosition != null && _lastBoundedOffset != null) {
           _floatingCursorResetController!.value = 0.0;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2184,6 +2184,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           _floatingCursorResetController!.stop();
           _onFloatingCursorResetTick();
         }
+        // Stop cursor blinking and making it visable.
+        _stopCursorTimer();
+        _cursorBlinkOpacityController!.value = 1.0;
+        
         // We want to send in points that are centered around a (0,0) origin, so
         // we cache the position.
         _pointOffsetOrigin = point.offset;
@@ -2193,7 +2197,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
         _lastBoundedOffset = _startCaretRect!.center - _floatingCursorOffset;
         _lastTextPosition = currentTextPosition;
-        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
+        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!, resetLerpValue: _floatingCursorResetController!.value);
         break;
       case FloatingCursorDragState.Update:
         final Offset centeredPoint = point.offset! - _pointOffsetOrigin!;
@@ -2201,9 +2205,12 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
         _lastBoundedOffset = renderEditable.calculateBoundedFloatingCursorOffset(rawCursorOffset);
         _lastTextPosition = renderEditable.getPositionForPoint(renderEditable.localToGlobal(_lastBoundedOffset! + _floatingCursorOffset));
-        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
+        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!, resetLerpValue: _floatingCursorResetController!.value);
         break;
       case FloatingCursorDragState.End:
+        // Resume cursor blinking
+        _startCursorTimer();
+        
         // We skip animation if no update has happened.
         if (_lastTextPosition != null && _lastBoundedOffset != null) {
           _floatingCursorResetController!.value = 0.0;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2185,7 +2185,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           _onFloatingCursorResetTick();
         }
         // Stop cursor blinking and making it visable.
-        _stopCursorTimer();
+        _stopCursorTimer(resetCharTicks: false);
         _cursorBlinkOpacityController!.value = 1.0;
         // We want to send in points that are centered around a (0,0) origin, so
         // we cache the position.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2184,7 +2184,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           _floatingCursorResetController!.stop();
           _onFloatingCursorResetTick();
         }
-        // Stop cursor blinking and making it visable.
+        // Stop cursor blinking and making it visible.
         _stopCursorBlink(resetCharTicks: false);
         _cursorBlinkOpacityController.value = 1.0;
         // We want to send in points that are centered around a (0,0) origin, so
@@ -2207,7 +2207,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
         break;
       case FloatingCursorDragState.End:
-        // Resume cursor blinking
+        // Resume cursor blinking.
         _startCursorBlink();
         // We skip animation if no update has happened.
         if (_lastTextPosition != null && _lastBoundedOffset != null) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2196,7 +2196,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
         _lastBoundedOffset = _startCaretRect!.center - _floatingCursorOffset;
         _lastTextPosition = currentTextPosition;
-        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!, resetLerpValue: _floatingCursorResetController!.value);
+        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
         break;
       case FloatingCursorDragState.Update:
         final Offset centeredPoint = point.offset! - _pointOffsetOrigin!;
@@ -2204,7 +2204,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
         _lastBoundedOffset = renderEditable.calculateBoundedFloatingCursorOffset(rawCursorOffset);
         _lastTextPosition = renderEditable.getPositionForPoint(renderEditable.localToGlobal(_lastBoundedOffset! + _floatingCursorOffset));
-        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!, resetLerpValue: _floatingCursorResetController!.value);
+        renderEditable.setFloatingCursor(point.state, _lastBoundedOffset!, _lastTextPosition!);
         break;
       case FloatingCursorDragState.End:
         // Resume cursor blinking

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -731,7 +731,10 @@ void main() {
     // Check that the cursor visibility toggles after each blink interval.
     // Or if it's not blinking at all, it stays on.
     Future<void> checkCursorBlinking({ bool isBlinking = true }) async {
-      final bool initialShowCursor = isBlinking ? editableText.cursorCurrentlyVisible : true;
+      bool initialShowCursor = true;
+      if (isBlinking) {
+        initialShowCursor = editableText.cursorCurrentlyVisible;
+      }
       await tester.pump(editableText.cursorBlinkInterval);
       expect(editableText.cursorCurrentlyVisible, equals(isBlinking ? !initialShowCursor : initialShowCursor));
       await tester.pump(editableText.cursorBlinkInterval);

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -729,31 +729,17 @@ void main() {
     final EditableTextState editableText = tester.state(find.byType(EditableText));
 
     // Check that the cursor visibility toggles after each blink interval.
-    Future<void> checkCursorBinking() async {
-      final bool initialShowCursor = editableText.cursorCurrentlyVisible;
+    // Or if it's not blinking at all, it stays on.
+    Future<void> checkCursorBlinking({ bool isBlinking = true }) async {
+      final bool initialShowCursor = isBlinking ? editableText.cursorCurrentlyVisible : true;
       await tester.pump(editableText.cursorBlinkInterval);
-      expect(editableText.cursorCurrentlyVisible, equals(!initialShowCursor));
-      await tester.pump(editableText.cursorBlinkInterval);
-      expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
-      await tester.pump(editableText.cursorBlinkInterval ~/ 10);
-      expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
-      await tester.pump(editableText.cursorBlinkInterval);
-      expect(editableText.cursorCurrentlyVisible, equals(!initialShowCursor));
-      await tester.pump(editableText.cursorBlinkInterval);
-      expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
-    }
-
-    // Check that the cursor no blinking.
-    Future<void> checkCursorNoBlinking() async {
-      const bool initialShowCursor = true;
-      await tester.pump(editableText.cursorBlinkInterval);
-      expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
+      expect(editableText.cursorCurrentlyVisible, equals(isBlinking ? !initialShowCursor : initialShowCursor));
       await tester.pump(editableText.cursorBlinkInterval);
       expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
       await tester.pump(editableText.cursorBlinkInterval ~/ 10);
       expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
       await tester.pump(editableText.cursorBlinkInterval);
-      expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
+      expect(editableText.cursorCurrentlyVisible, equals(isBlinking ? !initialShowCursor : initialShowCursor));
       await tester.pump(editableText.cursorBlinkInterval);
       expect(editableText.cursorCurrentlyVisible, equals(initialShowCursor));
     }
@@ -764,19 +750,19 @@ void main() {
     await tester.pumpAndSettle();
 
     // Before dragging, the cursor should blink.
-    await checkCursorBinking();
+    await checkCursorBlinking();
 
     final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
     editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.Start));
 
     // When drag cursor, the cursor shouldn't blink.
-    await checkCursorNoBlinking();
+    await checkCursorBlinking(isBlinking: false);
 
     editableTextState.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End));
     await tester.pumpAndSettle();
 
     // After dragging, the cursor should blink.
-    await checkCursorBinking();
+    await checkCursorBlinking();
   });
 
   // Regression test for https://github.com/flutter/flutter/pull/30475.

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -901,6 +901,13 @@ void main() {
 
     expect(editable, paints
       ..rrect(
+      rrect: RRect.fromRectAndRadius(
+          const Rect.fromLTRB(463.3333435058594, -0.916666666666668, 465.3333435058594, 17.083333015441895),
+          const Radius.circular(2.0),
+        ),
+        color: const Color(0xff999999),
+      )
+      ..rrect(
         rrect: RRect.fromRectAndRadius(
           const Rect.fromLTRB(463.8333435058594, -0.916666666666668, 466.8333435058594, 19.083333969116211),
           const Radius.circular(1.0),
@@ -918,6 +925,13 @@ void main() {
     );
 
     expect(find.byType(EditableText), paints
+      ..rrect(
+        rrect: RRect.fromRectAndRadius(
+          const Rect.fromLTRB(191.3333282470703, -0.916666666666668, 193.3333282470703, 17.083333015441895),
+          const Radius.circular(2.0),
+        ),
+        color: const Color(0xff999999),
+      )
       ..rrect(
         rrect: RRect.fromRectAndRadius(
           const Rect.fromLTRB(193.83334350585938, -0.916666666666668, 196.83334350585938, 19.083333969116211),

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -901,7 +901,7 @@ void main() {
 
     expect(editable, paints
       ..rrect(
-      rrect: RRect.fromRectAndRadius(
+        rrect: RRect.fromRectAndRadius(
           const Rect.fromLTRB(463.3333435058594, -0.916666666666668, 465.3333435058594, 17.083333015441895),
           const Radius.circular(2.0),
         ),

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -11179,7 +11179,7 @@ void main() {
     // Start the floating cursor reset animation controller.
     state.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End, offset: Offset.zero));
 
-    expect(tester.binding.transientCallbackCount, 2);
+    expect(tester.binding.transientCallbackCount, 1);
 
     await tester.pumpWidget(const SizedBox());
     expect(tester.hasRunningAnimations, isFalse);

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -11179,7 +11179,7 @@ void main() {
     // Start the floating cursor reset animation controller.
     state.updateFloatingCursor(RawFloatingCursorPoint(state: FloatingCursorDragState.End, offset: Offset.zero));
 
-    expect(tester.binding.transientCallbackCount, 1);
+    expect(tester.binding.transientCallbackCount, 2);
 
     await tester.pumpWidget(const SizedBox());
     expect(tester.hasRunningAnimations, isFalse);


### PR DESCRIPTION
Fix #105454 

**Before**

https://user-images.githubusercontent.com/7621572/172214290-893f0868-0138-4c30-b8d0-ed02fada9331.mov

**After**

https://user-images.githubusercontent.com/7621572/172214298-f6a53820-1d65-4162-a21f-eae295c67342.mov

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
