### PR TITLE
Use `hasNoRemainingExpectations` matcher for fake process manager in tool tests

### DIFF
--- a/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_darwin_framework_test.dart
@@ -16,6 +16,7 @@ import 'package:flutter_tools/src/version.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/test_build_system.dart';
 
@@ -535,7 +536,7 @@ void main() {
         output,
         fakeProcessManager,
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('created with symbols', () async {
@@ -577,7 +578,7 @@ void main() {
         output,
         fakeProcessManager,
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
   });
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_macos_test.dart
@@ -23,6 +23,7 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
@@ -366,7 +367,7 @@ STDERR STUFF
         const <String>['build', 'macos', '--debug', '--no-pub']
     );
 
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -65,7 +65,7 @@ void main() {
 
     expect(await androidDevices.pollingGetDevices(), isEmpty);
     expect(await androidDevices.getDiagnostics(), isEmpty);
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
   testWithoutContext('AndroidDevices returns empty device list and diagnostics on null Android SDK', () async {

--- a/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_studio_validator_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 const String home = '/home/me';
 
@@ -65,7 +66,7 @@ void main() {
         return message.isError && message.message.contains('ProcessException');
       }).isNotEmpty, true);
     }
-    expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+    expect(fakeProcessManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,

--- a/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_errors_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/project.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 void main() {
@@ -670,7 +671,7 @@ assembleFooTest
           '└─────────────────────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
       Platform: () => fakePlatform('android'),
@@ -709,7 +710,7 @@ assembleProfile
           '└───────────────────────────────────────────────────────────────────────────────────────────────┘\n'
         )
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       GradleUtils: () => FakeGradleUtils(),
       Platform: () => fakePlatform('android'),

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -25,6 +25,7 @@ import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 
 void main() {
@@ -86,7 +87,7 @@ void main() {
       expect(applicationPackage.name, 'app.apk');
       expect(applicationPackage, isA<PrebuiltApplicationPackage>());
       expect((applicationPackage as PrebuiltApplicationPackage).applicationPackage.path, apkFile.path);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: overrides);
 
     testUsingContext('Licenses available, build tools not, apk exists', () async {
@@ -108,7 +109,7 @@ void main() {
         buildInfo: null,
         applicationBinary: globals.fs.file('app.apk'),
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: overrides);
 
     testUsingContext('Licenses available, build tools available, does not call gradle dependencies', () async {
@@ -119,7 +120,7 @@ void main() {
         TargetPlatform.android_arm,
         buildInfo: null,
       );
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: overrides);
 
     testWithoutContext('returns null when failed to extract manifest', () async {
@@ -136,7 +137,7 @@ void main() {
       );
 
       expect(androidApk, isNull);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/ios_test.dart
@@ -15,6 +15,7 @@ import 'package:flutter_tools/src/convert.dart';
 
 import '../../../src/common.dart';
 import '../../../src/context.dart';
+import '../../../src/fake_process_manager.dart';
 
 final Platform macPlatform = FakePlatform(operatingSystem: 'macos', environment: <String, String>{});
 
@@ -110,7 +111,7 @@ void main() {
     ]);
 
     await const DebugUniversalFramework().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -147,7 +148,7 @@ void main() {
     ]);
 
     await const DebugUniversalFramework().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -202,7 +203,7 @@ void main() {
     );
 
     await const DebugIosApplicationBundle().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
 
     expect(frameworkDirectoryBinary, exists);
     expect(frameworkDirectory.childFile('Info.plist'), exists);
@@ -247,7 +248,7 @@ void main() {
     );
 
     await const ReleaseIosApplicationBundle().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
 
     expect(frameworkDirectoryBinary, exists);
     expect(frameworkDirectory.childFile('Info.plist'), exists);
@@ -286,7 +287,7 @@ void main() {
         contains('release/profile builds are only supported for physical devices.'),
       )
     ));
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -313,7 +314,7 @@ void main() {
       'description',
       contains('required define SdkRoot but it was not provided'),
     )));
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -414,7 +415,7 @@ void main() {
       await const DebugUnpackIOS().build(environment);
 
       expect(logger.traceText, contains('Skipping lipo for non-fat file output/Flutter.framework/Flutter'));
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('fails when frameworks missing', () async {
@@ -565,7 +566,7 @@ void main() {
 
       expect(logger.traceText, contains('Skipping lipo for non-fat file output/Flutter.framework/Flutter'));
 
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('thins fat framework', () async {
@@ -613,7 +614,7 @@ void main() {
       ]);
 
       await const DebugUnpackIOS().build(environment);
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('fails when bitcode strip fails', () async {
@@ -656,7 +657,7 @@ void main() {
         )),
       );
 
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('strips framework', () async {
@@ -685,7 +686,7 @@ void main() {
       ]);
       await const DebugUnpackIOS().build(environment);
 
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('fails when codesign fails', () async {
@@ -730,7 +731,7 @@ void main() {
         )),
       );
 
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('codesigns framework', () async {
@@ -767,7 +768,7 @@ void main() {
       ]);
       await const DebugUnpackIOS().build(environment);
 
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -338,7 +338,7 @@ void main() {
     );
 
     await const DebugMacOSFramework().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -370,7 +370,7 @@ void main() {
     );
 
     await const DebugMacOSFramework().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => processManager,
@@ -434,7 +434,7 @@ void main() {
     ]);
 
     await const CompileMacOSFramework().build(environment);
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
 
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,

--- a/packages/flutter_tools/test/general.shard/channel_test.dart
+++ b/packages/flutter_tools/test/general.shard/channel_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_tools/src/version.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/test_flutter_command_runner.dart';
 
 void main() {
@@ -71,7 +72,7 @@ void main() {
       );
 
       await runner.run(<String>['channel']);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(testLogger.errorText, hasLength(0));
       // format the status text for a simpler assertion.
       final Iterable<String> rows = testLogger.statusText
@@ -95,7 +96,7 @@ void main() {
       );
 
       await runner.run(<String>['channel']);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(rows, containsAllInOrder(kOfficialChannels));
       expect(testLogger.errorText, hasLength(0));
       // format the status text for a simpler assertion.
@@ -119,7 +120,7 @@ void main() {
       );
 
       await runner.run(<String>['channel']);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(testLogger.errorText, hasLength(0));
       // check if available official channels are in order of stability
       int prev = -1;
@@ -153,7 +154,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel']);
 
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(testLogger.errorText, hasLength(0));
 
       // format the status text for a simpler assertion.
@@ -184,7 +185,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel']);
 
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(testLogger.errorText, hasLength(0));
 
       // format the status text for a simpler assertion.
@@ -217,7 +218,7 @@ void main() {
       final CommandRunner<void> runner = createTestCommandRunner(command);
       await runner.run(<String>['channel', 'beta']);
 
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
       expect(
         testLogger.statusText,
         containsIgnoringWhitespace("Switching to flutter channel 'beta'..."),
@@ -238,7 +239,7 @@ void main() {
 
       await runner.run(<String>['channel', 'stable']);
 
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => fakeProcessManager,
@@ -272,7 +273,7 @@ void main() {
           "from this channel, run 'flutter upgrade'"),
       );
       expect(testLogger.errorText, hasLength(0));
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => fakeProcessManager,
@@ -314,7 +315,7 @@ void main() {
       expect(testLogger.statusText, isNot(contains('A new version of Flutter')));
       expect(testLogger.errorText, hasLength(0));
       expect(versionCheckFile.existsSync(), isFalse);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       FileSystem: () => MemoryFileSystem.test(),
       ProcessManager: () => fakeProcessManager,

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -17,6 +17,7 @@ import 'package:test/fake.dart';
 
 import '../src/common.dart';
 import '../src/context.dart';
+import '../src/fake_process_manager.dart';
 import '../src/fakes.dart';
 
 const FakeEmulator emulator1 = FakeEmulator('Nexus_5', 'Nexus 5', 'Google');
@@ -329,7 +330,7 @@ void main() {
 
       const Emulator emulator = IOSEmulator('ios');
       await emulator.launch();
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
       Xcode: () => xcode,

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -95,7 +95,7 @@ void main() {
       }),
     ]);
     await device.start('example.dill');
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   });
 
   group('The FLUTTER_TEST environment variable is passed to the test process', () {
@@ -144,7 +144,7 @@ void main() {
       processManager.addCommand(flutterTestCommand('true'));
 
       await device.start('example.dill');
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('as true when set to true', () async {
@@ -152,7 +152,7 @@ void main() {
       processManager.addCommand(flutterTestCommand('true'));
 
       await device.start('example.dill');
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('as false when set to false', () async {
@@ -160,7 +160,7 @@ void main() {
       processManager.addCommand(flutterTestCommand('false'));
 
       await device.start('example.dill');
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
 
     testUsingContext('unchanged when set', () async {
@@ -168,7 +168,7 @@ void main() {
       processManager.addCommand(flutterTestCommand('neither true nor false'));
 
       await device.start('example.dill');
-      expect(processManager.hasRemainingExpectations, isFalse);
+      expect(processManager, hasNoRemainingExpectations);
     });
   });
 

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -78,7 +78,7 @@ void main() {
           '1234',
           IOSDeviceConnectionInterface.usb,
         ), throwsA(anything));
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       });
 
       testWithoutContext('idevicescreenshot captures and returns USB screenshot', () async {
@@ -101,7 +101,7 @@ void main() {
           '1234',
           IOSDeviceConnectionInterface.usb,
         );
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       });
 
       testWithoutContext('idevicescreenshot captures and returns network screenshot', () async {
@@ -124,7 +124,7 @@ void main() {
           '1234',
           IOSDeviceConnectionInterface.network,
         );
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       });
     });
   });

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -22,6 +22,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 
 final Platform macosPlatform = FakePlatform(
@@ -361,7 +362,7 @@ void main() {
 
       final File screenshot = MemoryFileSystem.test().file('screenshot.png');
       await deviceUnderTest.takeScreenshot(screenshot);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
   });
 
@@ -389,7 +390,7 @@ void main() {
         '/Library/Logs/CoreSimulator/x/system.log',
       ]));
       await launchDeviceSystemLogTool(device);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     },
     overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
@@ -428,7 +429,7 @@ void main() {
       ]));
 
       await launchDeviceUnifiedLogging(device, 'My Super Awesome App');
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     },
       overrides: <Type, Generator>{
       ProcessManager: () => fakeProcessManager,
@@ -461,7 +462,7 @@ void main() {
       ]));
 
       await launchDeviceUnifiedLogging(device, null);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     },
       overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
@@ -514,7 +515,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         expect(lines, <String>[
           'flutter: The Dart VM service is listening on http://127.0.0.1:64213/1Uoeu523990=/',
         ]);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
@@ -551,7 +552,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           '))))))))))',
           '#0      Object.noSuchMethod (dart:core-patch/dart:core/object_patch.dart:46)',
         ]);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
@@ -604,7 +605,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           '  and goes...',
           'Single line message, not the part of the above',
         ]);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
@@ -670,7 +671,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
           'Single line message', 'Multi line message\n  continues...\n  continues...',
           'Single line message, not the part of the above',
         ]);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
@@ -711,7 +712,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         final List<String> lines = await logReader.logLines.toList();
         expect(lines, isEmpty);
         expect(logger.errorText, contains('Logger returned non-JSON response'));
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
         ProcessManager: () => fakeProcessManager,
         FileSystem: () => fileSystem,
@@ -813,7 +814,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
       expect(phone3.category, 'com.apple.CoreSimulator.SimRuntime.iOS-16-0');
       expect(phone3.name, 'iPhone 13');
       expect(phone3.udid, 'iPhone 13-UDID');
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('getConnectedDevices handles bad simctl output', () async {
@@ -833,7 +834,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
       final List<BootedSimDevice> devices = await simControl.getConnectedDevices();
 
       expect(devices, isEmpty);
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     });
 
     testWithoutContext('sdkMajorVersion defaults to 11 when sdkNameAndVersion is junk', () async {

--- a/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/xcode_test.dart
@@ -20,6 +20,7 @@ import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 
 void main() {
   late BufferLogger logger;
@@ -70,7 +71,7 @@ void main() {
         );
 
         expect(xcode.isSimctlInstalled, isTrue);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       });
 
       testWithoutContext('isSimctlInstalled is true when simctl list fails', () {
@@ -92,7 +93,7 @@ void main() {
         );
 
         expect(xcode.isSimctlInstalled, isFalse);
-        expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+        expect(fakeProcessManager, hasNoRemainingExpectations);
       });
 
       group('macOS', () {
@@ -111,10 +112,11 @@ void main() {
           fakeProcessManager.addCommand(const FakeCommand(
             command: <String>['/usr/bin/xcode-select', '--print-path'],
             stdout: xcodePath,
-          ));
+          ),
+          );
 
           expect(xcode.xcodeSelectPath, xcodePath);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('xcodeSelectPath returns null when xcode-select is not installed', () {
@@ -124,7 +126,7 @@ void main() {
           ));
 
           expect(xcode.xcodeSelectPath, isNull);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
 
           fakeProcessManager.addCommand(FakeCommand(
             command: const <String>['/usr/bin/xcode-select', '--print-path'],
@@ -132,7 +134,7 @@ void main() {
           ));
 
           expect(xcode.xcodeSelectPath, isNull);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('version checks fail when version is less than minimum', () {
@@ -186,7 +188,7 @@ void main() {
           xcodeProjectInterpreter.isInstalled = false;
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('isInstalledAndMeetsVersionCheck is false when version not satisfied', () {
@@ -194,7 +196,7 @@ void main() {
           xcodeProjectInterpreter.version = Version(10, 2, 0);
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isFalse);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('isInstalledAndMeetsVersionCheck is true when macOS and installed and version is satisfied', () {
@@ -202,7 +204,7 @@ void main() {
           xcodeProjectInterpreter.version = Version(13, null, null);
 
           expect(xcode.isInstalledAndMeetsVersionCheck, isTrue);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('eulaSigned is false when clang output indicates EULA not yet accepted', () {
@@ -216,7 +218,7 @@ void main() {
           ]);
 
           expect(xcode.eulaSigned, isFalse);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('eulaSigned is false when clang is not installed', () {
@@ -241,7 +243,7 @@ void main() {
             ],
           );
           expect(xcode.eulaSigned, isTrue);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testWithoutContext('SDK name', () {
@@ -259,7 +261,7 @@ void main() {
             ));
 
             expect(await xcode.sdkLocation(EnvironmentType.physical), sdkroot);
-            expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+            expect(fakeProcessManager, hasNoRemainingExpectations);
           });
 
           testWithoutContext('--show-sdk-path fails', () async {
@@ -271,7 +273,7 @@ void main() {
 
             expect(() async => xcode.sdkLocation(EnvironmentType.physical),
               throwsToolExit(message: 'Could not find SDK location'));
-            expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+            expect(fakeProcessManager, hasNoRemainingExpectations);
           });
         });
       });
@@ -490,7 +492,7 @@ void main() {
           expect(devices[2].name, 'iPad 2');
           expect(await devices[2].sdkNameAndVersion, 'iOS 10.1 14C54');
           expect(devices[2].cpuArchitecture, DarwinArch.arm64); // Defaults to arm64 for unknown architecture.
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
           Artifacts: () => Artifacts.test(),
@@ -511,7 +513,7 @@ void main() {
             stdout: '[]',
           ));
           await xcdevice.getAvailableIOSDevices(timeout: const Duration(seconds: 20));
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         });
 
         testUsingContext('ignores "Preparing debugger support for iPhone" error', () async {
@@ -546,7 +548,7 @@ void main() {
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
           expect(devices, hasLength(1));
           expect(devices[0].id, '43ad2fda7991b34fe1acbda82f9e2fd3d6ddc9f7');
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
           Artifacts: () => Artifacts.test(),
@@ -589,7 +591,7 @@ void main() {
           final List<IOSDevice> devices = await xcdevice.getAvailableIOSDevices();
           expect(devices[0].cpuArchitecture, DarwinArch.armv7);
           expect(devices[1].cpuArchitecture, DarwinArch.arm64);
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
           Artifacts: () => Artifacts.test(),
@@ -694,7 +696,7 @@ void main() {
           await xcdevice.getAvailableIOSDevices();
           final List<String> errors = await xcdevice.getDiagnostics();
           expect(errors, hasLength(1));
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
         });
@@ -836,7 +838,7 @@ void main() {
           expect(errors[2], 'Error: Xcode pairing error. (code -13)');
           expect(errors[3], 'Error: iPhone is busy: Preparing debugger support for iPhone. Xcode will continue when iPhone is finished. (code -10)');
           expect(errors, isNot(contains('Xcode will continue')));
-          expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+          expect(fakeProcessManager, hasNoRemainingExpectations);
         }, overrides: <Type, Generator>{
           Platform: () => macPlatform,
         });

--- a/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
+++ b/packages/flutter_tools/test/general.shard/tester/flutter_tester_test.dart
@@ -18,6 +18,7 @@ import 'package:flutter_tools/src/tester/flutter_tester.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/fake_process_manager.dart';
 import '../../src/fakes.dart';
 import '../../src/test_build_system.dart';
 
@@ -167,7 +168,7 @@ Hello!
       expect(result.started, isTrue);
       expect(result.observatoryUri, observatoryUri);
       expect(logLines.last, 'Hello!');
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: startOverrides);
 
     testUsingContext('performs a build and starts in debug mode with track-widget-creation', () async {
@@ -200,7 +201,7 @@ Hello!
       expect(result.started, isTrue);
       expect(result.observatoryUri, observatoryUri);
       expect(logLines.last, 'Hello!');
-      expect(fakeProcessManager.hasRemainingExpectations, isFalse);
+      expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: startOverrides);
   });
 }

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -121,7 +121,7 @@ void main() {
         expect(flutterVersion.getBranchName(redactUnknownBranches: true), channel);
 
         expect(testLogger.statusText, isEmpty);
-        expect(processManager.hasRemainingExpectations, isFalse);
+        expect(processManager, hasNoRemainingExpectations);
       }, overrides: <Type, Generator>{
         FlutterVersion: () => FlutterVersion(clock: _testClock),
         ProcessManager: () => processManager,
@@ -428,7 +428,7 @@ void main() {
     expect(flutterVersion.getBranchName(), 'feature-branch');
     expect(flutterVersion.getVersionString(redactUnknownBranches: true), '[user-branch]/1234abcd');
     expect(flutterVersion.getBranchName(redactUnknownBranches: true), '[user-branch]');
-    expect(processManager.hasRemainingExpectations, isFalse);
+    expect(processManager, hasNoRemainingExpectations);
   }, overrides: <Type, Generator>{
     FlutterVersion: () => FlutterVersion(clock: _testClock),
     ProcessManager: () => processManager,


### PR DESCRIPTION
`expect(fakeProcessManager.hasRemainingExpectations, isFalse)` failures look like:
```
Expected: false
  Actual: <true>
```
Using the `_HasNoRemainingExpectations` matcher, `expect(fakeProcessManager, hasNoRemainingExpectations)` says which command expectations are remaining. 
```
  Expected: a fake process manager with no remaining expectations
    Actual: <Instance of '_SequenceProcessManager'>
     Which: has remaining expectations:
            [the, command]
```

https://github.com/flutter/flutter/blob/f852c46c877bc321c1705403cfb2b94e5976de3f/packages/flutter_tools/test/src/fake_process_manager.dart#L456-L465


Switch `false`/`isFalse` matcher to `hasNoRemainingExpectations` everywhere.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
