### PR TITLE
Fixed middle prop in CupertinoSliverNavigationBar to adhere to the docs and expected iOS behavior.

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -651,8 +651,8 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// A widget to place in the middle of the static navigation bar instead of
   /// the [largeTitle].
   ///
-  /// This widget is visible in both collapsed and expanded states. The text
-  /// supplied in [largeTitle] will no longer appear in collapsed state if a
+  /// This widget is visible in collapsed state. The text supplied in
+  /// [largeTitle] will no longer appear in collapsed state if a
   /// [middle] widget is provided.
   final Widget? middle;
 

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -742,7 +742,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
           transitionBetweenRoutes: widget.transitionBetweenRoutes,
           heroTag: widget.heroTag,
           persistentHeight: _kNavBarPersistentHeight + MediaQuery.of(context).padding.top,
-          alwaysShowMiddle: widget.middle != null,
+          alwaysShowMiddle: false,
           stretchConfiguration: widget.stretch ? OverScrollHeaderStretchConfiguration() : null,
         ),
       ),

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -501,7 +501,6 @@ void main() {
     expect(scrollController.offset, 0.0);
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
-
     expect(find.text('Title'), findsOneWidget);
     // The middle is invisible without scrolling.
     expect(

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -501,6 +501,7 @@ void main() {
     expect(scrollController.offset, 0.0);
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
+
     expect(find.text('Title'), findsOneWidget);
     // The middle is invisible without scrolling.
     expect(

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -513,7 +513,8 @@ void main() {
         tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
   });
 
-  testWidgets('User specified middle is only visible in sliver on scroll',
+  testWidgets(
+      'User specified middle is only visible in sliver if navigation bar is collapsed',
       (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -475,29 +475,17 @@ void main() {
     expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
   });
 
-  testWidgets('User specified middle is always visible in sliver', (WidgetTester tester) async {
+  testWidgets('User specified middle is only visible in sliver on scroll', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
-    final Key segmentedControlsKey = UniqueKey();
     await tester.pumpWidget(
       CupertinoApp(
         home: CupertinoPageScaffold(
           child: CustomScrollView(
             controller: scrollController,
             slivers: <Widget>[
-              CupertinoSliverNavigationBar(
-                middle: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 200.0),
-                  child: CupertinoSegmentedControl<int>(
-                    key: segmentedControlsKey,
-                    children: const <int, Widget>{
-                      0: Text('Option A'),
-                      1: Text('Option B'),
-                    },
-                    onValueChanged: (int selected) { },
-                    groupValue: 0,
-                  ),
-                ),
-                largeTitle: const Text('Title'),
+              const CupertinoSliverNavigationBar(
+                middle: Text('Middle'),
+                largeTitle: Text('Title'),
               ),
               SliverToBoxAdapter(
                 child: Container(
@@ -513,9 +501,12 @@ void main() {
     expect(scrollController.offset, 0.0);
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
-
     expect(find.text('Title'), findsOneWidget);
-    expect(tester.getCenter(find.byKey(segmentedControlsKey)).dx, 400.0);
+    // The middle is invisible without scrolling.
+    expect(
+      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Middle')).opacity.value,
+      0.0,
+    );
 
     expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
     expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
@@ -524,7 +515,7 @@ void main() {
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    expect(tester.getCenter(find.byKey(segmentedControlsKey)).dx, 400.0);
+    expect(tester.getCenter(find.text('Middle')).dx, 400.0);
     // The large title is invisible now.
     expect(
       tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Title')).opacity.value,

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -17,8 +17,7 @@ import '../widgets/semantics_tester.dart';
 int count = 0;
 
 void main() {
-  testWidgets('Middle still in center with asymmetrical actions',
-      (WidgetTester tester) async {
+  testWidgets('Middle still in center with asymmetrical actions', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -35,8 +34,7 @@ void main() {
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
   });
 
-  testWidgets('Middle still in center with back button',
-      (WidgetTester tester) async {
+  testWidgets('Middle still in center with back button', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -45,9 +43,7 @@ void main() {
       ),
     );
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(CupertinoPageRoute<void>(
+    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
       builder: (BuildContext context) {
         return const CupertinoNavigationBar(
           middle: Text('Page 2'),
@@ -62,11 +58,8 @@ void main() {
     expect(tester.getCenter(find.text('Page 2')).dx, 400.0);
   });
 
-  testWidgets(
-      'Opaque background does not add blur effects, non-opaque background adds blur effects',
-      (WidgetTester tester) async {
-    const CupertinoDynamicColor background =
-        CupertinoDynamicColor.withBrightness(
+  testWidgets('Opaque background does not add blur effects, non-opaque background adds blur effects', (WidgetTester tester) async {
+    const CupertinoDynamicColor background = CupertinoDynamicColor.withBrightness(
       color: Color(0xFFE5E5E5),
       darkColor: Color(0xF3E5E5E5),
     );
@@ -81,8 +74,7 @@ void main() {
       ),
     );
     expect(find.byType(BackdropFilter), findsNothing);
-    expect(find.byType(CupertinoNavigationBar),
-        paints..rect(color: background.color));
+    expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.color));
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -94,12 +86,10 @@ void main() {
       ),
     );
     expect(find.byType(BackdropFilter), findsOneWidget);
-    expect(find.byType(CupertinoNavigationBar),
-        paints..rect(color: background.darkColor));
+    expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.darkColor));
   });
 
-  testWidgets('Non-opaque background adds blur effects',
-      (WidgetTester tester) async {
+  testWidgets('Non-opaque background adds blur effects', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -147,8 +137,7 @@ void main() {
         home: Align(
           alignment: Alignment.topCenter,
           child: CupertinoNavigationBar(
-            leading:
-                const CupertinoButton(onPressed: null, child: Text('Cheetah')),
+            leading: const CupertinoButton(onPressed: null, child: Text('Cheetah')),
             // Let the box take all the vertical space to test vertical padding but let
             // the nav bar position it horizontally.
             middle: Align(
@@ -156,8 +145,7 @@ void main() {
               widthFactor: 1.0,
               child: const Text('Title'),
             ),
-            trailing:
-                const CupertinoButton(onPressed: null, child: Text('Puma')),
+            trailing: const CupertinoButton(onPressed: null, child: Text('Puma')),
             padding: const EdgeInsetsDirectional.only(
               start: 10.0,
               end: 20.0,
@@ -177,11 +165,8 @@ void main() {
       44.0 - 4.0,
     );
 
-    expect(
-        tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Cheetah')).dx,
-        10.0);
-    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Puma')).dx,
-        800.0 - 20.0);
+    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Cheetah')).dx, 10.0);
+    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Puma')).dx, 800.0 - 20.0);
 
     // Title is still exactly centered.
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
@@ -278,11 +263,8 @@ void main() {
       ),
     );
 
-    expect(
-        tester.getTopRight(find.widgetWithText(CupertinoButton, 'Cheetah')).dx,
-        800.0 - 10.0);
-    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Puma')).dx,
-        20.0);
+    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Cheetah')).dx, 800.0 - 10.0);
+    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Puma')).dx, 20.0);
 
     // Title is still exactly centered.
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
@@ -294,16 +276,13 @@ void main() {
       CupertinoApp(
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () {},
-            child: _ExpectStyles(
-                color: CupertinoColors.systemBlue.color, index: 0x000001),
+            onPressed: () { },
+            child: _ExpectStyles(color: CupertinoColors.systemBlue.color, index: 0x000001),
           ),
-          middle: const _ExpectStyles(
-              color: CupertinoColors.black, index: 0x000100),
+          middle: const _ExpectStyles(color: CupertinoColors.black, index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () {},
-            child: _ExpectStyles(
-                color: CupertinoColors.systemBlue.color, index: 0x010000),
+            onPressed: () { },
+            child: _ExpectStyles(color: CupertinoColors.systemBlue.color, index: 0x010000),
           ),
         ),
       ),
@@ -318,16 +297,13 @@ void main() {
         theme: const CupertinoThemeData(brightness: Brightness.dark),
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () {},
-            child: _ExpectStyles(
-                color: CupertinoColors.systemBlue.darkColor, index: 0x000001),
+            onPressed: () { },
+            child: _ExpectStyles(color: CupertinoColors.systemBlue.darkColor, index: 0x000001),
           ),
-          middle: const _ExpectStyles(
-              color: CupertinoColors.white, index: 0x000100),
+          middle: const _ExpectStyles(color: CupertinoColors.white, index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () {},
-            child: _ExpectStyles(
-                color: CupertinoColors.systemBlue.darkColor, index: 0x010000),
+            onPressed: () { },
+            child: _ExpectStyles(color: CupertinoColors.systemBlue.darkColor, index: 0x010000),
           ),
         ),
       ),
@@ -335,24 +311,20 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('Theme active color can be overridden',
-      (WidgetTester tester) async {
+  testWidgets('Theme active color can be overridden', (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(
         theme: const CupertinoThemeData(primaryColor: Color(0xFF001122)),
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () {},
-            child:
-                const _ExpectStyles(color: Color(0xFF001122), index: 0x000001),
+            onPressed: () { },
+            child: const _ExpectStyles(color: Color(0xFF001122), index: 0x000001),
           ),
-          middle:
-              const _ExpectStyles(color: Color(0xFF000000), index: 0x000100),
+          middle: const _ExpectStyles(color: Color(0xFF000000), index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () {},
-            child:
-                const _ExpectStyles(color: Color(0xFF001122), index: 0x010000),
+            onPressed: () { },
+            child: const _ExpectStyles(color: Color(0xFF001122), index: 0x010000),
           ),
         ),
       ),
@@ -375,8 +347,7 @@ void main() {
     expect(find.byType(SliverPersistentHeader), findsNothing);
   });
 
-  testWidgets('Media padding is applied to CupertinoSliverNavigationBar',
-      (WidgetTester tester) async {
+  testWidgets('Media padding is applied to CupertinoSliverNavigationBar', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     final Key leadingKey = GlobalKey();
     final Key middleKey = GlobalKey();
@@ -416,15 +387,12 @@ void main() {
     );
 
     // Media padding applied to leading (T,L), middle (T), trailing (T, R).
-    expect(tester.getTopLeft(find.byKey(leadingKey)),
-        const Offset(16.0 + 20.0, 10.0));
+    expect(tester.getTopLeft(find.byKey(leadingKey)), const Offset(16.0 + 20.0, 10.0));
     expect(tester.getRect(find.byKey(middleKey)).top, 10.0);
-    expect(tester.getTopRight(find.byKey(trailingKey)),
-        const Offset(800.0 - 16.0 - 40.0, 10.0));
+    expect(tester.getTopRight(find.byKey(trailingKey)), const Offset(800.0 - 16.0 - 40.0, 10.0));
 
     // Top and left padding is applied to large title.
-    expect(tester.getTopLeft(find.byKey(titleKey)),
-        const Offset(16.0 + 20.0, 54.0 + 10.0));
+    expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(16.0 + 20.0, 54.0 + 10.0));
   });
 
   testWidgets('Large title nav bar scrolls', (WidgetTester tester) async {
@@ -455,49 +423,45 @@ void main() {
 
     expect(find.text('Title'), findsNWidgets(2)); // Though only one is visible.
 
-    List<Element> titles = tester.elementList(find.text('Title')).toList()
-      ..sort((Element a, Element b) {
-        final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
-        final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
-        return aParagraph.text.style!.fontSize!
-            .compareTo(bParagraph.text.style!.fontSize!);
-      });
+    List<Element> titles = tester.elementList(find.text('Title'))
+        .toList()
+        ..sort((Element a, Element b) {
+          final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
+          final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
+          return aParagraph.text.style!.fontSize!.compareTo(bParagraph.text.style!.fontSize!);
+        });
 
     Iterable<double> opacities = titles.map<double>((Element element) {
-      final RenderAnimatedOpacity renderOpacity =
-          element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+      final RenderAnimatedOpacity renderOpacity = element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
       return renderOpacity.opacity.value;
     });
 
-    expect(opacities, <double>[
+    expect(opacities, <double> [
       0.0, // Initially the smaller font title is invisible.
       1.0, // The larger font title is visible.
     ]);
 
-    expect(
-        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
-    expect(
-        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
+    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    titles = tester.elementList(find.text('Title')).toList()
-      ..sort((Element a, Element b) {
-        final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
-        final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
-        return aParagraph.text.style!.fontSize!
-            .compareTo(bParagraph.text.style!.fontSize!);
-      });
+    titles = tester.elementList(find.text('Title'))
+        .toList()
+        ..sort((Element a, Element b) {
+          final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
+          final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
+          return aParagraph.text.style!.fontSize!.compareTo(bParagraph.text.style!.fontSize!);
+        });
 
     opacities = titles.map<double>((Element element) {
-      final RenderAnimatedOpacity renderOpacity =
-          element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+      final RenderAnimatedOpacity renderOpacity = element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
       return renderOpacity.opacity.value;
     });
 
-    expect(opacities, <double>[
+    expect(opacities, <double> [
       1.0, // Smaller font title now visible
       0.0, // Larger font title invisible.
     ]);
@@ -506,16 +470,12 @@ void main() {
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
 
-    expect(
-        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
     // The OverflowBox is squished with the text in it.
-    expect(
-        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
+    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
   });
 
-  testWidgets(
-      'User specified middle is only visible in sliver if navigation bar is collapsed',
-      (WidgetTester tester) async {
+  testWidgets('User specified middle is only visible in sliver if navigation bar is collapsed', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       CupertinoApp(
@@ -544,18 +504,12 @@ void main() {
     expect(find.text('Title'), findsOneWidget);
     // The middle is invisible without scrolling.
     expect(
-      tester
-          .renderObject<RenderAnimatedOpacity>(
-              find.widgetWithText(AnimatedOpacity, 'Middle'))
-          .opacity
-          .value,
+      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Middle')).opacity.value,
       0.0,
     );
 
-    expect(
-        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
-    expect(
-        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
+    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
@@ -564,11 +518,7 @@ void main() {
     expect(tester.getCenter(find.text('Middle')).dx, 400.0);
     // The large title is invisible now.
     expect(
-      tester
-          .renderObject<RenderAnimatedOpacity>(
-              find.widgetWithText(AnimatedOpacity, 'Title'))
-          .opacity
-          .value,
+      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Title')).opacity.value,
       0.0,
     );
   });
@@ -603,9 +553,8 @@ void main() {
     expect(find.text('Title'), findsOneWidget);
     expect(find.text('Different title'), findsOneWidget);
 
-    RenderAnimatedOpacity largeTitleOpacity = tester
-        .element(find.text('Title'))
-        .findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    RenderAnimatedOpacity largeTitleOpacity =
+        tester.element(find.text('Title')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
     // Large title initially visible.
     expect(
       largeTitleOpacity.opacity.value,
@@ -613,22 +562,18 @@ void main() {
     );
     // Middle widget not even wrapped with RenderOpacity, i.e. is always visible.
     expect(
-      tester
-          .element(find.text('Different title'))
-          .findAncestorRenderObjectOfType<RenderOpacity>(),
+      tester.element(find.text('Different title')).findAncestorRenderObjectOfType<RenderOpacity>(),
       isNull,
     );
 
-    expect(tester.getBottomLeft(find.text('Title')).dy,
-        44.0 + 52.0 - 8.0); // Static part + extension - padding.
+    expect(tester.getBottomLeft(find.text('Title')).dy, 44.0 + 52.0 - 8.0); // Static part + extension - padding.
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    largeTitleOpacity = tester
-        .element(find.text('Title'))
-        .findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    largeTitleOpacity =
+        tester.element(find.text('Title')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
     // Large title no longer visible.
     expect(
       largeTitleOpacity.opacity.value,
@@ -639,8 +584,7 @@ void main() {
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
 
-    expect(tester.getBottomLeft(find.text('Title')).dy,
-        44.0 - 8.0); // Extension gone, (static part - padding) left.
+    expect(tester.getBottomLeft(find.text('Title')).dy, 44.0 - 8.0); // Extension gone, (static part - padding) left.
   });
 
   testWidgets('Auto back/close button', (WidgetTester tester) async {
@@ -654,9 +598,7 @@ void main() {
 
     expect(find.byType(CupertinoButton), findsNothing);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(CupertinoPageRoute<void>(
+    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
       builder: (BuildContext context) {
         return const CupertinoNavigationBar(
           middle: Text('Page 2'),
@@ -668,19 +610,16 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.byType(CupertinoButton), findsOneWidget);
-    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)),
-        findsOneWidget);
+    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
 
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(CupertinoPageRoute<void>(
-          fullscreenDialog: true,
-          builder: (BuildContext context) {
-            return const CupertinoNavigationBar(
-              middle: Text('Dialog page'),
-            );
-          },
-        ));
+    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
+      fullscreenDialog: true,
+      builder: (BuildContext context) {
+        return const CupertinoNavigationBar(
+          middle: Text('Dialog page'),
+        );
+      },
+    ));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -695,8 +634,7 @@ void main() {
 
     expect(find.text('Page 2'), findsOneWidget);
 
-    await tester
-        .tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -727,8 +665,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(
-        find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
+    expect(find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
 
     tester.state<NavigatorState>(find.byType(Navigator)).push(
       CupertinoPageRoute<void>(
@@ -748,8 +685,7 @@ void main() {
     expect(find.widgetWithText(CupertinoButton, 'Back'), findsOneWidget);
   });
 
-  testWidgets('Border should be displayed by default',
-      (WidgetTester tester) async {
+  testWidgets('Border should be displayed by default', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -758,12 +694,10 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester
-        .widgetList(find.descendant(
-          of: find.byType(CupertinoNavigationBar),
-          matching: find.byType(DecoratedBox),
-        ))
-        .first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
+      of: find.byType(CupertinoNavigationBar),
+      matching: find.byType(DecoratedBox),
+    )).first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -788,12 +722,10 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester
-        .widgetList(find.descendant(
-          of: find.byType(CupertinoNavigationBar),
-          matching: find.byType(DecoratedBox),
-        ))
-        .first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
+      of: find.byType(CupertinoNavigationBar),
+      matching: find.byType(DecoratedBox),
+    )).first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -804,8 +736,7 @@ void main() {
     expect(side.color, const Color(0xFFAABBCC));
   });
 
-  testWidgets('Border should not be displayed when null',
-      (WidgetTester tester) async {
+  testWidgets('Border should not be displayed when null', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -815,20 +746,17 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester
-        .widgetList(find.descendant(
-          of: find.byType(CupertinoNavigationBar),
-          matching: find.byType(DecoratedBox),
-        ))
-        .first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
+      of: find.byType(CupertinoNavigationBar),
+      matching: find.byType(DecoratedBox),
+    )).first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
     expect(decoration.border, isNull);
   });
 
-  testWidgets('Border is displayed by default in sliver nav bar',
-      (WidgetTester tester) async {
+  testWidgets('Border is displayed by default in sliver nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -843,12 +771,10 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester
-        .widgetList(find.descendant(
-          of: find.byType(CupertinoSliverNavigationBar),
-          matching: find.byType(DecoratedBox),
-        ))
-        .first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
+      of: find.byType(CupertinoSliverNavigationBar),
+      matching: find.byType(DecoratedBox),
+    )).first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -858,8 +784,7 @@ void main() {
     expect(bottom, isNotNull);
   });
 
-  testWidgets('Border is not displayed when null in sliver nav bar',
-      (WidgetTester tester) async {
+  testWidgets('Border is not displayed when null in sliver nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -875,20 +800,17 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester
-        .widgetList(find.descendant(
-          of: find.byType(CupertinoSliverNavigationBar),
-          matching: find.byType(DecoratedBox),
-        ))
-        .first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
+      of: find.byType(CupertinoSliverNavigationBar),
+      matching: find.byType(DecoratedBox),
+    )).first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
     expect(decoration.border, isNull);
   });
 
-  testWidgets('CupertinoSliverNavigationBar has semantics',
-      (WidgetTester tester) async {
+  testWidgets('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(const CupertinoApp(
@@ -904,19 +826,16 @@ void main() {
       ),
     ));
 
-    expect(
-        semantics.nodesWith(
-          label: 'Large Title',
-          flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-          textDirection: TextDirection.ltr,
-        ),
-        hasLength(1));
+    expect(semantics.nodesWith(
+      label: 'Large Title',
+      flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+      textDirection: TextDirection.ltr,
+    ), hasLength(1));
 
     semantics.dispose();
   });
 
-  testWidgets('CupertinoNavigationBar has semantics',
-      (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(CupertinoApp(
@@ -928,19 +847,16 @@ void main() {
       ),
     ));
 
-    expect(
-        semantics.nodesWith(
-          label: 'Fixed Title',
-          flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-          textDirection: TextDirection.ltr,
-        ),
-        hasLength(1));
+    expect(semantics.nodesWith(
+      label: 'Fixed Title',
+      flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+      textDirection: TextDirection.ltr,
+    ), hasLength(1));
 
     semantics.dispose();
   });
 
-  testWidgets('Border can be overridden in sliver nav bar',
-      (WidgetTester tester) async {
+  testWidgets('Border can be overridden in sliver nav bar', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -961,12 +877,10 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester
-        .widgetList(find.descendant(
-          of: find.byType(CupertinoSliverNavigationBar),
-          matching: find.byType(DecoratedBox),
-        ))
-        .first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
+      of: find.byType(CupertinoSliverNavigationBar),
+      matching: find.byType(DecoratedBox),
+    )).first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -1034,8 +948,7 @@ void main() {
     },
   );
 
-  testWidgets('NavBar draws a light system bar for a dark background',
-      (WidgetTester tester) async {
+  testWidgets('NavBar draws a light system bar for a dark background', (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -1055,8 +968,7 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.light);
   });
 
-  testWidgets('NavBar draws a dark system bar for a light background',
-      (WidgetTester tester) async {
+  testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -1076,22 +988,15 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets(
-      'CupertinoNavigationBarBackButton shows an error when manually added outside a route',
-      (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoNavigationBarBackButton());
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(
-        exception.toString(),
-        contains(
-            'CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets(
-      'CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped',
-      (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBarBackButton(),
@@ -1100,15 +1005,10 @@ void main() {
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(
-        exception.toString(),
-        contains(
-            'CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets(
-      'CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere',
-      (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere', (WidgetTester tester) async {
     bool backPressed = false;
 
     await tester.pumpWidget(
@@ -1120,8 +1020,7 @@ void main() {
     );
 
     expect(tester.takeException(), isNull);
-    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)),
-        findsOneWidget);
+    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
 
     await tester.tap(find.byType(CupertinoNavigationBarBackButton));
 
@@ -1130,7 +1029,7 @@ void main() {
 
   testWidgets(
     'Manually inserted CupertinoNavigationBarBackButton still automatically '
-    'show previous page title when possible',
+        'show previous page title when possible',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         const CupertinoApp(
@@ -1139,28 +1038,28 @@ void main() {
       );
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-            CupertinoPageRoute<void>(
-              title: 'An iPod',
-              builder: (BuildContext context) {
-                return const CupertinoPageScaffold(
-                  navigationBar: CupertinoNavigationBar(),
-                  child: Placeholder(),
-                );
-              },
-            ),
-          );
+        CupertinoPageRoute<void>(
+          title: 'An iPod',
+          builder: (BuildContext context) {
+            return const CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(),
+              child: Placeholder(),
+            );
+          },
+        ),
+      );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-            CupertinoPageRoute<void>(
-              title: 'A Phone',
-              builder: (BuildContext context) {
-                return const CupertinoNavigationBarBackButton();
-              },
-            ),
-          );
+        CupertinoPageRoute<void>(
+          title: 'A Phone',
+          builder: (BuildContext context) {
+            return const CupertinoNavigationBarBackButton();
+          },
+        ),
+      );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -1180,35 +1079,35 @@ void main() {
       );
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-            CupertinoPageRoute<void>(
-              title: 'An iPod',
-              builder: (BuildContext context) {
-                return const CupertinoPageScaffold(
-                  navigationBar: CupertinoNavigationBar(),
-                  child: Placeholder(),
-                );
-              },
-            ),
-          );
+        CupertinoPageRoute<void>(
+          title: 'An iPod',
+          builder: (BuildContext context) {
+            return const CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(),
+              child: Placeholder(),
+            );
+          },
+        ),
+      );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-            CupertinoPageRoute<void>(
-              title: 'A Phone',
-              builder: (BuildContext context) {
-                return CupertinoPageScaffold(
-                  navigationBar: CupertinoNavigationBar(
-                    leading: CupertinoNavigationBarBackButton(
-                      onPressed: () => backPressed = true,
-                    ),
-                  ),
-                  child: const Placeholder(),
-                );
-              },
-            ),
-          );
+        CupertinoPageRoute<void>(
+          title: 'A Phone',
+          builder: (BuildContext context) {
+            return CupertinoPageScaffold(
+              navigationBar: CupertinoNavigationBar(
+                leading: CupertinoNavigationBarBackButton(
+                  onPressed: () => backPressed = true,
+                ),
+              ),
+              child: const Placeholder(),
+            );
+          },
+        ),
+      );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -1271,25 +1170,23 @@ void main() {
     expect(contents.any((RichText t) => t.textScaleFactor != 99), isFalse);
 
     // Also works with implicitly added widgets.
-    tester
-        .state<NavigatorState>(find.byType(Navigator))
-        .push(CupertinoPageRoute<void>(
-          title: 'title',
-          builder: (BuildContext context) {
-            return MediaQuery(
-              data: MediaQuery.of(context).copyWith(textScaleFactor: 99),
-              child: const CupertinoPageScaffold(
-                child: CustomScrollView(
-                  slivers: <Widget>[
-                    CupertinoSliverNavigationBar(
-                      previousPageTitle: 'previous title',
-                    ),
-                  ],
+    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
+      title: 'title',
+      builder: (BuildContext context) {
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaleFactor: 99),
+          child: const CupertinoPageScaffold(
+            child: CustomScrollView(
+              slivers: <Widget>[
+                CupertinoSliverNavigationBar(
+                  previousPageTitle: 'previous title',
                 ),
-              ),
-            );
-          },
-        ));
+              ],
+            ),
+          ),
+        );
+      },
+    ));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -1335,17 +1232,13 @@ void main() {
       final Finder trailingTextFinder = find.byWidget(trailingText).first;
       final Finder titleTextFinder = find.byWidget(titleText).first;
 
-      final Offset initialTrailingTextToLargeTitleOffset =
-          tester.getTopLeft(trailingTextFinder) -
-              tester.getTopLeft(titleTextFinder);
+      final Offset initialTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
 
       // Drag for overscroll
       await tester.drag(find.byType(Scrollable), const Offset(0.0, 150.0));
       await tester.pump();
 
-      final Offset stretchedTrailingTextToLargeTitleOffset =
-          tester.getTopLeft(trailingTextFinder) -
-              tester.getTopLeft(titleTextFinder);
+      final Offset stretchedTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
 
       expect(
         stretchedTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1355,9 +1248,7 @@ void main() {
       // Ensure overscroll retracts to original size after releasing gesture
       await tester.pumpAndSettle();
 
-      final Offset finalTrailingTextToLargeTitleOffset =
-          tester.getTopLeft(trailingTextFinder) -
-              tester.getTopLeft(titleTextFinder);
+      final Offset finalTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
 
       expect(
         finalTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1395,17 +1286,13 @@ void main() {
       final Finder trailingTextFinder = find.byWidget(trailingText).first;
       final Finder titleTextFinder = find.byWidget(titleText).first;
 
-      final Offset initialTrailingTextToLargeTitleOffset =
-          tester.getTopLeft(trailingTextFinder) -
-              tester.getTopLeft(titleTextFinder);
+      final Offset initialTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
 
       // Drag for overscroll
       await tester.drag(find.byType(Scrollable), const Offset(0.0, 150.0));
       await tester.pump();
 
-      final Offset stretchedTrailingTextToLargeTitleOffset =
-          tester.getTopLeft(trailingTextFinder) -
-              tester.getTopLeft(titleTextFinder);
+      final Offset stretchedTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
 
       expect(
         stretchedTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1415,9 +1302,7 @@ void main() {
       // Ensure overscroll is zero after releasing gesture
       await tester.pumpAndSettle();
 
-      final Offset finalTrailingTextToLargeTitleOffset =
-          tester.getTopLeft(trailingTextFinder) -
-              tester.getTopLeft(titleTextFinder);
+      final Offset finalTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
 
       expect(
         finalTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1426,8 +1311,7 @@ void main() {
     },
   );
 
-  testWidgets('Null NavigationBar border transition',
-      (WidgetTester tester) async {
+  testWidgets('Null NavigationBar border transition', (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/71389
     await tester.pumpWidget(
       const CupertinoApp(
@@ -1460,8 +1344,7 @@ void main() {
     expect(find.text('Page 1'), findsNothing);
     expect(find.text('Page 2'), findsOneWidget);
 
-    await tester
-        .tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     expect(find.text('Page 1'), findsOneWidget);

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -17,7 +17,8 @@ import '../widgets/semantics_tester.dart';
 int count = 0;
 
 void main() {
-  testWidgets('Middle still in center with asymmetrical actions', (WidgetTester tester) async {
+  testWidgets('Middle still in center with asymmetrical actions',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -34,7 +35,8 @@ void main() {
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
   });
 
-  testWidgets('Middle still in center with back button', (WidgetTester tester) async {
+  testWidgets('Middle still in center with back button',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -43,7 +45,9 @@ void main() {
       ),
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
       builder: (BuildContext context) {
         return const CupertinoNavigationBar(
           middle: Text('Page 2'),
@@ -58,8 +62,11 @@ void main() {
     expect(tester.getCenter(find.text('Page 2')).dx, 400.0);
   });
 
-  testWidgets('Opaque background does not add blur effects, non-opaque background adds blur effects', (WidgetTester tester) async {
-    const CupertinoDynamicColor background = CupertinoDynamicColor.withBrightness(
+  testWidgets(
+      'Opaque background does not add blur effects, non-opaque background adds blur effects',
+      (WidgetTester tester) async {
+    const CupertinoDynamicColor background =
+        CupertinoDynamicColor.withBrightness(
       color: Color(0xFFE5E5E5),
       darkColor: Color(0xF3E5E5E5),
     );
@@ -74,7 +81,8 @@ void main() {
       ),
     );
     expect(find.byType(BackdropFilter), findsNothing);
-    expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.color));
+    expect(find.byType(CupertinoNavigationBar),
+        paints..rect(color: background.color));
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -86,10 +94,12 @@ void main() {
       ),
     );
     expect(find.byType(BackdropFilter), findsOneWidget);
-    expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.darkColor));
+    expect(find.byType(CupertinoNavigationBar),
+        paints..rect(color: background.darkColor));
   });
 
-  testWidgets('Non-opaque background adds blur effects', (WidgetTester tester) async {
+  testWidgets('Non-opaque background adds blur effects',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -137,7 +147,8 @@ void main() {
         home: Align(
           alignment: Alignment.topCenter,
           child: CupertinoNavigationBar(
-            leading: const CupertinoButton(onPressed: null, child: Text('Cheetah')),
+            leading:
+                const CupertinoButton(onPressed: null, child: Text('Cheetah')),
             // Let the box take all the vertical space to test vertical padding but let
             // the nav bar position it horizontally.
             middle: Align(
@@ -145,7 +156,8 @@ void main() {
               widthFactor: 1.0,
               child: const Text('Title'),
             ),
-            trailing: const CupertinoButton(onPressed: null, child: Text('Puma')),
+            trailing:
+                const CupertinoButton(onPressed: null, child: Text('Puma')),
             padding: const EdgeInsetsDirectional.only(
               start: 10.0,
               end: 20.0,
@@ -165,8 +177,11 @@ void main() {
       44.0 - 4.0,
     );
 
-    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Cheetah')).dx, 10.0);
-    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Puma')).dx, 800.0 - 20.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Cheetah')).dx,
+        10.0);
+    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Puma')).dx,
+        800.0 - 20.0);
 
     // Title is still exactly centered.
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
@@ -263,8 +278,11 @@ void main() {
       ),
     );
 
-    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Cheetah')).dx, 800.0 - 10.0);
-    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Puma')).dx, 20.0);
+    expect(
+        tester.getTopRight(find.widgetWithText(CupertinoButton, 'Cheetah')).dx,
+        800.0 - 10.0);
+    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Puma')).dx,
+        20.0);
 
     // Title is still exactly centered.
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
@@ -276,13 +294,16 @@ void main() {
       CupertinoApp(
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.color, index: 0x000001),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.color, index: 0x000001),
           ),
-          middle: const _ExpectStyles(color: CupertinoColors.black, index: 0x000100),
+          middle: const _ExpectStyles(
+              color: CupertinoColors.black, index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.color, index: 0x010000),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.color, index: 0x010000),
           ),
         ),
       ),
@@ -297,13 +318,16 @@ void main() {
         theme: const CupertinoThemeData(brightness: Brightness.dark),
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.darkColor, index: 0x000001),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.darkColor, index: 0x000001),
           ),
-          middle: const _ExpectStyles(color: CupertinoColors.white, index: 0x000100),
+          middle: const _ExpectStyles(
+              color: CupertinoColors.white, index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.darkColor, index: 0x010000),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.darkColor, index: 0x010000),
           ),
         ),
       ),
@@ -311,20 +335,24 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('Theme active color can be overridden', (WidgetTester tester) async {
+  testWidgets('Theme active color can be overridden',
+      (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(
         theme: const CupertinoThemeData(primaryColor: Color(0xFF001122)),
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () { },
-            child: const _ExpectStyles(color: Color(0xFF001122), index: 0x000001),
+            onPressed: () {},
+            child:
+                const _ExpectStyles(color: Color(0xFF001122), index: 0x000001),
           ),
-          middle: const _ExpectStyles(color: Color(0xFF000000), index: 0x000100),
+          middle:
+              const _ExpectStyles(color: Color(0xFF000000), index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () { },
-            child: const _ExpectStyles(color: Color(0xFF001122), index: 0x010000),
+            onPressed: () {},
+            child:
+                const _ExpectStyles(color: Color(0xFF001122), index: 0x010000),
           ),
         ),
       ),
@@ -347,7 +375,8 @@ void main() {
     expect(find.byType(SliverPersistentHeader), findsNothing);
   });
 
-  testWidgets('Media padding is applied to CupertinoSliverNavigationBar', (WidgetTester tester) async {
+  testWidgets('Media padding is applied to CupertinoSliverNavigationBar',
+      (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     final Key leadingKey = GlobalKey();
     final Key middleKey = GlobalKey();
@@ -387,12 +416,15 @@ void main() {
     );
 
     // Media padding applied to leading (T,L), middle (T), trailing (T, R).
-    expect(tester.getTopLeft(find.byKey(leadingKey)), const Offset(16.0 + 20.0, 10.0));
+    expect(tester.getTopLeft(find.byKey(leadingKey)),
+        const Offset(16.0 + 20.0, 10.0));
     expect(tester.getRect(find.byKey(middleKey)).top, 10.0);
-    expect(tester.getTopRight(find.byKey(trailingKey)), const Offset(800.0 - 16.0 - 40.0, 10.0));
+    expect(tester.getTopRight(find.byKey(trailingKey)),
+        const Offset(800.0 - 16.0 - 40.0, 10.0));
 
     // Top and left padding is applied to large title.
-    expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(16.0 + 20.0, 54.0 + 10.0));
+    expect(tester.getTopLeft(find.byKey(titleKey)),
+        const Offset(16.0 + 20.0, 54.0 + 10.0));
   });
 
   testWidgets('Large title nav bar scrolls', (WidgetTester tester) async {
@@ -423,45 +455,49 @@ void main() {
 
     expect(find.text('Title'), findsNWidgets(2)); // Though only one is visible.
 
-    List<Element> titles = tester.elementList(find.text('Title'))
-        .toList()
-        ..sort((Element a, Element b) {
-          final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
-          final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
-          return aParagraph.text.style!.fontSize!.compareTo(bParagraph.text.style!.fontSize!);
-        });
+    List<Element> titles = tester.elementList(find.text('Title')).toList()
+      ..sort((Element a, Element b) {
+        final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
+        final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
+        return aParagraph.text.style!.fontSize!
+            .compareTo(bParagraph.text.style!.fontSize!);
+      });
 
     Iterable<double> opacities = titles.map<double>((Element element) {
-      final RenderAnimatedOpacity renderOpacity = element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+      final RenderAnimatedOpacity renderOpacity =
+          element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
       return renderOpacity.opacity.value;
     });
 
-    expect(opacities, <double> [
+    expect(opacities, <double>[
       0.0, // Initially the smaller font title is invisible.
       1.0, // The larger font title is visible.
     ]);
 
-    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
-    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(
+        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    titles = tester.elementList(find.text('Title'))
-        .toList()
-        ..sort((Element a, Element b) {
-          final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
-          final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
-          return aParagraph.text.style!.fontSize!.compareTo(bParagraph.text.style!.fontSize!);
-        });
+    titles = tester.elementList(find.text('Title')).toList()
+      ..sort((Element a, Element b) {
+        final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
+        final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
+        return aParagraph.text.style!.fontSize!
+            .compareTo(bParagraph.text.style!.fontSize!);
+      });
 
     opacities = titles.map<double>((Element element) {
-      final RenderAnimatedOpacity renderOpacity = element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+      final RenderAnimatedOpacity renderOpacity =
+          element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
       return renderOpacity.opacity.value;
     });
 
-    expect(opacities, <double> [
+    expect(opacities, <double>[
       1.0, // Smaller font title now visible
       0.0, // Larger font title invisible.
     ]);
@@ -470,12 +506,16 @@ void main() {
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
 
-    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
     // The OverflowBox is squished with the text in it.
-    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
+    expect(
+        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
   });
 
-  testWidgets('User specified middle is only visible in sliver if navigation bar is collapsed', (WidgetTester tester) async {
+  testWidgets(
+      'User specified middle is only visible in sliver if navigation bar is collapsed',
+      (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       CupertinoApp(
@@ -504,12 +544,18 @@ void main() {
     expect(find.text('Title'), findsOneWidget);
     // The middle is invisible without scrolling.
     expect(
-      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Middle')).opacity.value,
+      tester
+          .renderObject<RenderAnimatedOpacity>(
+              find.widgetWithText(AnimatedOpacity, 'Middle'))
+          .opacity
+          .value,
       0.0,
     );
 
-    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
-    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(
+        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
@@ -518,7 +564,11 @@ void main() {
     expect(tester.getCenter(find.text('Middle')).dx, 400.0);
     // The large title is invisible now.
     expect(
-      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Title')).opacity.value,
+      tester
+          .renderObject<RenderAnimatedOpacity>(
+              find.widgetWithText(AnimatedOpacity, 'Title'))
+          .opacity
+          .value,
       0.0,
     );
   });
@@ -553,8 +603,9 @@ void main() {
     expect(find.text('Title'), findsOneWidget);
     expect(find.text('Different title'), findsOneWidget);
 
-    RenderAnimatedOpacity largeTitleOpacity =
-        tester.element(find.text('Title')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    RenderAnimatedOpacity largeTitleOpacity = tester
+        .element(find.text('Title'))
+        .findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
     // Large title initially visible.
     expect(
       largeTitleOpacity.opacity.value,
@@ -562,18 +613,22 @@ void main() {
     );
     // Middle widget not even wrapped with RenderOpacity, i.e. is always visible.
     expect(
-      tester.element(find.text('Different title')).findAncestorRenderObjectOfType<RenderOpacity>(),
+      tester
+          .element(find.text('Different title'))
+          .findAncestorRenderObjectOfType<RenderOpacity>(),
       isNull,
     );
 
-    expect(tester.getBottomLeft(find.text('Title')).dy, 44.0 + 52.0 - 8.0); // Static part + extension - padding.
+    expect(tester.getBottomLeft(find.text('Title')).dy,
+        44.0 + 52.0 - 8.0); // Static part + extension - padding.
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    largeTitleOpacity =
-        tester.element(find.text('Title')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    largeTitleOpacity = tester
+        .element(find.text('Title'))
+        .findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
     // Large title no longer visible.
     expect(
       largeTitleOpacity.opacity.value,
@@ -584,7 +639,8 @@ void main() {
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
 
-    expect(tester.getBottomLeft(find.text('Title')).dy, 44.0 - 8.0); // Extension gone, (static part - padding) left.
+    expect(tester.getBottomLeft(find.text('Title')).dy,
+        44.0 - 8.0); // Extension gone, (static part - padding) left.
   });
 
   testWidgets('Auto back/close button', (WidgetTester tester) async {
@@ -598,7 +654,9 @@ void main() {
 
     expect(find.byType(CupertinoButton), findsNothing);
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
       builder: (BuildContext context) {
         return const CupertinoNavigationBar(
           middle: Text('Page 2'),
@@ -610,16 +668,19 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.byType(CupertinoButton), findsOneWidget);
-    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
+    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)),
+        findsOneWidget);
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
-      fullscreenDialog: true,
-      builder: (BuildContext context) {
-        return const CupertinoNavigationBar(
-          middle: Text('Dialog page'),
-        );
-      },
-    ));
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
+          fullscreenDialog: true,
+          builder: (BuildContext context) {
+            return const CupertinoNavigationBar(
+              middle: Text('Dialog page'),
+            );
+          },
+        ));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -634,7 +695,8 @@ void main() {
 
     expect(find.text('Page 2'), findsOneWidget);
 
-    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester
+        .tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -665,7 +727,8 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
+    expect(
+        find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
 
     tester.state<NavigatorState>(find.byType(Navigator)).push(
       CupertinoPageRoute<void>(
@@ -685,7 +748,8 @@ void main() {
     expect(find.widgetWithText(CupertinoButton, 'Back'), findsOneWidget);
   });
 
-  testWidgets('Border should be displayed by default', (WidgetTester tester) async {
+  testWidgets('Border should be displayed by default',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -694,10 +758,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -722,10 +788,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -736,7 +804,8 @@ void main() {
     expect(side.color, const Color(0xFFAABBCC));
   });
 
-  testWidgets('Border should not be displayed when null', (WidgetTester tester) async {
+  testWidgets('Border should not be displayed when null',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -746,17 +815,20 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
     expect(decoration.border, isNull);
   });
 
-  testWidgets('Border is displayed by default in sliver nav bar', (WidgetTester tester) async {
+  testWidgets('Border is displayed by default in sliver nav bar',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -771,10 +843,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoSliverNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoSliverNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -784,7 +858,8 @@ void main() {
     expect(bottom, isNotNull);
   });
 
-  testWidgets('Border is not displayed when null in sliver nav bar', (WidgetTester tester) async {
+  testWidgets('Border is not displayed when null in sliver nav bar',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -800,17 +875,20 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoSliverNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoSliverNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
     expect(decoration.border, isNull);
   });
 
-  testWidgets('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
+  testWidgets('CupertinoSliverNavigationBar has semantics',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(const CupertinoApp(
@@ -826,16 +904,19 @@ void main() {
       ),
     ));
 
-    expect(semantics.nodesWith(
-      label: 'Large Title',
-      flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-      textDirection: TextDirection.ltr,
-    ), hasLength(1));
+    expect(
+        semantics.nodesWith(
+          label: 'Large Title',
+          flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+          textDirection: TextDirection.ltr,
+        ),
+        hasLength(1));
 
     semantics.dispose();
   });
 
-  testWidgets('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBar has semantics',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(CupertinoApp(
@@ -847,16 +928,19 @@ void main() {
       ),
     ));
 
-    expect(semantics.nodesWith(
-      label: 'Fixed Title',
-      flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-      textDirection: TextDirection.ltr,
-    ), hasLength(1));
+    expect(
+        semantics.nodesWith(
+          label: 'Fixed Title',
+          flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+          textDirection: TextDirection.ltr,
+        ),
+        hasLength(1));
 
     semantics.dispose();
   });
 
-  testWidgets('Border can be overridden in sliver nav bar', (WidgetTester tester) async {
+  testWidgets('Border can be overridden in sliver nav bar',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -877,10 +961,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoSliverNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoSliverNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -948,7 +1034,8 @@ void main() {
     },
   );
 
-  testWidgets('NavBar draws a light system bar for a dark background', (WidgetTester tester) async {
+  testWidgets('NavBar draws a light system bar for a dark background',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -968,7 +1055,8 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.light);
   });
 
-  testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
+  testWidgets('NavBar draws a dark system bar for a light background',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -988,15 +1076,22 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
+  testWidgets(
+      'CupertinoNavigationBarBackButton shows an error when manually added outside a route',
+      (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoNavigationBarBackButton());
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+    expect(
+        exception.toString(),
+        contains(
+            'CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
+  testWidgets(
+      'CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBarBackButton(),
@@ -1005,10 +1100,15 @@ void main() {
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+    expect(
+        exception.toString(),
+        contains(
+            'CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets('CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere', (WidgetTester tester) async {
+  testWidgets(
+      'CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere',
+      (WidgetTester tester) async {
     bool backPressed = false;
 
     await tester.pumpWidget(
@@ -1020,7 +1120,8 @@ void main() {
     );
 
     expect(tester.takeException(), isNull);
-    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
+    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)),
+        findsOneWidget);
 
     await tester.tap(find.byType(CupertinoNavigationBarBackButton));
 
@@ -1029,7 +1130,7 @@ void main() {
 
   testWidgets(
     'Manually inserted CupertinoNavigationBarBackButton still automatically '
-        'show previous page title when possible',
+    'show previous page title when possible',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         const CupertinoApp(
@@ -1038,28 +1139,28 @@ void main() {
       );
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'An iPod',
-          builder: (BuildContext context) {
-            return const CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(),
-              child: Placeholder(),
-            );
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'A Phone',
-          builder: (BuildContext context) {
-            return const CupertinoNavigationBarBackButton();
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBarBackButton();
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -1079,35 +1180,35 @@ void main() {
       );
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'An iPod',
-          builder: (BuildContext context) {
-            return const CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(),
-              child: Placeholder(),
-            );
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'A Phone',
-          builder: (BuildContext context) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                leading: CupertinoNavigationBarBackButton(
-                  onPressed: () => backPressed = true,
-                ),
-              ),
-              child: const Placeholder(),
-            );
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(
+                    leading: CupertinoNavigationBarBackButton(
+                      onPressed: () => backPressed = true,
+                    ),
+                  ),
+                  child: const Placeholder(),
+                );
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -1170,23 +1271,25 @@ void main() {
     expect(contents.any((RichText t) => t.textScaleFactor != 99), isFalse);
 
     // Also works with implicitly added widgets.
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
-      title: 'title',
-      builder: (BuildContext context) {
-        return MediaQuery(
-          data: MediaQuery.of(context).copyWith(textScaleFactor: 99),
-          child: const CupertinoPageScaffold(
-            child: CustomScrollView(
-              slivers: <Widget>[
-                CupertinoSliverNavigationBar(
-                  previousPageTitle: 'previous title',
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
+          title: 'title',
+          builder: (BuildContext context) {
+            return MediaQuery(
+              data: MediaQuery.of(context).copyWith(textScaleFactor: 99),
+              child: const CupertinoPageScaffold(
+                child: CustomScrollView(
+                  slivers: <Widget>[
+                    CupertinoSliverNavigationBar(
+                      previousPageTitle: 'previous title',
+                    ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-        );
-      },
-    ));
+              ),
+            );
+          },
+        ));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -1232,13 +1335,17 @@ void main() {
       final Finder trailingTextFinder = find.byWidget(trailingText).first;
       final Finder titleTextFinder = find.byWidget(titleText).first;
 
-      final Offset initialTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset initialTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       // Drag for overscroll
       await tester.drag(find.byType(Scrollable), const Offset(0.0, 150.0));
       await tester.pump();
 
-      final Offset stretchedTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset stretchedTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         stretchedTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1248,7 +1355,9 @@ void main() {
       // Ensure overscroll retracts to original size after releasing gesture
       await tester.pumpAndSettle();
 
-      final Offset finalTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset finalTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         finalTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1286,13 +1395,17 @@ void main() {
       final Finder trailingTextFinder = find.byWidget(trailingText).first;
       final Finder titleTextFinder = find.byWidget(titleText).first;
 
-      final Offset initialTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset initialTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       // Drag for overscroll
       await tester.drag(find.byType(Scrollable), const Offset(0.0, 150.0));
       await tester.pump();
 
-      final Offset stretchedTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset stretchedTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         stretchedTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1302,7 +1415,9 @@ void main() {
       // Ensure overscroll is zero after releasing gesture
       await tester.pumpAndSettle();
 
-      final Offset finalTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset finalTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         finalTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1311,7 +1426,8 @@ void main() {
     },
   );
 
-  testWidgets('Null NavigationBar border transition', (WidgetTester tester) async {
+  testWidgets('Null NavigationBar border transition',
+      (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/71389
     await tester.pumpWidget(
       const CupertinoApp(
@@ -1344,7 +1460,8 @@ void main() {
     expect(find.text('Page 1'), findsNothing);
     expect(find.text('Page 2'), findsOneWidget);
 
-    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester
+        .tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     expect(find.text('Page 1'), findsOneWidget);

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -17,7 +17,8 @@ import '../widgets/semantics_tester.dart';
 int count = 0;
 
 void main() {
-  testWidgets('Middle still in center with asymmetrical actions', (WidgetTester tester) async {
+  testWidgets('Middle still in center with asymmetrical actions',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -34,7 +35,8 @@ void main() {
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
   });
 
-  testWidgets('Middle still in center with back button', (WidgetTester tester) async {
+  testWidgets('Middle still in center with back button',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -43,7 +45,9 @@ void main() {
       ),
     );
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
       builder: (BuildContext context) {
         return const CupertinoNavigationBar(
           middle: Text('Page 2'),
@@ -58,8 +62,11 @@ void main() {
     expect(tester.getCenter(find.text('Page 2')).dx, 400.0);
   });
 
-  testWidgets('Opaque background does not add blur effects, non-opaque background adds blur effects', (WidgetTester tester) async {
-    const CupertinoDynamicColor background = CupertinoDynamicColor.withBrightness(
+  testWidgets(
+      'Opaque background does not add blur effects, non-opaque background adds blur effects',
+      (WidgetTester tester) async {
+    const CupertinoDynamicColor background =
+        CupertinoDynamicColor.withBrightness(
       color: Color(0xFFE5E5E5),
       darkColor: Color(0xF3E5E5E5),
     );
@@ -74,7 +81,8 @@ void main() {
       ),
     );
     expect(find.byType(BackdropFilter), findsNothing);
-    expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.color));
+    expect(find.byType(CupertinoNavigationBar),
+        paints..rect(color: background.color));
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -86,10 +94,12 @@ void main() {
       ),
     );
     expect(find.byType(BackdropFilter), findsOneWidget);
-    expect(find.byType(CupertinoNavigationBar), paints..rect(color: background.darkColor));
+    expect(find.byType(CupertinoNavigationBar),
+        paints..rect(color: background.darkColor));
   });
 
-  testWidgets('Non-opaque background adds blur effects', (WidgetTester tester) async {
+  testWidgets('Non-opaque background adds blur effects',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -137,7 +147,8 @@ void main() {
         home: Align(
           alignment: Alignment.topCenter,
           child: CupertinoNavigationBar(
-            leading: const CupertinoButton(onPressed: null, child: Text('Cheetah')),
+            leading:
+                const CupertinoButton(onPressed: null, child: Text('Cheetah')),
             // Let the box take all the vertical space to test vertical padding but let
             // the nav bar position it horizontally.
             middle: Align(
@@ -145,7 +156,8 @@ void main() {
               widthFactor: 1.0,
               child: const Text('Title'),
             ),
-            trailing: const CupertinoButton(onPressed: null, child: Text('Puma')),
+            trailing:
+                const CupertinoButton(onPressed: null, child: Text('Puma')),
             padding: const EdgeInsetsDirectional.only(
               start: 10.0,
               end: 20.0,
@@ -165,8 +177,11 @@ void main() {
       44.0 - 4.0,
     );
 
-    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Cheetah')).dx, 10.0);
-    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Puma')).dx, 800.0 - 20.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Cheetah')).dx,
+        10.0);
+    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Puma')).dx,
+        800.0 - 20.0);
 
     // Title is still exactly centered.
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
@@ -263,8 +278,11 @@ void main() {
       ),
     );
 
-    expect(tester.getTopRight(find.widgetWithText(CupertinoButton, 'Cheetah')).dx, 800.0 - 10.0);
-    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Puma')).dx, 20.0);
+    expect(
+        tester.getTopRight(find.widgetWithText(CupertinoButton, 'Cheetah')).dx,
+        800.0 - 10.0);
+    expect(tester.getTopLeft(find.widgetWithText(CupertinoButton, 'Puma')).dx,
+        20.0);
 
     // Title is still exactly centered.
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
@@ -276,13 +294,16 @@ void main() {
       CupertinoApp(
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.color, index: 0x000001),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.color, index: 0x000001),
           ),
-          middle: const _ExpectStyles(color: CupertinoColors.black, index: 0x000100),
+          middle: const _ExpectStyles(
+              color: CupertinoColors.black, index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.color, index: 0x010000),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.color, index: 0x010000),
           ),
         ),
       ),
@@ -297,13 +318,16 @@ void main() {
         theme: const CupertinoThemeData(brightness: Brightness.dark),
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.darkColor, index: 0x000001),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.darkColor, index: 0x000001),
           ),
-          middle: const _ExpectStyles(color: CupertinoColors.white, index: 0x000100),
+          middle: const _ExpectStyles(
+              color: CupertinoColors.white, index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () { },
-            child: _ExpectStyles(color: CupertinoColors.systemBlue.darkColor, index: 0x010000),
+            onPressed: () {},
+            child: _ExpectStyles(
+                color: CupertinoColors.systemBlue.darkColor, index: 0x010000),
           ),
         ),
       ),
@@ -311,20 +335,24 @@ void main() {
     expect(count, 0x010101);
   });
 
-  testWidgets('Theme active color can be overridden', (WidgetTester tester) async {
+  testWidgets('Theme active color can be overridden',
+      (WidgetTester tester) async {
     count = 0x000000;
     await tester.pumpWidget(
       CupertinoApp(
         theme: const CupertinoThemeData(primaryColor: Color(0xFF001122)),
         home: CupertinoNavigationBar(
           leading: CupertinoButton(
-            onPressed: () { },
-            child: const _ExpectStyles(color: Color(0xFF001122), index: 0x000001),
+            onPressed: () {},
+            child:
+                const _ExpectStyles(color: Color(0xFF001122), index: 0x000001),
           ),
-          middle: const _ExpectStyles(color: Color(0xFF000000), index: 0x000100),
+          middle:
+              const _ExpectStyles(color: Color(0xFF000000), index: 0x000100),
           trailing: CupertinoButton(
-            onPressed: () { },
-            child: const _ExpectStyles(color: Color(0xFF001122), index: 0x010000),
+            onPressed: () {},
+            child:
+                const _ExpectStyles(color: Color(0xFF001122), index: 0x010000),
           ),
         ),
       ),
@@ -347,7 +375,8 @@ void main() {
     expect(find.byType(SliverPersistentHeader), findsNothing);
   });
 
-  testWidgets('Media padding is applied to CupertinoSliverNavigationBar', (WidgetTester tester) async {
+  testWidgets('Media padding is applied to CupertinoSliverNavigationBar',
+      (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     final Key leadingKey = GlobalKey();
     final Key middleKey = GlobalKey();
@@ -387,12 +416,15 @@ void main() {
     );
 
     // Media padding applied to leading (T,L), middle (T), trailing (T, R).
-    expect(tester.getTopLeft(find.byKey(leadingKey)), const Offset(16.0 + 20.0, 10.0));
+    expect(tester.getTopLeft(find.byKey(leadingKey)),
+        const Offset(16.0 + 20.0, 10.0));
     expect(tester.getRect(find.byKey(middleKey)).top, 10.0);
-    expect(tester.getTopRight(find.byKey(trailingKey)), const Offset(800.0 - 16.0 - 40.0, 10.0));
+    expect(tester.getTopRight(find.byKey(trailingKey)),
+        const Offset(800.0 - 16.0 - 40.0, 10.0));
 
     // Top and left padding is applied to large title.
-    expect(tester.getTopLeft(find.byKey(titleKey)), const Offset(16.0 + 20.0, 54.0 + 10.0));
+    expect(tester.getTopLeft(find.byKey(titleKey)),
+        const Offset(16.0 + 20.0, 54.0 + 10.0));
   });
 
   testWidgets('Large title nav bar scrolls', (WidgetTester tester) async {
@@ -423,45 +455,49 @@ void main() {
 
     expect(find.text('Title'), findsNWidgets(2)); // Though only one is visible.
 
-    List<Element> titles = tester.elementList(find.text('Title'))
-        .toList()
-        ..sort((Element a, Element b) {
-          final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
-          final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
-          return aParagraph.text.style!.fontSize!.compareTo(bParagraph.text.style!.fontSize!);
-        });
+    List<Element> titles = tester.elementList(find.text('Title')).toList()
+      ..sort((Element a, Element b) {
+        final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
+        final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
+        return aParagraph.text.style!.fontSize!
+            .compareTo(bParagraph.text.style!.fontSize!);
+      });
 
     Iterable<double> opacities = titles.map<double>((Element element) {
-      final RenderAnimatedOpacity renderOpacity = element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+      final RenderAnimatedOpacity renderOpacity =
+          element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
       return renderOpacity.opacity.value;
     });
 
-    expect(opacities, <double> [
+    expect(opacities, <double>[
       0.0, // Initially the smaller font title is invisible.
       1.0, // The larger font title is visible.
     ]);
 
-    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
-    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(
+        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    titles = tester.elementList(find.text('Title'))
-        .toList()
-        ..sort((Element a, Element b) {
-          final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
-          final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
-          return aParagraph.text.style!.fontSize!.compareTo(bParagraph.text.style!.fontSize!);
-        });
+    titles = tester.elementList(find.text('Title')).toList()
+      ..sort((Element a, Element b) {
+        final RenderParagraph aParagraph = a.renderObject! as RenderParagraph;
+        final RenderParagraph bParagraph = b.renderObject! as RenderParagraph;
+        return aParagraph.text.style!.fontSize!
+            .compareTo(bParagraph.text.style!.fontSize!);
+      });
 
     opacities = titles.map<double>((Element element) {
-      final RenderAnimatedOpacity renderOpacity = element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+      final RenderAnimatedOpacity renderOpacity =
+          element.findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
       return renderOpacity.opacity.value;
     });
 
-    expect(opacities, <double> [
+    expect(opacities, <double>[
       1.0, // Smaller font title now visible
       0.0, // Larger font title invisible.
     ]);
@@ -470,12 +506,15 @@ void main() {
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
 
-    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
     // The OverflowBox is squished with the text in it.
-    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
+    expect(
+        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
   });
 
-  testWidgets('User specified middle is only visible in sliver if navigation bar is collapsed', (WidgetTester tester) async {
+  testWidgets('User specified middle is only visible in sliver on scroll',
+      (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       CupertinoApp(
@@ -504,12 +543,18 @@ void main() {
     expect(find.text('Title'), findsOneWidget);
     // The middle is invisible without scrolling.
     expect(
-      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Middle')).opacity.value,
+      tester
+          .renderObject<RenderAnimatedOpacity>(
+              find.widgetWithText(AnimatedOpacity, 'Middle'))
+          .opacity
+          .value,
       0.0,
     );
 
-    expect(tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
-    expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
+    expect(
+        tester.getTopLeft(find.widgetWithText(OverflowBox, 'Title')).dy, 44.0);
+    expect(
+        tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 52.0);
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
@@ -518,7 +563,11 @@ void main() {
     expect(tester.getCenter(find.text('Middle')).dx, 400.0);
     // The large title is invisible now.
     expect(
-      tester.renderObject<RenderAnimatedOpacity>(find.widgetWithText(AnimatedOpacity, 'Title')).opacity.value,
+      tester
+          .renderObject<RenderAnimatedOpacity>(
+              find.widgetWithText(AnimatedOpacity, 'Title'))
+          .opacity
+          .value,
       0.0,
     );
   });
@@ -553,8 +602,9 @@ void main() {
     expect(find.text('Title'), findsOneWidget);
     expect(find.text('Different title'), findsOneWidget);
 
-    RenderAnimatedOpacity largeTitleOpacity =
-        tester.element(find.text('Title')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    RenderAnimatedOpacity largeTitleOpacity = tester
+        .element(find.text('Title'))
+        .findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
     // Large title initially visible.
     expect(
       largeTitleOpacity.opacity.value,
@@ -562,18 +612,22 @@ void main() {
     );
     // Middle widget not even wrapped with RenderOpacity, i.e. is always visible.
     expect(
-      tester.element(find.text('Different title')).findAncestorRenderObjectOfType<RenderOpacity>(),
+      tester
+          .element(find.text('Different title'))
+          .findAncestorRenderObjectOfType<RenderOpacity>(),
       isNull,
     );
 
-    expect(tester.getBottomLeft(find.text('Title')).dy, 44.0 + 52.0 - 8.0); // Static part + extension - padding.
+    expect(tester.getBottomLeft(find.text('Title')).dy,
+        44.0 + 52.0 - 8.0); // Static part + extension - padding.
 
     scrollController.jumpTo(600.0);
     await tester.pump(); // Once to trigger the opacity animation.
     await tester.pump(const Duration(milliseconds: 300));
 
-    largeTitleOpacity =
-        tester.element(find.text('Title')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    largeTitleOpacity = tester
+        .element(find.text('Title'))
+        .findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
     // Large title no longer visible.
     expect(
       largeTitleOpacity.opacity.value,
@@ -584,7 +638,8 @@ void main() {
     expect(tester.getTopLeft(find.byType(NavigationToolbar)).dy, 0.0);
     expect(tester.getSize(find.byType(NavigationToolbar)).height, 44.0);
 
-    expect(tester.getBottomLeft(find.text('Title')).dy, 44.0 - 8.0); // Extension gone, (static part - padding) left.
+    expect(tester.getBottomLeft(find.text('Title')).dy,
+        44.0 - 8.0); // Extension gone, (static part - padding) left.
   });
 
   testWidgets('Auto back/close button', (WidgetTester tester) async {
@@ -598,7 +653,9 @@ void main() {
 
     expect(find.byType(CupertinoButton), findsNothing);
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
       builder: (BuildContext context) {
         return const CupertinoNavigationBar(
           middle: Text('Page 2'),
@@ -610,16 +667,19 @@ void main() {
     await tester.pump(const Duration(milliseconds: 500));
 
     expect(find.byType(CupertinoButton), findsOneWidget);
-    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
+    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)),
+        findsOneWidget);
 
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
-      fullscreenDialog: true,
-      builder: (BuildContext context) {
-        return const CupertinoNavigationBar(
-          middle: Text('Dialog page'),
-        );
-      },
-    ));
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
+          fullscreenDialog: true,
+          builder: (BuildContext context) {
+            return const CupertinoNavigationBar(
+              middle: Text('Dialog page'),
+            );
+          },
+        ));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -634,7 +694,8 @@ void main() {
 
     expect(find.text('Page 2'), findsOneWidget);
 
-    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester
+        .tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -665,7 +726,8 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
 
-    expect(find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
+    expect(
+        find.widgetWithText(CupertinoButton, '012345678901'), findsOneWidget);
 
     tester.state<NavigatorState>(find.byType(Navigator)).push(
       CupertinoPageRoute<void>(
@@ -685,7 +747,8 @@ void main() {
     expect(find.widgetWithText(CupertinoButton, 'Back'), findsOneWidget);
   });
 
-  testWidgets('Border should be displayed by default', (WidgetTester tester) async {
+  testWidgets('Border should be displayed by default',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -694,10 +757,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -722,10 +787,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -736,7 +803,8 @@ void main() {
     expect(side.color, const Color(0xFFAABBCC));
   });
 
-  testWidgets('Border should not be displayed when null', (WidgetTester tester) async {
+  testWidgets('Border should not be displayed when null',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(
@@ -746,17 +814,20 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
     expect(decoration.border, isNull);
   });
 
-  testWidgets('Border is displayed by default in sliver nav bar', (WidgetTester tester) async {
+  testWidgets('Border is displayed by default in sliver nav bar',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -771,10 +842,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoSliverNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoSliverNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -784,7 +857,8 @@ void main() {
     expect(bottom, isNotNull);
   });
 
-  testWidgets('Border is not displayed when null in sliver nav bar', (WidgetTester tester) async {
+  testWidgets('Border is not displayed when null in sliver nav bar',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -800,17 +874,20 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoSliverNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoSliverNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
     expect(decoration.border, isNull);
   });
 
-  testWidgets('CupertinoSliverNavigationBar has semantics', (WidgetTester tester) async {
+  testWidgets('CupertinoSliverNavigationBar has semantics',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(const CupertinoApp(
@@ -826,16 +903,19 @@ void main() {
       ),
     ));
 
-    expect(semantics.nodesWith(
-      label: 'Large Title',
-      flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-      textDirection: TextDirection.ltr,
-    ), hasLength(1));
+    expect(
+        semantics.nodesWith(
+          label: 'Large Title',
+          flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+          textDirection: TextDirection.ltr,
+        ),
+        hasLength(1));
 
     semantics.dispose();
   });
 
-  testWidgets('CupertinoNavigationBar has semantics', (WidgetTester tester) async {
+  testWidgets('CupertinoNavigationBar has semantics',
+      (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(CupertinoApp(
@@ -847,16 +927,19 @@ void main() {
       ),
     ));
 
-    expect(semantics.nodesWith(
-      label: 'Fixed Title',
-      flags: <SemanticsFlag>[SemanticsFlag.isHeader],
-      textDirection: TextDirection.ltr,
-    ), hasLength(1));
+    expect(
+        semantics.nodesWith(
+          label: 'Fixed Title',
+          flags: <SemanticsFlag>[SemanticsFlag.isHeader],
+          textDirection: TextDirection.ltr,
+        ),
+        hasLength(1));
 
     semantics.dispose();
   });
 
-  testWidgets('Border can be overridden in sliver nav bar', (WidgetTester tester) async {
+  testWidgets('Border can be overridden in sliver nav bar',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoPageScaffold(
@@ -877,10 +960,12 @@ void main() {
       ),
     );
 
-    final DecoratedBox decoratedBox = tester.widgetList(find.descendant(
-      of: find.byType(CupertinoSliverNavigationBar),
-      matching: find.byType(DecoratedBox),
-    )).first as DecoratedBox;
+    final DecoratedBox decoratedBox = tester
+        .widgetList(find.descendant(
+          of: find.byType(CupertinoSliverNavigationBar),
+          matching: find.byType(DecoratedBox),
+        ))
+        .first as DecoratedBox;
     expect(decoratedBox.decoration.runtimeType, BoxDecoration);
 
     final BoxDecoration decoration = decoratedBox.decoration as BoxDecoration;
@@ -948,7 +1033,8 @@ void main() {
     },
   );
 
-  testWidgets('NavBar draws a light system bar for a dark background', (WidgetTester tester) async {
+  testWidgets('NavBar draws a light system bar for a dark background',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -968,7 +1054,8 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.light);
   });
 
-  testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
+  testWidgets('NavBar draws a dark system bar for a light background',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       WidgetsApp(
         color: const Color(0xFFFFFFFF),
@@ -988,15 +1075,22 @@ void main() {
     expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
   });
 
-  testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {
+  testWidgets(
+      'CupertinoNavigationBarBackButton shows an error when manually added outside a route',
+      (WidgetTester tester) async {
     await tester.pumpWidget(const CupertinoNavigationBarBackButton());
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+    expect(
+        exception.toString(),
+        contains(
+            'CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets('CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped', (WidgetTester tester) async {
+  testWidgets(
+      'CupertinoNavigationBarBackButton shows an error when placed in a route that cannot be popped',
+      (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBarBackButton(),
@@ -1005,10 +1099,15 @@ void main() {
 
     final dynamic exception = tester.takeException();
     expect(exception, isAssertionError);
-    expect(exception.toString(), contains('CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
+    expect(
+        exception.toString(),
+        contains(
+            'CupertinoNavigationBarBackButton should only be used in routes that can be popped'));
   });
 
-  testWidgets('CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere', (WidgetTester tester) async {
+  testWidgets(
+      'CupertinoNavigationBarBackButton with a custom onPressed callback can be placed anywhere',
+      (WidgetTester tester) async {
     bool backPressed = false;
 
     await tester.pumpWidget(
@@ -1020,7 +1119,8 @@ void main() {
     );
 
     expect(tester.takeException(), isNull);
-    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)), findsOneWidget);
+    expect(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)),
+        findsOneWidget);
 
     await tester.tap(find.byType(CupertinoNavigationBarBackButton));
 
@@ -1029,7 +1129,7 @@ void main() {
 
   testWidgets(
     'Manually inserted CupertinoNavigationBarBackButton still automatically '
-        'show previous page title when possible',
+    'show previous page title when possible',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         const CupertinoApp(
@@ -1038,28 +1138,28 @@ void main() {
       );
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'An iPod',
-          builder: (BuildContext context) {
-            return const CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(),
-              child: Placeholder(),
-            );
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'A Phone',
-          builder: (BuildContext context) {
-            return const CupertinoNavigationBarBackButton();
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return const CupertinoNavigationBarBackButton();
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -1079,35 +1179,35 @@ void main() {
       );
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'An iPod',
-          builder: (BuildContext context) {
-            return const CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(),
-              child: Placeholder(),
-            );
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'An iPod',
+              builder: (BuildContext context) {
+                return const CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(),
+                  child: Placeholder(),
+                );
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
-        CupertinoPageRoute<void>(
-          title: 'A Phone',
-          builder: (BuildContext context) {
-            return CupertinoPageScaffold(
-              navigationBar: CupertinoNavigationBar(
-                leading: CupertinoNavigationBarBackButton(
-                  onPressed: () => backPressed = true,
-                ),
-              ),
-              child: const Placeholder(),
-            );
-          },
-        ),
-      );
+            CupertinoPageRoute<void>(
+              title: 'A Phone',
+              builder: (BuildContext context) {
+                return CupertinoPageScaffold(
+                  navigationBar: CupertinoNavigationBar(
+                    leading: CupertinoNavigationBarBackButton(
+                      onPressed: () => backPressed = true,
+                    ),
+                  ),
+                  child: const Placeholder(),
+                );
+              },
+            ),
+          );
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 500));
@@ -1170,23 +1270,25 @@ void main() {
     expect(contents.any((RichText t) => t.textScaleFactor != 99), isFalse);
 
     // Also works with implicitly added widgets.
-    tester.state<NavigatorState>(find.byType(Navigator)).push(CupertinoPageRoute<void>(
-      title: 'title',
-      builder: (BuildContext context) {
-        return MediaQuery(
-          data: MediaQuery.of(context).copyWith(textScaleFactor: 99),
-          child: const CupertinoPageScaffold(
-            child: CustomScrollView(
-              slivers: <Widget>[
-                CupertinoSliverNavigationBar(
-                  previousPageTitle: 'previous title',
+    tester
+        .state<NavigatorState>(find.byType(Navigator))
+        .push(CupertinoPageRoute<void>(
+          title: 'title',
+          builder: (BuildContext context) {
+            return MediaQuery(
+              data: MediaQuery.of(context).copyWith(textScaleFactor: 99),
+              child: const CupertinoPageScaffold(
+                child: CustomScrollView(
+                  slivers: <Widget>[
+                    CupertinoSliverNavigationBar(
+                      previousPageTitle: 'previous title',
+                    ),
+                  ],
                 ),
-              ],
-            ),
-          ),
-        );
-      },
-    ));
+              ),
+            );
+          },
+        ));
 
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
@@ -1232,13 +1334,17 @@ void main() {
       final Finder trailingTextFinder = find.byWidget(trailingText).first;
       final Finder titleTextFinder = find.byWidget(titleText).first;
 
-      final Offset initialTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset initialTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       // Drag for overscroll
       await tester.drag(find.byType(Scrollable), const Offset(0.0, 150.0));
       await tester.pump();
 
-      final Offset stretchedTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset stretchedTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         stretchedTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1248,7 +1354,9 @@ void main() {
       // Ensure overscroll retracts to original size after releasing gesture
       await tester.pumpAndSettle();
 
-      final Offset finalTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset finalTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         finalTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1286,13 +1394,17 @@ void main() {
       final Finder trailingTextFinder = find.byWidget(trailingText).first;
       final Finder titleTextFinder = find.byWidget(titleText).first;
 
-      final Offset initialTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset initialTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       // Drag for overscroll
       await tester.drag(find.byType(Scrollable), const Offset(0.0, 150.0));
       await tester.pump();
 
-      final Offset stretchedTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset stretchedTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         stretchedTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1302,7 +1414,9 @@ void main() {
       // Ensure overscroll is zero after releasing gesture
       await tester.pumpAndSettle();
 
-      final Offset finalTrailingTextToLargeTitleOffset = tester.getTopLeft(trailingTextFinder) - tester.getTopLeft(titleTextFinder);
+      final Offset finalTrailingTextToLargeTitleOffset =
+          tester.getTopLeft(trailingTextFinder) -
+              tester.getTopLeft(titleTextFinder);
 
       expect(
         finalTrailingTextToLargeTitleOffset.dy.abs(),
@@ -1311,7 +1425,8 @@ void main() {
     },
   );
 
-  testWidgets('Null NavigationBar border transition', (WidgetTester tester) async {
+  testWidgets('Null NavigationBar border transition',
+      (WidgetTester tester) async {
     // This is a regression test for https://github.com/flutter/flutter/issues/71389
     await tester.pumpWidget(
       const CupertinoApp(
@@ -1344,7 +1459,8 @@ void main() {
     expect(find.text('Page 1'), findsNothing);
     expect(find.text('Page 2'), findsOneWidget);
 
-    await tester.tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
+    await tester
+        .tap(find.text(String.fromCharCode(CupertinoIcons.back.codePoint)));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 500));
     expect(find.text('Page 1'), findsOneWidget);

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -475,7 +475,7 @@ void main() {
     expect(tester.getSize(find.widgetWithText(OverflowBox, 'Title')).height, 0.0);
   });
 
-  testWidgets('User specified middle is only visible in sliver on scroll', (WidgetTester tester) async {
+  testWidgets('User specified middle is only visible in sliver if navigation bar is collapsed', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(
       CupertinoApp(


### PR DESCRIPTION
In reference to #86983

Credit: https://github.com/flutter/flutter/issues/53788#issuecomment-864361170
Closes https://github.com/flutter/flutter/issues/53788 if I understood it correctly. https://github.com/flutter/flutter/issues/78607 is partly closed.

After fix:

https://user-images.githubusercontent.com/1446685/158810187-7d1213ae-ac68-4c6f-a989-86a4aa9febfa.mp4

Before fix:

https://user-images.githubusercontent.com/1446685/158810218-ec1d55ac-27a4-42ca-980e-e76373eb303a.mp4