### PR TITLE
[flutter_tools] [dap] Ensure DAP sends app.stop/app.detach during terminate

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -400,6 +400,16 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     if (isAttach) {
       await preventBreakingAndResume();
     }
+
+    // Send a request to stop/detach to give Flutter chance to do some cleanup.
+    // It's possible the Flutter process will terminate before we process the
+    // response, so accept either a response or the process exiting.
+    final String method = isAttach ? 'app.detach' : 'app.stop';
+    await Future.any<void>(<Future<void>>[
+      sendFlutterRequest(method, <String, Object?>{'appId': _appId}),
+      _process?.exitCode ?? Future<void>.value(),
+    ]);
+
     terminatePids(ProcessSignal.sigterm);
     await _process?.exitCode;
   }

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -43,6 +43,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   late String executable;
   late List<String> processArgs;
   late Map<String, String>? env;
+  final List<String> flutterRequests = <String>[];
 
   @override
   Future<void> launchAsProcess({
@@ -57,6 +58,16 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     // Pretend we launched the app and got the app.started event so that
     // launchRequest will complete.
     appStartedCompleter.complete();
+  }
+
+  @override
+  Future<Object?> sendFlutterRequest(
+    String method,
+    Map<String, Object?>? params, {
+    bool failSilently = true,
+  }) {
+    flutterRequests.add(method);
+    return super.sendFlutterRequest(method, params, failSilently: failSilently);
   }
 
   @override

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -64,6 +64,7 @@ void main() {
         'Launching $relativeMainPath on Flutter test device in debug mode...',
         startsWith('Connecting to VM Service at'),
         'topLevelFunction',
+        'Application finished.',
         '',
         startsWith('Exited'),
       ]);
@@ -94,6 +95,7 @@ void main() {
       expectLines(output, <Object>[
         'Launching $relativeMainPath on Flutter test device in debug mode...',
         'topLevelFunction',
+        'Application finished.',
         '',
         startsWith('Exited'),
       ]);

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -29,7 +29,7 @@ final bool useInProcessDap = Platform.environment['DAP_TEST_INTERNAL'] == 'true'
 /// This is useful for debugging locally or on the bots and will include both
 /// DAP traffic (between the test DAP client and the DAP server) and the VM
 /// Service traffic (wrapped in a custom 'dart.log' event).
-final bool verboseLogging = false; //Platform.environment['DAP_TEST_VERBOSE'] == 'true';
+final bool verboseLogging = Platform.environment['DAP_TEST_VERBOSE'] == 'true';
 
 const String endOfErrorOutputMarker = '════════════════════════════════════════════════════════════════════════════════════════════════════';
 

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_support.dart
@@ -29,7 +29,7 @@ final bool useInProcessDap = Platform.environment['DAP_TEST_INTERNAL'] == 'true'
 /// This is useful for debugging locally or on the bots and will include both
 /// DAP traffic (between the test DAP client and the DAP server) and the VM
 /// Service traffic (wrapped in a custom 'dart.log' event).
-final bool verboseLogging = Platform.environment['DAP_TEST_VERBOSE'] == 'true';
+final bool verboseLogging = false; //Platform.environment['DAP_TEST_VERBOSE'] == 'true';
 
 const String endOfErrorOutputMarker = '════════════════════════════════════════════════════════════════════════════════════════════════════';
 


### PR DESCRIPTION
Fixes an issue where the flutter_tester device may not be cleaned up correctly if we just terminate the Flutter process in the DAP when the client calls terminateRequest. This calls the [app.stop/app.detach commands](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/doc/daemon.md#appstop) first and waits for them to complete (or the process to terminate).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
