### PR TITLE
[flutter_tools] Catch more general XmlException rather than XmlParserException

### DIFF
--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -139,7 +139,7 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
     XmlDocument document;
     try {
       document = XmlDocument.parse(manifestString);
-    } on XmlParserException catch (exception) {
+    } on XmlException catch (exception) {
       String manifestLocation;
       if (androidProject.isUsingGradle) {
         manifestLocation = fileSystem.path.join(androidProject.hostAppGradleRoot.path, 'app', 'src', 'main', 'AndroidManifest.xml');

--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -84,7 +84,7 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
     XmlDocument document;
     try {
       document = XmlDocument.parse(appManifestFile.readAsStringSync());
-    } on XmlParserException {
+    } on XmlException {
       invalidFiles[appManifestFile.path] = 'Error parsing $appManifestFile '
         'Please ensure that the android manifest is a valid XML document and '
         'try again.';

--- a/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
@@ -136,7 +136,7 @@ class DeferredComponentsPrebuildValidator extends DeferredComponentsValidator {
       XmlDocument document;
       try {
         document = XmlDocument.parse(stringRes.readAsStringSync());
-      } on XmlParserException {
+      } on XmlException {
         invalidFiles[stringRes.path] = 'Error parsing $stringRes '
         'Please ensure that the strings.xml is a valid XML document and '
         'try again.';

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -958,7 +958,7 @@ String _getLocalArtifactVersion(String pomPath, FileSystem fileSystem) {
   XmlDocument document;
   try {
     document = XmlDocument.parse(pomFile.readAsStringSync());
-  } on XmlParserException {
+  } on XmlException {
     throwToolExit(
       'Error parsing $pomPath. Please ensure that this is a valid XML document.'
     );

--- a/packages/flutter_tools/lib/src/android/multidex.dart
+++ b/packages/flutter_tools/lib/src/android/multidex.dart
@@ -93,9 +93,7 @@ bool androidManifestHasNameVariable(final Directory projectDir) {
   XmlDocument document;
   try {
     document = XmlDocument.parse(manifestFile.readAsStringSync());
-  } on XmlParserException {
-    return false;
-  } on XmlTagException {
+  } on XmlException {
     return false;
   } on FileSystemException {
     return false;

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -645,11 +645,14 @@ The detected reason was:
       return AndroidEmbeddingVersionResult(AndroidEmbeddingVersion.v1, 'No `${appManifestFile.absolute.path}` file');
     }
     XmlDocument document;
+    final String parseExceptionMessage = 'Error parsing $appManifestFile '
+      'Please ensure that the android manifest is a valid XML document and try again.';
     try {
       document = XmlDocument.parse(appManifestFile.readAsStringSync());
     } on XmlParserException {
-      throwToolExit('Error parsing $appManifestFile '
-                    'Please ensure that the android manifest is a valid XML document and try again.');
+      throwToolExit(parseExceptionMessage);
+    } on XmlTagException {
+      throwToolExit(parseExceptionMessage);
     } on FileSystemException {
       throwToolExit('Error reading $appManifestFile even though it exists. '
                     'Please ensure that you have read permission to this file and try again.');

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -645,14 +645,11 @@ The detected reason was:
       return AndroidEmbeddingVersionResult(AndroidEmbeddingVersion.v1, 'No `${appManifestFile.absolute.path}` file');
     }
     XmlDocument document;
-    final String parseExceptionMessage = 'Error parsing $appManifestFile '
-      'Please ensure that the android manifest is a valid XML document and try again.';
     try {
       document = XmlDocument.parse(appManifestFile.readAsStringSync());
-    } on XmlParserException {
-      throwToolExit(parseExceptionMessage);
-    } on XmlTagException {
-      throwToolExit(parseExceptionMessage);
+    } on XmlException {
+      throwToolExit('Error parsing $appManifestFile '
+                    'Please ensure that the android manifest is a valid XML document and try again.');
     } on FileSystemException {
       throwToolExit('Error reading $appManifestFile even though it exists. '
                     'Please ensure that you have read permission to this file and try again.');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106365

In package:xml, there are [many possible types of exceptions](https://github.com/renggli/dart-xml/commit/1a699c462f589b84d024acfc965640b0f899833b#diff-8d65dca72338d373d886c6eb3eae4e4af22dca9c15af2d9229a1fa5c30e886bd) that could be thrown from an invalid Xml document; however, historically the tool has only caught XmlParserException. This changes the exception handling to catch instead the abstract parent class, `XmlException`; we want to handle ALL types of invalid XML documents and direct the user to repair it themselves.