### PR TITLE
[platform_view]terminate the app in tear down for platform view xcuitest

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -23,11 +23,18 @@ static const CGFloat kStandardTimeOut = 60.0;
 @implementation PlatformViewUITests
 
 - (void)setUp {
+  [super setup];
   self.continueAfterFailure = NO;
 
   self.app = [[XCUIApplication alloc] init];
   [self.app launch];
 }
+
+- (void)tearDown {
+  [self.app terminate];
+  [super tearDown];
+}
+
 - (void)testPlatformViewFocus {
   XCUIElement *entranceButton = self.app.buttons[@"platform view focus test"];
   XCTAssertTrue([entranceButton waitForExistenceWithTimeout:kStandardTimeOut], @"The element tree is %@", self.app.debugDescription);

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -31,6 +31,11 @@ static const CGFloat kStandardTimeOut = 60.0;
 }
 
 - (void)tearDown {
+  // This is trying to fix a "failed to terminate" failure, which is likely a bug in Xcode.
+  // In theory the terminate call is not necessary, but many has encountered this similar
+  // issue, and fixed it by terminating the app and relaunching it if needed for each test.
+  // Here we simply try terminating the app in tearDown, but if it does not work,
+  // then alternative solution is to terminate and relaunch the app.
   [self.app terminate];
   [super tearDown];
 }


### PR DESCRIPTION
This test failure is due to the previously installed app is not terminated in the previous test. 

This seems to be a bug in XCUITest. There are many similar issues online, such as [this](https://stackoverflow.com/questions/55487136/how-to-fix-failed-to-terminate-app-error-in-xcuitests), [this](https://developer.apple.com/forums/thread/94054) and [this](https://stackoverflow.com/questions/53181823/xcuitest-class-teardown-isnt-deleting-the-app-but-works-if-its-instance-teardow)

Radar: [this](http://www.openradar.appspot.com/25548393) and [this](https://openradar.appspot.com/29735288)

A promising solution is to retry launch if the first launch fails, as described [here](https://stackoverflow.com/questions/41872848/xctests-failing-to-launch-app-in-simulator-intermittently). 

I noticed that we did not terminate the app in tearDown. Our other tests do not have tearDown either, but it's worth a try. If it doesn't work, we can try relaunching the app. 


*List which issues are fixed by this PR. You must list at least one issue.*
Fixes 
*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

Fixes https://github.com/flutter/flutter/issues/109697

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
