### PR TITLE
Remove deprecated Ruby File.exists? in helper script

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -63,6 +63,7 @@ def flutter_additional_ios_build_settings(target)
         build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]'] = "\"#{configuration_engine_dir}/#{xcframework_file}\" $(inherited)"
       elsif xcframework_file.start_with?('ios-') # ios-arm64
         build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]'] = "\"#{configuration_engine_dir}/#{xcframework_file}\" $(inherited)"
+       # else Info.plist or another platform.
       end
     end
     build_configuration.build_settings['OTHER_LDFLAGS'] = '$(inherited) -framework Flutter'

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -14,12 +14,10 @@ require 'json'
 # target 'Runner' do
 # ...
 # end
-def flutter_ios_podfile_setup
-end
+def flutter_ios_podfile_setup; end
 
 # Same as flutter_ios_podfile_setup for macOS.
-def flutter_macos_podfile_setup
-end
+def flutter_macos_podfile_setup; end
 
 # Add iOS build settings to pod targets.
 #
@@ -60,13 +58,11 @@ def flutter_additional_ios_build_settings(target)
     # Profile can't be derived from the CocoaPods build configuration. Use release framework (for linking only).
     configuration_engine_dir = build_configuration.type == :debug ? debug_framework_dir : release_framework_dir
     Dir.new(configuration_engine_dir).each_child do |xcframework_file|
-      next if xcframework_file.start_with?(".") # Hidden file, possibly on external disk.
-      if xcframework_file.end_with?("-simulator") # ios-arm64_x86_64-simulator
+      next if xcframework_file.start_with?('.') # Hidden file, possibly on external disk.
+      if xcframework_file.end_with?('-simulator') # ios-arm64_x86_64-simulator
         build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS[sdk=iphonesimulator*]'] = "\"#{configuration_engine_dir}/#{xcframework_file}\" $(inherited)"
-      elsif xcframework_file.start_with?("ios-") # ios-arm64
+      elsif xcframework_file.start_with?('ios-') # ios-arm64
         build_configuration.build_settings['FRAMEWORK_SEARCH_PATHS[sdk=iphoneos*]'] = "\"#{configuration_engine_dir}/#{xcframework_file}\" $(inherited)"
-      else
-        # Info.plist or another platform.
       end
     end
     build_configuration.build_settings['OTHER_LDFLAGS'] = '$(inherited) -framework Flutter'
@@ -158,7 +154,7 @@ end
 #                                      Optional, defaults to the Podfile directory.
 def flutter_install_ios_engine_pod(ios_application_path = nil)
   # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
-  ios_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  ios_application_path ||= File.dirname(defined_in_file.realpath) if respond_to?(:defined_in_file)
   raise 'Could not find iOS application path' unless ios_application_path
 
   podspec_directory = File.join(ios_application_path, 'Flutter')
@@ -167,7 +163,7 @@ def flutter_install_ios_engine_pod(ios_application_path = nil)
   # Generate a fake podspec to represent the Flutter framework.
   # This is only necessary because plugin podspecs contain `s.dependency 'Flutter'`, and if this Podfile
   # does not add a `pod 'Flutter'` CocoaPods will try to download it from the CocoaPods trunk.
-  File.open(copied_podspec_path, 'w') { |podspec|
+  File.open(copied_podspec_path, 'w') do |podspec|
     podspec.write <<~EOF
       #
       # NOTE: This podspec is NOT to be published. It is only used as a local source!
@@ -188,16 +184,16 @@ def flutter_install_ios_engine_pod(ios_application_path = nil)
         s.vendored_frameworks = 'path/to/nothing'
       end
     EOF
-  }
+  end
 
   # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'Flutter', :path => flutter_relative_path_from_podfile(podspec_directory)
+  pod 'Flutter', path: flutter_relative_path_from_podfile(podspec_directory)
 end
 
 # Same as flutter_install_ios_engine_pod for macOS.
 def flutter_install_macos_engine_pod(mac_application_path = nil)
   # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
-  mac_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  mac_application_path ||= File.dirname(defined_in_file.realpath) if respond_to?(:defined_in_file)
   raise 'Could not find macOS application path' unless mac_application_path
 
   copied_podspec_path = File.expand_path('FlutterMacOS.podspec', File.join(mac_application_path, 'Flutter', 'ephemeral'))
@@ -205,7 +201,7 @@ def flutter_install_macos_engine_pod(mac_application_path = nil)
   # Generate a fake podspec to represent the FlutterMacOS framework.
   # This is only necessary because plugin podspecs contain `s.dependency 'FlutterMacOS'`, and if this Podfile
   # does not add a `pod 'FlutterMacOS'` CocoaPods will try to download it from the CocoaPods trunk.
-  File.open(copied_podspec_path, 'w') { |podspec|
+  File.open(copied_podspec_path, 'w') do |podspec|
     podspec.write <<~EOF
       #
       # NOTE: This podspec is NOT to be published. It is only used as a local source!
@@ -226,10 +222,10 @@ def flutter_install_macos_engine_pod(mac_application_path = nil)
         s.vendored_frameworks = 'path/to/nothing'
       end
     EOF
-  }
+  end
 
   # Keep pod path relative so it can be checked into Podfile.lock.
-  pod 'FlutterMacOS', :path => File.join('Flutter', 'ephemeral')
+  pod 'FlutterMacOS', path: File.join('Flutter', 'ephemeral')
 end
 
 # Install Flutter plugin pods.
@@ -238,7 +234,7 @@ end
 #                                   Optional, defaults to the Podfile directory.
 def flutter_install_plugin_pods(application_path = nil, relative_symlink_dir, platform)
   # defined_in_file is set by CocoaPods and is a Pathname to the Podfile.
-  application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
+  application_path ||= File.dirname(defined_in_file.realpath) if respond_to?(:defined_in_file)
   raise 'Could not find application path' unless application_path
 
   # Prepare symlinks folder. We use symlinks to avoid having Podfile.lock
@@ -256,15 +252,14 @@ def flutter_install_plugin_pods(application_path = nil, relative_symlink_dir, pl
     plugin_name = plugin_hash['name']
     plugin_path = plugin_hash['path']
     has_native_build = plugin_hash.fetch('native_build', true)
-    if (plugin_name && plugin_path && has_native_build)
-      symlink = File.join(symlink_plugins_dir, plugin_name)
-      File.symlink(plugin_path, symlink)
+    next unless plugin_name && plugin_path && has_native_build
+    symlink = File.join(symlink_plugins_dir, plugin_name)
+    File.symlink(plugin_path, symlink)
 
-      # Keep pod path relative so it can be checked into Podfile.lock.
-      relative = flutter_relative_path_from_podfile(symlink)
+    # Keep pod path relative so it can be checked into Podfile.lock.
+    relative = flutter_relative_path_from_podfile(symlink)
 
-      pod plugin_name, :path => File.join(relative, platform)
-    end
+    pod plugin_name, path: File.join(relative, platform)
   end
 end
 
@@ -272,7 +267,7 @@ end
 # https://flutter.dev/go/plugins-list-migration
 def flutter_parse_plugins_file(file, platform)
   file_path = File.expand_path(file)
-  return [] unless File.exists? file_path
+  return [] unless File.exist? file_path
 
   dependencies_file = File.read(file)
   dependencies_hash = JSON.parse(dependencies_file)

--- a/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
+++ b/packages/flutter_tools/templates/module/ios/library/Flutter.tmpl/podhelper.rb.tmpl
@@ -67,7 +67,7 @@ def install_flutter_plugin_pods(flutter_application_path)
 
   # Keep pod path relative so it can be checked into Podfile.lock.
   relative = flutter_relative_path_from_podfile(ios_application_path)
-  pod 'FlutterPluginRegistrant', :path => File.join(relative, 'Flutter', 'FlutterPluginRegistrant'), :inhibit_warnings => true
+  pod 'FlutterPluginRegistrant', path: File.join(relative, 'Flutter', 'FlutterPluginRegistrant'), inhibit_warnings: true
 end
 
 # Install Flutter application pod.
@@ -87,27 +87,25 @@ def install_flutter_application_pod(flutter_application_path)
   # Keep script phase paths relative so they can be checked into source control.
   relative = flutter_relative_path_from_podfile(export_script_directory)
 
-  flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh');
+  flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh')
 
   # Compile App.framework and move it and Flutter.framework to "BUILT_PRODUCTS_DIR"
-  script_phase :name => 'Run Flutter Build {{projectName}} Script',
-    :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build",
-    :execution_position => :before_compile
+  script_phase name: 'Run Flutter Build {{projectName}} Script',
+    script: "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build",
+    execution_position: :before_compile
 
   # Embed App.framework AND Flutter.framework.
-  script_phase :name => 'Embed Flutter Build {{projectName}} Script',
-    :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh embed_and_thin",
-    :execution_position => :after_compile
+  script_phase name: 'Embed Flutter Build {{projectName}} Script',
+    script: "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh embed_and_thin",
+    execution_position: :after_compile
 end
 
 def flutter_root
   generated_xcode_build_settings_path = File.expand_path(File.join('..', '..', 'Flutter', 'Generated.xcconfig'), __FILE__)
-  unless File.exist?(generated_xcode_build_settings_path)
-    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
-  end
+  raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first" unless File.exist?(generated_xcode_build_settings_path)
 
   File.foreach(generated_xcode_build_settings_path) do |line|
-    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    matches = line.match(/FLUTTER_ROOT=(.*)/)
     return matches[1].strip if matches
   end
   # This should never happen...
@@ -127,7 +125,7 @@ def flutter_post_install(installer, skip: false)
   return if skip
 
   installer.pods_project.targets.each do |target|
-    target.build_configurations.each do |build_configuration|
+    target.build_configurations.each do |_build_configuration|
       # flutter_additional_ios_build_settings is in Flutter root podhelper.rb
       flutter_additional_ios_build_settings(target)
     end


### PR DESCRIPTION
`File.exists?` has evidently been deprecated in Ruby 2.1 and was removed in Ruby 3.2 preview 1 (3.2 has not yet been released). https://bugs.ruby-lang.org/issues/17391
https://www.ruby-lang.org/en/news/2022/04/03/ruby-3-2-0-preview1-released/

I ran the [RuboCop](https://docs.rubocop.org/) linter on the two Ruby files in our repo, which caught the deprecation, as well as some outdated syntax.

On `podhelper.rb`:
```
podhelper.rb:17:1: C: [Corrected] Style/EmptyMethod: Put empty method definitions on a single line.
def flutter_ios_podfile_setup ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:21:1: C: [Corrected] Style/EmptyMethod: Put empty method definitions on a single line.
def flutter_macos_podfile_setup ...
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:63:44: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
      next if xcframework_file.start_with?(".") # Hidden file, possibly on external disk.
                                           ^^^
podhelper.rb:64:37: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
      if xcframework_file.end_with?("-simulator") # ios-arm64_x86_64-simulator
                                    ^^^^^^^^^^^^
podhelper.rb:66:42: C: [Corrected] Style/StringLiterals: Prefer single-quoted strings when you don't need string interpolation or special symbols.
      elsif xcframework_file.start_with?("ios-") # ios-arm64
                                         ^^^^^^
podhelper.rb:68:7: C: [Corrected] Style/EmptyElse: Redundant else-clause.
      else
      ^^^^
podhelper.rb:161:70: C: [Corrected] Style/RedundantSelf: Redundant self detected.
  ios_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
                                                                     ^^^^
podhelper.rb:170:39: C: [Corrected] Style/BlockDelimiters: Avoid using {...} for multi-line blocks.
  File.open(copied_podspec_path, 'w') { |podspec|
podhelper.rb:194:18: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
  pod 'Flutter', :path => flutter_relative_path_from_podfile(podspec_directory)
                 ^^^^^^^^
podhelper.rb:200:70: C: [Corrected] Style/RedundantSelf: Redundant self detected.
  mac_application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
                                                                     ^^^^
podhelper.rb:208:39: C: [Corrected] Style/BlockDelimiters: Avoid using {...} for multi-line blocks.
  File.open(copied_podspec_path, 'w') { |podspec|
                                      ^
podhelper.rb:232:23: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
  pod 'FlutterMacOS', :path => File.join('Flutter', 'ephemeral')
podhelper.rb:241:66: C: [Corrected] Style/RedundantSelf: Redundant self detected.
  application_path ||= File.dirname(defined_in_file.realpath) if self.respond_to?(:defined_in_file)
                                                                 ^^^^
podhelper.rb:255:17: C: [Corrected] Style/ParenthesesAroundCondition: Don't use parentheses around the condition of an unless.
    next unless (plugin_name && plugin_path && has_native_build)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:259:5: C: [Corrected] Style/Next: Use next to skip iteration.
    if (plugin_name && plugin_path && has_native_build)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:259:8: C: [Corrected] Style/ParenthesesAroundCondition: Don't use parentheses around the condition of an if.
    if (plugin_name && plugin_path && has_native_build)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:266:24: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
      pod plugin_name, :path => File.join(relative, platform)
                       ^^^^^^^^
podhelper.rb:275:25: W: [Corrected] Lint/DeprecatedClassMethods: File.exists? is deprecated in favor of File.exist?.
  return [] unless File.exists? file_path
                        ^^^^^^^
podhelper.rb:276:38: C: [Correctable] Style/PreferredHashMethods: Use Hash#key? instead of Hash#has_key?.
  return [] unless dependencies_hash.has_key?('plugins')
                                     ^^^^^^^^
podhelper.rb:277:49: C: [Correctable] Style/PreferredHashMethods: Use Hash#key? instead of Hash#has_key?.
  return [] unless dependencies_hash['plugins'].has_key?('ios')
```
and the template script:
```
podhelper.rb:70:34: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
  pod 'FlutterPluginRegistrant', :path => File.join(relative, 'Flutter', 'FlutterPluginRegistrant'), :inhibit_warnings => true
                                 ^^^^^^^^
podhelper.rb:70:102: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
  pod 'FlutterPluginRegistrant', :path => File.join(relative, 'Flutter', 'FlutterPluginRegistrant'), :inhibit_warnings => true
                                                                                                     ^^^^^^^^^^^^^^^^^^^^
podhelper.rb:90:103: C: [Corrected] Style/Semicolon: Do not use semicolons to terminate expressions.
  flutter_export_environment_path = File.join('${SRCROOT}', relative, 'flutter_export_environment.sh');
                                                                                                      ^
podhelper.rb:93:16: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
  script_phase :name => 'Run Flutter Build {{projectName}} Script',
               ^^^^^^^^
podhelper.rb:94:5: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
    :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh build",
    ^^^^^^^^^^
podhelper.rb:95:5: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
    :execution_position => :before_compile
    ^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:98:16: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
  script_phase :name => 'Embed Flutter Build {{projectName}} Script',
               ^^^^^^^^
podhelper.rb:99:5: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
    :script => "set -e\nset -u\nsource \"#{flutter_export_environment_path}\"\nexport VERBOSE_SCRIPT_LOGGING=1 && \"$FLUTTER_ROOT\"/packages/flutter_tools/bin/xcode_backend.sh embed_and_thin",
    ^^^^^^^^^^
podhelper.rb:100:5: C: [Corrected] Style/HashSyntax: Use the new Ruby 1.9 hash syntax.
    :execution_position => :after_compile
    ^^^^^^^^^^^^^^^^^^^^^^
podhelper.rb:105:3: C: [Corrected] Style/IfUnlessModifier: Favor modifier unless usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
  unless File.exist?(generated_xcode_build_settings_path)
  ^^^^^^
podhelper.rb:110:39: C: [Corrected] Style/RedundantRegexpEscape: Redundant escape inside regexp literal
    matches = line.match(/FLUTTER_ROOT\=(.*)/)
                                      ^^
podhelper.rb:130:42: W: [Corrected] Lint/UnusedBlockArgument: Unused block argument - build_configuration. You can omit the argument if you don't care about it.
    target.build_configurations.each do |build_configuration|
                                         ^^^^^^^^^^^^^^^^^^^
```

We have good test coverage of both these methods, but they are running on a stable version of Ruby in our CI (I think it's just using the macOS default system version 2.6).   
Getting a preview version of Ruby into our CI system doesn't seem feasible, so filed https://github.com/flutter/flutter/issues/109431 to get a linter running in CI to catch deprecations like this.

Fixes https://github.com/flutter/flutter/issues/109385

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
