### PR TITLE
[gen_l10n] Warn users when placeholder types are converted to 'num' when using pluralization

### DIFF
--- a/packages/flutter_tools/lib/src/commands/generate_localizations.dart
+++ b/packages/flutter_tools/lib/src/commands/generate_localizations.dart
@@ -252,9 +252,10 @@ class GenerateLocalizationsCommand extends FlutterCommand {
         areResourceAttributesRequired: areResourceAttributesRequired,
         untranslatedMessagesFile: untranslatedMessagesFile,
         usesNullableGetter: usesNullableGetter,
+        logger: _logger,
       )
         ..loadResources()
-        ..writeOutputFiles(_logger);
+        ..writeOutputFiles();
     } on L10nException catch (e) {
       throwToolExit(e.message);
     }

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1151,6 +1151,12 @@ class LocalizationsGenerator {
     // Warn users when placeholder types are overrided to 'num'.
     for (final Message message in messages) {
       if (message.isPlural) {
+        if (message.placeholders.isEmpty) {
+          throw L10nException(
+              'Unable to find placeholders for the plural message: ${message.resourceId}.\n'
+              'Check to see if the plural message is in the proper ICU syntax format '
+              'and ensure that placeholders are properly specified.');
+        }
         final Placeholder countPlaceholder = message.getCountPlaceholder();
         if (countPlaceholder.type != null && countPlaceholder.type != 'num') {
           logger.printWarning("${message.resourceId} Placeholders for plurals are automatically converted to type 'num'.");

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1153,7 +1153,7 @@ class LocalizationsGenerator {
       if (message.isPlural) {
         final Placeholder countPlaceholder = message.getCountPlaceholder();
         if (countPlaceholder.type != null && countPlaceholder.type != 'num') {
-          logger.printWarning("Placeholders for plurals are automatically converted to type 'num'.");
+          logger.printWarning("${message.resourceId} Placeholders for plurals are automatically converted to type 'num'.");
         }
       }
     }

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1159,7 +1159,7 @@ class LocalizationsGenerator {
         }
         final Placeholder countPlaceholder = message.getCountPlaceholder();
         if (countPlaceholder.type != null && countPlaceholder.type != 'num') {
-          logger.printWarning("${message.resourceId} Placeholders for plurals are automatically converted to type 'num'.");
+          logger.printWarning("Placeholders for plurals are automatically converted to type 'num' for the message: ${message.resourceId}.");
         }
       }
     }

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1148,7 +1148,6 @@ class LocalizationsGenerator {
       );
     });
 
-    // Warn users when placeholder types are overrided to 'num'.
     for (final Message message in messages) {
       if (message.isPlural) {
         if (message.placeholders.isEmpty) {

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -64,9 +64,10 @@ LocalizationsGenerator generateLocalizations({
       areResourceAttributesRequired: options.areResourceAttributesRequired,
       untranslatedMessagesFile: options.untranslatedMessagesFile?.toFilePath(),
       usesNullableGetter: options.usesNullableGetter,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(logger, isFromYaml: true);
+      ..writeOutputFiles(isFromYaml: true);
   } on L10nException catch (e) {
     throwToolExit(e.message);
   }
@@ -698,6 +699,7 @@ class LocalizationsGenerator {
     bool areResourceAttributesRequired = false,
     String? untranslatedMessagesFile,
     bool usesNullableGetter = true,
+    required Logger logger,
   }) {
     final Directory? projectDirectory = projectDirFromPath(fileSystem, projectPathString);
     final Directory inputDirectory = inputDirectoryFromPath(fileSystem, inputPathString, projectDirectory);
@@ -718,6 +720,7 @@ class LocalizationsGenerator {
       untranslatedMessagesFile: _untranslatedMessagesFileFromPath(fileSystem, untranslatedMessagesFile),
       inputsAndOutputsListFile: _inputsAndOutputsListFileFromPath(fileSystem, inputsAndOutputsListPath),
       areResourceAttributesRequired: areResourceAttributesRequired,
+      logger: logger,
     );
   }
 
@@ -739,6 +742,7 @@ class LocalizationsGenerator {
     this.areResourceAttributesRequired = false,
     this.untranslatedMessagesFile,
     this.usesNullableGetter = true,
+    required this.logger,
   });
 
   final FileSystem _fs;
@@ -858,6 +862,9 @@ class LocalizationsGenerator {
   /// Resource attributes provide metadata about the message.
   @visibleForTesting
   final bool areResourceAttributesRequired;
+
+  /// Logger to be used during the execution of the script.
+  Logger logger;
 
   static final RegExp _selectRE = RegExp(r'\{([\w\s,]*),\s*select\s*,\s*([\w\d]+\s*\{.*\})+\s*\}');
 
@@ -1141,6 +1148,16 @@ class LocalizationsGenerator {
       );
     });
 
+    // Warn users when placeholder types are overrided to 'num'.
+    for (final Message message in messages) {
+      if (message.isPlural) {
+        final Placeholder countPlaceholder = message.getCountPlaceholder();
+        if (countPlaceholder.type != null && countPlaceholder.type != 'num') {
+          logger.printWarning("Placeholders for plurals are automatically converted to type 'num'.");
+        }
+      }
+    }
+
     return classFileTemplate
       .replaceAll('@(header)', header.isEmpty ? '' : '$header\n\n')
       .replaceAll('@(language)', describeLocale(locale.toString()))
@@ -1317,7 +1334,7 @@ class LocalizationsGenerator {
         || message.placeholdersRequireFormatting;
   });
 
-  void writeOutputFiles(Logger logger, { bool isFromYaml = false }) {
+  void writeOutputFiles({ bool isFromYaml = false }) {
     // First, generate the string contents of all necessary files.
     final String generatedLocalizationsFile = _generateCode();
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -61,12 +61,14 @@ void _standardFlutterDirectoryL10nSetup(FileSystem fs) {
 
 void main() {
   late MemoryFileSystem fs;
+  late BufferLogger logger;
   late String defaultL10nPathString;
   late String syntheticPackagePath;
   late String syntheticL10nPackagePath;
 
   setUp(() {
     fs = MemoryFileSystem.test();
+    logger = BufferLogger.test();
 
     defaultL10nPathString = fs.path.join('lib', 'l10n');
     syntheticPackagePath = fs.path.join('.dart_tool', 'flutter_gen');
@@ -123,9 +125,10 @@ void main() {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       // Output files should be generated in the provided absolute path.
       expect(
@@ -171,6 +174,7 @@ void main() {
           templateArbFileName: defaultTemplateArbFileName,
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         ),
         throwsA(isA<L10nException>().having(
           (L10nException e) => e.message,
@@ -197,6 +201,7 @@ void main() {
           templateArbFileName: defaultTemplateArbFileName,
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         ),
         throwsA(isA<L10nException>().having(
           (L10nException e) => e.message,
@@ -268,6 +273,7 @@ void main() {
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
       headerString: '/// Sample header',
+      logger: logger,
     );
 
     expect(generator.header, '/// Sample header');
@@ -288,6 +294,7 @@ void main() {
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
       headerFile: 'header.txt',
+      logger: logger,
     );
 
     expect(generator.header, '/// Sample header in a text file');
@@ -306,9 +313,10 @@ void main() {
         templateArbFileName: 'app_localizations_en.arb',
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final Directory outputDirectory = fs.directory(syntheticL10nPackagePath);
     expect(outputDirectory.childFile('output-localization-file.dart').existsSync(), isTrue);
@@ -331,6 +339,7 @@ void main() {
           templateArbFileName: 'app_localizations_en.arb',
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         ).loadResources();
       },
       throwsA(isA<L10nException>().having(
@@ -355,9 +364,10 @@ void main() {
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
       untranslatedMessagesFile: fs.path.join('lib', 'l10n', 'unimplemented_message_translations.json'),
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final File unimplementedOutputFile = fs.file(
       fs.path.join('lib', 'l10n', 'unimplemented_message_translations.json'),
@@ -388,9 +398,10 @@ void main() {
       classNameString: defaultClassNameString,
       useSyntheticPackage: false,
       untranslatedMessagesFile: fs.path.join('lib', 'l10n', 'unimplemented_message_translations.json'),
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final File unimplementedOutputFile = fs.file(
       fs.path.join('lib', 'l10n', 'unimplemented_message_translations.json'),
@@ -410,7 +421,6 @@ void main() {
     'untranslated messages suggestion is printed when translation is missing: '
     'command line message',
     () {
-      final BufferLogger testLogger = BufferLogger.test();
       fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
         ..createSync(recursive: true)
         ..childFile(defaultTemplateArbFileName).writeAsStringSync(twoMessageArbFileString)
@@ -424,16 +434,17 @@ void main() {
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
           useSyntheticPackage: false,
+          logger: logger,
         )
         ..loadResources()
-        ..writeOutputFiles(testLogger);
+        ..writeOutputFiles();
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('To see a detailed report, use the --untranslated-messages-file'),
       );
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('flutter gen-l10n --untranslated-messages-file=desiredFileName.txt'),
       );
     },
@@ -443,7 +454,6 @@ void main() {
     'untranslated messages suggestion is printed when translation is missing: '
     'l10n.yaml message',
     () {
-      final BufferLogger testLogger = BufferLogger.test();
       fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
         ..createSync(recursive: true)
         ..childFile(defaultTemplateArbFileName).writeAsStringSync(twoMessageArbFileString)
@@ -455,16 +465,17 @@ void main() {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(testLogger, isFromYaml: true);
+        ..writeOutputFiles(isFromYaml: true);
 
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('To see a detailed report, use the untranslated-messages-file'),
       );
       expect(
-        testLogger.statusText,
+        logger.statusText,
         contains('untranslated-messages-file: desiredFileName.txt'),
       );
     },
@@ -474,7 +485,6 @@ void main() {
     'unimplemented messages suggestion is not printed when all messages '
     'are fully translated',
     () {
-      final BufferLogger testLogger = BufferLogger.test();
       fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
         ..createSync(recursive: true)
         ..childFile(defaultTemplateArbFileName).writeAsStringSync(twoMessageArbFileString)
@@ -487,11 +497,12 @@ void main() {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(testLogger);
+        ..writeOutputFiles();
 
-      expect(testLogger.statusText, '');
+      expect(logger.statusText, '');
     },
   );
 
@@ -506,9 +517,10 @@ void main() {
       classNameString: defaultClassNameString,
       inputsAndOutputsListPath: syntheticL10nPackagePath,
       untranslatedMessagesFile: fs.path.join('lib', 'l10n', 'unimplemented_message_translations.json'),
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final File inputsAndOutputsList = fs.file(
       fs.path.join(syntheticL10nPackagePath, 'gen_l10n_inputs_and_outputs.json'),
@@ -535,9 +547,10 @@ void main() {
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         useSyntheticPackage: false,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final Directory outputDirectory = fs.directory('lib').childDirectory('l10n');
       expect(outputDirectory.childFile('output-localization-file.dart').existsSync(), isTrue);
@@ -572,9 +585,10 @@ void main() {
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         useSyntheticPackage: false,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final Directory outputDirectory = fs.directory('lib').childDirectory('l10n').childDirectory('output');
       expect(outputDirectory.existsSync(), isTrue);
@@ -598,9 +612,10 @@ void main() {
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
           useSyntheticPackage: false,
+          logger: logger,
         )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final Directory outputDirectory = fs.directory('lib').childDirectory('l10n').childDirectory('output');
       expect(outputDirectory.existsSync(), isTrue);
@@ -624,9 +639,10 @@ void main() {
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         useSyntheticPackage: false,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final Directory outputDirectory = fs.directory('lib').childDirectory('l10n').childDirectory('output');
       expect(outputDirectory.existsSync(), isTrue);
@@ -656,9 +672,10 @@ void main() {
         classNameString: defaultClassNameString,
         useSyntheticPackage: false,
         usesNullableGetter: false,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final Directory outputDirectory = fs.directory('lib').childDirectory('l10n').childDirectory('output');
       expect(outputDirectory.existsSync(), isTrue);
@@ -684,9 +701,10 @@ void main() {
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
       inputsAndOutputsListPath: syntheticL10nPackagePath,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final File inputsAndOutputsList = fs.file(
       fs.path.join(syntheticL10nPackagePath, 'gen_l10n_inputs_and_outputs.json'),
@@ -724,6 +742,7 @@ void main() {
           classNameString: defaultClassNameString,
           headerString: '/// Sample header for localizations file.',
           headerFile: 'header.txt',
+          logger: logger,
         );
       },
       throwsA(isA<L10nException>().having(
@@ -754,6 +773,7 @@ void main() {
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
           headerFile: 'header.tx', // Intentionally spelled incorrectly
+          logger: logger,
         );
       },
       throwsA(isA<L10nException>().having(
@@ -786,7 +806,7 @@ void main() {
       final LocalizationsGenerator generator = generateLocalizations(
         fileSystem: fs,
         options: options,
-        logger: BufferLogger.test(),
+        logger: logger,
         projectDir: fs.currentDirectory,
         dependenciesDir: fs.currentDirectory,
       );
@@ -899,7 +919,7 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFile: Uri.file(defaultTemplateArbFileName, windows: false),
         useSyntheticPackage: false,
       ),
-      logger: BufferLogger.test(),
+      logger: logger,
       projectDir: fs.currentDirectory,
       dependenciesDir: fs.currentDirectory,
     );
@@ -931,6 +951,7 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources();
 
@@ -956,6 +977,7 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources();
 
@@ -983,6 +1005,7 @@ class AppLocalizationsEn extends AppLocalizations {
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         preferredSupportedLocales: preferredSupportedLocale,
+        logger: logger,
       )
         ..loadResources();
 
@@ -1014,6 +1037,7 @@ class AppLocalizationsEn extends AppLocalizations {
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
               preferredSupportedLocales: preferredSupportedLocale,
+              logger: logger,
             ).loadResources();
           },
           throwsA(isA<L10nException>().having(
@@ -1043,6 +1067,7 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources();
 
@@ -1084,6 +1109,7 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: 'first_file.arb',
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources();
 
@@ -1126,6 +1152,7 @@ class AppLocalizationsEn extends AppLocalizations {
             templateArbFileName: 'app_es.arb',
             outputFileString: defaultOutputFileString,
             classNameString: defaultClassNameString,
+            logger: logger,
           ).loadResources();
         },
         throwsA(isA<L10nException>().having(
@@ -1150,6 +1177,7 @@ class AppLocalizationsEn extends AppLocalizations {
             templateArbFileName: 'app.arb',
             outputFileString: defaultOutputFileString,
             classNameString: defaultClassNameString,
+            logger: logger,
           ).loadResources();
         },
         throwsA(isA<L10nException>().having(
@@ -1182,6 +1210,7 @@ class AppLocalizationsEn extends AppLocalizations {
           templateArbFileName: 'app_en.arb',
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         ).loadResources(),
         throwsA(isA<L10nException>().having(
           (L10nException e) => e.message,
@@ -1216,6 +1245,7 @@ class AppLocalizationsEn extends AppLocalizations {
             templateArbFileName: 'app_en.arb',
             outputFileString: defaultOutputFileString,
             classNameString: defaultClassNameString,
+            logger: logger,
           ).loadResources();
         },
         throwsA(isA<L10nException>().having(
@@ -1241,6 +1271,7 @@ class AppLocalizationsEn extends AppLocalizations {
             templateArbFileName: 'app_en_US.arb',
             outputFileString: defaultOutputFileString,
             classNameString: defaultClassNameString,
+            logger: logger,
           ).loadResources();
         },
         throwsA(isA<L10nException>().having(
@@ -1255,7 +1286,6 @@ class AppLocalizationsEn extends AppLocalizations {
   group('writeOutputFiles', () {
     testWithoutContext('message without placeholders - should generate code comment with description and template message translation', () {
       _standardFlutterDirectoryL10nSetup(fs);
-      final BufferLogger testLogger = BufferLogger.test();
       LocalizationsGenerator(
         fileSystem: fs,
         inputPathString: defaultL10nPathString,
@@ -1263,9 +1293,10 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(testLogger);
+        ..writeOutputFiles();
 
       final File baseLocalizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
@@ -1304,9 +1335,10 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(testLogger);
+        ..writeOutputFiles();
 
       final File baseLocalizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
@@ -1353,9 +1385,10 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(testLogger);
+        ..writeOutputFiles();
 
       final File baseLocalizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart')
@@ -1387,9 +1420,10 @@ class AppLocalizationsEn extends AppLocalizations {
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart')), true);
       expect(fs.isFileSync(fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en_US.dart')), false);
@@ -1416,9 +1450,10 @@ class AppLocalizationsEn extends AppLocalizations {
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         preferredSupportedLocales: preferredSupportedLocale,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, defaultOutputFileString),
@@ -1443,9 +1478,10 @@ import 'output-localization-file_zh.dart';
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: 'output-localization-file.g.dart',
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String baseLocalizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.g.dart'),
@@ -1477,9 +1513,10 @@ import 'output-localization-file.g.dart';
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: 'asdf',
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1502,9 +1539,10 @@ import 'output-localization-file.g.dart';
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: '.g.dart',
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1530,9 +1568,10 @@ import 'output-localization-file.g.dart';
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         useDeferredLoading: true,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, defaultOutputFileString),
@@ -1570,9 +1609,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           templateArbFileName: defaultTemplateArbFileName,
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         )
           ..loadResources()
-          ..writeOutputFiles(BufferLogger.test());
+          ..writeOutputFiles();
 
         final String localizationsFile = fs.file(
           fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
@@ -1608,9 +1648,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1651,9 +1692,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           templateArbFileName: defaultTemplateArbFileName,
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         )
           ..loadResources()
-          ..writeOutputFiles(BufferLogger.test());
+          ..writeOutputFiles();
 
         final String localizationsFile = fs.file(
           fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
@@ -1688,9 +1730,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           templateArbFileName: defaultTemplateArbFileName,
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         )
           ..loadResources()
-          ..writeOutputFiles(BufferLogger.test());
+          ..writeOutputFiles();
 
         final String localizationsFile = fs.file(
           fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
@@ -1725,9 +1768,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1765,9 +1809,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           templateArbFileName: defaultTemplateArbFileName,
           outputFileString: defaultOutputFileString,
           classNameString: defaultClassNameString,
+          logger: logger,
         )
           ..loadResources()
-          ..writeOutputFiles(BufferLogger.test());
+          ..writeOutputFiles();
 
         final String localizationsFile = fs.file(
           fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
@@ -1803,9 +1848,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1844,9 +1890,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1880,9 +1927,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1912,9 +1960,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1947,9 +1996,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -1960,6 +2010,36 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             ),
           )),
         );
+      });
+
+      testWithoutContext('should warn attempting to generate a plural message whose placeholder is not num or null', () {
+        const String pluralMessageWithIncorrectPlaceholderType = '''
+{
+  "helloWorlds": "{count,plural, =0{Hello}=1{Hello World}=2{Hello two worlds}few{Hello {count} worlds}many{Hello all {count} worlds}other{Hello other {count} worlds}}",
+  "@helloWorlds": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
+}''';
+        final Directory l10nDirectory = fs.currentDirectory.childDirectory('lib').childDirectory('l10n')
+          ..createSync(recursive: true);
+        l10nDirectory.childFile(defaultTemplateArbFileName)
+          .writeAsStringSync(pluralMessageWithIncorrectPlaceholderType);
+        LocalizationsGenerator(
+          fileSystem: fs,
+          inputPathString: defaultL10nPathString,
+          outputPathString: defaultL10nPathString,
+          templateArbFileName: defaultTemplateArbFileName,
+          outputFileString: defaultOutputFileString,
+          classNameString: defaultClassNameString,
+          logger: logger,
+        )
+          ..loadResources()
+          ..writeOutputFiles(); 
+        expect(logger.warningText, contains("Placeholders for plurals are automatically converted to type 'num'."));
       });
     });
 
@@ -1987,9 +2067,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2023,9 +2104,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2055,9 +2137,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2090,9 +2173,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2130,9 +2214,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2158,9 +2243,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file_es.dart'),
@@ -2198,9 +2284,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file_es.dart'),
@@ -2238,9 +2325,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file_es.dart'),
@@ -2258,9 +2346,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart'),
@@ -2292,9 +2381,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
         useDeferredLoading: true,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart'),
@@ -2314,9 +2404,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart'),
@@ -2438,9 +2529,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file_es.dart'),
@@ -2507,9 +2599,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         templateArbFileName: defaultTemplateArbFileName,
         outputFileString: defaultOutputFileString,
         classNameString: defaultClassNameString,
+        logger: logger,
       )
         ..loadResources()
-        ..writeOutputFiles(BufferLogger.test());
+        ..writeOutputFiles();
 
       final String localizationsFile = fs.file(
         fs.path.join(syntheticL10nPackagePath, 'output-localization-file_es.dart'),
@@ -2553,9 +2646,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2590,9 +2684,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             outputFileString: defaultOutputFileString,
             classNameString: defaultClassNameString,
             areResourceAttributesRequired: true,
+            logger: logger,
           )
             ..loadResources()
-            ..writeOutputFiles(BufferLogger.test());
+            ..writeOutputFiles();
         },
         throwsA(isA<L10nException>().having(
           (L10nException e) => e.message,
@@ -2625,9 +2720,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2659,9 +2755,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2692,9 +2789,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
               templateArbFileName: defaultTemplateArbFileName,
               outputFileString: defaultOutputFileString,
               classNameString: defaultClassNameString,
+              logger: logger,
             )
               ..loadResources()
-              ..writeOutputFiles(BufferLogger.test());
+              ..writeOutputFiles();
           },
           throwsA(isA<L10nException>().having(
             (L10nException e) => e.message,
@@ -2726,9 +2824,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
             templateArbFileName: 'app_invalid.arb',
             outputFileString: defaultOutputFileString,
             classNameString: defaultClassNameString,
+            logger: logger,
           )
             ..loadResources()
-            ..writeOutputFiles(BufferLogger.test());
+            ..writeOutputFiles();
         },
         throwsA(isA<L10nException>().having(
           (L10nException e) => e.message,
@@ -2747,9 +2846,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
       templateArbFileName: defaultTemplateArbFileName,
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final Directory outputDirectory = fs.directory(syntheticPackagePath);
     final File pubspecFile = outputDirectory.childFile('pubspec.yaml');
@@ -2777,9 +2877,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
       templateArbFileName: defaultTemplateArbFileName,
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     // The original pubspec file should not be overwritten.
     expect(pubspecFile.readAsStringSync(), 'abcd');
@@ -2811,9 +2912,10 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
       templateArbFileName: defaultTemplateArbFileName,
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final String localizationsFile = fs.file(
       fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),
@@ -2839,9 +2941,10 @@ String orderNumber(int number) {
       templateArbFileName: defaultTemplateArbFileName,
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final String localizationsFile = fs.file(
       fs.path.join(syntheticL10nPackagePath, 'output-localization-file.dart'),
@@ -2883,9 +2986,10 @@ AppLocalizations lookupAppLocalizations(Locale locale) {
       templateArbFileName: defaultTemplateArbFileName,
       outputFileString: defaultOutputFileString,
       classNameString: defaultClassNameString,
+      logger: logger,
     )
       ..loadResources()
-      ..writeOutputFiles(BufferLogger.test());
+      ..writeOutputFiles();
 
     final String localizationsFile = fs.file(
       fs.path.join(syntheticL10nPackagePath, 'output-localization-file_en.dart'),

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -1326,8 +1326,6 @@ class AppLocalizationsEn extends AppLocalizations {
       l10nDirectory.childFile(esArbFileName)
         .writeAsStringSync(singleEsMessageArbFileString);
 
-      final BufferLogger testLogger = BufferLogger.test();
-
       LocalizationsGenerator(
         fileSystem: fs,
         inputPathString: defaultL10nPathString,
@@ -1377,7 +1375,6 @@ class AppLocalizationsEn extends AppLocalizations {
   "price": "el precio de este artículo es: ${price}"
 }''');
 
-      final BufferLogger testLogger = BufferLogger.test();
       LocalizationsGenerator(
         fileSystem: fs,
         inputPathString: defaultL10nPathString,

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -2039,7 +2039,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
         )
           ..loadResources()
           ..writeOutputFiles(); 
-        expect(logger.warningText, contains("Placeholders for plurals are automatically converted to type 'num'."));
+        expect(logger.warningText, contains("Placeholders for plurals are automatically converted to type 'num'"));
       });
     });
 

--- a/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/general.shard/generate_localizations_test.dart
@@ -2038,7 +2038,7 @@ import 'output-localization-file_en.dart' deferred as output-localization-file_e
           logger: logger,
         )
           ..loadResources()
-          ..writeOutputFiles(); 
+          ..writeOutputFiles();
         expect(logger.warningText, contains("Placeholders for plurals are automatically converted to type 'num'"));
       });
     });


### PR DESCRIPTION
See title. This PR refactors logging so that the logger is saved as an instance variable of the `LocalizationsGenerator` class, and adds a warning when there is a pluralization placeholder whose type isn't num.

Fixes #98868

Tested locally:
```
Multiple devices found:
macOS (desktop) • macos  • darwin-arm64   • macOS 12.4 21F79 darwin-arm (Rosetta)
Chrome (web)    • chrome • web-javascript • Google Chrome 103.0.5060.114
[1]: macOS (macos)
[2]: Chrome (chrome)
Please choose one (To quit, press "q/Q"): 2
Placeholders for plurals are automatically converted to type 'num'.
Placeholders for plurals are automatically converted to type 'num'.
Running "flutter pub get" in i18n_test...                          698ms
```
I didn't think I needed to add tests here since there's really no change other than logging.