### PR TITLE
[web][debug] Remove RequireJS timeouts for debug builds.

### DIFF
--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -28,6 +28,7 @@ var styles = `
     position: absolute;
     top: 0px;
     left: 0px;
+    overflow: hidden;
   }
 
   .indeterminate {

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -132,6 +132,10 @@ String generateMainModule({
 }) {
   return '''
 /* ENTRYPOINT_EXTENTION_MARKER */
+// Disable require module timeout
+require.config({
+  waitSeconds: 0
+});
 // Create the main module loaded below.
 define("$bootstrapModule", ["$entrypoint", "dart_sdk"], function(app, dart_sdk) {
   dart_sdk.dart.setStartAsyncSynchronously(true);

--- a/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/bootstrap_test.dart
@@ -21,13 +21,43 @@ void main() {
     expect(result, contains('requireEl.setAttribute("data-main", "main_module.bootstrap");'));
   });
 
-test('generateBootstrapScript includes loading indicator', () {
+  test('generateBootstrapScript includes loading indicator', () {
     final String result = generateBootstrapScript(
       requireUrl: 'require.js',
       mapperUrl: 'mapper.js',
     );
     expect(result, contains('"flutter-loader"'));
     expect(result, contains('"indeterminate"'));
+  });
+
+  // https://github.com/flutter/flutter/issues/107742
+  test('generateBootstrapScript loading indicator does not trigger scrollbars', () {
+    final String result = generateBootstrapScript(
+      requireUrl: 'require.js',
+      mapperUrl: 'mapper.js',
+    );
+
+    // See: https://regexr.com/6q0ft
+    final RegExp regex = RegExp(r'(?:\.flutter-loader\s*\{)[^}]+(?:overflow\:\s*hidden;)[^}]+}');
+
+    expect(result, matches(regex), reason: '.flutter-loader must have overflow: hidden');
+  });
+
+  // https://github.com/flutter/flutter/issues/82524
+  test('generateMainModule removes timeout from requireJS', () {
+    final String result = generateMainModule(
+      entrypoint: 'foo/bar/main.js',
+      nullAssertions: false,
+      nativeNullAssertions: false,
+    );
+
+    // See: https://regexr.com/6q0kp
+    final RegExp regex = RegExp(
+      r'(?:require\.config\(\{)(?:.|\s(?!\}\);))*'
+        r'(?:waitSeconds\:\s*0[,]?)'
+      r'(?:(?!\}\);).|\s)*\}\);');
+
+    expect(result, matches(regex), reason: 'require.config must have a waitSeconds: 0 config entry');
   });
 
   test('generateMainModule embeds urls correctly', () {


### PR DESCRIPTION
By default, requireJS times out loading modules at [7 seconds](https://requirejs.org/docs/api.html#config-waitSeconds). This is a problem for Flutter web apps in debug mode over slow(ish) network connections and cold caches, where some of the assets may take longer of 7 seconds to load.

This PR sets the `waitSeconds` requireJS property to `0` to "disable the timeout".

While testing the fix, I noticed that the default loading indicator introduced by flutter in debug mode causes horizontal scrollbars to show up, and I fixed that too with a line of CSS.

Fixes: https://github.com/flutter/flutter/issues/82524
Fixes: https://github.com/flutter/flutter/issues/107742

Added unit test for both changes.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
