### PR TITLE
Replace NavigatorObserver._navigator with a static expando.

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -620,7 +620,17 @@ abstract class Page<T> extends RouteSettings {
 class NavigatorObserver {
   /// The navigator that the observer is observing, if any.
   NavigatorState? get navigator => _navigators[this];
-  static final _navigators = Expando<NavigatorState>();
+
+  /// Expando mapping instances of NavigatorObserver to their associated
+  /// NavigatorState (or `null`, if there is no associated NavigatorState).  The
+  /// reason we don't simply use a private instance field of type
+  /// `NavigatorState?` is because as part of implementing
+  /// https://github.com/dart-lang/language/issues/2020, it will soon become a
+  /// runtime error to invoke a private member that is mocked in another
+  /// library.  By using an expando rather than an instance field, we ensure
+  /// that a mocked NavigatorObserver can still properly keep track of its
+  /// associated NavigatorState.
+  static final Expando<NavigatorState> _navigators = Expando<NavigatorState>();
 
   /// The [Navigator] pushed `route`.
   ///

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -619,8 +619,8 @@ abstract class Page<T> extends RouteSettings {
 /// An interface for observing the behavior of a [Navigator].
 class NavigatorObserver {
   /// The navigator that the observer is observing, if any.
-  NavigatorState? get navigator => _navigator;
-  NavigatorState? _navigator;
+  NavigatorState? get navigator => _navigators[this];
+  static final _navigators = Expando<NavigatorState>();
 
   /// The [Navigator] pushed `route`.
   ///
@@ -3236,7 +3236,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     }());
     for (final NavigatorObserver observer in widget.observers) {
       assert(observer.navigator == null);
-      observer._navigator = this;
+      NavigatorObserver._navigators[observer] = this;
     }
     _effectiveObservers = widget.observers;
 
@@ -3359,12 +3359,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
             ServicesBinding.instance.addPostFrameCallback((Duration timestamp) {
               // We only check if this navigator still owns the hero controller.
               if (_heroControllerFromScope == newHeroController) {
-                final bool hasHeroControllerOwnerShip = _heroControllerFromScope!._navigator == this;
+                final bool hasHeroControllerOwnerShip = _heroControllerFromScope!.navigator == this;
                 if (!hasHeroControllerOwnerShip ||
                     previousOwner._heroControllerFromScope == newHeroController) {
                   final NavigatorState otherOwner = hasHeroControllerOwnerShip
                     ? previousOwner
-                    : _heroControllerFromScope!._navigator!;
+                    : _heroControllerFromScope!.navigator!;
                   FlutterError.reportError(
                     FlutterErrorDetails(
                       exception: FlutterError(
@@ -3386,12 +3386,12 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
           }
           return true;
         }());
-        newHeroController._navigator = this;
+        NavigatorObserver._navigators[newHeroController] = this;
       }
       // Only unsubscribe the hero controller when it is currently subscribe to
       // this navigator.
-      if (_heroControllerFromScope?._navigator == this) {
-        _heroControllerFromScope?._navigator = null;
+      if (_heroControllerFromScope?.navigator == this) {
+        NavigatorObserver._navigators[_heroControllerFromScope!] = null;
       }
       _heroControllerFromScope = newHeroController;
       _updateEffectiveObservers();
@@ -3440,11 +3440,11 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     }());
     if (oldWidget.observers != widget.observers) {
       for (final NavigatorObserver observer in oldWidget.observers) {
-        observer._navigator = null;
+        NavigatorObserver._navigators[observer] = null;
       }
       for (final NavigatorObserver observer in widget.observers) {
         assert(observer.navigator == null);
-        observer._navigator = this;
+        NavigatorObserver._navigators[observer] = this;
       }
       _updateEffectiveObservers();
     }
@@ -3489,7 +3489,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
   @override
   void deactivate() {
     for (final NavigatorObserver observer in _effectiveObservers) {
-      observer._navigator = null;
+      NavigatorObserver._navigators[observer] = null;
     }
     super.deactivate();
   }
@@ -3499,7 +3499,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     super.activate();
     for (final NavigatorObserver observer in _effectiveObservers) {
       assert(observer.navigator == null);
-      observer._navigator = this;
+      NavigatorObserver._navigators[observer] = this;
     }
   }
 
@@ -3512,7 +3512,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
     }());
     assert(() {
       for (final NavigatorObserver observer in _effectiveObservers) {
-        assert(observer._navigator != this);
+        assert(observer.navigator != this);
       }
       return true;
     }());

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -3867,7 +3867,7 @@ void main() {
       });
 
   testWidgets('class implementing NavigatorObserver can be used without problems', (WidgetTester tester) async {
-    final observer = _MockNavigatorObserver();
+    final _MockNavigatorObserver observer = _MockNavigatorObserver();
     Widget build([Key? key]) {
       return Directionality(
         textDirection: TextDirection.ltr,
@@ -3887,16 +3887,16 @@ void main() {
     }
 
     await tester.pumpWidget(build());
-    observer._checkInvocations([#navigator, #didPush]);
+    observer._checkInvocations(<Symbol>[#navigator, #didPush]);
     await tester.pumpWidget(Container(child: build()));
-    observer._checkInvocations([#navigator, #didPush, #navigator]);
+    observer._checkInvocations(<Symbol>[#navigator, #didPush, #navigator]);
     await tester.pumpWidget(Container());
-    observer._checkInvocations([#navigator]);
+    observer._checkInvocations(<Symbol>[#navigator]);
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(build(key));
-    observer._checkInvocations([#navigator, #didPush]);
+    observer._checkInvocations(<Symbol>[#navigator, #didPush]);
     await tester.pumpWidget(Container(child: build(key)));
-    observer._checkInvocations([#navigator, #navigator]);
+    observer._checkInvocations(<Symbol>[#navigator, #navigator]);
   });
 }
 
@@ -4150,7 +4150,7 @@ class ZeroDurationPageRoute extends PageRoute<void> {
 }
 
 class _MockNavigatorObserver implements NavigatorObserver {
-  List<Symbol> _invocations = [];
+  final List<Symbol> _invocations = <Symbol>[];
 
   void _checkInvocations(List<Symbol> expected) {
     expect(_invocations, expected);

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -3865,6 +3865,34 @@ void main() {
         await tester.pumpAndSettle();
         expect(focusNode.hasFocus, true);
       });
+
+  testWidgets('class implementing NavigatorObserver can be used without problems', (WidgetTester tester) async {
+    final NavigatorObserver observer = _MockNavigatorObserver();
+    Widget build([Key? key]) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Navigator(
+          key: key,
+          observers: <NavigatorObserver>[observer],
+          onGenerateRoute: (RouteSettings settings) {
+            return PageRouteBuilder<void>(
+              settings: settings,
+              pageBuilder: (BuildContext _, Animation<double> __, Animation<double> ___) {
+                return Container();
+              },
+            );
+          },
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build());
+    await tester.pumpWidget(Container(child: build()));
+    await tester.pumpWidget(Container());
+    final GlobalKey key = GlobalKey();
+    await tester.pumpWidget(build(key));
+    await tester.pumpWidget(Container(child: build(key)));
+  });
 }
 
 typedef AnnouncementCallBack = void Function(Route<dynamic>?);
@@ -4114,4 +4142,11 @@ class ZeroDurationPageRoute extends PageRoute<void> {
 
   @override
   String? get barrierLabel => null;
+}
+
+class _MockNavigatorObserver implements NavigatorObserver {
+  @override
+  Object? noSuchMethod(Invocation invocation) {
+    throw 'TODO(paulberry): $invocation';
+  }
 }

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -3867,7 +3867,7 @@ void main() {
       });
 
   testWidgets('class implementing NavigatorObserver can be used without problems', (WidgetTester tester) async {
-    final NavigatorObserver observer = _MockNavigatorObserver();
+    final observer = _MockNavigatorObserver();
     Widget build([Key? key]) {
       return Directionality(
         textDirection: TextDirection.ltr,
@@ -3887,11 +3887,16 @@ void main() {
     }
 
     await tester.pumpWidget(build());
+    observer._checkInvocations([#navigator, #didPush]);
     await tester.pumpWidget(Container(child: build()));
+    observer._checkInvocations([#navigator, #didPush, #navigator]);
     await tester.pumpWidget(Container());
+    observer._checkInvocations([#navigator]);
     final GlobalKey key = GlobalKey();
     await tester.pumpWidget(build(key));
+    observer._checkInvocations([#navigator, #didPush]);
     await tester.pumpWidget(Container(child: build(key)));
+    observer._checkInvocations([#navigator, #navigator]);
   });
 }
 
@@ -4145,8 +4150,16 @@ class ZeroDurationPageRoute extends PageRoute<void> {
 }
 
 class _MockNavigatorObserver implements NavigatorObserver {
+  List<Symbol> _invocations = [];
+
+  void _checkInvocations(List<Symbol> expected) {
+    expect(_invocations, expected);
+    _invocations.clear();
+  }
+
   @override
   Object? noSuchMethod(Invocation invocation) {
-    throw 'TODO(paulberry): $invocation';
+    _invocations.add(invocation.memberName);
+    return null;
   }
 }


### PR DESCRIPTION
This change replaces `NavigatorObserver._navigator` (an instance field that points from a `NavigatorObserver` to the `NavigatorState` it's observing) with an expando that maps from `NavigatorObserver` to `NavigatorState`.  There is no change to the public API, and no change to the behavior of users' production code.

The change ensures that if a customer's test replaces an instance of `NavigatorObserver` with a mock, but doesn't replace `NavigatorState` with a mock, the code in `NavigatorState` won't try to access the private `_navigator` field in `NavigatorObserver`.  This is important because an upcoming change to the dart language is going to cause such accesses to throw exceptions (see https://github.com/flutter/flutter/issues/109237 and https://github.com/dart-lang/language/issues/2020 for details).

Fixes https://github.com/flutter/flutter/issues/109237.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
