### PR TITLE
fix null safe check in RenderIndexedStack

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -790,7 +790,7 @@ class RenderIndexedStack extends RenderStack {
     while (child != null) {
       children.add(child.toDiagnosticsNode(
         name: 'child ${i + 1}',
-        style: i != index! ? DiagnosticsTreeStyle.offstage : null,
+        style: i != index ? DiagnosticsTreeStyle.offstage : null,
       ));
       child = (child.parentData! as StackParentData).nextSibling;
       i += 1;

--- a/packages/flutter/test/rendering/stack_test.dart
+++ b/packages/flutter/test/rendering/stack_test.dart
@@ -145,6 +145,34 @@ void main() {
       expect(diagnosticNodes[2].name, 'child 3');
       expect(diagnosticNodes[2].style, DiagnosticsTreeStyle.sparse);
     });
+
+    test('debugDescribeChildren handles a null index', () {
+      final RenderBox child1 = RenderConstrainedBox(
+        additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      );
+      final RenderBox child2 = RenderConstrainedBox(
+        additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      );
+      final RenderBox child3 = RenderConstrainedBox(
+        additionalConstraints: BoxConstraints.tight(const Size(100.0, 100.0)),
+      );
+
+      final RenderBox stack = RenderIndexedStack(
+        index: null,
+        children: <RenderBox>[child1, child2, child3],
+      );
+
+      final List<DiagnosticsNode> diagnosticNodes = stack.debugDescribeChildren();
+
+      expect(diagnosticNodes[0].name, 'child 1');
+      expect(diagnosticNodes[0].style, DiagnosticsTreeStyle.offstage);
+
+      expect(diagnosticNodes[1].name, 'child 2');
+      expect(diagnosticNodes[1].style, DiagnosticsTreeStyle.offstage);
+
+      expect(diagnosticNodes[2].name, 'child 3');
+      expect(diagnosticNodes[2].style, DiagnosticsTreeStyle.offstage);
+    });
   });
 
   test('Stack in Flex can layout with no children', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/107481

The affected code was introduced in https://github.com/flutter/flutter/commit/36a8f0f2ae01701a451846e5696a64678b0c8011, where I think a `!` was used where it was neither necessary nor correct to do so (since it is valid to have `_index == null`)