### PR TITLE
Add initial compile tests

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1340,7 +1340,7 @@ class CompileTest {
       await flutter('packages', options: <String>['get']);
 
       // "initial" compile required downloading and creating the `android/.gradle` directory while "full"
-      // compiles only run `flutter clean` between runs.gi
+      // compiles only run `flutter clean` between runs.
       final Map<String, dynamic> compileInitialRelease = await _compileApp(deleteGradleCache: true);
       final Map<String, dynamic> compileFullRelease = await _compileApp(deleteGradleCache: false);
       final Map<String, dynamic> compileInitialDebug = await _compileDebug(


### PR DESCRIPTION
In discussion for https://github.com/flutter/flutter/issues/84868, We are seeing differences when running flutter build depending on if the contents of `android/.gradle` directory is populated or not. This is because gradle will download dependencies and generate the .gradle file on first run of the app.

This PR splits the inital compile time into `initial` and `full`, where initial implies building from a fully untouched never-before-compiled project, while `full` implies building after just running `flutter clean`.

This change adds about ~30s of build time to the `hello_world_android__compile` test task