### PR TITLE
[flutter_tools] Fix race condition with completer in devfs_web

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -206,12 +206,9 @@ class WebAssetServer implements AssetReader {
     const int kMaxRetries = 4;
     for (int i = 0; i <= kMaxRetries; i++) {
       try {
-        print('about to try binding');
         httpServer = await HttpServer.bind(address, port ?? await globals.os.findFreePort());
-        print('succeeded binding');
         break;
       } on SocketException catch (e, s) {
-        print('whoops!');
         if (i >= kMaxRetries) {
           globals.printError('Failed to bind web development server:\n$e', stackTrace: s);
           throwToolExit('Failed to bind web development server:\n$e');
@@ -698,7 +695,6 @@ class WebDevFS implements DevFS {
     @visibleForTesting
     VmServiceFactory vmServiceFactory = createVmServiceDelegate,
   }) {
-    print('connect started');
     final Completer<ConnectionResult> firstConnection =
         Completer<ConnectionResult>();
     // Note there is an asynchronous gap between this being set to true and
@@ -713,30 +709,25 @@ class WebDevFS implements DevFS {
                 dwds.extensionDebugConnections.stream.first)
             : await dwds.debugConnection(appConnection);
         if (foundFirstConnection) {
-        //if (firstConnection.isCompleted) { // TODO delete
-          print('second foo');
           appConnection.runMain();
         } else {
-          print('about to call the factory');
           foundFirstConnection = true;
           final vm_service.VmService vmService = await vmServiceFactory(
             Uri.parse(debugConnection.uri),
             logger: globals.logger,
           );
-          print('completing first connection...');
           firstConnection
               .complete(ConnectionResult(appConnection, debugConnection, vmService));
         }
       } on Exception catch (error, stackTrace) {
-        print('caught foo');
         if (!firstConnection.isCompleted) {
           firstConnection.completeError(error, stackTrace);
         }
       }
     }, onError: (Object error, StackTrace stackTrace) {
-      print('caught bar');
       globals.printError(
-          'Unknown error while waiting for debug connection:$error\n$stackTrace');
+        'Unknown error while waiting for debug connection:$error\n$stackTrace',
+      );
       if (!firstConnection.isCompleted) {
         firstConnection.completeError(error, stackTrace);
       }
@@ -779,7 +770,6 @@ class WebDevFS implements DevFS {
       nullSafetyMode,
       testMode: testMode,
     );
-    print('got a server!');
 
     final int selectedPort = webAssetServer.selectedPort;
     if (buildInfo.dartDefines.contains('FLUTTER_WEB_AUTO_DETECT=true')) {
@@ -792,7 +782,6 @@ class WebDevFS implements DevFS {
     } else {
       _baseUri = Uri.http('$hostname:$selectedPort', webAssetServer.basePath!);
     }
-    print('about to return $_baseUri');
     return _baseUri!;
   }
 

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -232,7 +232,6 @@ class WebAssetServer implements AssetReader {
       nullSafetyMode,
     );
     if (testMode) {
-      print('returning early because testmode');
       return server;
     }
 

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -532,10 +532,6 @@ class ResidentWebRunner extends ResidentRunner {
       final WebDevFS webDevFS = device!.devFS! as WebDevFS;
       final bool useDebugExtension = device!.device is WebServerDevice && debuggingOptions.startPaused;
       _connectionResult = await webDevFS.connect(useDebugExtension);
-      print('Received connection result!');
-      print('waiting for 5 seconds...');
-      await Future<void>.delayed(const Duration(seconds: 5));
-      print('done waiting!');
       unawaited(_connectionResult!.debugConnection!.onDone.whenComplete(_cleanupAndExit));
 
       void onLogEvent(vmservice.Event event)  {

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -532,6 +532,10 @@ class ResidentWebRunner extends ResidentRunner {
       final WebDevFS webDevFS = device!.devFS! as WebDevFS;
       final bool useDebugExtension = device!.device is WebServerDevice && debuggingOptions.startPaused;
       _connectionResult = await webDevFS.connect(useDebugExtension);
+      print('Received connection result!');
+      print('waiting for 5 seconds...');
+      await Future<void>.delayed(const Duration(seconds: 5));
+      print('done waiting!');
       unawaited(_connectionResult!.debugConnection!.onDone.whenComplete(_cleanupAndExit));
 
       void onLogEvent(vmservice.Event event)  {

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1352,7 +1352,7 @@ class FakeWebDevFS extends Fake implements WebDevFS {
   }
 
   @override
-  Future<ConnectionResult> connect(bool useDebugExtension) async {
+  Future<ConnectionResult> connect(bool useDebugExtension, {VmServiceFactory vmServiceFactory = createVmServiceDelegate}) async {
     if (exception != null) {
       assert(exception is Exception || exception is Error);
       // ignore: only_throw_errors, exception is either Error or Exception here.

--- a/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devfs_web_test.dart
@@ -870,6 +870,117 @@ void main() {
     Artifacts: () => Artifacts.test(),
   }));
 
+  test('foo bar bar foo', () => testbed.run(() async {
+    final File outputFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      ..createSync(recursive: true);
+    outputFile.parent.childFile('a.sources').writeAsStringSync('');
+    outputFile.parent.childFile('a.json').writeAsStringSync('{}');
+    outputFile.parent.childFile('a.map').writeAsStringSync('{}');
+    outputFile.parent.childFile('a.metadata').writeAsStringSync('{}');
+
+    final ResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..output = const CompilerOutput('a', 0, <Uri>[]);
+
+    final WebDevFS webDevFS = WebDevFS(
+      hostname: 'localhost',
+      port: 0,
+      packagesFilePath: '.packages',
+      urlTunneller: null,
+      useSseForDebugProxy: true,
+      useSseForDebugBackend: true,
+      useSseForInjectedClient: true,
+      nullAssertions: true,
+      nativeNullAssertions: true,
+      buildInfo: const BuildInfo(
+        BuildMode.debug,
+        '',
+        treeShakeIcons: false,
+      ),
+      enableDwds: true,
+      enableDds: false,
+      entrypoint: Uri.base,
+      testMode: true,
+      expressionCompiler: null,
+      chromiumLauncher: null,
+      nullSafetyMode: NullSafetyMode.sound,
+    );
+    webDevFS.requireJS.createSync(recursive: true);
+    webDevFS.stackTraceMapper.createSync(recursive: true);
+
+    final Uri uri = await webDevFS.create();
+    final ConnectionResult foo = await webDevFS.connect(false);
+    //webDevFS.webAssetServer.entrypointCacheDirectory = globals.fs.currentDirectory;
+    //globals.fs.currentDirectory
+    //  .childDirectory('lib')
+    //  .childFile('web_entrypoint.dart')
+    //  ..createSync(recursive: true)
+    //  ..writeAsStringSync('GENERATED');
+    //final String webPrecompiledSdk = globals.artifacts
+    //  .getHostArtifact(HostArtifact.webPrecompiledSoundSdk).path;
+    //final String webPrecompiledSdkSourcemaps = globals.artifacts
+    //  .getHostArtifact(HostArtifact.webPrecompiledSoundSdkSourcemaps).path;
+    //final String webPrecompiledCanvaskitSdk = globals.artifacts
+    //  .getHostArtifact(HostArtifact.webPrecompiledCanvaskitSoundSdk).path;
+    //final String webPrecompiledCanvaskitSdkSourcemaps = globals.artifacts
+    //  .getHostArtifact(HostArtifact.webPrecompiledCanvaskitSoundSdkSourcemaps).path;
+    //globals.fs.file(webPrecompiledSdk)
+    //  ..createSync(recursive: true)
+    //  ..writeAsStringSync('HELLO');
+    //globals.fs.file(webPrecompiledSdkSourcemaps)
+    //  ..createSync(recursive: true)
+    //  ..writeAsStringSync('THERE');
+    //globals.fs.file(webPrecompiledCanvaskitSdk)
+    //  ..createSync(recursive: true)
+    //  ..writeAsStringSync('OL');
+    //globals.fs.file(webPrecompiledCanvaskitSdkSourcemaps)
+    //  ..createSync(recursive: true)
+    //  ..writeAsStringSync('CHUM');
+
+    //await webDevFS.update(
+    //  mainUri: globals.fs.file(globals.fs.path.join('lib', 'main.dart')).uri,
+    //  generator: residentCompiler,
+    //  trackWidgetCreation: true,
+    //  bundleFirstUpload: true,
+    //  invalidatedFiles: <Uri>[],
+    //  packageConfig: PackageConfig.empty,
+    //  pathToReload: '',
+    //  dillOutputPath: '',
+    //  shaderCompiler: const FakeShaderCompiler(),
+    //);
+
+    //expect(webDevFS.webAssetServer.getFile('require.js'), isNotNull);
+    //expect(webDevFS.webAssetServer.getFile('stack_trace_mapper.js'), isNotNull);
+    //expect(webDevFS.webAssetServer.getFile('main.dart'), isNotNull);
+    //expect(webDevFS.webAssetServer.getFile('manifest.json'), isNotNull);
+    //expect(webDevFS.webAssetServer.getFile('flutter.js'), isNotNull);
+    //expect(webDevFS.webAssetServer.getFile('flutter_service_worker.js'), isNotNull);
+    //expect(webDevFS.webAssetServer.getFile('version.json'), isNotNull);
+    //expect(await webDevFS.webAssetServer.dartSourceContents('dart_sdk.js'), 'HELLO');
+    //expect(await webDevFS.webAssetServer.dartSourceContents('dart_sdk.js.map'), 'THERE');
+
+    //// Update to the SDK.
+    //globals.fs.file(webPrecompiledSdk).writeAsStringSync('BELLOW');
+
+    //// New SDK should be visible..
+    //expect(await webDevFS.webAssetServer.dartSourceContents('dart_sdk.js'), 'BELLOW');
+
+    //// Toggle CanvasKit
+    //webDevFS.webAssetServer.webRenderer = WebRendererMode.canvaskit;
+    //expect(await webDevFS.webAssetServer.dartSourceContents('dart_sdk.js'), 'OL');
+    //expect(await webDevFS.webAssetServer.dartSourceContents('dart_sdk.js.map'), 'CHUM');
+
+    //// Generated entrypoint.
+    //expect(await webDevFS.webAssetServer.dartSourceContents('web_entrypoint.dart'),
+    //  contains('GENERATED'));
+
+    //// served on localhost
+    //expect(uri.host, 'localhost');
+
+    await webDevFS.destroy();
+  }, overrides: <Type, Generator>{
+    Artifacts: () => Artifacts.test(),
+  }));
+
   test('Can start web server with hostname any', () => testbed.run(() async {
     final File outputFile = globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
       ..createSync(recursive: true);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/96988

Checking if the future was completed in the async stream handler was a bug, so instead we use a bool to keep track of if we've already seen the first connection.