### PR TITLE
[flutter_test] perf: find.ancestor

### DIFF
--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -923,7 +923,8 @@ class _DescendantFinder extends Finder {
 
   @override
   Iterable<Element> apply(Iterable<Element> candidates) {
-    return candidates.where((Element element) => descendant.evaluate().contains(element));
+    final Iterable<Element> descendants = descendant.evaluate();
+    return candidates.where((Element element) => descendants.contains(element));
   }
 
   @override
@@ -956,7 +957,8 @@ class _AncestorFinder extends Finder {
 
   @override
   Iterable<Element> apply(Iterable<Element> candidates) {
-    return candidates.where((Element element) => ancestor.evaluate().contains(element));
+    final Iterable<Element> ancestors = ancestor.evaluate();
+    return candidates.where((Element element) => ancestors.contains(element));
   }
 
   @override

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -361,6 +361,30 @@ void main() {
         matchRoot: true,
       ), findsOneWidget);
     });
+
+    testWidgets('is fast in deep tree', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: _deepWidgetTree(
+            depth: 1000,
+            child: Row(
+              children: <Widget>[
+                _deepWidgetTree(
+                  depth: 1000,
+                  child: Column(children: fooBarTexts),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(find.ancestor(
+        of: find.text('bar'),
+        matching: find.byType(Row),
+      ), findsOneWidget);
+    });
   });
 
   group('pageBack', () {
@@ -853,4 +877,13 @@ class _AlwaysRepaint extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     onPaint();
   }
+}
+
+/// Wraps [child] in [depth] layers of [SizedBox]
+Widget _deepWidgetTree({required int depth, required Widget child}) {
+  Widget tree = child;
+  for (int i = 0; i < depth; i += 1) {
+    tree = SizedBox(child: tree);
+  }
+  return tree;
 }


### PR DESCRIPTION
I noticed that `find.ancestor()` is quite slow. Mostly due to unnecessary `evaluate()` calls of the `ancestor` Finder. 

The `_AncestorFinder` called `ancestor.evaluate()` for every candidate. Now it is called beforehand. 

The new test now runs 4x faster.

```
Before: 538ms
After: 127ms
```

In my own tests I could see 10x and more improvements. 

Fixes #108920

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
