### PR TITLE
Add `FocusNode` to `InputDatePickerFormField` and add missing `autofocus` test.

### DIFF
--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -57,6 +57,7 @@ class InputDatePickerFormField extends StatefulWidget {
     this.fieldHintText,
     this.fieldLabelText,
     this.keyboardType,
+    this.focusNode,
     this.autofocus = false,
   }) : assert(firstDate != null),
        assert(lastDate != null),
@@ -129,6 +130,9 @@ class InputDatePickerFormField extends StatefulWidget {
   ///
   /// If this is null, it will default to [TextInputType.datetime]
   final TextInputType? keyboardType;
+
+  /// {@macro flutter.widgets.Focus.focusNode}
+  final FocusNode? focusNode;
 
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
@@ -250,6 +254,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
       keyboardType: widget.keyboardType ?? TextInputType.datetime,
       onSaved: _handleSaved,
       onFieldSubmitted: _handleSubmitted,
+      focusNode: widget.focusNode,
       autofocus: widget.autofocus,
       controller: _controller,
     );

--- a/packages/flutter/test/material/input_date_picker_form_field_test.dart
+++ b/packages/flutter/test/material/input_date_picker_form_field_test.dart
@@ -45,6 +45,7 @@ void main() {
     String? errorInvalidText,
     String? fieldHintText,
     String? fieldLabelText,
+    FocusNode? focusNode,
     bool autofocus = false,
     Key? formKey,
     ThemeData? theme,
@@ -68,6 +69,7 @@ void main() {
             errorInvalidText: errorInvalidText,
             fieldHintText: fieldHintText,
             fieldLabelText: fieldLabelText,
+            focusNode: focusNode,
             autofocus: autofocus,
           ),
         ),
@@ -345,5 +347,28 @@ void main() {
         )
       );
     });
+  });
+
+  testWidgets('FocusNode can request focus', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    await tester.pumpWidget(inputDatePickerField(
+      focusNode: focusNode,
+    ));
+
+    expect(focusNode.hasFocus, isFalse);
+
+    focusNode.requestFocus();
+    await tester.pumpAndSettle();
+    expect(focusNode.hasFocus, isTrue);
+  });
+
+  testWidgets('autofocus:true gives focus to the widget', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode();
+    await tester.pumpWidget(inputDatePickerField(
+      focusNode: focusNode,
+      autofocus: true,
+    ));
+
+    expect(focusNode.hasFocus, isTrue);
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/105881

This PR adds `FocusNode` to `InputDatePickerFormField` and a missing `autofocus` text. (I can see similar `focusNode` and `autofocus` test in `SearchField`)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
