### PR TITLE
Only run `pod install` on the first iOS build

### DIFF
--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -62,7 +62,9 @@ class Fingerprinter {
   void writeFingerprint() {
     try {
       final Fingerprint fingerprint = buildFingerprint();
-      _fileSystem.file(fingerprintPath).writeAsStringSync(fingerprint.toJson());
+      final File fingerprintFile = _fileSystem.file(fingerprintPath);
+      fingerprintFile.createSync(recursive: true);
+      fingerprintFile.writeAsStringSync(fingerprint.toJson());
     } on Exception catch (e) {
       // Log exception and continue, fingerprinting is only a performance improvement.
       _logger.printTrace('Fingerprint write error: $e');

--- a/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapod_utils.dart
@@ -28,7 +28,6 @@ Future<void> processPodsIfNeeded(
     paths: <String>[
       xcodeProject.xcodeProjectInfoFile.path,
       xcodeProject.podfile.path,
-      xcodeProject.generatedXcodePropertiesFile.path,
       globals.fs.path.join(
         Cache.flutterRoot!,
         'packages',

--- a/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/fingerprint_test.dart
@@ -5,6 +5,7 @@
 import 'dart:convert' show json;
 
 import 'package:file/memory.dart';
+import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/fingerprint.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/utils.dart';
@@ -57,29 +58,33 @@ void main() {
       );
       expect(fingerprinter.doesFingerprintMatch(), isFalse);
     });
+
     testWithoutContext('fingerprint does match if identical', () {
       fileSystem.file('a.dart').createSync();
       fileSystem.file('b.dart').createSync();
 
+      const String fingerprintPath = 'path/to/out.fingerprint';
       final Fingerprinter fingerprinter = Fingerprinter(
-        fingerprintPath: 'out.fingerprint',
+        fingerprintPath: fingerprintPath,
         paths: <String>['a.dart', 'b.dart'],
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
       );
       fingerprinter.writeFingerprint();
       expect(fingerprinter.doesFingerprintMatch(), isTrue);
+      expect(fileSystem.file(fingerprintPath), exists);
     });
 
     testWithoutContext('fails to write fingerprint if inputs are missing', () {
+      const String fingerprintPath = 'path/to/out.fingerprint';
       final Fingerprinter fingerprinter = Fingerprinter(
-        fingerprintPath: 'out.fingerprint',
+        fingerprintPath: fingerprintPath,
         paths: <String>['a.dart'],
         fileSystem: fileSystem,
         logger: BufferLogger.test(),
       );
       fingerprinter.writeFingerprint();
-      expect(fileSystem.file('out.fingerprint').existsSync(), isFalse);
+      expect(fileSystem.file(fingerprintPath), isNot(exists));
     });
 
   group('Fingerprint', () {

--- a/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_ios_config_only_test.dart
@@ -11,15 +11,20 @@ import 'test_utils.dart';
 
 void main() {
   test('flutter build ios --config only updates generated xcconfig file without performing build', () async {
-    final String workingDirectory = fileSystem.path.join(getFlutterRoot(), 'examples', 'hello_world');
+    final String workingDirectory = fileSystem.path.join(
+      getFlutterRoot(),
+      'dev',
+      'integration_tests',
+      'flutter_gallery',
+    );
     final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
 
     await processManager.run(<String>[
       flutterBin,
-       ...getLocalEngineArguments(),
+      ...getLocalEngineArguments(),
       'clean',
     ], workingDirectory: workingDirectory);
-    final ProcessResult result = await processManager.run(<String>[
+    final List<String> buildCommand = <String>[
       flutterBin,
       ...getLocalEngineArguments(),
       'build',
@@ -29,25 +34,48 @@ void main() {
       '--obfuscate',
       '--split-debug-info=info',
       '--no-codesign',
-    ], workingDirectory: workingDirectory);
+    ];
+    final ProcessResult firstRunResult = await processManager.run(buildCommand, workingDirectory: workingDirectory);
 
     printOnFailure('Output of flutter build ios:');
-    printOnFailure(result.stdout.toString());
-    printOnFailure(result.stderr.toString());
+    final String firstRunStdout = firstRunResult.stdout.toString();
+    printOnFailure('First run stdout: $firstRunStdout');
+    printOnFailure('First run stderr: ${firstRunResult.stderr.toString()}');
 
-    expect(result.exitCode, 0);
+    expect(firstRunResult.exitCode, 0);
+    expect(firstRunStdout, contains('Running pod install'));
 
-    final File generatedConfig = fileSystem.file(
-      fileSystem.path.join(workingDirectory, 'ios', 'Flutter', 'Generated.xcconfig'));
+    final File generatedConfig = fileSystem.file(fileSystem.path.join(
+      workingDirectory,
+      'ios',
+      'Flutter',
+      'Generated.xcconfig',
+    ));
 
     // Config is updated if command succeeded.
     expect(generatedConfig, exists);
     expect(generatedConfig.readAsStringSync(), contains('DART_OBFUSCATION=true'));
 
     // file that only exists if app was fully built.
-    final File frameworkPlist = fileSystem.file(
-      fileSystem.path.join(workingDirectory, 'build', 'ios', 'iphoneos', 'Runner.app', 'AppFrameworkInfo.plist'));
+    final File frameworkPlist = fileSystem.file(fileSystem.path.join(
+      workingDirectory,
+      'build',
+      'ios',
+      'iphoneos',
+      'Runner.app',
+      'AppFrameworkInfo.plist',
+    ));
 
     expect(frameworkPlist, isNot(exists));
+
+    // Run again with no changes.
+    final ProcessResult secondRunResult = await processManager.run(buildCommand, workingDirectory: workingDirectory);
+    final String secondRunStdout = secondRunResult.stdout.toString();
+    printOnFailure('Second run stdout: $secondRunStdout');
+    printOnFailure('Second run stderr: ${secondRunResult.stderr.toString()}');
+
+    expect(secondRunResult.exitCode, 0);
+    // Do not run "pod install" when nothing changes.
+    expect(secondRunStdout, isNot(contains('pod install')));
   }, skip: !platform.isMacOS); // [intended] iOS builds only work on macos.
 }


### PR DESCRIPTION
1. `pod install` is skipped based on SHAs stored in a fingerprint file. Fix the bug where the fingerprint file isn't being written to the first time when the directory structure isn't created.
2. Do not run `pod install` when `Generated.xcconfig` changes.  The build settings in the file should not impact any of the dependencies anymore, and that file changes _all the time_ like every time you run a different `integration_test` test.

Fixes https://github.com/flutter/flutter/issues/108202

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
