### PR TITLE
Add load-extension option to flutter driver command for Flutter Web test

### DIFF
--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -141,6 +141,9 @@ class DriveCommand extends RunCommandBase {
       ..addOption('chrome-binary',
         help: 'Location of the Chrome binary. '
               'Works only if "browser-name" is set to "chrome".')
+      ..addOption('load-extension',
+        help: 'Paths to extensions to load at startup separated by comma. '
+              'Works only if "browser-name" is set to "chrome".')
       ..addOption('write-sksl-on-exit',
         help: 'Attempts to write an SkSL file when the drive process is finished '
               'to the provided file, overwriting it if necessary.')
@@ -282,6 +285,7 @@ class DriveCommand extends RunCommandBase {
         webBrowserFlags: stringsArg(FlutterOptions.kWebBrowserFlag),
         browserDimension: stringArgDeprecated('browser-dimension')!.split(','),
         browserName: stringArgDeprecated('browser-name'),
+        extensions: stringArgDeprecated('load-extension')?.split(','),
         driverPort: stringArgDeprecated('driver-port') != null
           ? int.tryParse(stringArgDeprecated('driver-port')!)
           : null,

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -99,6 +99,7 @@ abstract class DriverService {
     int? driverPort,
     List<String> webBrowserFlags,
     List<String>? browserDimension,
+    List<String>? extensions,
     String? profileMemory,
   });
 
@@ -257,6 +258,7 @@ class FlutterDriverService extends DriverService {
     int? driverPort,
     List<String> webBrowserFlags = const <String>[],
     List<String>? browserDimension,
+    List<String>? extensions,
     String? profileMemory,
   }) async {
     if (profileMemory != null) {

--- a/packages/flutter_tools/lib/src/drive/web_driver_service.dart
+++ b/packages/flutter_tools/lib/src/drive/web_driver_service.dart
@@ -138,6 +138,7 @@ class WebDriverService extends DriverService {
     int? driverPort,
     List<String> webBrowserFlags = const <String>[],
     List<String>? browserDimension,
+    List<String>? extensions,
     String? profileMemory,
   }) async {
     late async_io.WebDriver webDriver;
@@ -150,6 +151,7 @@ class WebDriverService extends DriverService {
           headless,
           webBrowserFlags: webBrowserFlags,
           chromeBinary: chromeBinary,
+          extensions: extensions,
         ),
       );
     } on SocketException catch (error) {
@@ -248,9 +250,13 @@ Map<String, dynamic> getDesiredCapabilities(
   bool? headless, {
   List<String> webBrowserFlags = const <String>[],
   String? chromeBinary,
+  List<String>? extensions,
 }) {
   switch (browser) {
     case Browser.chrome:
+      final String chromeExtensionFlag = extensions == null
+        ? '--disable-extensions'
+        : '--load-extension=${extensions.join(',')}';
       return <String, dynamic>{
         'acceptInsecureCerts': true,
         'browserName': 'chrome',
@@ -266,12 +272,12 @@ Map<String, dynamic> getDesiredCapabilities(
             '--bwsi',
             '--disable-background-timer-throttling',
             '--disable-default-apps',
-            '--disable-extensions',
             '--disable-popup-blocking',
             '--disable-translate',
             '--no-default-browser-check',
             '--no-sandbox',
             '--no-first-run',
+            chromeExtensionFlag,
             if (headless!) '--headless',
             ...webBrowserFlags,
           ],

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -355,6 +355,7 @@ class FailingFakeDriverService extends Fake implements DriverService {
       int driverPort,
       List<String> webBrowserFlags,
       List<String> browserDimension,
+      List<String> extensions,
       String profileMemory,
     }) async => 1;
 }

--- a/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/web_driver_service_test.dart
@@ -28,7 +28,6 @@ const List<String> kChromeArgs = <String>[
   '--bwsi',
   '--disable-background-timer-throttling',
   '--disable-default-apps',
-  '--disable-extensions',
   '--disable-popup-blocking',
   '--disable-translate',
   '--no-default-browser-check',
@@ -49,6 +48,7 @@ void main() {
         'w3c': false,
         'args': <String>[
           ...kChromeArgs,
+          '--disable-extensions',
           '--headless',
         ],
         'perfLoggingPrefs': <String, String>{
@@ -75,7 +75,10 @@ void main() {
       'chromeOptions': <String, dynamic>{
         'binary': chromeBinary,
         'w3c': false,
-        'args': kChromeArgs,
+        'args': [
+          ...kChromeArgs,
+          '--disable-extensions',
+        ],
         'perfLoggingPrefs': <String, String>{
           'traceCategories':
           'devtools.timeline,'
@@ -106,6 +109,7 @@ void main() {
         'w3c': false,
         'args': <String>[
           ...kChromeArgs,
+          '--disable-extensions',
           '--autoplay-policy=no-user-gesture-required',
           '--incognito',
           '--auto-select-desktop-capture-source="Entire screen"',
@@ -120,6 +124,58 @@ void main() {
     };
 
     expect(getDesiredCapabilities(Browser.chrome, false, webBrowserFlags: webBrowserFlags), expected);
+  });
+
+  testWithoutContext('getDesiredCapabilities Chrome with one extension', () {
+    final Map<String, dynamic> expected = <String, dynamic>{
+      'acceptInsecureCerts': true,
+      'browserName': 'chrome',
+      'goog:loggingPrefs': <String, String>{
+        sync_io.LogType.browser: 'INFO',
+        sync_io.LogType.performance: 'ALL',
+      },
+      'chromeOptions': <String, dynamic>{
+        'w3c': false,
+        'args': <String>[
+          ...kChromeArgs,
+          '--load-extension=extension_folder1',
+        ],
+        'perfLoggingPrefs': <String, String>{
+          'traceCategories':
+          'devtools.timeline,'
+              'v8,blink.console,benchmark,blink,'
+              'blink.user_timing',
+        },
+      },
+    };
+
+    expect(getDesiredCapabilities(Browser.chrome, false, extensions: <String>['extension_folder1']), expected);
+  });
+
+  testWithoutContext('getDesiredCapabilities Chrome with one extension', () {
+    final Map<String, dynamic> expected = <String, dynamic>{
+      'acceptInsecureCerts': true,
+      'browserName': 'chrome',
+      'goog:loggingPrefs': <String, String>{
+        sync_io.LogType.browser: 'INFO',
+        sync_io.LogType.performance: 'ALL',
+      },
+      'chromeOptions': <String, dynamic>{
+        'w3c': false,
+        'args': <String>[
+          ...kChromeArgs,
+          '--load-extension=extension_folder1,extension_folder2',
+        ],
+        'perfLoggingPrefs': <String, String>{
+          'traceCategories':
+          'devtools.timeline,'
+              'v8,blink.console,benchmark,blink,'
+              'blink.user_timing',
+        },
+      },
+    };
+
+    expect(getDesiredCapabilities(Browser.chrome, false, extensions: <String>['extension_folder1', 'extension_folder2']), expected);
   });
 
   testWithoutContext('getDesiredCapabilities Firefox with headless on', () {


### PR DESCRIPTION
## Description
Allow user to load Chrome extension in Flutter Driver via argument `--load-extension`.

Note that this change follow the implemention in PR #53275 to add `--chrome-binary` option.

For example,

```
flutter drive -d web-server --web-port 7357 --browser-name chrome --driver test_driver/integration_test.dart --target integration_test/hocho_test.dart --no-headless --load-extension=/Users/pussycat/PlayGround/debug_extension/metamask
```

## Related Issues
#109156

## Tests
Updated flutter_tools's commands.shard and general.shard to reflect the change.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
