### PR TITLE
Fix `ModalBarrier` drag to dismiss behavior

### DIFF
--- a/packages/flutter/lib/src/widgets/modal_barrier.dart
+++ b/packages/flutter/lib/src/widgets/modal_barrier.dart
@@ -312,6 +312,17 @@ class _ModalBarrierGestureDetector extends StatelessWidget {
   Widget build(BuildContext context) {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{
       _AnyTapGestureRecognizer: _AnyTapGestureRecognizerFactory(onAnyTapUp: onDismiss),
+      // Should dismiss the barrier when the user perform some drag.
+      VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<VerticalDragGestureRecognizer>(
+        () => VerticalDragGestureRecognizer(debugOwner: this),
+        (VerticalDragGestureRecognizer instance) {
+          instance.onUpdate = (DragUpdateDetails details) {
+            if (details.primaryDelta !> 0) {
+              onDismiss();
+            }
+          };
+        },
+      ),
     };
 
     return RawGestureDetector(

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -470,7 +470,32 @@ void main() {
 
       semantics.dispose();
     });
+
+    testWidgets('Drag to dismiss ModalBarrier', (WidgetTester tester) async {
+      final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+        '/': (BuildContext context) => const FirstWidget(),
+        '/modal': (BuildContext context) => const SecondWidget(),
+      };
+
+      await tester.pumpWidget(MaterialApp(routes: routes));
+
+      // Initially the barrier is not visible
+      expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+
+      await tester.tap(find.text('X'));
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(const ValueKey<String>('barrier')), findsOneWidget);
+
+      // Drag the mouse to the top of the screen.
+      await tester.dragFrom(const Offset(10.0, 10.0), const Offset(200.0, 200.0), touchSlopY: 0);
+      await tester.pumpAndSettle();
+
+      // The barrier should be dismissed.
+      expect(find.byKey(const ValueKey<String>('barrier')), findsNothing);
+    });
   });
+
   group('AnimatedModalBarrier', () {
     testWidgets('prevents interactions with widgets behind it', (WidgetTester tester) async {
       final Widget subject = Stack(


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/90223


`ModalBarrier` should be dismissed when a user drags the finger or mouse on it. Currently, it only dismisses when there is `onTapUp` event.

More details in https://github.com/flutter/flutter/pull/98191



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
