### PR TITLE
Fixes a NestedScrollView UserScrollNotification issue

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1344,6 +1344,7 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
   @override
   void goIdle() {
     beginActivity(IdleScrollActivity(this));
+    coordinator.updateUserScrollDirection(ScrollDirection.idle);
   }
 
   // This is called by activities when they finish their work and want to go

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -120,6 +120,59 @@ Widget buildTest({
 }
 
 void main() {
+  testWidgets('ScrollDirection test', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/107101
+    final List<ScrollDirection> receivedResult = <ScrollDirection>[];
+    const List<ScrollDirection> expectedReverseResult = <ScrollDirection>[ScrollDirection.reverse, ScrollDirection.idle];
+    const List<ScrollDirection> expectedFrowardResult = <ScrollDirection>[ScrollDirection.forward, ScrollDirection.idle];
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: NotificationListener<UserScrollNotification>(
+          onNotification: (UserScrollNotification notification) {
+            if (notification.depth != 1) {
+              return true;
+            }
+            receivedResult.add(notification.direction);
+            return true;
+          },
+          child: NestedScrollView(
+            headerSliverBuilder: (BuildContext context, bool innerBoxIsScrolled) => <Widget>[
+              const SliverAppBar(
+                expandedHeight: 250.0,
+                pinned: true,
+              ),
+            ],
+            body: ListView.builder(
+              padding: const EdgeInsets.all(8),
+              itemCount: 30,
+              itemBuilder: (BuildContext context, int index) {
+                return SizedBox(
+                  height: 50,
+                  child: Center(child: Text('Item $index')),
+                );
+              },
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    // Fling down to trigger ballistic activity
+    await tester.fling(find.text('Item 3'), const Offset(0.0, -250.0), 10000.0);
+    await tester.pumpAndSettle();
+
+    expect(receivedResult, expectedReverseResult);
+
+    receivedResult.clear();
+
+    // Drag forward, without ballistic activity
+    await tester.drag(find.text('Item 29'), const Offset(0.0, 20.0));
+    await tester.pump();
+
+    expect(receivedResult, expectedFrowardResult);
+  });
+
   testWidgets('NestedScrollView respects clipBehavior', (WidgetTester tester) async {
     Widget build(NestedScrollView nestedScrollView) {
       return Localizations(

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -124,7 +124,7 @@ void main() {
     // Regression test for https://github.com/flutter/flutter/issues/107101
     final List<ScrollDirection> receivedResult = <ScrollDirection>[];
     const List<ScrollDirection> expectedReverseResult = <ScrollDirection>[ScrollDirection.reverse, ScrollDirection.idle];
-    const List<ScrollDirection> expectedFrowardResult = <ScrollDirection>[ScrollDirection.forward, ScrollDirection.idle];
+    const List<ScrollDirection> expectedForwardResult = <ScrollDirection>[ScrollDirection.forward, ScrollDirection.idle];
 
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
@@ -170,7 +170,7 @@ void main() {
     await tester.drag(find.text('Item 29'), const Offset(0.0, 20.0));
     await tester.pump();
 
-    expect(receivedResult, expectedFrowardResult);
+    expect(receivedResult, expectedForwardResult);
   });
 
   testWidgets('NestedScrollView respects clipBehavior', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/107101

We do not notify the idle state if ending the drag with a velocity.

We only notify the idle state if no scrolling occurs when the drag ends.
https://github.com/flutter/flutter/blob/5a5d021e51ca9a16fdfc64b34a8d64c75be1b500/packages/flutter/lib/src/widgets/nested_scroll_view.dart#L656-L658