### PR TITLE
[flutter_test] Add flag to send device pointer events to the framework

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -495,7 +495,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// When [handlePointerEvent] is called directly, [pointerEventSource]
   /// is [TestBindingEventSource.device].
   ///
-  /// This default means that pointer events triggered by the [WidgetController]
+  /// This means that pointer events triggered by the [WidgetController] (e.g. via [WidgetController.tap])
   /// will result in actual interactions with the UI, but other pointer events
   /// such as those from physical taps will be delegated to
   /// [deviceEventDispatcher] *instead*. See also

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -495,11 +495,11 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   /// When [handlePointerEvent] is called directly, [pointerEventSource]
   /// is [TestBindingEventSource.device].
   ///
-  /// This means that pointer events triggered by the [WidgetController] (e.g. via [WidgetController.tap])
-  /// will result in actual interactions with the UI, but other pointer events
-  /// such as those from physical taps will be delegated to
-  /// [deviceEventDispatcher] *instead*. See also
-  /// [shouldPropagateDevicePointerEvents] if this is undesired.
+  /// This means that pointer events triggered by the [WidgetController] (e.g.
+  /// via [WidgetController.tap]) will result in actual interactions with the
+  /// UI, but other pointer events such as those from physical taps will be
+  /// dropped. See also [shouldPropagateDevicePointerEvents] if this is
+  /// undesired.
   TestBindingEventSource get pointerEventSource => _pointerEventSource;
   TestBindingEventSource _pointerEventSource = TestBindingEventSource.device;
 
@@ -852,6 +852,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     final bool autoUpdateGoldensBeforeTest = autoUpdateGoldenFiles && !isBrowser;
     final TestExceptionReporter reportTestExceptionBeforeTest = reportTestException;
     final ErrorWidgetBuilder errorWidgetBuilderBeforeTest = ErrorWidget.builder;
+    final bool shouldPropagateDevicePointerEventsBeforeTest = shouldPropagateDevicePointerEvents;
 
     // run the test
     await testBody();
@@ -870,6 +871,7 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _verifyAutoUpdateGoldensUnset(autoUpdateGoldensBeforeTest && !isBrowser);
       _verifyReportTestExceptionUnset(reportTestExceptionBeforeTest);
       _verifyErrorWidgetBuilderUnset(errorWidgetBuilderBeforeTest);
+      _verifyShouldPropagateDevicePointerEventsUnset(shouldPropagateDevicePointerEventsBeforeTest);
       _verifyInvariants();
     }
 
@@ -950,6 +952,21 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
         FlutterError.reportError(FlutterErrorDetails(
           exception: FlutterError(
               'The value of ErrorWidget.builder was changed by the test.',
+          ),
+          stack: StackTrace.current,
+          library: 'Flutter test framework',
+        ));
+      }
+      return true;
+    }());
+  }
+
+  void _verifyShouldPropagateDevicePointerEventsUnset(bool valueBeforeTest) {
+    assert(() {
+      if (shouldPropagateDevicePointerEvents != valueBeforeTest) {
+        FlutterError.reportError(FlutterErrorDetails(
+          exception: FlutterError(
+              'The value of shouldPropagateDevicePointerEvents was changed by the test.',
           ),
           stack: StackTrace.current,
           library: 'Flutter test framework',

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -502,6 +502,10 @@ Future<void> expectLater(
 ///
 /// For convenience, instances of this class (such as the one provided by
 /// `testWidgets`) can be used as the `vsync` for `AnimationController` objects.
+///
+/// When the binding is [LiveTestWidgetsFlutterBinding], events from
+/// [LiveTestWidgetsFlutterBinding.deviceEventDispatcher] will be handled in
+/// [dispatchEvent].
 class WidgetTester extends WidgetController implements HitTestDispatcher, TickerProvider {
   WidgetTester._(super.binding) {
     if (binding is LiveTestWidgetsFlutterBinding) {
@@ -817,6 +821,10 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   }
 
   /// Handler for device events caught by the binding in live test mode.
+  ///
+  /// [PointerDownEvent]s received here will only print a diagnostic message
+  /// showing possible [Finder]s that can be used to interact with the widget at
+  /// the location of [result].
   @override
   void dispatchEvent(PointerEvent event, HitTestResult result) {
     if (event is PointerDownEvent) {

--- a/packages/flutter_test/test/live_binding_test.dart
+++ b/packages/flutter_test/test/live_binding_test.dart
@@ -8,7 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 // This file is for testings that require a `LiveTestWidgetsFlutterBinding`
 void main() {
-  LiveTestWidgetsFlutterBinding();
+  final LiveTestWidgetsFlutterBinding binding = LiveTestWidgetsFlutterBinding();
   testWidgets('Input PointerAddedEvent', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(home: Text('Test')));
     await tester.pump();
@@ -99,4 +99,57 @@ void main() {
 
     await expectLater(tester.binding.reassembleApplication(), completes);
   }, timeout: const Timeout(Duration(seconds: 30)));
+
+  testWidgets('shouldPropagateDevicePointerEvents can override events from ${TestBindingEventSource.device}', (WidgetTester tester) async {
+    binding.shouldPropagateDevicePointerEvents = true;
+
+    await tester.pumpWidget(_ShowNumTaps());
+
+    final Offset position = tester.getCenter(find.text('0'));
+
+    // Simulates a real device tap.
+    //
+    // `handlePointerEventForSource defaults to sending events using
+    // TestBindingEventSource.device. This will not be forwarded to the actual
+    // gesture handlers, unless `shouldPropagateDevicePointerEvents` is true.
+    binding.handlePointerEventForSource(
+      PointerDownEvent(position: position),
+    );
+    binding.handlePointerEventForSource(
+      PointerUpEvent(position: position),
+    );
+
+    await tester.pump();
+
+    expect(find.text('1'), findsOneWidget);
+
+    // Reset the value, otherwise the test will fail when it checks that this
+    // has not been changed as an invariant.
+    binding.shouldPropagateDevicePointerEvents = false;
+  });
+}
+
+/// A widget that shows the number of times it has been tapped.
+class _ShowNumTaps extends StatefulWidget {
+  @override
+  _ShowNumTapsState createState() => _ShowNumTapsState();
+}
+
+class _ShowNumTapsState extends State<_ShowNumTaps> {
+  int _counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          _counter++;
+        });
+      },
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: Text(_counter.toString()),
+      ),
+    );
+  }
 }


### PR DESCRIPTION
#107976 was an alternative to overcome the limitation of how pointer events from `adb shell input` and other physical taps cannot be received by the app. 

The reason for this limitation is that these events surface as `TestBindingEventSource.device`, and are not propagated to the actual gesture handlers when `TestWidgetsFlutterBinding` is used. Specifically for `LiveTestWidgetsFlutterBinding`, these events result in a diagnostic message on finders that can be used to interact with widgets at the location of the tap.

This PR adds a `shouldPropagateDevicePointerEvents` flag to send these pointer events to the actual gesture handlers when it is true, so `customer: money` will be able to use `adb shell input` to control the app in tests.

Fixes #107934
b/239762849

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
