### PR TITLE
Fix BottomNavigationBarItem tooltip defaults to label

### DIFF
--- a/packages/flutter/lib/src/material/bottom_navigation_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar.dart
@@ -455,7 +455,7 @@ class _BottomNavigationTile extends StatelessWidget {
     final double unselectedIconDiff = math.max(unselectedIconSize - selectedIconSize, 0);
 
     // The effective tool tip message to be shown on the BottomNavigationBarItem.
-    final String? effectiveTooltip = item.tooltip == '' ? null : item.tooltip ?? item.label;
+    final String? effectiveTooltip = item.tooltip == '' ? null : item.tooltip;
 
     // Defines the padding for the animating icons + labels.
     //

--- a/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
+++ b/packages/flutter/lib/src/widgets/bottom_navigation_bar_item.dart
@@ -81,12 +81,10 @@ class BottomNavigationBarItem {
   ///    the icons themselves.
   final Color? backgroundColor;
 
-  /// The text to display in the tooltip for this [BottomNavigationBarItem], when
-  /// the user long presses the item.
+  /// The text to display in the [Tooltip] for this [BottomNavigationBarItem].
   ///
-  /// The [Tooltip] will only appear on an item in a Material design [BottomNavigationBar], and
-  /// when the string is not empty.
+  /// A [Tooltip] will only appear on this item if `tooltip` is set to a non-empty string.
   ///
-  /// Defaults to null, in which case the [label] text will be used.
+  /// Defaults to null, in which case the tooltip is not shown.
   final String? tooltip;
 }

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -1209,7 +1209,7 @@ void main() {
 
     expect(find.text('B'), findsOneWidget);
     await tester.longPress(find.text('B'));
-    expect(find.byTooltip('B'), findsOneWidget);
+    expect(find.byTooltip('B'), findsNothing);
 
     expect(find.text('C'), findsOneWidget);
     await tester.longPress(find.text('C'));


### PR DESCRIPTION
## Description

This PR updates `BottomNavigationBar` to not show a tooltip when `BottomNavigationBarItem.tooltip` is null (instead of displaying the label text). 

## Related Issue

Fixes https://github.com/flutter/flutter/issues/107036

## Tests

Updates 1 test.