### PR TITLE
Fix Dismissible with CupertinoSlider as child not slidable

### DIFF
--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -296,6 +296,7 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
       vsync: vsync,
       textDirection: Directionality.of(context),
       cursor: kIsWeb ? SystemMouseCursors.click : MouseCursor.defer,
+      gestureSettings: MediaQuery.of(context).gestureSettings,
     );
   }
 
@@ -311,7 +312,8 @@ class _CupertinoSliderRenderObjectWidget extends LeafRenderObjectWidget {
       ..onChanged = onChanged
       ..onChangeStart = onChangeStart
       ..onChangeEnd = onChangeEnd
-      ..textDirection = Directionality.of(context);
+      ..textDirection = Directionality.of(context)
+      ..gestureSettings = MediaQuery.of(context).gestureSettings;
     // Ticker provider cannot change since there's a 1:1 relationship between
     // the _SliderRenderObjectWidget object and the _SliderState object.
   }
@@ -334,6 +336,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
     ValueChanged<double>? onChanged,
     this.onChangeStart,
     this.onChangeEnd,
+    required DeviceGestureSettings gestureSettings,
     required TickerProvider vsync,
     required TextDirection textDirection,
     MouseCursor cursor = MouseCursor.defer,
@@ -352,7 +355,8 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
     _drag = HorizontalDragGestureRecognizer()
       ..onStart = _handleDragStart
       ..onUpdate = _handleDragUpdate
-      ..onEnd = _handleDragEnd;
+      ..onEnd = _handleDragEnd
+      ..gestureSettings = gestureSettings;
     _position = AnimationController(
       value: value,
       duration: _kDiscreteTransitionDuration,
@@ -432,6 +436,11 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
   ValueChanged<double>? onChangeStart;
   ValueChanged<double>? onChangeEnd;
 
+  DeviceGestureSettings? get gestureSettings => _drag.gestureSettings;
+  set gestureSettings(DeviceGestureSettings? gestureSettings) {
+    _drag.gestureSettings = gestureSettings;
+  }
+  
   TextDirection get textDirection => _textDirection;
   TextDirection _textDirection;
   set textDirection(TextDirection value) {

--- a/packages/flutter/lib/src/cupertino/slider.dart
+++ b/packages/flutter/lib/src/cupertino/slider.dart
@@ -440,7 +440,7 @@ class _RenderCupertinoSlider extends RenderConstrainedBox implements MouseTracke
   set gestureSettings(DeviceGestureSettings? gestureSettings) {
     _drag.gestureSettings = gestureSettings;
   }
-  
+
   TextDirection get textDirection => _textDirection;
   TextDirection _textDirection;
   set textDirection(TextDirection value) {


### PR DESCRIPTION
With the latest stable version of Flutter (3.0.4), the CupertinoSlider is not sliding properly when it has Dismissible as their parent, similar issues has been discussed in #105429, and has been fixed in 3.0.2, but only fixed the issue of Slider widget, while CupertinoSlider still has this problem.

This fix adds **gestureSettings** paramter to the initialization of **HorizontalDragGestureRecognizer**.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.