### PR TITLE
Migrate Mac/Windows+android targets to cocoon scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3018,7 +3018,6 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
-    scheduler: luci
 
   - name: Mac_android hello_world_android__compile
     recipe: devicelab/devicelab_drone
@@ -3028,7 +3027,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: hello_world_android__compile
-    scheduler: luci
 
   - name: Mac_arm64_android hello_world_android__compile
     recipe: devicelab/devicelab_drone
@@ -3038,7 +3036,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac", "arm64"]
       task_name: hello_world_android__compile
-    scheduler: luci
 
   - name: Mac_android hot_mode_dev_cycle__benchmark
     recipe: devicelab/devicelab_drone
@@ -3048,7 +3045,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: hot_mode_dev_cycle__benchmark
-    scheduler: luci
 
   - name: Mac_android integration_test_test
     recipe: devicelab/devicelab_drone
@@ -3058,7 +3054,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: integration_test_test
-    scheduler: luci
 
   - name: Mac_arm64_android integration_test_test
     recipe: devicelab/devicelab_drone
@@ -3077,7 +3072,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: integration_ui_frame_number
-    scheduler: luci
 
   - name: Mac_android microbenchmarks
     recipe: devicelab/devicelab_drone
@@ -3087,7 +3081,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: microbenchmarks
-    scheduler: luci
 
   - name: Mac_android run_release_test
     recipe: devicelab/devicelab_drone
@@ -3099,7 +3092,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: run_release_test
-    scheduler: luci
 
   - name: Mac_arm64_android run_release_test
     recipe: devicelab/devicelab_drone
@@ -3111,7 +3103,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac", "arm64"]
       task_name: run_release_test
-    scheduler: luci
 
   - name: Mac_android flutter_gallery_mac__start_up
     recipe: devicelab/devicelab_drone
@@ -3121,7 +3112,6 @@ targets:
       tags: >
         ["devicelab", "android", "mac"]
       task_name: flutter_gallery_mac__start_up
-    scheduler: luci
 
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -4188,7 +4178,6 @@ targets:
       tags: >
         ["devicelab", "android", "windows"]
       task_name: basic_material_app_win__compile
-    scheduler: luci
 
   - name: Windows_android channels_integration_test_win
     recipe: devicelab/devicelab_drone
@@ -4198,7 +4187,6 @@ targets:
       tags: >
         ["devicelab", "android", "windows"]
       task_name: channels_integration_test_win
-    scheduler: luci
 
   - name: Windows_android complex_layout_win__compile
     recipe: devicelab/devicelab_drone
@@ -4212,7 +4200,6 @@ targets:
         [
           {"dependency": "open_jdk", "version": "11"}
         ]
-    scheduler: luci
 
   - name: Windows_android flavors_test_win
     recipe: devicelab/devicelab_drone
@@ -4222,7 +4209,6 @@ targets:
       tags: >
         ["devicelab", "android", "windows"]
       task_name: flavors_test_win
-    scheduler: luci
 
   - name: Windows_android flutter_gallery_win__compile
     recipe: devicelab/devicelab_drone
@@ -4232,7 +4218,6 @@ targets:
       tags: >
         ["devicelab", "android", "windows"]
       task_name: flutter_gallery_win__compile
-    scheduler: luci
 
   - name: Windows_android hot_mode_dev_cycle_win__benchmark
     recipe: devicelab/devicelab_drone
@@ -4242,7 +4227,6 @@ targets:
       tags: >
         ["devicelab", "android", "windows"]
       task_name: hot_mode_dev_cycle_win__benchmark
-    scheduler: luci
 
   - name: Windows_android windows_chrome_dev_mode
     recipe: devicelab/devicelab_drone
@@ -4252,4 +4236,3 @@ targets:
       tags: >
         ["devicelab", "android", "windows"]
       task_name: windows_chrome_dev_mode
-    scheduler: luci


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/92300