### PR TITLE
Adds shape, collapsedShape properties to Expansion Tile

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -10,6 +10,7 @@ import 'expansion_tile_theme.dart';
 import 'icons.dart';
 import 'list_tile.dart';
 import 'list_tile_theme.dart';
+import 'material.dart';
 import 'theme.dart';
 
 const Duration _kExpand = Duration(milliseconds: 200);
@@ -68,8 +69,8 @@ class ExpansionTile extends StatefulWidget {
     this.collapsedTextColor,
     this.iconColor,
     this.collapsedIconColor,
-    this.border,
-    this.collapsedBorder,
+    this.shape,
+    this.collapsedShape,
     this.controlAffinity,
   }) : assert(initiallyExpanded != null),
        assert(maintainState != null),
@@ -256,13 +257,27 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final Color? collapsedTextColor;
 
-  /// Tile's border when the sublist is expanded.
-  /// If this property is null then a [Border] with vertical direction sides default to Color [Theme.divider] is used
-  final Border? border;
+  /// Tile's border shape when the sublist is expanded.
+  ///
+  /// If this property is null then [ExpansionTileThemeData.shape] is used. If that
+  /// is also null then a [Border] with vertical direction sides default to Color [Theme.divider] is used
+  ///
+  /// See also:
+  ///
+  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
+  ///   [ExpansionTileThemeData].
+  final ShapeBorder? shape;
 
-  /// Tile's border when the sublist is collapsed.
-  /// If this property is null then a [Border] with vertical direction sides default to Color [Colors.transparent] is used
-  final Border? collapsedBorder;
+  /// Tile's border shape when the sublist is collapsed.
+  ///
+  /// If this property is null then [ExpansionTileThemeData.collapsedShape] is used. If that
+  /// is also null then a [Border] with vertical direction sides default to Color [Colors.transparent] is used
+  ///
+  /// See also:
+  ///
+  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
+  ///   [ExpansionTileThemeData].
+  final ShapeBorder? collapsedShape;
 
   /// Typically used to force the expansion arrow icon to the tile's leading or trailing edge.
   ///
@@ -279,7 +294,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);
   static final Animatable<double> _halfTween = Tween<double>(begin: 0.0, end: 0.5);
 
-  final BorderTween _borderTween = BorderTween();
+  final ShapeBorderTween _borderTween = ShapeBorderTween();
   final ColorTween _headerColorTween = ColorTween();
   final ColorTween _iconColorTween = ColorTween();
   final ColorTween _backgroundColorTween = ColorTween();
@@ -287,7 +302,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   late AnimationController _controller;
   late Animation<double> _iconTurns;
   late Animation<double> _heightFactor;
-  late Animation<Border?> _border;
+  late Animation<ShapeBorder?> _border;
   late Animation<Color?> _headerColor;
   late Animation<Color?> _iconColor;
   late Animation<Color?> _backgroundColor;
@@ -371,12 +386,14 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
 
   Widget _buildChildren(BuildContext context, Widget? child) {
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
-    final Border expansionTileBorder = _border.value ?? const Border();
+    final ShapeBorder expansionTileBorder = _border.value ?? const Border();
 
     return Container(
-      decoration: BoxDecoration(
-        color: _backgroundColor.value ?? expansionTileTheme.backgroundColor ?? Colors.transparent,
-        border: expansionTileBorder,
+      decoration: ShapeDecoration(
+        color: _backgroundColor.value
+                  ?? expansionTileTheme.backgroundColor
+                  ?? Colors.transparent,
+        shape: expansionTileBorder,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -413,14 +430,18 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
     _borderTween
-      ..begin = widget.collapsedBorder ?? const Border(
-        top: BorderSide(color: Colors.transparent),
-        bottom: BorderSide(color: Colors.transparent)
-      )
-      ..end = widget.border ?? Border(
-        top: BorderSide(color: theme.dividerColor),
-        bottom: BorderSide(color: theme.dividerColor),
-      );
+      ..begin = widget.collapsedShape
+        ?? expansionTileTheme.collapsedShape
+        ?? const Border(
+          top: BorderSide(color: Colors.transparent),
+          bottom: BorderSide(color: Colors.transparent)
+        )
+      ..end = widget.shape
+        ?? expansionTileTheme.collapsedShape
+        ?? Border(
+          top: BorderSide(color: theme.dividerColor),
+          bottom: BorderSide(color: theme.dividerColor),
+        );
     _headerColorTween
       ..begin = widget.collapsedTextColor
         ?? expansionTileTheme.collapsedTextColor

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -260,7 +260,7 @@ class ExpansionTile extends StatefulWidget {
   /// Tile's border shape when the sublist is expanded.
   ///
   /// If this property is null then [ExpansionTileThemeData.shape] is used. If that
-  /// is also null then a [Border] with vertical direction sides default to Color [Theme.divider] is used
+  /// is also null then a [Border] with vertical direction sides default to Color [Theme.dividerColor] is used
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -71,6 +71,7 @@ class ExpansionTile extends StatefulWidget {
     this.collapsedIconColor,
     this.shape,
     this.collapsedShape,
+    this.clipBehavior = Clip.none,
     this.controlAffinity,
   }) : assert(initiallyExpanded != null),
        assert(maintainState != null),
@@ -279,6 +280,17 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final ShapeBorder? collapsedShape;
 
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// If this property is null then [ExpansionTileThemeData.clipBehavior] is used. If that
+  /// is also null then a [Clip.none] is used
+  ///
+  /// See also:
+  ///
+  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
+  ///   [ExpansionTileThemeData].
+  final Clip? clipBehavior;
+
   /// Typically used to force the expansion arrow icon to the tile's leading or trailing edge.
   ///
   /// By default, the value of [controlAffinity] is [ListTileControlAffinity.platform],
@@ -390,9 +402,10 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
             top: BorderSide(color: Colors.transparent),
             bottom: BorderSide(color: Colors.transparent),
           );
+    final Clip clipBehavior = widget.clipBehavior ?? expansionTileTheme.clipBehavior ?? Clip.none;
 
     return Container(
-      clipBehavior: Clip.antiAlias,
+      clipBehavior: clipBehavior,
       decoration: ShapeDecoration(
         color: _backgroundColor.value
                   ?? expansionTileTheme.backgroundColor

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -68,6 +68,8 @@ class ExpansionTile extends StatefulWidget {
     this.collapsedTextColor,
     this.iconColor,
     this.collapsedIconColor,
+    this.borderColor,
+    this.collapsedBorderColor,
     this.controlAffinity,
   }) : assert(initiallyExpanded != null),
        assert(maintainState != null),
@@ -254,6 +256,30 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final Color? collapsedTextColor;
 
+  /// The color of the tile's vertical border when the sublist is expanded.
+  ///
+  /// Used to override to the [Theme.dividerColor].
+  ///
+  /// If this property is null then [ExpansionTileThemeData.borderColor] is used. If that
+  /// is also null then the value of [Theme.dividerColor] is used.
+  ///
+  /// See also:
+  ///
+  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
+  ///   [ExpansionTileThemeData].
+  final Color? borderColor;
+
+  /// The color of the tile's vertical border when the sublist is collapsed.
+  ///
+  /// If this property is null then [ExpansionTileThemeData.collapsedBorderColor] is used. If that
+  /// is also null then [Colors.transparent] is used.
+  ///
+  /// See also:
+  ///
+  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
+  ///   [ExpansionTileThemeData].
+  final Color? collapsedBorderColor;
+
   /// Typically used to force the expansion arrow icon to the tile's leading or trailing edge.
   ///
   /// By default, the value of [controlAffinity] is [ListTileControlAffinity.platform],
@@ -405,7 +431,11 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ThemeData theme = Theme.of(context);
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
-    _borderColorTween.end = theme.dividerColor;
+    _borderColorTween
+      ..begin = widget.collapsedBorderColor
+        ?? expansionTileTheme.collapsedBorderColor
+        ?? theme.dividerColor
+      ..end = widget.borderColor ?? expansionTileTheme.borderColor ?? Colors.transparent;
     _headerColorTween
       ..begin = widget.collapsedTextColor
         ?? expansionTileTheme.collapsedTextColor

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -68,8 +68,8 @@ class ExpansionTile extends StatefulWidget {
     this.collapsedTextColor,
     this.iconColor,
     this.collapsedIconColor,
-    this.borderColor,
-    this.collapsedBorderColor,
+    this.border,
+    this.collapsedBorder,
     this.controlAffinity,
   }) : assert(initiallyExpanded != null),
        assert(maintainState != null),
@@ -256,29 +256,13 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final Color? collapsedTextColor;
 
-  /// The color of the tile's vertical border when the sublist is expanded.
-  ///
-  /// Used to override to the [Theme.dividerColor].
-  ///
-  /// If this property is null then [ExpansionTileThemeData.borderColor] is used. If that
-  /// is also null then the value of [Theme.dividerColor] is used.
-  ///
-  /// See also:
-  ///
-  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
-  ///   [ExpansionTileThemeData].
-  final Color? borderColor;
+  /// Tile's border when the sublist is expanded.
+  /// If this property is null then a [Border] with vertical direction sides default to Color [Theme.divider] is used
+  final Border? border;
 
-  /// The color of the tile's vertical border when the sublist is collapsed.
-  ///
-  /// If this property is null then [ExpansionTileThemeData.collapsedBorderColor] is used. If that
-  /// is also null then [Colors.transparent] is used.
-  ///
-  /// See also:
-  ///
-  /// * [ExpansionTileTheme.of], which returns the nearest [ExpansionTileTheme]'s
-  ///   [ExpansionTileThemeData].
-  final Color? collapsedBorderColor;
+  /// Tile's border when the sublist is collapsed.
+  /// If this property is null then a [Border] with all the sides default to [BorderSide.none] is used
+  final Border? collapsedBorder;
 
   /// Typically used to force the expansion arrow icon to the tile's leading or trailing edge.
   ///
@@ -295,7 +279,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   static final Animatable<double> _easeInTween = CurveTween(curve: Curves.easeIn);
   static final Animatable<double> _halfTween = Tween<double>(begin: 0.0, end: 0.5);
 
-  final ColorTween _borderColorTween = ColorTween();
+  final BorderTween _borderTween = BorderTween();
   final ColorTween _headerColorTween = ColorTween();
   final ColorTween _iconColorTween = ColorTween();
   final ColorTween _backgroundColorTween = ColorTween();
@@ -303,7 +287,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
   late AnimationController _controller;
   late Animation<double> _iconTurns;
   late Animation<double> _heightFactor;
-  late Animation<Color?> _borderColor;
+  late Animation<Border?> _border;
   late Animation<Color?> _headerColor;
   late Animation<Color?> _iconColor;
   late Animation<Color?> _backgroundColor;
@@ -316,7 +300,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     _controller = AnimationController(duration: _kExpand, vsync: this);
     _heightFactor = _controller.drive(_easeInTween);
     _iconTurns = _controller.drive(_halfTween.chain(_easeInTween));
-    _borderColor = _controller.drive(_borderColorTween.chain(_easeOutTween));
+    _border = _controller.drive(_borderTween.chain(_easeOutTween));
     _headerColor = _controller.drive(_headerColorTween.chain(_easeInTween));
     _iconColor = _controller.drive(_iconColorTween.chain(_easeInTween));
     _backgroundColor = _controller.drive(_backgroundColorTween.chain(_easeOutTween));
@@ -387,15 +371,12 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
 
   Widget _buildChildren(BuildContext context, Widget? child) {
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
-    final Color borderSideColor = _borderColor.value ?? Colors.transparent;
+    final Border expansionTileBorder = _border.value ?? const Border();
 
     return Container(
       decoration: BoxDecoration(
         color: _backgroundColor.value ?? expansionTileTheme.backgroundColor ?? Colors.transparent,
-        border: Border(
-          top: BorderSide(color: borderSideColor),
-          bottom: BorderSide(color: borderSideColor),
-        ),
+        border: expansionTileBorder,
       ),
       child: Column(
         mainAxisSize: MainAxisSize.min,
@@ -431,11 +412,12 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ThemeData theme = Theme.of(context);
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
-    _borderColorTween
-      ..begin = widget.collapsedBorderColor
-        ?? expansionTileTheme.collapsedBorderColor
-        ?? theme.dividerColor
-      ..end = widget.borderColor ?? expansionTileTheme.borderColor ?? Colors.transparent;
+    _borderTween
+      ..begin = widget.collapsedBorder ?? const Border()
+      ..end = widget.border ?? Border(
+        top: BorderSide(color: theme.dividerColor),
+        bottom: BorderSide(color: theme.dividerColor),
+      );
     _headerColorTween
       ..begin = widget.collapsedTextColor
         ?? expansionTileTheme.collapsedTextColor

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -260,7 +260,7 @@ class ExpansionTile extends StatefulWidget {
   /// Tile's border shape when the sublist is expanded.
   ///
   /// If this property is null then [ExpansionTileThemeData.shape] is used. If that
-  /// is also null then a [Border] with vertical direction sides default to Color [Theme.dividerColor] is used
+  /// is also null then a [Border] with vertical direction sides default to [ThemeData.dividerColor] is used
   ///
   /// See also:
   ///

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -261,7 +261,7 @@ class ExpansionTile extends StatefulWidget {
   final Border? border;
 
   /// Tile's border when the sublist is collapsed.
-  /// If this property is null then a [Border] with all the sides default to [BorderSide.none] is used
+  /// If this property is null then a [Border] with vertical direction sides default to Color [Colors.transparent] is used
   final Border? collapsedBorder;
 
   /// Typically used to force the expansion arrow icon to the tile's leading or trailing edge.
@@ -413,7 +413,10 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
     final ColorScheme colorScheme = theme.colorScheme;
     _borderTween
-      ..begin = widget.collapsedBorder ?? const Border()
+      ..begin = widget.collapsedBorder ?? const Border(
+        top: BorderSide(color: Colors.transparent),
+        bottom: BorderSide(color: Colors.transparent)
+      )
       ..end = widget.border ?? Border(
         top: BorderSide(color: theme.dividerColor),
         bottom: BorderSide(color: theme.dividerColor),

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -257,10 +257,10 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final Color? collapsedTextColor;
 
-  /// Tile's border shape when the sublist is expanded.
+  /// The tile's border shape when the sublist is expanded.
   ///
   /// If this property is null then [ExpansionTileThemeData.shape] is used. If that
-  /// is also null then a [Border] with vertical direction sides default to [ThemeData.dividerColor] is used
+  /// is also null then a [Border] with vertical sides default to [ThemeData.dividerColor] is used
   ///
   /// See also:
   ///
@@ -268,10 +268,10 @@ class ExpansionTile extends StatefulWidget {
   ///   [ExpansionTileThemeData].
   final ShapeBorder? shape;
 
-  /// Tile's border shape when the sublist is collapsed.
+  /// The tile's border shape when the sublist is collapsed.
   ///
   /// If this property is null then [ExpansionTileThemeData.collapsedShape] is used. If that
-  /// is also null then a [Border] with vertical direction sides default to Color [Colors.transparent] is used
+  /// is also null then a [Border] with vertical sides default to Color [Colors.transparent] is used
   ///
   /// See also:
   ///
@@ -386,7 +386,10 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
 
   Widget _buildChildren(BuildContext context, Widget? child) {
     final ExpansionTileThemeData expansionTileTheme = ExpansionTileTheme.of(context);
-    final ShapeBorder expansionTileBorder = _border.value ?? const Border();
+    final ShapeBorder expansionTileBorder = _border.value ?? const Border(
+            top: BorderSide(color: Colors.transparent),
+            bottom: BorderSide(color: Colors.transparent),
+          );
 
     return Container(
       clipBehavior: Clip.antiAlias,
@@ -435,7 +438,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
         ?? expansionTileTheme.collapsedShape
         ?? const Border(
           top: BorderSide(color: Colors.transparent),
-          bottom: BorderSide(color: Colors.transparent)
+          bottom: BorderSide(color: Colors.transparent),
         )
       ..end = widget.shape
         ?? expansionTileTheme.collapsedShape

--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -389,6 +389,7 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
     final ShapeBorder expansionTileBorder = _border.value ?? const Border();
 
     return Container(
+      clipBehavior: Clip.antiAlias,
       decoration: ShapeDecoration(
         color: _backgroundColor.value
                   ?? expansionTileTheme.backgroundColor

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -49,6 +49,8 @@ class ExpansionTileThemeData with Diagnosticable {
     this.collapsedIconColor,
     this.textColor,
     this.collapsedTextColor,
+    this.shape,
+    this.collapsedShape,
   });
 
   /// Overrides the default value of [ExpansionTile.backgroundColor].
@@ -78,6 +80,12 @@ class ExpansionTileThemeData with Diagnosticable {
   /// Overrides the default value of [ExpansionTile.collapsedTextColor].
   final Color? collapsedTextColor;
 
+  /// Overrides the default value of [ExpansionTile.shape].
+  final ShapeBorder? shape;
+
+  /// Overrides the default value of [ExpansionTile.collapsedShape].
+  final ShapeBorder? collapsedShape;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ExpansionTileThemeData copyWith({
@@ -90,6 +98,8 @@ class ExpansionTileThemeData with Diagnosticable {
     Color? collapsedIconColor,
     Color? textColor,
     Color? collapsedTextColor,
+    ShapeBorder? shape,
+    ShapeBorder? collapsedShape,
   }) {
     return ExpansionTileThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -101,6 +111,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor: collapsedIconColor ?? this.collapsedIconColor,
       textColor: textColor ?? this.textColor,
       collapsedTextColor: collapsedTextColor ?? this.collapsedTextColor,
+      shape: shape ?? this.shape,
+      collapsedShape: collapsedShape ?? this.collapsedShape,
     );
   }
 
@@ -120,6 +132,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor: Color.lerp(a?.collapsedIconColor, b?.collapsedIconColor, t),
       textColor: Color.lerp(a?.textColor, b?.textColor, t),
       collapsedTextColor: Color.lerp(a?.collapsedTextColor, b?.collapsedTextColor, t),
+      shape: ShapeBorder.lerp(a?.shape, b?.shape, t),
+      collapsedShape: ShapeBorder.lerp(a?.collapsedShape, b?.collapsedShape, t),
     );
   }
 
@@ -135,6 +149,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor,
       textColor,
       collapsedTextColor,
+      shape,
+      collapsedShape,
     );
   }
 
@@ -155,7 +171,9 @@ class ExpansionTileThemeData with Diagnosticable {
       && other.iconColor == iconColor
       && other.collapsedIconColor == collapsedIconColor
       && other.textColor == textColor
-      && other.collapsedTextColor == collapsedTextColor;
+      && other.collapsedTextColor == collapsedTextColor
+      && other.shape == shape
+      && other.collapsedShape == collapsedShape;
   }
 
   @override
@@ -170,6 +188,8 @@ class ExpansionTileThemeData with Diagnosticable {
     properties.add(ColorProperty('collapsedIconColor', collapsedIconColor, defaultValue: null));
     properties.add(ColorProperty('textColor', textColor, defaultValue: null));
     properties.add(ColorProperty('collapsedTextColor', collapsedTextColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
+    properties.add(DiagnosticsProperty<ShapeBorder>('collapsedShape', collapsedShape, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -51,6 +51,7 @@ class ExpansionTileThemeData with Diagnosticable {
     this.collapsedTextColor,
     this.shape,
     this.collapsedShape,
+    this.clipBehavior,
   });
 
   /// Overrides the default value of [ExpansionTile.backgroundColor].
@@ -86,6 +87,9 @@ class ExpansionTileThemeData with Diagnosticable {
   /// Overrides the default value of [ExpansionTile.collapsedShape].
   final ShapeBorder? collapsedShape;
 
+  /// Overrides the default value of [ExpansionTile.clipBehavior].
+  final Clip? clipBehavior;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ExpansionTileThemeData copyWith({
@@ -100,6 +104,7 @@ class ExpansionTileThemeData with Diagnosticable {
     Color? collapsedTextColor,
     ShapeBorder? shape,
     ShapeBorder? collapsedShape,
+    Clip? clipBehavior,
   }) {
     return ExpansionTileThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -113,6 +118,7 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedTextColor: collapsedTextColor ?? this.collapsedTextColor,
       shape: shape ?? this.shape,
       collapsedShape: collapsedShape ?? this.collapsedShape,
+      clipBehavior: clipBehavior ?? this.clipBehavior,
     );
   }
 
@@ -151,6 +157,7 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedTextColor,
       shape,
       collapsedShape,
+      clipBehavior,
     );
   }
 
@@ -173,7 +180,8 @@ class ExpansionTileThemeData with Diagnosticable {
       && other.textColor == textColor
       && other.collapsedTextColor == collapsedTextColor
       && other.shape == shape
-      && other.collapsedShape == collapsedShape;
+      && other.collapsedShape == collapsedShape
+      && other.clipBehavior == clipBehavior;
   }
 
   @override
@@ -190,6 +198,7 @@ class ExpansionTileThemeData with Diagnosticable {
     properties.add(ColorProperty('collapsedTextColor', collapsedTextColor, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('shape', shape, defaultValue: null));
     properties.add(DiagnosticsProperty<ShapeBorder>('collapsedShape', collapsedShape, defaultValue: null));
+    properties.add(DiagnosticsProperty<Clip>('clipBehavior', clipBehavior, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -49,6 +49,8 @@ class ExpansionTileThemeData with Diagnosticable {
     this.collapsedIconColor,
     this.textColor,
     this.collapsedTextColor,
+    this.borderColor,
+    this.collapsedBorderColor,
   });
 
   /// Overrides the default value of [ExpansionTile.backgroundColor].
@@ -78,6 +80,12 @@ class ExpansionTileThemeData with Diagnosticable {
   /// Overrides the default value of [ExpansionTile.collapsedTextColor].
   final Color? collapsedTextColor;
 
+  /// Overrides the default value of [ExpansionTile.borderColor].
+  final Color? borderColor;
+
+  /// Overrides the default value of [ExpansionTile.collapseBorderColor].
+  final Color? collapsedBorderColor;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ExpansionTileThemeData copyWith({
@@ -90,6 +98,8 @@ class ExpansionTileThemeData with Diagnosticable {
     Color? collapsedIconColor,
     Color? textColor,
     Color? collapsedTextColor,
+    Color? borderColor,
+    Color? collapsedBorderColor,
   }) {
     return ExpansionTileThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -101,6 +111,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor: collapsedIconColor ?? this.collapsedIconColor,
       textColor: textColor ?? this.textColor,
       collapsedTextColor: collapsedTextColor ?? this.collapsedTextColor,
+      borderColor: borderColor ?? this.borderColor,
+      collapsedBorderColor: collapsedBorderColor ?? this.collapsedBorderColor,
     );
   }
 
@@ -120,6 +132,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor: Color.lerp(a?.collapsedIconColor, b?.collapsedIconColor, t),
       textColor: Color.lerp(a?.textColor, b?.textColor, t),
       collapsedTextColor: Color.lerp(a?.collapsedTextColor, b?.collapsedTextColor, t),
+      borderColor: Color.lerp(a?.borderColor, b?.borderColor, t),
+      collapsedBorderColor: Color.lerp(a?.collapsedBorderColor, b?.collapsedBorderColor, t),
     );
   }
 
@@ -135,6 +149,8 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor,
       textColor,
       collapsedTextColor,
+      borderColor,
+      collapsedBorderColor,
     );
   }
 
@@ -155,7 +171,9 @@ class ExpansionTileThemeData with Diagnosticable {
       && other.iconColor == iconColor
       && other.collapsedIconColor == collapsedIconColor
       && other.textColor == textColor
-      && other.collapsedTextColor == collapsedTextColor;
+      && other.collapsedTextColor == collapsedTextColor
+      && other.borderColor == borderColor
+      && other.collapsedBorderColor == collapsedBorderColor;
   }
 
   @override
@@ -170,6 +188,8 @@ class ExpansionTileThemeData with Diagnosticable {
     properties.add(ColorProperty('collapsedIconColor', collapsedIconColor, defaultValue: null));
     properties.add(ColorProperty('textColor', textColor, defaultValue: null));
     properties.add(ColorProperty('collapsedTextColor', collapsedTextColor, defaultValue: null));
+    properties.add(ColorProperty('borderColor', borderColor, defaultValue: null));
+    properties.add(ColorProperty('collapsedBorderColor', collapsedBorderColor, defaultValue: null));
   }
 }
 

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -49,8 +49,6 @@ class ExpansionTileThemeData with Diagnosticable {
     this.collapsedIconColor,
     this.textColor,
     this.collapsedTextColor,
-    this.borderColor,
-    this.collapsedBorderColor,
   });
 
   /// Overrides the default value of [ExpansionTile.backgroundColor].
@@ -80,12 +78,6 @@ class ExpansionTileThemeData with Diagnosticable {
   /// Overrides the default value of [ExpansionTile.collapsedTextColor].
   final Color? collapsedTextColor;
 
-  /// Overrides the default value of [ExpansionTile.borderColor].
-  final Color? borderColor;
-
-  /// Overrides the default value of [ExpansionTile.collapseBorderColor].
-  final Color? collapsedBorderColor;
-
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   ExpansionTileThemeData copyWith({
@@ -98,8 +90,6 @@ class ExpansionTileThemeData with Diagnosticable {
     Color? collapsedIconColor,
     Color? textColor,
     Color? collapsedTextColor,
-    Color? borderColor,
-    Color? collapsedBorderColor,
   }) {
     return ExpansionTileThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -111,8 +101,6 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor: collapsedIconColor ?? this.collapsedIconColor,
       textColor: textColor ?? this.textColor,
       collapsedTextColor: collapsedTextColor ?? this.collapsedTextColor,
-      borderColor: borderColor ?? this.borderColor,
-      collapsedBorderColor: collapsedBorderColor ?? this.collapsedBorderColor,
     );
   }
 
@@ -132,8 +120,6 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor: Color.lerp(a?.collapsedIconColor, b?.collapsedIconColor, t),
       textColor: Color.lerp(a?.textColor, b?.textColor, t),
       collapsedTextColor: Color.lerp(a?.collapsedTextColor, b?.collapsedTextColor, t),
-      borderColor: Color.lerp(a?.borderColor, b?.borderColor, t),
-      collapsedBorderColor: Color.lerp(a?.collapsedBorderColor, b?.collapsedBorderColor, t),
     );
   }
 
@@ -149,8 +135,6 @@ class ExpansionTileThemeData with Diagnosticable {
       collapsedIconColor,
       textColor,
       collapsedTextColor,
-      borderColor,
-      collapsedBorderColor,
     );
   }
 
@@ -171,9 +155,7 @@ class ExpansionTileThemeData with Diagnosticable {
       && other.iconColor == iconColor
       && other.collapsedIconColor == collapsedIconColor
       && other.textColor == textColor
-      && other.collapsedTextColor == collapsedTextColor
-      && other.borderColor == borderColor
-      && other.collapsedBorderColor == collapsedBorderColor;
+      && other.collapsedTextColor == collapsedTextColor;
   }
 
   @override
@@ -188,8 +170,6 @@ class ExpansionTileThemeData with Diagnosticable {
     properties.add(ColorProperty('collapsedIconColor', collapsedIconColor, defaultValue: null));
     properties.add(ColorProperty('textColor', textColor, defaultValue: null));
     properties.add(ColorProperty('collapsedTextColor', collapsedTextColor, defaultValue: null));
-    properties.add(ColorProperty('borderColor', borderColor, defaultValue: null));
-    properties.add(ColorProperty('collapsedBorderColor', collapsedBorderColor, defaultValue: null));
   }
 }
 

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -129,7 +129,6 @@ void main() {
     await tester.pump(const Duration(milliseconds: 100));
     final ShapeDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
     expect(collapsingContainerDecoration.color, Colors.transparent);
-    // Opacity should change but color component should remain the same.
     expect((collapsingContainerDecoration.shape as Border?)!.top.color, const Color(0x15222222));
     expect((collapsingContainerDecoration.shape as Border?)!.bottom.color, const Color(0x15222222));
 

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -109,15 +109,15 @@ void main() {
     expect(getHeight(topKey), getHeight(collapsedKey) - 2.0);
     expect(getHeight(topKey), getHeight(defaultKey) - 2.0);
 
-    BoxDecoration expandedContainerDecoration = getContainer(expandedKey).decoration! as BoxDecoration;
+    ShapeDecoration expandedContainerDecoration = getContainer(expandedKey).decoration! as ShapeDecoration;
     expect(expandedContainerDecoration.color, Colors.red);
-    expect(expandedContainerDecoration.border!.top.color, dividerColor);
-    expect(expandedContainerDecoration.border!.bottom.color, dividerColor);
+    expect((expandedContainerDecoration.shape as Border?)!.top.color, dividerColor);
+    expect((expandedContainerDecoration.shape as Border?)!.bottom.color, dividerColor);
 
-    BoxDecoration collapsedContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
+    ShapeDecoration collapsedContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
     expect(collapsedContainerDecoration.color, Colors.transparent);
-    expect(collapsedContainerDecoration.border!.top.color, Colors.transparent);
-    expect(collapsedContainerDecoration.border!.bottom.color, Colors.transparent);
+    expect((collapsedContainerDecoration.shape as Border?)!.top.color, Colors.transparent);
+    expect((collapsedContainerDecoration.shape as Border?)!.bottom.color, Colors.transparent);
 
     await tester.tap(find.text('Expanded'));
     await tester.tap(find.text('Collapsed'));
@@ -127,11 +127,11 @@ void main() {
 
     // Pump to the middle of the animation for expansion.
     await tester.pump(const Duration(milliseconds: 100));
-    final BoxDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
+    final ShapeDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
     expect(collapsingContainerDecoration.color, Colors.transparent);
     // Opacity should change but color component should remain the same.
-    expect(collapsingContainerDecoration.border!.top.color, const Color(0x15222222));
-    expect(collapsingContainerDecoration.border!.bottom.color, const Color(0x15222222));
+    expect((collapsingContainerDecoration.shape as Border?)!.top.color, const Color(0x15222222));
+    expect((collapsingContainerDecoration.shape as Border?)!.bottom.color, const Color(0x15222222));
 
     // Pump all the way to the end now.
     await tester.pump(const Duration(seconds: 1));
@@ -141,16 +141,16 @@ void main() {
     expect(getHeight(topKey), getHeight(defaultKey) - getHeight(tileKey) - 2.0);
 
     // Expanded should be collapsed now.
-    expandedContainerDecoration = getContainer(expandedKey).decoration! as BoxDecoration;
+    expandedContainerDecoration = getContainer(expandedKey).decoration! as ShapeDecoration;
     expect(expandedContainerDecoration.color, Colors.transparent);
-    expect(expandedContainerDecoration.border!.top.color, Colors.transparent);
-    expect(expandedContainerDecoration.border!.bottom.color, Colors.transparent);
+    expect((expandedContainerDecoration.shape as Border?)!.top.color, Colors.transparent);
+    expect((expandedContainerDecoration.shape as Border?)!.bottom.color, Colors.transparent);
 
     // Collapsed should be expanded now.
-    collapsedContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
+    collapsedContainerDecoration = getContainer(collapsedKey).decoration! as ShapeDecoration;
     expect(collapsedContainerDecoration.color, Colors.transparent);
-    expect(collapsedContainerDecoration.border!.top.color, dividerColor);
-    expect(collapsedContainerDecoration.border!.bottom.color, dividerColor);
+    expect((collapsedContainerDecoration.shape as Border?)!.top.color, dividerColor);
+    expect((collapsedContainerDecoration.shape as Border?)!.bottom.color, dividerColor);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets('ExpansionTile Theme dependencies', (WidgetTester tester) async {
@@ -500,22 +500,22 @@ void main() {
       ),
     ));
 
-    BoxDecoration boxDecoration =  tester.firstWidget<Container>(find.descendant(
+    ShapeDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(expansionTileKey),
       matching: find.byType(Container),
-    )).decoration! as BoxDecoration;
+    )).decoration! as ShapeDecoration;
 
-    expect(boxDecoration.color, collapsedBackgroundColor);
+    expect(shapeDecoration.color, collapsedBackgroundColor);
 
     await tester.tap(find.text('Title'));
     await tester.pumpAndSettle();
 
-    boxDecoration =  tester.firstWidget<Container>(find.descendant(
+    shapeDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(expansionTileKey),
       matching: find.byType(Container),
-    )).decoration! as BoxDecoration;
+    )).decoration! as ShapeDecoration;
 
-    expect(boxDecoration.color, backgroundColor);
+    expect(shapeDecoration.color, backgroundColor);
   });
 
   testWidgets('ExpansionTile iconColor, textColor', (WidgetTester tester) async {

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -130,8 +130,8 @@ void main() {
     final BoxDecoration collapsingContainerDecoration = getContainer(collapsedKey).decoration! as BoxDecoration;
     expect(collapsingContainerDecoration.color, Colors.transparent);
     // Opacity should change but color component should remain the same.
-    expect(collapsingContainerDecoration.border!.top.color, const Color(0x15333333));
-    expect(collapsingContainerDecoration.border!.bottom.color, const Color(0x15333333));
+    expect(collapsingContainerDecoration.border!.top.color, const Color(0x15222222));
+    expect(collapsingContainerDecoration.border!.bottom.color, const Color(0x15222222));
 
     // Pump all the way to the end now.
     await tester.pump(const Duration(seconds: 1));
@@ -553,6 +553,54 @@ void main() {
 
     expect(getIconColor(), iconColor);
     expect(getTextColor(), textColor);
+  });
+
+  testWidgets('ExpansionTile Border', (WidgetTester tester) async {
+    const Key expansionTileKey = PageStorageKey<String>('expansionTile');
+
+    const Border collapsedBorder = Border(
+      top: BorderSide(color: Colors.blue),
+      bottom: BorderSide(color: Colors.green)
+    );
+    final Border border = Border.all(color: Colors.red);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Material(
+        child: SingleChildScrollView(
+          child: Column(
+            children: <Widget>[
+              ExpansionTile(
+                key: expansionTileKey,
+                title: const Text('ExpansionTile'),
+                collapsedBorder: collapsedBorder,
+                border: border,
+                children: const <Widget>[
+                  ListTile(
+                    title: Text('0'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ));
+
+    Container getContainer(Key key) => tester.firstWidget(find.descendant(
+      of: find.byKey(key),
+      matching: find.byType(Container),
+    ));
+
+    // expansionTile should be Collapsed now.
+    BoxDecoration expandedContainerDecoration = getContainer(expansionTileKey).decoration! as BoxDecoration;
+    expect(expandedContainerDecoration.border, collapsedBorder);
+
+    await tester.tap(find.text('ExpansionTile'));
+    await tester.pumpAndSettle();
+
+    // expansionTile should be Expanded now.
+    expandedContainerDecoration = getContainer(expansionTileKey).decoration! as BoxDecoration;
+    expect(expandedContainerDecoration.border, border);
   });
 
   testWidgets('ExpansionTile platform controlAffinity test', (WidgetTester tester) async {

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -558,11 +558,11 @@ void main() {
   testWidgets('ExpansionTile Border', (WidgetTester tester) async {
     const Key expansionTileKey = PageStorageKey<String>('expansionTile');
 
-    const Border collapsedBorder = Border(
+    const Border collapsedShape = Border(
       top: BorderSide(color: Colors.blue),
       bottom: BorderSide(color: Colors.green)
     );
-    final Border border = Border.all(color: Colors.red);
+    final Border shape = Border.all(color: Colors.red);
 
     await tester.pumpWidget(MaterialApp(
       home: Material(
@@ -572,8 +572,8 @@ void main() {
               ExpansionTile(
                 key: expansionTileKey,
                 title: const Text('ExpansionTile'),
-                collapsedBorder: collapsedBorder,
-                border: border,
+                collapsedShape: collapsedShape,
+                shape: shape,
                 children: const <Widget>[
                   ListTile(
                     title: Text('0'),
@@ -592,15 +592,15 @@ void main() {
     ));
 
     // expansionTile should be Collapsed now.
-    BoxDecoration expandedContainerDecoration = getContainer(expansionTileKey).decoration! as BoxDecoration;
-    expect(expandedContainerDecoration.border, collapsedBorder);
+    ShapeDecoration expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
+    expect(expandedContainerDecoration.shape, collapsedShape);
 
     await tester.tap(find.text('ExpansionTile'));
     await tester.pumpAndSettle();
 
     // expansionTile should be Expanded now.
-    expandedContainerDecoration = getContainer(expansionTileKey).decoration! as BoxDecoration;
-    expect(expandedContainerDecoration.border, border);
+    expandedContainerDecoration = getContainer(expansionTileKey).decoration! as ShapeDecoration;
+    expect(expandedContainerDecoration.shape, shape);
   });
 
   testWidgets('ExpansionTile platform controlAffinity test', (WidgetTester tester) async {

--- a/packages/flutter/test/material/expansion_tile_theme_test.dart
+++ b/packages/flutter/test/material/expansion_tile_theme_test.dart
@@ -58,6 +58,8 @@ void main() {
     expect(theme.collapsedIconColor, null);
     expect(theme.textColor, null);
     expect(theme.collapsedTextColor, null);
+    expect(theme.shape, null);
+    expect(theme.collapsedShape, null);
   });
 
   testWidgets('Default ExpansionTileThemeData debugFillProperties', (WidgetTester tester) async {
@@ -84,6 +86,8 @@ void main() {
       collapsedIconColor: Color(0xffdd0b1f),
       textColor: Color(0xffffffff),
       collapsedTextColor: Color(0xff522bab),
+      shape: Border(),
+      collapsedShape: Border(),
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -101,6 +105,8 @@ void main() {
       'collapsedIconColor: Color(0xffdd0b1f)',
       'textColor: Color(0xffffffff)',
       'collapsedTextColor: Color(0xff522bab)',
+      'shape: Border.all(BorderSide(Color(0xff000000), 0.0, BorderStyle.none))',
+      'collapsedShape: Border.all(BorderSide(Color(0xff000000), 0.0, BorderStyle.none))',
     ]);
   });
 
@@ -114,6 +120,14 @@ void main() {
     const Color collapsedIconColor = Colors.blue;
     const Color textColor = Colors.black;
     const Color collapsedTextColor = Colors.white;
+    const ShapeBorder shape = Border(
+      top: BorderSide(color: Colors.red),
+      bottom: BorderSide(color: Colors.red),
+    );
+    const ShapeBorder collapsedShape = Border(
+      top: BorderSide(color: Colors.green),
+      bottom: BorderSide(color: Colors.green),
+    );
 
     await tester.pumpWidget(
       MaterialApp(
@@ -128,6 +142,8 @@ void main() {
             collapsedIconColor: collapsedIconColor,
             textColor: textColor,
             collapsedTextColor: collapsedTextColor,
+            shape: shape,
+            collapsedShape: collapsedShape,
           ),
         ),
         home: Material(
@@ -143,12 +159,12 @@ void main() {
       ),
     );
 
-    final BoxDecoration boxDecoration =  tester.firstWidget<Container>(find.descendant(
+    final ShapeDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(tileKey),
       matching: find.byType(Container),
-    )).decoration! as BoxDecoration;
+    )).decoration! as ShapeDecoration;
     // Check the tile's collapsed background color when collapsedBackgroundColor is applied.
-    expect(boxDecoration.color, collapsedBackgroundColor);
+    expect(shapeDecoration.color, collapsedBackgroundColor);
 
     final Rect titleRect = tester.getRect(find.text('Collapsed Tile'));
     final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
@@ -171,6 +187,8 @@ void main() {
     expect(getIconColor(), collapsedIconColor);
     // Check the collapsed text color when textColor is applied.
     expect(getTextColor(), collapsedTextColor);
+    // Check the collapsed ShapeBorder when shape is applied.
+    expect(shapeDecoration.shape, collapsedShape);
   });
 
   testWidgets('ExpansionTileTheme - expanded', (WidgetTester tester) async {
@@ -183,6 +201,14 @@ void main() {
     const Color collapsedIconColor = Colors.blue;
     const Color textColor = Colors.black;
     const Color collapsedTextColor = Colors.white;
+    const ShapeBorder shape = Border(
+      top: BorderSide(color: Colors.red),
+      bottom: BorderSide(color: Colors.red),
+    );
+    const ShapeBorder collapsedShape = Border(
+      top: BorderSide(color: Colors.green),
+      bottom: BorderSide(color: Colors.green),
+    );
 
     await tester.pumpWidget(
       MaterialApp(
@@ -197,6 +223,8 @@ void main() {
             collapsedIconColor: collapsedIconColor,
             textColor: textColor,
             collapsedTextColor: collapsedTextColor,
+            shape: shape,
+            collapsedShape: collapsedShape,
           ),
         ),
         home: Material(
@@ -213,12 +241,12 @@ void main() {
       ),
     );
 
-    final BoxDecoration boxDecoration =  tester.firstWidget<Container>(find.descendant(
+    final ShapeDecoration shapeDecoration =  tester.firstWidget<Container>(find.descendant(
       of: find.byKey(tileKey),
       matching: find.byType(Container),
-    )).decoration! as BoxDecoration;
+    )).decoration! as ShapeDecoration;
     // Check the tile's background color when backgroundColor is applied.
-    expect(boxDecoration.color, backgroundColor);
+    expect(shapeDecoration.color, backgroundColor);
 
     final Rect titleRect = tester.getRect(find.text('Expanded Tile'));
     final Rect trailingRect = tester.getRect(find.byIcon(Icons.expand_more));
@@ -241,6 +269,8 @@ void main() {
     expect(getIconColor(), iconColor);
     // Check the expanded text color when textColor is applied.
     expect(getTextColor(), textColor);
+    // Check the expanded ShapeBorder when shape is applied.
+    expect(shapeDecoration.shape, collapsedShape);
 
     // Check the child position when expandedAlignment is applied.
     final Rect childRect = tester.getRect(find.text('Tile 1'));


### PR DESCRIPTION
Adds [~~borderColor, collapsedBorderColor~~,~~border, collapsedBorder~~] shape, collapsedShape properties to Expansion Tile widget.

- uses ShapeBorderTween to add expand/close animation

- replaces _borderColorTween with _borderTween

- Changes Container decoration of expansionTile from `BoxDecoration` to `ShapeDecoration`

*List which issues are fixed by this PR.*
- Fix https://github.com/flutter/flutter/issues/108357
- Fix https://github.com/flutter/flutter/issues/85901

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
