### PR TITLE
Remove doc for --ignore-deprecation and check for pubspec before v1 embedding check

### DIFF
--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -599,8 +599,8 @@ class AndroidProject extends FlutterProjectPlatform {
 Warning
 ──────────────────────────────────────────────────────────────────────────────
 Your Flutter application is created using an older version of the Android
-embedding. It is being deprecated in favor of Android embedding v2. Migrate
-your project by following the steps at
+embedding. It is being deprecated in favor of Android embedding v2. To migrate
+your project, follow the steps at:
 
 https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -377,7 +377,7 @@ class FlutterProject {
   }
 
   void checkForDeprecation({DeprecationBehavior deprecationBehavior = DeprecationBehavior.none}) {
-    if (android.existsSync()) {
+    if (android.existsSync() && pubspecFile.existsSync()) {
       android.checkForDeprecation(deprecationBehavior: deprecationBehavior);
     }
   }
@@ -599,14 +599,11 @@ class AndroidProject extends FlutterProjectPlatform {
 Warning
 ──────────────────────────────────────────────────────────────────────────────
 Your Flutter application is created using an older version of the Android
-embedding. It is being deprecated in favor of Android embedding v2. Follow the
-steps at
+embedding. It is being deprecated in favor of Android embedding v2. Migrate
+your project by following the steps at
 
 https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects
 
-to migrate your project. You may also pass the --ignore-deprecation flag to
-ignore this check and continue with the deprecated v1 embedding. However,
-the v1 Android embedding will be removed in future versions of Flutter.
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 The detected reason was:
 

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -239,7 +239,7 @@ void main() {
         expect(testLogger.statusText, contains('https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects'));
       });
       _testInMemory('Android project no pubspec continues', () async {
-        final FlutterProject project = await someProject(includePubspec: false);
+        final FlutterProject project = await someProject();
         // The default someProject with an empty <manifest> already indicates
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -191,7 +191,7 @@ void main() {
       _testInMemory('checkForDeprecation fails on invalid android app manifest file', () async {
         // This is not a valid Xml document
         const String invalidManifest = '<manifest></application>';
-        final FlutterProject project = await someProject(androidManifestOverride: invalidManifest);
+        final FlutterProject project = await someProject(androidManifestOverride: invalidManifest, includePubspec: true);
 
         expect(
           () => project.checkForDeprecation(deprecationBehavior: DeprecationBehavior.ignore),
@@ -199,7 +199,7 @@ void main() {
         );
       });
       _testInMemory('Android project not on v2 embedding shows a warning', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = await someProject(includePubspec: true);
         // The default someProject with an empty <manifest> already indicates
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.
@@ -208,7 +208,7 @@ void main() {
         expect(testLogger.statusText, contains('https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects'));
       });
       _testInMemory('Android project not on v2 embedding exits', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = await someProject(includePubspec: true);
         // The default someProject with an empty <manifest> already indicates
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.
@@ -221,7 +221,7 @@ void main() {
         expect(testLogger.statusText, contains('No `<meta-data android:name="flutterEmbedding" android:value="2"/>` in '));
       });
       _testInMemory('Project not on v2 embedding does not warn if deprecation status is irrelevant', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = await someProject(includePubspec: true);
         // The default someProject with an empty <manifest> already indicates
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.
@@ -230,13 +230,22 @@ void main() {
         expect(testLogger.statusText, isEmpty);
       });
       _testInMemory('Android project not on v2 embedding ignore continues', () async {
-        final FlutterProject project = await someProject();
+        final FlutterProject project = await someProject(includePubspec: true);
         // The default someProject with an empty <manifest> already indicates
         // v1 embedding, as opposed to having <meta-data
         // android:name="flutterEmbedding" android:value="2" />.
 
         project.checkForDeprecation(deprecationBehavior: DeprecationBehavior.ignore);
         expect(testLogger.statusText, contains('https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects'));
+      });
+      _testInMemory('Android project no pubspec continues', () async {
+        final FlutterProject project = await someProject(includePubspec: false);
+        // The default someProject with an empty <manifest> already indicates
+        // v1 embedding, as opposed to having <meta-data
+        // android:name="flutterEmbedding" android:value="2" />.
+
+        project.checkForDeprecation(deprecationBehavior: DeprecationBehavior.ignore);
+        expect(testLogger.statusText, isNot(contains('https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects')));
       });
       _testInMemory('Android plugin project does not throw v1 embedding deprecation warning', () async {
         final FlutterProject project = await aPluginProject();
@@ -781,12 +790,18 @@ apply plugin: 'kotlin-android'
 
 Future<FlutterProject> someProject({
   String androidManifestOverride,
+  bool includePubspec = false,
 }) async {
   final Directory directory = globals.fs.directory('some_project');
   directory.childDirectory('.dart_tool')
     .childFile('package_config.json')
     ..createSync(recursive: true)
     ..writeAsStringSync('{"configVersion":2,"packages":[]}');
+  if (includePubspec) {
+    directory.childFile('pubspec.yaml')
+    ..createSync(recursive: true)
+    ..writeAsStringSync(validPubspec);
+  }
   directory.childDirectory('ios').createSync(recursive: true);
   final Directory androidDirectory = directory
       .childDirectory('android')


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/96642

Also removes the documentation for the `--ignore-deprecation` flag as we no longer want developers to ignore this warning. The flag still works and can be used, but developers will no longer see the suggestion to use it anymore.

The next step is to deprecate the `--ignore-deprecation` flag entirely to disable building for v1 embedding.