### PR TITLE
Add macOS-specific scroll physics

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -480,6 +480,9 @@ class CupertinoScrollBehavior extends ScrollBehavior {
 
   @override
   ScrollPhysics getScrollPhysics(BuildContext context) {
+    if (getPlatform(context) == TargetPlatform.macOS) {
+      return const BouncingScrollPhysics(decelerationRate: ScrollDecelerationRate.fast);
+    }
     return const BouncingScrollPhysics();
   }
 }

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -373,3 +373,61 @@ class IOSScrollViewFlingVelocityTracker extends VelocityTracker {
     }
   }
 }
+
+/// A [VelocityTracker] subclass that provides a close approximation of macOS
+/// scroll view's velocity estimation strategy.
+///
+/// The estimated velocity reported by this class is a close approximation of
+/// the velocity an macOS scroll view would report with the same
+/// [PointerMoveEvent]s, when the touch that initiates a fling is released.
+///
+/// This class differs from the [VelocityTracker] class in that it uses weighted
+/// average of the latest few velocity samples of the tracked pointer, instead
+/// of doing a linear regression on a relatively large amount of data points, to
+/// estimate the velocity of the tracked pointer. Adding data points and
+/// estimating the velocity are both cheap.
+///
+/// To obtain a velocity, call [getVelocity] or [getVelocityEstimate]. The
+/// estimated velocity is typically used as the initial flinging velocity of a
+/// `Scrollable`, when its drag gesture ends.
+class MacOSScrollViewFlingVelocityTracker extends IOSScrollViewFlingVelocityTracker {
+  /// Create a new MacOSScrollViewFlingVelocityTracker.
+  MacOSScrollViewFlingVelocityTracker(super.kind);
+
+  @override
+  VelocityEstimate getVelocityEstimate() {
+    // The velocity estimated using this expression is an approximation of the
+    // scroll velocity of an macOS scroll view at the moment the user touch was
+    // released.
+    final Offset estimatedVelocity = _previousVelocityAt(-2) * 0.15
+                                   + _previousVelocityAt(-1) * 0.65
+                                   + _previousVelocityAt(0) * 0.2;
+
+    final _PointAtTime? newestSample = _touchSamples[_index];
+    _PointAtTime? oldestNonNullSample;
+
+    for (int i = 1; i <= IOSScrollViewFlingVelocityTracker._sampleSize; i += 1) {
+      oldestNonNullSample = _touchSamples[(_index + i) % IOSScrollViewFlingVelocityTracker._sampleSize];
+      if (oldestNonNullSample != null) {
+        break;
+      }
+    }
+
+    if (oldestNonNullSample == null || newestSample == null) {
+      assert(false, 'There must be at least 1 point in _touchSamples: $_touchSamples');
+      return const VelocityEstimate(
+        pixelsPerSecond: Offset.zero,
+        confidence: 0.0,
+        duration: Duration.zero,
+        offset: Offset.zero,
+      );
+    } else {
+      return VelocityEstimate(
+        pixelsPerSecond: estimatedVelocity,
+        confidence: 1.0,
+        duration: newestSample.time - oldestNonNullSample.time,
+        offset: newestSample.point - oldestNonNullSample.point,
+      );
+    }
+  }
+}

--- a/packages/flutter/lib/src/gestures/velocity_tracker.dart
+++ b/packages/flutter/lib/src/gestures/velocity_tracker.dart
@@ -378,7 +378,7 @@ class IOSScrollViewFlingVelocityTracker extends VelocityTracker {
 /// scroll view's velocity estimation strategy.
 ///
 /// The estimated velocity reported by this class is a close approximation of
-/// the velocity an macOS scroll view would report with the same
+/// the velocity a macOS scroll view would report with the same
 /// [PointerMoveEvent]s, when the touch that initiates a fling is released.
 ///
 /// This class differs from the [VelocityTracker] class in that it uses weighted
@@ -397,7 +397,7 @@ class MacOSScrollViewFlingVelocityTracker extends IOSScrollViewFlingVelocityTrac
   @override
   VelocityEstimate getVelocityEstimate() {
     // The velocity estimated using this expression is an approximation of the
-    // scroll velocity of an macOS scroll view at the moment the user touch was
+    // scroll velocity of a macOS scroll view at the moment the user touch was
     // released.
     final Offset estimatedVelocity = _previousVelocityAt(-2) * 0.15
                                    + _previousVelocityAt(-1) * 0.65

--- a/packages/flutter/lib/src/physics/friction_simulation.dart
+++ b/packages/flutter/lib/src/physics/friction_simulation.dart
@@ -83,7 +83,11 @@ class FrictionSimulation extends Simulation {
   final double _x;
   final double _v;
   final double _constantDeceleration;
-  double _finalTime = double.infinity; // will be changed in constructor
+  // The time at which the simulation should be stopped.
+  // This is needed when constantDeceleration is not zero (on Desktop), when
+  // using the pure friction simulation, acceleration naturally reduces to zero
+  // and creates a stopping point.
+  double _finalTime = double.infinity; // needs to be infinity for newtonsMethod call in constructor.
 
   // Return the drag value for a FrictionSimulation whose x() and dx() values pass
   // through the specified start and end position/velocity values.

--- a/packages/flutter/lib/src/physics/friction_simulation.dart
+++ b/packages/flutter/lib/src/physics/friction_simulation.dart
@@ -10,6 +10,20 @@ import 'simulation.dart';
 
 export 'tolerance.dart' show Tolerance;
 
+double _newtonsMethod({
+  required double guess,
+  required double target,
+  required double Function(double) f,
+  required double Function(double) df,
+  required int iterations
+}) {
+  double g = guess;
+  for (int i = 0; i < iterations; i++) {
+    g = g - (f(g) - target) / df(g);
+  }
+  return g;
+}
+
 /// A simulation that applies a drag to slow a particle down.
 ///
 /// Models a particle affected by fluid drag, e.g. air resistance.
@@ -26,10 +40,20 @@ class FrictionSimulation extends Simulation {
     double position,
     double velocity, {
     super.tolerance,
+    double constantDeceleration = 0
   }) : _drag = drag,
        _dragLog = math.log(drag),
        _x = position,
-       _v = velocity;
+       _v = velocity,
+       _constantDeceleration = constantDeceleration * velocity.sign {
+      _finalTime = _newtonsMethod(
+        guess: 0,
+        target: 0,
+        f: dx,
+        df: (double time) => (_v * math.pow(_drag, time) * _dragLog) - _constantDeceleration,
+        iterations: 10
+      );
+    }
 
   /// Creates a new friction simulation with its fluid drag coefficient (_cₓ_) set so
   /// as to ensure that the simulation starts and ends at the specified
@@ -58,6 +82,8 @@ class FrictionSimulation extends Simulation {
   final double _dragLog;
   final double _x;
   final double _v;
+  final double _constantDeceleration;
+  double _finalTime = double.infinity; // will be changed in constructor
 
   // Return the drag value for a FrictionSimulation whose x() and dx() values pass
   // through the specified start and end position/velocity values.
@@ -71,13 +97,28 @@ class FrictionSimulation extends Simulation {
   }
 
   @override
-  double x(double time) => _x + _v * math.pow(_drag, time) / _dragLog - _v / _dragLog;
+  double x(double time) {
+    if (time > _finalTime) {
+      return finalX;
+    }
+    return _x + _v * math.pow(_drag, time) / _dragLog - _v / _dragLog - ((_constantDeceleration / 2) * time * time);
+  }
 
   @override
-  double dx(double time) => _v * math.pow(_drag, time);
+  double dx(double time) {
+    if (time > _finalTime) {
+      return 0;
+    }
+    return _v * math.pow(_drag, time) - _constantDeceleration * time;
+  }
 
   /// The value of [x] at `double.infinity`.
-  double get finalX => _x - _v / _dragLog;
+  double get finalX {
+    if (_constantDeceleration == 0) {
+      return _x - _v / _dragLog;
+    }
+    return x(_finalTime);
+  }
 
   /// The time at which the value of `x(time)` will equal [x].
   ///
@@ -89,11 +130,19 @@ class FrictionSimulation extends Simulation {
     if (_v == 0.0 || (_v > 0 ? (x < _x || x > finalX) : (x > _x || x < finalX))) {
       return double.infinity;
     }
-    return math.log(_dragLog * (x - _x) / _v + 1.0) / _dragLog;
+    return _newtonsMethod(
+      target: x,
+      guess: 0,
+      f: this.x,
+      df: dx,
+      iterations: 10
+    );
   }
 
   @override
-  bool isDone(double time) => dx(time).abs() < tolerance.velocity;
+  bool isDone(double time) {
+    return dx(time).abs() < tolerance.velocity;
+  }
 
   @override
   String toString() => '${objectRuntimeType(this, 'FrictionSimulation')}(cₓ: ${_drag.toStringAsFixed(1)}, x₀: ${_x.toStringAsFixed(1)}, dx₀: ${_v.toStringAsFixed(1)})';

--- a/packages/flutter/lib/src/physics/friction_simulation.dart
+++ b/packages/flutter/lib/src/physics/friction_simulation.dart
@@ -10,18 +10,20 @@ import 'simulation.dart';
 
 export 'tolerance.dart' show Tolerance;
 
+/// Numerically determine the input value which produces output value [target]
+/// for a function [f], given its first-derivative [df].
 double _newtonsMethod({
-  required double guess,
+  required double initialGuess,
   required double target,
   required double Function(double) f,
   required double Function(double) df,
   required int iterations
 }) {
-  double g = guess;
+  double guess = initialGuess;
   for (int i = 0; i < iterations; i++) {
-    g = g - (f(g) - target) / df(g);
+    guess = guess - (f(guess) - target) / df(guess);
   }
-  return g;
+  return guess;
 }
 
 /// A simulation that applies a drag to slow a particle down.
@@ -47,7 +49,7 @@ class FrictionSimulation extends Simulation {
        _v = velocity,
        _constantDeceleration = constantDeceleration * velocity.sign {
       _finalTime = _newtonsMethod(
-        guess: 0,
+        initialGuess: 0,
         target: 0,
         f: dx,
         df: (double time) => (_v * math.pow(_drag, time) * _dragLog) - _constantDeceleration,
@@ -136,7 +138,7 @@ class FrictionSimulation extends Simulation {
     }
     return _newtonsMethod(
       target: x,
-      guess: 0,
+      initialGuess: 0,
       f: this.x,
       df: dx,
       iterations: 10

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -231,7 +231,10 @@ class ScrollBehavior {
   }
 
   static const ScrollPhysics _bouncingPhysics = BouncingScrollPhysics(parent: RangeMaintainingScrollPhysics());
-  static const ScrollPhysics _bouncingDesktopPhysics = BouncingDesktopScrollPhysics(parent: RangeMaintainingScrollPhysics());
+  static const ScrollPhysics _bouncingDesktopPhysics = BouncingScrollPhysics(
+    decelerationRate: ScrollDecelerationRate.fast,
+    parent: RangeMaintainingScrollPhysics()
+  );
   static const ScrollPhysics _clampingPhysics = ClampingScrollPhysics(parent: RangeMaintainingScrollPhysics());
 
   /// The scroll physics to use for the platform given by [getPlatform].

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -219,8 +219,9 @@ class ScrollBehavior {
   GestureVelocityTrackerBuilder velocityTrackerBuilder(BuildContext context) {
     switch (getPlatform(context)) {
       case TargetPlatform.iOS:
+        return (PointerEvent event) => IOSScrollViewFlingVelocityTracker(event.kind); // FIXME(moffatmN)
       case TargetPlatform.macOS:
-        return (PointerEvent event) => IOSScrollViewFlingVelocityTracker(event.kind);
+        return (PointerEvent event) => MacOSScrollViewFlingVelocityTracker(event.kind);
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
@@ -230,6 +231,7 @@ class ScrollBehavior {
   }
 
   static const ScrollPhysics _bouncingPhysics = BouncingScrollPhysics(parent: RangeMaintainingScrollPhysics());
+  static const ScrollPhysics _bouncingDesktopPhysics = BouncingDesktopScrollPhysics(parent: RangeMaintainingScrollPhysics());
   static const ScrollPhysics _clampingPhysics = ClampingScrollPhysics(parent: RangeMaintainingScrollPhysics());
 
   /// The scroll physics to use for the platform given by [getPlatform].
@@ -240,8 +242,9 @@ class ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) {
     switch (getPlatform(context)) {
       case TargetPlatform.iOS:
+      return _bouncingPhysics;
       case TargetPlatform.macOS:
-        return _bouncingPhysics;
+        return _bouncingDesktopPhysics;
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -219,7 +219,7 @@ class ScrollBehavior {
   GestureVelocityTrackerBuilder velocityTrackerBuilder(BuildContext context) {
     switch (getPlatform(context)) {
       case TargetPlatform.iOS:
-        return (PointerEvent event) => IOSScrollViewFlingVelocityTracker(event.kind); // FIXME(moffatmN)
+        return (PointerEvent event) => IOSScrollViewFlingVelocityTracker(event.kind);
       case TargetPlatform.macOS:
         return (PointerEvent event) => MacOSScrollViewFlingVelocityTracker(event.kind);
       case TargetPlatform.android:

--- a/packages/flutter/lib/src/widgets/scroll_configuration.dart
+++ b/packages/flutter/lib/src/widgets/scroll_configuration.dart
@@ -245,7 +245,7 @@ class ScrollBehavior {
   ScrollPhysics getScrollPhysics(BuildContext context) {
     switch (getPlatform(context)) {
       case TargetPlatform.iOS:
-      return _bouncingPhysics;
+        return _bouncingPhysics;
       case TargetPlatform.macOS:
         return _bouncingDesktopPhysics;
       case TargetPlatform.android:

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -713,6 +713,79 @@ class BouncingScrollPhysics extends ScrollPhysics {
   double get dragStartDistanceMotionThreshold => 3.5;
 }
 
+/// Scroll physics for environments that allow the scroll offset to go beyond
+/// the bounds of the content, but then bounce the content back to the edge of
+/// those bounds. Tuned for use with trackpad.
+///
+/// This is the behavior typically seen on macOS.
+///
+/// [BouncingDesktopScrollPhysics] by itself will not create an overscroll effect if
+/// the contents of the scroll view do not extend beyond the size of the
+/// viewport. To create the overscroll and bounce effect regardless of the
+/// length of your scroll view, combine with [AlwaysScrollableScrollPhysics].
+///
+/// {@tool snippet}
+/// ```dart
+/// const BouncingDesktopScrollPhysics(parent: AlwaysScrollableScrollPhysics())
+/// ```
+/// {@end-tool}
+///
+/// See also:
+///
+///  * [ScrollConfiguration], which uses this to provide the default
+///    scroll behavior on macOS.
+///  * [BouncingScrollPhysics], which is the analogous physics for iOS's
+///    behavior.
+///  * [ScrollPhysics], for more examples of combining [ScrollPhysics] objects
+///    of different types to get the desired scroll physics.
+class BouncingDesktopScrollPhysics extends BouncingScrollPhysics {
+  /// Creates scroll physics that bounce back from the edge.
+  const BouncingDesktopScrollPhysics({ super.parent });
+
+  @override
+  BouncingDesktopScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return BouncingDesktopScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  /// The multiple applied to overscroll to make it appear that scrolling past
+  /// the edge of the scrollable contents is harder than scrolling the list.
+  /// This is done by reducing the ratio of the scroll effect output vs the
+  /// scroll gesture input.
+  ///
+  /// This factor starts at 0.07 and progressively becomes harder to overscroll
+  /// as more of the area past the edge is dragged in (represented by an increasing
+  /// `overscrollFraction` which starts at 0 when there is no overscroll).
+  @override
+  double frictionFactor(double overscrollFraction) => 0.07 * math.pow(1 - overscrollFraction, 2);
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    final Tolerance tolerance = this.tolerance;
+    if (velocity.abs() >= tolerance.velocity || position.outOfRange) {
+      return BouncingScrollSimulation(
+        spring: spring,
+        position: position.pixels,
+        velocity: velocity,
+        leadingExtent: position.minScrollExtent,
+        trailingExtent: position.maxScrollExtent,
+        tolerance: tolerance,
+        constantDeceleration: 1400,
+      );
+    }
+    return null;
+  }
+
+  @override
+  double get maxFlingVelocity => kMaxFlingVelocity * 8.0;
+
+  @override
+  SpringDescription get spring => SpringDescription.withDampingRatio(
+    mass: 0.3,
+    stiffness: 75.0,
+    ratio: 1.3,
+  );
+}
+
 /// Scroll physics for environments that prevent the scroll offset from reaching
 /// beyond the bounds of the content.
 ///

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -638,10 +638,12 @@ class BouncingScrollPhysics extends ScrollPhysics {
   /// as more of the area past the edge is dragged in (represented by an increasing
   /// `overscrollFraction` which starts at 0 when there is no overscroll).
   double frictionFactor(double overscrollFraction) {
-    if (decelerationRate == ScrollDecelerationRate.fast) {
-      return 0.07 * math.pow(1 - overscrollFraction, 2);
+    switch (decelerationRate) {
+      case ScrollDecelerationRate.fast:
+        return 0.07 * math.pow(1 - overscrollFraction, 2);
+      case ScrollDecelerationRate.normal:
+        return 0.52 * math.pow(1 - overscrollFraction, 2);
     }
-    return 0.52 * math.pow(1 - overscrollFraction, 2);
   }
 
   @override
@@ -689,6 +691,15 @@ class BouncingScrollPhysics extends ScrollPhysics {
   Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
     final Tolerance tolerance = this.tolerance;
     if (velocity.abs() >= tolerance.velocity || position.outOfRange) {
+      double constantDeceleration;
+      switch (decelerationRate) {
+        case ScrollDecelerationRate.fast:
+          constantDeceleration = 1400;
+          break;
+        case ScrollDecelerationRate.normal:
+          constantDeceleration = 0;
+          break;
+      }
       return BouncingScrollSimulation(
         spring: spring,
         position: position.pixels,
@@ -696,7 +707,7 @@ class BouncingScrollPhysics extends ScrollPhysics {
         leadingExtent: position.minScrollExtent,
         trailingExtent: position.maxScrollExtent,
         tolerance: tolerance,
-        constantDeceleration: decelerationRate == ScrollDecelerationRate.fast ? 1400 : 0
+        constantDeceleration: constantDeceleration
       );
     }
     return null;
@@ -734,22 +745,26 @@ class BouncingScrollPhysics extends ScrollPhysics {
 
   @override
   double get maxFlingVelocity {
-    if (decelerationRate == ScrollDecelerationRate.fast) {
-      return kMaxFlingVelocity * 8.0;
+    switch (decelerationRate) {
+      case ScrollDecelerationRate.fast:
+        return kMaxFlingVelocity * 8.0;
+      case ScrollDecelerationRate.normal:
+        return super.maxFlingVelocity;
     }
-    return super.maxFlingVelocity;
   }
 
   @override
   SpringDescription get spring {
-    if (decelerationRate == ScrollDecelerationRate.fast) {
-      return SpringDescription.withDampingRatio(
-        mass: 0.3,
-        stiffness: 75.0,
-        ratio: 1.3,
-      );
+    switch (decelerationRate) {
+      case ScrollDecelerationRate.fast:
+        return SpringDescription.withDampingRatio(
+          mass: 0.3,
+          stiffness: 75.0,
+          ratio: 1.3,
+        );
+      case ScrollDecelerationRate.normal:
+        return super.spring;
     }
-    return super.spring;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -18,9 +18,12 @@ export 'package:flutter/physics.dart' show ScrollSpringSimulation, Simulation, T
 
 /// The rate at which scroll momentum will be decelerated.
 enum ScrollDecelerationRate {
-  /// The standard deceleration expected on touchscreen apps.
+  /// Standard deceleration, aligned with mobile software expectations.
   normal,
-  /// Faster deceleration aligned with desktop software conventions.
+  /// Increased deceleration, aligned with desktop software expectations.
+  ///
+  /// Appropriate for use with input devices more precise than touch screens,
+  /// such as trackpads or mouse wheels.
   fast
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -34,6 +34,7 @@ class BouncingScrollSimulation extends Simulation {
     required this.leadingExtent,
     required this.trailingExtent,
     required this.spring,
+    double constantDeceleration = 0,
     super.tolerance,
   }) : assert(position != null),
        assert(velocity != null),
@@ -50,7 +51,7 @@ class BouncingScrollSimulation extends Simulation {
     } else {
       // Taken from UIScrollView.decelerationRate (.normal = 0.998)
       // 0.998^1000 = ~0.135
-      _frictionSimulation = FrictionSimulation(0.135, position, velocity);
+      _frictionSimulation = FrictionSimulation(0.135, position, velocity, constantDeceleration: constantDeceleration);
       final double finalX = _frictionSimulation.finalX;
       if (velocity > 0.0 && finalX > trailingExtent) {
         _springTime = _frictionSimulation.timeAtX(trailingExtent);

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -421,7 +421,7 @@ void main() {
         // Falling back to 0 shouldn't produce more callbacks.
         <int>[8, 6, 4, 2, 0],
       );
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
   });
 
   testWidgets('Picker adapts to MaterialApp dark mode', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
@@ -397,9 +398,11 @@ void main() {
         warnIfMissed: false, // has an IgnorePointer
       );
 
-      // Should have been flung far enough that even the first item goes off
-      // screen and gets removed.
-      expect(find.widgetWithText(SizedBox, '0').evaluate().isEmpty, true);
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.iOS) {
+        // Should have been flung far enough that even the first item goes off
+        // screen and gets removed.
+        expect(find.widgetWithText(SizedBox, '0').evaluate().isEmpty, true);
+      }
 
       expect(
         selectedItems,
@@ -421,7 +424,7 @@ void main() {
         // Falling back to 0 shouldn't produce more callbacks.
         <int>[8, 6, 4, 2, 0],
       );
-    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }));
+    }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
   });
 
   testWidgets('Picker adapts to MaterialApp dark mode', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -6,6 +6,7 @@
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -150,13 +151,25 @@ void main() {
           refreshTriggerPullDistance: 100,  // default value.
           refreshIndicatorExtent: 60,  // default value.
         ),
-        matchesBuilder(
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) matchesBuilder(
+          refreshState: RefreshIndicatorMode.drag,
+          pulledExtent: moreOrLessEquals(48.07979523362715),
+          refreshTriggerPullDistance: 100,  // default value.
+          refreshIndicatorExtent: 60,  // default value.
+        )
+        else matchesBuilder(
           refreshState: RefreshIndicatorMode.drag,
           pulledExtent: moreOrLessEquals(48.36801747187993),
           refreshTriggerPullDistance: 100,  // default value.
           refreshIndicatorExtent: 60,  // default value.
         ),
-        matchesBuilder(
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) matchesBuilder(
+          refreshState: RefreshIndicatorMode.drag,
+          pulledExtent: moreOrLessEquals(43.98499220391114),
+          refreshTriggerPullDistance: 100,  // default value.
+          refreshIndicatorExtent: 60,  // default value.
+        )
+        else matchesBuilder(
           refreshState: RefreshIndicatorMode.drag,
           pulledExtent: moreOrLessEquals(44.63031931875867),
           refreshTriggerPullDistance: 100,  // default value.
@@ -199,7 +212,12 @@ void main() {
       await tester.pump();
       await gesture.moveBy(const Offset(0.0, -30.0));
       await tester.pump();
-      await gesture.moveBy(const Offset(0.0, 50.0));
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        await gesture.moveBy(const Offset(0.0, 70.0));
+      }
+      else {
+        await gesture.moveBy(const Offset(0.0, 50.0));
+      }
       await tester.pump();
 
       expect(mockHelper.invocations, containsAllInOrder(<void>[
@@ -209,13 +227,25 @@ void main() {
           refreshTriggerPullDistance: 100,  // default value.
           refreshIndicatorExtent: 60,  // default value.
         ),
-        matchesBuilder(
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) matchesBuilder(
+          refreshState: RefreshIndicatorMode.drag,
+          pulledExtent: moreOrLessEquals(97.3552275),
+          refreshTriggerPullDistance: 100,  // default value.
+          refreshIndicatorExtent: 60,  // default value.
+        )
+        else matchesBuilder(
           refreshState: RefreshIndicatorMode.drag,
           pulledExtent: moreOrLessEquals(86.78169),
           refreshTriggerPullDistance: 100,  // default value.
           refreshIndicatorExtent: 60,  // default value.
         ),
-        matchesBuilder(
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) matchesBuilder(
+          refreshState: RefreshIndicatorMode.armed,
+          pulledExtent: moreOrLessEquals(100.79409877743257),
+          refreshTriggerPullDistance: 100,  // default value.
+          refreshIndicatorExtent: 60,  // default value.
+        )
+        else matchesBuilder(
           refreshState: RefreshIndicatorMode.armed,
           pulledExtent: moreOrLessEquals(105.80452021305739),
           refreshTriggerPullDistance: 100,  // default value.
@@ -262,7 +292,13 @@ void main() {
             refreshIndicatorExtent: 60, // Default value.
           ),
           equals(const RefreshTaskInvocation()),
-          matchesBuilder(
+          if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) matchesBuilder(
+            refreshState: RefreshIndicatorMode.armed,
+            pulledExtent: moreOrLessEquals(124.87933920045268),
+            refreshTriggerPullDistance: 100, // Default value.
+            refreshIndicatorExtent: 60, // Default value.
+          )
+          else matchesBuilder(
             refreshState: RefreshIndicatorMode.armed,
             pulledExtent: moreOrLessEquals(127.10396988577114),
             refreshTriggerPullDistance: 100, // Default value.
@@ -306,6 +342,7 @@ void main() {
       (WidgetTester tester) async {
         final FlutterError error = FlutterError('Oops');
         double errorCount = 0;
+        final TargetPlatform? platform = debugDefaultTargetPlatformOverride; // Will not be correct within the zone.
 
         runZonedGuarded(
           () async {
@@ -337,7 +374,13 @@ void main() {
                 refreshTriggerPullDistance: 100, // Default value.
               ),
               equals(const RefreshTaskInvocation()),
-              matchesBuilder(
+              if (platform == TargetPlatform.macOS) matchesBuilder(
+                refreshState: RefreshIndicatorMode.armed,
+                pulledExtent: moreOrLessEquals(124.87933920045268),
+                refreshTriggerPullDistance: 100, // Default value.
+                refreshIndicatorExtent: 60, // Default value.
+              )
+              else matchesBuilder(
                 refreshState: RefreshIndicatorMode.armed,
                 pulledExtent: moreOrLessEquals(127.10396988577114),
                 refreshIndicatorExtent: 60, // Default value.
@@ -415,7 +458,12 @@ void main() {
         const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
       );
 
-      await tester.drag(find.text('0'), const Offset(0.0, -300.0), touchSlopY: 0, warnIfMissed: false); // hits the list
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        await tester.drag(find.text('0'), const Offset(0.0, -600.0), touchSlopY: 0, warnIfMissed: false); // hits the list
+      }
+      else {
+        await tester.drag(find.text('0'), const Offset(0.0, -300.0), touchSlopY: 0, warnIfMissed: false); // hits the list
+      }
       await tester.pump();
 
       // Refresh indicator still being told to layout the same way.
@@ -427,18 +475,34 @@ void main() {
       )));
 
       // Now the sliver is scrolled off screen.
-      expect(
-        tester.getTopLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-        moreOrLessEquals(-175.38461538461536),
-      );
-      expect(
-        tester.getBottomLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-        moreOrLessEquals(-115.38461538461536),
-      );
-      expect(
-        tester.getTopLeft(find.widgetWithText(Center, '0')).dy,
-        moreOrLessEquals(-115.38461538461536),
-      );
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        expect(
+          tester.getTopLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
+          moreOrLessEquals(-38.625),
+        );
+        expect(
+          tester.getBottomLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
+          moreOrLessEquals(21.375),
+        );
+        expect(
+          tester.getTopLeft(find.widgetWithText(Center, '0')).dy,
+          moreOrLessEquals(21.375),
+        );
+      }
+      else {
+        expect(
+          tester.getTopLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
+          moreOrLessEquals(-175.38461538461536),
+        );
+        expect(
+          tester.getBottomLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
+          moreOrLessEquals(-115.38461538461536),
+        );
+        expect(
+          tester.getTopLeft(find.widgetWithText(Center, '0')).dy,
+          moreOrLessEquals(-115.38461538461536),
+        );
+      }
 
       // Scroll the top of the refresh indicator back to overscroll, it will
       // snap to the size of the refresh indicator and stay there.
@@ -586,20 +650,38 @@ void main() {
       // Waiting for refresh control to reach approximately 5% of height
       await tester.pump(const Duration(milliseconds: 400));
 
-      expect(
-        tester.getRect(find.widgetWithText(Center, '0')).top,
-        moreOrLessEquals(3.0, epsilon: 4e-1),
-      );
-      expect(
-        tester.getRect(find.widgetWithText(Center, '-1')).height,
-        moreOrLessEquals(3.0, epsilon: 4e-1),
-      );
-      expect(mockHelper.invocations, contains(matchesBuilder(
-        refreshState: RefreshIndicatorMode.inactive,
-        pulledExtent: 2.6980688300546443, // ~5% of 60.0
-        refreshTriggerPullDistance: 100,  // default value.
-        refreshIndicatorExtent: 60,  // default value.
-      )));
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        expect(
+          tester.getRect(find.widgetWithText(Center, '0')).top,
+          moreOrLessEquals(3.9543032206542765, epsilon: 4e-1),
+        );
+        expect(
+          tester.getRect(find.widgetWithText(Center, '-1')).height,
+          moreOrLessEquals(3.9543032206542765, epsilon: 4e-1),
+        );
+        expect(mockHelper.invocations, contains(matchesBuilder(
+          refreshState: RefreshIndicatorMode.inactive,
+          pulledExtent: 3.9543032206542765, // ~5% of 60.0
+          refreshTriggerPullDistance: 100,  // default value.
+          refreshIndicatorExtent: 60,  // default value.
+        )));
+      }
+      else {
+        expect(
+          tester.getRect(find.widgetWithText(Center, '0')).top,
+          moreOrLessEquals(3.0, epsilon: 4e-1),
+        );
+        expect(
+          tester.getRect(find.widgetWithText(Center, '-1')).height,
+          moreOrLessEquals(3.0, epsilon: 4e-1),
+        );
+        expect(mockHelper.invocations, contains(matchesBuilder(
+          refreshState: RefreshIndicatorMode.inactive,
+          pulledExtent: 2.6980688300546443, // ~5% of 60.0
+          refreshTriggerPullDistance: 100,  // default value.
+          refreshIndicatorExtent: 60,  // default value.
+        )));
+      }
       expect(find.text('-1'), findsOneWidget);
     }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
@@ -638,17 +720,30 @@ void main() {
         // Let it start going away but not fully.
         await tester.pump(const Duration(milliseconds: 100));
         // The refresh indicator is still building.
-        expect(mockHelper.invocations, contains(matchesBuilder(
-          refreshState: RefreshIndicatorMode.done,
-          pulledExtent: 91.31180913199277,
-          refreshTriggerPullDistance: 100,  // default value.
-          refreshIndicatorExtent: 60,  // default value.
-        )));
-
-        expect(
-          tester.getBottomLeft(find.widgetWithText(Center, '-1')).dy,
-          moreOrLessEquals(91.311809131992776),
-        );
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          expect(mockHelper.invocations, contains(matchesBuilder(
+            refreshState: RefreshIndicatorMode.done,
+            pulledExtent: 90.13497854600749,
+            refreshTriggerPullDistance: 100,  // default value.
+            refreshIndicatorExtent: 60,  // default value.
+          )));
+          expect(
+            tester.getBottomLeft(find.widgetWithText(Center, '-1')).dy,
+            moreOrLessEquals(90.13497854600749),
+          );
+        }
+        else {
+          expect(mockHelper.invocations, contains(matchesBuilder(
+            refreshState: RefreshIndicatorMode.done,
+            pulledExtent: 91.31180913199277,
+            refreshTriggerPullDistance: 100,  // default value.
+            refreshIndicatorExtent: 60,  // default value.
+          )));
+          expect(
+            tester.getBottomLeft(find.widgetWithText(Center, '-1')).dy,
+            moreOrLessEquals(91.311809131992776),
+          );
+        }
 
         // Start another drag by an amount that would have been enough to
         // trigger another refresh if it were in the right state.
@@ -657,12 +752,22 @@ void main() {
 
         // Instead, it's still in the done state because the sliver never
         // fully retracted.
-        expect(mockHelper.invocations, contains(matchesBuilder(
-          refreshState: RefreshIndicatorMode.done,
-          pulledExtent: 147.3772721631821,
-          refreshTriggerPullDistance: 100,  // default value.
-          refreshIndicatorExtent: 60,  // default value.
-        )));
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          expect(mockHelper.invocations, contains(matchesBuilder(
+            refreshState: RefreshIndicatorMode.done,
+            pulledExtent: 97.71721346565732,
+            refreshTriggerPullDistance: 100,  // default value.
+            refreshIndicatorExtent: 60,  // default value.
+          )));
+        }
+        else {
+          expect(mockHelper.invocations, contains(matchesBuilder(
+            refreshState: RefreshIndicatorMode.done,
+            pulledExtent: 147.3772721631821,
+            refreshTriggerPullDistance: 100,  // default value.
+            refreshIndicatorExtent: 60,  // default value.
+          )));
+        }
 
         // Now let it fully go away.
         await tester.pump(const Duration(seconds: 5));
@@ -881,12 +986,22 @@ void main() {
 
         await tester.pump(const Duration(milliseconds: 10));
 
-        expect(mockHelper.invocations.last, matchesBuilder(
-          refreshState: RefreshIndicatorMode.done,
-          pulledExtent: moreOrLessEquals(148.6463892921364),
-          refreshTriggerPullDistance: 100.0, // Default value.
-          refreshIndicatorExtent: 60.0, // Default value.
-        ));
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          expect(mockHelper.invocations.last, matchesBuilder(
+            refreshState: RefreshIndicatorMode.done,
+            pulledExtent: moreOrLessEquals(148.36088180097366),
+            refreshTriggerPullDistance: 100.0, // Default value.
+            refreshIndicatorExtent: 60.0, // Default value.
+          ));
+        }
+        else {
+          expect(mockHelper.invocations.last, matchesBuilder(
+            refreshState: RefreshIndicatorMode.done,
+            pulledExtent: moreOrLessEquals(148.6463892921364),
+            refreshTriggerPullDistance: 100.0, // Default value.
+            refreshIndicatorExtent: 60.0, // Default value.
+          ));
+        }
 
         await tester.pump(const Duration(seconds: 5));
         expect(find.text('-1'), findsNothing);
@@ -1038,8 +1153,12 @@ void main() {
         CupertinoSliverRefreshControl.state(tester.element(find.byType(LayoutBuilder))),
         RefreshIndicatorMode.drag,
       );
-
-      await gesture.moveBy(const Offset(0.0, 3.0)); // Overscrolling, need to move more than 1px.
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        await gesture.moveBy(const Offset(0.0, 20.0)); // Overscrolling, need to move more than 1px.
+      }
+      else {
+        await gesture.moveBy(const Offset(0.0, 3.0)); // Overscrolling, need to move more than 1px.
+      }
       await tester.pump();
       expect(
         CupertinoSliverRefreshControl.state(tester.element(find.byType(LayoutBuilder))),
@@ -1074,12 +1193,25 @@ void main() {
           RefreshIndicatorMode.armed,
         );
 
-        await gesture.moveBy(const Offset(0.0, -80.0)); // Overscrolling, need to move more than -40.
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          await gesture.moveBy(const Offset(0.0, -310.0)); // Overscrolling, need to move more than -40.
+        }
+        else {
+          await gesture.moveBy(const Offset(0.0, -80.0)); // Overscrolling, need to move more than -40.
+        }
         await tester.pump();
-        expect(
-          tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-          moreOrLessEquals(49.775111111111116), // Below 50 now.
-        );
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          expect(
+            tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
+            moreOrLessEquals(49.469222222222214), // Below 50 now.
+          );
+        }
+        else {
+          expect(
+            tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
+            moreOrLessEquals(49.775111111111116), // Below 50 now.
+          );
+        }
         expect(
           CupertinoSliverRefreshControl.state(tester.element(find.byType(LayoutBuilder))),
           RefreshIndicatorMode.refresh,
@@ -1169,24 +1301,50 @@ void main() {
         await tester.pump();
 
         // Now back in overscroll mode.
-        await gesture.moveBy(const Offset(0.0, -200.0));
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          await gesture.moveBy(const Offset(0.0, -590.0));
+        }
+        else {
+          await gesture.moveBy(const Offset(0.0, -200.0));
+        }
         await tester.pump();
-        expect(
-          tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-          moreOrLessEquals(27.944444444444457),
-        );
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          expect(
+            tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
+            moreOrLessEquals(25.916444444444423),
+          );
+        }
+        else {
+          expect(
+            tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
+            moreOrLessEquals(27.944444444444457),
+          );
+        }
         // Need to bring it to 100 * 0.1 to reset to inactive.
         expect(
           CupertinoSliverRefreshControl.state(tester.element(find.byType(LayoutBuilder))),
           RefreshIndicatorMode.done,
         );
 
-        await gesture.moveBy(const Offset(0.0, -35.0));
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          await gesture.moveBy(const Offset(0.0, -160.0));
+        }
+        else {
+          await gesture.moveBy(const Offset(0.0, -35.0));
+        }
         await tester.pump();
-        expect(
-          tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-          moreOrLessEquals(9.313890708161875),
-        );
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          expect(
+            tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
+            moreOrLessEquals(9.15133037440173),
+          );
+        }
+        else {
+          expect(
+            tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
+            moreOrLessEquals(9.313890708161875),
+          );
+        }
         expect(
           CupertinoSliverRefreshControl.state(tester.element(find.byType(LayoutBuilder))),
           RefreshIndicatorMode.inactive,
@@ -1221,12 +1379,19 @@ void main() {
         );
         await tester.pump(); // Sliver scroll offset correction is applied one frame later.
 
-        await gesture.moveBy(const Offset(0.0, -300.0));
+        double indicatorDestinationPosition = -145.0332383665717;
+        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+          await gesture.moveBy(const Offset(0.0, -600.0));
+          indicatorDestinationPosition = -164.33475946989466;
+        }
+        else {
+          await gesture.moveBy(const Offset(0.0, -300.0));
+        }
         await tester.pump();
         // The refresh indicator is offscreen now.
         expect(
           tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-          moreOrLessEquals(-145.0332383665717),
+          moreOrLessEquals(indicatorDestinationPosition),
         );
         expect(
           CupertinoSliverRefreshControl.state(tester.element(find.byType(LayoutBuilder, skipOffstage: false))),
@@ -1243,13 +1408,13 @@ void main() {
         // Nothing moved.
         expect(
           tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-          moreOrLessEquals(-145.0332383665717),
+          moreOrLessEquals(indicatorDestinationPosition),
         );
         await tester.pump(const Duration(seconds: 2));
         // Everything stayed as is.
         expect(
           tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-          moreOrLessEquals(-145.0332383665717),
+          moreOrLessEquals(indicatorDestinationPosition),
         );
       },
       variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -406,7 +407,12 @@ void main() {
       ),
     );
 
-    await tester.fling(find.text('A'), const Offset(0.0, 1500.0), 10000.0);
+    if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+      await tester.fling(find.text('A'), const Offset(0.0, 1500.0), 10000.0);
+    }
+    else {
+      await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0);
+    }
     await tester.pump(const Duration(milliseconds: 100));
     expect(lastScrollOffset = controller.offset, lessThan(0.0));
     expect(refreshCalled, isFalse);

--- a/packages/flutter/test/material/refresh_indicator_test.dart
+++ b/packages/flutter/test/material/refresh_indicator_test.dart
@@ -406,12 +406,12 @@ void main() {
       ),
     );
 
-    await tester.fling(find.text('A'), const Offset(0.0, 300.0), 1000.0);
+    await tester.fling(find.text('A'), const Offset(0.0, 1500.0), 10000.0);
     await tester.pump(const Duration(milliseconds: 100));
     expect(lastScrollOffset = controller.offset, lessThan(0.0));
     expect(refreshCalled, isFalse);
 
-    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pump(const Duration(milliseconds: 400));
     expect(controller.offset, greaterThan(lastScrollOffset));
     expect(controller.offset, lessThan(0.0));
     expect(refreshCalled, isTrue);

--- a/packages/flutter/test/physics/friction_simulation_test.dart
+++ b/packages/flutter/test/physics/friction_simulation_test.dart
@@ -47,4 +47,25 @@ void main() {
     expect(friction.timeAtX(101.0), double.infinity);
     expect(friction.timeAtX(40.0), double.infinity);
   });
+
+  test('Friction simulation constant deceleration', () {
+    final FrictionSimulation friction = FrictionSimulation(0.135, 100.0, -100.0, constantDeceleration: 100);
+
+    expect(friction.x(0.0), moreOrLessEquals(100.0));
+    expect(friction.dx(0.0), moreOrLessEquals(-100.0));
+
+    expect(friction.x(0.1), moreOrLessEquals(91.0, epsilon: 1.0));
+    expect(friction.x(0.5), moreOrLessEquals(80.0, epsilon: 1.0));
+    expect(friction.x(2.0), moreOrLessEquals(80.0, epsilon: 1.0));
+
+    expect(friction.finalX, moreOrLessEquals(80.0, epsilon: 1.0));
+
+    expect(friction.timeAtX(100.0), 0.0);
+    expect(friction.timeAtX(friction.x(0.1)), moreOrLessEquals(0.1));
+    expect(friction.timeAtX(friction.x(0.2)), moreOrLessEquals(0.2));
+    expect(friction.timeAtX(friction.x(0.3)), moreOrLessEquals(0.3));
+
+    expect(friction.timeAtX(101.0), double.infinity);
+    expect(friction.timeAtX(40.0), double.infinity);
+  });
 }

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -287,7 +287,12 @@ void main() {
       expect(taps, 1);
       expect(find.text('Item 1'), findsNothing);
       expect(find.text('Item 21'), findsNothing);
-      expect(find.text('Item 70'), findsOneWidget);
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        expect(find.text('Item 40'), findsOneWidget);
+      }
+      else {
+        expect(find.text('Item 70'), findsOneWidget);
+      }
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('Can be flung down when not full height', (WidgetTester tester) async {
@@ -321,9 +326,14 @@ void main() {
       expect(taps, 1);
       expect(find.text('Item 1'), findsNothing);
       expect(find.text('Item 21'), findsNothing);
-      expect(find.text('Item 70'), findsOneWidget);
-
-      await tester.fling(find.text('Item 70'), const Offset(0, 200), 2000);
+      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+        expect(find.text('Item 40'), findsOneWidget);
+        await tester.fling(find.text('Item 40'), const Offset(0, 200), 2000);
+      }
+      else {
+        expect(find.text('Item 70'), findsOneWidget);
+        await tester.fling(find.text('Item 70'), const Offset(0, 200), 2000);
+      }
       await tester.pumpAndSettle();
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'), warnIfMissed: false);

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -6,6 +6,7 @@
 // machines.
 @Tags(<String>['reduced-test-set'])
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1352,7 +1353,8 @@ void main() {
         find.byType(ListWheelScrollView),
         // High and random numbers that's unlikely to land on exact multiples of 100.
         const Offset(0.0, -567.0),
-        678.0,
+        // macOS has reduced ballistic distance, need to increase speed to compensate.
+        debugDefaultTargetPlatformOverride == TargetPlatform.macOS ? 1678.0 : 678.0,
       );
 
       // After the drag, 40 + 567px should be on the 46th item.

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -227,7 +227,7 @@ void main() {
     expect(find.text('aaa2'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 250));
     final Offset point1 = tester.getCenter(find.text('aaa1'));
-    await tester.dragFrom(point1, const Offset(0.0, 200.0));
+    await tester.dragFrom(point1, const Offset(0.0, 400.0));
     await tester.pump();
     expect(
       tester.renderObject<RenderBox>(find.byType(AppBar)).size.height,
@@ -245,7 +245,7 @@ void main() {
     expect(find.text('aaa2'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 250));
     final Offset point = tester.getCenter(find.text('aaa1'));
-    await tester.flingFrom(point, const Offset(0.0, 200.0), 5000.0);
+    await tester.flingFrom(point, const Offset(0.0, 200.0), 15000.0);
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pump(const Duration(milliseconds: 10));

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -227,7 +227,12 @@ void main() {
     expect(find.text('aaa2'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 250));
     final Offset point1 = tester.getCenter(find.text('aaa1'));
-    await tester.dragFrom(point1, const Offset(0.0, 400.0));
+    if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+      await tester.dragFrom(point1, const Offset(0.0, 400.0));
+    }
+    else {
+      await tester.dragFrom(point1, const Offset(0.0, 200.0));
+    }
     await tester.pump();
     expect(
       tester.renderObject<RenderBox>(find.byType(AppBar)).size.height,
@@ -245,7 +250,12 @@ void main() {
     expect(find.text('aaa2'), findsOneWidget);
     await tester.pump(const Duration(milliseconds: 250));
     final Offset point = tester.getCenter(find.text('aaa1'));
-    await tester.flingFrom(point, const Offset(0.0, 200.0), 15000.0);
+    if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+      await tester.flingFrom(point, const Offset(0.0, 200.0), 15000.0);
+    }
+    else {
+      await tester.flingFrom(point, const Offset(0.0, 200.0), 5000.0);
+    }
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pump(const Duration(milliseconds: 10));
     await tester.pump(const Duration(milliseconds: 10));

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
@@ -271,7 +272,12 @@ void main() {
     expect(sizeOf(0), equals(const Size(800.0, 600.0)));
 
     // Easing overscroll past overscroll limit.
-    await tester.drag(find.byType(PageView), const Offset(-500.0, 0.0));
+    if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
+      await tester.drag(find.byType(PageView), const Offset(-500.0, 0.0));
+    }
+    else {
+      await tester.drag(find.byType(PageView), const Offset(-200.0, 0.0));
+    }
     await tester.pump();
 
     expect(leftOf(0), lessThan(0.0));

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -271,7 +271,7 @@ void main() {
     expect(sizeOf(0), equals(const Size(800.0, 600.0)));
 
     // Easing overscroll past overscroll limit.
-    await tester.drag(find.byType(PageView), const Offset(-200.0, 0.0));
+    await tester.drag(find.byType(PageView), const Offset(-500.0, 0.0));
     await tester.pump();
 
     expect(leftOf(0), lessThan(0.0));

--- a/packages/flutter/test/widgets/scrollable_fling_test.dart
+++ b/packages/flutter/test/widgets/scrollable_fling_test.dart
@@ -85,6 +85,7 @@ void main() {
     final double macOSResult = getCurrentOffset();
 
     expect(androidResult, lessThan(iOSResult)); // iOS is slipperier than Android
+    expect(macOSResult, lessThan(iOSResult)); // iOS is slipperier than macOS
     expect(macOSResult, lessThan(androidResult)); // Android is slipperier than macOS
     expect(linuxResult, lessThan(iOSResult)); // iOS is slipperier than Linux
     expect(macOSResult, lessThan(linuxResult)); // Linux is slipperier than macOS

--- a/packages/flutter/test/widgets/scrollable_fling_test.dart
+++ b/packages/flutter/test/widgets/scrollable_fling_test.dart
@@ -85,11 +85,11 @@ void main() {
     final double macOSResult = getCurrentOffset();
 
     expect(androidResult, lessThan(iOSResult)); // iOS is slipperier than Android
-    expect(androidResult, lessThan(macOSResult)); // macOS is slipperier than Android
+    expect(macOSResult, lessThan(androidResult)); // Android is slipperier than macOS
     expect(linuxResult, lessThan(iOSResult)); // iOS is slipperier than Linux
-    expect(linuxResult, lessThan(macOSResult)); // macOS is slipperier than Linux
+    expect(macOSResult, lessThan(linuxResult)); // Linux is slipperier than macOS
     expect(windowsResult, lessThan(iOSResult)); // iOS is slipperier than Windows
-    expect(windowsResult, lessThan(macOSResult)); // macOS is slipperier than Windows
+    expect(macOSResult, lessThan(windowsResult)); // Windows is slipperier than macOS
     expect(windowsResult, equals(androidResult));
     expect(windowsResult, equals(androidResult));
     expect(linuxResult, equals(androidResult));

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -135,7 +135,7 @@ void main() {
     final double macOSResult = getScrollOffset(tester);
 
     expect(androidResult, lessThan(iOSResult)); // iOS is slipperier than Android
-    expect(androidResult, lessThan(macOSResult)); // macOS is slipperier than Android
+    expect(macOSResult, lessThan(iOSResult)); // iOS is slipperier than macOS
   });
 
   testWidgets('Holding scroll', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -134,6 +134,7 @@ void main() {
     await tester.pump(const Duration(seconds: 5));
     final double macOSResult = getScrollOffset(tester);
 
+    expect(macOSResult, lessThan(androidResult)); // macOS is slipperier than Android
     expect(androidResult, lessThan(iOSResult)); // iOS is slipperier than Android
     expect(macOSResult, lessThan(iOSResult)); // iOS is slipperier than macOS
   });


### PR DESCRIPTION

<img width="1572" alt="image" src="https://user-images.githubusercontent.com/789275/180816607-c48ea09e-cb9f-401c-9a48-3fcae1218289.png">

Dotted line = `BouncingScrollPhysics`
Solid line = new `BouncingDesktopScrollPhysics`
X-marks = Recorded data

Fixes #107752

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

