### PR TITLE
updateEditingValueWithDeltas should fail loudly when TextRange is invalid

### DIFF
--- a/packages/flutter/lib/src/services/text_editing_delta.dart
+++ b/packages/flutter/lib/src/services/text_editing_delta.dart
@@ -148,7 +148,7 @@ abstract class TextEditingDelta {
         composing: newComposing,
       );
     }
-  
+
     assert(_textRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText));
 
     final String newText = _replace(oldText, replacementSource, replacementDestinationStart, replacementDestinationEnd);

--- a/packages/flutter/lib/src/services/text_editing_delta.dart
+++ b/packages/flutter/lib/src/services/text_editing_delta.dart
@@ -26,24 +26,22 @@ TextAffinity? _toTextAffinity(String? affinity) {
 
 // Replaces a range of text in the original string with the text given in the
 // replacement string.
-String _replace(String originalText, String replacementText, int start, int end) {
-  assert(_textRangeIsValid(TextRange(start: start, end: end), originalText));
-  final String textStart = originalText.substring(0, start);
-  final String textEnd = originalText.substring(end, originalText.length);
-  final String newText = textStart + replacementText + textEnd;
-  return newText;
+String _replace(String originalText, String replacementText, TextRange replacementRange) {
+  assert(replacementRange.isValid);
+  return originalText.replaceRange(replacementRange.start, replacementRange.end, replacementText);
 }
 
 // Verify that the given range is within the text.
-bool _textRangeIsValid(TextRange range, String text) {
-  if (range.start == -1 && range.end == -1) {
+bool _debugTextRangeIsValid(TextRange range, String text) {
+  if (!range.isValid) {
     return true;
   }
-  assert(range.start >= 0 && range.start <= text.length,
-      'Range start ${range.start} is out of text of length ${text.length}');
-  assert(range.end >= 0 && range.end <= text.length,
-      'Range end ${range.end} is out of text of length ${text.length}');
-  return true;
+
+  if ((range.start >= 0 && range.start <= text.length) && (range.end >= 0 && range.end <= text.length)) {
+    return true;
+  }
+
+  return false;
 }
 
 /// A structure representing a granular change that has occurred to the editing
@@ -139,8 +137,8 @@ abstract class TextEditingDelta {
     );
 
     if (isNonTextUpdate) {
-      assert(_textRangeIsValid(newSelection, oldText));
-      assert(_textRangeIsValid(newComposing, oldText));
+      assert(_debugTextRangeIsValid(newSelection, oldText), 'TextEditingDelta.fromJSON failed, the selection range: $newSelection is not within the bounds of text: $oldText of length: ${oldText.length}');
+      assert(_debugTextRangeIsValid(newComposing, oldText), 'TextEditingDelta.fromJSON failed, the composing range: $newComposing is not within the bounds of text: $oldText of length: ${oldText.length}');
 
       return TextEditingDeltaNonTextUpdate(
         oldText: oldText,
@@ -149,12 +147,12 @@ abstract class TextEditingDelta {
       );
     }
 
-    assert(_textRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText));
+    assert(_debugTextRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText), 'TextEditingDelta.fromJSON failed, the delta range ${TextRange(start: replacementSourceStart, end: replacementSourceEnd)} is not within the bounds of text: $oldText of length: ${oldText.length}');
 
-    final String newText = _replace(oldText, replacementSource, replacementDestinationStart, replacementDestinationEnd);
+    final String newText = _replace(oldText, replacementSource, TextRange(start: replacementDestinationStart, end: replacementDestinationEnd));
 
-    assert(_textRangeIsValid(newSelection, newText));
-    assert(_textRangeIsValid(newComposing, newText));
+    assert(_debugTextRangeIsValid(newSelection, newText), 'TextEditingDelta.fromJSON failed, the selection range: $newSelection is not within the bounds of text: $newText of length: ${newText.length}');
+    assert(_debugTextRangeIsValid(newComposing, newText), 'TextEditingDelta.fromJSON failed, the composing range: $newComposing is not within the bounds of text: $newText of length: ${newText.length}');
 
     final bool isEqual = oldText == newText;
 
@@ -287,7 +285,10 @@ class TextEditingDeltaInsertion extends TextEditingDelta {
     // policy and apply the delta to the oldText. This is due to the asyncronous
     // nature of the connection between the framework and platform text input plugins.
     String newText = oldText;
-    newText = _replace(newText, textInserted, insertionOffset, insertionOffset);
+    assert(_debugTextRangeIsValid(TextRange.collapsed(insertionOffset), newText), 'Applying TextEditingDeltaInsertion failed, the insertionOffset: $insertionOffset is not within the bounds of $newText of length: ${newText.length}');
+    newText = _replace(newText, textInserted, TextRange.collapsed(insertionOffset));
+    assert(_debugTextRangeIsValid(selection, newText), 'Applying TextEditingDeltaInsertion failed, the selection range: $selection is not within the bounds of $newText of length: ${newText.length}');
+    assert(_debugTextRangeIsValid(composing, newText), 'Applying TextEditingDeltaInsertion failed, the composing range: $composing is not within the bounds of $newText of length: ${newText.length}');
     return value.copyWith(text: newText, selection: selection, composing: composing);
   }
 }
@@ -320,7 +321,10 @@ class TextEditingDeltaDeletion extends TextEditingDelta {
     // policy and apply the delta to the oldText. This is due to the asyncronous
     // nature of the connection between the framework and platform text input plugins.
     String newText = oldText;
-    newText = _replace(newText, '', deletedRange.start, deletedRange.end);
+    assert(_debugTextRangeIsValid(deletedRange, newText), 'Applying TextEditingDeltaDeletion failed, the deletedRange: $deletedRange is not within the bounds of $newText of length: ${newText.length}');
+    newText = _replace(newText, '', deletedRange);
+    assert(_debugTextRangeIsValid(selection, newText), 'Applying TextEditingDeltaDeletion failed, the selection range: $selection is not within the bounds of $newText of length: ${newText.length}');
+    assert(_debugTextRangeIsValid(composing, newText), 'Applying TextEditingDeltaDeletion failed, the composing range: $composing is not within the bounds of $newText of length: ${newText.length}');
     return value.copyWith(text: newText, selection: selection, composing: composing);
   }
 }
@@ -363,7 +367,10 @@ class TextEditingDeltaReplacement extends TextEditingDelta {
     // policy and apply the delta to the oldText. This is due to the asyncronous
     // nature of the connection between the framework and platform text input plugins.
     String newText = oldText;
-    newText = _replace(newText, replacementText, replacedRange.start, replacedRange.end);
+    assert(_debugTextRangeIsValid(replacedRange, newText), 'Applying TextEditingDeltaReplacement failed, the replacedRange: $replacedRange is not within the bounds of $newText of length: ${newText.length}');
+    newText = _replace(newText, replacementText, replacedRange);
+    assert(_debugTextRangeIsValid(selection, newText), 'Applying TextEditingDeltaReplacement failed, the selection range: $selection is not within the bounds of $newText of length: ${newText.length}');
+    assert(_debugTextRangeIsValid(composing, newText), 'Applying TextEditingDeltaReplacement failed, the composing range: $composing is not within the bounds of $newText of length: ${newText.length}');
     return value.copyWith(text: newText, selection: selection, composing: composing);
   }
 }
@@ -394,6 +401,8 @@ class TextEditingDeltaNonTextUpdate extends TextEditingDelta {
     // To stay inline with the plain text model we should follow a last write wins
     // policy and apply the delta to the oldText. This is due to the asyncronous
     // nature of the connection between the framework and platform text input plugins.
+    assert(_debugTextRangeIsValid(selection, oldText), 'Applying TextEditingDeltaNonTextUpdate failed, the selection range: $selection is not within the bounds of $oldText of length: ${oldText.length}');
+    assert(_debugTextRangeIsValid(composing, oldText), 'Applying TextEditingDeltaNonTextUpdate failed, the composing region: $composing is not within the bounds of $oldText of length: ${oldText.length}');
     return TextEditingValue(text: oldText, selection: selection, composing: composing);
   }
 }

--- a/packages/flutter/lib/src/services/text_editing_delta.dart
+++ b/packages/flutter/lib/src/services/text_editing_delta.dart
@@ -37,11 +37,8 @@ bool _debugTextRangeIsValid(TextRange range, String text) {
     return true;
   }
 
-  if ((range.start >= 0 && range.start <= text.length) && (range.end >= 0 && range.end <= text.length)) {
-    return true;
-  }
-
-  return false;
+  return ((range.start >= 0 && range.start <= text.length)
+                            && (range.end >= 0 && range.end <= text.length));
 }
 
 /// A structure representing a granular change that has occurred to the editing
@@ -137,8 +134,8 @@ abstract class TextEditingDelta {
     );
 
     if (isNonTextUpdate) {
-      assert(_debugTextRangeIsValid(newSelection, oldText), 'TextEditingDelta.fromJSON failed, the selection range: $newSelection is not within the bounds of text: $oldText of length: ${oldText.length}');
-      assert(_debugTextRangeIsValid(newComposing, oldText), 'TextEditingDelta.fromJSON failed, the composing range: $newComposing is not within the bounds of text: $oldText of length: ${oldText.length}');
+      assert(_debugTextRangeIsValid(newSelection, oldText), 'The selection range: $newSelection is not within the bounds of text: $oldText of length: ${oldText.length}');
+      assert(_debugTextRangeIsValid(newComposing, oldText), 'The composing range: $newComposing is not within the bounds of text: $oldText of length: ${oldText.length}');
 
       return TextEditingDeltaNonTextUpdate(
         oldText: oldText,
@@ -147,12 +144,12 @@ abstract class TextEditingDelta {
       );
     }
 
-    assert(_debugTextRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText), 'TextEditingDelta.fromJSON failed, the delta range: ${TextRange(start: replacementSourceStart, end: replacementSourceEnd)} is not within the bounds of text: $oldText of length: ${oldText.length}');
+    assert(_debugTextRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText), 'The delta range: ${TextRange(start: replacementSourceStart, end: replacementSourceEnd)} is not within the bounds of text: $oldText of length: ${oldText.length}');
 
     final String newText = _replace(oldText, replacementSource, TextRange(start: replacementDestinationStart, end: replacementDestinationEnd));
 
-    assert(_debugTextRangeIsValid(newSelection, newText), 'TextEditingDelta.fromJSON failed, the selection range: $newSelection is not within the bounds of text: $newText of length: ${newText.length}');
-    assert(_debugTextRangeIsValid(newComposing, newText), 'TextEditingDelta.fromJSON failed, the composing range: $newComposing is not within the bounds of text: $newText of length: ${newText.length}');
+    assert(_debugTextRangeIsValid(newSelection, newText), 'The selection range: $newSelection is not within the bounds of text: $newText of length: ${newText.length}');
+    assert(_debugTextRangeIsValid(newComposing, newText), 'The composing range: $newComposing is not within the bounds of text: $newText of length: ${newText.length}');
 
     final bool isEqual = oldText == newText;
 

--- a/packages/flutter/lib/src/services/text_editing_delta.dart
+++ b/packages/flutter/lib/src/services/text_editing_delta.dart
@@ -37,8 +37,8 @@ bool _debugTextRangeIsValid(TextRange range, String text) {
     return true;
   }
 
-  return ((range.start >= 0 && range.start <= text.length)
-                            && (range.end >= 0 && range.end <= text.length));
+  return (range.start >= 0 && range.start <= text.length)
+                            && (range.end >= 0 && range.end <= text.length);
 }
 
 /// A structure representing a granular change that has occurred to the editing

--- a/packages/flutter/lib/src/services/text_editing_delta.dart
+++ b/packages/flutter/lib/src/services/text_editing_delta.dart
@@ -24,13 +24,26 @@ TextAffinity? _toTextAffinity(String? affinity) {
   return null;
 }
 
-/// Replaces a range of text in the original string with the text given in the
-/// replacement string.
+// Replaces a range of text in the original string with the text given in the
+// replacement string.
 String _replace(String originalText, String replacementText, int start, int end) {
+  assert(_textRangeIsValid(TextRange(start: start, end: end), originalText));
   final String textStart = originalText.substring(0, start);
   final String textEnd = originalText.substring(end, originalText.length);
   final String newText = textStart + replacementText + textEnd;
   return newText;
+}
+
+// Verify that the given range is within the text.
+bool _textRangeIsValid(TextRange range, String text) {
+  if (range.start == -1 && range.end == -1) {
+    return true;
+  }
+  assert(range.start >= 0 && range.start <= text.length,
+      'Range start ${range.start} is out of text of length ${text.length}');
+  assert(range.end >= 0 && range.end <= text.length,
+      'Range end ${range.end} is out of text of length ${text.length}');
+  return true;
 }
 
 /// A structure representing a granular change that has occurred to the editing
@@ -126,14 +139,23 @@ abstract class TextEditingDelta {
     );
 
     if (isNonTextUpdate) {
+      assert(_textRangeIsValid(newSelection, oldText));
+      assert(_textRangeIsValid(newComposing, oldText));
+
       return TextEditingDeltaNonTextUpdate(
         oldText: oldText,
         selection: newSelection,
         composing: newComposing,
       );
     }
+  
+    assert(_textRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText));
 
     final String newText = _replace(oldText, replacementSource, replacementDestinationStart, replacementDestinationEnd);
+
+    assert(_textRangeIsValid(newSelection, newText));
+    assert(_textRangeIsValid(newComposing, newText));
+
     final bool isEqual = oldText == newText;
 
     final bool isDeletionGreaterThanOne = (replacementDestinationEnd - replacementDestinationStart) - (replacementSourceEnd - replacementSourceStart) > 1;

--- a/packages/flutter/lib/src/services/text_editing_delta.dart
+++ b/packages/flutter/lib/src/services/text_editing_delta.dart
@@ -147,7 +147,7 @@ abstract class TextEditingDelta {
       );
     }
 
-    assert(_debugTextRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText), 'TextEditingDelta.fromJSON failed, the delta range ${TextRange(start: replacementSourceStart, end: replacementSourceEnd)} is not within the bounds of text: $oldText of length: ${oldText.length}');
+    assert(_debugTextRangeIsValid(TextRange(start: replacementDestinationStart, end: replacementDestinationEnd), oldText), 'TextEditingDelta.fromJSON failed, the delta range: ${TextRange(start: replacementSourceStart, end: replacementSourceEnd)} is not within the bounds of text: $oldText of length: ${oldText.length}');
 
     final String newText = _replace(oldText, replacementSource, TextRange(start: replacementDestinationStart, end: replacementDestinationEnd));
 

--- a/packages/flutter/test/services/delta_text_input_test.dart
+++ b/packages/flutter/test/services/delta_text_input_test.dart
@@ -112,7 +112,7 @@ void main() {
         record.add(details);
       };
 
-      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(const TextEditingValue(text: ''));
+      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(TextEditingValue.empty);
       const TextInputConfiguration configuration = TextInputConfiguration(enableDeltaModel: true);
       TextInput.attach(client, configuration);
 
@@ -151,7 +151,7 @@ void main() {
         record.add(details);
       };
 
-      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(const TextEditingValue(text: ''));
+      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(TextEditingValue.empty);
       const TextInputConfiguration configuration = TextInputConfiguration(enableDeltaModel: true);
       TextInput.attach(client, configuration);
 

--- a/packages/flutter/test/services/delta_text_input_test.dart
+++ b/packages/flutter/test/services/delta_text_input_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'text_input_test.dart' show FakeTextInputClient;
 import 'text_input_utils.dart';
 
 void main() {
@@ -226,13 +225,66 @@ void main() {
   });
 }
 
-class FakeDeltaTextInputClient extends FakeTextInputClient with DeltaTextInputClient {
-  FakeDeltaTextInputClient(super.currentTextEditingValue);
+class FakeDeltaTextInputClient implements DeltaTextInputClient {
+  FakeDeltaTextInputClient(this.currentTextEditingValue);
+
+  String latestMethodCall = '';
+
   @override
-  TextInputConfiguration get configuration => const TextInputConfiguration(enableDeltaModel: true);
+  TextEditingValue currentTextEditingValue;
+
+  @override
+  AutofillScope? get currentAutofillScope => null;
+
+  @override
+  void performAction(TextInputAction action) {
+    latestMethodCall = 'performAction';
+  }
+
+  @override
+  void performPrivateCommand(String action, Map<String, dynamic> data) {
+    latestMethodCall = 'performPrivateCommand';
+  }
+
+  @override
+  void updateEditingValue(TextEditingValue value) {
+    latestMethodCall = 'updateEditingValue';
+  }
 
   @override
   void updateEditingValueWithDeltas(List<TextEditingDelta> textEditingDeltas) {
     latestMethodCall = 'updateEditingValueWithDeltas';
   }
+
+  @override
+  void updateFloatingCursor(RawFloatingCursorPoint point) {
+    latestMethodCall = 'updateFloatingCursor';
+  }
+
+  @override
+  void connectionClosed() {
+    latestMethodCall = 'connectionClosed';
+  }
+
+  @override
+  void showAutocorrectionPromptRect(int start, int end) {
+    latestMethodCall = 'showAutocorrectionPromptRect';
+  }
+
+  @override
+  void insertTextPlaceholder(Size size) {
+    latestMethodCall = 'insertTextPlaceholder';
+  }
+
+  @override
+  void removeTextPlaceholder() {
+    latestMethodCall = 'removeTextPlaceholder';
+  }
+
+  @override
+  void showToolbar() {
+    latestMethodCall = 'showToolbar';
+  }
+
+  TextInputConfiguration get configuration => const TextInputConfiguration(enableDeltaModel: true);
 }

--- a/packages/flutter/test/services/delta_text_input_test.dart
+++ b/packages/flutter/test/services/delta_text_input_test.dart
@@ -102,8 +102,8 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\brange.start >= 0 && range.start <= text.length\b')));
-      expect(record[0].exception.toString(), matches(RegExp(r'\bRange start 3 is out of text of length 1\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: 1 of length: 1\b')));
     });
 
     test('Invalid TextRange fails loudly when being converted to JSON - Faulty deltaStart and deltaEnd', () async {
@@ -141,8 +141,8 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\brange.end >= 0 && range.end <= text.length\b')));
-      expect(record[0].exception.toString(), matches(RegExp(r'\bRange end 1 is out of text of length 0\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the delta range\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text:  of length: 0\b')));
     });
 
     test('Invalid TextRange fails loudly when being converted to JSON - Faulty Selection', () async {
@@ -180,8 +180,8 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\brange.start >= 0 && range.start <= text.length\b')));
-      expect(record[0].exception.toString(), matches(RegExp(r'\bRange start 6 is out of text of length 5\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: hello of length: 5\b')));
     });
 
     test('Invalid TextRange fails loudly when being converted to JSON - Faulty Composing Region', () async {
@@ -198,13 +198,13 @@ void main() {
           '"oldText": "worl",'
           ' "deltaText": "world",'
           ' "deltaStart": 0,'
-          ' "deltaEnd": 5,'
+          ' "deltaEnd": 4,'
           ' "selectionBase": 5,'
           ' "selectionExtent": 5,'
           ' "selectionAffinity" : "TextAffinity.downstream" ,'
           ' "selectionIsDirectional": false,'
           ' "composingBase": 0,'
-          ' "composingExtent": 5}';
+          ' "composingExtent": 6}';
 
       final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
         'method': 'TextInputClient.updateEditingStateWithDeltas',
@@ -219,8 +219,8 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\brange.end >= 0 && range.end <= text.length\b')));
-      expect(record[0].exception.toString(), matches(RegExp(r'\bRange end 5 is out of text of length 4\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the composing rangesss\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: world of length: 5\b')));
     });
   });
 }

--- a/packages/flutter/test/services/delta_text_input_test.dart
+++ b/packages/flutter/test/services/delta_text_input_test.dart
@@ -4,9 +4,11 @@
 
 import 'dart:convert' show jsonDecode;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'text_input_test.dart' show FakeTextInputClient;
 import 'text_input_utils.dart';
 
 void main() {
@@ -65,69 +67,172 @@ void main() {
         expect(client.latestMethodCall, 'updateEditingValueWithDeltas');
       },
     );
+
+    test('Invalid TextRange fails loudly when being converted to JSON - NonTextUpdate', () async {
+      final List<FlutterErrorDetails> record = <FlutterErrorDetails>[];
+      FlutterError.onError = (FlutterErrorDetails details) {
+        record.add(details);
+      };
+
+      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(const TextEditingValue(text: '1'));
+      const TextInputConfiguration configuration = TextInputConfiguration(enableDeltaModel: true);
+      TextInput.attach(client, configuration);
+
+      const String jsonDelta = '{'
+          '"oldText": "1",'
+          ' "deltaText": "",'
+          ' "deltaStart": -1,'
+          ' "deltaEnd": -1,'
+          ' "selectionBase": 3,'
+          ' "selectionExtent": 3,'
+          ' "selectionAffinity" : "TextAffinity.downstream" ,'
+          ' "selectionIsDirectional": false,'
+          ' "composingBase": -1,'
+          ' "composingExtent": -1}';
+
+      final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'method': 'TextInputClient.updateEditingStateWithDeltas',
+        'args': <dynamic>[-1, jsonDecode('{"deltas": [$jsonDelta]}')],
+      });
+
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        messageBytes,
+        (ByteData? _) {},
+      );
+      expect(record.length, 1);
+      // Verify the error message in parts because Web formats the message
+      // differently from others.
+      expect(record[0].exception.toString(), matches(RegExp(r'\brange.start >= 0 && range.start <= text.length\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bRange start 3 is out of text of length 1\b')));
+    });
+
+    test('Invalid TextRange fails loudly when being converted to JSON - Faulty deltaStart and deltaEnd', () async {
+      final List<FlutterErrorDetails> record = <FlutterErrorDetails>[];
+      FlutterError.onError = (FlutterErrorDetails details) {
+        record.add(details);
+      };
+
+      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(const TextEditingValue(text: ''));
+      const TextInputConfiguration configuration = TextInputConfiguration(enableDeltaModel: true);
+      TextInput.attach(client, configuration);
+
+      const String jsonDelta = '{'
+          '"oldText": "",'
+          ' "deltaText": "hello",'
+          ' "deltaStart": 0,'
+          ' "deltaEnd": 1,'
+          ' "selectionBase": 5,'
+          ' "selectionExtent": 5,'
+          ' "selectionAffinity" : "TextAffinity.downstream" ,'
+          ' "selectionIsDirectional": false,'
+          ' "composingBase": -1,'
+          ' "composingExtent": -1}';
+
+      final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'method': 'TextInputClient.updateEditingStateWithDeltas',
+        'args': <dynamic>[-1, jsonDecode('{"deltas": [$jsonDelta]}')],
+      });
+
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        messageBytes,
+        (ByteData? _) {},
+      );
+      expect(record.length, 1);
+      // Verify the error message in parts because Web formats the message
+      // differently from others.
+      expect(record[0].exception.toString(), matches(RegExp(r'\brange.end >= 0 && range.end <= text.length\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bRange end 1 is out of text of length 0\b')));
+    });
+
+    test('Invalid TextRange fails loudly when being converted to JSON - Faulty Selection', () async {
+      final List<FlutterErrorDetails> record = <FlutterErrorDetails>[];
+      FlutterError.onError = (FlutterErrorDetails details) {
+        record.add(details);
+      };
+
+      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(const TextEditingValue(text: ''));
+      const TextInputConfiguration configuration = TextInputConfiguration(enableDeltaModel: true);
+      TextInput.attach(client, configuration);
+
+      const String jsonDelta = '{'
+          '"oldText": "",'
+          ' "deltaText": "hello",'
+          ' "deltaStart": 0,'
+          ' "deltaEnd": 0,'
+          ' "selectionBase": 6,'
+          ' "selectionExtent": 6,'
+          ' "selectionAffinity" : "TextAffinity.downstream" ,'
+          ' "selectionIsDirectional": false,'
+          ' "composingBase": -1,'
+          ' "composingExtent": -1}';
+
+      final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'method': 'TextInputClient.updateEditingStateWithDeltas',
+        'args': <dynamic>[-1, jsonDecode('{"deltas": [$jsonDelta]}')],
+      });
+
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        messageBytes,
+        (ByteData? _) {},
+      );
+      expect(record.length, 1);
+      // Verify the error message in parts because Web formats the message
+      // differently from others.
+      expect(record[0].exception.toString(), matches(RegExp(r'\brange.start >= 0 && range.start <= text.length\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bRange start 6 is out of text of length 5\b')));
+    });
+
+    test('Invalid TextRange fails loudly when being converted to JSON - Faulty Composing Region', () async {
+      final List<FlutterErrorDetails> record = <FlutterErrorDetails>[];
+      FlutterError.onError = (FlutterErrorDetails details) {
+        record.add(details);
+      };
+
+      final FakeDeltaTextInputClient client = FakeDeltaTextInputClient(const TextEditingValue(text: 'worl'));
+      const TextInputConfiguration configuration = TextInputConfiguration(enableDeltaModel: true);
+      TextInput.attach(client, configuration);
+
+      const String jsonDelta = '{'
+          '"oldText": "worl",'
+          ' "deltaText": "world",'
+          ' "deltaStart": 0,'
+          ' "deltaEnd": 5,'
+          ' "selectionBase": 5,'
+          ' "selectionExtent": 5,'
+          ' "selectionAffinity" : "TextAffinity.downstream" ,'
+          ' "selectionIsDirectional": false,'
+          ' "composingBase": 0,'
+          ' "composingExtent": 5}';
+
+      final ByteData? messageBytes = const JSONMessageCodec().encodeMessage(<String, dynamic>{
+        'method': 'TextInputClient.updateEditingStateWithDeltas',
+        'args': <dynamic>[-1, jsonDecode('{"deltas": [$jsonDelta]}')],
+      });
+
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/textinput',
+        messageBytes,
+        (ByteData? _) {},
+      );
+      expect(record.length, 1);
+      // Verify the error message in parts because Web formats the message
+      // differently from others.
+      expect(record[0].exception.toString(), matches(RegExp(r'\brange.end >= 0 && range.end <= text.length\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bRange end 5 is out of text of length 4\b')));
+    });
   });
 }
 
-class FakeDeltaTextInputClient implements DeltaTextInputClient {
-  FakeDeltaTextInputClient(this.currentTextEditingValue);
-
-  String latestMethodCall = '';
-
+class FakeDeltaTextInputClient extends FakeTextInputClient with DeltaTextInputClient {
+  FakeDeltaTextInputClient(super.currentTextEditingValue);
   @override
-  TextEditingValue currentTextEditingValue;
-
-  @override
-  AutofillScope? get currentAutofillScope => null;
-
-  @override
-  void performAction(TextInputAction action) {
-    latestMethodCall = 'performAction';
-  }
-
-  @override
-  void performPrivateCommand(String action, Map<String, dynamic> data) {
-    latestMethodCall = 'performPrivateCommand';
-  }
-
-  @override
-  void updateEditingValue(TextEditingValue value) {
-    latestMethodCall = 'updateEditingValue';
-  }
+  TextInputConfiguration get configuration => const TextInputConfiguration(enableDeltaModel: true);
 
   @override
   void updateEditingValueWithDeltas(List<TextEditingDelta> textEditingDeltas) {
     latestMethodCall = 'updateEditingValueWithDeltas';
   }
-
-  @override
-  void updateFloatingCursor(RawFloatingCursorPoint point) {
-    latestMethodCall = 'updateFloatingCursor';
-  }
-
-  @override
-  void connectionClosed() {
-    latestMethodCall = 'connectionClosed';
-  }
-
-  @override
-  void showAutocorrectionPromptRect(int start, int end) {
-    latestMethodCall = 'showAutocorrectionPromptRect';
-  }
-
-  @override
-  void insertTextPlaceholder(Size size) {
-    latestMethodCall = 'insertTextPlaceholder';
-  }
-
-  @override
-  void removeTextPlaceholder() {
-    latestMethodCall = 'removeTextPlaceholder';
-  }
-
-  @override
-  void showToolbar() {
-    latestMethodCall = 'showToolbar';
-  }
-
-  TextInputConfiguration get configuration => const TextInputConfiguration(enableDeltaModel: true);
 }

--- a/packages/flutter/test/services/delta_text_input_test.dart
+++ b/packages/flutter/test/services/delta_text_input_test.dart
@@ -102,7 +102,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range: TextSelection.collapsed\(offset: 3, affinity: TextAffinity.downstream, isDirectional: false\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: 1 of length: 1\b')));
     });
 
@@ -141,7 +141,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the delta range\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the delta range: TextRange\(start: 0, end: 5\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text:  of length: 0\b')));
     });
 
@@ -180,7 +180,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range: TextSelection.collapsed\(offset: 6, affinity: TextAffinity.downstream, isDirectional: false\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: hello of length: 5\b')));
     });
 
@@ -219,7 +219,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the composing rangesss\b')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the composing range: TextRange\(start: 0, end: 6\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: world of length: 5\b')));
     });
   });

--- a/packages/flutter/test/services/delta_text_input_test.dart
+++ b/packages/flutter/test/services/delta_text_input_test.dart
@@ -102,7 +102,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range: TextSelection.collapsed\(offset: 3, affinity: TextAffinity.downstream, isDirectional: false\)(?!\w)')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bThe selection range: TextSelection.collapsed\(offset: 3, affinity: TextAffinity.downstream, isDirectional: false\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: 1 of length: 1\b')));
     });
 
@@ -141,7 +141,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the delta range: TextRange\(start: 0, end: 5\)(?!\w)')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bThe delta range: TextRange\(start: 0, end: 5\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text:  of length: 0\b')));
     });
 
@@ -180,7 +180,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the selection range: TextSelection.collapsed\(offset: 6, affinity: TextAffinity.downstream, isDirectional: false\)(?!\w)')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bThe selection range: TextSelection.collapsed\(offset: 6, affinity: TextAffinity.downstream, isDirectional: false\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: hello of length: 5\b')));
     });
 
@@ -219,7 +219,7 @@ void main() {
       expect(record.length, 1);
       // Verify the error message in parts because Web formats the message
       // differently from others.
-      expect(record[0].exception.toString(), matches(RegExp(r'\bTextEditingDelta.fromJSON failed, the composing range: TextRange\(start: 0, end: 6\)(?!\w)')));
+      expect(record[0].exception.toString(), matches(RegExp(r'\bThe composing range: TextRange\(start: 0, end: 6\)(?!\w)')));
       expect(record[0].exception.toString(), matches(RegExp(r'\bis not within the bounds of text: world of length: 5\b')));
     });
   });

--- a/packages/flutter/test/services/text_editing_delta_test.dart
+++ b/packages/flutter/test/services/text_editing_delta_test.dart
@@ -59,12 +59,12 @@ void main() {
     });
 
     test('Verify invalid TextEditingDeltaInsertion fails to apply', () {
-      const TextEditingDeltaInsertion delta = 
+      const TextEditingDeltaInsertion delta =
               TextEditingDeltaInsertion(
-                oldText: 'hello worl', 
-                textInserted: 'd', 
-                insertionOffset: 11, 
-                selection: TextSelection.collapsed(offset: 11), 
+                oldText: 'hello worl',
+                textInserted: 'd',
+                insertionOffset: 11,
+                selection: TextSelection.collapsed(offset: 11),
                 composing: TextRange.empty,
               );
 
@@ -124,11 +124,11 @@ void main() {
     });
 
     test('Verify invalid TextEditingDeltaDeletion fails to apply', () {
-      const TextEditingDeltaDeletion delta = 
+      const TextEditingDeltaDeletion delta =
               TextEditingDeltaDeletion(
-                oldText: 'hello world', 
+                oldText: 'hello world',
                 deletedRange: TextRange(start: 5, end: 12),
-                selection: TextSelection.collapsed(offset: 5), 
+                selection: TextSelection.collapsed(offset: 5),
                 composing: TextRange.empty,
               );
 
@@ -216,12 +216,12 @@ void main() {
     });
 
     test('Verify invalid TextEditingDeltaReplacement fails to apply', () {
-      const TextEditingDeltaReplacement delta = 
+      const TextEditingDeltaReplacement delta =
               TextEditingDeltaReplacement(
-                oldText: 'hello worl', 
-                replacementText: 'world', 
-                replacedRange: TextRange(start: 5, end: 11), 
-                selection: TextSelection.collapsed(offset: 11), 
+                oldText: 'hello worl',
+                replacementText: 'world',
+                replacedRange: TextRange(start: 5, end: 11),
+                selection: TextSelection.collapsed(offset: 11),
                 composing: TextRange.empty,
               );
 
@@ -253,10 +253,10 @@ void main() {
     });
 
     test('Verify invalid TextEditingDeltaNonTextUpdate fails to apply', () {
-      const TextEditingDeltaNonTextUpdate delta = 
+      const TextEditingDeltaNonTextUpdate delta =
               TextEditingDeltaNonTextUpdate(
-                oldText: 'hello world', 
-                selection: TextSelection.collapsed(offset: 12), 
+                oldText: 'hello world',
+                selection: TextSelection.collapsed(offset: 12),
                 composing: TextRange.empty,
               );
 

--- a/packages/flutter/test/services/text_editing_delta_test.dart
+++ b/packages/flutter/test/services/text_editing_delta_test.dart
@@ -57,6 +57,19 @@ void main() {
       expect(delta.selection, expectedSelection);
       expect(delta.composing, expectedComposing);
     });
+
+    test('Verify invalid TextEditingDeltaInsertion fails to apply', () {
+      const TextEditingDeltaInsertion delta = 
+              TextEditingDeltaInsertion(
+                oldText: 'hello worl', 
+                textInserted: 'd', 
+                insertionOffset: 11, 
+                selection: TextSelection.collapsed(offset: 11), 
+                composing: TextRange.empty,
+              );
+
+      expect(() { delta.apply(TextEditingValue.empty); }, throwsAssertionError);
+    });
   });
 
   group('TextEditingDeltaDeletion', () {
@@ -108,6 +121,18 @@ void main() {
       expect(delta.deletedRange, expectedDeletedRange);
       expect(delta.selection, expectedSelection);
       expect(delta.composing, expectedComposing);
+    });
+
+    test('Verify invalid TextEditingDeltaDeletion fails to apply', () {
+      const TextEditingDeltaDeletion delta = 
+              TextEditingDeltaDeletion(
+                oldText: 'hello world', 
+                deletedRange: TextRange(start: 5, end: 12),
+                selection: TextSelection.collapsed(offset: 5), 
+                composing: TextRange.empty,
+              );
+
+      expect(() { delta.apply(TextEditingValue.empty); }, throwsAssertionError);
     });
   });
 
@@ -189,6 +214,19 @@ void main() {
       expect(delta.selection, expectedSelection);
       expect(delta.composing, expectedComposing);
     });
+
+    test('Verify invalid TextEditingDeltaReplacement fails to apply', () {
+      const TextEditingDeltaReplacement delta = 
+              TextEditingDeltaReplacement(
+                oldText: 'hello worl', 
+                replacementText: 'world', 
+                replacedRange: TextRange(start: 5, end: 11), 
+                selection: TextSelection.collapsed(offset: 11), 
+                composing: TextRange.empty,
+              );
+
+      expect(() { delta.apply(TextEditingValue.empty); }, throwsAssertionError);
+    });
   });
 
   group('TextEditingDeltaNonTextUpdate', () {
@@ -212,6 +250,17 @@ void main() {
       expect(delta.oldText, 'hello world');
       expect(delta.selection, expectedSelection);
       expect(delta.composing, expectedComposing);
+    });
+
+    test('Verify invalid TextEditingDeltaNonTextUpdate fails to apply', () {
+      const TextEditingDeltaNonTextUpdate delta = 
+              TextEditingDeltaNonTextUpdate(
+                oldText: 'hello world', 
+                selection: TextSelection.collapsed(offset: 12), 
+                composing: TextRange.empty,
+              );
+
+      expect(() { delta.apply(TextEditingValue.empty); }, throwsAssertionError);
     });
   });
 }


### PR DESCRIPTION
This PR addresses a concern brought up in #107127 where the creation of a `TextEditingDelta` through the `fromJson` method will fail silently when given bad text bounds (delta range, selection, or composing region). A similar issue was addressed for non-delta text input in #104711 and this change adds the same text bound checks to delta text input.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
