### PR TITLE
Fix Chips vertical padding on desktop (per `MaterialTapTargetSize`)

### DIFF
--- a/packages/flutter/lib/src/material/chip.dart
+++ b/packages/flutter/lib/src/material/chip.dart
@@ -1299,7 +1299,9 @@ class _RawChipState extends State<RawChip> with MaterialStateMixin, TickerProvid
         );
         break;
       case MaterialTapTargetSize.shrinkWrap:
-        constraints = const BoxConstraints();
+        constraints = BoxConstraints(
+          minHeight: kMinInteractiveDimension  + densityAdjustment.dy,
+        );
         break;
     }
     result = _ChipRedirectingHitDetectionWidget(

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -549,7 +549,7 @@ void main() {
         ),
       );
       expect(tester.getSize(find.byType(Chip).first), const Size(48.0, 48.0));
-      expect(tester.getSize(find.byType(Chip).last), const Size(38.0, 32.0));
+      expect(tester.getSize(find.byType(Chip).last), const Size(38.0, 48.0));
     },
   );
 
@@ -1756,7 +1756,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byKey(key2)), const Size(80.0, 32.0));
+    expect(tester.getSize(find.byKey(key2)), const Size(80.0, 48.0));
   });
 
   testWidgets('Chip uses the right theme colors for the right components', (WidgetTester tester) async {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/67797

This is fixing vertical padding for chips on the desktop, meeting`MaterialTapTargetSize` requirement as per https://github.com/flutter/flutter/issues/67797#issuecomment-760459799

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
