### PR TITLE
Fix Text selection handler disappear when dragged to new words

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1082,9 +1082,23 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     });
   }
 
+
+  bool _isOnlyAffinityChanged(TextSelection selection, TextSelection other) {
+    return selection.affinity != other.affinity &&
+        selection.copyWith(affinity: TextAffinity.upstream) == other.copyWith(affinity: TextAffinity.upstream);
+  }
+
+  TextSelection? _lastSelection;
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
+    bool onlyAffinityChanged = false;
+    if (_lastSelection != null) {
+      onlyAffinityChanged = _isOnlyAffinityChanged(_lastSelection!, selection);
+     }
+    _lastSelection = selection;
+
     final bool willShowSelectionHandles = _shouldShowSelectionHandles(cause);
-    if (willShowSelectionHandles != _showSelectionHandles) {
+    if (willShowSelectionHandles != _showSelectionHandles &&
+        !(onlyAffinityChanged && cause == SelectionChangedCause.keyboard)) {
       setState(() {
         _showSelectionHandles = willShowSelectionHandles;
       });

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1082,12 +1082,6 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     });
   }
 
-
-  bool _isOnlyAffinityChanged(TextSelection selection, TextSelection other) {
-    return selection.affinity != other.affinity &&
-        selection.copyWith(affinity: TextAffinity.upstream) == other.copyWith(affinity: TextAffinity.upstream);
-  }
-
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
     final bool willShowSelectionHandles = _shouldShowSelectionHandles(cause);
     if (willShowSelectionHandles != _showSelectionHandles) {

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1088,17 +1088,9 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         selection.copyWith(affinity: TextAffinity.upstream) == other.copyWith(affinity: TextAffinity.upstream);
   }
 
-  TextSelection? _lastSelection;
   void _handleSelectionChanged(TextSelection selection, SelectionChangedCause? cause) {
-    bool onlyAffinityChanged = false;
-    if (_lastSelection != null) {
-      onlyAffinityChanged = _isOnlyAffinityChanged(_lastSelection!, selection);
-     }
-    _lastSelection = selection;
-
     final bool willShowSelectionHandles = _shouldShowSelectionHandles(cause);
-    if (willShowSelectionHandles != _showSelectionHandles &&
-        !(onlyAffinityChanged && cause == SelectionChangedCause.keyboard)) {
+    if (willShowSelectionHandles != _showSelectionHandles) {
       setState(() {
         _showSelectionHandles = willShowSelectionHandles;
       });

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2194,13 +2194,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
 
   bool _checkNeedsAdjustAffinity(TextEditingValue value) {
     // Trust the engine affinity if the text changes or selection changes.
-    if (value.text == _value.text &&
-        value.selection.isCollapsed == _value.selection.isCollapsed &&
-        value.selection.start == _value.selection.start &&
-        value.selection.affinity != _value.selection.affinity) {
-      return true;
-    }
-    return false;
+    return value.text == _value.text &&
+      value.selection.isCollapsed == _value.selection.isCollapsed &&
+      value.selection.start == _value.selection.start &&
+      value.selection.affinity != _value.selection.affinity;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2143,7 +2143,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     }
 
     if (value.selection.isCollapsed && value.selection.affinity != _value.selection.affinity) {
-      // The text input server does not know the text affinity, so should repect the client value.
+      // The text input server does not know the text affinity, so should respect the client value.
       value = value.copyWith(selection: value.selection.copyWith(affinity: _value.selection.affinity));
     }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2142,6 +2142,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       return;
     }
 
+    if (value.selection.isCollapsed && value.selection.affinity != _value.selection.affinity) {
+      // The text input server does not know the text affinity, so should repect the client value.
+      value = value.copyWith(selection: value.selection.copyWith(affinity: _value.selection.affinity));
+    }
+
     if (widget.readOnly) {
       // In the read-only case, we only care about selection changes, and reject
       // everything else.

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2165,6 +2165,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // `selection` is the only change.
       _handleSelectionChanged(value.selection, (_textInputConnection?.scribbleInProgress ?? false) ? SelectionChangedCause.scribble : SelectionChangedCause.keyboard);
     } else {
+      // Only hide the toolbar overlay, the selection handler's visibility will be handled
+      // by `_handleSelectionChanged`. https://github.com/flutter/flutter/issues/108673
       hideToolbar(false);
       _currentPromptRectRange = null;
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2160,7 +2160,6 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // `selection` is the only change.
       _handleSelectionChanged(value.selection, (_textInputConnection?.scribbleInProgress ?? false) ? SelectionChangedCause.scribble : SelectionChangedCause.keyboard);
     } else {
-      hideToolbar();
       _currentPromptRectRange = null;
 
       final bool revealObscuredInput = _hasInputConnection

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2142,8 +2142,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       return;
     }
 
-    if (value.selection.isCollapsed && value.selection.affinity != _value.selection.affinity) {
-      // The text input server does not know the text affinity, so should respect the client value.
+    if (_checkNeedsAdjustAffinity(value)) {
       value = value.copyWith(selection: value.selection.copyWith(affinity: _value.selection.affinity));
     }
 
@@ -2191,6 +2190,17 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _stopCursorBlink(resetCharTicks: false);
       _startCursorBlink();
     }
+  }
+
+  bool _checkNeedsAdjustAffinity(TextEditingValue value) {
+    // Trust the engine affinity if the text changes or selection changes.
+    if (value.text == _value.text &&
+        value.selection.isCollapsed == _value.selection.isCollapsed &&
+        value.selection.start == _value.selection.start &&
+        value.selection.affinity != _value.selection.affinity) {
+      return true;
+    }
+    return false;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2165,6 +2165,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // `selection` is the only change.
       _handleSelectionChanged(value.selection, (_textInputConnection?.scribbleInProgress ?? false) ? SelectionChangedCause.scribble : SelectionChangedCause.keyboard);
     } else {
+      hideToolbar(false);
       _currentPromptRectRange = null;
 
       final bool revealObscuredInput = _hasInputConnection

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2165,7 +2165,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       // `selection` is the only change.
       _handleSelectionChanged(value.selection, (_textInputConnection?.scribbleInProgress ?? false) ? SelectionChangedCause.scribble : SelectionChangedCause.keyboard);
     } else {
-      // Only hide the toolbar overlay, the selection handler's visibility will be handled
+      // Only hide the toolbar overlay, the selection handle's visibility will be handled
       // by `_handleSelectionChanged`. https://github.com/flutter/flutter/issues/108673
       hideToolbar(false);
       _currentPromptRectRange = null;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -220,11 +220,8 @@ void main() {
             child: SizedBox(
               width: 100,
               height: 100,
-              child: Opacity(
-                opacity: 0.5,
-                child: TextField(
-                  decoration: InputDecoration(hintText: 'Placeholder'),
-                ),
+              child: TextField(
+                decoration: InputDecoration(hintText: 'Placeholder'),
               ),
             ),
           ),
@@ -251,7 +248,6 @@ void main() {
 
     // This is needed for the AnimatedOpacity to turn from 0 to 1 so the toolbar is visible.
     await tester.pumpAndSettle();
-    await tester.pump(const Duration(seconds: 1));
 
     // Sanity check that the toolbar widget exists.
     expect(find.text('Paste'), findsOneWidget);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -212,6 +212,61 @@ void main() {
     );
   }
 
+  testWidgets('text field selection toolbar should hide when the user starts typing', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              width: 100,
+              height: 100,
+              child: Opacity(
+                opacity: 0.5,
+                child: TextField(
+                  decoration: InputDecoration(hintText: 'Placeholder'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.showKeyboard(find.byType(TextField));
+
+    const String testValue = 'A B C';
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(
+        text: testValue,
+      ),
+    );
+    await tester.pump();
+
+    // The selectWordsInRange with SelectionChangedCause.tap seems to be needed to show the toolbar.
+    // (This is true even if we provide selection parameter to the TextEditingValue above.)
+    final EditableTextState state = tester.state<EditableTextState>(find.byType(EditableText));
+    state.renderEditable.selectWordsInRange(from: Offset.zero, cause: SelectionChangedCause.tap);
+
+    expect(state.showToolbar(), true);
+
+    // This is needed for the AnimatedOpacity to turn from 0 to 1 so the toolbar is visible.
+    await tester.pumpAndSettle();
+    await tester.pump(const Duration(seconds: 1));
+
+    // Sanity check that the toolbar widget exists.
+    expect(find.text('Paste'), findsOneWidget);
+
+    const String newValue = 'A B C D';
+    tester.testTextInput.updateEditingValue(
+      const TextEditingValue(
+        text: newValue,
+      ),
+    );
+    await tester.pump();
+
+    expect(state.selectionOverlay!.toolbarIsVisible, isFalse);
+  }, skip: isContextMenuProvidedByPlatform);
+
   testWidgets('Composing change does not hide selection handle caret', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/108673
     final TextEditingController controller = TextEditingController();

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -265,7 +265,7 @@ void main() {
     await tester.pump();
 
     expect(state.selectionOverlay!.toolbarIsVisible, isFalse);
-  }, skip: isContextMenuProvidedByPlatform);
+  }, skip: isContextMenuProvidedByPlatform); // [intended] only applies to platforms where we supply the context menu.
 
   testWidgets('Composing change does not hide selection handle caret', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/108673


### PR DESCRIPTION
Fixes #108673
Fixes #84849 

## Issue 1 - Tap the word the handler appear randomly
1, Tap on the middle of 'Hello'
2, Local value update to
```dart
TextEditingValue(text: ┤Hello World├, selection: TextSelection.collapsed(offset: 2, affinity: TextAffinity.upstream, isDirectional: false), composing: TextRange(start: -1, end: -1))
```
3, Send the new local value to remote, and then, the auto correction will update the composing back to framework
```dart
TextEditingValue(text: ┤Hello World├, selection: TextSelection.collapsed(offset: 2, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: 0, end: 2))
```
But the affinity will mutate randomly. I'm not sure if this is a problem with the engine, but I understand that in this scenario, affinity is meaningless.

If the affinity was mutate, the handle will be hide by `_TextFieldState._handleSelectionChanged` because the cause is keyboard.

## Issue 2 - The handler can not drag to a new word

https://github.com/flutter/flutter/blob/2d771d4966b6a8562bd026807fccbbddecf42e2e/packages/flutter/lib/src/widgets/editable_text.dart#L2148-L2149
This is because we remove the handler overlay during drag because the engine update the composing during drag.

I found that we can remove the line, the handler's visibility will be updated by `_TextFieldState._handleSelectionChanged` CC @LongCatIsLooong 

