### PR TITLE
Pass fit property to RenderIndexedStack

### DIFF
--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -715,6 +715,7 @@ class RenderIndexedStack extends RenderStack {
     super.alignment,
     super.textDirection,
     super.fit,
+    super.clipBehavior,
     int? index = 0,
   }) : _index = index;
 

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -714,6 +714,7 @@ class RenderIndexedStack extends RenderStack {
     super.children,
     super.alignment,
     super.textDirection,
+    super.fit,
     int? index = 0,
   }) : _index = index;
 

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3919,6 +3919,7 @@ class IndexedStack extends Stack {
     return RenderIndexedStack(
       index: index,
       fit:fit,
+      clipBehavior: clipBehavior,
       alignment: alignment,
       textDirection: textDirection ?? Directionality.maybeOf(context),
     );

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3931,6 +3931,7 @@ class IndexedStack extends Stack {
     renderObject
       ..index = index
       ..fit = fit
+      ..clipBehavior = clipBehavior
       ..alignment = alignment
       ..textDirection = textDirection ?? Directionality.maybeOf(context);
   }

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3904,6 +3904,7 @@ class IndexedStack extends Stack {
     super.key,
     super.alignment,
     super.textDirection,
+    super.clipBehavior,
     StackFit sizing = StackFit.loose,
     this.index = 0,
     super.children,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3917,6 +3917,7 @@ class IndexedStack extends Stack {
     assert(_debugCheckHasDirectionality(context));
     return RenderIndexedStack(
       index: index,
+      fit:fit,
       alignment: alignment,
       textDirection: textDirection ?? Directionality.maybeOf(context),
     );
@@ -3927,6 +3928,7 @@ class IndexedStack extends Stack {
     assert(_debugCheckHasDirectionality(context));
     renderObject
       ..index = index
+      ..fit = fit
       ..alignment = alignment
       ..textDirection = textDirection ?? Directionality.maybeOf(context);
   }

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -807,7 +807,7 @@ void main() {
         tester.allRenderObjects.whereType<RenderIndexedStack>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
-    /// Update clipBehavior to Clip.antiAlias
+    // Update clipBehavior to Clip.antiAlias
 
     await tester.pumpWidget(IndexedStack(
       textDirection: TextDirection.ltr,
@@ -816,5 +816,47 @@ void main() {
     final RenderIndexedStack renderIndexedObject =
       tester.allRenderObjects.whereType<RenderIndexedStack>().first;
     expect(renderIndexedObject.clipBehavior, equals(Clip.antiAlias));
+  });
+
+  testWidgets('IndexedStack sizing: explicit', (WidgetTester tester) async {
+    final List<String> logs = <String>[];
+    Widget buildIndexedStack(StackFit sizing) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(
+              minWidth: 2.0,
+              maxWidth: 3.0,
+              minHeight: 5.0,
+              maxHeight: 7.0,
+            ),
+            child: IndexedStack(
+              sizing: sizing,
+              children: <Widget>[
+                LayoutBuilder(
+                  builder: (BuildContext context, BoxConstraints constraints) {
+                    logs.add(constraints.toString());
+                    return const Placeholder();
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildIndexedStack(StackFit.loose));
+    logs.add('=1=');
+    await tester.pumpWidget(buildIndexedStack(StackFit.expand));
+    logs.add('=2=');
+    await tester.pumpWidget(buildIndexedStack(StackFit.passthrough));
+    expect(logs, <String>[
+      'BoxConstraints(0.0<=w<=3.0, 0.0<=h<=7.0)',
+      '=1=',
+      'BoxConstraints(w=3.0, h=7.0)',
+      '=2=',
+      'BoxConstraints(2.0<=w<=3.0, 5.0<=h<=7.0)',
+    ]);
   });
 }

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -804,7 +804,7 @@ void main() {
       (WidgetTester tester) async {
     await tester.pumpWidget(IndexedStack(textDirection: TextDirection.ltr));
     final RenderIndexedStack renderObject =
-        tester.allRenderObjects.whereType<RenderIndexedStack>().first;
+      tester.renderObject<RenderIndexedStack>(find.byType(IndexedStack));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Update clipBehavior to Clip.antiAlias
@@ -814,7 +814,7 @@ void main() {
       clipBehavior: Clip.antiAlias,
     ));
     final RenderIndexedStack renderIndexedObject =
-      tester.allRenderObjects.whereType<RenderIndexedStack>().first;
+      tester.renderObject<RenderIndexedStack>(find.byType(IndexedStack));
     expect(renderIndexedObject.clipBehavior, equals(Clip.antiAlias));
   });
 

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -799,4 +799,22 @@ void main() {
       "'alignment', or an explicit 'textDirection', to the Stack.",
     );
   });
+
+  testWidgets('Can update clipBehavior of IndexedStack',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(IndexedStack(textDirection: TextDirection.ltr));
+    final RenderIndexedStack renderObject =
+        tester.allRenderObjects.whereType<RenderIndexedStack>().first;
+    expect(renderObject.clipBehavior, equals(Clip.hardEdge));
+
+    /// Update clipBehavior to Clip.antiAlias
+
+    await tester.pumpWidget(IndexedStack(
+      textDirection: TextDirection.ltr,
+      clipBehavior: Clip.antiAlias,
+    ));
+    final RenderIndexedStack renderIndexedObject =
+      tester.allRenderObjects.whereType<RenderIndexedStack>().first;
+    expect(renderIndexedObject.clipBehavior, equals(Clip.antiAlias));
+  });
 }


### PR DESCRIPTION
Pass fit property from IndexedStack to RenderIndexedStack so as to fit Children within a Stack

Fixes: https://github.com/flutter/flutter/issues/109247

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
