### PR TITLE
Revert "Upgrade Gradle and AGP versions to 7.5/7.2 and migrate examples/tests"

### DIFF
--- a/dev/benchmarks/complex_layout/android/build.gradle
+++ b/dev/benchmarks/complex_layout/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/macrobenchmarks/android/build.gradle
+++ b/dev/benchmarks/macrobenchmarks/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/microbenchmarks/android/build.gradle
+++ b/dev/benchmarks/microbenchmarks/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/platform_views_layout/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/benchmarks/test_apps/stocks/android/build.gradle
+++ b/dev/benchmarks/test_apps/stocks/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/integration_tests/android_views/android/build.gradle
+++ b/dev/integration_tests/android_views/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/integration_tests/deferred_components_test/android/build.gradle
+++ b/dev/integration_tests/deferred_components_test/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/dev/integration_tests/flutter_gallery/android/build.gradle
+++ b/dev/integration_tests/flutter_gallery/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/examples/api/android/build.gradle
+++ b/examples/api/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/examples/flutter_view/android/build.gradle
+++ b/examples/flutter_view/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/examples/hello_world/android/build.gradle
+++ b/examples/hello_world/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/examples/image_list/android/build.gradle
+++ b/examples/image_list/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/examples/layers/android/build.gradle
+++ b/examples/layers/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/examples/platform_channel/android/build.gradle
+++ b/examples/platform_channel/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/examples/platform_view/android/build.gradle
+++ b/examples/platform_view/android/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:{{agpVersion}}'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -27,10 +27,10 @@ import 'android_sdk.dart';
 // For more information about the latest version, check:
 // https://developer.android.com/studio/releases/gradle-plugin#updating-gradle
 // https://kotlinlang.org/docs/gradle.html#plugin-and-versions
-const String templateDefaultGradleVersion = '7.5';
-const String templateAndroidGradlePluginVersion = '7.2.0';
-const String templateDefaultGradleVersionForModule = '7.2.0';
-const String templateKotlinGradlePluginVersion = '1.7.10';
+const String templateDefaultGradleVersion = '7.4';
+const String templateAndroidGradlePluginVersion = '7.1.2';
+const String templateDefaultGradleVersionForModule = '7.1.2';
+const String templateKotlinGradlePluginVersion = '1.6.10';
 
 // These versions should match the values in flutter.gradle (FlutterExtension).
 // The Flutter Gradle plugin is only applied to app projects, and modules that are built from source
@@ -204,8 +204,8 @@ String getGradleVersionFor(String androidPluginVersion) {
   if (_isWithinVersionRange(androidPluginVersion, min: '4.0.0', max: '4.1.0')) {
     return '6.7';
   }
-  if (_isWithinVersionRange(androidPluginVersion, min: '7.0', max: '7.5')) {
-    return '7.5';
+  if (_isWithinVersionRange(androidPluginVersion, min: '7.0', max: '7.4')) {
+    return '7.4';
   }
   throwToolExit('Unsupported Android Plugin version: $androidPluginVersion.');
 }

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -907,10 +907,10 @@ A problem occurred evaluating project ':app'.
           '│ To fix this issue, replace the following content:                                │\n'
           '│ /android/build.gradle:                                                           │\n'
           "│     - classpath 'com.android.tools.build:gradle:<current-version>'               │\n"
-          "│     + classpath 'com.android.tools.build:gradle:7.2.0'                           │\n"
+          "│     + classpath 'com.android.tools.build:gradle:7.1.2'                           │\n"
           '│ /android/gradle/wrapper/gradle-wrapper.properties:                               │\n'
           '│     - https://services.gradle.org/distributions/gradle-<current-version>-all.zip │\n'
-          '│     + https://services.gradle.org/distributions/gradle-7.5-all.zip               │\n'
+          '│     + https://services.gradle.org/distributions/gradle-7.4-all.zip               │\n'
           '└──────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );

--- a/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_find_bundle_test.dart
@@ -357,7 +357,7 @@ void main() {
         'gradle',
         label: 'gradle-expected-file-not-found',
         parameters: CustomDimensions.fromMap(<String, String> {
-          'cd37': 'androidGradlePluginVersion: 7.5, fileExtension: .aab',
+          'cd37': 'androidGradlePluginVersion: 7.4, fileExtension: .aab',
         }),
       ),
     ));

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -443,9 +443,9 @@ flutter:
       expect(getGradleVersionFor('4.0.0'), '6.7');
       expect(getGradleVersionFor('4.1.0'), '6.7');
 
-      expect(getGradleVersionFor('7.0'), '7.5');
-      expect(getGradleVersionFor('7.1.2'), '7.5');
-      expect(getGradleVersionFor('7.2'), '7.5');
+      expect(getGradleVersionFor('7.0'), '7.4');
+      expect(getGradleVersionFor('7.1.2'), '7.4');
+      expect(getGradleVersionFor('7.2'), '7.4');
     });
 
     testWithoutContext('throws on unsupported versions', () {

--- a/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_utils_test.dart
@@ -73,7 +73,7 @@ void main() {
             'distributionPath=wrapper/dists\n'
             'zipStoreBase=GRADLE_USER_HOME\n'
             'zipStorePath=wrapper/dists\n'
-            'distributionUrl=https\\://services.gradle.org/distributions/gradle-7.5-all.zip\n');
+            'distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4-all.zip\n');
     });
 
     testWithoutContext('injects the wrapper when some files are missing', () {
@@ -110,7 +110,7 @@ void main() {
           'distributionPath=wrapper/dists\n'
           'zipStoreBase=GRADLE_USER_HOME\n'
           'zipStorePath=wrapper/dists\n'
-          'distributionUrl=https\\://services.gradle.org/distributions/gradle-7.5-all.zip\n');
+          'distributionUrl=https\\://services.gradle.org/distributions/gradle-7.4-all.zip\n');
     });
 
     testWithoutContext('injects the wrapper and the Gradle version is derivated from the AGP version', () {

--- a/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
+++ b/packages/flutter_tools/test/integration.shard/android_plugin_example_app_build_test.dart
@@ -58,12 +58,12 @@ void main() {
     final RegExp androidPluginRegExp =
         RegExp(r'com\.android\.tools\.build:gradle:(\d+\.\d+\.\d+)');
 
-    // Use AGP 7.2.0
+    // Use AGP 4.1.0
     final String newBuildGradle = buildGradle.replaceAll(
-        androidPluginRegExp, 'com.android.tools.build:gradle:7.2.0');
+        androidPluginRegExp, 'com.android.tools.build:gradle:4.1.0');
     buildGradleFile.writeAsStringSync(newBuildGradle);
 
-    // Run flutter build apk using AGP 7.2.0
+    // Run flutter build apk using AGP 4.1.0
     result = processManager.runSync(<String>[
       flutterBin,
       ...getLocalEngineArguments(),


### PR DESCRIPTION
Reverts flutter/flutter#108197

Failing consistently on Mac_android microbenchmarks:
```
[microbenchmarks] [STDOUT] [STDOUT] [+1142 ms] > Configure project :
[microbenchmarks] [STDOUT] [STDOUT] [        ] Evaluating root project 'android' using build file '/opt/s/w/ir/x/w/recipe_cleanup/tmp17zz_ptv/flutter sdk/dev/benchmarks/microbenchmarks/android/build.gradle'.
[microbenchmarks] [STDOUT] [STDOUT] [        ] Resource missing. [HTTP GET: https://dl.google.com/dl/android/maven2/com/android/tools/build/gradle/%7B%7BagpVersion%7D%7D/gradle-%7B%7BagpVersion%7D%7D.pom]
[microbenchmarks] [STDOUT] [STDOUT] [        ] Resource missing. [HTTP GET: https://repo.maven.apache.org/maven2/com/android/tools/build/gradle/%7B%7BagpVersion%7D%7D/gradle-%7B%7BagpVersion%7D%7D.pom]
[microbenchmarks] [STDOUT] [STDOUT] [+2222 ms] Running Gradle task 'assembleProfile'... (completed in 6.6s)
[microbenchmarks] [STDOUT] [STDOUT] [   +3 ms] "flutter run" took 7,347ms.
[microbenchmarks] [STDOUT] [STDOUT] [   +1 ms] ensureAnalyticsSent: 0ms
[microbenchmarks] [STDOUT] [STDOUT] [        ] Running shutdown hooks
[microbenchmarks] [STDOUT] [STDOUT] [        ] Shutdown hooks complete
[microbenchmarks] [STDOUT] [STDOUT] [        ] exiting with code 1
```