### PR TITLE
Set `IconButton.visualDensity` default to `VisualDensity.standard`

### DIFF
--- a/dev/tools/gen_defaults/lib/icon_button_template.dart
+++ b/dev/tools/gen_defaults/lib/icon_button_template.dart
@@ -108,7 +108,7 @@ class _${blockName}DefaultsM3 extends ButtonStyle {
     });
 
   @override
-  VisualDensity? get visualDensity => Theme.of(context).visualDensity;
+  VisualDensity? get visualDensity => VisualDensity.standard;
 
   @override
   MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;

--- a/examples/api/lib/material/icon_button/icon_button.3.dart
+++ b/examples/api/lib/material/icon_button/icon_button.3.dart
@@ -19,10 +19,6 @@ class IconButtonToggleApp extends StatelessWidget {
       theme: ThemeData(
         colorSchemeSeed: const Color(0xff6750a4),
         useMaterial3: true,
-        // Desktop and web platforms have a compact visual density by default.
-        // To see buttons with circular background on desktop/web, the "visualDensity"
-        // needs to be set to "VisualDensity.standard".
-        visualDensity: VisualDensity.standard,
       ),
       title: 'Icon Button Types',
       home: const Scaffold(

--- a/examples/api/test/widgets/heroes/hero.0_test.dart
+++ b/examples/api/test/widgets/heroes/hero.0_test.dart
@@ -13,32 +13,32 @@ void main() {
     );
 
     expect(find.text('Hero Sample'), findsOneWidget);
-    await tester.tap(find.byType(Container));
+    await tester.tap(find.byType(example.BoxWidget));
     await tester.pump();
 
-    Size heroSize = tester.getSize(find.byType(Container));
+    Size heroSize = tester.getSize(find.byType(example.BoxWidget));
 
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize.width.roundToDouble(), 103.0);
     expect(heroSize.height.roundToDouble(), 60.0);
 
     // Jump to 50% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize.width.roundToDouble(), 189.0);
     expect(heroSize.height.roundToDouble(), 146.0);
 
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize.width.roundToDouble(), 199.0);
     expect(heroSize.height.roundToDouble(), 190.0);
 
     // Jump to 100% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize, const Size(200.0, 200.0));
 
     expect(find.byIcon(Icons.arrow_back), findsOneWidget);
@@ -47,25 +47,25 @@ void main() {
 
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize.width.roundToDouble(), 199.0);
     expect(heroSize.height.roundToDouble(), 190.0);
 
     // Jump to 50% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize.width.roundToDouble(), 189.0);
     expect(heroSize.height.roundToDouble(), 146.0);
 
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize.width.roundToDouble(), 103.0);
     expect(heroSize.height.roundToDouble(), 60.0);
 
     // Jump to 100% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container));
+    heroSize = tester.getSize(find.byType(example.BoxWidget));
     expect(heroSize, const Size(50.0, 50.0));
   });
 }

--- a/examples/api/test/widgets/heroes/hero.1_test.dart
+++ b/examples/api/test/widgets/heroes/hero.1_test.dart
@@ -16,30 +16,30 @@ void main() {
     await tester.tap(find.byType(ElevatedButton));
     await tester.pump();
 
-    Size heroSize = tester.getSize(find.byType(Container).first);
+    Size heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize, const Size(50.0, 50.0));
 
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 171.0);
     expect(heroSize.height.roundToDouble(), 73.0);
 
     // Jump to 50% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 371.0);
     expect(heroSize.height.roundToDouble(), 273.0);
 
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 398.0);
     expect(heroSize.height.roundToDouble(), 376.0);
 
     // Jump to 100% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize, const Size(400.0, 400.0));
 
     expect(find.byIcon(Icons.arrow_back), findsOneWidget);
@@ -48,25 +48,25 @@ void main() {
 
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 398.0);
     expect(heroSize.height.roundToDouble(), 376.0);
 
     // Jump to 50% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 371.0);
     expect(heroSize.height.roundToDouble(), 273.0);
 
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 171.0);
     expect(heroSize.height.roundToDouble(), 73.0);
 
     // Jump to 100% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize, const Size(50.0, 50.0));
   });
 
@@ -79,30 +79,30 @@ void main() {
     await tester.tap(find.byType(ElevatedButton));
     await tester.pump();
 
-    Size heroSize = tester.getSize(find.byType(Container).last);
+    Size heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize, const Size(50.0, 50.0));
 
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize.width.roundToDouble(), 133.0);
     expect(heroSize.height.roundToDouble(), 133.0);
 
     // Jump to 50% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize.width.roundToDouble(), 321.0);
     expect(heroSize.height.roundToDouble(), 321.0);
 
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).first);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).first);
     expect(heroSize.width.roundToDouble(), 398.0);
     expect(heroSize.height.roundToDouble(), 376.0);
 
     // Jump to 100% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize, const Size(400.0, 400.0));
 
     expect(find.byIcon(Icons.arrow_back), findsOneWidget);
@@ -111,25 +111,25 @@ void main() {
 
     // Jump 25% into the transition (total length = 300ms)
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize.width.roundToDouble(), 386.0);
     expect(heroSize.height.roundToDouble(), 386.0);
 
     // Jump to 50% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize.width.roundToDouble(), 321.0);
     expect(heroSize.height.roundToDouble(), 321.0);
 
     // Jump to 75% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize.width.roundToDouble(), 133.0);
     expect(heroSize.height.roundToDouble(), 133.0);
 
     // Jump to 100% into the transition.
     await tester.pump(const Duration(milliseconds: 75)); // 25% of 300ms
-    heroSize = tester.getSize(find.byType(Container).last);
+    heroSize = tester.getSize(find.byType(example.BoxWidget).last);
     expect(heroSize, const Size(50.0, 50.0));
   });
 }

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -991,7 +991,8 @@ class _AppBarState extends State<AppBar> {
       }
     }
     if (leading != null) {
-      leading = ConstrainedBox(
+      leading = Container(
+        alignment: Alignment.center,
         constraints: BoxConstraints.tightFor(width: widget.leadingWidth ?? _kLeadingWidth),
         child: leading,
       );
@@ -1049,7 +1050,6 @@ class _AppBarState extends State<AppBar> {
     if (widget.actions != null && widget.actions!.isNotEmpty) {
       actions = Row(
         mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.stretch,
         children: widget.actions!,
       );
     } else if (hasEndDrawer) {

--- a/packages/flutter/lib/src/material/icon_button.dart
+++ b/packages/flutter/lib/src/material/icon_button.dart
@@ -118,6 +118,11 @@ const double _kMinButtonSize = kMinInteractiveDimension;
 /// precedence: widget property, [IconButtonTheme] property, [IconTheme] property and
 /// internal default property value.
 ///
+/// In Material Design 3, the [IconButton.visualDensity] defaults to [VisualDensity.standard]
+/// for all platforms because the button will have a rounded rectangle shape if
+/// the [IconButton.visualDensity] is set to [VisualDensity.compact]. Users can
+/// customize it by using [IconButtonTheme], [IconButton.style] or [IconButton.visualDensity].
+///
 /// {@tool dartpad}
 /// This sample shows creation of [IconButton] widgets for standard, filled,
 /// filled tonal and outlined types, as described in: https://m3.material.io/components/icon-buttons/overview
@@ -203,6 +208,9 @@ class IconButton extends StatelessWidget {
   /// Defines how compact the icon button's layout will be.
   ///
   /// {@macro flutter.material.themedata.visualDensity}
+  ///
+  /// This property can be null. If null, it defaults to [VisualDensity.standard]
+  /// in Material Design 3 to make sure the button will be circular on all platforms.
   ///
   /// See also:
   ///
@@ -779,7 +787,7 @@ class _IconButtonM3 extends ButtonStyleButton {
   /// * `mouseCursor`
   ///   * disabled - SystemMouseCursors.basic
   ///   * others - SystemMouseCursors.click
-  /// * `visualDensity` - theme.visualDensity
+  /// * `visualDensity` - VisualDensity.standard
   /// * `tapTargetSize` - theme.materialTapTargetSize
   /// * `animationDuration` - kThemeChangeDuration
   /// * `enableFeedback` - true
@@ -1021,7 +1029,7 @@ class _IconButtonDefaultsM3 extends ButtonStyle {
     });
 
   @override
-  VisualDensity? get visualDensity => Theme.of(context).visualDensity;
+  VisualDensity? get visualDensity => VisualDensity.standard;
 
   @override
   MaterialTapTargetSize? get tapTargetSize => Theme.of(context).materialTapTargetSize;

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -263,6 +263,11 @@ class ThemeData with Diagnosticable {
   /// a component theme parameter like [sliderTheme], [toggleButtonsTheme],
   /// or [bottomNavigationBarTheme].
   ///
+  /// In Material Design 3, the [IconButton.visualDensity] isn't affected by
+  /// [Theme.of(context).visualDensity], and has [VisualDensity.standard] as its default
+  /// value. To override the default value of [IconButton.visualDensity], provide a
+  /// [iconButtonTheme] parameter.
+  ///
   /// See also:
   ///
   ///  * [ThemeData.from], which creates a ThemeData from a [ColorScheme].

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1254,7 +1254,7 @@ class ThemeData with Diagnosticable {
   /// In Material Design 3, the [visualDensity] does not override the value of
   /// [IconButton.visualDensity] which defaults to [VisualDensity.standard]
   /// for all platforms. To override the default value of [IconButton.visualDensity],
-  /// use [iconButtonTheme] parameter instead.
+  /// use [ThemeData.iconButtonTheme] instead.
   /// {@endtemplate}
   final VisualDensity visualDensity;
 

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -263,11 +263,6 @@ class ThemeData with Diagnosticable {
   /// a component theme parameter like [sliderTheme], [toggleButtonsTheme],
   /// or [bottomNavigationBarTheme].
   ///
-  /// In Material Design 3, the [IconButton.visualDensity] isn't affected by
-  /// [Theme.of(context).visualDensity], and has [VisualDensity.standard] as its default
-  /// value. To override the default value of [IconButton.visualDensity], provide a
-  /// [iconButtonTheme] parameter.
-  ///
   /// See also:
   ///
   ///  * [ThemeData.from], which creates a ThemeData from a [ColorScheme].
@@ -1255,6 +1250,11 @@ class ThemeData with Diagnosticable {
   ///
   /// A larger value translates to a spacing increase (less dense), and a
   /// smaller value translates to a spacing decrease (more dense).
+  ///
+  /// In Material Design 3, the [visualDensity] does not override the value of
+  /// [IconButton.visualDensity] which defaults to [VisualDensity.standard]
+  /// for all platforms. To override the default value of [IconButton.visualDensity],
+  /// use [iconButtonTheme] parameter instead.
   /// {@endtemplate}
   final VisualDensity visualDensity;
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -712,11 +712,9 @@ void main() {
   });
 
   testWidgets('test action is 4dp from edge and 48dp min', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData(platform: TargetPlatform.android);
-
     await tester.pumpWidget(
       MaterialApp(
-        theme: theme,
+        theme: ThemeData(platform: TargetPlatform.android),
         home: Scaffold(
           appBar: AppBar(
             title: const Text('X'),

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -707,14 +707,16 @@ void main() {
     );
 
     final Finder hamburger = find.byTooltip('Open navigation menu');
-    expect(tester.getTopLeft(hamburger), Offset.zero);
-    expect(tester.getSize(hamburger), const Size(56.0, 56.0));
+    expect(tester.getTopLeft(hamburger), const Offset(4.0, 4.0));
+    expect(tester.getSize(hamburger), const Size(48.0, 48.0));
   });
 
   testWidgets('test action is 4dp from edge and 48dp min', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(platform: TargetPlatform.android);
+
     await tester.pumpWidget(
       MaterialApp(
-        theme: ThemeData(platform: TargetPlatform.android),
+        theme: theme,
         home: Scaffold(
           appBar: AppBar(
             title: const Text('X'),
@@ -737,14 +739,14 @@ void main() {
       ),
     );
 
-    final Finder addButton = find.byTooltip('Add');
+    final Finder addButton = find.widgetWithIcon(IconButton, Icons.add);
     expect(tester.getTopRight(addButton), const Offset(800.0, 0.0));
     // It's still the size it was plus the 2 * 8dp padding from IconButton.
     expect(tester.getSize(addButton), const Size(60.0 + 2 * 8.0, 56.0));
 
-    final Finder shareButton = find.byTooltip('Share');
+    final Finder shareButton = find.widgetWithIcon(IconButton, Icons.share);
     // The 20dp icon is expanded to fill the IconButton's touch target to 48dp.
-    expect(tester.getSize(shareButton), const Size(48.0, 56.0));
+    expect(tester.getSize(shareButton), const Size(48.0, 48.0));
   });
 
   testWidgets('SliverAppBar default configuration', (WidgetTester tester) async {
@@ -1672,7 +1674,7 @@ void main() {
       ),
     );
     await tester.tap(find.byKey(key));
-    expect(painter, paints..save()..translate()..save()..translate()..circle(x: 24.0, y: 28.0));
+    expect(painter, paints..save()..translate()..save()..translate()..circle(x: 24.0, y: 24.0));
   });
 
   testWidgets('AppBar handles loose children 0', (WidgetTester tester) async {

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -459,7 +459,7 @@ void main() {
     );
 
     final RenderBox iconBox = tester.renderObject(find.byType(IconButton));
-    expect(iconBox.size.height, kMinInteractiveDimension);
+    expect(iconBox.size.height, 48.0);
     expect(tester.getCenter(find.byType(IconButton)).dy, 28);
   });
 

--- a/packages/flutter/test/material/icon_button_test.dart
+++ b/packages/flutter/test/material/icon_button_test.dart
@@ -275,11 +275,17 @@ void main() {
 
   testWidgets('Small icons comply with VisualDensity requirements', (WidgetTester tester) async {
     final bool material3 = theme.useMaterial3;
-    final ThemeData themeDataM2 = ThemeData(visualDensity: const VisualDensity(horizontal: 1, vertical: -1), useMaterial3: material3);
+    final ThemeData themeDataM2 = ThemeData(
+      useMaterial3: material3,
+      visualDensity: const VisualDensity(horizontal: 1, vertical: -1),
+    );
     final ThemeData themeDataM3 = ThemeData(
-        iconButtonTheme: IconButtonThemeData(
-            style: IconButton.styleFrom(visualDensity: const VisualDensity(horizontal: 1, vertical: -1))),
-      useMaterial3: material3
+      useMaterial3: material3,
+      iconButtonTheme: IconButtonThemeData(
+        style: IconButton.styleFrom(
+            visualDensity: const VisualDensity(horizontal: 1, vertical: -1)
+        )
+      ),
     );
     await tester.pumpWidget(
       wrap(
@@ -1635,14 +1641,17 @@ void main() {
     expect(find.byIcon(Icons.ac_unit), findsOneWidget);
   });
 
-  testWidgets('The visualDensity of M3 IconButton can be configrued by IconButtonTheme, '
+  testWidgets('The visualDensity of M3 IconButton can be configured by IconButtonTheme, '
       'but cannot be configured by ThemeData - M3' , (WidgetTester tester) async {
     Future<void> buildTest({VisualDensity? iconButtonThemeVisualDensity, VisualDensity? themeVisualDensity}) async {
       return tester.pumpWidget(
         MaterialApp(
-          theme: ThemeData.from(colorScheme: colorScheme, useMaterial3: true)
-              .copyWith(iconButtonTheme: IconButtonThemeData(style: IconButton.styleFrom(visualDensity: iconButtonThemeVisualDensity)),
-                        visualDensity: themeVisualDensity),
+          theme: ThemeData.from(colorScheme: colorScheme, useMaterial3: true).copyWith(
+            iconButtonTheme: IconButtonThemeData(
+              style: IconButton.styleFrom(visualDensity: iconButtonThemeVisualDensity)
+            ),
+            visualDensity: themeVisualDensity
+          ),
           home: Material(
             child: Center(
               child: IconButton(
@@ -1668,7 +1677,7 @@ void main() {
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(64, 64)));
 
-    // ThemeData.visualDensity will be ignored
+    // ThemeData.visualDensity will be ignored because useMaterial3 is true
     await buildTest(themeVisualDensity: VisualDensity.standard);
     await tester.pumpAndSettle();
     expect(box.size, equals(const Size(48, 48)));

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -2321,13 +2321,14 @@ void main() {
     await tester.pumpAndSettle();
 
     final Offset button = tester.getTopRight(find.byKey(buttonKey));
-    expect(button, const Offset(800.0, 32.0)); // The topPadding is 32.0.
+    // The topPadding is 32 + (56 - 20) / 2, and the 56 pixels is the app bar height.
+    expect(button, const Offset(800.0, 50.0));
 
     final Offset popupMenu = tester.getTopRight(find.byType(SingleChildScrollView));
 
     // The menu should be positioned directly next to the top of the button.
     // The 8.0 pixels is [_kMenuScreenPadding].
-    expect(popupMenu, Offset(button.dx - 8.0, button.dy + 8.0));
+    expect(popupMenu, Offset(button.dx - 8.0, button.dy));
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/82874
@@ -2387,7 +2388,7 @@ void main() {
     await tester.pumpAndSettle();
 
     final Offset button = tester.getTopRight(find.byKey(buttonKey));
-    expect(button, Offset(800.0 - padding.right, padding.top)); // The topPadding is 32.0.
+    expect(button, Offset(800.0 - padding.right, 50.0)); // The topPadding is 32 + (56 - 20) / 2.
 
     final Offset popupMenuTopRight = tester.getTopRight(find.byType(SingleChildScrollView));
 


### PR DESCRIPTION
This PR fixes #64702, so the `IconButton`s on AppBar have a proper circular splash.
<img width="384" alt="Screen Shot 2022-08-10 at 1 39 38 PM" src="https://user-images.githubusercontent.com/36861262/184015794-ed04a628-fb43-48e4-a5df-69e1dd6c9fa3.png">
<img width="385" alt="Screen Shot 2022-08-10 at 1 40 59 PM" src="https://user-images.githubusercontent.com/36861262/184016017-48f93282-d5ab-4258-97b4-df51d515084f.png">


This PR also sets the default `visualDensity` of IconButton to `VisualDensity.standard`, to ensure the default IconButton will have a circular shape even if the app is running on desktop/web platforms (whose default compact visual density changes the shape to be rounded rectangle). 

Just for more information, the default `IconButton` has a size of 48x48, 4 pixels of padding, and a circular shape. However, if a button changes to a different size or shape, the padding between buttons might be different from the default. The below code can achieve a combination of circular IconButton and rounded rectangle IconButton with the same paddings between each other, like the screenshot below.
<img width="324" alt="Screen Shot 2022-08-10 at 1 56 50 PM" src="https://user-images.githubusercontent.com/36861262/184018578-b451b0f1-6d3a-4734-b1d8-c31d0b19b1c3.png">

</details>

<details>

```dart
import 'package:flutter/material.dart';

void main() {
  runApp(const IconButtonApp());
}

class IconButtonApp extends StatelessWidget {
  const IconButtonApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      theme: ThemeData(
        brightness: Brightness.dark,
        colorSchemeSeed: const Color(0xff3c602b),
        useMaterial3: true,
        materialTapTargetSize: MaterialTapTargetSize.padded
    ),
      home: const Scaffold(
        body: ButtonExample(),
      ),
    );
  }
}

class ButtonExample extends StatelessWidget {
  const ButtonExample({super.key});

  Widget filledIconButton(ColorScheme colors) =>
    IconButton(
      icon: const Icon(Icons.back_hand),
      onPressed: () {},
      style: IconButton.styleFrom(
        foregroundColor: colors.onPrimary,
        backgroundColor: colors.primary,
      ),
    );

  Widget outlinedIconButton(ColorScheme colors) =>
    IconButton(
      icon: const Icon(Icons.more_vert),
      onPressed: () {},
      style: IconButton.styleFrom(
        focusColor: colors.onSurfaceVariant.withOpacity(0.12),
        highlightColor: colors.onSurface.withOpacity(0.12),
        side: BorderSide(color: colors.outline),
      ).copyWith(
        foregroundColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
          if (states.contains(MaterialState.pressed)) {
            return colors.onSurface;
          }
          return null;
        }),
      ),
    );

  Widget roundedRectangleButton(ColorScheme colors) =>
    IconButton(
      icon: const Icon(Icons.call_end),
      onPressed: () {},
      style: IconButton.styleFrom(
        foregroundColor: colors.error,
        backgroundColor: colors.errorContainer,
        visualDensity: const VisualDensity(horizontal: 2),
      ),
    );

  @override
  Widget build(BuildContext context) {
    final ColorScheme colors = Theme.of(context).colorScheme;

    return Center(
      child: IntrinsicHeight(
        child: Row(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            filledIconButton(colors),
            outlinedIconButton(colors),
            Padding(
              padding: const EdgeInsets.symmetric(horizontal: 4),
              child: roundedRectangleButton(colors),
            ),
          ],
        ),
      ),
    );
  }
}
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
