### PR TITLE
Added onSelectionChange callback to SelectionRegion and SelectionArea

### DIFF
--- a/packages/flutter/lib/src/material/selection_area.dart
+++ b/packages/flutter/lib/src/material/selection_area.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/rendering.dart';
 
 import 'debug.dart';
 import 'desktop_text_selection.dart';
@@ -41,6 +42,7 @@ class SelectionArea extends StatefulWidget {
     this.focusNode,
     this.selectionControls,
     this.magnifierConfiguration,
+    this.onSelectionChanged,
     required this.child,
   });
 
@@ -62,6 +64,9 @@ class SelectionArea extends StatefulWidget {
   ///
   /// If it is null, the platform specific selection control is used.
   final TextSelectionControls? selectionControls;
+
+  /// Called when the selected content changes.
+  final ValueChanged<SelectedContent?>? onSelectionChanged;
 
   /// The child widget this selection area applies to.
   ///
@@ -112,6 +117,7 @@ class _SelectionAreaState extends State<SelectionArea> {
       focusNode: _effectiveFocusNode,
       selectionControls: controls,
       magnifierConfiguration: widget.magnifierConfiguration ?? TextMagnifier.adaptiveMagnifierConfiguration,
+      onSelectionChanged: widget.onSelectionChanged,
       child: widget.child,
     );
   }

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -4,8 +4,16 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+
+Offset textOffsetToPosition(RenderParagraph paragraph, int offset) {
+  const Rect caret = Rect.fromLTWH(0.0, 0.0, 2.0, 20.0);
+  final Offset localOffset = paragraph.getOffsetForCaret(TextPosition(offset: offset), caret);
+  return paragraph.localToGlobal(localOffset);
+}
 
 void main() {
   testWidgets('SelectionArea uses correct selection controls', (WidgetTester tester) async {
@@ -33,4 +41,35 @@ void main() {
         break;
     }
   }, variant: TargetPlatformVariant.all());
+
+  testWidgets('onSelectionChange is called when the selection changes', (WidgetTester tester) async {
+    SelectedContent? content;
+
+    await tester.pumpWidget(MaterialApp(
+      home: SelectionArea(
+        child: const Text('How are you'),
+        onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
+      ),
+    ));
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 4), kind: PointerDeviceKind.mouse);
+    expect(content, isNull);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    await gesture.moveTo(textOffsetToPosition(paragraph, 7));
+    await gesture.up();
+    await tester.pump();
+    expect(content, isNotNull);
+    expect(content!.plainText, 'are');
+
+    // Backwards selection.
+    await gesture.down(textOffsetToPosition(paragraph, 3));
+    expect(content, isNull);
+    await gesture.moveTo(textOffsetToPosition(paragraph, 0));
+    await gesture.up();
+    await tester.pump();
+    expect(content, isNotNull);
+    expect(content!.plainText, 'How');
+  });
 }

--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -1208,6 +1208,43 @@ void main() {
     skip: kIsWeb, // [intended] Web uses its native context menu.
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.android }),
   );
+
+  testWidgets('onSelectionChange is called when the selection changes', (WidgetTester tester) async {
+    SelectedContent? content;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SelectableRegion(
+          onSelectionChanged: (SelectedContent? selectedContent) => content = selectedContent,
+          focusNode: FocusNode(),
+          selectionControls: materialTextSelectionControls,
+          child: const Center(
+            child: Text('How are you'),
+          ),
+        ),
+      ),
+    );
+    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('How are you'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph, 4), kind: PointerDeviceKind.mouse);
+    expect(content, isNull);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+
+    await gesture.moveTo(textOffsetToPosition(paragraph, 7));
+    await gesture.up();
+    await tester.pump();
+    expect(content, isNotNull);
+    expect(content!.plainText, 'are');
+
+    // Backwards selection.
+    await gesture.down(textOffsetToPosition(paragraph, 3));
+    expect(content, isNull);
+    await gesture.moveTo(textOffsetToPosition(paragraph, 0));
+    await gesture.up();
+    await tester.pump();
+    expect(content, isNotNull);
+    expect(content!.plainText, 'How');
+  });
 }
 
 class SelectionSpy extends LeafRenderObjectWidget {


### PR DESCRIPTION
This PR adds onSelectionChange callback to SelectionRegion and SelectionArea so its possible to get the selected text.

Fixes: #108231

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
