### PR TITLE
[platform_view]longer wait time for element

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -34,6 +34,7 @@ static const CGFloat kStandardTimeOut = 60.0;
   /// https://github.com/flutter/flutter/pull/90535
   BOOL newPageAppeared = [self.app.textFields[@"platform_view[0]"] waitForExistenceWithTimeout:kStandardTimeOut];
   if (!newPageAppeared) {
+    NSLog(@"First try failed. The tree is %@", self.app.debugDescription);
     [self waitForAndTapElement:self.app.buttons[@"platform view focus test"]];
   }
 

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -29,9 +29,13 @@ static const CGFloat kStandardTimeOut = 60.0;
   [self.app launch];
 }
 - (void)testPlatformViewFocus {
-  XCUIElement *entranceButton = self.app.buttons[@"platform view focus test"];
-  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);
-  [entranceButton tap];
+  [self waitForAndTapElement:self.app.buttons[@"platform view focus test"]];
+  /// Tries to wait and tap the button the second time, if the first time failed.
+  /// https://github.com/flutter/flutter/pull/90535
+  BOOL newPageAppeared = [self.app.textFields[@"platform_view[0]"] waitForExistenceWithTimeout:kStandardTimeOut];
+  if (!newPageAppeared) {
+    [self waitForAndTapElement:self.app.buttons[@"platform view focus test"]];
+  }
 
   XCUIElement *platformView = self.app.textFields[@"platform_view[0]"];
   XCTAssertTrue([platformView waitForExistenceWithTimeout:kStandardTimeOut]);
@@ -47,6 +51,13 @@ static const CGFloat kStandardTimeOut = 60.0;
   [platformView tap];
   XCTAssertTrue(platformView.flt_hasKeyboardFocus);
   XCTAssertFalse(flutterTextField.flt_hasKeyboardFocus);
+}
+
+- (void)waitForAndTapElement:(XCUIElement *)element {
+  NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
+  [self expectationForPredicate:hittable evaluatedWithObject:element handler:nil];
+  [self waitForExpectationsWithTimeout:30.0 handler:nil];
+  [element tap];
 }
 
 @end

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -29,14 +29,13 @@ static const CGFloat kStandardTimeOut = 60.0;
   [self.app launch];
 }
 - (void)testPlatformViewFocus {
-  [self waitForAndTapElement:self.app.buttons[@"platform view focus test"]];
-  /// Tries to wait and tap the button the second time, if the first time failed.
-  /// https://github.com/flutter/flutter/pull/90535
-  BOOL newPageAppeared = [self.app.textFields[@"platform_view[0]"] waitForExistenceWithTimeout:kStandardTimeOut];
-  if (!newPageAppeared) {
-    NSLog(@"First try failed. The tree is %@", self.app.debugDescription);
-    [self waitForAndTapElement:self.app.buttons[@"platform view focus test"]];
+  XCUIElement *entranceButton = self.app.buttons[@"platform view focus test"];
+  BOOL entranceButtonAppeared = [entranceButton waitForExistenceWithTimeout:kStandardTimeOut];
+  if (!entranceButtonAppeared) {
+    NSLog(@"The element tree is %@", self.app.debugDescription);
+    XCTFail(@"Entrance button should have appeared by now.");
   }
+  [entranceButton tap];
 
   XCUIElement *platformView = self.app.textFields[@"platform_view[0]"];
   XCTAssertTrue([platformView waitForExistenceWithTimeout:kStandardTimeOut]);
@@ -52,13 +51,6 @@ static const CGFloat kStandardTimeOut = 60.0;
   [platformView tap];
   XCTAssertTrue(platformView.flt_hasKeyboardFocus);
   XCTAssertFalse(flutterTextField.flt_hasKeyboardFocus);
-}
-
-- (void)waitForAndTapElement:(XCUIElement *)element {
-  NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
-  [self expectationForPredicate:hittable evaluatedWithObject:element handler:nil];
-  [self waitForExpectationsWithTimeout:30.0 handler:nil];
-  [element tap];
 }
 
 @end

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -30,11 +30,7 @@ static const CGFloat kStandardTimeOut = 60.0;
 }
 - (void)testPlatformViewFocus {
   XCUIElement *entranceButton = self.app.buttons[@"platform view focus test"];
-  BOOL entranceButtonAppeared = [entranceButton waitForExistenceWithTimeout:kStandardTimeOut];
-  if (!entranceButtonAppeared) {
-    NSLog(@"The element tree is %@", self.app.debugDescription);
-    XCTFail(@"Entrance button should have appeared by now.");
-  }
+  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut], @"The element tree is %@", self.app.debugDescription);
   [entranceButton tap];
 
   XCUIElement *platformView = self.app.textFields[@"platform_view[0]"];

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -4,6 +4,8 @@
 
 @import XCTest;
 
+static const CGFloat kStandardTimeOut = 60.0;
+
 @interface XCUIElement(KeyboardFocus)
 @property (nonatomic, readonly) BOOL flt_hasKeyboardFocus;
 @end
@@ -27,18 +29,17 @@
   [self.app launch];
 }
 - (void)testPlatformViewFocus {
-
   XCUIElement *entranceButton = self.app.buttons[@"platform view focus test"];
-  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:1]);
+  XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut]);
   [entranceButton tap];
 
   XCUIElement *platformView = self.app.textFields[@"platform_view[0]"];
-  XCTAssertTrue([platformView waitForExistenceWithTimeout:1]);
+  XCTAssertTrue([platformView waitForExistenceWithTimeout:kStandardTimeOut]);
   XCUIElement *flutterTextField = self.app.textFields[@"Flutter Text Field"];
-  XCTAssertTrue([flutterTextField waitForExistenceWithTimeout:1]);
+  XCTAssertTrue([flutterTextField waitForExistenceWithTimeout:kStandardTimeOut]);
 
   [flutterTextField tap];
-  XCTAssertTrue([self.app.windows.element waitForExistenceWithTimeout:1]);
+  XCTAssertTrue([self.app.windows.element waitForExistenceWithTimeout:kStandardTimeOut]);
   XCTAssertFalse(platformView.flt_hasKeyboardFocus);
   XCTAssertTrue(flutterTextField.flt_hasKeyboardFocus);
 


### PR DESCRIPTION
All the flakiness linked in the issue failed at `Checking existence of "platform view focus test" Button`. The other XCUITest we have uses 60 seconds instead of 1 second. So I follow this convention. 

Some recent failed test has a different failure that fails to even launching the app. 

Let's try this solution first: https://github.com/flutter/flutter/pull/90535

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/108898

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
