### PR TITLE
Update web links for autofill

### DIFF
--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -49,7 +49,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_BIRTH_DATE_FULL](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_BIRTH_DATE_FULL).
-  /// * web: ["bday"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["bday"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String birthday = 'birthday';
 
@@ -58,7 +58,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_BIRTH_DATE_DAY](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_BIRTH_DATE_DAY).
-  /// * web: ["bday-day"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["bday-day"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String birthdayDay = 'birthdayDay';
 
@@ -67,7 +67,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_BIRTH_DATE_MONTH](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_BIRTH_DATE_MONTH).
-  /// * web: ["bday-month"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["bday-month"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String birthdayMonth = 'birthdayMonth';
 
@@ -76,7 +76,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_BIRTH_DATE_YEAR](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_BIRTH_DATE_YEAR).
-  /// * web: ["bday-year"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["bday-year"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String birthdayYear = 'birthdayYear';
 
@@ -85,7 +85,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["country"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["country"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String countryCode = 'countryCode';
 
@@ -95,7 +95,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_POSTAL_ADDRESS_COUNTRY](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_POSTAL_ADDRESS_COUNTRY).
   /// * iOS: [countryName](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["country-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["country-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String countryName = 'countryName';
 
@@ -104,7 +104,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_CREDIT_CARD_NUMBER](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_CREDIT_CARD_NUMBER).
-  /// * web: ["cc-exp"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-exp"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardExpirationDate = 'creditCardExpirationDate';
 
@@ -121,7 +121,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_MONTH).
-  /// * web: ["cc-exp-month"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-exp-month"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardExpirationMonth = 'creditCardExpirationMonth';
 
@@ -130,7 +130,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_CREDIT_CARD_EXPIRATION_YEAR).
-  /// * web: ["cc-exp-year"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-exp-year"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardExpirationYear = 'creditCardExpirationYear';
 
@@ -139,7 +139,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["cc-family-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-family-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardFamilyName = 'creditCardFamilyName';
 
@@ -148,7 +148,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["cc-given-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-given-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardGivenName = 'creditCardGivenName';
 
@@ -157,7 +157,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["cc-additional-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-additional-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardMiddleName = 'creditCardMiddleName';
 
@@ -165,7 +165,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["cc-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardName = 'creditCardName';
 
@@ -175,7 +175,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_CREDIT_CARD_NUMBER](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_CREDIT_CARD_NUMBER).
   /// * iOS: [creditCardNumber](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["cc-number"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-number"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardNumber = 'creditCardNumber';
 
@@ -184,7 +184,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_CREDIT_CARD_SECURITY_CODE).
-  /// * web: ["cc-csc"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-csc"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardSecurityCode = 'creditCardSecurityCode';
 
@@ -192,7 +192,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["cc-type"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["cc-type"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String creditCardType = 'creditCardType';
 
@@ -202,7 +202,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_EMAIL_ADDRESS](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_EMAIL_ADDRESS).
   /// * iOS: [emailAddress](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["email"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["email"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String email = 'email';
 
@@ -212,7 +212,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PERSON_NAME_FAMILY](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PERSON_NAME_FAMILY).
   /// * iOS: [familyName](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["family-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["family-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String familyName = 'familyName';
 
@@ -222,7 +222,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_POSTAL_ADDRESS_STREET_ADDRESS](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_POSTAL_ADDRESS_STREET_ADDRESS).
   /// * iOS: [fullStreetAddress](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["street-address"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["street-address"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String fullStreetAddress = 'fullStreetAddress';
 
@@ -231,7 +231,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_GENDER](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_GENDER).
-  /// * web: ["sex"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["sex"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String gender = 'gender';
 
@@ -241,7 +241,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PERSON_NAME_GIVEN](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PERSON_NAME_GIVEN).
   /// * iOS: [givenName](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["given-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["given-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String givenName = 'givenName';
 
@@ -250,7 +250,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["impp"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["impp"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String impp = 'impp';
 
@@ -259,7 +259,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * iOS: [jobTitle](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["organization-title"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["organization-title"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String jobTitle = 'jobTitle';
 
@@ -267,7 +267,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["language"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["language"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String language = 'language';
 
@@ -294,7 +294,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PERSON_NAME_MIDDLE](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PERSON_NAME_MIDDLE).
   /// * iOS: [middleName](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["additional-name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["additional-name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String middleName = 'middleName';
 
@@ -304,7 +304,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PERSON_NAME](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PERSON_NAME).
   /// * iOS: [name](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["name"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["name"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String name = 'name';
 
@@ -314,7 +314,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PERSON_NAME_PREFIX](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PERSON_NAME_PREFIX).
   /// * iOS: [namePrefix](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["honorific-prefix"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["honorific-prefix"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String namePrefix = 'namePrefix';
 
@@ -324,7 +324,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PERSON_NAME_SUFFIX](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PERSON_NAME_SUFFIX).
   /// * iOS: [nameSuffix](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["honorific-suffix"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["honorific-suffix"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String nameSuffix = 'nameSuffix';
 
@@ -334,7 +334,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_NEW_PASSWORD](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_NEW_PASSWORD).
   /// * iOS: [newPassword](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["new-password"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["new-password"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String newPassword = 'newPassword';
 
@@ -351,7 +351,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * iOS: [nickname](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["nickname"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["nickname"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String nickname = 'nickname';
 
@@ -361,7 +361,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_SMS_OTP](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_SMS_OTP).
   /// * iOS: [oneTimeCode](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["one-time-code"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["one-time-code"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String oneTimeCode = 'oneTimeCode';
 
@@ -372,7 +372,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * iOS: [organizationName](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["organization"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["organization"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String organizationName = 'organizationName';
 
@@ -382,7 +382,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PASSWORD](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PASSWORD).
   /// * iOS: [password](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["current-password"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["current-password"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String password = 'password';
 
@@ -392,7 +392,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["photo"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["photo"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String photo = 'photo';
 
@@ -418,7 +418,8 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_POSTAL_ADDRESS_EXTENDED_POSTAL_CODE](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_POSTAL_ADDRESS_EXTENDED_POSTAL_CODE).
   /// * Otherwise, the hint string will be used as-is.
-  static const String postalAddressExtendedPostalCode = 'postalAddressExtendedPostalCode';
+  static const String postalAddressExtendedPostalCode =
+      'postalAddressExtendedPostalCode';
 
   /// The input field expects a postal code.
   ///
@@ -426,7 +427,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_POSTAL_CODE](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_POSTAL_CODE).
   /// * iOS: [postalCode](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["postal-code"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["postal-code"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String postalCode = 'postalCode';
 
@@ -437,7 +438,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["address-level1"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-level1"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLevel1 = 'streetAddressLevel1';
 
@@ -447,7 +448,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["address-level2"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-level2"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLevel2 = 'streetAddressLevel2';
 
@@ -456,7 +457,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["address-level3"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-level3"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLevel3 = 'streetAddressLevel3';
 
@@ -465,7 +466,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["address-level4"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-level4"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLevel4 = 'streetAddressLevel4';
 
@@ -474,7 +475,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * iOS: [streetAddressLine1](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["address-line1"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-line1"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLine1 = 'streetAddressLine1';
 
@@ -484,7 +485,7 @@ class AutofillHints {
   ///
   /// * iOS: [streetAddressLine2](https://developer.apple.com/documentation/uikit/uitextcontenttype).
   ///   As of iOS 14.2 this hint does not trigger autofill.
-  /// * web: ["address-line2"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-line2"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLine2 = 'streetAddressLine2';
 
@@ -492,7 +493,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["address-line3"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["address-line3"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String streetAddressLine3 = 'streetAddressLine3';
 
@@ -510,7 +511,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_PHONE_NUMBER](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PHONE_NUMBER).
   /// * iOS: [telephoneNumber](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["tel"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumber = 'telephoneNumber';
 
@@ -519,7 +520,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["tel-area-code"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-area-code"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberAreaCode = 'telephoneNumberAreaCode';
 
@@ -528,7 +529,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_PHONE_COUNTRY_CODE](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PHONE_COUNTRY_CODE).
-  /// * web: ["tel-country-code"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-country-code"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberCountryCode = 'telephoneNumberCountryCode';
 
@@ -545,7 +546,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["tel-extension"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-extension"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberExtension = 'telephoneNumberExtension';
 
@@ -554,7 +555,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["tel-local"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-local"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberLocal = 'telephoneNumberLocal';
 
@@ -564,7 +565,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["tel-local-prefix"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-local-prefix"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberLocalPrefix = 'telephoneNumberLocalPrefix';
 
@@ -574,7 +575,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["tel-local-suffix"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-local-suffix"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberLocalSuffix = 'telephoneNumberLocalSuffix';
 
@@ -583,7 +584,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * Android: [AUTOFILL_HINT_PHONE_NATIONAL](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_PHONE_NATIONAL).
-  /// * web: ["tel-national"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["tel-national"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String telephoneNumberNational = 'telephoneNumberNational';
 
@@ -592,7 +593,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["transaction-amount"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["transaction-amount"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String transactionAmount = 'transactionAmount';
 
@@ -601,7 +602,7 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * web: ["transaction-currency"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["transaction-currency"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String transactionCurrency = 'transactionCurrency';
 
@@ -610,7 +611,7 @@ class AutofillHints {
   /// This hint will be translated to the below values on different platforms:
   ///
   /// * iOS: [URL](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["url"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["url"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String url = 'url';
 
@@ -620,7 +621,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_USERNAME](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_USERNAME).
   /// * iOS: [username](https://developer.apple.com/documentation/uikit/uitextcontenttype).
-  /// * web: ["username"](https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute).
+  /// * web: ["username"](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofilling-form-controls:-the-autocomplete-attribute).
   /// * Otherwise, the hint string will be used as-is.
   static const String username = 'username';
 }

--- a/packages/flutter/lib/src/services/autofill.dart
+++ b/packages/flutter/lib/src/services/autofill.dart
@@ -22,7 +22,6 @@ class AutofillHints {
   ///
   /// This hint will be translated to the below values on different platforms:
   ///
-  /// * Android: [AUTOFILL_HINT_POSTAL_ADDRESS_LOCALITY](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_POSTAL_ADDRESS_LOCALITY).
   /// * iOS: [addressCity](https://developer.apple.com/documentation/uikit/uitextcontenttype).
   /// * Otherwise, the hint string will be used as-is.
   static const String addressCity = 'addressCity';
@@ -418,8 +417,7 @@ class AutofillHints {
   ///
   /// * Android: [AUTOFILL_HINT_POSTAL_ADDRESS_EXTENDED_POSTAL_CODE](https://developer.android.com/reference/androidx/autofill/HintConstants#AUTOFILL_HINT_POSTAL_ADDRESS_EXTENDED_POSTAL_CODE).
   /// * Otherwise, the hint string will be used as-is.
-  static const String postalAddressExtendedPostalCode =
-      'postalAddressExtendedPostalCode';
+  static const String postalAddressExtendedPostalCode = 'postalAddressExtendedPostalCode';
 
   /// The input field expects a postal code.
   ///


### PR DESCRIPTION
Just doc comment updates. No test updates.
Old links redirected to – nothing useful.
