### PR TITLE
Single tap should show toolbar on iOS

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -84,7 +84,6 @@ class _TextFieldSelectionGestureDetectorBuilder extends TextSelectionGestureDete
 
   @override
   void onSingleTapUp(TapUpDetails details) {
-    editableText.hideToolbar();
     super.onSingleTapUp(details);
     _state._requestKeyboard();
     _state.widget.onTap?.call();

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3186,10 +3186,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   }
 
   /// Toggles the visibility of the toolbar.
-  void toggleToolbar() {
+  void toggleToolbar([bool hideHandles = true]) {
     assert(_selectionOverlay != null);
     if (_selectionOverlay!.toolbarIsVisible) {
-      hideToolbar();
+      hideToolbar(hideHandles);
     } else {
       showToolbar();
     }

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -1927,7 +1927,14 @@ class TextSelectionGestureDetectorBuilder {
             case PointerDeviceKind.touch:
             case PointerDeviceKind.unknown:
               // On iOS/iPadOS a touch tap places the cursor at the edge of the word.
+              final TextSelection oldSelection =
+                  renderEditable.textSelectionDelegate.textEditingValue.selection;
               renderEditable.selectWordEdge(cause: SelectionChangedCause.tap);
+              final TextSelection nextSelection =
+                  renderEditable.textSelectionDelegate.textEditingValue.selection;
+              if (oldSelection.isValid && oldSelection == nextSelection) {
+                editableText.showToolbar();
+              }
               break;
           }
           break;

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1752,8 +1752,12 @@ void main() {
       expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
 
-      // No toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
+      // Shows the toolbar only on iOS.
+      if (defaultTargetPlatform == TargetPlatform.iOS) {
+        expect(find.byType(CupertinoButton), findsWidgets);
+      } else {
+        expect(find.byType(CupertinoButton), findsNothing);
+      }
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }));
 
   testWidgets(

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7410,8 +7410,12 @@ void main() {
       expect(controller.selection.isCollapsed, isTrue);
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
 
-      // No toolbar.
-      expect(find.byType(CupertinoButton), findsNothing);
+      // Shows the toolbar on iOS.
+      if (defaultTargetPlatform == TargetPlatform.iOS) {
+        expect(find.byType(CupertinoButton), findsWidgets);
+      } else {
+        expect(find.byType(CupertinoButton), findsNothing);
+      }
     },
     variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
   );

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -8084,9 +8084,9 @@ void main() {
       expect(controller.selection.baseOffset, isTargetPlatformMobile ? 7 : 6);
 
       // Collapsed toolbar shows 2 buttons.
-      expect(find.byType(CupertinoButton), findsNothing);
+      expect(find.byType(CupertinoButton), findsNWidgets(2));
     },
-    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS,  TargetPlatform.macOS }),
+    variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS }),
   );
 
   testWidgets(


### PR DESCRIPTION
Tapping once on the text field on iOS should show the text selection toolbar.

The full fix is https://github.com/flutter/flutter/issues/101151, but this is bothering enough people that I think we need to hack it for now.

An earlier fix was attempted in https://github.com/flutter/flutter/pull/95644 but the PR was closed.

Fixes https://github.com/flutter/flutter/issues/48434