### PR TITLE
Nth part of async FragmentProgram.fromAsset transition

### DIFF
--- a/packages/flutter/lib/src/material/ink_sparkle.dart
+++ b/packages/flutter/lib/src/material/ink_sparkle.dart
@@ -520,7 +520,7 @@ class FragmentShaderManager {
   /// Creates an [FragmentShaderManager] with an [InkSparkle] effect.
   static Future<FragmentShaderManager> inkSparkle() async {
     final FragmentShaderManager manager = FragmentShaderManager._();
-    _program = await ui.FragmentProgram.fromAssetAsync(
+    _program = await ui.FragmentProgram.fromAsset(
       'shaders/ink_sparkle.frag',
     );
     return manager;


### PR DESCRIPTION
Renaming from `FragmentProgram.fromAssetAsync` to `FragmentProgram.fromAsset` now that they are the same.