### PR TITLE
Fix `CupertinoListTile``s onTap with delay throws exception

### DIFF
--- a/packages/flutter/lib/src/cupertino/list_tile.dart
+++ b/packages/flutter/lib/src/cupertino/list_tile.dart
@@ -385,7 +385,9 @@ class _CupertinoListTileState extends State<CupertinoListTile> {
       onTapCancel: () => setState(() { _tapped = false; }),
       onTap: () async {
         await widget.onTap!();
-        setState(() { _tapped = false; });
+        if (mounted) {
+          setState(() { _tapped = false; });
+        }
       },
       behavior: HitTestBehavior.opaque,
       child: child,

--- a/packages/flutter/test/cupertino/list_tile_test.dart
+++ b/packages/flutter/test/cupertino/list_tile_test.dart
@@ -479,4 +479,44 @@ void main() {
       expect(foundInfo.dx > foundTrailing.dx, isTrue);
     });
   });
+
+  testWidgets('onTap with delay does not throw an exception', (WidgetTester tester) async {
+    const Widget title = Text('CupertinoListTile');
+    bool showTile = true;
+
+    Future<void> onTap() async {
+      showTile = false;
+      await Future<void>.delayed(
+        const Duration(seconds: 1),
+        () => showTile = true,
+      );
+    }
+
+    Widget buildCupertinoListTile() {
+      return CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                if (showTile)
+                  CupertinoListTile(
+                    onTap: onTap,
+                    title: title,
+                  ),
+               ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildCupertinoListTile());
+    expect(showTile, isTrue);
+    await tester.tap(find.byType(CupertinoListTile));
+    expect(showTile, isFalse);
+    await tester.pumpWidget(buildCupertinoListTile());
+    await tester.pumpAndSettle(const Duration(seconds: 5));
+    expect(tester.takeException(), null);
+  });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/109024

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
