### PR TITLE
Ignore one avoid_redundant_argument_values, requires linter fix.

### DIFF
--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/controls_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/controls_page.dart
@@ -68,6 +68,8 @@ class _SelectionControlsPageState extends State<SelectionControlsPage> {
               const Checkbox(
                 key: checkbox2Key,
                 value: false,
+                // TODO(scheglov): Requires linter fix, https://github.com/dart-lang/sdk/issues/49596.
+                // ignore: avoid_redundant_argument_values
                 onChanged: null,
               ),
             ],


### PR DESCRIPTION
With https://dart-review.googlesource.com/c/sdk/+/253705 landed, https://github.com/dart-lang/sdk/issues/49596 flakiness is fixed, and now the linter always reports this lint. However semantically it is not quite correct. The behavior of the analyzer itself is correct though. So, for now we should ignore the lint instance, then fix the linter, and then go over the ignores and remove where possible.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
