### PR TITLE
Add SafeArea for NavigationRail

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -409,52 +409,55 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
         child: Material(
           elevation: elevation,
           color: backgroundColor,
-          child: Column(
-            children: <Widget>[
-              _verticalSpacer,
-              if (widget.leading != null)
-                ...<Widget>[
-                  widget.leading!,
-                  _verticalSpacer,
-                ],
-              Expanded(
-                child: Align(
-                  alignment: Alignment(0, groupAlignment),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      for (int i = 0; i < widget.destinations.length; i += 1)
-                        _RailDestination(
-                          minWidth: minWidth,
-                          minExtendedWidth: minExtendedWidth,
-                          extendedTransitionAnimation: _extendedAnimation,
-                          selected: widget.selectedIndex == i,
-                          icon: widget.selectedIndex == i ? widget.destinations[i].selectedIcon : widget.destinations[i].icon,
-                          label: widget.destinations[i].label,
-                          destinationAnimation: _destinationAnimations[i],
-                          labelType: labelType,
-                          iconTheme: widget.selectedIndex == i ? selectedIconTheme : effectiveUnselectedIconTheme,
-                          labelTextStyle: widget.selectedIndex == i ? selectedLabelTextStyle : unselectedLabelTextStyle,
-                          padding: widget.destinations[i].padding,
-                          useIndicator: useIndicator,
-                          indicatorColor: useIndicator ? indicatorColor : null,
-                          onTap: () {
-                            if (widget.onDestinationSelected != null) {
-                              widget.onDestinationSelected!(i);
-                            }
-                          },
-                          indexLabel: localizations.tabLabel(
-                            tabIndex: i + 1,
-                            tabCount: widget.destinations.length,
+          child: SafeArea(
+            right: false,
+            child: Column(
+              children: <Widget>[
+                _verticalSpacer,
+                if (widget.leading != null)
+                  ...<Widget>[
+                    widget.leading!,
+                    _verticalSpacer,
+                  ],
+                Expanded(
+                  child: Align(
+                    alignment: Alignment(0, groupAlignment),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        for (int i = 0; i < widget.destinations.length; i += 1)
+                          _RailDestination(
+                            minWidth: minWidth,
+                            minExtendedWidth: minExtendedWidth,
+                            extendedTransitionAnimation: _extendedAnimation,
+                            selected: widget.selectedIndex == i,
+                            icon: widget.selectedIndex == i ? widget.destinations[i].selectedIcon : widget.destinations[i].icon,
+                            label: widget.destinations[i].label,
+                            destinationAnimation: _destinationAnimations[i],
+                            labelType: labelType,
+                            iconTheme: widget.selectedIndex == i ? selectedIconTheme : effectiveUnselectedIconTheme,
+                            labelTextStyle: widget.selectedIndex == i ? selectedLabelTextStyle : unselectedLabelTextStyle,
+                            padding: widget.destinations[i].padding,
+                            useIndicator: useIndicator,
+                            indicatorColor: useIndicator ? indicatorColor : null,
+                            onTap: () {
+                              if (widget.onDestinationSelected != null) {
+                                widget.onDestinationSelected!(i);
+                              }
+                            },
+                            indexLabel: localizations.tabLabel(
+                              tabIndex: i + 1,
+                              tabCount: widget.destinations.length,
+                            ),
                           ),
-                        ),
-                      if (widget.trailing != null)
-                        widget.trailing!,
-                    ],
+                        if (widget.trailing != null)
+                          widget.trailing!,
+                      ],
+                    ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -402,6 +402,8 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
       ? unselectedIconTheme
       : unselectedIconTheme.copyWith(opacity: unselectedIconTheme.opacity ?? defaults.unselectedIconTheme!.opacity);
 
+    final bool isRTLDirection = Directionality.of(context) == TextDirection.rtl;
+
     return _ExtendedNavigationRailAnimation(
       animation: _extendedAnimation,
       child: Semantics(
@@ -410,7 +412,8 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
           elevation: elevation,
           color: backgroundColor,
           child: SafeArea(
-            right: false,
+            right: isRTLDirection,
+            left: !isRTLDirection,
             child: Column(
               children: <Widget>[
                 _verticalSpacer,

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2314,9 +2314,15 @@ void main() {
       ),
     );
 
-    final Padding firstItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Abc'));
-    final Padding secondItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Def'));
-    final Padding thirdItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Ghi'));
+    final Padding firstItem = tester.widget<Padding>(
+      find.descendant(of: find.widgetWithText(InkResponse, 'Abc'), matching: find.widgetWithText(Padding, 'Abc'))
+    );
+    final Padding secondItem = tester.widget<Padding>(
+      find.descendant(of: find.widgetWithText(InkResponse, 'Def'), matching: find.widgetWithText(Padding, 'Def'))
+    );
+    final Padding thirdItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Ghi'), matching: find.widgetWithText(Padding, 'Ghi'))
+    );
 
     expect(firstItem.padding, defaultPadding);
     expect(secondItem.padding, secondItemPadding);
@@ -2355,9 +2361,15 @@ void main() {
       ),
     );
 
-    final Padding firstItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Abc'));
-    final Padding secondItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Def'));
-    final Padding thirdItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Ghi'));
+    final Padding firstItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Abc'), matching: find.widgetWithText(Padding, 'Abc'))
+    );
+    final Padding secondItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Def'), matching: find.widgetWithText(Padding, 'Def'))
+    );
+    final Padding thirdItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Ghi'), matching: find.widgetWithText(Padding, 'Ghi'))
+    );
 
     expect(firstItem.padding, defaultPadding);
     expect(secondItem.padding, secondItemPadding);
@@ -2396,9 +2408,15 @@ void main() {
       ),
     );
 
-    final Padding firstItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Abc'));
-    final Padding secondItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Def'));
-    final Padding thirdItem = tester.widget<Padding>(find.widgetWithText(Padding, 'Ghi'));
+    final Padding firstItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Abc'), matching: find.widgetWithText(Padding, 'Abc'))
+    );
+    final Padding secondItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Def'), matching: find.widgetWithText(Padding, 'Def'))
+    );
+    final Padding thirdItem = tester.widget<Padding>(
+        find.descendant(of: find.widgetWithText(InkResponse, 'Ghi'), matching: find.widgetWithText(Padding, 'Ghi'))
+    );
 
     expect(firstItem.padding, defaultPadding);
     expect(secondItem.padding, secondItemPadding);
@@ -2635,6 +2653,44 @@ void main() {
     // Indicator without Stack widget
     final RenderBox lastIndicator = tester.renderObject(find.byType(Icon).last);
     expect(lastIndicator.localToGlobal(Offset.zero).dx, 28.0);
+  });
+
+  testWidgets('NavigationRail respects the notch/system navigation bar in landscape mode', (WidgetTester tester) async {
+    const double safeAreaPadding = 40.0;
+    NavigationRail navigationRail() {
+      return NavigationRail(
+        selectedIndex: 0,
+        destinations: const <NavigationRailDestination>[
+          NavigationRailDestination(
+            icon: Icon(Icons.favorite_border),
+            selectedIcon: Icon(Icons.favorite),
+            label: Text('Abc'),
+          ),
+          NavigationRailDestination(
+            icon: Icon(Icons.bookmark_border),
+            selectedIcon: Icon(Icons.bookmark),
+            label: Text('Def'),
+          ),
+        ],
+      );
+    }
+
+    await tester.pumpWidget(_buildWidget(navigationRail()));
+    final double defaultWidth = tester.getSize(find.byType(NavigationRail)).width;
+    expect(defaultWidth, 80);
+
+    await tester.pumpWidget(
+      _buildWidget(
+        MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(left: safeAreaPadding),
+          ),
+          child: navigationRail(),
+        ),
+      ),
+    );
+    final double updatedWidth = tester.getSize(find.byType(NavigationRail)).width;
+    expect(updatedWidth, defaultWidth + safeAreaPadding);
   });
 
   group('Material 2', () {
@@ -4392,6 +4448,45 @@ void main() {
       expect(lastIndicator.localToGlobal(Offset.zero).dx, 24.0);
     });
 
+    testWidgets('NavigationRail respects the notch/system navigation bar in landscape mode', (WidgetTester tester) async {
+      const double safeAreaPadding = 40.0;
+      NavigationRail navigationRail() {
+        return NavigationRail(
+          selectedIndex: 0,
+          destinations: const <NavigationRailDestination>[
+            NavigationRailDestination(
+              icon: Icon(Icons.favorite_border),
+              selectedIcon: Icon(Icons.favorite),
+              label: Text('Abc'),
+            ),
+            NavigationRailDestination(
+              icon: Icon(Icons.bookmark_border),
+              selectedIcon: Icon(Icons.bookmark),
+              label: Text('Def'),
+            ),
+          ],
+        );
+      }
+
+      await tester.pumpWidget(_buildWidget(navigationRail(), useMaterial3: false));
+      final double defaultWidth = tester.getSize(find.byType(NavigationRail)).width;
+      expect(defaultWidth, 72);
+
+      await tester.pumpWidget(
+        _buildWidget(
+            MediaQuery(
+              data: const MediaQueryData(
+                padding: EdgeInsets.only(left: safeAreaPadding),
+              ),
+              child: navigationRail(),
+            ),
+            useMaterial3: false
+        ),
+      );
+      final double updatedWidth = tester.getSize(find.byType(NavigationRail)).width;
+      expect(updatedWidth, defaultWidth + safeAreaPadding);
+    });
+
   }); // End Material 2 group
 }
 
@@ -4592,6 +4687,22 @@ Material _railMaterial(WidgetTester tester) {
     find.descendant(
       of: find.byType(NavigationRail),
       matching: find.byType(Material),
+    ),
+  );
+}
+
+Widget _buildWidget(Widget child, {bool useMaterial3 = true}) {
+  return MaterialApp(
+    theme: ThemeData(useMaterial3: useMaterial3),
+    home: Scaffold(
+      body: Row(
+        children: <Widget>[
+          child,
+          const Expanded(
+            child: Text('body'),
+          ),
+        ],
+      ),
     ),
   );
 }

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2691,6 +2691,21 @@ void main() {
     );
     final double updatedWidth = tester.getSize(find.byType(NavigationRail)).width;
     expect(updatedWidth, defaultWidth + safeAreaPadding);
+
+    // test width when text direction is RTL.
+    await tester.pumpWidget(
+      _buildWidget(
+        MediaQuery(
+          data: const MediaQueryData(
+            padding: EdgeInsets.only(right: safeAreaPadding),
+          ),
+          child: navigationRail(),
+        ),
+        isRTL: true,
+      ),
+    );
+    final double updatedWidthRTL = tester.getSize(find.byType(NavigationRail)).width;
+    expect(updatedWidthRTL, defaultWidth + safeAreaPadding);
   });
 
   group('Material 2', () {
@@ -4485,6 +4500,22 @@ void main() {
       );
       final double updatedWidth = tester.getSize(find.byType(NavigationRail)).width;
       expect(updatedWidth, defaultWidth + safeAreaPadding);
+
+      // test width when text direction is RTL.
+      await tester.pumpWidget(
+        _buildWidget(
+          MediaQuery(
+            data: const MediaQueryData(
+              padding: EdgeInsets.only(right: safeAreaPadding),
+            ),
+            child: navigationRail(),
+          ),
+          useMaterial3: false,
+          isRTL: true,
+        ),
+      );
+      final double updatedWidthRTL = tester.getSize(find.byType(NavigationRail)).width;
+      expect(updatedWidthRTL, defaultWidth + safeAreaPadding);
     });
 
   }); // End Material 2 group
@@ -4691,17 +4722,20 @@ Material _railMaterial(WidgetTester tester) {
   );
 }
 
-Widget _buildWidget(Widget child, {bool useMaterial3 = true}) {
+Widget _buildWidget(Widget child, {bool useMaterial3 = true, bool isRTL = false}) {
   return MaterialApp(
     theme: ThemeData(useMaterial3: useMaterial3),
-    home: Scaffold(
-      body: Row(
-        children: <Widget>[
-          child,
-          const Expanded(
-            child: Text('body'),
-          ),
-        ],
+    home: Directionality(
+      textDirection: isRTL ? TextDirection.rtl : TextDirection.ltr,
+      child: Scaffold(
+        body: Row(
+          children: <Widget>[
+            child,
+            const Expanded(
+              child: Text('body'),
+            ),
+          ],
+        ),
       ),
     ),
   );


### PR DESCRIPTION
This pr adds a SafeArea for NavigationRail component so that the NavigationRail will not be covered by notch/system navigation bar in landscape mode.

<img width="729" alt="Screen Shot 2022-07-13 at 5 50 20 PM" src="https://user-images.githubusercontent.com/36861262/178861359-41faf143-319e-4858-9a01-b3ba585d1536.png">


Fixes #107407.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
