### PR TITLE
fix horizontal scrolling by mouse wheel

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -685,9 +685,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   // Returns the delta that should result from applying [event] with axis and
   // direction taken into account.
   double _pointerSignalEventDelta(PointerScrollEvent event) {
-    double delta = widget.axis == Axis.horizontal
-      ? event.scrollDelta.dx
-      : event.scrollDelta.dy;
+    double delta = event.scrollDelta.dy;
 
     if (axisDirectionIsReversed(widget.axisDirection)) {
       delta *= -1;


### PR DESCRIPTION
This **_PR_** fixes #109117

### explanation:

The `Scrollable` widget uses the `Listener` widget to manage scrolling by mouse wheel.When it wants to calculate amount of delta for scrolling,it uses the following method:

```dart

// Returns the delta that should result from applying [event] with axis and
  // direction taken into account.
  double _pointerSignalEventDelta(PointerScrollEvent event) {
    double delta = widget.axis == Axis.horizontal
        ? event.scrollDelta.dx
        : event.scrollDelta.dy;

    if (axisDirectionIsReversed(widget.axisDirection)) {
      delta *= -1;
    }
    return delta;
  }
```

Therefore if `axis` is `Axis.horizontal`, the delta will be `event.scrollDelta.dx`
The problem with this approach is that `event.scrollDelta.dx`  is always 0.0.
The solution is that we use `event.scrollDelta.dx` In both cases.

```dart

// Returns the delta that should result from applying [event] with axis and
  // direction taken into account.
  double _pointerSignalEventDelta(PointerScrollEvent event) {
    double delta = event.scrollDelta.dy;

    if (axisDirectionIsReversed(widget.axisDirection)) {
      delta *= -1;
    }
    return delta;
  }
```
