### PR TITLE
Fix some issues with launching E2E benchmarks and add page delays in textfield benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/text.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/text.dart
@@ -11,6 +11,7 @@ class TextPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Material(
       child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
         children: const <Widget>[
           SizedBox(
             width: 200,

--- a/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/textfield_perf_e2e.dart
@@ -12,11 +12,7 @@ void main() {
   macroPerfTestE2E(
     'textfield_perf',
     kTextRouteName,
-    // The driver version doesn't have this delay because the delay caused
-    // by the communication between the host and the test device is long enough
-    // for the driver test, but there isn't such delay in this host independent
-    // test.
-    pageDelay: const Duration(milliseconds: 50),
+    pageDelay: const Duration(seconds: 1),
     body: (WidgetController controller) async {
       final Finder textfield = find.byKey(const ValueKey<String>('basic-textfield'));
       controller.tap(textfield);

--- a/dev/benchmarks/macrobenchmarks/test/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test/util.dart
@@ -25,9 +25,16 @@ void macroPerfTestE2E(
   ControlCallback? body,
   ControlCallback? setup,
 }) {
-  macroPerfTestMultiPageE2E(testName, <ScrollableButtonRoute>[
-    ScrollableButtonRoute(kScrollableName, routeName),
-  ]);
+  macroPerfTestMultiPageE2E(
+    testName,
+    <ScrollableButtonRoute>[
+      ScrollableButtonRoute(kScrollableName, routeName),
+    ],
+    pageDelay: pageDelay,
+    duration: duration,
+    body: body,
+    setup: setup,
+  );
 }
 
 void macroPerfTestMultiPageE2E(

--- a/dev/benchmarks/macrobenchmarks/test_driver/textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/textfield_perf_test.dart
@@ -11,6 +11,7 @@ void main() {
   macroPerfTest(
     'textfield_perf',
     kTextRouteName,
+    pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
       final SerializableFinder textfield = find.byValueKey('basic-textfield');
       driver.tap(textfield);

--- a/dev/benchmarks/macrobenchmarks/test_driver/util.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/util.dart
@@ -52,10 +52,10 @@ void macroPerfTest(
       }
 
       timeline = await driver.traceAction(() async {
-      final Future<void> durationFuture = Future<void>.delayed(duration);
-      if (driverOps != null) {
-        await driverOps(driver);
-      }
+        final Future<void> durationFuture = Future<void>.delayed(duration);
+        if (driverOps != null) {
+          await driverOps(driver);
+        }
         await durationFuture;
       });
     });


### PR DESCRIPTION
The E2E textfield benchmarks were not displaying a caret due to failing to pass along the benchmark driver properties. This problem will also affect all E2E benchmarks that use code to drive the benchmark (i.e. the textfield benchmarks had to click on the text field in order to get the caret to appear).

Also, adding a page delay to both the timeline and E2E version of these benchmarks to ensure that the page transition to the benchmark page finishes before the benchmarks start measuring.