### PR TITLE
Handle updated error message when iOS device is locked

### DIFF
--- a/packages/flutter_tools/lib/src/ios/ios_deploy.dart
+++ b/packages/flutter_tools/lib/src/ios/ios_deploy.dart
@@ -22,6 +22,7 @@ import 'iproxy.dart';
 const String noProvisioningProfileErrorOne = 'Error 0xe8008015';
 const String noProvisioningProfileErrorTwo = 'Error 0xe8000067';
 const String deviceLockedError = 'e80000e2';
+const String deviceLockedErrorMessage = 'the device was not, or could not be, unlocked';
 const String unknownAppLaunchError = 'Error 0xe8000022';
 
 class IOSDeploy {
@@ -520,7 +521,7 @@ String _monitorIOSDeployFailure(String stdout, Logger logger) {
     logger.printError(noProvisioningProfileInstruction, emphasis: true);
 
     // Launch issues.
-  } else if (stdout.contains(deviceLockedError)) {
+  } else if (stdout.contains(deviceLockedError) || stdout.contains(deviceLockedErrorMessage)) {
     logger.printError('''
 ═══════════════════════════════════════════════════════════════════════════════════
 Your device is locked. Unlock your device first before running.

--- a/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_deploy_test.dart
@@ -258,11 +258,26 @@ void main () {
         expect(logger.errorText, contains('No Provisioning Profile was found'));
       });
 
-      testWithoutContext('device locked', () async {
+      testWithoutContext('device locked code', () async {
         final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
           const FakeCommand(
             command: <String>['ios-deploy'],
             stdout: 'e80000e2',
+          ),
+        ]);
+        final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(
+          processManager: processManager,
+          logger: logger,
+        );
+        await iosDeployDebugger.launchAndAttach();
+        expect(logger.errorText, contains('Your device is locked.'));
+      });
+
+      testWithoutContext('device locked message', () async {
+        final FakeProcessManager processManager = FakeProcessManager.list(<FakeCommand>[
+          const FakeCommand(
+            command: <String>['ios-deploy'],
+            stdout: '[  +95 ms] error: The operation couldn’t be completed. Unable to launch io.flutter.examples.gallery because the device was not, or could not be, unlocked.',
           ),
         ]);
         final IOSDeployDebugger iosDeployDebugger = IOSDeployDebugger.test(


### PR DESCRIPTION
I'm not sure when this error message from the device changed.

```
$ flutter run -d 1234
Running "flutter pub get" in test_create...                        245ms
Launching lib/main.dart on iPhone 12 Pro in debug mode...
Automatically signing iOS for device deployment using specified development team in Xcode project:
Running Xcode build...
 └─Compiling, linking and signing...                      1,887ms
Xcode build done.                                            6.8s
═══════════════════════════════════════════════════════════════════════════════════
Your device is locked. Unlock your device first before running.
═══════════════════════════════════════════════════════════════════════════════════
Could not run build/ios/iphoneos/Runner.app on 1234.
Try launching Xcode and selecting "Product > Run" to fix the problem:
  open ios/Runner.xcworkspace

Installing and launching...                                         5.9s
Error launching application on iPhone 12 Pro.
```

Fixes https://github.com/flutter/flutter/issues/107983
See also #12977.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
