### PR TITLE
[CP] Remove deprecated Ruby File.exists? in helper script

### DIFF
--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -272,7 +272,7 @@ end
 # https://flutter.dev/go/plugins-list-migration
 def flutter_parse_plugins_file(file, platform)
   file_path = File.expand_path(file)
-  return [] unless File.exists? file_path
+  return [] unless File.exist? file_path
 
   dependencies_file = File.read(file)
   dependencies_hash = JSON.parse(dependencies_file)


### PR DESCRIPTION
Limited cherry-pick of https://github.com/flutter/flutter/pull/109428 that only has the deprecation method replacement without the other lint fixes.  Limited the cp to just this line to reduce risk.  

Re lack of testing:
> We have good test coverage of both these methods, but they are running on a stable version of Ruby in our CI (I think it's just using the macOS default system version 2.6).
> Getting a preview version of Ruby into our CI system doesn't seem feasible.

Fixes https://github.com/flutter/flutter/issues/109476