### PR TITLE
fix to add both flutter_test and integration_test

### DIFF
--- a/packages/integration_test/README.md
+++ b/packages/integration_test/README.md
@@ -11,8 +11,11 @@ Add a dependency on the `integration_test` and `flutter_test` package in the
 `pubspec.yaml` of the example app:
 
 ```yaml
-integration_test:
-  sdk: flutter
+dev_dependencies:
+  integration_test:
+    sdk: flutter
+  flutter_test:
+    sdk: flutter
 ```
 
 Create a `integration_test/` directory for your package. In this directory,
@@ -126,7 +129,7 @@ void main() {
 ```
 
 You can use a driver script to pull in the screenshot from the device.
-This way, you can store the images locally on your computer.  On iOS, the
+This way, you can store the images locally on your computer. On iOS, the
 screenshot will also be available in Xcode test results.
 
 **test_driver/integration_test.dart**
@@ -277,6 +280,7 @@ end
 ```
 
 To build `integration_test/foo_test.dart` from the command line, run:
+
 ```sh
 flutter build ios --config-only integration_test/foo_test.dart
 ```


### PR DESCRIPTION
This changes the documentation of the integration test to align with the official introduction.
Previously, it only listed `integration_test`, but should add `flutter_test` as well.
https://docs.flutter.dev/cookbook/testing/integration/introduction

flutter/website#8436


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x ] I listed at least one issue that this PR fixes in the description above.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
