### PR TITLE
Allow setting of TestWidgetsFlutterBinding.pointerEventSource

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -494,8 +494,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   ///
   /// When [handlePointerEvent] is called directly, [pointerEventSource]
   /// is [TestBindingEventSource.device].
-  TestBindingEventSource get pointerEventSource => _pointerEventSource;
-  TestBindingEventSource _pointerEventSource = TestBindingEventSource.device;
+  TestBindingEventSource pointerEventSource = TestBindingEventSource.device;
 
   /// Dispatch an event to the targets found by a hit test on its position,
   /// and remember its source as [pointerEventSource].
@@ -530,12 +529,12 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// to the previous value.
   @protected
   void withPointerEventSource(TestBindingEventSource source, VoidCallback task) {
-    final TestBindingEventSource previousSource = _pointerEventSource;
-    _pointerEventSource = source;
+    final TestBindingEventSource previousSource = pointerEventSource;
+    pointerEventSource = source;
     try {
       task();
     } finally {
-      _pointerEventSource = previousSource;
+      pointerEventSource = previousSource;
     }
   }
 

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -31,6 +31,11 @@ void main() {
       binding.defaultTestTimeout = const test_package.Timeout(Duration(minutes: 5));
       expect(binding.defaultTestTimeout.duration, const Duration(minutes: 5));
     });
+
+    test('allows setting pointerEventSource to TestBindingEventSource.test', () {
+      binding.pointerEventSource = TestBindingEventSource.test;
+      expect(binding.pointerEventSource, TestBindingEventSource.test);
+    });
   });
 
   // The next three tests must run in order -- first using `test`, then `testWidgets`, then `test` again.


### PR DESCRIPTION
Solves #107934.

This PR allows setting of TestWidgetsFlutterBinding.pointerEventSource. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
