### PR TITLE
Add stepPadding as Stepper attribute instead of hardwritten value

### DIFF
--- a/packages/flutter/lib/src/material/stepper.dart
+++ b/packages/flutter/lib/src/material/stepper.dart
@@ -209,6 +209,7 @@ class Stepper extends StatefulWidget {
     this.controlsBuilder,
     this.elevation,
     this.margin,
+    this.stepPadding = const EdgeInsets.all(24.0),
   }) : assert(steps != null),
        assert(type != null),
        assert(currentStep != null),
@@ -236,6 +237,9 @@ class Stepper extends StatefulWidget {
 
   /// The index into [steps] of the current step whose content is displayed.
   final int currentStep;
+
+  /// The padding around all Step Widgets
+  final EdgeInsets stepPadding;
 
   /// The callback called when a step is tapped, with its index passed as
   /// an argument.
@@ -799,7 +803,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
         Material(
           elevation: widget.elevation ?? 2,
           child: Container(
-            margin: const EdgeInsets.symmetric(horizontal: 24.0),
+            margin: widget.stepPadding,
             child: Row(
               children: children,
             ),

--- a/packages/flutter/test/material/stepper_test.dart
+++ b/packages/flutter/test/material/stepper_test.dart
@@ -1228,6 +1228,71 @@ testWidgets('Stepper custom indexed controls test', (WidgetTester tester) async 
         tester.widget<Text>(find.text('Label ${index + 2}'));
     expect(bodyText2Style, nextLabelTextWidget.style);
   });
+
+   testWidgets('Stepper custom step padding', (WidgetTester tester) async {
+    const EdgeInsets padding = EdgeInsets.all(16.0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SizedBox(
+            width: 200,
+            height: 75,
+            child: Stepper(
+              stepPadding: padding,
+              type: StepperType.horizontal,
+              steps: const <Step>[
+                Step(
+                    title: Text('Regular title'),
+                    content: Text('Text content')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Stepper material = tester.firstWidget<Stepper>(
+      find.descendant(
+        of: find.byType(Material),
+        matching: find.byType(Stepper),
+      ),
+    );
+
+    expect(material.stepPadding, equals(padding));
+  });
+
+   testWidgets('Stepper custom step default padding', (WidgetTester tester) async {
+    const EdgeInsets padding = EdgeInsets.all(24.0);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Material(
+          child: SizedBox(
+            width: 200,
+            height: 75,
+            child: Stepper(
+              type: StepperType.horizontal,
+              steps: const <Step>[
+                Step(
+                    title: Text('Regular title'),
+                    content: Text('Text content')),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Stepper material = tester.firstWidget<Stepper>(
+      find.descendant(
+        of: find.byType(Material),
+        matching: find.byType(Stepper),
+      ),
+    );
+
+    expect(material.stepPadding, equals(padding));
+  });
 }
 
 class _TappableColorWidget extends StatefulWidget {


### PR DESCRIPTION
Adding stepPadding as Stepper attribute. It was currently hardWritten.

Before: Hardwritten padding around Step `const EdgeInsets.all(24.0)`
![image](https://user-images.githubusercontent.com/9638281/181489183-8b5f6c3a-9cff-4e45-8b0d-3db5c4874e8f.png)

After: Customizable padding around Step
Example: `const EdgeInsets.all(0)`
![image](https://user-images.githubusercontent.com/9638281/181489003-357e6f90-6c63-4a7b-9c6f-89d64cb9d18d.png)

Example: `const EdgeInsets.all(16)`
![image](https://user-images.githubusercontent.com/9638281/181489109-4375dc29-a0fd-428f-ad5e-6888e11479ad.png)


[Issue Fixed](https://github.com/flutter/flutter/issues/108530#issue-1320728473)