### PR TITLE
Update EdgeInsets to EdgeInsetsGeometry in PopupMenuItem #106866

### DIFF
--- a/packages/flutter/lib/src/material/popup_menu.dart
+++ b/packages/flutter/lib/src/material/popup_menu.dart
@@ -263,7 +263,7 @@ class PopupMenuItem<T> extends PopupMenuEntry<T> {
   /// is provided, then the padding's effect will not be visible.
   ///
   /// When null, the horizontal padding defaults to 16.0 on both sides.
-  final EdgeInsets? padding;
+  final EdgeInsetsGeometry? padding;
 
   /// The text style of the popup menu item.
   ///


### PR DESCRIPTION
In `PopupMenuItem`  I upgrade `EdgeInsets` to `EdgeInsetsGeometry` for multiple languages support (right to left and vice versa), where if there is more than one language in the application it requires the use of EdgeInsetsDirectional instead of EdgeInsets.

#106866