### PR TITLE
Migrate Mac_ios targets to cocoon scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2604,7 +2604,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: module_test_ios
-    scheduler: luci
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -2664,7 +2663,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: plugin_lint_mac
-    scheduler: luci
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -3018,7 +3016,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
-    scheduler: luci
 
   - name: Mac_ios backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3028,7 +3025,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: backdrop_filter_perf_ios__timeline_summary
-    scheduler: luci
 
   - name: Mac_ios basic_material_app_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3038,7 +3034,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: basic_material_app_ios__compile
-    scheduler: luci
 
   - name: Mac_ios channels_integration_test_ios
     recipe: devicelab/devicelab_drone
@@ -3048,7 +3043,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: channels_integration_test_ios
-    scheduler: luci
 
   - name: Mac_ios complex_layout_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3062,7 +3056,6 @@ targets:
         [
           {"dependency": "open_jdk", "version": "11"}
         ]
-    scheduler: luci
 
   - name: Mac_ios complex_layout_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -3076,7 +3069,6 @@ targets:
         [
           {"dependency": "open_jdk", "version": "11"}
         ]
-    scheduler: luci
 
   - name: Mac_ios complex_layout_scroll_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3090,7 +3082,6 @@ targets:
         [
           {"dependency": "open_jdk", "version": "11"}
         ]
-    scheduler: luci
 
   - name: Mac_ios cubic_bezier_perf_ios_sksl_warmup__timeline_summary
     bringup: true # Flaky https://github.com/flutter/flutter/issues/102230
@@ -3120,7 +3111,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: route_test_ios
-    scheduler: luci
 
   - name: Mac_ios flavors_test_ios
     recipe: devicelab/devicelab_drone
@@ -3130,7 +3120,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flavors_test_ios
-    scheduler: luci
 
   - name: Mac_ios flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3140,7 +3129,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__compile
-    scheduler: luci
 
   - name: Mac_arm64_ios flutter_gallery_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3150,7 +3138,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: flutter_gallery_ios__compile
-    scheduler: luci
 
   - name: Mac_ios flutter_gallery_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -3160,7 +3147,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios__start_up
-    scheduler: luci
 
   - name: Mac_ios flutter_view_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -3170,7 +3156,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: flutter_view_ios__start_up
-    scheduler: luci
 
   - name: Mac_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3180,7 +3165,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: hello_world_ios__compile
-    scheduler: luci
 
   - name: Mac_arm64_ios hello_world_ios__compile
     recipe: devicelab/devicelab_drone
@@ -3190,7 +3174,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: hello_world_ios__compile
-    scheduler: luci
 
   - name: Mac_ios hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
@@ -3202,7 +3185,6 @@ targets:
     runIf:
       - dev/**
       - .ci.yaml
-    scheduler: luci
 
   - name: Mac_arm64_ios hot_mode_dev_cycle_macos_target__benchmark
     recipe: devicelab/devicelab_drone
@@ -3214,7 +3196,6 @@ targets:
       task_name: hot_mode_dev_cycle_macos_target__benchmark
     runIf:
       - dev/**
-    scheduler: luci
 
   - name: Mac_ios integration_test_test_ios
     recipe: devicelab/devicelab_drone
@@ -3224,7 +3205,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_test_test_ios
-    scheduler: luci
 
   - name: Mac_ios integration_ui_ios_driver
     recipe: devicelab/devicelab_drone
@@ -3234,7 +3214,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_driver
-    scheduler: luci
 
   - name: Mac_ios integration_ui_ios_frame_number
     recipe: devicelab/devicelab_drone
@@ -3244,7 +3223,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_frame_number
-    scheduler: luci
 
   - name: Mac_ios integration_ui_ios_keyboard_resize
     recipe: devicelab/devicelab_drone
@@ -3254,7 +3232,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_keyboard_resize
-    scheduler: luci
 
   - name: Mac_ios integration_ui_ios_screenshot
     recipe: devicelab/devicelab_drone
@@ -3264,7 +3241,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_screenshot
-    scheduler: luci
 
   - name: Mac_ios integration_ui_ios_textfield
     recipe: devicelab/devicelab_drone
@@ -3274,7 +3250,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: integration_ui_ios_textfield
-    scheduler: luci
 
   - name: Mac_ios ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
@@ -3284,7 +3259,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_app_with_extensions_test
-    scheduler: luci
 
   - name: Mac_arm64_ios ios_app_with_extensions_test
     recipe: devicelab/devicelab_drone
@@ -3294,7 +3268,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: ios_app_with_extensions_test
-    scheduler: luci
 
   - name: Mac_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
@@ -3304,7 +3277,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_content_validation_test
-    scheduler: luci
 
   - name: Mac_arm64_ios ios_content_validation_test
     recipe: devicelab/devicelab_drone
@@ -3314,7 +3286,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: ios_content_validation_test
-    scheduler: luci
 
   - name: Mac_ios ios_defines_test
     recipe: devicelab/devicelab_drone
@@ -3324,7 +3295,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_defines_test
-    scheduler: luci
 
   - name: Mac_ios ios_platform_view_tests
     recipe: devicelab/devicelab_drone
@@ -3334,7 +3304,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: ios_platform_view_tests
-    scheduler: luci
 
   - name: Mac_ios large_image_changer_perf_ios
     recipe: devicelab/devicelab_drone
@@ -3344,7 +3313,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: large_image_changer_perf_ios
-    scheduler: luci
 
   - name: Mac_ios macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
@@ -3354,7 +3322,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: macos_chrome_dev_mode
-    scheduler: luci
 
   - name: Mac_arm64_ios macos_chrome_dev_mode
     recipe: devicelab/devicelab_drone
@@ -3364,7 +3331,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: macos_chrome_dev_mode
-    scheduler: luci
 
   - name: Mac_ios microbenchmarks_ios
     recipe: devicelab/devicelab_drone
@@ -3374,7 +3340,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios
-    scheduler: luci
 
   - name: Mac_ios new_gallery_ios__transition_perf
     recipe: devicelab/devicelab_drone
@@ -3384,7 +3349,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: new_gallery_ios__transition_perf
-    scheduler: luci
 
   - name: Mac_ios new_gallery_impeller_ios__transition_perf
     bringup: true # Flaky https://github.com/flutter/flutter/issues/96401
@@ -3413,7 +3377,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channel_sample_test_ios
-    scheduler: luci
 
   - name: Mac_ios platform_channel_sample_test_swift
     recipe: devicelab/devicelab_drone
@@ -3423,7 +3386,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channel_sample_test_swift
-    scheduler: luci
 
   - name: Mac_ios platform_channels_benchmarks_ios
     recipe: devicelab/devicelab_drone
@@ -3433,7 +3395,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_channels_benchmarks_ios
-    scheduler: luci
 
   - name: Mac_ios platform_interaction_test_ios
     recipe: devicelab/devicelab_drone
@@ -3443,7 +3404,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_interaction_test_ios
-    scheduler: luci
 
   - name: Mac_ios platform_view_ios__start_up
     recipe: devicelab/devicelab_drone
@@ -3453,7 +3413,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_view_ios__start_up
-    scheduler: luci
 
   - name: Mac_ios platform_views_scroll_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3463,7 +3422,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: platform_views_scroll_perf_ios__timeline_summary
-    scheduler: luci
 
   - name: Mac_ios post_backdrop_filter_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3473,7 +3431,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: post_backdrop_filter_perf_ios__timeline_summary
-    scheduler: luci
 
   - name: Mac_ios simple_animation_perf_ios
     recipe: devicelab/devicelab_drone
@@ -3483,7 +3440,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: simple_animation_perf_ios
-    scheduler: luci
 
   - name: Mac_ios hot_mode_dev_cycle_ios__benchmark
     recipe: devicelab/devicelab_drone
@@ -3493,7 +3449,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: hot_mode_dev_cycle_ios__benchmark
-    scheduler: luci
 
   - name: Mac_ios tiles_scroll_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
@@ -3503,7 +3458,6 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: tiles_scroll_perf_ios__timeline_summary
-    scheduler: luci
 
   - name: Mac native_ui_tests_macos
     recipe: devicelab/devicelab_drone
@@ -3517,7 +3471,6 @@ targets:
       tags: >
         ["devicelab", "hostonly"]
       task_name: native_ui_tests_macos
-    scheduler: luci
     runIf:
       - dev/**
       - packages/flutter_tools/**
@@ -3555,7 +3508,6 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
-    scheduler: luci
 
   - name: Mac_arm64_ios run_release_test_macos
     recipe: devicelab/devicelab_drone
@@ -3570,7 +3522,6 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
-    scheduler: luci
 
   - name: Windows build_tests_1_3
     recipe: flutter/flutter_drone
@@ -3635,7 +3586,6 @@ targets:
       validation_name: Customer testing
       tags: >
         ["framework", "hostonly"]
-    scheduler: luci
 
   - name: Windows framework_tests_libraries
     recipe: flutter/flutter_drone


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/92300