### PR TITLE
[flutter_tools] Make flutter test -v print timing of different phases

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -193,7 +193,7 @@ List<FlutterCommand> generateCommands({
   RunCommand(verboseHelp: verboseHelp),
   ScreenshotCommand(),
   ShellCompletionCommand(),
-  TestCommand(verboseHelp: verboseHelp),
+  TestCommand(verboseHelp: verboseHelp, verbose: verbose),
   UpgradeCommand(verboseHelp: verboseHelp),
   SymbolizeCommand(
     stdio: globals.stdio,

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -308,7 +308,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
 
     TestTimeRecorder? testTimeRecorder;
     if (verbose) {
-      testTimeRecorder = TestTimeRecorder();
+      testTimeRecorder = TestTimeRecorder(globals.logger);
     }
 
     if (buildInfo.packageConfig['test_api'] == null) {

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -69,13 +69,13 @@ class CoverageCollector extends TestWatcher {
   }
 
   void _addHitmap(Map<String, coverage.HitMap> hitmap) {
-    final Stopwatch? stopwatch = testTimeRecorder?.start(TestTimePhases.Coverage_addHitmap);
+    final Stopwatch? stopwatch = testTimeRecorder?.start(TestTimePhases.CoverageAddHitmap);
     if (_globalHitmap == null) {
       _globalHitmap = hitmap;
     } else {
       _globalHitmap!.merge(hitmap);
     }
-    testTimeRecorder?.stop(TestTimePhases.Coverage_addHitmap, stopwatch!);
+    testTimeRecorder?.stop(TestTimePhases.CoverageAddHitmap, stopwatch!);
   }
 
   /// The directory of the package for which coverage is being collected.
@@ -129,7 +129,7 @@ class CoverageCollector extends TestWatcher {
 
     Map<String, dynamic>? data;
 
-    final Stopwatch? collectTestTimeRecorderStopwatch = testTimeRecorder?.start(TestTimePhases.Coverage_collect);
+    final Stopwatch? collectTestTimeRecorderStopwatch = testTimeRecorder?.start(TestTimePhases.CoverageCollect);
 
     final Future<void> processComplete = testDevice.finished.catchError(
       (Object error) => throw Exception(
@@ -153,16 +153,16 @@ class CoverageCollector extends TestWatcher {
 
     await Future.any<void>(<Future<void>>[ processComplete, collectionComplete ]);
     assert(data != null);
-    testTimeRecorder?.stop(TestTimePhases.Coverage_collect, collectTestTimeRecorderStopwatch!);
+    testTimeRecorder?.stop(TestTimePhases.CoverageCollect, collectTestTimeRecorderStopwatch!);
 
     _logMessage('Merging coverage data...');
-    final Stopwatch? parseTestTimeRecorderStopwatch = testTimeRecorder?.start(TestTimePhases.Coverage_parseJson);
+    final Stopwatch? parseTestTimeRecorderStopwatch = testTimeRecorder?.start(TestTimePhases.CoverageParseJson);
     final Map<String, coverage.HitMap> hitmap = coverage.HitMap.parseJsonSync(
         data!['coverage'] as List<Map<String, dynamic>>,
         checkIgnoredLines: true,
         resolver: resolver ?? await CoverageCollector.getResolver(packageDirectory),
         ignoredLinesInFilesCache: _ignoredLinesInFilesCache);
-    testTimeRecorder?.stop(TestTimePhases.Coverage_parseJson, parseTestTimeRecorderStopwatch!);
+    testTimeRecorder?.stop(TestTimePhases.CoverageParseJson, parseTestTimeRecorderStopwatch!);
 
     _addHitmap(hitmap);
     _logMessage('Done merging coverage data into global coverage map.');

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -35,6 +35,7 @@ import '../web/compile.dart';
 import '../web/memory_fs.dart';
 import 'flutter_web_goldens.dart';
 import 'test_compiler.dart';
+import 'test_time_recorder.dart';
 
 class FlutterWebPlatform extends PlatformPlugin {
   FlutterWebPlatform._(this._server, this._config, this._root, {
@@ -51,6 +52,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     required Artifacts? artifacts,
     required ProcessManager processManager,
     required Cache cache,
+    TestTimeRecorder? testTimeRecorder,
   }) : _fileSystem = fileSystem,
       _flutterToolPackageConfig = flutterToolPackageConfig,
       _chromiumLauncher = chromiumLauncher,
@@ -76,7 +78,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     _server.mount(cascade.handler);
     _testGoldenComparator = TestGoldenComparator(
       shellPath,
-      () => TestCompiler(buildInfo, flutterProject),
+      () => TestCompiler(buildInfo, flutterProject, testTimeRecorder: testTimeRecorder),
       fileSystem: _fileSystem,
       logger: _logger,
       processManager: processManager,
@@ -120,6 +122,7 @@ class FlutterWebPlatform extends PlatformPlugin {
     required Artifacts? artifacts,
     required ProcessManager processManager,
     required Cache cache,
+    TestTimeRecorder? testTimeRecorder,
   }) async {
     final shelf_io.IOServer server = shelf_io.IOServer(await HttpMultiServer.loopback(0));
     final PackageConfig packageConfig = await loadPackageConfigWithLogging(
@@ -149,6 +152,7 @@ class FlutterWebPlatform extends PlatformPlugin {
       nullAssertions: nullAssertions,
       processManager: processManager,
       cache: cache,
+      testTimeRecorder: testTimeRecorder,
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -13,6 +13,7 @@ import '../web/chrome.dart';
 import '../web/memory_fs.dart';
 import 'flutter_platform.dart' as loader;
 import 'flutter_web_platform.dart';
+import 'test_time_recorder.dart';
 import 'test_wrapper.dart';
 import 'watcher.dart';
 import 'web_test_compiler.dart';
@@ -51,6 +52,7 @@ abstract class FlutterTestRunner {
     int? totalShards,
     Device? integrationTestDevice,
     String? integrationTestUserIdentifier,
+    TestTimeRecorder? testTimeRecorder,
   });
 }
 
@@ -87,6 +89,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     int? totalShards,
     Device? integrationTestDevice,
     String? integrationTestUserIdentifier,
+    TestTimeRecorder? testTimeRecorder,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts!.getArtifactPath(Artifact.flutterTester);
@@ -173,6 +176,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
               logger: globals.logger,
             ),
             cache: globals.cache,
+            testTimeRecorder: testTimeRecorder,
           );
         },
       );
@@ -204,6 +208,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       icudtlPath: icudtlPath,
       integrationTestDevice: integrationTestDevice,
       integrationTestUserIdentifier: integrationTestUserIdentifier,
+      testTimeRecorder: testTimeRecorder,
     );
 
     try {

--- a/packages/flutter_tools/lib/src/test/test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/test_compiler.dart
@@ -16,6 +16,7 @@ import '../compile.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
 import '../project.dart';
+import 'test_time_recorder.dart';
 
 /// A request to the [TestCompiler] for recompilation.
 class CompilationRequest {
@@ -40,10 +41,12 @@ class TestCompiler {
   ///
   /// If [precompiledDillPath] is passed, it will be used to initialize the
   /// compiler.
+  ///
+  /// If [testTimeRecorder] is passed, times will be recorded in it.
   TestCompiler(
     this.buildInfo,
     this.flutterProject,
-    { String? precompiledDillPath }
+    { String? precompiledDillPath, this.testTimeRecorder }
   ) : testFilePath = precompiledDillPath ?? globals.fs.path.join(
         flutterProject!.directory.path,
         getBuildDirectory(),
@@ -73,6 +76,7 @@ class TestCompiler {
   final BuildInfo buildInfo;
   final String testFilePath;
   final bool shouldCopyDillFile;
+  final TestTimeRecorder? testTimeRecorder;
 
 
   ResidentCompiler? compiler;
@@ -139,6 +143,7 @@ class TestCompiler {
       final CompilationRequest request = compilationQueue.first;
       globals.printTrace('Compiling ${request.mainUri}');
       final Stopwatch compilerTime = Stopwatch()..start();
+      final Stopwatch? testTimeRecorderStopwatch = testTimeRecorder?.start(TestTimePhases.Compile);
       bool firstCompile = false;
       if (compiler == null) {
         compiler = await createCompiler();
@@ -200,6 +205,7 @@ class TestCompiler {
         compiler!.reset();
       }
       globals.printTrace('Compiling ${request.mainUri} took ${compilerTime.elapsedMilliseconds}ms');
+      testTimeRecorder?.stop(TestTimePhases.Compile, testTimeRecorderStopwatch!);
       // Only remove now when we finished processing the element
       compilationQueue.removeAt(0);
     }

--- a/packages/flutter_tools/lib/src/test/test_time_recorder.dart
+++ b/packages/flutter_tools/lib/src/test/test_time_recorder.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_tools/lib/src/test/test_time_recorder.dart
+++ b/packages/flutter_tools/lib/src/test/test_time_recorder.dart
@@ -1,0 +1,81 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../globals.dart' as globals;
+
+class TestTimeRecorder {
+  final List<TestTimeRecord> _phaseRecords = List<TestTimeRecord>.generate(TestTimePhases.values.length, (_) => TestTimeRecord());
+
+  Stopwatch start(TestTimePhases phase) {
+    return _phaseRecords[phase.index].start();
+  }
+
+  void stop(TestTimePhases phase, Stopwatch stopwatch) {
+    _phaseRecords[phase.index].stop(stopwatch);
+  }
+
+  void print() {
+    for(final TestTimePhases phase in TestTimePhases.values) {
+      globals.printTrace(_getPrintStringForPhase(phase));
+    }
+  }
+
+  List<String> getPrintAsListForTesting() {
+    final List<String> result = <String>[];
+    for(final TestTimePhases phase in TestTimePhases.values) {
+      result.add(_getPrintStringForPhase(phase));
+    }
+    return result;
+  }
+
+  String _getPrintStringForPhase(final TestTimePhases phase) {
+    assert(_phaseRecords[phase.index].isDone());
+    return 'Runtime for phase ${phase.name}: ${_phaseRecords[phase.index]}';
+  }
+}
+
+class TestTimeRecord {
+  Duration _combinedRuntime = Duration.zero;
+  final Stopwatch _wallClockRuntime = Stopwatch();
+  int _currentlyRunningCount = 0;
+
+  Stopwatch start() {
+    final Stopwatch stopwatch = Stopwatch()..start();
+    if (_currentlyRunningCount == 0) {
+      _wallClockRuntime.start();
+    }
+    _currentlyRunningCount++;
+    return stopwatch;
+  }
+
+  void stop(Stopwatch stopwatch) {
+    _currentlyRunningCount--;
+    if (_currentlyRunningCount == 0) {
+      _wallClockRuntime.stop();
+    }
+    _combinedRuntime = _combinedRuntime + stopwatch.elapsed;
+    assert(_currentlyRunningCount >= 0);
+  }
+
+  @override
+  String toString() {
+    return 'Wall-clock: ${_wallClockRuntime.elapsed}; combined: $_combinedRuntime.';
+  }
+
+  bool isDone() {
+    return _currentlyRunningCount == 0;
+  }
+}
+
+enum TestTimePhases {
+  TestRunner,
+  Compile,
+  Run,
+  CoverageTotal,
+  Coverage_collect,
+  Coverage_parseJson,
+  Coverage_addHitmap,
+  CoverageDataCollect,
+  WatcherFinishedTest,
+}

--- a/packages/flutter_tools/lib/src/test/test_time_recorder.dart
+++ b/packages/flutter_tools/lib/src/test/test_time_recorder.dart
@@ -2,10 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../globals.dart' as globals;
+import 'package:meta/meta.dart';
 
+import '../base/logger.dart';
+
+/// Utility class that can record time used in different phases of a test run.
 class TestTimeRecorder {
-  final List<TestTimeRecord> _phaseRecords = List<TestTimeRecord>.generate(TestTimePhases.values.length, (_) => TestTimeRecord());
+  TestTimeRecorder(this.logger,
+      {this.stopwatchFactory = const StopwatchFactory()})
+      : _phaseRecords = List<TestTimeRecord>.generate(
+          TestTimePhases.values.length,
+          (_) => TestTimeRecord(stopwatchFactory),
+        );
+
+  final List<TestTimeRecord> _phaseRecords;
+  final Logger logger;
+  final StopwatchFactory stopwatchFactory;
 
   Stopwatch start(TestTimePhases phase) {
     return _phaseRecords[phase.index].start();
@@ -16,17 +28,23 @@ class TestTimeRecorder {
   }
 
   void print() {
-    for(final TestTimePhases phase in TestTimePhases.values) {
-      globals.printTrace(_getPrintStringForPhase(phase));
+    for (final TestTimePhases phase in TestTimePhases.values) {
+      logger.printTrace(_getPrintStringForPhase(phase));
     }
   }
 
+  @visibleForTesting
   List<String> getPrintAsListForTesting() {
     final List<String> result = <String>[];
-    for(final TestTimePhases phase in TestTimePhases.values) {
+    for (final TestTimePhases phase in TestTimePhases.values) {
       result.add(_getPrintStringForPhase(phase));
     }
     return result;
+  }
+
+  @visibleForTesting
+  Stopwatch getPhaseWallClockStopwatchForTesting(final TestTimePhases phase) {
+    return _phaseRecords[phase.index]._wallClockRuntime;
   }
 
   String _getPrintStringForPhase(final TestTimePhases phase) {
@@ -35,13 +53,18 @@ class TestTimeRecorder {
   }
 }
 
+/// Utility class that can record time used in a specific phase of a test run.
 class TestTimeRecord {
+  TestTimeRecord(this.stopwatchFactory)
+      : _wallClockRuntime = stopwatchFactory.createStopwatch();
+
+  final StopwatchFactory stopwatchFactory;
   Duration _combinedRuntime = Duration.zero;
-  final Stopwatch _wallClockRuntime = Stopwatch();
+  final Stopwatch _wallClockRuntime;
   int _currentlyRunningCount = 0;
 
   Stopwatch start() {
-    final Stopwatch stopwatch = Stopwatch()..start();
+    final Stopwatch stopwatch = stopwatchFactory.createStopwatch()..start();
     if (_currentlyRunningCount == 0) {
       _wallClockRuntime.start();
     }
@@ -69,13 +92,38 @@ class TestTimeRecord {
 }
 
 enum TestTimePhases {
+  /// Covers entire TestRunner run, i.e. from the test runner was asked to `runTests` until it is done.
+  ///
+  /// This implicitly includes all the other phases.
   TestRunner,
+
+  /// Covers time spent compiling, including subsequent copying of files.
   Compile,
+
+  /// Covers time spent running, i.e. from starting the test device until the test has finished.
   Run,
+
+  /// Covers all time spent collecting coverage.
   CoverageTotal,
-  Coverage_collect,
-  Coverage_parseJson,
-  Coverage_addHitmap,
+
+  /// Covers collecting the coverage, but not parsing nor adding to hit map.
+  ///
+  /// This is included in [CoverageTotal]
+  CoverageCollect,
+
+  /// Covers parsing the json from the coverage collected.
+  ///
+  /// This is included in [CoverageTotal]
+  CoverageParseJson,
+
+  /// Covers adding the parsed coverage to the hitmap.
+  ///
+  /// This is included in [CoverageTotal]
+  CoverageAddHitmap,
+
+  /// Covers time spent in `collectCoverageData`, mostly formatting and writing coverage data to file.
   CoverageDataCollect,
+
+  /// Covers time spend in the Watchers `handleFinishedTest` call. This is probably collecting coverage.
   WatcherFinishedTest,
 }

--- a/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
+++ b/packages/flutter_tools/test/general.shard/coverage_collector_test.dart
@@ -14,6 +14,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../src/common.dart';
 import '../src/fake_vm_services.dart';
+import '../src/logging_logger.dart';
 
 void main() {
   testWithoutContext('Coverage collector Can handle coverage SentinelException', () async {
@@ -408,7 +409,8 @@ void main() {
       fooFile.writeAsStringSync('hit\nnohit but ignored // coverage:ignore-line\nhit\n');
 
       final String packagesPath = packagesFile.path;
-      final TestTimeRecorder testTimeRecorder = TestTimeRecorder();
+      final LoggingLogger logger = LoggingLogger();
+      final TestTimeRecorder testTimeRecorder = TestTimeRecorder(logger);
       final CoverageCollector collector = CoverageCollector(
           libraryNames: <String>{'foo', 'bar'},
           verbose: false,

--- a/packages/flutter_tools/test/general.shard/devfs_test.dart
+++ b/packages/flutter_tools/test/general.shard/devfs_test.dart
@@ -16,7 +16,6 @@ import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/os.dart';
 import 'package:flutter_tools/src/base/platform.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/build_system/targets/shader_compiler.dart';
 import 'package:flutter_tools/src/compile.dart';
@@ -30,6 +29,7 @@ import '../src/context.dart';
 import '../src/fake_http_client.dart';
 import '../src/fake_vm_services.dart';
 import '../src/fakes.dart';
+import '../src/logging_logger.dart';
 
 final FakeVmServiceRequest createDevFSRequest = FakeVmServiceRequest(
   method: '_createDevFS',
@@ -713,27 +713,6 @@ class FakeDevFSWriter implements DevFSWriter {
   @override
   Future<void> write(Map<Uri, DevFSContent> entries, Uri baseUri, DevFSWriter parent) async {
     written = true;
-  }
-}
-
-class LoggingLogger extends BufferLogger {
-  LoggingLogger() : super.test();
-
-  List<String> messages = <String>[];
-
-  @override
-  void printError(String message, {StackTrace? stackTrace, bool? emphasis, TerminalColor? color, int? indent, int? hangingIndent, bool? wrap}) {
-    messages.add(message);
-  }
-
-  @override
-  void printStatus(String message, {bool? emphasis, TerminalColor? color, bool? newline, int? indent, int? hangingIndent, bool? wrap}) {
-    messages.add(message);
-  }
-
-  @override
-  void printTrace(String message) {
-    messages.add(message);
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -99,7 +99,7 @@ void main() {
 
   testUsingContext('TestCompiler records test timings when provided TestTimeRecorder', () async {
     residentCompiler.compilerOutput = const CompilerOutput('abc.dill', 0, <Uri>[]);
-    final TestTimeRecorder testTimeRecorder = TestTimeRecorder();
+    final TestTimeRecorder testTimeRecorder = TestTimeRecorder(logger);
     final FakeTestCompiler testCompiler = FakeTestCompiler(
       debugBuild,
       FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),

--- a/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_compiler_test.dart
@@ -11,11 +11,13 @@ import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/compile.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/test/test_compiler.dart';
+import 'package:flutter_tools/src/test/test_time_recorder.dart';
 import 'package:package_config/package_config_types.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
 import '../../src/context.dart';
+import '../../src/logging_logger.dart';
 
 final Platform linuxPlatform = FakePlatform(
   environment: <String, String>{},
@@ -33,6 +35,7 @@ final BuildInfo debugBuild = BuildInfo(
 void main() {
   late FakeResidentCompiler residentCompiler;
   late FileSystem fileSystem;
+  late LoggingLogger logger;
 
   setUp(() {
     fileSystem = MemoryFileSystem.test();
@@ -40,6 +43,7 @@ void main() {
     fileSystem.file('test/foo.dart').createSync(recursive: true);
     fileSystem.file('.packages').createSync();
     residentCompiler = FakeResidentCompiler(fileSystem);
+    logger = LoggingLogger();
   });
 
   testUsingContext('TestCompiler reports a dill file when compile is successful', () async {
@@ -90,6 +94,34 @@ void main() {
     Platform: () => linuxPlatform,
     ProcessManager: () => FakeProcessManager.any(),
     Logger: () => BufferLogger.test(),
+  });
+
+
+  testUsingContext('TestCompiler records test timings when provided TestTimeRecorder', () async {
+    residentCompiler.compilerOutput = const CompilerOutput('abc.dill', 0, <Uri>[]);
+    final TestTimeRecorder testTimeRecorder = TestTimeRecorder();
+    final FakeTestCompiler testCompiler = FakeTestCompiler(
+      debugBuild,
+      FlutterProject.fromDirectoryTest(fileSystem.currentDirectory),
+      residentCompiler,
+      testTimeRecorder: testTimeRecorder,
+    );
+    expect(await testCompiler.compile(Uri.parse('test/foo.dart')), 'test/foo.dart.dill');
+    testTimeRecorder.print();
+
+    // Expect one message for each phase.
+    final List<String> logPhaseMessages = logger.messages.where((String m) => m.startsWith('Runtime for phase ')).toList();
+    expect(logPhaseMessages, hasLength(TestTimePhases.values.length));
+
+    // As the compile method adds a job to a queue etc we expect at
+    // least one phase to take a non-zero amount of time.
+    final List<String> logPhaseMessagesNonZero = logPhaseMessages.where((String m) => !m.contains(Duration.zero.toString())).toList();
+    expect(logPhaseMessagesNonZero, isNotEmpty);
+  }, overrides: <Type, Generator>{
+    FileSystem: () => fileSystem,
+    Platform: () => linuxPlatform,
+    ProcessManager: () => FakeProcessManager.any(),
+    Logger: () => logger,
   });
 
   testUsingContext('TestCompiler disposing test compiler shuts down backing compiler', () async {
@@ -171,6 +203,7 @@ class FakeTestCompiler extends TestCompiler {
     super.flutterProject,
     this.residentCompiler, {
       super.precompiledDillPath,
+      super.testTimeRecorder,
     }
   );
 

--- a/packages/flutter_tools/test/general.shard/test/test_time_recorder_test.dart
+++ b/packages/flutter_tools/test/general.shard/test/test_time_recorder_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/test/test_time_recorder.dart';
+
+import '../../src/common.dart';
+import '../../src/fakes.dart';
+import '../../src/logging_logger.dart';
+
+void main() {
+  testWithoutContext('Test phases prints correctly', () {
+    const Duration zero = Duration.zero;
+    const Duration combinedDuration = Duration(seconds: 42);
+    const Duration wallClockDuration = Duration(seconds: 21);
+
+    for (final TestTimePhases phase in TestTimePhases.values) {
+      final TestTimeRecorder recorder = createRecorderWithTimesForPhase(
+          phase, combinedDuration, wallClockDuration);
+      final Set<String> prints = recorder.getPrintAsListForTesting().toSet();
+
+      // Expect one entry per phase.
+      expect(prints, hasLength(TestTimePhases.values.length));
+
+      // Expect this phase to have the specified times.
+      expect(
+        prints,
+        contains('Runtime for phase ${phase.name}: '
+            'Wall-clock: $wallClockDuration; combined: $combinedDuration.'),
+      );
+
+      // Expect all other phases to say 0.
+      for (final TestTimePhases innerPhase in TestTimePhases.values) {
+        if (phase == innerPhase) {
+          continue;
+        }
+        expect(
+          prints,
+          contains('Runtime for phase ${innerPhase.name}: '
+              'Wall-clock: $zero; combined: $zero.'),
+        );
+      }
+    }
+  });
+}
+
+TestTimeRecorder createRecorderWithTimesForPhase(TestTimePhases phase,
+    Duration combinedDuration, Duration wallClockDuration) {
+  final LoggingLogger logger = LoggingLogger();
+  final TestTimeRecorder recorder =
+      TestTimeRecorder(logger, stopwatchFactory: FakeStopwatchFactory());
+  final FakeStopwatch combinedStopwatch =
+      recorder.start(phase) as FakeStopwatch;
+  final FakeStopwatch wallClockStopwatch =
+      recorder.getPhaseWallClockStopwatchForTesting(phase) as FakeStopwatch;
+  wallClockStopwatch.elapsed = wallClockDuration;
+  combinedStopwatch.elapsed = combinedDuration;
+  recorder.stop(phase, combinedStopwatch);
+  return recorder;
+}

--- a/packages/flutter_tools/test/src/logging_logger.dart
+++ b/packages/flutter_tools/test/src/logging_logger.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter_tools/test/src/logging_logger.dart
+++ b/packages/flutter_tools/test/src/logging_logger.dart
@@ -1,0 +1,27 @@
+// Copyright 2022 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/terminal.dart';
+
+class LoggingLogger extends BufferLogger {
+  LoggingLogger() : super.test();
+
+  List<String> messages = <String>[];
+
+  @override
+  void printError(String message, {StackTrace? stackTrace, bool? emphasis, TerminalColor? color, int? indent, int? hangingIndent, bool? wrap}) {
+    messages.add(message);
+  }
+
+  @override
+  void printStatus(String message, {bool? emphasis, TerminalColor? color, bool? newline, int? indent, int? hangingIndent, bool? wrap}) {
+    messages.add(message);
+  }
+
+  @override
+  void printTrace(String message) {
+    messages.add(message);
+  }
+}


### PR DESCRIPTION
This PR adds timing to different phases of a `flutter test` run when run in verbose mode (i.e. really `flutter test -v`).
It is only done when run in verbose mode, and at the end of such a run something like this is printed (examples when run without and with coverage, respectively):

```
$ flutter test -v
[...]
04:08 +11253 ~66: All tests passed!
[...]
[   +1 ms] Runtime for phase TestRunner: Wall-clock: 0:04:10.433205; combined: 0:04:10.433270.
[        ] Runtime for phase Compile: Wall-clock: 0:02:26.767039; combined: 0:02:26.768384.
[        ] Runtime for phase Run: Wall-clock: 0:03:59.813981; combined: 0:34:41.530487.
[        ] Runtime for phase CoverageTotal: Wall-clock: 0:00:00.000000; combined: 0:00:00.000000.
[        ] Runtime for phase Coverage_collect: Wall-clock: 0:00:00.000000; combined: 0:00:00.000000.
[        ] Runtime for phase Coverage_parseJson: Wall-clock: 0:00:00.000000; combined: 0:00:00.000000.
[        ] Runtime for phase Coverage_addHitmap: Wall-clock: 0:00:00.000000; combined: 0:00:00.000000.
[        ] Runtime for phase CoverageDataCollect: Wall-clock: 0:00:00.000000; combined: 0:00:00.000000.
[        ] Runtime for phase WatcherFinishedTest: Wall-clock: 0:00:00.053933; combined: 0:00:00.055020.
[        ] "flutter test" took 251,741ms.

$ flutter test --coverage -v
[...]
10:36 +11253 ~66: All tests passed!
[...]
[        ] Runtime for phase TestRunner: Wall-clock: 0:10:38.437213; combined: 0:10:38.437255.
[        ] Runtime for phase Compile: Wall-clock: 0:03:41.295140; combined: 0:03:41.296021.
[        ] Runtime for phase Run: Wall-clock: 0:09:29.499648; combined: 0:38:39.588928.
[        ] Runtime for phase CoverageTotal: Wall-clock: 0:09:51.073961; combined: 0:51:35.341727.
[        ] Runtime for phase Coverage_collect: Wall-clock: 0:09:48.354589; combined: 0:51:03.565451.
[        ] Runtime for phase Coverage_parseJson: Wall-clock: 0:00:28.882393; combined: 0:00:28.883917.
[        ] Runtime for phase Coverage_addHitmap: Wall-clock: 0:00:02.765673; combined: 0:00:02.766548.
[        ] Runtime for phase CoverageDataCollect: Wall-clock: 0:00:00.074591; combined: 0:00:00.074591.
[        ] Runtime for phase WatcherFinishedTest: Wall-clock: 0:09:51.080064; combined: 0:51:35.401420.
```

This can be seen as a productization of https://github.com/flutter/flutter/issues/100751#issuecomment-1081774867 where these timing numbers (fewer, but still) helped debug what was slow on a CI. Similarly, I've used (a non-productization version of) these numbers to uncover the speed issue fixed in https://github.com/flutter/flutter/pull/107395.