### PR TITLE
Pass device-user in machine mode

### DIFF
--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -499,6 +499,7 @@ class AppDomain extends Domain {
     bool multidexEnabled = false,
     String? isolateFilter,
     bool machine = true,
+    String? userIdentifier,
   }) async {
     if (!await device.supportsRuntimeMode(options.buildInfo.mode)) {
       throw Exception(
@@ -517,6 +518,7 @@ class AppDomain extends Domain {
       target: target,
       buildInfo: options.buildInfo,
       platform: globals.platform,
+      userIdentifier: userIdentifier,
     );
 
     ResidentRunner runner;

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -605,6 +605,7 @@ class RunCommand extends RunCommandBase {
           dillOutputPath: stringArgDeprecated('output-dill'),
           ipv6: ipv6 ?? false,
           multidexEnabled: boolArgDeprecated('multidex'),
+          userIdentifier: userIdentifier,
         );
       } on Exception catch (error) {
         throwToolExit(error.toString());


### PR DESCRIPTION
Previously the `--device-user` flag was silently ignored when `--machine` mode is used.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
