### PR TITLE
disable new transition while toPictureSync is fixed

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -602,7 +602,7 @@ class ZoomPageTransitionsBuilder extends PageTransitionsBuilder {
     return _ZoomPageTransition(
       animation: animation,
       secondaryAnimation: secondaryAnimation,
-      preferRasterization: route?.preferRasterization ?? true,
+      preferRasterization: false, // TODO(jonahwilliams): https://github.com/flutter/flutter/issues/108389
       child: child,
     );
   }

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -174,7 +174,7 @@ void main() {
       MaterialApp(
         onGenerateRoute: (RouteSettings settings) {
           return MaterialPageRoute<void>(
-            preferRasterization: false,
+            // Defaults to false for _ZoomPageTransition due to https://github.com/flutter/flutter/issues/108389
             builder: (BuildContext context) {
               if (settings.name == '/') {
                 return const Material(child: Text('Page 1'));


### PR DESCRIPTION
Reverts default usage of toPictureSync while we work through https://github.com/flutter/flutter/issues/108389