### PR TITLE
Reland: Fix Android platform view creation flow

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -179,17 +179,9 @@ class RenderAndroidView extends PlatformViewRenderBox {
     Size targetSize;
     do {
       targetSize = size;
-      if (_viewController.isCreated) {
-        _currentTextureSize = await _viewController.setSize(targetSize);
-        if (_isDisposed) {
-          return;
-        }
-      } else {
-        await _viewController.create(size: targetSize);
-        if (_isDisposed) {
-          return;
-        }
-        _currentTextureSize = targetSize;
+      _currentTextureSize = await _viewController.setSize(targetSize);
+      if (_isDisposed) {
+        return;
       }
       // We've resized the platform view to targetSize, but it is possible that
       // while we were resizing the render object's size was changed again.

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -768,10 +768,9 @@ abstract class AndroidViewController extends PlatformViewController {
 
   /// Sends the message to create the platform view with an initial [size].
   ///
-  /// If [_createRequiresSize] is true, it is a programming error to call this
-  /// with a null size, and the call should instead be deferred until the size
-  /// is available.
-  Future<void> _sendCreateMessage({Size? size});
+  /// If [_createRequiresSize] is true, `size` is non-nullable, and the call
+  /// should instead be deferred until the size is available.
+  Future<void> _sendCreateMessage({required covariant Size? size});
 
   /// Sends the message to resize the platform view to [size].
   Future<Size> _sendResizeMessage(Size size);
@@ -1005,7 +1004,7 @@ class ExpensiveAndroidViewController extends AndroidViewController {
   bool get _createRequiresSize => false;
 
   @override
-  Future<void> _sendCreateMessage({Size? size}) async {
+  Future<void> _sendCreateMessage({required Size? size}) async {
     final Map<String, dynamic> args = <String, dynamic>{
       'id': viewId,
       'viewType': _viewType,
@@ -1125,15 +1124,14 @@ class TextureAndroidViewController extends AndroidViewController {
   bool get _createRequiresSize => true;
 
   @override
-  Future<void> _sendCreateMessage({Size? size}) async {
-    // Size must not be null due to _createRequiresSize returning true.
-    assert(size != null, 'trying to create $TextureAndroidViewController with a null size.');
-    assert(!size!.isEmpty, 'trying to create $TextureAndroidViewController without setting a valid size.');
+  // Size is non-nullable due to _createRequiresSize returning true.
+  Future<void> _sendCreateMessage({required Size size}) async {
+    assert(!size.isEmpty, 'trying to create $TextureAndroidViewController without setting a valid size.');
 
     final Map<String, dynamic> args = <String, dynamic>{
       'id': viewId,
       'viewType': _viewType,
-      'width': size!.width,
+      'width': size.width,
       'height': size.height,
       'direction': AndroidViewController._getAndroidDirection(_layoutDirection),
     };

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -764,17 +764,33 @@ abstract class AndroidViewController extends PlatformViewController {
   Future<void> _sendDisposeMessage();
 
   /// Sends the message to create the platform view with an initial [size].
-  Future<void> _sendCreateMessage({Size? size});
+  ///
+  /// Returns true if the view was actually created. In some cases (e.g.,
+  /// trying to create a texture-based view with a null size) creation will
+  /// fail and need to be re-attempted later.
+  Future<bool> _sendCreateMessage({Size? size});
+
+  /// Sends the message to resize the platform view to [size].
+  Future<Size> _sendResizeMessage(Size size);
+
+  @override
+  bool get awaitingCreation => _state == _AndroidViewState.waitingForSize;
 
   @override
   Future<void> create({Size? size}) async {
     assert(_state != _AndroidViewState.disposed, 'trying to create a disposed Android view');
 
-    await _sendCreateMessage(size: size);
+    assert(_state == _AndroidViewState.waitingForSize, 'Android view is already sized. View id: $viewId');
+    _state = _AndroidViewState.creating;
+    final bool created = await _sendCreateMessage(size: size);
 
-    _state = _AndroidViewState.created;
-    for (final PlatformViewCreatedCallback callback in _platformViewCreatedCallbacks) {
-      callback(viewId);
+    if (created) {
+      _state = _AndroidViewState.created;
+      for (final PlatformViewCreatedCallback callback in _platformViewCreatedCallbacks) {
+        callback(viewId);
+      }
+    } else {
+      _state = _AndroidViewState.waitingForSize;
     }
   }
 
@@ -792,7 +808,17 @@ abstract class AndroidViewController extends PlatformViewController {
   ///
   /// As a result, consumers are expected to clip the texture using [size], while using
   /// the return value to size the texture.
-  Future<Size> setSize(Size size);
+  Future<Size> setSize(Size size) async {
+    assert(_state != _AndroidViewState.disposed, 'Android view is disposed. View id: $viewId');
+    if (_state == _AndroidViewState.waitingForSize) {
+      // Either `create` hasn't been called, or it couldn't run due to missing
+      // size information, so create the view now.
+      await create(size: size);
+      return size;
+    } else {
+      return _sendResizeMessage(size);
+    }
+  }
 
   /// Sets the offset of the platform view.
   ///
@@ -972,7 +998,7 @@ class ExpensiveAndroidViewController extends AndroidViewController {
   })  : super._();
 
   @override
-  Future<void> _sendCreateMessage({Size? size}) {
+  Future<bool> _sendCreateMessage({Size? size}) async {
     final Map<String, dynamic> args = <String, dynamic>{
       'id': viewId,
       'viewType': _viewType,
@@ -988,7 +1014,8 @@ class ExpensiveAndroidViewController extends AndroidViewController {
         paramsByteData.lengthInBytes,
       );
     }
-    return SystemChannels.platform_views.invokeMethod<void>('create', args);
+    await SystemChannels.platform_views.invokeMethod<void>('create', args);
+    return true;
   }
 
   @override
@@ -1005,7 +1032,7 @@ class ExpensiveAndroidViewController extends AndroidViewController {
   }
 
   @override
-  Future<Size> setSize(Size size) {
+  Future<Size> _sendResizeMessage(Size size) {
     throw UnimplementedError('Not supported for $SurfaceAndroidViewController.');
   }
 
@@ -1044,8 +1071,7 @@ class TextureAndroidViewController extends AndroidViewController {
   Offset _off = Offset.zero;
 
   @override
-  Future<Size> setSize(Size size) async {
-    assert(_state != _AndroidViewState.disposed, 'Android view is disposed. View id: $viewId');
+  Future<Size> _sendResizeMessage(Size size) async {
     assert(_state != _AndroidViewState.waitingForSize, 'Android view must have an initial size. View id: $viewId');
     assert(size != null);
     assert(!size.isEmpty);
@@ -1062,16 +1088,6 @@ class TextureAndroidViewController extends AndroidViewController {
     assert(meta!.containsKey('width'));
     assert(meta!.containsKey('height'));
     return Size(meta!['width']! as double, meta['height']! as double);
-  }
-
-  @override
-  Future<void> create({Size? size}) async {
-    if (size == null) {
-      return;
-    }
-    assert(_state == _AndroidViewState.waitingForSize, 'Android view is already sized. View id: $viewId');
-    assert(!size.isEmpty);
-    return super.create(size: size);
   }
 
   @override
@@ -1100,9 +1116,9 @@ class TextureAndroidViewController extends AndroidViewController {
   }
 
   @override
-  Future<void> _sendCreateMessage({Size? size}) async {
+  Future<bool> _sendCreateMessage({Size? size}) async {
     if (size == null) {
-      return;
+      return false;
     }
 
     assert(!size.isEmpty, 'trying to create $TextureAndroidViewController without setting a valid size.');
@@ -1123,6 +1139,7 @@ class TextureAndroidViewController extends AndroidViewController {
       );
     }
     _textureId = await SystemChannels.platform_views.invokeMethod<int>('create', args);
+    return true;
   }
 
   @override
@@ -1218,6 +1235,15 @@ abstract class PlatformViewController {
   ///
   ///  * [PlatformViewsRegistry], which is a helper for managing platform view IDs.
   int get viewId;
+
+  /// True if [create] has not been successfully called the platform view.
+  ///
+  /// This can indicate either that [create] was never called, or that [create]
+  /// was deferred for implementation-specific reasons.
+  ///
+  /// A `false` return value does not necessarily indicate that the [Future]
+  /// returned by [create] has completed, only that creation has been started.
+  bool get awaitingCreation => false;
 
   /// Dispatches the `event` to the platform view.
   Future<void> dispatchPointerEvent(PointerEvent event);

--- a/packages/flutter/lib/src/widgets/platform_view.dart
+++ b/packages/flutter/lib/src/widgets/platform_view.dart
@@ -871,14 +871,20 @@ class _PlatformViewLinkState extends State<PlatformViewLink> {
 
   @override
   Widget build(BuildContext context) {
-    if (_controller == null) {
+    final PlatformViewController? controller = _controller;
+    if (controller == null) {
       return const SizedBox.expand();
     }
     if (!_platformViewCreated) {
-      // Depending on the platform, the initial size can be used to size the platform view.
-      return _PlatformViewPlaceHolder(onLayout: (Size size) => _controller!.create(size: size));
+      // Depending on the implementation, the initial size can be used to size
+      // the platform view.
+      return _PlatformViewPlaceHolder(onLayout: (Size size) {
+        if (controller.awaitingCreation) {
+          controller.create(size: size);
+        }
+      });
     }
-    _surface ??= widget._surfaceFactory(context, _controller!);
+    _surface ??= widget._surfaceFactory(context, controller);
     return Focus(
       focusNode: _focusNode,
       onFocusChange: _handleFrameworkFocusChanged,

--- a/packages/flutter/test/services/fake_platform_views.dart
+++ b/packages/flutter/test/services/fake_platform_views.dart
@@ -45,11 +45,16 @@ class FakePlatformViewController extends PlatformViewController {
 }
 
 class FakeAndroidViewController implements AndroidViewController {
-  FakeAndroidViewController(this.viewId);
+  FakeAndroidViewController(this.viewId, {this.requiresSize = false});
 
   bool disposed = false;
   bool focusCleared = false;
   bool created = false;
+  // If true, [create] won't be considered to have been called successfully
+  // unless it includes a size.
+  bool requiresSize;
+
+  bool _createCalledSuccessfully = false;
 
   /// Events that are dispatched.
   List<PointerEvent> dispatchedPointerEvents = <PointerEvent>[];
@@ -93,6 +98,9 @@ class FakeAndroidViewController implements AndroidViewController {
   int get textureId => 0;
 
   @override
+  bool get awaitingCreation => !_createCalledSuccessfully;
+
+  @override
   bool get isCreated => created;
 
   @override
@@ -114,7 +122,10 @@ class FakeAndroidViewController implements AndroidViewController {
   }
 
   @override
-  Future<void> create({Size? size}) async {}
+  Future<void> create({Size? size}) async {
+    assert(!_createCalledSuccessfully);
+    _createCalledSuccessfully = size != null || !requiresSize;
+  }
 
   @override
   List<PlatformViewCreatedCallback> get createdCallbacks => <PlatformViewCreatedCallback>[];

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -1026,6 +1026,7 @@ void main() {
 
       containerFocusNode.requestFocus();
 
+      viewsController.createCompleter!.complete();
       await tester.pump();
 
       expect(containerFocusNode.hasFocus, isTrue);
@@ -2423,7 +2424,110 @@ void main() {
           onCreatePlatformView: (PlatformViewCreationParams params) {
             onPlatformViewCreatedCallBack = params.onPlatformViewCreated;
             createdPlatformViewId = params.id;
-            return FakePlatformViewController(params.id);
+            return FakePlatformViewController(params.id)..create();
+          },
+          surfaceFactory: (BuildContext context, PlatformViewController controller) {
+            return PlatformViewSurface(
+              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+              controller: controller,
+              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            );
+          },
+        );
+
+        await tester.pumpWidget(platformViewLink);
+
+        expect(
+          tester.allWidgets.map((Widget widget) => widget.runtimeType.toString()).toList(),
+          equals(<String>['PlatformViewLink', '_PlatformViewPlaceHolder']),
+        );
+
+        onPlatformViewCreatedCallBack(createdPlatformViewId);
+
+        await tester.pump();
+
+        expect(
+          tester.allWidgets.map((Widget widget) => widget.runtimeType.toString()).toList(),
+          equals(<String>['PlatformViewLink', 'Focus', '_FocusMarker', 'Semantics', 'PlatformViewSurface']),
+        );
+
+        expect(createdPlatformViewId, currentViewId + 1);
+      },
+    );
+
+    testWidgets(
+      'PlatformViewLink calls create when needed for Android texture display modes',
+      (WidgetTester tester) async {
+        final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+        late int createdPlatformViewId;
+
+        late PlatformViewCreatedCallback onPlatformViewCreatedCallBack;
+        late PlatformViewController controller;
+
+        final PlatformViewLink platformViewLink = PlatformViewLink(
+          viewType: 'webview',
+          onCreatePlatformView: (PlatformViewCreationParams params) {
+            onPlatformViewCreatedCallBack = params.onPlatformViewCreated;
+            createdPlatformViewId = params.id;
+            controller = FakeAndroidViewController(params.id, requiresSize: true);
+            controller.create();
+            // This test should be simulating one of the texture-based display
+            // modes, where `create` is a no-op when not provided a size, and
+            // creation is triggered via a later call to setSize, or to `create`
+            // with a size.
+            expect(controller.awaitingCreation, true);
+            return controller;
+          },
+          surfaceFactory: (BuildContext context, PlatformViewController controller) {
+            return PlatformViewSurface(
+              gestureRecognizers: const <Factory<OneSequenceGestureRecognizer>>{},
+              controller: controller,
+              hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+            );
+          },
+        );
+
+        await tester.pumpWidget(platformViewLink);
+
+        expect(
+          tester.allWidgets.map((Widget widget) => widget.runtimeType.toString()).toList(),
+          equals(<String>['PlatformViewLink', '_PlatformViewPlaceHolder']),
+        );
+
+        onPlatformViewCreatedCallBack(createdPlatformViewId);
+
+        await tester.pump();
+
+        expect(
+          tester.allWidgets.map((Widget widget) => widget.runtimeType.toString()).toList(),
+          equals(<String>['PlatformViewLink', 'Focus', '_FocusMarker', 'Semantics', 'PlatformViewSurface']),
+        );
+
+        expect(createdPlatformViewId, currentViewId + 1);
+        expect(controller.awaitingCreation, false);
+      },
+    );
+
+    testWidgets(
+      'PlatformViewLink does not double-call create for Android Hybrid Composition',
+      (WidgetTester tester) async {
+        final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+        late int createdPlatformViewId;
+
+        late PlatformViewCreatedCallback onPlatformViewCreatedCallBack;
+        late PlatformViewController controller;
+
+        final PlatformViewLink platformViewLink = PlatformViewLink(
+          viewType: 'webview',
+          onCreatePlatformView: (PlatformViewCreationParams params) {
+            onPlatformViewCreatedCallBack = params.onPlatformViewCreated;
+            createdPlatformViewId = params.id;
+            controller = FakeAndroidViewController(params.id);
+            controller.create();
+            // This test should be simulating Hybrid Composition mode, where
+            // `create` takes effect immidately.
+            expect(controller.awaitingCreation, false);
+            return controller;
           },
           surfaceFactory: (BuildContext context, PlatformViewController controller) {
             return PlatformViewSurface(


### PR DESCRIPTION
Re-lands https://github.com/flutter/flutter/pull/109232 with a fix for `google_mobile_ads`

There was a subtle race in the previous version of the PR, which `google_mobile_ads` hit but the plugin I was testing with did not: because `_sendCreateMessage` is async, even if it returned false synchronously due to `null` size, `create` didn't necessarily continue synchronously. This created a brief async gap for TLHC where the state was `creating`, and thus `awaitingCreation` would return false, and the second `create` call from `PlatformViewLink` wouldn't fire.

This fixes that (see second commit in the PR) by using a synchronous getter rather than an async bool return value from the subclass to know whether to drop null-size calls to `create`.

Fixes (at least part of) https://github.com/flutter/flutter/issues/107297

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
