### PR TITLE
Persistent BottomSheet are not dismissible via a11y

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2182,7 +2182,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
             ),
           );
         },
-        true,
+        isPersistent: true,
         animationController: animationController,
       );
     }
@@ -2225,8 +2225,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
   }
 
   PersistentBottomSheetController<T> _buildBottomSheet<T>(
-    WidgetBuilder builder,
-    bool isPersistent, {
+    WidgetBuilder builder, {
+    required bool isPersistent,
     required AnimationController animationController,
     Color? backgroundColor,
     double? elevation,
@@ -2412,7 +2412,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     setState(() {
       _currentBottomSheet = _buildBottomSheet<T>(
         builder,
-        false,
+        isPersistent: false,
         animationController: controller,
         backgroundColor: backgroundColor,
         elevation: elevation,
@@ -3165,7 +3165,7 @@ class _StandardBottomSheetState extends State<_StandardBottomSheet> {
       },
       child: Semantics(
         container: true,
-        onDismiss: close,
+        onDismiss: !widget.isPersistent ? close : null,
         child:  NotificationListener<DraggableScrollableNotification>(
           onNotification: extentChanged,
           child: BottomSheet(

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2599,6 +2599,28 @@ void main() {
     final ErrorSummary summary = error.diagnostics.first as ErrorSummary;
     expect(summary.toString(), 'The showSnackBar() method cannot be called during build.');
   });
+
+  testWidgets('Persistent BottomSheet is not dismissible via a11y means', (WidgetTester tester) async {
+    final Key bottomSheetKey = UniqueKey();
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        bottomSheet: Container(
+          key: bottomSheetKey,
+          height: 44,
+          color: Colors.blue,
+          child: const Text('BottomSheet'),
+        ),
+      ),
+    ));
+
+    expect(
+      tester.getSemantics(find.byKey(bottomSheetKey)),
+      // Having the redundant argument value makes the intent of the test clear.
+      // ignore: avoid_redundant_argument_values
+      matchesSemantics(label: 'BottomSheet', hasDismissAction: false),
+    );
+  });
 }
 
 class _GeometryListener extends StatefulWidget {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/107429.

A Scaffold's persistent BottomSheet is not dismissible and therefore we shouldn't expose a dismiss action in the semantics tree.