### PR TITLE
Correct links and grammar in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,19 @@ open source.
 ## Documentation
 
 * [Install Flutter](https://flutter.dev/get-started/)
-* [Flutter documentation](https://flutter.dev/docs)
+* [Flutter documentation](https://docs.flutter.dev/)
 * [Development wiki](https://github.com/flutter/flutter/wiki)
 * [Contributing to Flutter](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
 
 For announcements about new releases, follow the
 [flutter-announce@googlegroups.com](https://groups.google.com/forum/#!forum/flutter-announce)
 mailing list. Our documentation also tracks [breaking
-changes](https://flutter.dev/docs/release/breaking-changes) across releases.
+changes](https://docs.flutter.dev/release/breaking-changes) across releases.
 
 ## Terms of service
 
 The Flutter tool may occasionally download resources from Google servers. By
-downloading or using the Flutter SDK you agree to the Google Terms of Service:
+downloading or using the Flutter SDK, you agree to the Google Terms of Service:
 https://policies.google.com/terms
 
 For example, when installed from GitHub (as opposed to from a prepackaged
@@ -85,8 +85,8 @@ Flutter works with any development tool (or none at all), and also includes
 editor plug-ins for both [Visual Studio Code] and [IntelliJ / Android Studio].
 Flutter provides [tens of thousands of packages][Flutter packages] to speed your
 development, regardless of your target platform. And accessing other native code
-is easy, with support for both [FFI] and [platform-specific APIs][platform
-channels].
+is easy, with support for both FFI ([on Android][Android FFI], [on iOS][iOS FFI],
+and [on macOS][macOS FFI]) as well as [platform-specific APIs][platform channels].
 
 Flutter is a fully open-source project, and we welcome contributions.
 Information on how to get started can be found in our
@@ -99,7 +99,7 @@ Information on how to get started can be found in our
 [Discord badge]: https://img.shields.io/discord/608014603317936148
 [Twitter handle]: https://img.shields.io/twitter/follow/flutterdev.svg?style=social&label=Follow
 [Twitter badge]: https://twitter.com/intent/follow?screen_name=flutterdev
-[layered architecture]: https://flutter.dev/docs/resources/inside-flutter
+[layered architecture]: https://docs.flutter.dev/resources/inside-flutter
 [architectural overview]: https://docs.flutter.dev/resources/architectural-overview
 [widget catalog]: https://flutter.dev/widgets/
 [Cupertino]: https://docs.flutter.dev/development/ui/widgets/cupertino
@@ -111,6 +111,8 @@ Information on how to get started can be found in our
 [Visual Studio Code]: https://marketplace.visualstudio.com/items?itemName=Dart-Code.flutter
 [IntelliJ / Android Studio]: https://plugins.jetbrains.com/plugin/9212-flutter
 [Flutter packages]: https://pub.dev/flutter
-[FFI]: https://flutter.dev/docs/development/platform-integration/c-interop
-[platform channels]: https://flutter.dev/docs/development/platform-integration/platform-channels
+[Android FFI]: https://docs.flutter.dev/development/platform-integration/android/c-interop
+[iOS FFI]: https://docs.flutter.dev/development/platform-integration/android/c-interop
+[macOS FFI]: https://docs.flutter.dev/development/platform-integration/macos/c-interop
+[platform channels]: https://docs.flutter.dev/development/platform-integration/platform-channels
 [interop example]: https://github.com/flutter/flutter/tree/master/examples/platform_channel


### PR DESCRIPTION
I noticed that the old FFI link (`https://flutter.dev/docs/development/platform-integration/c-interop`) is broken, i.e. it no longer exists.  
Therefore, I replaced the link with the specific links to the Android, iOS, and macOS articles. In the same go, I corrected all other `flutter.dev/docs` links and a small grammar issue.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
