### PR TITLE
Allow trackpad inertia cancel events

### DIFF
--- a/packages/flutter/lib/src/gestures/events.dart
+++ b/packages/flutter/lib/src/gestures/events.dart
@@ -1718,7 +1718,7 @@ abstract class PointerSignalEvent extends PointerEvent {
     super.device,
     super.position,
     super.embedderId,
-  }) : assert(!identical(kind, PointerDeviceKind.trackpad));
+  });
 }
 
 mixin _CopyPointerScrollEvent on PointerEvent {
@@ -1787,7 +1787,8 @@ class PointerScrollEvent extends PointerSignalEvent with _PointerEventDescriptio
        assert(kind != null),
        assert(device != null),
        assert(position != null),
-       assert(scrollDelta != null);
+       assert(scrollDelta != null),
+       assert(!identical(kind, PointerDeviceKind.trackpad));
 
   @override
   final Offset scrollDelta;

--- a/packages/flutter/test/gestures/events_test.dart
+++ b/packages/flutter/test/gestures/events_test.dart
@@ -848,12 +848,14 @@ void main() {
   test('Ensure certain event types are allowed', () {
     // Regression test for https://github.com/flutter/flutter/issues/107962
     expect(const PointerHoverEvent(kind: PointerDeviceKind.trackpad), isNotNull);
-
+    // Regression test for https://github.com/flutter/flutter/issues/108176
+    expect(const PointerScrollInertiaCancelEvent(kind: PointerDeviceKind.trackpad), isNotNull);
     // The test passes if it compiles.
   });
 
   test('Ensure certain event types are not allowed', () {
     expect(() => PointerDownEvent(kind: PointerDeviceKind.trackpad), throwsAssertionError);
+    expect(() => PointerScrollEvent(kind: PointerDeviceKind.trackpad), throwsAssertionError);
   });
 }
 


### PR DESCRIPTION
Trackpad scroll inertia cancel events were being mistakenly asserted. I moved the assertion to only handle the `PointerScrollEvent` case

Fixes #108176

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
