### PR TITLE
[flutter_tool] Allow includes relative to shader path

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
@@ -68,6 +68,7 @@ class ShaderCompiler {
       '--spirv=$outputPath',
       '--input=${input.path}',
       '--input-type=frag',
+      '--include=${input.parent.path}',
     ];
     final Process impellercProcess = await _processManager.start(cmd);
     final int code = await impellercProcess.exitCode;

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -397,6 +397,7 @@ flutter:
     late Artifacts artifacts;
     late String impellerc;
     late Directory output;
+    late String assetsPath;
     late String shaderPath;
     late String outputPath;
 
@@ -408,8 +409,9 @@ flutter:
       fileSystem.file(impellerc).createSync(recursive: true);
 
       output = fileSystem.directory('asset_output')..createSync(recursive: true);
-      shaderPath = fileSystem.path.join('assets', 'shader.frag');
-      outputPath = fileSystem.path.join(output.path, 'assets', 'shader.frag');
+      assetsPath = 'assets';
+      shaderPath = fileSystem.path.join(assetsPath, 'shader.frag');
+      outputPath = fileSystem.path.join(output.path, assetsPath, 'shader.frag');
       fileSystem.file(shaderPath).createSync(recursive: true);
     });
 
@@ -445,6 +447,7 @@ flutter:
             '--spirv=$outputPath',
             '--input=/$shaderPath',
             '--input-type=frag',
+            '--include=/$assetsPath',
           ],
           onRun: () {
             fileSystem.file(outputPath).createSync(recursive: true);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/build_system/targets/shader_compiler.dart';
 import '../../../src/common.dart';
 import '../../../src/fake_process_manager.dart';
 
+const String fragDir = '/shaders';
 const String fragPath = '/shaders/my_shader.frag';
 const String notFragPath = '/shaders/not_a_frag.file';
 const String outputPath = '/output/shaders/my_shader.spv';
@@ -40,6 +41,7 @@ void main() {
           '--spirv=$outputPath',
           '--input=$fragPath',
           '--input-type=frag',
+          '--include=$fragDir',
         ],
         onRun: () {
           fileSystem.file(outputPath).createSync(recursive: true);
@@ -72,6 +74,7 @@ void main() {
           '--spirv=$outputPath',
           '--input=$notFragPath',
           '--input-type=frag',
+          '--include=$fragDir',
         ],
         onRun: () {
           fileSystem.file(outputPath).createSync(recursive: true);
@@ -104,6 +107,7 @@ void main() {
           '--spirv=$outputPath',
           '--input=$notFragPath',
           '--input-type=frag',
+          '--include=$fragDir',
         ],
         exitCode: 1,
       ),


### PR DESCRIPTION
This PR passes `--include=$shaderDir` to `impellerc`.

Related: https://github.com/flutter/flutter/issues/107812