### PR TITLE
Keep `dirty` manipulations private to `Element` base class

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -1016,9 +1016,6 @@ class _NullElement extends Element {
 
   @override
   bool get debugDoingBuild => throw UnimplementedError();
-
-  @override
-  void performRebuild() { }
 }
 
 class _NullWidget extends Widget {

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -591,9 +591,6 @@ class _NullElement extends Element {
 
   @override
   bool get debugDoingBuild => throw UnimplementedError();
-
-  @override
-  void performRebuild() { }
 }
 
 class _NullWidget extends Widget {

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -221,11 +221,6 @@ class _TestElement extends Element {
   _TestElement() : super(const Placeholder());
 
   @override
-  void performRebuild() {
-    // Intentionally left empty.
-  }
-
-  @override
   bool get debugDoingBuild => throw UnimplementedError();
 }
 

--- a/packages/flutter/test/widgets/did_update_widget_test.dart
+++ b/packages/flutter/test/widgets/did_update_widget_test.dart
@@ -50,7 +50,7 @@ class _WidgetUnderTestState extends State<WidgetUnderTest> {
     super.didUpdateWidget(oldWidget);
     didUpdateWidgetCalled += 1;
     if (oldWidget.text != widget.text) {
-      // This setState is load-barring for the test.
+      // This setState is load bearing for the test.
       setState(() {
         text = widget.text;
       });

--- a/packages/flutter/test/widgets/did_update_widget_test.dart
+++ b/packages/flutter/test/widgets/did_update_widget_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Can call setState from didUpdateWidget', (WidgetTester tester) async {
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: WidgetUnderTest(text: 'hello'),
+    ));
+
+    expect(find.text('hello'), findsOneWidget);
+    expect(find.text('world'), findsNothing);
+    final _WidgetUnderTestState state = tester.state<_WidgetUnderTestState>(find.byType(WidgetUnderTest));
+    expect(state.setStateCalled, 0);
+    expect(state.didUpdateWidgetCalled, 0);
+
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: WidgetUnderTest(text: 'world'),
+    ));
+
+    expect(find.text('world'), findsOneWidget);
+    expect(find.text('hello'), findsNothing);
+    expect(state.setStateCalled, 1);
+    expect(state.didUpdateWidgetCalled, 1);
+  });
+}
+
+class WidgetUnderTest extends StatefulWidget {
+  const WidgetUnderTest({super.key, required this.text});
+
+  final String text;
+
+  @override
+  State<WidgetUnderTest> createState() => _WidgetUnderTestState();
+}
+
+class _WidgetUnderTestState extends State<WidgetUnderTest> {
+  late String text = widget.text;
+
+  int setStateCalled = 0;
+  int didUpdateWidgetCalled = 0;
+
+  @override
+  void didUpdateWidget(WidgetUnderTest oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    didUpdateWidgetCalled += 1;
+    if (oldWidget.text != widget.text) {
+      // This setState is load-barring for the test.
+      setState(() {
+        text = widget.text;
+      });
+    }
+  }
+
+  @override
+  void setState(VoidCallback fn) {
+    super.setState(fn);
+    setStateCalled += 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(text);
+  }
+}

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1965,9 +1965,9 @@ class StatefulElementSpy extends StatefulElement {
   _Stateful get _statefulWidget => widget as _Stateful;
 
   @override
-  void rebuild({bool force = true}) {
+  void rebuild({bool force = false}) {
     _statefulWidget.onElementRebuild?.call(this);
-    super.rebuild();
+    super.rebuild(force: force);
   }
 }
 

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1862,9 +1862,6 @@ class DirtyElementWithCustomBuildOwner extends Element {
   final BuildOwner _owner;
 
   @override
-  void performRebuild() {}
-
-  @override
   BuildOwner get owner => _owner;
 
   @override
@@ -1968,7 +1965,7 @@ class StatefulElementSpy extends StatefulElement {
   _Stateful get _statefulWidget => widget as _Stateful;
 
   @override
-  void rebuild() {
+  void rebuild({bool force = true}) {
     _statefulWidget.onElementRebuild?.call(this);
     super.rebuild();
   }
@@ -2115,9 +2112,6 @@ class _EmptyElement extends Element {
 
   @override
   bool get debugDoingBuild => false;
-
-  @override
-  void performRebuild() {}
 }
 
 class _TestLeaderLayerWidget extends SingleChildRenderObjectWidget {


### PR DESCRIPTION
I tried to create a custom Element that was a direct subclass of `Element` outside of the framework and it was impossible to implement this right because I couldn't properly set/unset the `dirty` flag when necessary. Element subclasses in the framework directly manipulate the private `Element._dirty` field, but subclasses outside of `framework.dart` don't have this option. This change keeps setting `Element._dirty` private to the `Element` class to give subclasses outside of the framework a fair chance. This is archived by:

* Resetting `_dirty` in the default implementation of `Element.performRebuild`. Subclasses are now expected to call this super implementation to reset the flag.
* Adding a `force` parameter to the `Element.rebuild` method to force rebuilding even if the `Element` isn't dirty. This is convenient to call from implementations of `update` in subclasses.

I don't expect this to be a breaking change. Elements implemented outside the framework, who are not calling `super.performRebuild` already, are essentially broken because they can't reset the `dirty` flag properly. Therefore, I am not expecting any implementations out there that override `performRebuild` without already calling super. Furthermore, the addition of a new parameter to `rebuild` shouldn't break any subclasses since subclasses should be overriding `performRebuild` instead and that signature is unchanged. (However, I did find one class in google3 that overrides `rebuild` directly and that override needs to be updated to include the newly added `force` parameter.)

Alternatives considered:
* Instead of adding `force` as a parameter to `rebuild`, add a new `forceRebuild` method. While this would be non-breaking in google3, it would deepen the call stack if we want to call into `forceRebuild` from `rebuild` to re-use code.
* Instead of introducing a new force rebuild functionality, have the base implementation of `Element.update` set the dirty flag to true so subclasses can call the regular `rebuild` method in their `update` method (since the element is now dirty, rebuild will actually do the rebuilding work). While this would work for all Element subclasses implemented in the framework, this would force every Element to always rebuild in `update` to clear the dirty flag. Conceptually, this seems incorrect as there could in theory be updates that don't require a rebuild because the update is essentially a no-op.
* Instead of having `Element.performRebuild` reset the dirty flag, provide a specific API to mark an Element as clean again (i.e. `Element.markAsClean()`). I am a little hesitant to give Element more API surface and adding that extra API feels easier to miss-use then having `performRebuild` clear the flag.