### PR TITLE
Suggest predicate-based formatter in [FilteringTextInputFormatter] docs for whole string matching

### DIFF
--- a/packages/flutter/lib/src/rendering/viewport.dart
+++ b/packages/flutter/lib/src/rendering/viewport.dart
@@ -751,8 +751,8 @@ abstract class RenderViewportBase<ParentDataClass extends ContainerParentDataMix
     // Steps to convert `rect` (from a RenderBox coordinate system) to its
     // scroll offset within this viewport (not in the exact order):
     //
-    // 1. Pick the outmost RenderBox (between which, and the viewport, there is
-    // nothing but RenderSlivers) as an intermediate reference frame
+    // 1. Pick the outermost RenderBox (between which, and the viewport, there
+    // is nothing but RenderSlivers) as an intermediate reference frame
     // (the `pivot`), convert `rect` to that coordinate space.
     //
     // 2. Convert `rect` from the `pivot` coordinate space to its sliver

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -218,11 +218,9 @@ class _TextEditingValueAccumulator {
 ///
 /// Instances of filtered characters found in the new [TextEditingValue]s
 /// will be replaced by the [replacementString] which defaults to the empty
-/// string.
-///
-/// A [FilteringTextInputFormatter] also tries to preserve the existing
-/// [TextEditingValue.selection] and the [TextEditingValue.composing] region,
-/// adjusting them accordingly if text within either of these ranges is replaced.
+/// string, and the current [TextEditingValue.selection] and 
+/// [TextEditingValue.composing] region will be adjusted to account for the
+/// replacement.
 ///
 /// This formatter is typically used to match potentially recurring [Pattern]s
 /// in the new [TextEditingValue]. It never completely rejects the new

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -218,7 +218,7 @@ class _TextEditingValueAccumulator {
 ///
 /// Instances of filtered characters found in the new [TextEditingValue]s
 /// will be replaced by the [replacementString] which defaults to the empty
-/// string, and the current [TextEditingValue.selection] and 
+/// string, and the current [TextEditingValue.selection] and
 /// [TextEditingValue.composing] region will be adjusted to account for the
 /// replacement.
 ///

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -229,7 +229,9 @@ class _TextEditingValueAccumulator {
 /// [TextEditingValue] and falls back to the current [TextEditingValue] when the
 /// given [filterPattern] fails to match. Consider using a different
 /// [TextInputFormatter] such as:
-/// `TextInputFormatter.withFunction((oldValue, newValue) => regExp.hasMatch(newValue.text) ? newValue : oldValue)`.
+/// ``dart
+/// TextInputFormatter.withFunction((oldValue, newValue) => regExp.hasMatch(newValue.text) ? newValue : oldValue)
+/// ```
 /// for accepting/rejecting new input based on a predicate on the full string.
 /// As an example, [FilteringTextInputFormatter] typically shouldn't be used
 /// with [RegExp]s that contain positional matchers (`^` or `$`) since these

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -229,7 +229,7 @@ class _TextEditingValueAccumulator {
 /// [TextEditingValue] and falls back to the current [TextEditingValue] when the
 /// given [filterPattern] fails to match. Consider using a different
 /// [TextInputFormatter] such as:
-/// ``dart
+/// ```dart
 /// TextInputFormatter.withFunction((oldValue, newValue) => regExp.hasMatch(newValue.text) ? newValue : oldValue)
 /// ```
 /// for accepting/rejecting new input based on a predicate on the full string.

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -212,18 +212,30 @@ class _TextEditingValueAccumulator {
   }
 }
 
-/// A [TextInputFormatter] that prevents the insertion of characters
-/// matching (or not matching) a particular pattern.
+/// A [TextInputFormatter] that prevents the insertion of characters matching
+/// (or not matching) a particular pattern, by replacing the characters with the
+/// given [replacementString].
 ///
 /// Instances of filtered characters found in the new [TextEditingValue]s
-/// will be replaced with the [replacementString] which defaults to the empty
+/// will be replaced by the [replacementString] which defaults to the empty
 /// string.
 ///
-/// Since this formatter only removes characters from the text, it attempts to
-/// preserve the existing [TextEditingValue.selection] to values it would now
-/// fall at with the removed characters.
+/// A [FilteringTextInputFormatter] also tries to preserve the existing
+/// [TextEditingValue.selection] and [TextEditingValue.composing], and adjusts
+/// them accordingly if text within either of these ranges is replaced.
+///
+/// This formatter is typically used to match potentially recurring [Pattern]s
+/// in the new [TextEditingValue], and it never completely rejects the new
+/// [TextEditingValue] and falls back to the current [TextEditingValue] when the
+/// given [filterPattern] fails to match. As a result, [RegExp]s with positional
+/// matchers (notably, `^` or `$`) often produce somewhat surprising results
+/// when used in a [FilteringTextInputFormatter], since such [RegExp]s usually
+/// act as predicates on the entire string. To prevent the user from entering
+/// new content based on a predicate on the new [TextEditingValue], consider
+/// using a different [TextInputFormatter] such as:
+/// `TextInputFormatter.withFunction((oldValue, newValue) => regExp.hasMatch(newValue.text) ? newValue : oldValue)`.
 class FilteringTextInputFormatter extends TextInputFormatter {
-  /// Creates a formatter that prevents the insertion of characters
+  /// Creates a formatter that replaces the insertion of characters
   /// based on a filter pattern.
   ///
   /// If [allow] is true, then the filter pattern is an allow list,

--- a/packages/flutter/lib/src/services/text_formatter.dart
+++ b/packages/flutter/lib/src/services/text_formatter.dart
@@ -221,22 +221,22 @@ class _TextEditingValueAccumulator {
 /// string.
 ///
 /// A [FilteringTextInputFormatter] also tries to preserve the existing
-/// [TextEditingValue.selection] and [TextEditingValue.composing], and adjusts
-/// them accordingly if text within either of these ranges is replaced.
+/// [TextEditingValue.selection] and the [TextEditingValue.composing] region,
+/// adjusting them accordingly if text within either of these ranges is replaced.
 ///
 /// This formatter is typically used to match potentially recurring [Pattern]s
-/// in the new [TextEditingValue], and it never completely rejects the new
+/// in the new [TextEditingValue]. It never completely rejects the new
 /// [TextEditingValue] and falls back to the current [TextEditingValue] when the
-/// given [filterPattern] fails to match. As a result, [RegExp]s with positional
-/// matchers (notably, `^` or `$`) often produce somewhat surprising results
-/// when used in a [FilteringTextInputFormatter], since such [RegExp]s usually
-/// act as predicates on the entire string. To prevent the user from entering
-/// new content based on a predicate on the new [TextEditingValue], consider
-/// using a different [TextInputFormatter] such as:
+/// given [filterPattern] fails to match. Consider using a different
+/// [TextInputFormatter] such as:
 /// `TextInputFormatter.withFunction((oldValue, newValue) => regExp.hasMatch(newValue.text) ? newValue : oldValue)`.
+/// for accepting/rejecting new input based on a predicate on the full string.
+/// As an example, [FilteringTextInputFormatter] typically shouldn't be used
+/// with [RegExp]s that contain positional matchers (`^` or `$`) since these
+/// patterns are usually meant for matching the whole string.
 class FilteringTextInputFormatter extends TextInputFormatter {
-  /// Creates a formatter that replaces the insertion of characters
-  /// based on a filter pattern.
+  /// Creates a formatter that replaces banned patterns with the given
+  /// [replacementString].
   ///
   /// If [allow] is true, then the filter pattern is an allow list,
   /// and characters must match the pattern to be accepted. See also

--- a/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
+++ b/packages/flutter/lib/src/widgets/slotted_render_object_widget.dart
@@ -299,7 +299,7 @@ class SlottedRenderObjectElement<S> extends RenderObjectElement {
       throw FlutterError.fromParts(<DiagnosticsNode>[
         ErrorSummary('Multiple widgets used the same key in ${widget.runtimeType}.'),
         ErrorDescription(
-          'The key ${duplicateKey.key} was used by multiple widgets. The parents of those widgets were:\n'
+          'The key ${duplicateKey.key} was used by multiple widgets. The offending widgets were:\n'
         ),
         for (final Element element in duplicateKey.value) ErrorDescription('  - $element\n'),
         ErrorDescription(

--- a/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
+++ b/packages/flutter/test/widgets/slotted_render_object_widget_test.dart
@@ -197,7 +197,7 @@ void main() {
 
     expect((tester.takeException() as FlutterError).toString(), equalsIgnoringHashCodes(
      'Multiple widgets used the same key in _Diagonal.\n'
-     "The key [<'widget 1'>] was used by multiple widgets. The parents of those widgets were:\n"
+     "The key [<'widget 1'>] was used by multiple widgets. The offending widgets were:\n"
      "  - SizedBox-[<'widget 1'>](width: 50.0, height: 50.0, renderObject: RenderConstrainedBox#00000 NEEDS-LAYOUT NEEDS-PAINT)\n"
      "  - SizedBox-[<'widget 1'>](width: 10.0, height: 10.0, renderObject: RenderConstrainedBox#00000 NEEDS-LAYOUT NEEDS-PAINT)\n"
      "  - SizedBox-[<'widget 1'>](width: 100.0, height: 100.0, renderObject: RenderConstrainedBox#a4685 NEEDS-LAYOUT NEEDS-PAINT)\n"


### PR DESCRIPTION
- Fixes #78100

Explains when not to use a `FilteringTextInputFormatter`.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
