### PR TITLE
replace engine and framework mirror args with github username arg

### DIFF
--- a/dev/conductor/README.md
+++ b/dev/conductor/README.md
@@ -39,8 +39,7 @@ Releases are initialized with the `start` sub-command, like:
 conductor start \
   --candidate-branch=flutter-2.2-candidate.10 \
   --release-channel=beta \
-  --framework-mirror=git@github.com:username/flutter.git \
-  --engine-mirror=git@github.com:username/engine.git \
+  --github-username=kingOfDevelopers \
   --engine-cherrypicks=72114dafe28c8700f1d5d629c6ae9d34172ba395 \
   --framework-cherrypicks=a3e66b396746f6581b2b7efd1b0d0f0074215128,d8d853436206e86f416236b930e97779b143a100 \
   --dart-revision=4511eb2a779a612d9d6b2012123575013e0aef12 \

--- a/dev/conductor/core/lib/src/start.dart
+++ b/dev/conductor/core/lib/src/start.dart
@@ -31,6 +31,7 @@ const String kEngineMirrorOption = 'engine-mirror';
 const String kReleaseOption = 'release-channel';
 const String kStateOption = 'state-file';
 const String kVersionOverrideOption = 'version-override';
+const String kGithubUsernameOption = 'github-username';
 
 /// Command to print the status of the current Flutter release.
 class StartCommand extends Command<void> {
@@ -54,7 +55,8 @@ class StartCommand extends Command<void> {
     argParser.addOption(
       kFrameworkUpstreamOption,
       defaultsTo: FrameworkRepository.defaultUpstream,
-      help: 'Configurable Framework repo upstream remote. Primarily for testing.',
+      help:
+          'Configurable Framework repo upstream remote. Primarily for testing.',
       hide: true,
     );
     argParser.addOption(
@@ -62,14 +64,6 @@ class StartCommand extends Command<void> {
       defaultsTo: EngineRepository.defaultUpstream,
       help: 'Configurable Engine repo upstream remote. Primarily for testing.',
       hide: true,
-    );
-    argParser.addOption(
-      kFrameworkMirrorOption,
-      help: 'Framework repo mirror remote.',
-    );
-    argParser.addOption(
-      kEngineMirrorOption,
-      help: 'Engine repo mirror remote.',
     );
     argParser.addOption(
       kStateOption,
@@ -98,7 +92,11 @@ class StartCommand extends Command<void> {
     argParser.addOption(
       kVersionOverrideOption,
       help: 'Explicitly set the desired version. This should only be used if '
-        'the version computed by the tool is not correct.',
+          'the version computed by the tool is not correct.',
+    );
+    argParser.addOption(
+      kGithubUsernameOption,
+      help: 'Github username',
     );
   }
 
@@ -130,21 +128,19 @@ class StartCommand extends Command<void> {
       argumentResults,
       platform.environment,
     )!;
-    final String frameworkMirror = getValueFromEnvOrArgs(
-      kFrameworkMirrorOption,
+    final String githubUsername = getValueFromEnvOrArgs(
+      kGithubUsernameOption,
       argumentResults,
       platform.environment,
     )!;
+    final String frameworkMirror =
+        'https://github.com/$githubUsername/flutter.git';
     final String engineUpstream = getValueFromEnvOrArgs(
       kEngineUpstreamOption,
       argumentResults,
       platform.environment,
     )!;
-    final String engineMirror = getValueFromEnvOrArgs(
-      kEngineMirrorOption,
-      argumentResults,
-      platform.environment,
-    )!;
+    final String engineMirror = 'https://github.com/$githubUsername/engine.git';
     final String candidateBranch = getValueFromEnvOrArgs(
       kCandidateOption,
       argumentResults,
@@ -177,7 +173,8 @@ class StartCommand extends Command<void> {
       platform.environment,
     );
     final File stateFile = checkouts.fileSystem.file(
-      getValueFromEnvOrArgs(kStateOption, argumentResults, platform.environment),
+      getValueFromEnvOrArgs(
+          kStateOption, argumentResults, platform.environment),
     );
     final String? versionOverrideString = getValueFromEnvOrArgs(
       kVersionOverrideOption,
@@ -206,6 +203,7 @@ class StartCommand extends Command<void> {
       stateFile: stateFile,
       force: force,
       versionOverride: versionOverride,
+      githubUsername: githubUsername,
     );
     return context.run();
   }
@@ -227,34 +225,36 @@ class StartContext extends Context {
     required this.conductorVersion,
     required this.processManager,
     required this.releaseChannel,
+    required this.githubUsername,
     required super.checkouts,
     required super.stateFile,
     this.force = false,
     this.versionOverride,
-  }) : git = Git(processManager),
-  engine = EngineRepository(
-    checkouts,
-    initialRef: 'upstream/$candidateBranch',
-    upstreamRemote: Remote(
-      name: RemoteName.upstream,
-      url: engineUpstream,
-    ),
-    mirrorRemote: Remote(
-      name: RemoteName.mirror,
-      url: engineMirror,
-    ),
-  ), framework = FrameworkRepository(
-    checkouts,
-    initialRef: 'upstream/$candidateBranch',
-    upstreamRemote: Remote(
-      name: RemoteName.upstream,
-      url: frameworkUpstream,
-    ),
-    mirrorRemote: Remote(
-      name: RemoteName.mirror,
-      url: frameworkMirror,
-    ),
-  );
+  })  : git = Git(processManager),
+        engine = EngineRepository(
+          checkouts,
+          initialRef: 'upstream/$candidateBranch',
+          upstreamRemote: Remote(
+            name: RemoteName.upstream,
+            url: engineUpstream,
+          ),
+          mirrorRemote: Remote(
+            name: RemoteName.mirror,
+            url: engineMirror,
+          ),
+        ),
+        framework = FrameworkRepository(
+          checkouts,
+          initialRef: 'upstream/$candidateBranch',
+          upstreamRemote: Remote(
+            name: RemoteName.upstream,
+            url: frameworkUpstream,
+          ),
+          mirrorRemote: Remote(
+            name: RemoteName.mirror,
+            url: frameworkMirror,
+          ),
+        );
 
   final String candidateBranch;
   final String? dartRevision;
@@ -269,6 +269,7 @@ class StartContext extends Context {
   final ProcessManager processManager;
   final String releaseChannel;
   final Version? versionOverride;
+  final String githubUsername;
 
   /// If validations should be overridden.
   final bool force;
@@ -298,7 +299,8 @@ class StartContext extends Context {
 
   Future<void> run() async {
     if (stateFile.existsSync()) {
-      throw ConductorException('Error! A persistent state file already found at ${stateFile.path}.\n\n'
+      throw ConductorException(
+          'Error! A persistent state file already found at ${stateFile.path}.\n\n'
           'Run `conductor clean` to cancel a previous release.');
     }
     if (!releaseCandidateBranchRegex.hasMatch(candidateBranch)) {
@@ -329,10 +331,12 @@ class StartContext extends Context {
       cherrypicks: engineCherrypickRevisions,
       upstreamRef: EngineRepository.defaultBranch,
       releaseRef: candidateBranch,
-    )).map((String revision) => pb.Cherrypick(
-      trunkRevision: revision,
-      state: pb.CherrypickState.PENDING,
-    )).toList();
+    ))
+        .map((String revision) => pb.Cherrypick(
+              trunkRevision: revision,
+              state: pb.CherrypickState.PENDING,
+            ))
+        .toList();
 
     for (final pb.Cherrypick cherrypick in engineCherrypicks) {
       final String revision = cherrypick.trunkRevision;
@@ -366,10 +370,12 @@ class StartContext extends Context {
       cherrypicks: frameworkCherrypickRevisions,
       upstreamRef: FrameworkRepository.defaultBranch,
       releaseRef: candidateBranch,
-    )).map((String revision) => pb.Cherrypick(
-      trunkRevision: revision,
-      state: pb.CherrypickState.PENDING,
-    )).toList();
+    ))
+        .map((String revision) => pb.Cherrypick(
+              trunkRevision: revision,
+              state: pb.CherrypickState.PENDING,
+            ))
+        .toList();
 
     for (final pb.Cherrypick cherrypick in frameworkCherrypicks) {
       final String revision = cherrypick.trunkRevision;
@@ -399,7 +405,8 @@ class StartContext extends Context {
     );
     final bool atBranchPoint = branchPoint == frameworkHead;
 
-    final ReleaseType releaseType = computeReleaseType(lastVersion, atBranchPoint);
+    final ReleaseType releaseType =
+        computeReleaseType(lastVersion, atBranchPoint);
     state.releaseType = releaseType;
 
     try {
@@ -451,10 +458,10 @@ class StartContext extends Context {
     switch (releaseType) {
       case ReleaseType.STABLE_INITIAL:
         nextVersion = Version(
-            x: lastVersion.x,
-            y: lastVersion.y,
-            z: 0,
-            type: VersionType.stable,
+          x: lastVersion.x,
+          y: lastVersion.y,
+          z: 0,
+          type: VersionType.stable,
         );
         break;
       case ReleaseType.STABLE_HOTFIX:
@@ -501,7 +508,8 @@ class StartContext extends Context {
       throw ConductorException('Aborting command.');
     }
 
-    stdio.printStatus('Applying the tag $requestedVersion at the branch point $branchPoint');
+    stdio.printStatus(
+        'Applying the tag $requestedVersion at the branch point $branchPoint');
 
     await framework.tag(
       branchPoint,
@@ -549,10 +557,13 @@ class StartContext extends Context {
     final List<String> upstreamRevlist = (await repository.revList(<String>[
       '--ancestry-path',
       '$branchPoint..$upstreamRef',
-    ])).reversed.toList();
+    ]))
+        .reversed
+        .toList();
 
     stdio.printStatus('upstreamRevList:\n${upstreamRevlist.join('\n')}\n');
-    stdio.printStatus('validatedCherrypicks:\n${validatedCherrypicks.join('\n')}\n');
+    stdio.printStatus(
+        'validatedCherrypicks:\n${validatedCherrypicks.join('\n')}\n');
     for (final String upstreamRevision in upstreamRevlist) {
       if (validatedCherrypicks.contains(upstreamRevision)) {
         validatedCherrypicks.remove(upstreamRevision);
@@ -569,7 +580,10 @@ class StartContext extends Context {
       'The following ${repository.name} cherrypicks were not found in the '
       'upstream $upstreamRef branch:',
     );
-    for (final String cp in <String>[...validatedCherrypicks, ...unknownCherrypicks]) {
+    for (final String cp in <String>[
+      ...validatedCherrypicks,
+      ...unknownCherrypicks
+    ]) {
       stdio.printError('\t$cp');
     }
     throw ConductorException(

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -934,17 +934,6 @@ void main() {
       expect(state.conductorVersion, conductorVersion);
       expect(state.releaseType, ReleaseType.STABLE_INITIAL);
     });
-
-    test('mirrors are interpreted from github username', () async {
-      const String githubUsername = 'user';
-      const String interpolatedFrameworkMirror =
-          'https://github.com/$githubUsername/flutter.git';
-      const String interpolatedEngineMirror =
-          'https://github.com/$githubUsername/engine.git';
-
-      expect(interpolatedFrameworkMirror, frameworkMirror);
-      expect(interpolatedEngineMirror, engineMirror);
-    });
     test(
         'StartContext gets engine and framework checkout directories after run',
         () async {

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -18,11 +18,14 @@ import './common.dart';
 
 void main() {
   group('start command', () {
-    const String branchPointRevision = '5131a6e5e0c50b8b7b2906cd58dab8746d6450be';
+    const String branchPointRevision =
+        '5131a6e5e0c50b8b7b2906cd58dab8746d6450be';
     const String flutterRoot = '/flutter';
     const String checkoutsParentDirectory = '$flutterRoot/dev/tools/';
-    const String frameworkMirror = 'https://github.com/user/flutter.git';
-    const String engineMirror = 'https://github.com/user/engine.git';
+    const String githubUsername = 'user';
+    const String frameworkMirror =
+        'https://github.com/$githubUsername/flutter.git';
+    const String engineMirror = 'https://github.com/$githubUsername/engine.git';
     const String candidateBranch = 'flutter-1.2-candidate.3';
     const String releaseChannel = 'beta';
     const String revision = 'abcd1234';
@@ -86,10 +89,6 @@ void main() {
       await expectLater(
         () async => runner.run(<String>[
           'start',
-          '--$kFrameworkMirrorOption',
-          frameworkMirror,
-          '--$kEngineMirrorOption',
-          engineMirror,
           '--$kCandidateOption',
           candidateBranch,
           '--$kReleaseOption',
@@ -99,24 +98,6 @@ void main() {
         ]),
         throwsExceptionWith(
           'Error! This tool is only supported on macOS and Linux',
-        ),
-      );
-    });
-
-    test('throws if --$kFrameworkMirrorOption not provided', () async {
-      final CommandRunner<void> runner = createRunner(
-        commands: <FakeCommand>[
-          const FakeCommand(
-            command: <String>['git', 'rev-parse', 'HEAD'],
-            stdout: revision,
-          ),
-        ],
-      );
-
-      await expectLater(
-        () async => runner.run(<String>['start']),
-        throwsExceptionWith(
-          'Expected either the CLI arg --$kFrameworkMirrorOption or the environment variable FRAMEWORK_MIRROR to be provided',
         ),
       );
     });
@@ -132,10 +113,6 @@ void main() {
       await expectLater(
         () async => runner.run(<String>[
           'start',
-          '--$kFrameworkMirrorOption',
-          frameworkMirror,
-          '--$kEngineMirrorOption',
-          engineMirror,
           '--$kCandidateOption',
           candidateBranch,
           '--$kReleaseOption',
@@ -144,6 +121,8 @@ void main() {
           stateFilePath,
           '--$kVersionOverrideOption',
           'an invalid version string',
+          '--$kGithubUsernameOption',
+          githubUsername,
         ]),
         throwsExceptionWith('an invalid version string cannot be parsed'),
       );
@@ -153,8 +132,10 @@ void main() {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';
       const String revision3 = '123abc';
-      const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
-      const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
+      const String previousDartRevision =
+          '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
+      const String nextDartRevision =
+          'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-1.0.pre';
       // This is what this release will be
       const String nextVersion = '1.2.0-1.1.pre';
@@ -181,7 +162,8 @@ void main() {
             onRun: () {
               // Create the DEPS file which the tool will update
               engine.createSync(recursive: true);
-              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+              depsFile
+                  .writeAsStringSync(generateMockDeps(previousDartRevision));
             }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
@@ -212,7 +194,12 @@ void main() {
           command: <String>['git', 'add', '--all'],
         ),
         const FakeCommand(
-          command: <String>['git', 'commit', '--message', 'Update Dart SDK to $nextDartRevision'],
+          command: <String>[
+            'git',
+            'commit',
+            '--message',
+            'Update Dart SDK to $nextDartRevision'
+          ],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
@@ -277,12 +264,23 @@ void main() {
           stdout: revision3,
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', 'upstream/$candidateBranch', 'upstream/master'],
+          command: <String>[
+            'git',
+            'merge-base',
+            'upstream/$candidateBranch',
+            'upstream/master'
+          ],
           stdout: branchPointRevision,
         ),
         // check if commit is tagged, zero exit code means it is tagged
         const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+          command: <String>[
+            'git',
+            'describe',
+            '--exact-match',
+            '--tags',
+            branchPointRevision
+          ],
         ),
       ];
 
@@ -300,10 +298,6 @@ void main() {
 
       await runner.run(<String>[
         'start',
-        '--$kFrameworkMirrorOption',
-        frameworkMirror,
-        '--$kEngineMirrorOption',
-        engineMirror,
         '--$kCandidateOption',
         candidateBranch,
         '--$kReleaseOption',
@@ -312,6 +306,8 @@ void main() {
         stateFilePath,
         '--$kDartRevisionOption',
         nextDartRevision,
+        '--$kGithubUsernameOption',
+        githubUsername,
       ]);
 
       final File stateFile = fileSystem.file(stateFilePath);
@@ -322,7 +318,10 @@ void main() {
       );
 
       expect(state.releaseType, ReleaseType.BETA_HOTFIX);
-      expect(stdio.error, isNot(contains('Tried to tag the branch point, however the target version')));
+      expect(
+          stdio.error,
+          isNot(contains(
+              'Tried to tag the branch point, however the target version')));
       expect(processManager, hasNoRemainingExpectations);
       expect(state.isInitialized(), true);
       expect(state.releaseChannel, releaseChannel);
@@ -333,7 +332,8 @@ void main() {
       expect(state.engine.upstream.url, 'git@github.com:flutter/engine.git');
       expect(state.framework.candidateBranch, candidateBranch);
       expect(state.framework.startingGitHead, revision3);
-      expect(state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
+      expect(
+          state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
     });
@@ -342,8 +342,10 @@ void main() {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';
       const String revision3 = '123abc';
-      const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
-      const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
+      const String previousDartRevision =
+          '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
+      const String nextDartRevision =
+          'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-1.0.pre';
       const String candidateBranch = 'flutter-1.2-candidate.1';
       const String versionOverride = '42.0.0-42.0.pre';
@@ -369,7 +371,8 @@ void main() {
             onRun: () {
               // Create the DEPS file which the tool will update
               engine.createSync(recursive: true);
-              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+              depsFile
+                  .writeAsStringSync(generateMockDeps(previousDartRevision));
             }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
@@ -400,7 +403,12 @@ void main() {
           command: <String>['git', 'add', '--all'],
         ),
         const FakeCommand(
-          command: <String>['git', 'commit', '--message', 'Update Dart SDK to $nextDartRevision'],
+          command: <String>[
+            'git',
+            'commit',
+            '--message',
+            'Update Dart SDK to $nextDartRevision'
+          ],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
@@ -465,7 +473,12 @@ void main() {
           stdout: revision3,
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', 'upstream/$candidateBranch', 'upstream/master'],
+          command: <String>[
+            'git',
+            'merge-base',
+            'upstream/$candidateBranch',
+            'upstream/master'
+          ],
           stdout: branchPointRevision,
         ),
       ];
@@ -484,10 +497,6 @@ void main() {
 
       await runner.run(<String>[
         'start',
-        '--$kFrameworkMirrorOption',
-        frameworkMirror,
-        '--$kEngineMirrorOption',
-        engineMirror,
         '--$kCandidateOption',
         candidateBranch,
         '--$kReleaseOption',
@@ -498,6 +507,8 @@ void main() {
         nextDartRevision,
         '--$kVersionOverrideOption',
         versionOverride,
+        '--$kGithubUsernameOption',
+        githubUsername,
       ]);
 
       final File stateFile = fileSystem.file(stateFilePath);
@@ -511,12 +522,15 @@ void main() {
       expect(state.releaseVersion, versionOverride);
     });
 
-    test('logs to STDERR but does not fail on an unexpected candidate branch', () async {
+    test('logs to STDERR but does not fail on an unexpected candidate branch',
+        () async {
       stdio.stdin.add('y'); // accept prompt from ensureBranchPointTagged()
       const String revision2 = 'def789';
       const String revision3 = '123abc';
-      const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
-      const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
+      const String previousDartRevision =
+          '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
+      const String nextDartRevision =
+          'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       // note that this significantly behind the candidate branch name
       const String previousVersion = '0.9.0-1.0.pre';
       // This is what this release will be
@@ -543,7 +557,8 @@ void main() {
             onRun: () {
               // Create the DEPS file which the tool will update
               engine.createSync(recursive: true);
-              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+              depsFile
+                  .writeAsStringSync(generateMockDeps(previousDartRevision));
             }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
@@ -574,7 +589,12 @@ void main() {
           command: <String>['git', 'add', '--all'],
         ),
         const FakeCommand(
-          command: <String>['git', 'commit', '--message', 'Update Dart SDK to $nextDartRevision'],
+          command: <String>[
+            'git',
+            'commit',
+            '--message',
+            'Update Dart SDK to $nextDartRevision'
+          ],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
@@ -639,12 +659,23 @@ void main() {
           stdout: revision3,
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', 'upstream/$candidateBranch', 'upstream/master'],
+          command: <String>[
+            'git',
+            'merge-base',
+            'upstream/$candidateBranch',
+            'upstream/master'
+          ],
           stdout: branchPointRevision,
         ),
         // check if commit is tagged, 0 exit code means it is tagged
         const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+          command: <String>[
+            'git',
+            'describe',
+            '--exact-match',
+            '--tags',
+            branchPointRevision
+          ],
         ),
       ];
 
@@ -662,10 +693,6 @@ void main() {
 
       await runner.run(<String>[
         'start',
-        '--$kFrameworkMirrorOption',
-        frameworkMirror,
-        '--$kEngineMirrorOption',
-        engineMirror,
         '--$kCandidateOption',
         candidateBranch,
         '--$kReleaseOption',
@@ -674,6 +701,8 @@ void main() {
         stateFilePath,
         '--$kDartRevisionOption',
         nextDartRevision,
+        '--$kGithubUsernameOption',
+        githubUsername,
       ]);
 
       final File stateFile = fileSystem.file(stateFilePath);
@@ -683,7 +712,8 @@ void main() {
         jsonDecode(stateFile.readAsStringSync()),
       );
 
-      expect(stdio.error, isNot(contains('Tried to tag the branch point, however')));
+      expect(stdio.error,
+          isNot(contains('Tried to tag the branch point, however')));
       expect(processManager, hasNoRemainingExpectations);
       expect(state.isInitialized(), true);
       expect(state.releaseChannel, releaseChannel);
@@ -694,18 +724,24 @@ void main() {
       expect(state.engine.upstream.url, 'git@github.com:flutter/engine.git');
       expect(state.framework.candidateBranch, candidateBranch);
       expect(state.framework.startingGitHead, revision3);
-      expect(state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
+      expect(
+          state.framework.upstream.url, 'git@github.com:flutter/flutter.git');
       expect(state.currentPhase, ReleasePhase.APPLY_ENGINE_CHERRYPICKS);
       expect(state.conductorVersion, conductorVersion);
       expect(state.releaseType, ReleaseType.BETA_HOTFIX);
-      expect(stdio.error, contains('Parsed version $previousVersion.42 has a different x value than candidate branch $candidateBranch'));
+      expect(
+          stdio.error,
+          contains(
+              'Parsed version $previousVersion.42 has a different x value than candidate branch $candidateBranch'));
     });
 
     test('can convert from dev style version to stable version', () async {
       const String revision2 = 'def789';
       const String revision3 = '123abc';
-      const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
-      const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
+      const String previousDartRevision =
+          '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
+      const String nextDartRevision =
+          'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-3.0.pre';
       const String nextVersion = '1.2.0';
 
@@ -730,7 +766,8 @@ void main() {
             onRun: () {
               // Create the DEPS file which the tool will update
               engine.createSync(recursive: true);
-              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+              depsFile
+                  .writeAsStringSync(generateMockDeps(previousDartRevision));
             }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
@@ -761,7 +798,12 @@ void main() {
           command: <String>['git', 'add', '--all'],
         ),
         const FakeCommand(
-          command: <String>['git', 'commit', '--message', 'Update Dart SDK to $nextDartRevision'],
+          command: <String>[
+            'git',
+            'commit',
+            '--message',
+            'Update Dart SDK to $nextDartRevision'
+          ],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
@@ -826,12 +868,23 @@ void main() {
           stdout: revision3,
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', 'upstream/$candidateBranch', 'upstream/master'],
+          command: <String>[
+            'git',
+            'merge-base',
+            'upstream/$candidateBranch',
+            'upstream/master'
+          ],
           stdout: branchPointRevision,
         ),
         // check if commit is tagged, 0 exit code thus it is tagged
         const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+          command: <String>[
+            'git',
+            'describe',
+            '--exact-match',
+            '--tags',
+            branchPointRevision
+          ],
         ),
       ];
 
@@ -849,10 +902,6 @@ void main() {
 
       await runner.run(<String>[
         'start',
-        '--$kFrameworkMirrorOption',
-        frameworkMirror,
-        '--$kEngineMirrorOption',
-        engineMirror,
         '--$kCandidateOption',
         candidateBranch,
         '--$kReleaseOption',
@@ -861,6 +910,8 @@ void main() {
         stateFilePath,
         '--$kDartRevisionOption',
         nextDartRevision,
+        '--$kGithubUsernameOption',
+        githubUsername,
       ]);
 
       final File stateFile = fileSystem.file(stateFilePath);
@@ -884,13 +935,27 @@ void main() {
       expect(state.releaseType, ReleaseType.STABLE_INITIAL);
     });
 
-    test('StartContext gets engine and framework checkout directories after run', () async {
+    test('mirrors are interpreted from github username', () async {
+      const String githubUsername = 'user';
+      const String interpolatedFrameworkMirror =
+          'https://github.com/$githubUsername/flutter.git';
+      const String interpolatedEngineMirror =
+          'https://github.com/$githubUsername/engine.git';
+
+      expect(interpolatedFrameworkMirror, frameworkMirror);
+      expect(interpolatedEngineMirror, engineMirror);
+    });
+    test(
+        'StartContext gets engine and framework checkout directories after run',
+        () async {
       stdio.stdin.add('y');
       const String revision2 = 'def789';
       const String revision3 = '123abc';
       const String branchPointRevision = 'deadbeef';
-      const String previousDartRevision = '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
-      const String nextDartRevision = 'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
+      const String previousDartRevision =
+          '171876a4e6cf56ee6da1f97d203926bd7afda7ef';
+      const String nextDartRevision =
+          'f6c91128be6b77aef8351e1e3a9d07c85bc2e46e';
       const String previousVersion = '1.2.0-1.0.pre';
       // This is a git tag applied to the branch point, not an actual release
       const String branchPointTag = '1.2.0-3.0.pre';
@@ -921,7 +986,8 @@ void main() {
             onRun: () {
               // Create the DEPS file which the tool will update
               engine.createSync(recursive: true);
-              depsFile.writeAsStringSync(generateMockDeps(previousDartRevision));
+              depsFile
+                  .writeAsStringSync(generateMockDeps(previousDartRevision));
             }),
         const FakeCommand(
           command: <String>['git', 'remote', 'add', 'mirror', engineMirror],
@@ -952,7 +1018,12 @@ void main() {
           command: <String>['git', 'add', '--all'],
         ),
         const FakeCommand(
-          command: <String>['git', 'commit', '--message', 'Update Dart SDK to $nextDartRevision'],
+          command: <String>[
+            'git',
+            'commit',
+            '--message',
+            'Update Dart SDK to $nextDartRevision'
+          ],
         ),
         const FakeCommand(
           command: <String>['git', 'rev-parse', 'HEAD'],
@@ -1014,12 +1085,23 @@ void main() {
           stdout: branchPointRevision,
         ),
         const FakeCommand(
-          command: <String>['git', 'merge-base', 'upstream/$candidateBranch', 'upstream/master'],
+          command: <String>[
+            'git',
+            'merge-base',
+            'upstream/$candidateBranch',
+            'upstream/master'
+          ],
           stdout: branchPointRevision,
         ),
         // check if commit is tagged
         const FakeCommand(
-          command: <String>['git', 'describe', '--exact-match', '--tags', branchPointRevision],
+          command: <String>[
+            'git',
+            'describe',
+            '--exact-match',
+            '--tags',
+            branchPointRevision
+          ],
           // non-zero exit code means branch point is NOT tagged
           exitCode: 128,
         ),
@@ -1027,7 +1109,12 @@ void main() {
           command: <String>['git', 'tag', branchPointTag, branchPointRevision],
         ),
         const FakeCommand(
-          command: <String>['git', 'push', FrameworkRepository.defaultUpstream, branchPointTag],
+          command: <String>[
+            'git',
+            'push',
+            FrameworkRepository.defaultUpstream,
+            branchPointTag
+          ],
         ),
       ];
 
@@ -1076,6 +1163,7 @@ void main() {
         releaseChannel: releaseChannel,
         processManager: processManager,
         conductorVersion: conductorVersion,
+        githubUsername: githubUsername,
         stateFile: stateFile,
       );
 
@@ -1086,8 +1174,10 @@ void main() {
         jsonDecode(stateFile.readAsStringSync()),
       );
 
-      expect((await startContext.engine.checkoutDirectory).path, equals(engine.path));
-      expect((await startContext.framework.checkoutDirectory).path, equals(framework.path));
+      expect((await startContext.engine.checkoutDirectory).path,
+          equals(engine.path));
+      expect((await startContext.framework.checkoutDirectory).path,
+          equals(framework.path));
       expect(state.releaseType, ReleaseType.BETA_INITIAL);
       expect(processManager, hasNoRemainingExpectations);
     });

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -593,7 +593,7 @@ void main() {
             'git',
             'commit',
             '--message',
-            'Update Dart SDK to $nextDartRevision'
+            'Update Dart SDK to $nextDartRevision',
           ],
         ),
         const FakeCommand(
@@ -663,7 +663,7 @@ void main() {
             'git',
             'merge-base',
             'upstream/$candidateBranch',
-            'upstream/master'
+            'upstream/master',
           ],
           stdout: branchPointRevision,
         ),
@@ -674,7 +674,7 @@ void main() {
             'describe',
             '--exact-match',
             '--tags',
-            branchPointRevision
+            branchPointRevision,
           ],
         ),
       ];
@@ -802,7 +802,7 @@ void main() {
             'git',
             'commit',
             '--message',
-            'Update Dart SDK to $nextDartRevision'
+            'Update Dart SDK to $nextDartRevision',
           ],
         ),
         const FakeCommand(
@@ -883,7 +883,7 @@ void main() {
             'describe',
             '--exact-match',
             '--tags',
-            branchPointRevision
+            branchPointRevision,
           ],
         ),
       ];

--- a/dev/conductor/core/test/start_test.dart
+++ b/dev/conductor/core/test/start_test.dart
@@ -198,7 +198,7 @@ void main() {
             'git',
             'commit',
             '--message',
-            'Update Dart SDK to $nextDartRevision'
+            'Update Dart SDK to $nextDartRevision',
           ],
         ),
         const FakeCommand(
@@ -268,7 +268,7 @@ void main() {
             'git',
             'merge-base',
             'upstream/$candidateBranch',
-            'upstream/master'
+            'upstream/master',
           ],
           stdout: branchPointRevision,
         ),
@@ -279,7 +279,7 @@ void main() {
             'describe',
             '--exact-match',
             '--tags',
-            branchPointRevision
+            branchPointRevision,
           ],
         ),
       ];


### PR DESCRIPTION
Remove the `--framework-mirror` and `--engine-mirror` args and replace them with the `--github-username` arg which interpolates the username into the framework and engine mirror urls.