### PR TITLE
Apply `indexToItemIndex` to indices returned by `findChildIndexCallback` in `SliverAnimatedListState`

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -514,10 +514,12 @@ class SliverAnimatedListState extends State<SliverAnimatedList> with TickerProvi
     return SliverChildBuilderDelegate(
       _itemBuilder,
       childCount: _itemsCount,
-      findChildIndexCallback: widget.findChildIndexCallback == null ? null : (Key key) {
-        final int? index = widget.findChildIndexCallback!(key);
-        return index != null ? _indexToItemIndex(index) : null;
-      },
+      findChildIndexCallback: widget.findChildIndexCallback == null
+          ? null
+          : (Key key) {
+              final int? index = widget.findChildIndexCallback!(key);
+              return index != null ? _indexToItemIndex(index) : null;
+            },
     );
   }
 

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -514,7 +514,10 @@ class SliverAnimatedListState extends State<SliverAnimatedList> with TickerProvi
     return SliverChildBuilderDelegate(
       _itemBuilder,
       childCount: _itemsCount,
-      findChildIndexCallback: widget.findChildIndexCallback,
+      findChildIndexCallback: widget.findChildIndexCallback == null ? null : (Key key) {
+        final int? index = widget.findChildIndexCallback!(key);
+        return index != null ? _indexToItemIndex(index) : null;
+      },
     );
   }
 

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -358,7 +358,7 @@ void main() {
       expect(tester.getTopLeft(find.text('item 0')).dy, 200);
     });
 
-    testWidgets('passes correctly derived index of findChildIndexCallback to inner SliverChildBuilderDelegate', (WidgetTester tester) async {
+    testWidgets('passes correctly derived index of findChildIndexCallback to the inner SliverChildBuilderDelegate', (WidgetTester tester) async {
       final List<int> items = <int>[0, 1, 2, 3];
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
@@ -369,7 +369,7 @@ void main() {
             slivers: <Widget>[
               SliverAnimatedList(
                 key: listKey,
-                initialItemCount: items.length, // we will insert one item later
+                initialItemCount: items.length,
                 itemBuilder: (BuildContext context, int index, Animation<double> animation) {
                   return _StatefulListItem(
                     key: ValueKey<int>(items[index]),

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -359,7 +359,7 @@ void main() {
     });
 
     testWidgets('passes correctly derived index of findChildIndexCallback to inner SliverChildBuilderDelegate', (WidgetTester tester) async {
-      final List<int> items = <int>[0, 1, 2];
+      final List<int> items = <int>[0, 1, 2, 3];
       final GlobalKey<SliverAnimatedListState> listKey = GlobalKey<SliverAnimatedListState>();
 
       await tester.pumpWidget(
@@ -369,9 +369,12 @@ void main() {
             slivers: <Widget>[
               SliverAnimatedList(
                 key: listKey,
-                initialItemCount: items.length,
+                initialItemCount: items.length, // we will insert one item later
                 itemBuilder: (BuildContext context, int index, Animation<double> animation) {
-                    return Text(key: ValueKey(index), 'item ${items[index]}');
+                  return _StatefulListItem(
+                    key: ValueKey<int>(items[index]),
+                    index: index,
+                  );
                 },
                 findChildIndexCallback: (Key key) {
                   final int index = items.indexOf((key as ValueKey<int>).value);
@@ -390,21 +393,30 @@ void main() {
       expect(listEntries[0].data, equals('item 0'));
       expect(listEntries[1].data, equals('item 1'));
       expect(listEntries[2].data, equals('item 2'));
+      expect(listEntries[3].data, equals('item 3'));
 
-      // reorder the items
+
+      // delete one item
+      listKey.currentState?.removeItem(0, (BuildContext context, Animation<double> animation) {
+        return Container();
+      });
+
+      // delete from list
+      items.removeAt(0);
+
+      // reorder list
       items.insert(0, items.removeLast());
 
-      // trigger a re-render
-      listKey.currentState!.setState(() {});
+      // render with new list order
       await tester.pumpAndSettle();
 
       // get all list entries in order
       final List<Text> reorderedListEntries = find.byType(Text).evaluate().map((Element e) => e.widget as Text).toList();
 
-      // check that the list is rendered in the order provided by findChildIndexCallback
-      expect(reorderedListEntries[0].data, equals('item 2'));
-      expect(reorderedListEntries[1].data, equals('item 0'));
-      expect(reorderedListEntries[2].data, equals('item 1'));
+      // check that the stateful items of the list are rendered in the order provided by findChildIndexCallback
+      expect(reorderedListEntries[0].data, equals('item 3'));
+      expect(reorderedListEntries[1].data, equals('item 1'));
+      expect(reorderedListEntries[2].data, equals('item 2'));
     });
   });
 
@@ -476,4 +488,26 @@ void main() {
 
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).clipBehavior, clipBehavior);
   });
+}
+
+
+class _StatefulListItem extends StatefulWidget {
+  final int index;
+
+  const _StatefulListItem({
+    Key? key,
+    required this.index,
+  }) : super(key: key);
+
+  @override
+  _StatefulListItemState createState() => _StatefulListItemState();
+}
+
+class _StatefulListItemState extends State<_StatefulListItem> {
+  late final int number = widget.index;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text('item $number');
+  }
 }

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -492,12 +492,12 @@ void main() {
 
 
 class _StatefulListItem extends StatefulWidget {
-  final int index;
-
   const _StatefulListItem({
-    Key? key,
+    super.key,
     required this.index,
-  }) : super(key: key);
+  });
+
+  final int index;
 
   @override
   _StatefulListItemState createState() => _StatefulListItemState();


### PR DESCRIPTION
In `SliverAnimatedListState`, the `insertItem()` and `removeItem()` index parameters are defined as if the `removeItem()` operation removed the corresponding list entry immediately. The entry is only actually removed from the `ListView` when the remove animation finishes.

`_indexToItemIndex` is used to convert the user-supplied index to the internal index, which takes item removal into account.

The user can also provide a `findChildIndexCallback` to the `SliverAnimatedList` which is passed on to the internal `SliverChildBuilderDelegate`. Since `delegate` renders all items, including items being removed, the same `_indexToItemIndex` needs to be applied to the indices returned by the user-provided function. Otherwise it is impossible for the user to implement `findChildIndexCallback`, because the internal state of the `SliverAnimatedList` and hence the current content of the `delegate` is not known to the user. 

`findChildIndexCallback` indices originate from the same user-facing source of truth as `insertItem()` and `removeItem()`, and hence must likewise be converted to internal indices.

The call to `_indexToItemIndex` in the inner `findChildIndexCallback` was previously omitted by oversight, making it impossible for the user to implement `findChildIndexCallback` correctly, resulting in unwanted rebuilds and state loss. This PR fixes this.