### PR TITLE
Ignore flakiness check for `external_ui_integration_test_ios`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3102,6 +3102,7 @@ targets:
       tags: >
         ["devicelab", "ios", "mac"]
       task_name: external_ui_integration_test_ios
+      ignore_flakiness: "true"
 
   - name: Mac_ios route_test_ios
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Context: https://github.com/flutter/flutter/issues/106806