### PR TITLE
Fix native platform view integration test config

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3687,6 +3687,10 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "13a233"}
+        ]
       tags: >
         ["devicelab", "hostonly"]
       task_name: native_platform_view_ui_tests_ios

--- a/dev/devicelab/bin/tasks/native_platform_view_ui_tests_ios.dart
+++ b/dev/devicelab/bin/tasks/native_platform_view_ui_tests_ios.dart
@@ -10,6 +10,7 @@ import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
 
 Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
   await task(() async {
     final String projectDirectory = '${flutterDirectory.path}/dev/integration_tests/ios_platform_view_tests';
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106745#issuecomment-1178378569

It turns out that I have to set the ios OS since android is the default one. 

Tested on the github CI (with presubmit flag on). 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
