### PR TITLE
Change default value of `effectiveInactivePressedOverlayColor` in Switch to refer to `effectiveInactiveThumbColor`

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -751,7 +751,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
     final Set<MaterialState> inactivePressedStates = inactiveStates..add(MaterialState.pressed);
     final Color effectiveInactivePressedOverlayColor = widget.overlayColor?.resolve(inactivePressedStates)
         ?? switchTheme.overlayColor?.resolve(inactivePressedStates)
-        ?? effectiveActiveThumbColor.withAlpha(kRadialReactionAlpha);
+        ?? effectiveInactiveThumbColor.withAlpha(kRadialReactionAlpha);
 
     final MaterialStateProperty<MouseCursor> effectiveMouseCursor = MaterialStateProperty.resolveWith<MouseCursor>((Set<MaterialState> states) {
       return MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1552,7 +1552,8 @@ void main() {
     final FocusNode focusNode = FocusNode(debugLabel: 'Switch');
     tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
 
-    const Color thumbColor = Color(0xFF000000);
+    const Color activeThumbColor = Color(0xFF000000);
+    const Color inactiveThumbColor = Color(0xFF000010);
     const Color activePressedOverlayColor = Color(0xFF000001);
     const Color inactivePressedOverlayColor = Color(0xFF000002);
     const Color hoverOverlayColor = Color(0xFF000003);
@@ -1585,7 +1586,12 @@ void main() {
             autofocus: focused,
             value: active,
             onChanged: (_) { },
-            thumbColor: const MaterialStatePropertyAll<Color>(thumbColor),
+            thumbColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return activeThumbColor;
+              }
+              return inactiveThumbColor;
+            }),
             overlayColor: useOverlay ? MaterialStateProperty.resolveWith(getOverlayColor) : null,
             hoverColor: hoverColor,
             focusColor: focusColor,
@@ -1595,7 +1601,7 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildSwitch(useOverlay: false));
+    await tester.pumpWidget(buildSwitch(useOverlay: false));  // inactive
     await tester.press(find.byType(Switch));
     await tester.pumpAndSettle();
 
@@ -1604,7 +1610,7 @@ void main() {
       paints
         ..rrect()
         ..circle(
-          color: thumbColor.withAlpha(kRadialReactionAlpha),
+          color: inactiveThumbColor.withAlpha(kRadialReactionAlpha),
           radius: splashRadius,
         ),
       reason: 'Default inactive pressed Switch should have overlay color from thumbColor',
@@ -1619,7 +1625,7 @@ void main() {
       paints
         ..rrect()
         ..circle(
-          color: thumbColor.withAlpha(kRadialReactionAlpha),
+          color: activeThumbColor.withAlpha(kRadialReactionAlpha),
           radius: splashRadius,
         ),
       reason: 'Default active pressed Switch should have overlay color from thumbColor',

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1601,7 +1601,8 @@ void main() {
       );
     }
 
-    await tester.pumpWidget(buildSwitch(useOverlay: false));  // inactive
+    // test inactive Switch, and overlayColor is set to null.
+    await tester.pumpWidget(buildSwitch(useOverlay: false));
     await tester.press(find.byType(Switch));
     await tester.pumpAndSettle();
 
@@ -1616,6 +1617,7 @@ void main() {
       reason: 'Default inactive pressed Switch should have overlay color from thumbColor',
     );
 
+    // test active Switch, and overlayColor is set to null.
     await tester.pumpWidget(buildSwitch(active: true, useOverlay: false));
     await tester.press(find.byType(Switch));
     await tester.pumpAndSettle();
@@ -1631,6 +1633,7 @@ void main() {
       reason: 'Default active pressed Switch should have overlay color from thumbColor',
     );
 
+    // test inactive Switch with an overlayColor
     await tester.pumpWidget(buildSwitch());
     await tester.press(find.byType(Switch));
     await tester.pumpAndSettle();
@@ -1646,6 +1649,7 @@ void main() {
       reason: 'Inactive pressed Switch should have overlay color: $inactivePressedOverlayColor',
     );
 
+    // test active Switch with an overlayColor
     await tester.pumpWidget(buildSwitch(active: true));
     await tester.press(find.byType(Switch));
     await tester.pumpAndSettle();


### PR DESCRIPTION
The default value of `effectiveInactivePressedOverlayColor` was determined by `effectiveActiveThumbColor` which supposed to be `effectiveInactiveThumbColor`.

This PR fixes the typo.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.