### PR TITLE
[flutter_tool] Build shaders as .iplr and use FragmentProgram.fromAsset for ink_sparkle

### DIFF
--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
-import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:vector_math/vector_math_64.dart';
 
@@ -522,14 +521,8 @@ class FragmentShaderManager {
   /// Creates an [FragmentShaderManager] with an [InkSparkle] effect.
   static Future<FragmentShaderManager> inkSparkle() async {
     final FragmentShaderManager manager = FragmentShaderManager._();
-    await manager._compile();
+    _program = ui.FragmentProgram.fromAsset('shaders/ink_sparkle.frag');
     return manager;
-  }
-
-  /// Compiles the spir-v bytecode into a shader program.
-  Future<void> _compile() async {
-    final ByteData data = await rootBundle.load('shaders/ink_sparkle.frag');
-    _program = await ui.FragmentProgram.compile(spirv: data.buffer);
   }
 
   /// Creates a shader with the original program and optional uniforms.

--- a/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
@@ -5,6 +5,7 @@
 import 'package:process/process.dart';
 
 import '../../artifacts.dart';
+import '../../base/error_handling_io.dart';
 import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../base/logger.dart';
@@ -64,8 +65,10 @@ class ShaderCompiler {
       // TODO(zanderso): When impeller is enabled, the correct flags for the
       // target backend will need to be passed.
       // https://github.com/flutter/flutter/issues/102853
-      '--flutter-spirv',
-      '--spirv=$outputPath',
+      '--sksl',
+      '--iplr',
+      '--sl=$outputPath',
+      '--spirv=$outputPath.spirv',
       '--input=${input.path}',
       '--input-type=frag',
       '--include=${input.parent.path}',
@@ -81,6 +84,7 @@ class ShaderCompiler {
       );
     }
 
+    ErrorHandlingFileSystem.deleteIfExists(_fs.file('$outputPath.spirv'));
     return true;
   }
 }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -443,14 +443,17 @@ flutter:
         FakeCommand(
           command: <String>[
             impellerc,
-            '--flutter-spirv',
-            '--spirv=$outputPath',
+            '--sksl',
+            '--iplr',
+            '--sl=$outputPath',
+            '--spirv=$outputPath.spirv',
             '--input=/$shaderPath',
             '--input-type=frag',
             '--include=/$assetsPath',
           ],
           onRun: () {
             fileSystem.file(outputPath).createSync(recursive: true);
+            fileSystem.file('$outputPath.spirv').createSync(recursive: true);
           },
         ),
       ]),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -13,7 +13,8 @@ import '../../../src/fake_process_manager.dart';
 const String fragDir = '/shaders';
 const String fragPath = '/shaders/my_shader.frag';
 const String notFragPath = '/shaders/not_a_frag.file';
-const String outputPath = '/output/shaders/my_shader.spv';
+const String outputSpirvPath = '/output/shaders/my_shader.frag.spirv';
+const String outputPath = '/output/shaders/my_shader.frag';
 
 void main() {
   late BufferLogger logger;
@@ -37,14 +38,17 @@ void main() {
       FakeCommand(
         command: <String>[
           impellerc,
-          '--flutter-spirv',
-          '--spirv=$outputPath',
+          '--sksl',
+          '--iplr',
+          '--sl=$outputPath',
+          '--spirv=$outputSpirvPath',
           '--input=$fragPath',
           '--input-type=frag',
           '--include=$fragDir',
         ],
         onRun: () {
           fileSystem.file(outputPath).createSync(recursive: true);
+          fileSystem.file(outputSpirvPath).createSync(recursive: true);
         },
       ),
     ]);
@@ -63,6 +67,7 @@ void main() {
       true,
     );
     expect(fileSystem.file(outputPath).existsSync(), true);
+    expect(fileSystem.file(outputSpirvPath).existsSync(), false);
   });
 
   testWithoutContext('compileShader invokes impellerc for non-.frag files', () async {
@@ -70,14 +75,17 @@ void main() {
       FakeCommand(
         command: <String>[
           impellerc,
-          '--flutter-spirv',
-          '--spirv=$outputPath',
+          '--sksl',
+          '--iplr',
+          '--sl=$outputPath',
+          '--spirv=$outputSpirvPath',
           '--input=$notFragPath',
           '--input-type=frag',
           '--include=$fragDir',
         ],
         onRun: () {
           fileSystem.file(outputPath).createSync(recursive: true);
+          fileSystem.file(outputSpirvPath).createSync(recursive: true);
         },
       ),
     ]);
@@ -96,6 +104,7 @@ void main() {
       true,
     );
     expect(fileSystem.file(outputPath).existsSync(), true);
+    expect(fileSystem.file(outputSpirvPath).existsSync(), false);
   });
 
   testWithoutContext('compileShader throws an exception when impellerc fails', () async {
@@ -103,8 +112,10 @@ void main() {
       FakeCommand(
         command: <String>[
           impellerc,
-          '--flutter-spirv',
-          '--spirv=$outputPath',
+          '--sksl',
+          '--iplr',
+          '--sl=$outputPath',
+          '--spirv=$outputSpirvPath',
           '--input=$notFragPath',
           '--input-type=frag',
           '--include=$fragDir',


### PR DESCRIPTION
This PR causes the tool to bundle shaders as SkSL in a `.iplr` container, and to use `FragmentProgram.fromAsset` to load the ink_sparkle shader.

This will require fixes to the internal build, which are here: cl/462521386 cc @chingjun 

After this lands we can start deleting the transpiler and old API.