### PR TITLE
Dispose _TextSpanEditingController. [prod-leak-fix]

### DIFF
--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -723,4 +723,10 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
       ),
     );
   }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
 }

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -509,7 +509,7 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
   @override
   void dispose() {
     _focusNode?.dispose();
-    _controller.removeListener(_onControllerChanged);
+    _controller.dispose();
     super.dispose();
   }
 
@@ -722,11 +722,5 @@ class _SelectableTextState extends State<SelectableText> implements TextSelectio
         child: child,
       ),
     );
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
   }
 }


### PR DESCRIPTION
The issue was detected by [leak-tracker](https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/screens/memory/panes/leaks/LEAK_TRACKING.md) for Gallery.

We will test cover the change after the leak tracker release.