### PR TITLE
Generate syntax for plugin registration that works both with and without null safety.

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -575,7 +575,6 @@ import 'package:{{name}}/{{file}}';
 {{/methodChannelPlugins}}
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-
 void registerPlugins([final Registrar? pluginRegistrar]) {
   final Registrar registrar = pluginRegistrar ?? webPluginRegistrar;
 {{#methodChannelPlugins}}

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -574,8 +574,11 @@ import 'package:{{name}}/{{file}}';
 {{/methodChannelPlugins}}
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-void registerPlugins([final Registrar? pluginRegistrar]) {
-  final Registrar registrar = pluginRegistrar ?? webPluginRegistrar;
+void registerPlugins() {
+  registerPluginsWithRegistrar(webPluginRegistrar);
+}
+
+void registerPluginsWithRegistrar(final Registrar registrar) {
 {{#methodChannelPlugins}}
   {{class}}.registerWith(registrar);
 {{/methodChannelPlugins}}

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -567,6 +567,7 @@ const String _dartPluginRegistryTemplate = '''
 // Generated file. Do not edit.
 //
 
+// @dart = 2.13
 // ignore_for_file: type=lint
 
 {{#methodChannelPlugins}}
@@ -574,11 +575,9 @@ import 'package:{{name}}/{{file}}';
 {{/methodChannelPlugins}}
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-void registerPlugins() {
-  registerPluginsWithRegistrar(webPluginRegistrar);
-}
 
-void registerPluginsWithRegistrar(final Registrar registrar) {
+void registerPlugins([final Registrar? pluginRegistrar]) {
+  final Registrar registrar = pluginRegistrar ?? webPluginRegistrar;
 {{#methodChannelPlugins}}
   {{class}}.registerWith(registrar);
 {{/methodChannelPlugins}}

--- a/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
@@ -62,10 +62,9 @@ void main() {
 
     // Ensure the contents match what we expect for a non-empty plugin registrant.
     final String contents = registrant.readAsStringSync();
+    expect(contents, contains('// @dart = 2.13'));
     expect(contents, contains("import 'package:shared_preferences_web/shared_preferences_web.dart';"));
-    expect(contents, contains('void registerPlugins() {'));
-    expect(contents, contains('  registerPluginsWithRegistrar(webPluginRegistrar);'));
-    expect(contents, contains('void registerPluginsWithRegistrar(final Registrar registrar) {'));
+    expect(contents, contains('void registerPlugins([final Registrar? pluginRegistrar]) {'));
     expect(contents, contains('SharedPreferencesPlugin.registerWith(registrar);'));
     expect(contents, contains('registrar.registerMessageHandler();'));
   }, overrides: <Type, Generator>{
@@ -110,10 +109,9 @@ void main() {
 
     // Ensure the contents match what we expect for a non-empty plugin registrant.
     final String contents = registrant.readAsStringSync();
+    expect(contents, contains('// @dart = 2.13'));
     expect(contents, contains("import 'package:shared_preferences_web/shared_preferences_web.dart';"));
-    expect(contents, contains('void registerPlugins() {'));
-    expect(contents, contains('  registerPluginsWithRegistrar(webPluginRegistrar);'));
-    expect(contents, contains('void registerPluginsWithRegistrar(final Registrar registrar) {'));
+    expect(contents, contains('void registerPlugins([final Registrar? pluginRegistrar]) {'));
     expect(contents, contains('SharedPreferencesPlugin.registerWith(registrar);'));
     expect(contents, contains('registrar.registerMessageHandler();'));
   }, overrides: <Type, Generator>{

--- a/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
+++ b/packages/flutter_tools/test/integration.shard/web_plugin_registrant_test.dart
@@ -370,12 +370,12 @@ PubspecEditor _setDartSDKVersionEditor(String version) {
 }
 
 PubspecEditor _composeEditors(Iterable<PubspecEditor> editors) {
-  void editor(List<String> lines) {
-    for (final PubspecEditor e in editors) {
-      e(lines);
+  void composedEditor(List<String> lines) {
+    for (final PubspecEditor editor in editors) {
+      editor(lines);
     }
   }
-  return editor;
+  return composedEditor;
 }
 
 Future<void> _addAnalysisOptions(


### PR DESCRIPTION
Add a language header to specify we can use null safety in the generated plugin registrant file.

This fixes https://github.com/flutter/flutter/issues/109160