### PR TITLE
[platform_view]run platform view ui test to physical device

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3485,20 +3485,14 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac native_platform_view_ui_tests_ios
+  - name: Mac_ios native_platform_view_ui_tests_ios
     bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:32v1"},
-          {"dependency": "open_jdk", "version": "11"},
-          {"dependency": "xcode", "version": "13a233"}
-        ]
       tags: >
-        ["devicelab", "hostonly"]
+        ["devicelab", "ios", "mac"]
       task_name: native_platform_view_ui_tests_ios
 
   - name: Mac run_release_test_macos

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3350,6 +3350,16 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: microbenchmarks_ios
 
+  - name: Mac_ios native_platform_view_ui_tests_ios
+    bringup: true
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
+      task_name: native_platform_view_ui_tests_ios
+
   - name: Mac_ios new_gallery_ios__transition_perf
     recipe: devicelab/devicelab_drone
     presubmit: false
@@ -3484,16 +3494,6 @@ targets:
       - packages/flutter_tools/**
       - bin/**
       - .ci.yaml
-
-  - name: Mac_ios native_platform_view_ui_tests_ios
-    bringup: true
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
-      task_name: native_platform_view_ui_tests_ios
 
   - name: Mac run_release_test_macos
     recipe: devicelab/devicelab_drone

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -174,6 +174,7 @@
 /dev/devicelab/bin/tasks/large_image_changer_perf_ios.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/macos_chrome_dev_mode.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/microbenchmarks_ios.dart @zanderso @flutter/engine
+/dev/devicelab/bin/tasks/native_platform_view_ui_tests_ios.dart @hellohuanlin @flutter/ios
 /dev/devicelab/bin/tasks/new_gallery_ios__transition_perf.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/new_gallery_impeller_ios__transition_perf.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/platform_channel_sample_test_ios.dart @zanderso @flutter/engine
@@ -198,7 +199,6 @@
 /dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_host_with_custom_build_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/module_test.dart @zanderso @flutter/tool
-/dev/devicelab/bin/tasks/native_platform_view_ui_tests_ios.dart @hellohuanlin @flutter/ios
 /dev/devicelab/bin/tasks/native_ui_tests_macos.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/platform_channel_sample_test_windows.dart @cbracken @flutter/desktop
 /dev/devicelab/bin/tasks/plugin_test.dart @stuartmorgan @flutter/plugin

--- a/dev/devicelab/bin/tasks/native_platform_view_ui_tests_ios.dart
+++ b/dev/devicelab/bin/tasks/native_platform_view_ui_tests_ios.dart
@@ -10,6 +10,7 @@ import 'package:flutter_devicelab/framework/utils.dart';
 import 'package:path/path.dart' as path;
 
 Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
   await task(() async {
     final String projectDirectory = '${flutterDirectory.path}/dev/integration_tests/ios_platform_view_tests';
 


### PR DESCRIPTION
The failure is because `await devices.workingDevice` requires a physical device, and we were running it using `Mac` name under `.ci.yaml`. 

There are 3 possible fixes: 
1. running on simulator. Use `testWithNewIOSSimulator` to get the device ID, and run the simulator. In this case we don't have to set `deviceOperatingSystem` because it's only for physical device. 
2. actually running it on physical device (This PR)
3. change this test to `flutter_drone` test which runs on simulator too, but it is a lot more involved (moving the test from `devicelab` to `flutter_drone`). 

We pick option 2 because it's relatively easier, and we may actually want to test platform views on device (e.g. measure performance, etc).



*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/106745#issuecomment-1199808744

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
