### PR TITLE
clean-up analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,12 +20,6 @@ analyzer:
     strict-casts: true
     strict-raw-types: true
   errors:
-    # treat missing required parameters as a warning (not a hint)
-    missing_required_param: warning
-    # treat missing returns as a warning (not a hint)
-    missing_return: warning
-    # allow having TODO comments in the code
-    todo: ignore
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore


### PR DESCRIPTION
Removed entries that don't have an effect anymore:
* `todo` - the analyzer appear to no longer warn about these, so no reason to ignore them.
* `missing_required_param` and `missing_return` - these warnings only apply to non-null-safe code. In null-safe code you get the `body_might_complete_normally`/`body_might_complete_normally_nullable` warning instead of `missing_return` and `missing_required_argument` instead of `missing_required_param`. Furthermore, all our systems are configured to also fail on hints, so there is no reason to elevate these two hints to warnings even for non-null-safe code (we don't do that with any other hints either).