### PR TITLE
Add a snapAnimationDuration param in DraggableScrollableSheet

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -369,7 +369,8 @@ class DraggableScrollableSheet extends StatefulWidget {
   /// Defines a duration for the snap animations.
   ///
   /// If it's not set, then the animation duration is the distance to the snap
-  /// target divided by the velocity of the widget.
+  /// target divided by the velocity of the widget. A negative or zero or less
+  /// than 1 millisecond duration is also considered as not set.
   final Duration? snapAnimationDuration;
 
   /// A controller that can be used to programmatically control this sheet.
@@ -1084,8 +1085,7 @@ class _SnappingSimulation extends Simulation {
   }) {
     _pixelSnapSize = _getSnapSize(initialVelocity, pixelSnapSize);
 
-    // The duration of the snap animation is defined.
-    if(snapAnimationDuration != null) {
+    if (snapAnimationDuration != null && snapAnimationDuration.inMilliseconds > 0) {
        velocity = (_pixelSnapSize - position) * 1000 / snapAnimationDuration.inMilliseconds;
     }
     // Check the direction of the target instead of the sign of the velocity because

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -299,6 +299,7 @@ class DraggableScrollableSheet extends StatefulWidget {
         assert(maxChildSize <= 1.0),
         assert(minChildSize <= initialChildSize),
         assert(initialChildSize <= maxChildSize),
+        assert(snapAnimationDuration == null || snapAnimationDuration > Duration.zero),
         assert(expand != null),
         assert(builder != null);
 
@@ -369,8 +370,7 @@ class DraggableScrollableSheet extends StatefulWidget {
   /// Defines a duration for the snap animations.
   ///
   /// If it's not set, then the animation duration is the distance to the snap
-  /// target divided by the velocity of the widget. A negative or zero or less
-  /// than 1 millisecond duration is also considered as not set.
+  /// target divided by the velocity of the widget.
   final Duration? snapAnimationDuration;
 
   /// A controller that can be used to programmatically control this sheet.

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -489,8 +489,9 @@ void main() {
 
   for (final Duration? snapAnimationDuration in <Duration?>[null, const Duration(seconds: 2)]) {
     testWidgets(
-        'Zero velocity drag snaps to nearest snap target with snapAnimationDuration: $snapAnimationDuration',
-        (WidgetTester tester) async {
+      'Zero velocity drag snaps to nearest snap target with '
+      'snapAnimationDuration: $snapAnimationDuration',
+      (WidgetTester tester) async {
       const Key stackKey = ValueKey<String>('stack');
       const Key containerKey = ValueKey<String>('container');
       await tester.pumpWidget(boilerplateWidget(null,


### PR DESCRIPTION
Add a new param so user can define the duration of the snap animation of a DraggableScrollableSheet.

video attached with snap animations duration = 0.5S

Fixed: #107033

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
