### PR TITLE
add page delays to the fullscreen versions of the textfield perf benchmarks

### DIFF
--- a/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
@@ -12,7 +12,7 @@ void main() {
   macroPerfTestE2E(
     'fullscreen_textfield_perf',
     kFullscreenTextRouteName,
-    // pageDelay: const Duration(seconds: 1),
+    pageDelay: const Duration(seconds: 1),
     body: (WidgetController controller) async {
       final Finder textfield = find.byKey(const ValueKey<String>('fullscreen-textfield'));
       controller.tap(textfield);

--- a/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
+++ b/dev/benchmarks/macrobenchmarks/test/fullscreen_textfield_perf_e2e.dart
@@ -12,11 +12,7 @@ void main() {
   macroPerfTestE2E(
     'fullscreen_textfield_perf',
     kFullscreenTextRouteName,
-    // The driver version doesn't have this delay because the delay caused
-    // by the communication between the host and the test device is long enough
-    // for the driver test, but there isn't such delay in this host independent
-    // test.
-    pageDelay: const Duration(milliseconds: 50),
+    // pageDelay: const Duration(seconds: 1),
     body: (WidgetController controller) async {
       final Finder textfield = find.byKey(const ValueKey<String>('fullscreen-textfield'));
       controller.tap(textfield);

--- a/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
+++ b/dev/benchmarks/macrobenchmarks/test_driver/fullscreen_textfield_perf_test.dart
@@ -11,7 +11,7 @@ void main() {
   macroPerfTest(
     'fullscreen_textfield_perf',
     kFullscreenTextRouteName,
-    pageDelay: const Duration(milliseconds: 50),
+    pageDelay: const Duration(seconds: 1),
     driverOps: (FlutterDriver driver) async {
       final SerializableFinder textfield = find.byValueKey('fullscreen-textfield');
       driver.tap(textfield);


### PR DESCRIPTION
This is similar to what was done with https://github.com/flutter/flutter/pull/107500 for the non-fullscreen versions. The page delay keeps us from measuring the page transition time.