### PR TITLE
Some changes needed to PlatformMenuBar before the MenuBar implementation change lands.

### DIFF
--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -73,12 +73,12 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
     //  │  └ There's a million things I haven't done, but just you wait.
     //  └ Quit
     return PlatformMenuBar(
-      menus: <MenuItem>[
+      menus: <PlatformMenuItem>[
         PlatformMenu(
           label: 'Flutter API Sample',
-          menus: <MenuItem>[
+          menus: <PlatformMenuItem>[
             PlatformMenuItemGroup(
-              members: <MenuItem>[
+              members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: 'About',
                   onSelected: () {
@@ -88,7 +88,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
               ],
             ),
             PlatformMenuItemGroup(
-              members: <MenuItem>[
+              members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   onSelected: () {
                     _handleMenuSelection(MenuSelection.showMessage);
@@ -98,7 +98,7 @@ class _MyMenuBarAppState extends State<MyMenuBarApp> {
                 ),
                 PlatformMenu(
                   label: 'Messages',
-                  menus: <MenuItem>[
+                  menus: <PlatformMenuItem>[
                     PlatformMenuItem(
                       label: 'I am not throwing away my shot.',
                       shortcut: const SingleActivator(LogicalKeyboardKey.digit1, meta: true),

--- a/packages/flutter/lib/src/services/system_channels.dart
+++ b/packages/flutter/lib/src/services/system_channels.dart
@@ -406,7 +406,7 @@ class SystemChannels {
   ///    encoding the list of top level menu items in window "0", which each
   ///    have a hierarchy of `Map<String, Object?>` containing the required
   ///    data, sent via a [StandardMessageCodec]. It is typically generated from
-  ///    a list of [MenuItem]s, and ends up looking like this example:
+  ///    a list of [PlatformMenuItem]s, and ends up looking like this example:
   ///
   /// ```dart
   /// Map<String, Object?> menu = <String, Object?>{

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -163,9 +163,9 @@ void main() {
         const MaterialApp(
           home: Material(
             child: PlatformMenuBar(
-              menus: <MenuItem>[],
+              menus: <PlatformMenuItem>[],
               child: PlatformMenuBar(
-                menus: <MenuItem>[],
+                menus: <PlatformMenuItem>[],
                 child: SizedBox(),
               ),
             ),
@@ -180,7 +180,7 @@ void main() {
         shortcut: SingleActivator(LogicalKeyboardKey.keyA),
       );
       const PlatformMenuBar menuBar = PlatformMenuBar(
-        menus: <MenuItem>[item],
+        menus: <PlatformMenuItem>[item],
         child: SizedBox(),
       );
 
@@ -205,14 +205,14 @@ void main() {
       );
     });
   });
-  group('PlatformMenuBarItem', () {
+  group('MenuBarItem', () {
     testWidgets('diagnostics', (WidgetTester tester) async {
       const PlatformMenuItem childItem = PlatformMenuItem(
         label: 'label',
       );
       const PlatformMenu item = PlatformMenu(
         label: 'label',
-        menus: <MenuItem>[childItem],
+        menus: <PlatformMenuItem>[childItem],
       );
 
       final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
@@ -258,19 +258,19 @@ const List<String> subMenu2 = <String>[
   'Sub Menu 20',
 ];
 
-List<MenuItem> createTestMenus({
+List<PlatformMenuItem> createTestMenus({
   void Function(String)? onActivate,
   void Function(String)? onOpen,
   void Function(String)? onClose,
   Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
   bool includeStandard = false,
 }) {
-  final List<MenuItem> result = <MenuItem>[
+  final List<PlatformMenuItem> result = <PlatformMenuItem>[
     PlatformMenu(
       label: mainMenu[0],
       onOpen: onOpen != null ? () => onOpen(mainMenu[0]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[0]) : null,
-      menus: <MenuItem>[
+      menus: <PlatformMenuItem>[
         PlatformMenuItem(
           label: subMenu0[0],
           onSelected: onActivate != null ? () => onActivate(subMenu0[0]) : null,
@@ -282,9 +282,9 @@ List<MenuItem> createTestMenus({
       label: mainMenu[1],
       onOpen: onOpen != null ? () => onOpen(mainMenu[1]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[1]) : null,
-      menus: <MenuItem>[
+      menus: <PlatformMenuItem>[
         PlatformMenuItemGroup(
-          members: <MenuItem>[
+          members: <PlatformMenuItem>[
             PlatformMenuItem(
               label: subMenu1[0],
               onSelected: onActivate != null ? () => onActivate(subMenu1[0]) : null,
@@ -296,9 +296,9 @@ List<MenuItem> createTestMenus({
           label: subMenu1[1],
           onOpen: onOpen != null ? () => onOpen(subMenu1[1]) : null,
           onClose: onClose != null ? () => onClose(subMenu1[1]) : null,
-          menus: <MenuItem>[
+          menus: <PlatformMenuItem>[
             PlatformMenuItemGroup(
-              members: <MenuItem>[
+              members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: subSubMenu10[0],
                   onSelected: onActivate != null ? () => onActivate(subSubMenu10[0]) : null,
@@ -307,7 +307,7 @@ List<MenuItem> createTestMenus({
               ],
             ),
             PlatformMenuItemGroup(
-              members: <MenuItem>[
+              members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: subSubMenu10[1],
                   onSelected: onActivate != null ? () => onActivate(subSubMenu10[1]) : null,
@@ -321,7 +321,7 @@ List<MenuItem> createTestMenus({
               shortcut: shortcuts[subSubMenu10[2]],
             ),
             PlatformMenuItemGroup(
-              members: <MenuItem>[
+              members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: subSubMenu10[3],
                   onSelected: onActivate != null ? () => onActivate(subSubMenu10[3]) : null,
@@ -342,7 +342,7 @@ List<MenuItem> createTestMenus({
       label: mainMenu[2],
       onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
-      menus: <MenuItem>[
+      menus: <PlatformMenuItem>[
         PlatformMenuItem(
           // Always disabled.
           label: subMenu2[0],
@@ -355,7 +355,7 @@ List<MenuItem> createTestMenus({
       label: mainMenu[3],
       onOpen: onOpen != null ? () => onOpen(mainMenu[2]) : null,
       onClose: onClose != null ? () => onClose(mainMenu[2]) : null,
-      menus: <MenuItem>[],
+      menus: <PlatformMenuItem>[],
     ),
   ];
   return result;


### PR DESCRIPTION
## Description

This removes the connection between MenuBar (not yet committed) and the platform menu bar, by removing the `MenuItem` class, and replacing it with `PlatformMenuItem`.

## Related Issues
 - https://github.com/flutter/flutter/issues/23600

## Tests
 - Adjusted the tests