### PR TITLE
Add a matcher for Matrix4 that includes epsilon

### DIFF
--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -266,6 +266,18 @@ Matcher rectMoreOrLessEquals(Rect value, { double epsilon = precisionErrorTolera
   return _IsWithinDistance<Rect>(_rectDistance, value, epsilon);
 }
 
+/// Asserts that two [Matrix4]s are equal, within some tolerated error.
+///
+/// {@macro flutter.flutter_test.moreOrLessEquals}
+///
+/// See also:
+///
+///  * [moreOrLessEquals], which is for [double]s.
+///  * [offsetMoreOrLessEquals], which is for [Offset]s.
+Matcher matrixMorOrLessEqual(Matrix4 value, { double epsilon = precisionErrorTolerance }) {
+  return _IsWithinDistance<Matrix4>(_matrixDistance, value, epsilon);
+}
+
 /// Asserts that two [Offset]s are equal, within some tolerated error.
 ///
 /// {@macro flutter.flutter_test.moreOrLessEquals}
@@ -1141,6 +1153,14 @@ double _rectDistance(Rect a, Rect b) {
   double delta = math.max<double>((a.left - b.left).abs(), (a.top - b.top).abs());
   delta = math.max<double>(delta, (a.right - b.right).abs());
   delta = math.max<double>(delta, (a.bottom - b.bottom).abs());
+  return delta;
+}
+
+double _matrixDistance(Matrix4 a, Matrix4 b) {
+  double delta = 0.0;
+  for (int i = 0; i < 16; i += 1) {
+    delta = math.max<double>((a[i] - b[i]).abs(), delta);
+  }
   return delta;
 }
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -274,7 +274,7 @@ Matcher rectMoreOrLessEquals(Rect value, { double epsilon = precisionErrorTolera
 ///
 ///  * [moreOrLessEquals], which is for [double]s.
 ///  * [offsetMoreOrLessEquals], which is for [Offset]s.
-Matcher matrixMorOrLessEqual(Matrix4 value, { double epsilon = precisionErrorTolerance }) {
+Matcher matrixMoreOrLessEquals(Matrix4 value, { double epsilon = precisionErrorTolerance }) {
   return _IsWithinDistance<Matrix4>(_matrixDistance, value, epsilon);
 }
 

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -198,10 +198,10 @@ void main() {
     expect(-11.0, moreOrLessEquals(11.0, epsilon: 100.0));
   });
 
-  test('matrixMorOrLessEqual', () {
+  test('matrixMoreOrLessEquals', () {
     expect(
       Matrix4.rotationZ(math.pi),
-      matrixMorOrLessEqual(Matrix4.fromList(<double>[
+      matrixMoreOrLessEquals(Matrix4.fromList(<double>[
        -1,  0, 0, 0,
         0, -1, 0, 0,
         0,  0, 1, 0,
@@ -211,7 +211,7 @@ void main() {
 
     expect(
       Matrix4.rotationZ(math.pi),
-      matrixMorOrLessEqual(Matrix4.fromList(<double>[
+      matrixMoreOrLessEquals(Matrix4.fromList(<double>[
        -2,  0, 0, 0,
         0, -2, 0, 0,
         0,  0, 1, 0,
@@ -221,7 +221,7 @@ void main() {
 
     expect(
       Matrix4.rotationZ(math.pi),
-      isNot(matrixMorOrLessEqual(Matrix4.fromList(<double>[
+      isNot(matrixMoreOrLessEquals(Matrix4.fromList(<double>[
        -2,  0, 0, 0,
         0, -2, 0, 0,
         0,  0, 1, 0,

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -4,6 +4,7 @@
 
 // flutter_ignore_for_file: golden_tag (see analyze.dart)
 
+import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:flutter/rendering.dart';
@@ -195,6 +196,38 @@ void main() {
 
     expect(11.0, moreOrLessEquals(-11.0, epsilon: 100.0));
     expect(-11.0, moreOrLessEquals(11.0, epsilon: 100.0));
+  });
+
+  test('matrixMorOrLessEqual', () {
+    expect(
+      Matrix4.rotationZ(math.pi),
+      matrixMorOrLessEqual(Matrix4.fromList(<double>[
+       -1,  0, 0, 0,
+        0, -1, 0, 0,
+        0,  0, 1, 0,
+        0,  0, 0, 1,
+      ]))
+    );
+
+    expect(
+      Matrix4.rotationZ(math.pi),
+      matrixMorOrLessEqual(Matrix4.fromList(<double>[
+       -2,  0, 0, 0,
+        0, -2, 0, 0,
+        0,  0, 1, 0,
+        0,  0, 0, 1,
+      ]), epsilon: 2)
+    );
+
+    expect(
+      Matrix4.rotationZ(math.pi),
+      isNot(matrixMorOrLessEqual(Matrix4.fromList(<double>[
+       -2,  0, 0, 0,
+        0, -2, 0, 0,
+        0,  0, 1, 0,
+        0,  0, 0, 1,
+      ])))
+    );
   });
 
   test('rectMoreOrLessEquals', () {


### PR DESCRIPTION
To make patterns like https://github.com/flutter/plugins/pull/6088#pullrequestreview-1033292266 easier, and encourage folks to compare doubles with an epsilon.