### PR TITLE
[flutter_tools] Test that DAP process terminates at the end of a session

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -99,6 +99,13 @@ void main() {
         '',
         startsWith('Exited'),
       ]);
+
+      // If we're running with an out-of-process debug adapter, ensure that its
+      // own process shuts down after we terminated.
+      final DapTestServer server = dap.server;
+      if (server is OutOfProcessDapTestServer) {
+        await server.exitCode;
+      }
     });
 
     testWithoutContext('outputs useful message on invalid DAP protocol messages', () async {


### PR DESCRIPTION
The debug adapter should terminate itself after terminating the debugee, but previously wasn't (and was relying on the editor to do it after getting the Terminate event).

The issue is fixed in the base debug adapter by https://dart-review.googlesource.com/c/sdk/+/252660/ but this updates a test to ensure that's working correctly.

This test won't pass until https://dart-review.googlesource.com/c/sdk/+/252660/ is released in a DDS release and rolled into Flutter. I'm raising this as a draft while it's all fresh in my mind, and will mark for-review once the DDS update is ready.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
