### PR TITLE
[framework] create animation from value listenable

### DIFF
--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -95,9 +95,9 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// After:
   ///
   /// ```dart
-  /// Widget build(BuildContext context) {
+  /// Widget build2(BuildContext context) {
   ///   return FadeTransition(
-  ///     opacity: Animation.fromValueListenable(_scrollPosition, transformer: (double value) {
+  ///     opacity: Animation<double>.fromValueListenable(_scrollPosition, transformer: (double value) {
   ///       return (value / 1000).clamp(0, 1);
   ///     }),
   ///     child: Container(

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -77,7 +77,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// Widget build(BuildContext context) {
   ///   return ValueListenableBuilder<double>(
   ///     valueListenable: _scrollPosition,
-  ///     builder: (BuildContext context, double value, Widget child) {
+  ///     builder: (BuildContext context, double value, Widget? child) {
   ///       final double opacity = (value / 1000).clamp(0, 1);
   ///       return Opacity(opacity: opacity, child: child);
   ///     },
@@ -95,7 +95,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///   return FadeTransition(
   ///     opacity: Animation.fromValueListenable(_scrollPosition, transformer: (double value) {
   ///       return (value / 1000).clamp(0, 1);
-  ///     })
+  ///     }),
   ///     child: Container(
   ///       child: const Text('Hello, Animation'),
   ///     ),

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -13,6 +13,7 @@ export 'tween.dart' show Animatable;
 
 // Examples can assume:
 // late AnimationController _controller;
+// late ValueNotifier<double> _scrollPosition
 
 /// The status of an animation.
 enum AnimationStatus {
@@ -73,16 +74,14 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// Before:
   ///
   /// ```dart
-  /// ValueNotifier<double> get scrollPosition;
-  ///
   /// return ValueListenableBuilder<double>(
-  ///   valueListenable: scrollPosition,
-  ///   builder: (BuildContext context, double value, Widget child) {
-  ///     double opacity = (value / 1000).clamp(0, 1);
+  ///   valueListenable: _scrollPosition,
+  ///   builder: (BuildContext context, double value, Widget? child) {
+  ///     final double opacity = (value / 1000).clamp(0, 1);
   ///     return Opacity(opacity: opacity, child: child);
   ///   },
   ///   child: Container(
-  ///     child: Text('Hello, Animation'),
+  ///     child: const Text('Hello, Animation'),
   ///   ),
   /// );
   /// ```
@@ -90,14 +89,12 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// After:
   ///
   /// ```dart
-  /// ValueNotifier<double> get scrollPosition;
-  ///
   /// return FadeTransition(
-  ///   opacity: Animation.fromValueListenable(scrollPosition, transformer: (double value) {
+  ///   opacity: Animation.fromValueListenable(_scrollPosition, transformer: (double value) {
   ///     return (value / 1000).clamp(0, 1);
   ///   })
   ///   child: Container(
-  ///     child: Text('Hello, Animation'),
+  ///     child: const Text('Hello, Animation'),
   ///   ),
   /// );
   /// ```

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -84,6 +84,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///   child: Container(
   ///     child: Text('Hello, Animation'),
   ///   ),
+  /// );
   /// ```
   ///
   /// After:
@@ -98,6 +99,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///   child: Container(
   ///     child: Text('Hello, Animation'),
   ///   ),
+  /// );
   /// ```
   /// {@end-tool}
   factory Animation.fromValueListenable(ValueListenable<T> listenable, {

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -13,7 +13,7 @@ export 'tween.dart' show Animatable;
 
 // Examples can assume:
 // late AnimationController _controller;
-// late ValueNotifier<double> _scrollPosition
+// late ValueNotifier<double> _scrollPosition;
 
 /// The status of an animation.
 enum AnimationStatus {
@@ -82,11 +82,15 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///       return Opacity(opacity: opacity, child: child);
   ///     },
   ///     child: Container(
+  ///       color: Colors.red,
   ///       child: const Text('Hello, Animation'),
   ///     ),
   ///   );
   /// }
   /// ```
+  ///
+  /// {@end-tool}
+  /// {@tool snippet}
   ///
   /// After:
   ///
@@ -97,6 +101,7 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   ///       return (value / 1000).clamp(0, 1);
   ///     }),
   ///     child: Container(
+  ///       color: Colors.red,
   ///       child: const Text('Hello, Animation'),
   ///     ),
   ///   );

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -75,16 +75,18 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// ```dart
   /// ValueNotifier<double> get scrollPosition;
   ///
-  /// return ValueListenableBuilder<double>(
-  ///   valueListenable: scrollPosition,
-  ///   builder: (BuildContext context, double value, Widget child) {
-  ///     double opacity = (value / 1000).clamp(0, 1);
-  ///     return Opacity(opacity: opacity, child: child);
-  ///   },
-  ///   child: Container(
-  ///     child: Text('Hello, Animation'),
-  ///   ),
-  /// );
+  /// Widget build(BuildContext context) {
+  ///   return ValueListenableBuilder<double>(
+  ///     valueListenable: scrollPosition,
+  ///     builder: (BuildContext context, double value, Widget child) {
+  ///       double opacity = (value / 1000).clamp(0, 1);
+  ///       return Opacity(opacity: opacity, child: child);
+  ///     },
+  ///     child: Container(
+  ///       child: Text('Hello, Animation'),
+  ///     ),
+  ///   );
+  /// }
   /// ```
   ///
   /// After:
@@ -92,14 +94,16 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// ```dart
   /// ValueNotifier<double> get scrollPosition;
   ///
-  /// return FadeTransition(
-  ///   opacity: Animation.fromValueListenable(scrollPosition, transformer: (double value) {
-  ///     return (value / 1000).clamp(0, 1);
-  ///   })
-  ///   child: Container(
-  ///     child: Text('Hello, Animation'),
-  ///   ),
-  /// );
+  /// Widget build(BuildContext context) {
+  ///   return FadeTransition(
+  ///     opacity: Animation.fromValueListenable(scrollPosition, transformer: (double value) {
+  ///       return (value / 1000).clamp(0, 1);
+  ///     })
+  ///     child: Container(
+  ///       child: Text('Hello, Animation'),
+  ///     ),
+  ///   );
+  /// }
   /// ```
   /// {@end-tool}
   factory Animation.fromValueListenable(ValueListenable<T> listenable, {

--- a/packages/flutter/lib/src/animation/animation.dart
+++ b/packages/flutter/lib/src/animation/animation.dart
@@ -64,6 +64,42 @@ abstract class Animation<T> extends Listenable implements ValueListenable<T> {
   /// The returned animation will always have an animations status of
   /// [AnimationStatus.forward]. The value of the provided listenable can
   /// be optionally transformed using the [transformer] function.
+  ///
+  /// {@tool snippet}
+  ///
+  /// This constructor can be used to replace instances of [ValueListenableBuilder]
+  /// widgets with a corresponding animated widget, like a [FadeTransition].
+  ///
+  /// Before:
+  ///
+  /// ```dart
+  /// ValueNotifier<double> get scrollPosition;
+  ///
+  /// return ValueListenableBuilder<double>(
+  ///   valueListenable: scrollPosition,
+  ///   builder: (BuildContext context, double value, Widget child) {
+  ///     double opacity = (value / 1000).clamp(0, 1);
+  ///     return Opacity(opacity: opacity, child: child);
+  ///   },
+  ///   child: Container(
+  ///     child: Text('Hello, Animation'),
+  ///   ),
+  /// ```
+  ///
+  /// After:
+  ///
+  /// ```dart
+  /// ValueNotifier<double> get scrollPosition;
+  ///
+  /// return FadeTransition(
+  ///   opacity: Animation.fromValueListenable(scrollPosition, transformer: (double value) {
+  ///     return (value / 1000).clamp(0, 1);
+  ///   })
+  ///   child: Container(
+  ///     child: Text('Hello, Animation'),
+  ///   ),
+  /// ```
+  /// {@end-tool}
   factory Animation.fromValueListenable(ValueListenable<T> listenable, {
     ValueListenableTransformer<T>? transformer,
   }) = _ValueListenableDelegateAnimation<T>;

--- a/packages/flutter/test/animation/animation_from_listener_test.dart
+++ b/packages/flutter/test/animation/animation_from_listener_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-
   test('Animation created from ValueListenable', () {
     final ValueNotifier<double> listenable = ValueNotifier<double>(0.0);
     final Animation<double> animation = Animation<double>.fromValueListenable(listenable);

--- a/packages/flutter/test/animation/animation_from_listener_test.dart
+++ b/packages/flutter/test/animation/animation_from_listener_test.dart
@@ -1,0 +1,52 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+
+  test('Animation created from ValueListenable', () {
+    final ValueNotifier<double> listenable = ValueNotifier<double>(0.0);
+    final Animation<double> animation = Animation<double>.fromValueListenable(listenable);
+
+    expect(animation.status, AnimationStatus.forward);
+    expect(animation.value, 0.0);
+
+    listenable.value = 1.0;
+
+    expect(animation.value, 1.0);
+
+    bool listenerCalled = false;
+    void listener() {
+      listenerCalled = true;
+    }
+
+    animation.addListener(listener);
+
+    listenable.value = 0.5;
+
+    expect(listenerCalled, true);
+    listenerCalled = false;
+
+    animation.removeListener(listener);
+
+    listenable.value = 0.2;
+    expect(listenerCalled, false);
+  });
+
+  test('Animation created from ValueListenable can transform value', () {
+    final ValueNotifier<double> listenable = ValueNotifier<double>(0.0);
+    final Animation<double> animation = Animation<double>.fromValueListenable(listenable, transformer: (double input) {
+      return input / 10;
+    });
+
+    expect(animation.status, AnimationStatus.forward);
+    expect(animation.value, 0.0);
+
+    listenable.value = 10.0;
+
+    expect(animation.value, 1.0);
+  });
+}


### PR DESCRIPTION
I've noticed a number of patterns in a certain customer app, where there is a desire to animate some part of the UI (opacity for example) based on something that is available via a value listenable (scroll position). Because there is no easy way to create an animation from a value listenable, I see a lot of ValueListenableBuilders used to animate things that could be FadeTransitions. This has the distinct disadvantage of bypassing the repaint boundary mechanisms introduced into animated opacities.