### PR TITLE
Fix the scroll delta negation in the E2E version of picture_cache_perf benchmark

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/picture_cache_perf_e2e.dart
@@ -19,7 +19,7 @@ void main() {
       Future<void> scrollOnce(double offset) async {
         await controller.timedDrag(
           nestedScroll,
-          Offset(-offset, 0.0),
+          Offset(offset, 0.0),
           const Duration(milliseconds: 300),
         );
         await Future<void>.delayed(const Duration(milliseconds: 500));


### PR DESCRIPTION
The negation of these deltas caused a difference in the behavior of the E2E version of this benchmark as compared to the timeline version. In particular, the deltas were designed to perform 2 scrolls to the right and 2 to the left, but by negating the deltas the E2E version would start off with 2 animations of the "you've scrolled too far to the left" indicator which would skew the results.