### PR TITLE
Dispose scaffold drawers.

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2578,6 +2578,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     _floatingActionButtonMoveController.dispose();
     _floatingActionButtonVisibilityController.dispose();
     _scaffoldMessenger?._unregister(this);
+    _drawerOpened.dispose();
+    _endDrawerOpened.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
The issue was detected by [leak-tracker](https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/screens/memory/panes/leaks/LEAK_TRACKING.md) for Gallery.

We will test cover the change after the leak tracker release.