### PR TITLE
Move MagnifierBuilder, MagnifierOverlayInfoBearer from text_selection.dart

### DIFF
--- a/packages/flutter/lib/src/cupertino/magnifier.dart
+++ b/packages/flutter/lib/src/cupertino/magnifier.dart
@@ -20,7 +20,7 @@ import 'package:flutter/widgets.dart';
 /// - has some vertical drag resistance; i.e. if a gesture is detected k units below the field,
 ///   then has vertical offset [dragResistance] * k.
 class CupertinoTextMagnifier extends StatefulWidget {
-  /// Construct a [RawMagnifier] in the Cupertino style, positioning with respect to
+  /// Constructs a [RawMagnifier] in the Cupertino style, positioning with respect to
   /// [magnifierOverlayInfoBearer].
   ///
   /// The default constructor parameters and constants were eyeballed on

--- a/packages/flutter/lib/src/cupertino/text_field.dart
+++ b/packages/flutter/lib/src/cupertino/text_field.dart
@@ -786,11 +786,11 @@ class CupertinoTextField extends StatefulWidget {
   /// {@macro flutter.services.TextInputConfiguration.enableIMEPersonalizedLearning}
   final bool enableIMEPersonalizedLearning;
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   ///
   /// By default, builds a [CupertinoTextMagnifier] on iOS and Android nothing on all other
   /// platforms. If it is desired to supress the magnifier, consider passing

--- a/packages/flutter/lib/src/material/magnifier.dart
+++ b/packages/flutter/lib/src/material/magnifier.dart
@@ -149,8 +149,8 @@ class _TextMagnifierState extends State<TextMagnifier> {
     // to always stay between line start and end.
     final double magnifierX = clampDouble(
         selectionInfo.globalGesturePosition.dx,
-        selectionInfo.currentLineBoundries.left,
-        selectionInfo.currentLineBoundries.right);
+        selectionInfo.currentLineBoundaries.left,
+        selectionInfo.currentLineBoundaries.right);
 
     // Place the magnifier at the previously calculated X, and the Y should be
     // exactly at the center of the handle.
@@ -160,7 +160,7 @@ class _TextMagnifierState extends State<TextMagnifier> {
 
     // Shift the magnifier so that, if we are ever out of the screen, we become in bounds.
     // This probably won't have much of an effect on the X, since it is already bound
-    // to the currentLineBoundries, but will shift vertically if the magnifier is out of bounds.
+    // to the currentLineBoundaries, but will shift vertically if the magnifier is out of bounds.
     final Rect screenBoundsAdjustedMagnifierRect =
         MagnifierController.shiftWithinBounds(
             bounds: screenRect, rect: unadjustedMagnifierRect);

--- a/packages/flutter/lib/src/material/selectable_text.dart
+++ b/packages/flutter/lib/src/material/selectable_text.dart
@@ -430,11 +430,11 @@ class SelectableText extends StatefulWidget {
   /// {@macro flutter.widgets.editableText.onSelectionChanged}
   final SelectionChangedCallback? onSelectionChanged;
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   ///
   /// By default, builds a [CupertinoTextMagnifier] on iOS and [TextMagnifier] on
   /// Android, and builds nothing on all other platforms. If it is desired to supress

--- a/packages/flutter/lib/src/material/selection_area.dart
+++ b/packages/flutter/lib/src/material/selection_area.dart
@@ -39,11 +39,11 @@ class SelectionArea extends StatefulWidget {
     required this.child,
   });
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   ///
   /// By default, builds a [CupertinoTextMagnifier] on iOS and [TextMagnifier] on
   /// Android, and builds nothing on all other platforms. If it is desired to supress

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -393,11 +393,11 @@ class TextField extends StatefulWidget {
                        paste: true,
                      )));
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   ///
   /// By default, builds a [CupertinoTextMagnifier] on iOS and [TextMagnifier] on
   /// Android, and builds nothing on all other platforms. If it is desired to supress

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -27,6 +27,7 @@ import 'focus_scope.dart';
 import 'focus_traversal.dart';
 import 'framework.dart';
 import 'localizations.dart';
+import 'magnifier.dart';
 import 'media_query.dart';
 import 'scroll_configuration.dart';
 import 'scroll_controller.dart';
@@ -1549,11 +1550,11 @@ class EditableText extends StatefulWidget {
   /// {@macro flutter.services.TextInputConfiguration.enableIMEPersonalizedLearning}
   final bool enableIMEPersonalizedLearning;
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   final TextMagnifierConfiguration magnifierConfiguration;
 
   bool get _userSelectionEnabled => enableInteractiveSelection && (!readOnly || !obscureText);

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -502,29 +502,23 @@ class _DonutClip extends CustomClipper<Path> {
 }
 
 class _Magnifier extends SingleChildRenderObjectWidget {
-  /// Construct a [_Magnifier].
   const _Magnifier({
-      super.child,
-      required this.shape,
-      this.magnificationScale = 1,
-      this.focalPointOffset = Offset.zero,
+    super.child,
+    required this.shape,
+    this.magnificationScale = 1,
+    this.focalPointOffset = Offset.zero,
   });
 
-  /// [focalPointOffset] is the area the center of the
-  /// [_Magnifier] points to, relative to the center of the magnifier.
-  ///
-  /// {@macro flutter.widgets.magnifier.offset}
+  // Area the center of the _Magnifier points to, relative to the center of the magnifier.
   final Offset focalPointOffset;
 
-  /// The scale of the magnification.
-  ///
-  /// A [magnificationScale] of 1 means that the content in the magnifier
-  /// is true to it's real size. Anything greater than one will appear bigger
-  /// in the magnifier, and anything less than one will appear smaller in
-  /// the magnifier.
+  // Scale of the magnification.
+  //
+  // If equal to 1.0, the content in the magnifier is true to its real size.
+  // If greater than 1.0, the content appears bigger in the magnifier.
   final double magnificationScale;
 
-  /// The shape of the magnifier is dictated by [shape.getOuterPath].
+  // Shape of the magnifier.
   final ShapeBorder shape;
 
   @override

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -16,7 +16,7 @@ import 'navigator.dart';
 import 'overlay.dart';
 
 /// {@template flutter.widgets.magnifier.MagnifierBuilder}
-/// Signature for a builder that builds a Widget with a [MagnifierController].
+/// Signature for a builder that builds a [Widget] with a [MagnifierController].
 ///
 /// Consuming [MagnifierController] or [ValueNotifier]<[MagnifierOverlayInfoBearer]> is not
 /// required, although if a Widget intends to have entry or exit animations, it should take
@@ -26,7 +26,7 @@ import 'overlay.dart';
 ///
 /// See also:
 ///
-/// - [MagnifierOverlayInfoBearer], the dataclass that updates the
+/// - [MagnifierOverlayInfoBearer], the data class that updates the
 ///   magnifier.
 typedef MagnifierBuilder = Widget? Function(
     BuildContext context,
@@ -34,12 +34,11 @@ typedef MagnifierBuilder = Widget? Function(
     ValueNotifier<MagnifierOverlayInfoBearer> magnifierOverlayInfoBearer,
 );
 
-/// A data class that allows the [SelectionOverlay] to delegate
-/// the magnifier's positioning to the magnifier itself, based on the
-/// info in [MagnifierOverlayInfoBearer].
+/// A data class that contains the geometry information of text layouts
+/// and selection gestures, used to position magnifiers.
 @immutable
 class MagnifierOverlayInfoBearer {
-  /// Construct a [MagnifierOverlayInfoBearer] from raw values.
+  /// Constructs a [MagnifierOverlayInfoBearer] from provided geometry values.
   const MagnifierOverlayInfoBearer({
     required this.globalGesturePosition,
     required this.caretRect,
@@ -47,20 +46,19 @@ class MagnifierOverlayInfoBearer {
     required this.currentLineBoundaries,
   });
 
-  /// Construct an empty [MagnifierOverlayInfoBearer], with all
-  /// values set to 0.
-  const MagnifierOverlayInfoBearer.empty() :
-    globalGesturePosition = Offset.zero,
-    caretRect = Rect.zero,
-    currentLineBoundaries = Rect.zero,
-    fieldBounds = Rect.zero;
+  /// Constructs an empty [MagnifierOverlayInfoBearer] with all values set to 0.
+  const MagnifierOverlayInfoBearer.empty()
+    : globalGesturePosition = Offset.zero,
+      caretRect = Rect.zero,
+      currentLineBoundaries = Rect.zero,
+      fieldBounds = Rect.zero;
 
   /// The offset of the gesture position that the magnifier should be shown at.
   final Offset globalGesturePosition;
 
-  /// The rect of the current line the magnifier should be shown at. Do not take
-  /// into account any padding of the field; only the position of the first
-  /// and last character.
+  /// The rect of the current line the magnifier should be shown at,
+  /// without taking into account any padding of the field; only the position
+  /// of the first and last character.
   final Rect currentLineBoundaries;
 
   /// The rect of the handle that the magnifier should follow.

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -47,12 +47,12 @@ class MagnifierOverlayInfoBearer {
   });
 
   /// Const [MagnifierOverlayInfoBearer] with all values set to 0.
-  const MagnifierOverlayInfoBearer empty = MagnifierOverlayInfoBearer({
+  static const MagnifierOverlayInfoBearer empty = MagnifierOverlayInfoBearer(
     globalGesturePosition: Offset.zero,
     caretRect: Rect.zero,
     currentLineBoundaries: Rect.zero,
     fieldBounds: Rect.zero,
-  });
+  );
 
   /// The offset of the gesture position that the magnifier should be shown at.
   final Offset globalGesturePosition;
@@ -87,6 +87,48 @@ class MagnifierOverlayInfoBearer {
     fieldBounds,
     currentLineBoundaries,
   );
+}
+
+/// {@template flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
+/// A configuration object for a magnifier.
+/// {@endtemplate}
+///
+/// {@macro flutter.widgets.magnifier.intro}
+///
+/// {@template flutter.widgets.magnifier.TextMagnifierConfiguration.details}
+/// In general, most features of the magnifier can be configured through
+/// [MagnifierBuilder]. [TextMagnifierConfiguration] is used to configure
+/// the magnifier's behavior through the [SelectionOverlay].
+/// {@endtemplate}
+class TextMagnifierConfiguration {
+  /// Constructs a [TextMagnifierConfiguration] from parts.
+  ///
+  /// If [magnifierBuilder] is null, a default [MagnifierBuilder] will be used
+  /// that never builds a magnifier.
+  const TextMagnifierConfiguration({
+    MagnifierBuilder? magnifierBuilder,
+    this.shouldDisplayHandlesInMagnifier = true
+  }) : _magnifierBuilder = magnifierBuilder;
+
+  /// The passed in [MagnifierBuilder].
+  ///
+  /// This is nullable because [disabled] needs to be static const,
+  /// so that it can be used as a default parameter. If left null,
+  /// the [magnifierBuilder] getter will be a function that always returns
+  /// null.
+  final MagnifierBuilder? _magnifierBuilder;
+
+  /// {@macro flutter.widgets.magnifier.MagnifierBuilder}
+  MagnifierBuilder get magnifierBuilder => _magnifierBuilder ?? (_, __, ___) => null;
+
+  /// Determines whether a magnifier should show the text editing handles or not.
+  final bool shouldDisplayHandlesInMagnifier;
+
+  /// A constant for a [TextMagnifierConfiguration] that is disabled.
+  ///
+  /// In particular, this [TextMagnifierConfiguration] is considered disabled
+  /// because it never builds anything, regardless of platform.
+  static const TextMagnifierConfiguration disabled = TextMagnifierConfiguration();
 }
 
 /// [MagnifierController]'s main benefit over holding a raw [OverlayEntry] is that

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -552,10 +552,11 @@ class _Magnifier extends SingleChildRenderObjectWidget {
     this.focalPointOffset = Offset.zero,
   });
 
-  // Area the center of the _Magnifier points to, relative to the center of the magnifier.
+  // The Offset that the center of the _Magnifier points to, relative
+  // to the center of the magnifier.
   final Offset focalPointOffset;
 
-  // Scale of the magnification.
+  // The enlarge multiplier of the magnification.
   //
   // If equal to 1.0, the content in the magnifier is true to its real size.
   // If greater than 1.0, the content appears bigger in the magnifier.

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -46,12 +46,13 @@ class MagnifierOverlayInfoBearer {
     required this.currentLineBoundaries,
   });
 
-  /// Constructs an empty [MagnifierOverlayInfoBearer] with all values set to 0.
-  const MagnifierOverlayInfoBearer.empty()
-    : globalGesturePosition = Offset.zero,
-      caretRect = Rect.zero,
-      currentLineBoundaries = Rect.zero,
-      fieldBounds = Rect.zero;
+  /// Const [MagnifierOverlayInfoBearer] with all values set to 0.
+  const MagnifierOverlayInfoBearer empty = MagnifierOverlayInfoBearer({
+    globalGesturePosition: Offset.zero,
+    caretRect: Rect.zero,
+    currentLineBoundaries: Rect.zero,
+    fieldBounds: Rect.zero,
+  });
 
   /// The offset of the gesture position that the magnifier should be shown at.
   final Offset globalGesturePosition;

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -44,7 +44,7 @@ class MagnifierOverlayInfoBearer {
     required this.globalGesturePosition,
     required this.caretRect,
     required this.fieldBounds,
-    required this.currentLineBoundries,
+    required this.currentLineBoundaries,
   });
 
   /// Construct an empty [MagnifierOverlayInfoBearer], with all
@@ -52,7 +52,7 @@ class MagnifierOverlayInfoBearer {
   const MagnifierOverlayInfoBearer.empty() :
     globalGesturePosition = Offset.zero,
     caretRect = Rect.zero,
-    currentLineBoundries = Rect.zero,
+    currentLineBoundaries = Rect.zero,
     fieldBounds = Rect.zero;
 
   /// The offset of the gesture position that the magnifier should be shown at.
@@ -61,7 +61,7 @@ class MagnifierOverlayInfoBearer {
   /// The rect of the current line the magnifier should be shown at. Do not take
   /// into account any padding of the field; only the position of the first
   /// and last character.
-  final Rect currentLineBoundries;
+  final Rect currentLineBoundaries;
 
   /// The rect of the handle that the magnifier should follow.
   final Rect caretRect;
@@ -77,7 +77,7 @@ class MagnifierOverlayInfoBearer {
     return other is MagnifierOverlayInfoBearer
         && other.globalGesturePosition == globalGesturePosition
         && other.caretRect == caretRect
-        && other.currentLineBoundries == currentLineBoundries
+        && other.currentLineBoundaries == currentLineBoundaries
         && other.fieldBounds == fieldBounds;
   }
 
@@ -86,7 +86,7 @@ class MagnifierOverlayInfoBearer {
     globalGesturePosition,
     caretRect,
     fieldBounds,
-    currentLineBoundries,
+    currentLineBoundaries,
   );
 }
 

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -15,6 +15,85 @@ import 'inherited_theme.dart';
 import 'navigator.dart';
 import 'overlay.dart';
 
+/// {@template flutter.widgets.magnifier.MagnifierBuilder}
+/// Signature for a builder that builds a Widget with a [MagnifierController].
+///
+/// Consuming [MagnifierController] or [ValueNotifier]<[MagnifierOverlayInfoBearer]> is not
+/// required, although if a Widget intends to have entry or exit animations, it should take
+/// [MagnifierController] and provide it an [AnimationController], so that [MagnifierController]
+/// can wait before removing it from the overlay.
+/// {@endtemplate}
+///
+/// See also:
+///
+/// - [MagnifierOverlayInfoBearer], the dataclass that updates the
+///   magnifier.
+typedef MagnifierBuilder = Widget? Function(
+    BuildContext context,
+    MagnifierController controller,
+    ValueNotifier<MagnifierOverlayInfoBearer> textSelectionData
+);
+
+/// A data class that allows the [SelectionOverlay] to delegate
+/// the magnifier's positioning to the magnifier itself, based on the
+/// info in [MagnifierOverlayInfoBearer].
+@immutable
+class MagnifierOverlayInfoBearer {
+  /// Construct a [MagnifierOverlayInfoBearer] from raw values.
+  const MagnifierOverlayInfoBearer({
+    required this.globalGesturePosition,
+    required this.caretRect,
+    required this.fieldBounds,
+    required this.currentLineBoundries,
+  });
+
+  /// Construct an empty [MagnifierOverlayInfoBearer], with all
+  /// values set to 0.
+  const MagnifierOverlayInfoBearer.empty() :
+    globalGesturePosition = Offset.zero,
+    caretRect = Rect.zero,
+    currentLineBoundries = Rect.zero,
+    fieldBounds = Rect.zero;
+
+  /// The offset of the gesture position that the magnifier should be shown at.
+  final Offset globalGesturePosition;
+
+  /// The rect of the current line the magnifier should be shown at. Do not take
+  /// into account any padding of the field; only the position of the first
+  /// and last character.
+  final Rect currentLineBoundries;
+
+  /// The rect of the handle that the magnifier should follow.
+  final Rect caretRect;
+
+  /// The bounds of the entire text field that the magnifier is bound to.
+  final Rect fieldBounds;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) {
+      return true;
+    }
+
+    if (other is! MagnifierOverlayInfoBearer) {
+      return false;
+    }
+
+    return other.globalGesturePosition == globalGesturePosition &&
+        other.caretRect == caretRect &&
+        other.currentLineBoundries == currentLineBoundries &&
+        other.fieldBounds == fieldBounds;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    globalGesturePosition,
+    caretRect,
+    fieldBounds,
+    currentLineBoundries
+  );
+}
+
 /// [MagnifierController]'s main benefit over holding a raw [OverlayEntry] is that
 /// [MagnifierController] will handle logic around waiting for a magnifier to animate in or out.
 ///

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -31,7 +31,7 @@ import 'overlay.dart';
 typedef MagnifierBuilder = Widget? Function(
     BuildContext context,
     MagnifierController controller,
-    ValueNotifier<MagnifierOverlayInfoBearer> textSelectionData
+    ValueNotifier<MagnifierOverlayInfoBearer> magnifierOverlayInfoBearer
 );
 
 /// A data class that allows the [SelectionOverlay] to delegate

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -31,7 +31,7 @@ import 'overlay.dart';
 typedef MagnifierBuilder = Widget? Function(
     BuildContext context,
     MagnifierController controller,
-    ValueNotifier<MagnifierOverlayInfoBearer> magnifierOverlayInfoBearer
+    ValueNotifier<MagnifierOverlayInfoBearer> magnifierOverlayInfoBearer,
 );
 
 /// A data class that allows the [SelectionOverlay] to delegate
@@ -90,7 +90,7 @@ class MagnifierOverlayInfoBearer {
     globalGesturePosition,
     caretRect,
     fieldBounds,
-    currentLineBoundries
+    currentLineBoundries,
   );
 }
 

--- a/packages/flutter/lib/src/widgets/magnifier.dart
+++ b/packages/flutter/lib/src/widgets/magnifier.dart
@@ -74,15 +74,11 @@ class MagnifierOverlayInfoBearer {
     if (identical(this, other)) {
       return true;
     }
-
-    if (other is! MagnifierOverlayInfoBearer) {
-      return false;
-    }
-
-    return other.globalGesturePosition == globalGesturePosition &&
-        other.caretRect == caretRect &&
-        other.currentLineBoundries == currentLineBoundries &&
-        other.fieldBounds == fieldBounds;
+    return other is MagnifierOverlayInfoBearer
+        && other.globalGesturePosition == globalGesturePosition
+        && other.caretRect == caretRect
+        && other.currentLineBoundries == currentLineBoundries
+        && other.fieldBounds == fieldBounds;
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -190,7 +190,7 @@ class SelectableRegion extends StatefulWidget {
   ///
   /// By default, [SelectableRegion]'s [TextMagnifierConfiguration] is disabled.
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   final TextMagnifierConfiguration magnifierConfiguration;
 
   /// {@macro flutter.widgets.Focus.focusNode}

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -184,7 +184,7 @@ class SelectableRegion extends StatefulWidget {
     this.magnifierConfiguration = TextMagnifierConfiguration.disabled,
   });
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -18,6 +18,7 @@ import 'focus_manager.dart';
 import 'focus_scope.dart';
 import 'framework.dart';
 import 'gesture_detector.dart';
+import 'magnifier.dart';
 import 'media_query.dart';
 import 'overlay.dart';
 import 'selection_container.dart';

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -536,7 +536,7 @@ class _SelectableRegionState extends State<SelectableRegion> with TextSelectionD
         globalGesturePosition: globalGesturePosition,
         caretRect: caretRect,
         fieldBounds: globalTransformAsOffset & _selectable!.size,
-        currentLineBoundries: globalTransformAsOffset & _selectable!.size,
+        currentLineBoundaries: globalTransformAsOffset & _selectable!.size,
       );
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -84,7 +84,7 @@ class ToolbarItemsParentData extends ContainerBoxParentData<RenderBox> {
 /// the magnifier's behavior through the [SelectionOverlay].
 /// {@endtemplate}
 class TextMagnifierConfiguration {
-  /// Construct a [TextMagnifierConfiguration] from parts.
+  /// Constructs a [TextMagnifierConfiguration] from parts.
   ///
   /// If [magnifierBuilder] is null, a default [MagnifierBuilder] will be used
   /// that never builds a magnifier.
@@ -758,7 +758,7 @@ class SelectionOverlay {
 
 
   final ValueNotifier<MagnifierOverlayInfoBearer> _magnifierOverlayInfoBearer =
-          ValueNotifier<MagnifierOverlayInfoBearer>(const MagnifierOverlayInfoBearer.empty());
+      ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty);
 
   /// [MagnifierController.show] and [MagnifierController.hide] should not be called directly, except
   /// from inside [showMagnifier] and [hideMagnifier]. If it is desired to show or hide the magnifier,

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -72,48 +72,6 @@ class ToolbarItemsParentData extends ContainerBoxParentData<RenderBox> {
   String toString() => '${super.toString()}; shouldPaint=$shouldPaint';
 }
 
-/// {@template flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
-/// A configuration object for a magnifier.
-/// {@endtemplate}
-///
-/// {@macro flutter.widgets.magnifier.intro}
-///
-/// {@template flutter.widgets.text_selection.TextMagnifierConfiguration.details}
-/// In general, most features of the magnifier can be configured through
-/// [MagnifierBuilder]. [TextMagnifierConfiguration] is used to configure
-/// the magnifier's behavior through the [SelectionOverlay].
-/// {@endtemplate}
-class TextMagnifierConfiguration {
-  /// Constructs a [TextMagnifierConfiguration] from parts.
-  ///
-  /// If [magnifierBuilder] is null, a default [MagnifierBuilder] will be used
-  /// that never builds a magnifier.
-  const TextMagnifierConfiguration({
-    MagnifierBuilder? magnifierBuilder,
-    this.shouldDisplayHandlesInMagnifier = true
-  }) : _magnifierBuilder = magnifierBuilder;
-
-  /// The passed in [MagnifierBuilder].
-  ///
-  /// This is nullable because [disabled] needs to be static const,
-  /// so that it can be used as a default parameter. If left null,
-  /// the [magnifierBuilder] getter will be a function that always returns
-  /// null.
-  final MagnifierBuilder? _magnifierBuilder;
-
-  /// {@macro flutter.widgets.magnifier.MagnifierBuilder}
-  MagnifierBuilder get magnifierBuilder => _magnifierBuilder ?? (_, __, ___) => null;
-
-  /// Determines whether a magnifier should show the text editing handles or not.
-  final bool shouldDisplayHandlesInMagnifier;
-
-  /// A constant for a [TextMagnifierConfiguration] that is disabled.
-  ///
-  /// In particular, this [TextMagnifierConfiguration] is considered disabled
-  /// because it never builds anything, regardless of platform.
-  static const TextMagnifierConfiguration disabled = TextMagnifierConfiguration();
-}
-
 /// An interface for building the selection UI, to be provided by the
 /// implementer of the toolbar widget.
 ///
@@ -766,13 +724,13 @@ class SelectionOverlay {
   /// with other properties in [SelectionOverlay].
   final MagnifierController _magnifierController = MagnifierController();
 
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.intro}
   ///
   /// {@macro flutter.widgets.magnifier.intro}
   ///
   /// By default, [SelectionOverlay]'s [TextMagnifierConfiguration] is disabled.
   ///
-  /// {@macro flutter.widgets.text_selection.TextMagnifierConfiguration.details}
+  /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   final TextMagnifierConfiguration magnifierConfiguration;
 
   /// Shows the magnifier, and hides the toolbar if it was showing when [showMagnifier]

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -517,14 +517,14 @@ class TextSelectionOverlay {
 
     final Rect lineBoundries = Rect.fromPoints(
       renderEditable.getLocalRectForCaret(positionAtBeginningOfLine).topCenter,
-      renderEditable.getLocalRectForCaret(positionAtEndOfLine).bottomCenter
+      renderEditable.getLocalRectForCaret(positionAtEndOfLine).bottomCenter,
     );
 
     return MagnifierOverlayInfoBearer(
       fieldBounds: globalRenderEditableTopLeft & renderEditable.size,
       globalGesturePosition: globalGesturePosition,
       caretRect: localCaretRect.shift(globalRenderEditableTopLeft),
-      currentLineBoundries: lineBoundries.shift(globalRenderEditableTopLeft)
+      currentLineBoundries: lineBoundries.shift(globalRenderEditableTopLeft),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -101,7 +101,7 @@ class TextMagnifierConfiguration {
   /// null.
   final MagnifierBuilder? _magnifierBuilder;
 
-  /// {@macro flutter.widgets.textSelection.MagnifierBuilder}
+  /// {@macro flutter.widgets.magnifier.MagnifierBuilder}
   MagnifierBuilder get magnifierBuilder => _magnifierBuilder ?? (_, __, ___) => null;
 
   /// Determines whether a magnifier should show the text editing handles or not.

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -515,7 +515,7 @@ class TextSelectionOverlay {
       offset: lineAtOffset.baseOffset,
     );
 
-    final Rect lineBoundries = Rect.fromPoints(
+    final Rect lineBoundaries = Rect.fromPoints(
       renderEditable.getLocalRectForCaret(positionAtBeginningOfLine).topCenter,
       renderEditable.getLocalRectForCaret(positionAtEndOfLine).bottomCenter,
     );
@@ -524,7 +524,7 @@ class TextSelectionOverlay {
       fieldBounds: globalRenderEditableTopLeft & renderEditable.size,
       globalGesturePosition: globalGesturePosition,
       caretRect: localCaretRect.shift(globalRenderEditableTopLeft),
-      currentLineBoundries: lineBoundries.shift(globalRenderEditableTopLeft),
+      currentLineBoundaries: lineBoundaries.shift(globalRenderEditableTopLeft),
     );
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -72,117 +72,6 @@ class ToolbarItemsParentData extends ContainerBoxParentData<RenderBox> {
   String toString() => '${super.toString()}; shouldPaint=$shouldPaint';
 }
 
-/// {@template flutter.widgets.textSelection.MagnifierBuilder}
-/// Signature for a builder that builds a Widget with a [MagnifierController].
-///
-/// Consuming [MagnifierController] or [ValueNotifier]<[MagnifierOverlayInfoBearer]> is not
-/// required, although if a Widget intends to have entry or exit animations, it should take
-/// [MagnifierController] and provide it an [AnimationController], so that [MagnifierController]
-/// can wait before removing it from the overlay.
-/// {@endtemplate}
-///
-/// See also:
-///
-/// - [MagnifierOverlayInfoBearer], the dataclass that updates the
-///   magnifier.
-typedef MagnifierBuilder = Widget? Function(
-    BuildContext context,
-    MagnifierController controller,
-    ValueNotifier<MagnifierOverlayInfoBearer> textSelectionData
-);
-
-/// A data class that allows the [SelectionOverlay] to delegate
-/// the magnifier's positioning to the magnifier itself, based on the
-/// info in [MagnifierOverlayInfoBearer].
-@immutable
-class MagnifierOverlayInfoBearer {
-  /// Construct a [MagnifierOverlayInfoBearer] from raw values.
-  const MagnifierOverlayInfoBearer({
-    required this.globalGesturePosition,
-    required this.caretRect,
-    required this.fieldBounds,
-    required this.currentLineBoundries,
-  });
-
-  factory MagnifierOverlayInfoBearer._fromRenderEditable({
-    required RenderEditable renderEditable,
-    required Offset globalGesturePosition,
-    required TextPosition currentTextPosition,
-  }) {
-    final Offset globalRenderEditableTopLeft = renderEditable.localToGlobal(Offset.zero);
-    final Rect localCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
-
-    final TextSelection lineAtOffset = renderEditable.getLineAtOffset(currentTextPosition);
-    final TextPosition positionAtEndOfLine = TextPosition(
-        offset: lineAtOffset.extentOffset,
-        affinity: TextAffinity.upstream,
-    );
-
-    // Default affinity is downstream.
-    final TextPosition positionAtBeginningOfLine = TextPosition(
-      offset: lineAtOffset.baseOffset,
-    );
-
-    final Rect lineBoundries = Rect.fromPoints(
-      renderEditable.getLocalRectForCaret(positionAtBeginningOfLine).topCenter,
-      renderEditable.getLocalRectForCaret(positionAtEndOfLine).bottomCenter
-    );
-
-    return MagnifierOverlayInfoBearer(
-      fieldBounds: globalRenderEditableTopLeft & renderEditable.size,
-      globalGesturePosition: globalGesturePosition,
-      caretRect: localCaretRect.shift(globalRenderEditableTopLeft),
-      currentLineBoundries: lineBoundries.shift(globalRenderEditableTopLeft)
-    );
-  }
-
-  /// Construct an empty [MagnifierOverlayInfoBearer], with all
-  /// values set to 0.
-  const MagnifierOverlayInfoBearer.empty() :
-    globalGesturePosition = Offset.zero,
-    caretRect = Rect.zero,
-    currentLineBoundries = Rect.zero,
-    fieldBounds = Rect.zero;
-
-  /// The offset of the gesture position that the magnifier should be shown at.
-  final Offset globalGesturePosition;
-
-  /// The rect of the current line the magnifier should be shown at. Do not take
-  /// into account any padding of the field; only the position of the first
-  /// and last character.
-  final Rect currentLineBoundries;
-
-  /// The rect of the handle that the magnifier should follow.
-  final Rect caretRect;
-
-  /// The bounds of the entire text field that the magnifier is bound to.
-  final Rect fieldBounds;
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-
-    if (other is! MagnifierOverlayInfoBearer) {
-      return false;
-    }
-
-    return other.globalGesturePosition == globalGesturePosition &&
-        other.caretRect == caretRect &&
-        other.currentLineBoundries == currentLineBoundries &&
-        other.fieldBounds == fieldBounds;
-  }
-
-  @override
-  int get hashCode => Object.hash(
-    globalGesturePosition,
-    caretRect,
-    fieldBounds,
-    currentLineBoundries
-  );
-}
-
 /// {@template flutter.widgets.text_selection.TextMagnifierConfiguration.intro}
 /// A configuration object for a magnifier.
 /// {@endtemplate}
@@ -607,6 +496,38 @@ class TextSelectionOverlay {
     return endHandleRect?.height ?? renderObject.preferredLineHeight;
   }
 
+  MagnifierOverlayInfoBearer _buildMagnifier({
+    required RenderEditable renderEditable,
+    required Offset globalGesturePosition,
+    required TextPosition currentTextPosition,
+  }) {
+    final Offset globalRenderEditableTopLeft = renderEditable.localToGlobal(Offset.zero);
+    final Rect localCaretRect = renderEditable.getLocalRectForCaret(currentTextPosition);
+
+    final TextSelection lineAtOffset = renderEditable.getLineAtOffset(currentTextPosition);
+    final TextPosition positionAtEndOfLine = TextPosition(
+        offset: lineAtOffset.extentOffset,
+        affinity: TextAffinity.upstream,
+    );
+
+    // Default affinity is downstream.
+    final TextPosition positionAtBeginningOfLine = TextPosition(
+      offset: lineAtOffset.baseOffset,
+    );
+
+    final Rect lineBoundries = Rect.fromPoints(
+      renderEditable.getLocalRectForCaret(positionAtBeginningOfLine).topCenter,
+      renderEditable.getLocalRectForCaret(positionAtEndOfLine).bottomCenter
+    );
+
+    return MagnifierOverlayInfoBearer(
+      fieldBounds: globalRenderEditableTopLeft & renderEditable.size,
+      globalGesturePosition: globalGesturePosition,
+      caretRect: localCaretRect.shift(globalRenderEditableTopLeft),
+      currentLineBoundries: lineBoundries.shift(globalRenderEditableTopLeft)
+    );
+  }
+
   late Offset _dragEndPosition;
 
   void _handleSelectionEndHandleDragStart(DragStartDetails details) {
@@ -620,7 +541,7 @@ class TextSelectionOverlay {
     _dragEndPosition = details.globalPosition + Offset(0.0, -handleSize.height);
     final TextPosition position = renderObject.getPositionForPoint(_dragEndPosition);
 
-    _selectionOverlay.showMagnifier(MagnifierOverlayInfoBearer._fromRenderEditable(
+    _selectionOverlay.showMagnifier(_buildMagnifier(
       currentTextPosition: position,
       globalGesturePosition: details.globalPosition,
       renderEditable: renderObject,
@@ -637,7 +558,7 @@ class TextSelectionOverlay {
     final TextSelection currentSelection = TextSelection.fromPosition(position);
 
     if (_selection.isCollapsed) {
-      _selectionOverlay.updateMagnifier(MagnifierOverlayInfoBearer._fromRenderEditable(
+      _selectionOverlay.updateMagnifier(_buildMagnifier(
         currentTextPosition: position,
         globalGesturePosition: details.globalPosition,
         renderEditable: renderObject,
@@ -676,7 +597,7 @@ class TextSelectionOverlay {
 
     _handleSelectionHandleChanged(newSelection, isEnd: true);
 
-     _selectionOverlay.updateMagnifier(MagnifierOverlayInfoBearer._fromRenderEditable(
+     _selectionOverlay.updateMagnifier(_buildMagnifier(
       currentTextPosition: newSelection.extent,
       globalGesturePosition: details.globalPosition,
       renderEditable: renderObject,
@@ -695,7 +616,7 @@ class TextSelectionOverlay {
     _dragStartPosition = details.globalPosition + Offset(0.0, -handleSize.height);
     final TextPosition position = renderObject.getPositionForPoint(_dragStartPosition);
 
-    _selectionOverlay.showMagnifier(MagnifierOverlayInfoBearer._fromRenderEditable(
+    _selectionOverlay.showMagnifier(_buildMagnifier(
       currentTextPosition: position,
       globalGesturePosition: details.globalPosition,
       renderEditable: renderObject,
@@ -710,7 +631,7 @@ class TextSelectionOverlay {
     final TextPosition position = renderObject.getPositionForPoint(_dragStartPosition);
 
     if (_selection.isCollapsed) {
-      _selectionOverlay.updateMagnifier(MagnifierOverlayInfoBearer._fromRenderEditable(
+      _selectionOverlay.updateMagnifier(_buildMagnifier(
         currentTextPosition: position,
         globalGesturePosition: details.globalPosition,
         renderEditable: renderObject,
@@ -747,7 +668,7 @@ class TextSelectionOverlay {
         break;
     }
 
-    _selectionOverlay.updateMagnifier(MagnifierOverlayInfoBearer._fromRenderEditable(
+    _selectionOverlay.updateMagnifier(_buildMagnifier(
       currentTextPosition: newSelection.extent.offset < newSelection.base.offset ? newSelection.extent : newSelection.base,
       globalGesturePosition: details.globalPosition,
       renderEditable: renderObject,

--- a/packages/flutter/test/cupertino/magnifier_test.dart
+++ b/packages/flutter/test/cupertino/magnifier_test.dart
@@ -79,7 +79,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifier =
             ValueNotifier<MagnifierOverlayInfoBearer>(
           MagnifierOverlayInfoBearer(
-            currentLineBoundries: fakeTextFieldRect,
+            currentLineBoundaries: fakeTextFieldRect,
             fieldBounds: fakeTextFieldRect,
             caretRect: fakeTextFieldRect,
             // The tap position is dragBelow units below the text field.
@@ -112,7 +112,7 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               fieldBounds: reasonableTextField,
               caretRect: reasonableTextField,
               // The tap position is far out of the right side of the app.
@@ -145,7 +145,7 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               fieldBounds: reasonableTextField,
               caretRect: reasonableTextField,
               // The tap position is dragBelow units below the text field.
@@ -179,7 +179,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifierinfo =
             ValueNotifier<MagnifierOverlayInfoBearer>(
           MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             // The tap position is dragBelow units below the text field.
@@ -193,7 +193,7 @@ void main() {
 
         // Move the gesture to one that should hide it.
         magnifierinfo.value = MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             globalGesturePosition: magnifierinfo.value.globalGesturePosition + const Offset(0, 100),
@@ -219,7 +219,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifierInfo =
             ValueNotifier<MagnifierOverlayInfoBearer>(
           MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             // The tap position is dragBelow units below the text field.
@@ -232,7 +232,7 @@ void main() {
 
         // Move the gesture to one that should hide it.
         magnifierInfo.value = MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             globalGesturePosition:
@@ -244,7 +244,7 @@ void main() {
 
         // Return the gesture to one that shows it.
         magnifierInfo.value = MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             globalGesturePosition: Offset(MediaQuery.of(context).size.width / 2,

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -5985,11 +5985,9 @@ void main() {
             defaultCupertinoTextField.magnifierConfiguration!.magnifierBuilder(
                 context,
                 MagnifierController(),
-                ValueNotifier<MagnifierOverlayInfoBearer>(
-                  const MagnifierOverlayInfoBearer.empty(),
-                )),
-            isA<Widget>().having(
-                (Widget widget) => widget.key, 'key', equals(customMagnifier.key)));
+                ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+              ),
+            isA<Widget>().having((Widget widget) => widget.key, 'key', equals(customMagnifier.key)));
       });
 
       group('defaults', () {
@@ -6005,9 +6003,8 @@ void main() {
               editableText.magnifierConfiguration.magnifierBuilder(
                   context,
                   MagnifierController(),
-                  ValueNotifier<MagnifierOverlayInfoBearer>(
-                    const MagnifierOverlayInfoBearer.empty(),
-                  )),
+                  ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+                ),
               isA<CupertinoTextMagnifier>());
         },
             variant: const TargetPlatformVariant(
@@ -6026,9 +6023,8 @@ void main() {
             editableText.magnifierConfiguration.magnifierBuilder(
                 context,
                 MagnifierController(),
-                ValueNotifier<MagnifierOverlayInfoBearer>(
-                  const MagnifierOverlayInfoBearer.empty(),
-                )),
+                ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+              ),
             isNull);
       },
           variant: TargetPlatformVariant.all(

--- a/packages/flutter/test/material/magnifier_test.dart
+++ b/packages/flutter/test/material/magnifier_test.dart
@@ -55,16 +55,12 @@ void main() {
         home: Placeholder(),
       ));
 
-      final BuildContext context =
-          tester.firstElement(find.byType(Placeholder));
+      final BuildContext context = tester.firstElement(find.byType(Placeholder));
 
-      final Widget? builtWidget =
-          TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
+      final Widget? builtWidget = TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
         context,
         MagnifierController(),
-        ValueNotifier<MagnifierOverlayInfoBearer>(
-          const MagnifierOverlayInfoBearer.empty(),
-        ),
+        ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
       );
 
       expect(builtWidget, isA<TextMagnifier>());
@@ -76,15 +72,13 @@ void main() {
         home: Placeholder(),
       ));
 
-      final BuildContext context =
-          tester.firstElement(find.byType(Placeholder));
+      final BuildContext context = tester.firstElement(find.byType(Placeholder));
 
-      final Widget? builtWidget =
-          TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
-              context,
-              MagnifierController(),
-              ValueNotifier<MagnifierOverlayInfoBearer>(
-                  const MagnifierOverlayInfoBearer.empty()));
+      final Widget? builtWidget = TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
+        context,
+        MagnifierController(),
+        ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+      );
 
       expect(builtWidget, isA<CupertinoTextMagnifier>());
     }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
@@ -95,17 +89,13 @@ void main() {
         home: Placeholder(),
       ));
 
-      final BuildContext context =
-          tester.firstElement(find.byType(Placeholder));
+      final BuildContext context = tester.firstElement(find.byType(Placeholder));
 
-        final Widget? builtWidget =
-            TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
-          context,
-          MagnifierController(),
-          ValueNotifier<MagnifierOverlayInfoBearer>(
-            const MagnifierOverlayInfoBearer.empty(),
-          ),
-        );
+      final Widget? builtWidget = TextMagnifier.adaptiveMagnifierConfiguration.magnifierBuilder(
+        context,
+        MagnifierController(),
+        ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+      );
 
       expect(builtWidget, isNull);
     },

--- a/packages/flutter/test/material/magnifier_test.dart
+++ b/packages/flutter/test/material/magnifier_test.dart
@@ -157,7 +157,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifierInfo =
             ValueNotifier<MagnifierOverlayInfoBearer>(
                 MagnifierOverlayInfoBearer(
-          currentLineBoundries: fakeTextFieldRect,
+          currentLineBoundaries: fakeTextFieldRect,
           fieldBounds: fakeTextFieldRect,
           caretRect: fakeTextFieldRect,
           // The tap position is dragBelow units below the text field.
@@ -191,9 +191,9 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               // Inflate these two to make sure we're bounding on the
-              // current line boundries, not anything else.
+              // current line boundaries, not anything else.
               fieldBounds: reasonableTextField.inflate(gestureOutsideLine),
               caretRect: reasonableTextField.inflate(gestureOutsideLine),
               // The tap position is far out of the right side of the app.
@@ -224,9 +224,9 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               // Inflate these two to make sure we're bounding on the
-              // current line boundries, not anything else.
+              // current line boundaries, not anything else.
               fieldBounds: reasonableTextField.inflate(gestureOutsideLine),
               caretRect: reasonableTextField.inflate(gestureOutsideLine),
               // The tap position is far out of the left side of the app.
@@ -252,7 +252,7 @@ void main() {
             tester,
             ValueNotifier<MagnifierOverlayInfoBearer>(
                 MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               fieldBounds: reasonableTextField,
               caretRect: reasonableTextField,
               globalGesturePosition: reasonableTextField.center,
@@ -279,7 +279,7 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: topOfScreenTextFieldRect,
+              currentLineBoundaries: topOfScreenTextFieldRect,
               fieldBounds: topOfScreenTextFieldRect,
               caretRect: topOfScreenTextFieldRect,
               globalGesturePosition: topOfScreenTextFieldRect.topCenter,
@@ -312,7 +312,7 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               fieldBounds: reasonableTextField,
               caretRect: reasonableTextField,
               // Gesture on the far right of the magnifier.
@@ -343,7 +343,7 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: topOfScreenTextFieldRect,
+              currentLineBoundaries: topOfScreenTextFieldRect,
               fieldBounds: topOfScreenTextFieldRect,
               caretRect: topOfScreenTextFieldRect,
               globalGesturePosition: topOfScreenTextFieldRect.topCenter,
@@ -376,7 +376,7 @@ void main() {
           tester,
           ValueNotifier<MagnifierOverlayInfoBearer>(
             MagnifierOverlayInfoBearer(
-              currentLineBoundries: reasonableTextField,
+              currentLineBoundaries: reasonableTextField,
               fieldBounds: reasonableTextField,
               caretRect: reasonableTextField,
               globalGesturePosition: reasonableTextField.center,
@@ -399,7 +399,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifierPositioner =
             ValueNotifier<MagnifierOverlayInfoBearer>(
           MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             globalGesturePosition: reasonableTextField.center,
@@ -410,7 +410,7 @@ void main() {
 
         // New position has a horizontal shift.
         magnifierPositioner.value = MagnifierOverlayInfoBearer(
-          currentLineBoundries: reasonableTextField,
+          currentLineBoundaries: reasonableTextField,
           fieldBounds: reasonableTextField,
           caretRect: reasonableTextField,
           globalGesturePosition:
@@ -435,7 +435,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifierPositioner =
             ValueNotifier<MagnifierOverlayInfoBearer>(
           MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             globalGesturePosition: reasonableTextField.center,
@@ -446,7 +446,7 @@ void main() {
 
         // New position has a vertical shift.
         magnifierPositioner.value = MagnifierOverlayInfoBearer(
-          currentLineBoundries: reasonableTextField.shift(verticalShift),
+          currentLineBoundaries: reasonableTextField.shift(verticalShift),
           fieldBounds: Rect.fromPoints(reasonableTextField.topLeft,
               reasonableTextField.bottomRight + verticalShift),
           caretRect: reasonableTextField.shift(verticalShift),
@@ -471,7 +471,7 @@ void main() {
         final ValueNotifier<MagnifierOverlayInfoBearer> magnifierPositioner =
             ValueNotifier<MagnifierOverlayInfoBearer>(
           MagnifierOverlayInfoBearer(
-            currentLineBoundries: reasonableTextField,
+            currentLineBoundaries: reasonableTextField,
             fieldBounds: reasonableTextField,
             caretRect: reasonableTextField,
             globalGesturePosition: reasonableTextField.center,
@@ -482,7 +482,7 @@ void main() {
 
         // New position has a vertical shift.
         magnifierPositioner.value = MagnifierOverlayInfoBearer(
-          currentLineBoundries: reasonableTextField.shift(verticalShift),
+          currentLineBoundaries: reasonableTextField.shift(verticalShift),
           fieldBounds: Rect.fromPoints(reasonableTextField.topLeft,
               reasonableTextField.bottomRight + verticalShift),
           caretRect: reasonableTextField.shift(verticalShift),

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11896,9 +11896,8 @@ void main() {
           textField.magnifierConfiguration!.magnifierBuilder(
               context,
               MagnifierController(),
-              ValueNotifier<MagnifierOverlayInfoBearer>(
-                const MagnifierOverlayInfoBearer.empty(),
-              )),
+              ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+            ),
           isA<Widget>().having(
               (Widget widget) => widget.key,
               'built magnifier key equal to passed in magnifier key',
@@ -11918,9 +11917,8 @@ void main() {
             editableText.magnifierConfiguration.magnifierBuilder(
                 context,
                 MagnifierController(),
-                ValueNotifier<MagnifierOverlayInfoBearer>(
-                  const MagnifierOverlayInfoBearer.empty(),
-                )),
+                ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+              ),
             isA<TextMagnifier>());
       }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
@@ -11937,9 +11935,8 @@ void main() {
             editableText.magnifierConfiguration.magnifierBuilder(
                 context,
                 MagnifierController(),
-                ValueNotifier<MagnifierOverlayInfoBearer>(
-                  const MagnifierOverlayInfoBearer.empty(),
-                )),
+                ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+              ),
             isA<CupertinoTextMagnifier>());
       }, variant: TargetPlatformVariant.only(TargetPlatform.iOS));
 
@@ -11956,9 +11953,8 @@ void main() {
             editableText.magnifierConfiguration.magnifierBuilder(
                 context,
                 MagnifierController(),
-                ValueNotifier<MagnifierOverlayInfoBearer>(
-                  const MagnifierOverlayInfoBearer.empty(),
-                )),
+                ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty),
+              ),
             isNull);
       },
       variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -12667,12 +12667,12 @@ void main() {
       final BuildContext context = tester.firstElement(find.byType(EditableText));
 
       expect(
-        editableText.magnifierConfiguration.magnifierBuilder(
-          context,
-          MagnifierController(),
-          ValueNotifier<MagnifierOverlayInfoBearer>(const MagnifierOverlayInfoBearer.empty())
-        ),
-        isNull
+          editableText.magnifierConfiguration.magnifierBuilder(
+              context,
+              MagnifierController(),
+              ValueNotifier<MagnifierOverlayInfoBearer>(MagnifierOverlayInfoBearer.empty)
+            ),
+          isNull,
       );
     });
   });


### PR DESCRIPTION
This PR moves the MagnifierBuilder, MagnifierOverlayInfoBearer and TextMagnifierConfiguration classes from text_selection.dart to magnifier.dart where they seem to belong better. Additional changes:
* MagnifierOverlayInfoBearer. _fromRenderEditable constructor is replaced by a simple method TextSelectionOverlay. _buildMagnifier()
* MagnifierOverlayInfoBearer.empty() constructor is replaced with static const MagnifierOverlayInfoBearer.empty

test-exempt: refactor only, no functional change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
