### PR TITLE
Update `flutter.gradle` AGP to 7.2.0 and bump default NDK version

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -746,6 +746,58 @@ class FlutterPlugin implements Plugin<Project> {
         return target
     }
 
+    /**
+     * In AGP 4.0, the Android linter task depends on the JAR tasks that generate `libapp.so`.
+     * When building APKs, this causes an issue where building release requires the debug JAR,
+     * but Gradle won't build debug.
+     *
+     * To workaround this issue, only configure the JAR task that is required given the task
+     * from the command line.
+     *
+     * The AGP team said that this issue is fixed in Gradle 7.0, which isn't released at the
+     * time of adding this code. Once released, this can be removed. However, after updating to
+     * AGP/Gradle 7.2.0/7.5, removing this hack still causes build failures. Futher
+     * investigation necessary to remote this.
+     *
+     * Tested cases:
+     * * `./gradlew assembleRelease`
+     * * `./gradlew app:assembleRelease.`
+     * * `./gradlew assemble{flavorName}Release`
+     * * `./gradlew app:assemble{flavorName}Release`
+     * * `./gradlew assemble.`
+     * * `./gradlew app:assemble.`
+     * * `./gradlew bundle.`
+     * * `./gradlew bundleRelease.`
+     * * `./gradlew app:bundleRelease.`
+     *
+     * Related issues:
+     * https://issuetracker.google.com/issues/158060799
+     * https://issuetracker.google.com/issues/158753935
+     */
+    private boolean shouldConfigureFlutterTask(Task assembleTask) {
+        def cliTasksNames = project.gradle.startParameter.taskNames
+        if (cliTasksNames.size() != 1 || !cliTasksNames.first().contains("assemble")) {
+            return true
+        }
+        def taskName = cliTasksNames.first().split(":").last()
+        if (taskName == "assemble") {
+            return true
+        }
+        if (taskName == assembleTask.name) {
+            return true
+        }
+        if (taskName.endsWith("Release") && assembleTask.name.endsWith("Release")) {
+            return true
+        }
+        if (taskName.endsWith("Debug") && assembleTask.name.endsWith("Debug")) {
+            return true
+        }
+        if (taskName.endsWith("Profile") && assembleTask.name.endsWith("Profile")) {
+            return true
+        }
+        return false
+    }
+
     private Task getAssembleTask(variant) {
         // `assemble` became `assembleProvider` in AGP 3.3.0.
         return variant.hasProperty("assembleProvider") ? variant.assembleProvider.get() : variant.assemble
@@ -926,6 +978,9 @@ class FlutterPlugin implements Plugin<Project> {
         if (isFlutterAppProject()) {
             project.android.applicationVariants.all { variant ->
                 Task assembleTask = getAssembleTask(variant)
+                if (!shouldConfigureFlutterTask(assembleTask)) {
+                  return
+                }
                 Task copyFlutterAssetsTask = addFlutterDeps(variant)
                 def variantOutput = variant.outputs.first()
                 def processResources = variantOutput.hasProperty("processResourcesProvider") ?
@@ -984,6 +1039,9 @@ class FlutterPlugin implements Plugin<Project> {
                 Task copyFlutterAssetsTask
                 appProject.android.applicationVariants.all { appProjectVariant ->
                     Task appAssembleTask = getAssembleTask(appProjectVariant)
+                    if (!shouldConfigureFlutterTask(appAssembleTask)) {
+                        return
+                    }
                     // Find a compatible application variant in the host app.
                     //
                     // For example, consider a host app that defines the following variants:

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -746,6 +746,7 @@ class FlutterPlugin implements Plugin<Project> {
         return target
     }
 
+    // TODO: Remove this AGP hack. https://github.com/flutter/flutter/issues/109560
     /**
      * In AGP 4.0, the Android linter task depends on the JAR tasks that generate `libapp.so`.
      * When building APKs, this causes an issue where building release requires the debug JAR,
@@ -757,7 +758,7 @@ class FlutterPlugin implements Plugin<Project> {
      * The AGP team said that this issue is fixed in Gradle 7.0, which isn't released at the
      * time of adding this code. Once released, this can be removed. However, after updating to
      * AGP/Gradle 7.2.0/7.5, removing this hack still causes build failures. Futher
-     * investigation necessary to remote this.
+     * investigation necessary to remove this.
      *
      * Tested cases:
      * * `./gradlew assembleRelease`

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -746,56 +746,6 @@ class FlutterPlugin implements Plugin<Project> {
         return target
     }
 
-    /**
-     * In AGP 4.0, the Android linter task depends on the JAR tasks that generate `libapp.so`.
-     * When building APKs, this causes an issue where building release requires the debug JAR,
-     * but Gradle won't build debug.
-     *
-     * To workaround this issue, only configure the JAR task that is required given the task
-     * from the command line.
-     *
-     * The AGP team said that this issue is fixed in Gradle 7.0, which isn't released at the
-     * time of adding this code. Once released, this can be removed.
-     *
-     * Tested cases:
-     * * `./gradlew assembleRelease`
-     * * `./gradlew app:assembleRelease.`
-     * * `./gradlew assemble{flavorName}Release`
-     * * `./gradlew app:assemble{flavorName}Release`
-     * * `./gradlew assemble.`
-     * * `./gradlew app:assemble.`
-     * * `./gradlew bundle.`
-     * * `./gradlew bundleRelease.`
-     * * `./gradlew app:bundleRelease.`
-     *
-     * Related issues:
-     * https://issuetracker.google.com/issues/158060799
-     * https://issuetracker.google.com/issues/158753935
-     */
-    private boolean shouldConfigureFlutterTask(Task assembleTask) {
-        def cliTasksNames = project.gradle.startParameter.taskNames
-        if (cliTasksNames.size() != 1 || !cliTasksNames.first().contains("assemble")) {
-            return true
-        }
-        def taskName = cliTasksNames.first().split(":").last()
-        if (taskName == "assemble") {
-            return true
-        }
-        if (taskName == assembleTask.name) {
-            return true
-        }
-        if (taskName.endsWith("Release") && assembleTask.name.endsWith("Release")) {
-            return true
-        }
-        if (taskName.endsWith("Debug") && assembleTask.name.endsWith("Debug")) {
-            return true
-        }
-        if (taskName.endsWith("Profile") && assembleTask.name.endsWith("Profile")) {
-            return true
-        }
-        return false
-    }
-
     private Task getAssembleTask(variant) {
         // `assemble` became `assembleProvider` in AGP 3.3.0.
         return variant.hasProperty("assembleProvider") ? variant.assembleProvider.get() : variant.assemble
@@ -976,9 +926,6 @@ class FlutterPlugin implements Plugin<Project> {
         if (isFlutterAppProject()) {
             project.android.applicationVariants.all { variant ->
                 Task assembleTask = getAssembleTask(variant)
-                if (!shouldConfigureFlutterTask(assembleTask)) {
-                  return
-                }
                 Task copyFlutterAssetsTask = addFlutterDeps(variant)
                 def variantOutput = variant.outputs.first()
                 def processResources = variantOutput.hasProperty("processResourcesProvider") ?
@@ -1037,9 +984,6 @@ class FlutterPlugin implements Plugin<Project> {
                 Task copyFlutterAssetsTask
                 appProject.android.applicationVariants.all { appProjectVariant ->
                     Task appAssembleTask = getAssembleTask(appProjectVariant)
-                    if (!shouldConfigureFlutterTask(appAssembleTask)) {
-                        return
-                    }
                     // Find a compatible application variant in the host app.
                     //
                     // For example, consider a host app that defines the following variants:

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -42,7 +42,7 @@ class FlutterExtension {
      * Sets the ndkVersion used by default in Flutter app projects.
      * Chosen as default version of the AGP version below.
      */
-    static String ndkVersion = "21.1.6352462"
+    static String ndkVersion = "21.4.7075529"
 
     /**
      * Specifies the relative directory to the Flutter project directory.
@@ -61,7 +61,7 @@ buildscript {
     }
     dependencies {
         /* When bumping, also update ndkVersion above. */
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:7.2.0'
     }
 }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -94,6 +94,8 @@ class FlutterPlugin implements Plugin<Project> {
     private static final String ARCH_X86        = "x86";
     private static final String ARCH_X86_64     = "x86_64";
 
+    private static final String INTERMEDIATE_DIR = "intermediate";
+
     /** Maps platforms to ABI architectures. */
     private static final Map PLATFORM_ARCH_MAP = [
         (PLATFORM_ARM32)    : ARCH_ARM32,
@@ -893,7 +895,7 @@ class FlutterPlugin implements Plugin<Project> {
                 trackWidgetCreation trackWidgetCreationValue
                 targetPlatformValues = targetPlatforms
                 sourceDir getFlutterSourceDirectory()
-                intermediateDir project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}/")
+                intermediateDir project.file("${project.buildDir}/$INTERMEDIATE_DIR/flutter/${variant.name}/")
                 extraFrontEndOptions extraFrontEndOptionsValue
                 extraGenSnapshotOptions extraGenSnapshotOptionsValue
                 splitDebugInfo splitDebugInfoValue
@@ -915,7 +917,7 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
-            File libJar = project.file("${project.buildDir}/${AndroidProject.FD_INTERMEDIATES}/flutter/${variant.name}/libs.jar")
+            File libJar = project.file("${project.buildDir}/$INTERMEDIATE_DIR/flutter/${variant.name}/libs.jar")
             Task packFlutterAppAotTask = project.tasks.create(name: "packLibs${FLUTTER_BUILD_PREFIX}${variant.name.capitalize()}", type: Jar) {
                 destinationDir libJar.parentFile
                 archiveName libJar.name

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -40,7 +40,8 @@ class FlutterExtension {
 
     /**
      * Sets the ndkVersion used by default in Flutter app projects.
-     * Chosen as default version of the AGP version below.
+     * Chosen as default version of the AGP version below as found in
+     * https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
      */
     static String ndkVersion = "21.4.7075529"
 
@@ -94,7 +95,7 @@ class FlutterPlugin implements Plugin<Project> {
     private static final String ARCH_X86        = "x86";
     private static final String ARCH_X86_64     = "x86_64";
 
-    private static final String INTERMEDIATE_DIR = "intermediate";
+    private static final String INTERMEDIATES_DIR = "intermediates";
 
     /** Maps platforms to ABI architectures. */
     private static final Map PLATFORM_ARCH_MAP = [
@@ -895,7 +896,7 @@ class FlutterPlugin implements Plugin<Project> {
                 trackWidgetCreation trackWidgetCreationValue
                 targetPlatformValues = targetPlatforms
                 sourceDir getFlutterSourceDirectory()
-                intermediateDir project.file("${project.buildDir}/$INTERMEDIATE_DIR/flutter/${variant.name}/")
+                intermediateDir project.file("${project.buildDir}/$INTERMEDIATES_DIR/flutter/${variant.name}/")
                 extraFrontEndOptions extraFrontEndOptionsValue
                 extraGenSnapshotOptions extraGenSnapshotOptionsValue
                 splitDebugInfo splitDebugInfoValue
@@ -917,7 +918,7 @@ class FlutterPlugin implements Plugin<Project> {
                     }
                 }
             }
-            File libJar = project.file("${project.buildDir}/$INTERMEDIATE_DIR/flutter/${variant.name}/libs.jar")
+            File libJar = project.file("${project.buildDir}/$INTERMEDIATES_DIR/flutter/${variant.name}/libs.jar")
             Task packFlutterAppAotTask = project.tasks.create(name: "packLibs${FLUTTER_BUILD_PREFIX}${variant.name.capitalize()}", type: Jar) {
                 destinationDir libJar.parentFile
                 archiveName libJar.name

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -41,7 +41,7 @@ const String templateKotlinGradlePluginVersion = '1.7.10';
 const String compileSdkVersion = '31';
 const String minSdkVersion = '16';
 const String targetSdkVersion = '31';
-const String ndkVersion = '21.1.6352462';
+const String ndkVersion = '21.4.7075529';
 
 final RegExp _androidPluginRegExp = RegExp(r'com\.android\.tools\.build:gradle:(\d+\.\d+\.\d+)');
 


### PR DESCRIPTION
Addresses https://github.com/flutter/flutter/issues/105040 as we have since updated the default AGP version to 7.2.0 already.