### PR TITLE
Fix HTML in skeletons (ampersands must be escaped)

### DIFF
--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -11,7 +11,7 @@
 <div class="snippet-container">
     <div class="snippet" id="longSnippet{{serial}}">
         {{description}}
-        <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&run=true&null_safety=true&sample_id={{id}}&sample_channel={{channel}}"></iframe>
+        <iframe class="snippet-dartpad" src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;null_safety=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}"></iframe>
         <div class="snippet-description">To create a local project with this code sample, run:<br/>
             <span class="snippet-create-command">flutter create --sample={{id}} mysample</span>
         </div>


### PR DESCRIPTION
Technically we should also be escaping the IDs and channel names and such but it's safe if we can guarantee they are always alphanumeric.
