### PR TITLE
Modify dataMap to include assertiveness only if it's not set to polite

### DIFF
--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -8,6 +8,21 @@ import 'package:flutter/painting.dart';
 
 export 'dart:ui' show TextDirection;
 
+/// Determines the assertiveness level of the accessibility announcement.
+///
+/// It is used by [AnnounceSemanticsEvent] to determine the priority with which
+/// assistive technology should treat announcements.
+enum Assertiveness {
+  /// The assistive technology will speak changes whenever the user is idle.
+  polite,
+
+  /// The assistive technology will interrupt any announcement that it is
+  /// currently making to notify the user about the change.
+  ///
+  /// It should only be used for time-sensitive/critical notifications.
+  assertive,
+}
+
 /// An event sent by the application to notify interested listeners that
 /// something happened to the user interface (e.g. a view scrolled).
 ///
@@ -71,7 +86,7 @@ abstract class SemanticsEvent {
 class AnnounceSemanticsEvent extends SemanticsEvent {
 
   /// Constructs an event that triggers an announcement by the platform.
-  const AnnounceSemanticsEvent(this.message, this.textDirection)
+  const AnnounceSemanticsEvent(this.message, this.textDirection, {this.assertiveness = Assertiveness.polite})
     : assert(message != null),
       assert(textDirection != null),
       super('announce');
@@ -86,12 +101,25 @@ class AnnounceSemanticsEvent extends SemanticsEvent {
   /// This property must not be null.
   final TextDirection textDirection;
 
+  /// Determines whether the announcement should interrupt any existing announcement,
+  /// or queue after it.
+  ///
+  /// On the web this option uses the aria-live level to set the assertiveness
+  /// of the announcement. On iOS, Android, Windows, Linux, macOS, and Fuchsia
+  /// this option currently has no effect.
+  final Assertiveness assertiveness;
+
   @override
   Map<String, dynamic> getDataMap() {
-    return <String, dynamic>{
+    final Map<String, dynamic> dataMap = <String, dynamic> {
       'message': message,
       'textDirection': textDirection.index,
     };
+
+    if (assertiveness == Assertiveness.assertive) {
+      dataMap['assertiveness']=assertiveness.index;
+    }
+    return dataMap;
   }
 }
 

--- a/packages/flutter/lib/src/semantics/semantics_event.dart
+++ b/packages/flutter/lib/src/semantics/semantics_event.dart
@@ -111,15 +111,12 @@ class AnnounceSemanticsEvent extends SemanticsEvent {
 
   @override
   Map<String, dynamic> getDataMap() {
-    final Map<String, dynamic> dataMap = <String, dynamic> {
+    return <String, dynamic> {
       'message': message,
       'textDirection': textDirection.index,
+      if (assertiveness != Assertiveness.polite)
+        'assertiveness': assertiveness.index,
     };
-
-    if (assertiveness == Assertiveness.assertive) {
-      dataMap['assertiveness']=assertiveness.index;
-    }
-    return dataMap;
   }
 }
 

--- a/packages/flutter/lib/src/semantics/semantics_service.dart
+++ b/packages/flutter/lib/src/semantics/semantics_service.dart
@@ -6,7 +6,7 @@ import 'dart:ui' show TextDirection;
 
 import 'package:flutter/services.dart' show SystemChannels;
 
-import 'semantics_event.dart' show AnnounceSemanticsEvent, TooltipSemanticsEvent;
+import 'semantics_event.dart' show AnnounceSemanticsEvent, Assertiveness, TooltipSemanticsEvent;
 
 export 'dart:ui' show TextDirection;
 
@@ -29,8 +29,12 @@ class SemanticsService {
   ///
   /// For example a camera application can use this method to make accessibility
   /// announcements regarding objects in the viewfinder.
-  static Future<void> announce(String message, TextDirection textDirection) async {
-    final AnnounceSemanticsEvent event = AnnounceSemanticsEvent(message, textDirection);
+  ///
+  /// The assertiveness level of the announcement is determined by [assertiveness].
+  /// Currently, this is only supported by the web engine and has no effect on
+  /// other platforms. The default mode is [Assertiveness.polite].
+  static Future<void> announce(String message, TextDirection textDirection, {Assertiveness assertiveness = Assertiveness.polite}) async {
+    final AnnounceSemanticsEvent event = AnnounceSemanticsEvent(message, textDirection, assertiveness: assertiveness);
     await SystemChannels.accessibility.send(event.toMap());
   }
 

--- a/packages/flutter/test/semantics/semantics_service_test.dart
+++ b/packages/flutter/test/semantics/semantics_service_test.dart
@@ -20,11 +20,10 @@ void main() {
     TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockDecodedMessageHandler<dynamic>(SystemChannels.accessibility, handleMessage);
 
     await SemanticsService.announce('announcement 1', TextDirection.ltr);
-    await SemanticsService.announce('announcement 2', TextDirection.rtl);
-
+    await SemanticsService.announce('announcement 2', TextDirection.rtl, assertiveness: Assertiveness.assertive);
     expect(log, equals(<Map<String, dynamic>>[
       <String, dynamic>{'type': 'announce', 'data': <String, dynamic>{'message': 'announcement 1', 'textDirection': 1}},
-      <String, dynamic>{'type': 'announce', 'data': <String, dynamic>{'message': 'announcement 2', 'textDirection': 0}},
+      <String, dynamic>{'type': 'announce', 'data': <String, dynamic>{'message': 'announcement 2', 'textDirection': 0, 'assertiveness': 1}},
     ]));
   });
 }


### PR DESCRIPTION
Add an optional flag to [Flutter's accessibility announcer service](https://api.flutter.dev/flutter/semantics/SemanticsService/announce.html) to support two different modes of aria announcements in flutter web. Developers can make the announcement assertive or polite using this flag. The change on the web engine side is tracked here: https://github.com/flutter/engine/pull/34640

The first [PR](https://github.com/flutter/flutter/pull/107568) was breaking some of the Google tests and had to get reverted. The tests were breaking because they were receiving an additional piece of information (`assertiveness`) in the dataMap string. In this fix, we don't include `assertiveness` if it has the default value of `polite`. 

Fixes https://github.com/flutter/flutter/issues/104109


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
