### PR TITLE
Fix TabBarView children are not updated

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1454,7 +1454,7 @@ class _TabBarViewState extends State<TabBarView> {
       _pageController.jumpToPage(_currentIndex!);
       _warpUnderwayCount -= 1;
     }
-    if (widget.children != oldWidget.children && _warpUnderwayCount == 0) {
+    if (widget.children != oldWidget.children) {
       _updateChildren();
     }
   }


### PR DESCRIPTION
## Description

This PR removes a check that prevents `TabBarView` from updating its children while a transition is running. 
The purpose of this check is not obvious and removing it doesn't break any existing tests. It will be interesting to see if it breaks some Google client tests and/or some Google internal tests.

From `TabBarView` history, the check was part of a [large refactoring](https://github.com/flutter/flutter/pull/7387) in early 2017, so maybe it was required at this time. Or maybe it is required for some use cases that are not covered by existing tests, if so I will update this PR to add such tests.

Before this PR, `TabBarView` children are not updated during a transition.
(The '+1' button updates the state with a slight delay. If the user selects a new tab before the end of this delay, the updated state is not reflected in the tab bar bodies, for more information see https://github.com/flutter/flutter/issues/107399):

https://user-images.githubusercontent.com/840911/178998031-47ffa8aa-87c8-4118-81b4-06d9cbbf55ac.mp4

After, `TabBarView` children can be updated during a transition :

https://user-images.githubusercontent.com/840911/179000242-c55b13dc-8c90-40d6-9756-260a6c4efa07.mp4

## Related Issue

Fixes https://github.com/flutter/flutter/issues/107399

## Tests

Adds 1 test.