### PR TITLE
Fix that RenderEditable (TextField) ignores offset in painting, making text selections shifted when offset is nonzero

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2540,14 +2540,14 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
     }
   }
 
-  void _paintHandleLayers(PaintingContext context, List<TextSelectionPoint> endpoints) {
+  void _paintHandleLayers(PaintingContext context, List<TextSelectionPoint> endpoints, Offset offset) {
     Offset startPoint = endpoints[0].point;
     startPoint = Offset(
       clampDouble(startPoint.dx, 0.0, size.width),
       clampDouble(startPoint.dy, 0.0, size.height),
     );
     context.pushLayer(
-      LeaderLayer(link: startHandleLayerLink, offset: startPoint),
+      LeaderLayer(link: startHandleLayerLink, offset: startPoint + offset),
       super.paint,
       Offset.zero,
     );
@@ -2558,7 +2558,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
         clampDouble(endPoint.dy, 0.0, size.height),
       );
       context.pushLayer(
-        LeaderLayer(link: endHandleLayerLink, offset: endPoint),
+        LeaderLayer(link: endHandleLayerLink, offset: endPoint + offset),
         super.paint,
         Offset.zero,
       );
@@ -2582,7 +2582,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
       _paintContents(context, offset);
     }
     if (selection!.isValid) {
-      _paintHandleLayers(context, getEndpointsForSelection(selection!));
+      _paintHandleLayers(context, getEndpointsForSelection(selection!), offset);
     }
   }
 

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -118,9 +118,17 @@ void main() {
     final TestPushLayerPaintingContext context = TestPushLayerPaintingContext();
 
     const Offset paintOffset = Offset(100, 200);
+    const double fontSize = 20.0;
+    const endpoint = Offset(0.0, fontSize);
 
     final RenderEditable editable = RenderEditable(
-      text: const TextSpan(text: 'text'),
+      text: const TextSpan(
+        text: 'text',
+        style: TextStyle(
+          fontSize: fontSize,
+          height: 1.0,
+        ),
+      ),
       textDirection: TextDirection.ltr,
       startHandleLayerLink: LayerLink(),
       endHandleLayerLink: LayerLink(),
@@ -133,7 +141,7 @@ void main() {
 
     final List<LeaderLayer> leaderLayers = context.pushedLayers.whereType<LeaderLayer>().toList();
     expect(leaderLayers, hasLength(1), reason: '_paintHandleLayers will paint a LeaderLayer');
-    expect(leaderLayers.single.offset, const Offset(0.0, 14.0) + paintOffset, reason: 'offset should respect paintOffset');
+    expect(leaderLayers.single.offset, endpoint + paintOffset, reason: 'offset should respect paintOffset');
   });
 
   test('editable intrinsics', () {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -117,7 +117,7 @@ void main() {
     const BoxConstraints viewport = BoxConstraints(maxHeight: 1000.0, maxWidth: 1000.0);
     final TestPushLayerPaintingContext context = TestPushLayerPaintingContext();
 
-    const paintOffset = Offset(100, 200);
+    const Offset paintOffset = Offset(100, 200);
 
     final RenderEditable editable = RenderEditable(
       text: const TextSpan(text: 'text'),
@@ -131,7 +131,7 @@ void main() {
     layout(editable, constraints: viewport, phase: EnginePhase.composite);
     editable.paint(context, paintOffset);
 
-    final leaderLayers = context.pushedLayers.whereType<LeaderLayer>().toList();
+    final List<LeaderLayer> leaderLayers = context.pushedLayers.whereType<LeaderLayer>().toList();
     expect(leaderLayers, hasLength(1), reason: '_paintHandleLayers will paint a LeaderLayer');
     expect(leaderLayers.single.offset, const Offset(0, 14) + paintOffset, reason: 'offset should respect paintOffset');
   });

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -133,7 +133,7 @@ void main() {
 
     final List<LeaderLayer> leaderLayers = context.pushedLayers.whereType<LeaderLayer>().toList();
     expect(leaderLayers, hasLength(1), reason: '_paintHandleLayers will paint a LeaderLayer');
-    expect(leaderLayers.single.offset, const Offset(0, 14) + paintOffset, reason: 'offset should respect paintOffset');
+    expect(leaderLayers.single.offset, const Offset(0.0, 14.0) + paintOffset, reason: 'offset should respect paintOffset');
   });
 
   test('editable intrinsics', () {

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -113,6 +113,29 @@ void main() {
     expect(visited, true);
   });
 
+  test('RenderEditable.paint respects offset argument', () {
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 1000.0, maxWidth: 1000.0);
+    final TestPushLayerPaintingContext context = TestPushLayerPaintingContext();
+
+    const paintOffset = Offset(100, 200);
+
+    final RenderEditable editable = RenderEditable(
+      text: const TextSpan(text: 'text'),
+      textDirection: TextDirection.ltr,
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      offset: ViewportOffset.zero(),
+      textSelectionDelegate: _FakeEditableTextState(),
+      selection: const TextSelection(baseOffset: 0, extentOffset: 0),
+    );
+    layout(editable, constraints: viewport, phase: EnginePhase.composite);
+    editable.paint(context, paintOffset);
+
+    final leaderLayers = context.pushedLayers.whereType<LeaderLayer>().toList();
+    expect(leaderLayers, hasLength(1), reason: '_paintHandleLayers will paint a LeaderLayer');
+    expect(leaderLayers.single.offset, const Offset(0, 14) + paintOffset, reason: 'offset should respect paintOffset');
+  });
+  
   test('editable intrinsics', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final RenderEditable editable = RenderEditable(

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -135,7 +135,7 @@ void main() {
     expect(leaderLayers, hasLength(1), reason: '_paintHandleLayers will paint a LeaderLayer');
     expect(leaderLayers.single.offset, const Offset(0, 14) + paintOffset, reason: 'offset should respect paintOffset');
   });
-  
+
   test('editable intrinsics', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final RenderEditable editable = RenderEditable(

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -119,7 +119,7 @@ void main() {
 
     const Offset paintOffset = Offset(100, 200);
     const double fontSize = 20.0;
-    const endpoint = Offset(0.0, fontSize);
+    const Offset endpoint = Offset(0.0, fontSize);
 
     final RenderEditable editable = RenderEditable(
       text: const TextSpan(

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -368,7 +368,7 @@ class TestClipPaintingContext extends PaintingContext {
 class TestPushLayerPaintingContext extends PaintingContext {
   TestPushLayerPaintingContext() : super(ContainerLayer(), Rect.zero);
 
-  final pushedLayers = <ContainerLayer>[];
+  final List<ContainerLayer> pushedLayers = <ContainerLayer>[];
 
   @override
   void pushLayer(

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -365,6 +365,23 @@ class TestClipPaintingContext extends PaintingContext {
   Clip clipBehavior = Clip.none;
 }
 
+class TestPushLayerPaintingContext extends PaintingContext {
+  TestPushLayerPaintingContext() : super(ContainerLayer(), Rect.zero);
+
+  final pushedLayers = <ContainerLayer>[];
+
+  @override
+  void pushLayer(
+    ContainerLayer childLayer,
+    PaintingContextCallback painter,
+    Offset offset, {
+    Rect? childPaintBounds
+  }) {
+    pushedLayers.add(childLayer);
+    super.pushLayer(childLayer, painter, offset, childPaintBounds: childPaintBounds);
+  }
+}
+
 void expectOverflowedErrors() {
   final FlutterErrorDetails errorDetails = TestRenderingFlutterBinding.instance.takeFlutterErrorDetails()!;
   final bool overflowed = errorDetails.toString().contains('overflowed');


### PR DESCRIPTION
**I will start adding tests once flutter team thinks this PR is acceptable, since I am not sure whether the team like to fix it, and if the team does not like it I will not waste time on it :)**

---

When implementing `RenderBox.paint`, we know we should respect the `offset` parameter. However, even though `_paintContents` respects it, the `_paintHandleLayers` does not - instead it completely ignores the offset parameter. This is logically wrong as it does not respect the definition and requirements of the function.

Luckily (or unluckily), currently it does not have *visible* harm *yet*. This is because `RenderEditable` is used by `_Editable` and future by `EditableText`. And, the `_Editable`'s ancestors widgets do not provide any offset (because the widgets in the same Layer paint child without shifting). Thus, `offset` parameter is always zero in the *current* version of Flutter.

However, I am still proposing this PR because of the following reasons:

1. It is logically wrong (violates definition of `paint`), so by definition it is a bug and we should fix it.
2. It may be a visible bug in future releases. With adding more functionality to text fields, surely we cannot guarantee RenderEditable's ancestors always give a zero offset. (If we think so, I should immediately raise another PR with `assert(offset==Offset.zero)` to enforce it.)
3. Users who need deep customization may directly use `RenderEditable` (since it is public), and even copy some of the source code and hack it (e.g. me). With their customizations, it is highly possible that the offset is no longer always zero, then they will find suddenly the text selections shifted weirdly. (Disclaimer: That is my case, and why I find this bug)

I have not come up with a way to make tests about this, because `_Editable` is private, and as mentioned above, it is logically wrong but not visible now.
However, this PR does not add any new logic, so making existing tests pass IMHO may be sufficient.

Close #109289

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

P.S. https://discord.com/channels/608014603317936148/608018585025118217/1006808038914654218

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
