### PR TITLE
Actually run customer_testing shard on Windows

### DIFF
--- a/dev/customer_testing/ci.bat
+++ b/dev/customer_testing/ci.bat
@@ -8,12 +8,20 @@ REM This should match the ci.sh file in this directory.
 REM This is called from the LUCI recipes:
 REM https://flutter.googlesource.com/recipes/+/refs/heads/master/recipe_modules/adhoc_validation/resources/customer_testing.bat
 
-dart __deprecated_pub get
+ECHO.
+ECHO Updating pub packages...
+CALL dart pub get
 CD ..\tools
-dart __deprecated_pub get
+CALL dart pub get
 CD ..\customer_testing
 
+ECHO.
+ECHO Finding correct version of customer tests...
 CMD /S /C "IF EXIST "..\..\bin\cache\pkg\tests\" RMDIR /S /Q ..\..\bin\cache\pkg\tests"
 git clone https://github.com/flutter/tests.git ..\..\bin\cache\pkg\tests
 FOR /F "usebackq tokens=*" %%a IN (`dart --enable-asserts ..\tools\bin\find_commit.dart ..\..\bin\cache\pkg\tests`) DO git -C ..\..\bin\cache\pkg\tests checkout %%a
-dart --enable-asserts run_tests.dart --verbose --skip-on-fetch-failure --skip-template ..\..\bin\cache\pkg\tests\registry\*.test
+
+ECHO.
+ECHO Running tests...
+CD ..\..\bin\cache\pkg\tests
+CALL dart --enable-asserts ..\..\..\..\dev\customer_testing\run_tests.dart --verbose --skip-on-fetch-failure --skip-template registry/*.test

--- a/dev/customer_testing/ci.sh
+++ b/dev/customer_testing/ci.sh
@@ -15,8 +15,8 @@ set -ex
 # largely not needed to run the flutter/tests tests.
 #
 # However, we do need to update this directory and the tools directory.
-dart __deprecated_pub get
-(cd ../tools; dart __deprecated_pub get) # used for find_commit.dart below
+dart pub get
+(cd ../tools; dart pub get) # used for find_commit.dart below
 
 # Next we need to update the flutter/tests checkout.
 #


### PR DESCRIPTION
When `dart` became a batch file, the semantics changed because on Windows calling a batch file directly aborts the calling file.
You have to use `CALL` to call a batch file from another.