### PR TITLE
Reland "Keep `dirty` manipulations private to `Element` base class (#109401)"

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -1016,9 +1016,6 @@ class _NullElement extends Element {
 
   @override
   bool get debugDoingBuild => throw UnimplementedError();
-
-  @override
-  void performRebuild() { }
 }
 
 class _NullWidget extends Widget {

--- a/packages/flutter/test/cupertino/colors_test.dart
+++ b/packages/flutter/test/cupertino/colors_test.dart
@@ -591,9 +591,6 @@ class _NullElement extends Element {
 
   @override
   bool get debugDoingBuild => throw UnimplementedError();
-
-  @override
-  void performRebuild() { }
 }
 
 class _NullWidget extends Widget {

--- a/packages/flutter/test/foundation/diagnostics_json_test.dart
+++ b/packages/flutter/test/foundation/diagnostics_json_test.dart
@@ -221,11 +221,6 @@ class _TestElement extends Element {
   _TestElement() : super(const Placeholder());
 
   @override
-  void performRebuild() {
-    // Intentionally left empty.
-  }
-
-  @override
   bool get debugDoingBuild => throw UnimplementedError();
 }
 

--- a/packages/flutter/test/widgets/did_update_widget_test.dart
+++ b/packages/flutter/test/widgets/did_update_widget_test.dart
@@ -1,0 +1,70 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Can call setState from didUpdateWidget', (WidgetTester tester) async {
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: WidgetUnderTest(text: 'hello'),
+    ));
+
+    expect(find.text('hello'), findsOneWidget);
+    expect(find.text('world'), findsNothing);
+    final _WidgetUnderTestState state = tester.state<_WidgetUnderTestState>(find.byType(WidgetUnderTest));
+    expect(state.setStateCalled, 0);
+    expect(state.didUpdateWidgetCalled, 0);
+
+    await tester.pumpWidget(const Directionality(
+      textDirection: TextDirection.ltr,
+      child: WidgetUnderTest(text: 'world'),
+    ));
+
+    expect(find.text('world'), findsOneWidget);
+    expect(find.text('hello'), findsNothing);
+    expect(state.setStateCalled, 1);
+    expect(state.didUpdateWidgetCalled, 1);
+  });
+}
+
+class WidgetUnderTest extends StatefulWidget {
+  const WidgetUnderTest({super.key, required this.text});
+
+  final String text;
+
+  @override
+  State<WidgetUnderTest> createState() => _WidgetUnderTestState();
+}
+
+class _WidgetUnderTestState extends State<WidgetUnderTest> {
+  late String text = widget.text;
+
+  int setStateCalled = 0;
+  int didUpdateWidgetCalled = 0;
+
+  @override
+  void didUpdateWidget(WidgetUnderTest oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    didUpdateWidgetCalled += 1;
+    if (oldWidget.text != widget.text) {
+      // This setState is load bearing for the test.
+      setState(() {
+        text = widget.text;
+      });
+    }
+  }
+
+  @override
+  void setState(VoidCallback fn) {
+    super.setState(fn);
+    setStateCalled += 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(text);
+  }
+}

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1862,9 +1862,6 @@ class DirtyElementWithCustomBuildOwner extends Element {
   final BuildOwner _owner;
 
   @override
-  void performRebuild() {}
-
-  @override
   BuildOwner get owner => _owner;
 
   @override
@@ -1968,9 +1965,9 @@ class StatefulElementSpy extends StatefulElement {
   _Stateful get _statefulWidget => widget as _Stateful;
 
   @override
-  void rebuild() {
+  void rebuild({bool force = false}) {
     _statefulWidget.onElementRebuild?.call(this);
-    super.rebuild();
+    super.rebuild(force: force);
   }
 }
 
@@ -2115,9 +2112,6 @@ class _EmptyElement extends Element {
 
   @override
   bool get debugDoingBuild => false;
-
-  @override
-  void performRebuild() {}
 }
 
 class _TestLeaderLayerWidget extends SingleChildRenderObjectWidget {

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -701,11 +701,11 @@ void main() {
           }
 
           @override
-          void rebuild() {
+          void rebuild({bool force = false}) {
             if (_throwOnRebuild) {
               throw 'rebuild';
             }
-            super.rebuild();
+            super.rebuild(force: force);
           }
         }
       ''',


### PR DESCRIPTION
This reverts commit 7887ca5bb58d1db4aa77f465deb6a41799f2b83f.

First commit is a straight reland of the change. The fix for the test that was broken by that change is in the second commit.