### PR TITLE
Fixes issue with sheet reset on rebuild

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -101,9 +101,8 @@ class DraggableScrollableController extends ChangeNotifier {
   /// The duration must not be zero. To jump to a particular value without an
   /// animation, use [jumpTo].
   ///
-  /// The sheet will not snap after calling [animateTo] even if it is not at a
-  /// snap point and [DraggableScrollableSheet.snap] is true. Snapping only
-  /// occurs after user drags.
+  /// The sheet will not snap after calling [animateTo] even if [DraggableScrollSheet.snap]
+  /// is true. Snapping only occurs after user drags.
   ///
   /// When calling [animateTo] in widget tests, `await`ing the returned
   /// [Future] may cause the test to hang and timeout. Instead, use
@@ -155,9 +154,8 @@ class DraggableScrollableController extends ChangeNotifier {
   /// is currently animating (e.g. responding to a user fling), that animation is
   /// canceled as well.
   ///
-  /// The sheet will not snap after calling [jumpTo] even if it is not at a snap
-  /// point and [DraggableScrollableSheet.snap] is true. Snapping only occurs
-  /// after user drags.
+  /// The sheet will not snap after calling [jumpTo] even if [DraggableScrollSheet.snap]
+  /// is true. Snapping only occurs after user drags.
   void jumpTo(double size) {
     _assertAttached();
     assert(size >= 0 && size <= 1);
@@ -240,6 +238,10 @@ class DraggableScrollableController extends ChangeNotifier {
 /// during a drag, set [snap] to `true`. The sheet will snap between
 /// [minChildSize] and [maxChildSize]. Use [snapSizes] to add more sizes for
 /// the sheet to snap between.
+///
+/// The snapping effect is only applied on user drags. Programmatically
+/// manipulating the sheet size via [DraggableScrollableController.animteTo] or
+/// [DraggableScrollableController.jumpTo] will ignore [snap] and [snapSizes].
 ///
 /// By default, the widget will expand its non-occupied area to fill available
 /// space in the parent. If this is not desired, e.g. because the parent wants
@@ -351,6 +353,9 @@ class DraggableScrollableSheet extends StatefulWidget {
   /// If the user's finger was still moving when they lifted it, the widget will
   /// snap to the next snap size (see [snapSizes]) in the direction of the drag.
   /// If their finger was still, the widget will snap to the nearest snap size.
+  ///
+  /// Snapping is not applied when the sheet is programmatically moved by
+  /// calling [DraggableScrollableController.animateTo] or [DraggableScrollableController.jumpTo].
   ///
   /// Rebuilding the sheet with snap newly enabled will immediately trigger a
   /// snap unless the sheet has not yet been dragged away from

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -509,8 +509,8 @@ class _DraggableSheetExtent {
   // this because we don't want to snap away from an initial or programmatically set size.
   bool hasDragged;
 
-  // Used to determine if the sheet move to the new initial size on changes of
-  // size.
+  // Used to determine if the sheet should move to the new initial size when it
+  // changes.
   // We need both `hasChanged` and `hasDragged` to achieve the following
   // behavior:
   //   1. The sheet should only snap following user drags (as opposed to

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -316,9 +316,9 @@ class DraggableScrollableSheet extends StatefulWidget {
   /// The initial fractional value of the parent container's height to use when
   /// displaying the widget.
   ///
-  /// Rebuilding the sheet with a new [initialChildSize] will move its current
-  /// size to the new initial size if the sheet hadn't been moved since the
-  /// its first build or last call to [DraggableScrollableActuator.reset].
+  /// Rebuilding the sheet with a new [initialChildSize] will only move the
+  /// the sheet to the new value if the sheet has not yet been dragged since it
+  /// was first built or since the last call to [DraggableScrollableActuator.reset].
   ///
   /// The default value is `0.5`.
   final double initialChildSize;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -86,8 +86,8 @@ class DraggableScrollableController extends ChangeNotifier {
     return _attachedController!.extent.pixelsToSize(pixels);
   }
 
-  /// Animates the attached sheet from its current size to [size] to the
-  /// provided new `size`, a fractional value of the parent container's height.
+  /// Animates the attached sheet from its current size to the given [size], a
+  /// fractional value of the parent container's height.
   ///
   /// Any active sheet animation is canceled. If the sheet's internal scrollable
   /// is currently animating (e.g. responding to a user fling), that animation is
@@ -100,6 +100,10 @@ class DraggableScrollableController extends ChangeNotifier {
   ///
   /// The duration must not be zero. To jump to a particular value without an
   /// animation, use [jumpTo].
+  ///
+  /// The sheet will not snap after calling [animateTo] even if it is not at a
+  /// snap point and [DraggableScrollableSheet.snap] is true. Snapping only
+  /// occurs after user drags.
   ///
   /// When calling [animateTo] in widget tests, `await`ing the returned
   /// [Future] may cause the test to hang and timeout. Instead, use
@@ -150,6 +154,10 @@ class DraggableScrollableController extends ChangeNotifier {
   /// Any active sheet animation is canceled. If the sheet's inner scrollable
   /// is currently animating (e.g. responding to a user fling), that animation is
   /// canceled as well.
+  ///
+  /// The sheet will not snap after calling [jumpTo] even if it is not at a snap
+  /// point and [DraggableScrollableSheet.snap] is true. Snapping only occurs
+  /// after user drags.
   void jumpTo(double size) {
     _assertAttached();
     assert(size >= 0 && size <= 1);
@@ -308,9 +316,9 @@ class DraggableScrollableSheet extends StatefulWidget {
   /// The initial fractional value of the parent container's height to use when
   /// displaying the widget.
   ///
-  /// Rebuilding the sheet with a new [initialChildSize] will only move the
-  /// the sheet to the new value if the sheet has not yet been dragged since it
-  /// was first built or since the last call to [DraggableScrollableActuator.reset].
+  /// Rebuilding the sheet with a new [initialChildSize] will move its current
+  /// size to the new initial size if the sheet hadn't been moved since the
+  /// its first build or last call to [DraggableScrollableActuator.reset].
   ///
   /// The default value is `0.5`.
   final double initialChildSize;
@@ -514,8 +522,8 @@ class _DraggableSheetExtent {
   // We need both `hasChanged` and `hasDragged` to achieve the following
   // behavior:
   //   1. The sheet should only snap following user drags (as opposed to
-  //      programmatic sheet changes.
-  //   2. The sheet should move to a new initial position on rebuild iff the
+  //      programmatic sheet changes).
+  //   2. The sheet should move to a new initial child size on rebuild iff the
   //      sheet has not changed, either by drag or programmatic control.
   bool hasChanged;
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -513,18 +513,18 @@ class _DraggableSheetExtent {
   final VoidCallback onSizeChanged;
   double availablePixels;
 
-  // Used to disable snapping until the user has dragged on the sheet. We do
-  // this because we don't want to snap away from an initial or programmatically set size.
+  // Used to disable snapping until the user has dragged on the sheet.
   bool hasDragged;
 
-  // Used to determine if the sheet should move to the new initial size when it
+  // Used to determine if the sheet should move to a new initial size when it
   // changes.
   // We need both `hasChanged` and `hasDragged` to achieve the following
   // behavior:
   //   1. The sheet should only snap following user drags (as opposed to
-  //      programmatic sheet changes).
+  //      programmatic sheet changes). See docs for `animateTo` and `jumpTo`.
   //   2. The sheet should move to a new initial child size on rebuild iff the
-  //      sheet has not changed, either by drag or programmatic control.
+  //      sheet has not changed, either by drag or programmatic control. See
+  //      docs for `initialChildSize`.
   bool hasChanged;
 
   bool get isAtMin => minSize >= _currentSize.value;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -101,7 +101,7 @@ class DraggableScrollableController extends ChangeNotifier {
   /// The duration must not be zero. To jump to a particular value without an
   /// animation, use [jumpTo].
   ///
-  /// The sheet will not snap after calling [animateTo] even if [DraggableScrollSheet.snap]
+  /// The sheet will not snap after calling [animateTo] even if [DraggableScrollableSheet.snap]
   /// is true. Snapping only occurs after user drags.
   ///
   /// When calling [animateTo] in widget tests, `await`ing the returned
@@ -154,7 +154,7 @@ class DraggableScrollableController extends ChangeNotifier {
   /// is currently animating (e.g. responding to a user fling), that animation is
   /// canceled as well.
   ///
-  /// The sheet will not snap after calling [jumpTo] even if [DraggableScrollSheet.snap]
+  /// The sheet will not snap after calling [jumpTo] even if [DraggableScrollableSheet.snap]
   /// is true. Snapping only occurs after user drags.
   void jumpTo(double size) {
     _assertAttached();
@@ -240,7 +240,7 @@ class DraggableScrollableController extends ChangeNotifier {
 /// the sheet to snap between.
 ///
 /// The snapping effect is only applied on user drags. Programmatically
-/// manipulating the sheet size via [DraggableScrollableController.animteTo] or
+/// manipulating the sheet size via [DraggableScrollableController.animateTo] or
 /// [DraggableScrollableController.jumpTo] will ignore [snap] and [snapSizes].
 ///
 /// By default, the widget will expand its non-occupied area to fill available

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1361,7 +1361,7 @@ void main() {
     expect(() => controller.animateTo(.5, duration: Duration.zero, curve: Curves.linear), throwsAssertionError);
   });
 
-  testWidgets('DraggableScrollableController must be attached before using any of its paramters', (WidgetTester tester) async {
+  testWidgets('DraggableScrollableController must be attached before using any of its parameters', (WidgetTester tester) async {
     final DraggableScrollableController controller = DraggableScrollableController();
     expect(controller.isAttached, false);
     expect(()=>controller.size, throwsAssertionError);
@@ -1389,4 +1389,70 @@ void main() {
       expect(controller.isAttached, false);
       expect(tester.takeException(), isNull);
     });
+
+  testWidgets('DraggableScrollableSheet should not reset programmatic drag on rebuild', (WidgetTester tester) async {
+    // regression test for
+    const Key stackKey = ValueKey<String>('stack');
+    const Key containerKey = ValueKey<String>('container');
+    final DraggableScrollableController controller = DraggableScrollableController();
+    await tester.pumpWidget(boilerplateWidget(
+      null,
+      controller: controller,
+      stackKey: stackKey,
+      containerKey: containerKey,
+    ));
+    await tester.pumpAndSettle();
+    final double screenHeight = tester.getSize(find.byKey(stackKey)).height;
+
+    controller.jumpTo(.6);
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(find.byKey(containerKey)).height / screenHeight,
+      closeTo(.6, precisionErrorTolerance),
+    );
+
+    // Force an arbitrary rebuild by pushing a new widget.
+    await tester.pumpWidget(boilerplateWidget(
+      null,
+      controller: controller,
+      stackKey: stackKey,
+      containerKey: containerKey,
+    ));
+    // Sheet remains at .6.
+    expect(
+      tester.getSize(find.byKey(containerKey)).height / screenHeight,
+      closeTo(.6, precisionErrorTolerance),
+    );
+
+    controller.reset();
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(find.byKey(containerKey)).height / screenHeight,
+      closeTo(.5, precisionErrorTolerance),
+    );
+
+    controller.animateTo(
+      .6,
+      curve: Curves.linear,
+      duration: const Duration(milliseconds: 200),
+    );
+    await tester.pumpAndSettle();
+    expect(
+      tester.getSize(find.byKey(containerKey)).height / screenHeight,
+      closeTo(.6, precisionErrorTolerance),
+    );
+
+    // Force an arbitrary rebuild by pushing a new widget.
+    await tester.pumpWidget(boilerplateWidget(
+      null,
+      controller: controller,
+      stackKey: stackKey,
+      containerKey: containerKey,
+    ));
+    // Sheet remains at .6.
+    expect(
+      tester.getSize(find.byKey(containerKey)).height / screenHeight,
+      closeTo(.6, precisionErrorTolerance),
+    );
+  });
 }

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1391,7 +1391,7 @@ void main() {
     });
 
   testWidgets('DraggableScrollableSheet should not reset programmatic drag on rebuild', (WidgetTester tester) async {
-    // regression test for
+    // regression test for https://github.com/flutter/flutter/issues/101114
     const Key stackKey = ValueKey<String>('stack');
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1391,7 +1391,7 @@ void main() {
     });
 
   testWidgets('DraggableScrollableSheet should not reset programmatic drag on rebuild', (WidgetTester tester) async {
-    // regression test for https://github.com/flutter/flutter/issues/101114
+    // Regression test for https://github.com/flutter/flutter/issues/101114
     const Key stackKey = ValueKey<String>('stack');
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();


### PR DESCRIPTION
There was a bug where the sheet would reset to `initialChildSize` on rebuild if the last change to the sheet was programmatic. This PR introduces a test and fix for this behavior.

Fixes: https://github.com/flutter/flutter/issues/101114

Having both `hasDragged` and `hasChanged` feels quite sloppy to me, but they're the only way to produce the developer-expected behavior here (see code comment above where the two are declared).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
