### PR TITLE
Copy doc files from new to old location.

### DIFF
--- a/dev/tools/java_and_objc_doc.dart
+++ b/dev/tools/java_and_objc_doc.dart
@@ -7,7 +7,6 @@ import 'dart:math';
 
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;
-import 'package:io/io.dart' as io;
 import 'package:path/path.dart' as path;
 
 const String kDocRoot = 'dev/docs/doc';
@@ -81,10 +80,10 @@ Future<void> generateDocs(String url, String docName, String checkFile) async {
 
 /// Copies the files in a directory recursively to a new location.
 void copyFolder(Directory source, Directory destination) {
-  source.listSync(recursive: false)
+  source.listSync()
   .forEach((FileSystemEntity entity) {
     if (entity is Directory) {
-      Directory newDirectory = Directory(path.join(destination.absolute.path, path.basename(entity.path)));
+      final Directory newDirectory = Directory(path.join(destination.absolute.path, path.basename(entity.path)));
       newDirectory.createSync();
       copyFolder(entity.absolute, newDirectory);
     } else if (entity is File) {

--- a/dev/tools/java_and_objc_doc.dart
+++ b/dev/tools/java_and_objc_doc.dart
@@ -7,6 +7,8 @@ import 'dart:math';
 
 import 'package:archive/archive.dart';
 import 'package:http/http.dart' as http;
+import 'package:io/io.dart' as io;
+import 'package:path/path.dart' as path;
 
 const String kDocRoot = 'dev/docs/doc';
 
@@ -63,10 +65,30 @@ Future<void> generateDocs(String url, String docName, String checkFile) async {
     }
   }
 
+  /// If object then copy files to old location if the archive is using the new location.
+  final bool exists = Directory('$kDocRoot/$docName/objectc_docs').existsSync();
+  if (exists) {
+    copyFolder(Directory('$kDocRoot/$docName/objectc_docs'), Directory('$kDocRoot/$docName/'));
+  }
+
   final File testFile = File('${output.path}/$checkFile');
   if (!testFile.existsSync()) {
     print('Expected file ${testFile.path} not found');
     exit(1);
   }
   print('$docName ready to go!');
+}
+
+/// Copies the files in a directory recursively to a new location.
+void copyFolder(Directory source, Directory destination) {
+  source.listSync(recursive: false)
+  .forEach((FileSystemEntity entity) {
+    if (entity is Directory) {
+      Directory newDirectory = Directory(path.join(destination.absolute.path, path.basename(entity.path)));
+      newDirectory.createSync();
+      copyFolder(entity.absolute, newDirectory);
+    } else if (entity is File) {
+      entity.copySync(path.join(destination.path, path.basename(entity.path)));
+    }
+  });
 }


### PR DESCRIPTION
Changes to the objectc docs to make destination paths consistent cause
failures in the documentation scripts becase some of the files could not
be found anymore. This change copies files to the old location if it
identifies the new location exist.

Bug: https://github.com/flutter/flutter/issues/109229

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
