### PR TITLE
Fix ExpansionTile shows children background when expanded

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -10,6 +10,7 @@ import 'expansion_tile_theme.dart';
 import 'icons.dart';
 import 'list_tile.dart';
 import 'list_tile_theme.dart';
+import 'material.dart';
 import 'theme.dart';
 
 const Duration _kExpand = Duration(milliseconds: 200);
@@ -432,11 +433,13 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
       offstage: closed,
       child: TickerMode(
         enabled: !closed,
-        child: Padding(
-          padding: widget.childrenPadding ?? expansionTileTheme.childrenPadding ?? EdgeInsets.zero,
-          child: Column(
-            crossAxisAlignment: widget.expandedCrossAxisAlignment ?? CrossAxisAlignment.center,
-            children: widget.children,
+        child: Material(
+          child: Padding(
+            padding: widget.childrenPadding ?? expansionTileTheme.childrenPadding ?? EdgeInsets.zero,
+            child: Column(
+              crossAxisAlignment: widget.expandedCrossAxisAlignment ?? CrossAxisAlignment.center,
+              children: widget.children,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Description

This PR adds a `Material` widget above `ExpansionTile` children. This Material widget is added only when the `ExpansionTile` is expanded.

## Motivation

When an `ExpansionTile` has a `ListTile` in its children list, the `ListTile` background leaks on the `ExpansionTile` title widget during the expansion animation.

Demo (here “Test2” is the `ExpansionTile` title, ‘Foo’ is a `ListTile` with a green background color, see #107030 for more information) :

https://user-images.githubusercontent.com/840911/177329283-71a828b3-6fe8-4b0d-9e93-fb03f613ebd1.mp4

## Discussion

- #102310 was a generic PR trying to add a `Material` widget in all `ListTile`. It was rejected due to performance concerns.
- #107104 replaced 102310 by adding some useful comments on ListTile.
- This PR uses the fix proposed by #107104, and applied it to the ExpansionTile widget.

**Pros**: users putting a ListTile in an ExpansionTile won’t have the background color leak.
**Cons**: a Material Widget is added on any expanded ExpansionTile, whatever the ExpansionTile content is.

One goal of this PR is to get an answer to the following question  “do we add some Material widget on some high level widget (such as ExpansionTile) or do we guide the user to find this solution?”. In this particular case, it is not obvious for a user to understand that the problem is not related to the ExpansionTile so she/he might have some hard time to find the fix proposed on `ListTile` documentation.


## Related Issue

Fixes https://github.com/flutter/flutter/issues/107030

## Tests

Adds 1 test.