### PR TITLE
Expose the duration and curve for theme animation in MaterialApp.

### DIFF
--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -480,11 +480,11 @@ class MaterialApp extends StatefulWidget {
   ///
   /// When the theme changes (either by the [theme], [darkTheme] or [themeMode]
   /// parameters changing) it is animated to the new theme over time.
-  /// [themeAnimationDuration] determines how long this animation takes.
+  /// The [themeAnimationDuration] determines how long this animation takes.
   ///
   /// To have the theme change immediately, you can set this to [Duration.zero].
   ///
-  /// The default it is [kThemeAnimationDuration].
+  /// The default is [kThemeAnimationDuration].
   ///
   /// See also:
   ///   [themeAnimationCurve], which defines the curve used for the animation.
@@ -492,7 +492,9 @@ class MaterialApp extends StatefulWidget {
 
   /// The curve to apply when animating theme changes.
   ///
-  /// The default it is [Curves.linear].
+  /// The default is [Curves.linear].
+  ///
+  /// This is ignored if [themeAnimationDuration] is [Duration.zero].
   ///
   /// See also:
   ///   [themeAnimationDuration], which defines how long the animation is.

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -220,6 +220,8 @@ class MaterialApp extends StatefulWidget {
     this.highContrastTheme,
     this.highContrastDarkTheme,
     this.themeMode = ThemeMode.system,
+    this.themeAnimationDuration = kThemeAnimationDuration,
+    this.themeAnimationCurve = Curves.linear,
     this.locale,
     this.localizationsDelegates,
     this.localeListResolutionCallback,
@@ -271,6 +273,8 @@ class MaterialApp extends StatefulWidget {
     this.highContrastTheme,
     this.highContrastDarkTheme,
     this.themeMode = ThemeMode.system,
+    this.themeAnimationDuration = kThemeAnimationDuration,
+    this.themeAnimationCurve = Curves.linear,
     this.locale,
     this.localizationsDelegates,
     this.localeListResolutionCallback,
@@ -471,6 +475,28 @@ class MaterialApp extends StatefulWidget {
   ///  * [ThemeData.brightness], which indicates to various parts of the
   ///    system what kind of theme is being used.
   final ThemeMode? themeMode;
+
+  /// The duration of animated theme changes.
+  ///
+  /// When the theme changes (either by the [theme], [darkTheme] or [themeMode]
+  /// parameters changing) it is animated to the new theme over time.
+  /// [themeAnimationDuration] determines how long this animation takes.
+  ///
+  /// To have the theme change immediately, you can set this to [Duration.zero].
+  ///
+  /// The default it is [kThemeAnimationDuration].
+  ///
+  /// See also:
+  ///   [themeAnimationCurve], which defines the curve used for the animation.
+  final Duration themeAnimationDuration;
+
+  /// The curve to apply when animating theme changes.
+  ///
+  /// The default it is [Curves.linear].
+  ///
+  /// See also:
+  ///   [themeAnimationDuration], which defines how long the animation is.
+  final Curve themeAnimationCurve;
 
   /// {@macro flutter.widgets.widgetsApp.color}
   final Color? color;
@@ -896,6 +922,8 @@ class _MaterialAppState extends State<MaterialApp> {
         cursorColor: effectiveCursorColor,
         child: AnimatedTheme(
           data: theme,
+          duration: widget.themeAnimationDuration,
+          curve: widget.themeAnimationCurve,
           child: widget.builder != null
             ? Builder(
                 builder: (BuildContext context) {


### PR DESCRIPTION
When a `MaterialApp`'s theme changes, it is animated over time (via the `AnimatedTheme` widget). This PR exposes the duration and curve used for this animation:

```dart
MaterialApp(
  theme: ThemeData.light(),
  darkTheme: ThemeData.dark(),
  themeMode: ThemeMode.dark,
  themeAnimationDuration: const Duration(milliseconds: 750),
  themeAnimationCurve: Curves.bounceInOut,
  // ...
```

Or if you want to turn off the animation altogether, you can set the duration to zero:

```dart
MaterialApp(
  theme: ThemeData.light(),
  darkTheme: ThemeData.dark(),
  themeMode: ThemeMode.dark,
  themeAnimationDuration: Duration.zero,
  // ...
```

Fixed: #105883

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
