### PR TITLE
Provide more useful error message if a non-compliant DAP tool (or user) sends bad input to DAP server

### DIFF
--- a/packages/flutter_tools/lib/src/commands/debug_adapter.dart
+++ b/packages/flutter_tools/lib/src/commands/debug_adapter.dart
@@ -59,6 +59,14 @@ class DebugAdapterCommand extends FlutterCommand {
       ipv6: ipv6 ?? false,
       enableDds: enableDds,
       test: boolArgDeprecated('test'),
+      onError: (Object? e) {
+        globals.stdio.stderrWrite(
+          'Input could not be parsed as a Debug Adapter Protocol message.\n'
+          'The "flutter debug-adapter" command is intended for use by tooling '
+          'that communicates using the Debug Adapter Protocol.\n\n'
+          '$e',
+        );
+      },
     );
 
     await server.channel.closed;

--- a/packages/flutter_tools/lib/src/commands/debug_adapter.dart
+++ b/packages/flutter_tools/lib/src/commands/debug_adapter.dart
@@ -60,7 +60,7 @@ class DebugAdapterCommand extends FlutterCommand {
       enableDds: enableDds,
       test: boolArgDeprecated('test'),
       onError: (Object? e) {
-        globals.stdio.stderrWrite(
+        globals.printError(
           'Input could not be parsed as a Debug Adapter Protocol message.\n'
           'The "flutter debug-adapter" command is intended for use by tooling '
           'that communicates using the Debug Adapter Protocol.\n\n'

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -28,6 +28,7 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     bool enableDds = true,
     super.enableAuthCodes,
     super.logger,
+    super.onError,
   })  : _enableDds = enableDds,
         // Always disable in the DAP layer as it's handled in the spawned
         // 'flutter' process.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -28,6 +28,7 @@ class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArgum
     bool enableDds = true,
     super.enableAuthCodes,
     super.logger,
+    super.onError,
   })  : _enableDds = enableDds,
         // Always disable in the DAP layer as it's handled in the spawned
         // 'flutter' process.

--- a/packages/flutter_tools/lib/src/debug_adapters/server.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/server.dart
@@ -30,21 +30,28 @@ class DapServer {
     this.enableAuthCodes = true,
     bool test = false,
     this.logger,
+    void Function(Object? e)? onError,
   }) : channel = ByteStreamServerChannel(input, output, logger) {
     adapter = test
-        ? FlutterTestDebugAdapter(channel,
+        ? FlutterTestDebugAdapter(
+            channel,
             fileSystem: fileSystem,
             platform: platform,
             ipv6: ipv6,
             enableDds: enableDds,
             enableAuthCodes: enableAuthCodes,
-            logger: logger)
-        : FlutterDebugAdapter(channel,
+            logger: logger,
+            onError: onError,
+          )
+        : FlutterDebugAdapter(
+            channel,
             fileSystem: fileSystem,
             platform: platform,
             enableDds: enableDds,
             enableAuthCodes: enableAuthCodes,
-            logger: logger);
+            logger: logger,
+            onError: onError,
+          );
   }
 
   final ByteStreamServerChannel channel;

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -118,7 +118,7 @@ void main() {
       // This test only runs with out-of-process DAP as it's testing _actual_
       // stderr output and that the debug-adapter process terminates, which is
       // not possible when running the DAP Server in-process.
-    }, skip: useInProcessDap);
+    }, skip: useInProcessDap); // [intended] See above.
 
     testWithoutContext('correctly outputs launch errors and terminates', () async {
       final CompileErrorProject project = CompileErrorProject();

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -8,6 +8,7 @@ import 'package:dds/dap.dart';
 import 'package:dds/src/dap/protocol_generated.dart';
 import 'package:file/file.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/convert.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
@@ -15,6 +16,7 @@ import '../test_data/basic_project.dart';
 import '../test_data/compile_error_project.dart';
 import '../test_utils.dart';
 import 'test_client.dart';
+import 'test_server.dart';
 import 'test_support.dart';
 
 void main() {
@@ -96,6 +98,27 @@ void main() {
         startsWith('Exited'),
       ]);
     });
+
+    testWithoutContext('outputs useful message on invalid DAP protocol messages', () async {
+      final OutOfProcessDapTestServer server = dap.server as OutOfProcessDapTestServer;
+      final CompileErrorProject project = CompileErrorProject();
+      await project.setUpIn(tempDir);
+
+      final StringBuffer stderrOutput = StringBuffer();
+      dap.server.onStderrOutput = stderrOutput.write;
+
+      // Write invalid headers and await the error.
+      dap.server.sink.add(utf8.encode('foo\r\nbar\r\n\r\n'));
+      await server.exitCode;
+
+      // Verify the user-friendly message was included in the output.
+      final String error = stderrOutput.toString();
+      expect(error, contains('Input could not be parsed as a Debug Adapter Protocol message'));
+      expect(error, contains('The "flutter debug-adapter" command is intended for use by tooling'));
+      // This test only runs with out-of-process DAP as it's testing _actual_
+      // stderr output and that the debug-adapter process terminates, which is
+      // not possible when running the DAP Server in-process.
+    }, skip: useInProcessDap);
 
     testWithoutContext('correctly outputs launch errors and terminates', () async {
       final CompileErrorProject project = CompileErrorProject();

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -325,7 +325,7 @@ extension DapTestClientExtension on DapTestClient {
   Future<List<OutputEventBody>> collectAllOutput({
     String? program,
     String? cwd,
-    Future<Response> Function()? start,
+    Future<void> Function()? start,
     Future<Response> Function()? launch,
     bool skipInitialPubGetOutput = true
   }) async {


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/99734 which was a crash if `flutter debug-adapter` is run and then invalid DAP protocol messages were sent (perhaps from a non-compliant tool, or a user that discovered this command and is running it interactively).

Invalid message now result in a message printed before the real exception:

> Input could not be parsed as a Debug Adapter Protocol message.
> The "flutter debug-adapter" command is intended for use by tooling that communicates using the Debug Adapter Protocol.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
