### PR TITLE
[flutter_tools] ensure setAssetDirectory uses windows path

### DIFF
--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1047,6 +1047,7 @@ class HotRunner extends ResidentRunner {
             assetsDirectory: deviceAssetsDirectoryUri,
             uiIsolateId: view.uiIsolate!.id,
             viewId: view.id,
+            windows: device.targetPlatform == TargetPlatform.windows_x64,
           )
         ));
         for (final FlutterView view in views) {

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -478,12 +478,13 @@ class FlutterVmService {
     required Uri assetsDirectory,
     required String? viewId,
     required String? uiIsolateId,
+    required bool windows,
   }) async {
     await callMethodWrapper(kSetAssetBundlePathMethod,
       isolateId: uiIsolateId,
       args: <String, Object?>{
         'viewId': viewId,
-        'assetDirectory': assetsDirectory.toFilePath(windows: false),
+        'assetDirectory': assetsDirectory.toFilePath(windows: windows),
       });
   }
 

--- a/packages/flutter_tools/test/general.shard/vmservice_test.dart
+++ b/packages/flutter_tools/test/general.shard/vmservice_test.dart
@@ -214,6 +214,7 @@ void main() {
       assetsDirectory: Uri(path: 'abc', scheme: 'file'),
       viewId: 'abc',
       uiIsolateId: 'def',
+      windows: false,
     ));
 
     final Map<String, Object> rawRequest = json.decode(await completer.future) as Map<String, Object>;
@@ -223,6 +224,34 @@ void main() {
       containsPair('params', allOf(<Matcher>[
         containsPair('viewId', 'abc'),
         containsPair('assetDirectory', '/abc'),
+        containsPair('isolateId', 'def'),
+      ])),
+    ]));
+  });
+
+  testWithoutContext('setAssetDirectory forwards arguments correctly - windows', () async {
+    final Completer<String> completer = Completer<String>();
+    final vm_service.VmService  vmService = vm_service.VmService(
+      const Stream<String>.empty(),
+      completer.complete,
+    );
+    final FlutterVmService flutterVmService = FlutterVmService(vmService);
+    unawaited(flutterVmService.setAssetDirectory(
+      assetsDirectory: Uri(path: 'C:/Users/Tester/AppData/Local/Temp/hello_worldb42a6da5/hello_world/build/flutter_assets', scheme: 'file'),
+      viewId: 'abc',
+      uiIsolateId: 'def',
+      // If windows is not set to `true`, then the file path below is incorrectly prepended with a `/` which
+      // causes the engine asset manager to interpret the file scheme as invalid.
+      windows: true,
+    ));
+
+    final Map<String, Object> rawRequest = json.decode(await completer.future) as Map<String, Object>;
+
+    expect(rawRequest, allOf(<Matcher>[
+      containsPair('method', kSetAssetBundlePathMethod),
+      containsPair('params', allOf(<Matcher>[
+        containsPair('viewId', 'abc'),
+        containsPair('assetDirectory', r'C:\Users\Tester\AppData\Local\Temp\hello_worldb42a6da5\hello_world\build\flutter_assets'),
         containsPair('isolateId', 'def'),
       ])),
     ]));


### PR DESCRIPTION
I was sort of right, except it was a URI conversion. Without this change, when the tool calls setAssetDirectory, we would send a path like: `/C:/Users/Tester/AppData/Local/Temp/hello_worldb42a6da5/hello_world/build/flutter_assets` . While the forward slashes are OK, the leading slash causes the file path to be invalid according to the engine asset manager. 

Background:

The purpose of calling `setAssetDirectory` is to provide a location where the application should load assets from ahead of the bundled assets. This goes through https://github.com/flutter/engine/blob/main/shell/common/shell.cc#L1760 which ultimately attempts to create a new asset resolver from the provided path here: https://github.com/flutter/engine/blob/main/shell/common/shell.cc#L1776-L1779

Unfortunately the behavior of PushFront/PushBack on the asset manager is to silently fail if the provided path is invalid. Thus we would continue using the old resolver. An entirely different code path re-sets the asset directory once we've done a hot restart, and that path is valid.

As a follow up, we should consider having the AssetManager return a signal as to whether adding the resolver was successful, and then plumb that data back into the response of setAssetDirectory to make any future breakages here easier to track down.

Fixes https://github.com/flutter/flutter/issues/108492

