### PR TITLE
Mark NavigationBar as non-const to match reality

### DIFF
--- a/packages/flutter/lib/src/material/navigation_bar.dart
+++ b/packages/flutter/lib/src/material/navigation_bar.dart
@@ -54,7 +54,9 @@ class NavigationBar extends StatelessWidget {
   ///
   /// The value of [destinations] must be a list of two or more
   /// [NavigationDestination] values.
-  const NavigationBar({
+  // TODO(goderbauer): This class cannot be const constructed, https://github.com/dart-lang/linter/issues/3366.
+  // ignore: prefer_const_constructors_in_immutables
+  NavigationBar({
     super.key,
     this.animationDuration,
     this.selectedIndex = 0,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/102460.

Removing the const constructor shouldn't be a breaking change because if somebody is currently const-constructing a NavigationBar their code is already broken since NavigationBar cannot be const constructed in practice.