### PR TITLE
Fix lerp to eccentric circle.

### DIFF
--- a/dev/manual_tests/lib/star_border.dart
+++ b/dev/manual_tests/lib/star_border.dart
@@ -501,9 +501,9 @@ ShapeBorder? lerpBorder(StarBorder border, LerpTarget target, double t, {bool to
   switch (target) {
     case LerpTarget.circle:
       if (to) {
-        return border.lerpTo(const CircleBorder(side: lerpToBorder), t);
+        return border.lerpTo(const CircleBorder(side: lerpToBorder, eccentricity: 0.5), t);
       } else {
-        return border.lerpFrom(const CircleBorder(side: lerpToBorder), t);
+        return border.lerpFrom(const CircleBorder(side: lerpToBorder, eccentricity: 0.5), t);
       }
     case LerpTarget.roundedRect:
       if (to) {

--- a/packages/flutter/lib/src/painting/star_border.dart
+++ b/packages/flutter/lib/src/painting/star_border.dart
@@ -312,6 +312,7 @@ class StarBorder extends OutlinedBorder {
         return StarBorder(
           side: BorderSide.lerp(side, b.side, t),
           points: lerpedPoints,
+          squash: ui.lerpDouble(squash, b.eccentricity, t)!,
           rotation: rotation,
           innerRadiusRatio: ui.lerpDouble(innerRadiusRatio, math.cos(math.pi / lerpedPoints), t)!,
           pointRounding: ui.lerpDouble(pointRounding, 1.0, t)!,
@@ -322,6 +323,7 @@ class StarBorder extends OutlinedBorder {
         return StarBorder(
           side: BorderSide.lerp(side, b.side, t),
           points: lerpedPoints,
+          squash: ui.lerpDouble(squash, b.eccentricity, t)!,
           rotation: rotation,
           innerRadiusRatio: ui.lerpDouble(innerRadiusRatio, 1, t)!,
           pointRounding: ui.lerpDouble(pointRounding, 0.5, t)!,

--- a/packages/flutter/lib/src/painting/star_border.dart
+++ b/packages/flutter/lib/src/painting/star_border.dart
@@ -232,6 +232,7 @@ class StarBorder extends OutlinedBorder {
         return StarBorder(
           side: BorderSide.lerp(a.side, side, t),
           points: lerpedPoints,
+          squash: ui.lerpDouble(a.eccentricity, squash, t)!,
           rotation: rotation,
           innerRadiusRatio: ui.lerpDouble(math.cos(math.pi / lerpedPoints), innerRadiusRatio, t)!,
           pointRounding: ui.lerpDouble(1.0, pointRounding, t)!,
@@ -244,6 +245,7 @@ class StarBorder extends OutlinedBorder {
         return StarBorder(
           side: BorderSide.lerp(a.side, side, t),
           points: lerpedPoints,
+          squash: ui.lerpDouble(a.eccentricity, squash, t)!,
           rotation: rotation,
           innerRadiusRatio: ui.lerpDouble(1, innerRadiusRatio, t)!,
           pointRounding: ui.lerpDouble(0.5, pointRounding, t)!,

--- a/packages/flutter/test/painting/star_border_test.dart
+++ b/packages/flutter/test/painting/star_border_test.dart
@@ -152,12 +152,15 @@ void main() {
   testWidgets('StarBorder lerped with CircleBorder', (WidgetTester tester) async {
     const StarBorder from = StarBorder();
     const ShapeBorder otherBorder = CircleBorder();
+    const ShapeBorder eccentricCircle = CircleBorder(eccentricity: 0.6);
     await testBorder(tester, 'to_circle_border_2', from, lerpTo: otherBorder, lerpAmount: 0.2);
     await testBorder(tester, 'to_circle_border_7', from, lerpTo: otherBorder, lerpAmount: 0.7);
     await testBorder(tester, 'to_circle_border_10', from, lerpTo: otherBorder, lerpAmount: 1.0);
     await testBorder(tester, 'from_circle_border_2', from, lerpFrom: otherBorder, lerpAmount: 0.2);
     await testBorder(tester, 'from_circle_border_7', from, lerpFrom: otherBorder, lerpAmount: 0.7);
     await testBorder(tester, 'from_circle_border_10', from, lerpFrom: otherBorder, lerpAmount: 1.0);
+    await testBorder(tester, 'to_eccentric_circle_border', from, lerpTo: eccentricCircle, lerpAmount: 0.4);
+    await testBorder(tester, 'from_eccentric_circle_border', from, lerpFrom: eccentricCircle, lerpAmount: 0.4);
   });
 
   testWidgets('StarBorder lerped with RoundedRectangleBorder', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Fixes an oversight in star => circle lerping where it ignored the eccentricity.

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/108707

## Tests
 - Added test for eccentric lerping.