### PR TITLE
Avoid null terminating characters in strings from Utf8FromUtf16()

### DIFF
--- a/dev/benchmarks/complex_layout/windows/runner/utils.cpp
+++ b/dev/benchmarks/complex_layout/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/benchmarks/complex_layout/windows/runner/utils.cpp
+++ b/dev/benchmarks/complex_layout/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
@@ -60,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      target_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
@@ -53,6 +53,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
+  int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
   if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -60,7 +61,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      target_length, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
+++ b/dev/integration_tests/flutter_gallery/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/dev/integration_tests/ui/windows/runner/utils.cpp
+++ b/dev/integration_tests/ui/windows/runner/utils.cpp
@@ -51,16 +51,16 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   }
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/ui/windows/runner/utils.cpp
+++ b/dev/integration_tests/ui/windows/runner/utils.cpp
@@ -60,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      target_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/ui/windows/runner/utils.cpp
+++ b/dev/integration_tests/ui/windows/runner/utils.cpp
@@ -53,6 +53,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
+  int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
   if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -60,7 +61,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      target_length, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/windows_startup_test/lib/main.dart
+++ b/dev/integration_tests/windows_startup_test/lib/main.dart
@@ -51,7 +51,7 @@ void main() async {
       // which will use the UTF16 to UTF8 utility function to convert them to a
       // std::string, which should equate to the original expected string.
       // TODO(schectman): Remove trailing null from returned string
-      const String expected = 'ABC';
+      const String expected = 'ABCℵ';
       final Int32List codePoints = Int32List.fromList(expected.codeUnits);
       final String converted = await testStringConversion(codePoints);
       return (converted == expected)

--- a/dev/integration_tests/windows_startup_test/lib/main.dart
+++ b/dev/integration_tests/windows_startup_test/lib/main.dart
@@ -51,7 +51,7 @@ void main() async {
       // which will use the UTF16 to UTF8 utility function to convert them to a
       // std::string, which should equate to the original expected string.
       // TODO(schectman): Remove trailing null from returned string
-      const String expected = 'ABCℵ\x00';
+      const String expected = 'ABC';
       final Int32List codePoints = Int32List.fromList(expected.codeUnits);
       final String converted = await testStringConversion(codePoints);
       return (converted == expected)

--- a/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
@@ -114,6 +114,7 @@ bool FlutterWindow::OnCreate() {
         for (int32_t code_point : code_points) {
           wide_str.push_back((wchar_t)(code_point));
         }
+        wide_str.push_back((wchar_t)0);
         const std::string string = Utf8FromUtf16(wide_str.data());
         result->Success(string);
       } else {

--- a/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
@@ -51,16 +51,16 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   }
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
@@ -60,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      target_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/utils.cpp
@@ -53,6 +53,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
+  int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
   if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -60,7 +61,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      target_length, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/manual_tests/windows/runner/utils.cpp
+++ b/dev/manual_tests/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/dev/manual_tests/windows/runner/utils.cpp
+++ b/dev/manual_tests/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/examples/api/windows/runner/utils.cpp
+++ b/examples/api/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/api/windows/runner/utils.cpp
+++ b/examples/api/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/examples/flutter_view/windows/runner/utils.cpp
+++ b/examples/flutter_view/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/flutter_view/windows/runner/utils.cpp
+++ b/examples/flutter_view/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/examples/hello_world/windows/runner/utils.cpp
+++ b/examples/hello_world/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/hello_world/windows/runner/utils.cpp
+++ b/examples/hello_world/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/examples/platform_channel/windows/runner/utils.cpp
+++ b/examples/platform_channel/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/platform_channel/windows/runner/utils.cpp
+++ b/examples/platform_channel/windows/runner/utils.cpp
@@ -49,16 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int target_length =
-      ::WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string, -1,
-                            nullptr, 0, nullptr, nullptr);
+  int source_length = static_cast<int>(wcslen(utf16_string));
+  int target_length = ::WideCharToMultiByte(
+      CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
-      CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string, -1, utf8_string.data(),
+      CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/examples/platform_view/windows/runner/utils.cpp
+++ b/examples/platform_view/windows/runner/utils.cpp
@@ -49,19 +49,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/examples/platform_view/windows/runner/utils.cpp
+++ b/examples/platform_view/windows/runner/utils.cpp
@@ -49,9 +49,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -59,7 +60,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
@@ -56,7 +56,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(), target_length, nullptr, nullptr);
+      target_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
@@ -45,19 +45,18 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
-  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, nullptr, 0, nullptr, nullptr);
+      -1, nullptr, 0, nullptr, nullptr)
+    -1; // remove the trailing null character
   std::string utf8_string;
-  if (target_length == 0 || target_length > utf8_string.max_size()) {
+  if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
   }
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      source_length, utf8_string.data(),
-      target_length, nullptr, nullptr);
+      -1, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
@@ -49,6 +49,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
       -1, nullptr, 0, nullptr, nullptr)
     -1; // remove the trailing null character
+  int input_length = (int)wcslen(utf16_string);
   std::string utf8_string;
   if (target_length <= 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -56,7 +57,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      target_length, utf8_string.data(), target_length, nullptr, nullptr);
+      input_length, utf8_string.data(), target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();
   }

--- a/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
+++ b/packages/flutter_tools/templates/app_shared/windows.tmpl/runner/utils.cpp
@@ -45,9 +45,10 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   if (utf16_string == nullptr) {
     return std::string();
   }
+  int source_length = static_cast<int>(wcslen(utf16_string));
   int target_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, nullptr, 0, nullptr, nullptr);
+      source_length, nullptr, 0, nullptr, nullptr);
   std::string utf8_string;
   if (target_length == 0 || target_length > utf8_string.max_size()) {
     return utf8_string;
@@ -55,7 +56,7 @@ std::string Utf8FromUtf16(const wchar_t* utf16_string) {
   utf8_string.resize(target_length);
   int converted_length = ::WideCharToMultiByte(
       CP_UTF8, WC_ERR_INVALID_CHARS, utf16_string,
-      -1, utf8_string.data(),
+      source_length, utf8_string.data(),
       target_length, nullptr, nullptr);
   if (converted_length == 0) {
     return std::string();


### PR DESCRIPTION
This PR adds passing source wchar_t* string length to WideCharToMultiByte() in Utf8FromUtf16() in order to avoid including the terminating null character in the resulting string. This was found when the Utf8FromUtf16() function in the generated utils.cpp file was used for another purpose (a platform specific extension using method channel).

From https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-widechartomultibyte:

> [in] cchWideChar
> Size, in characters, of the string indicated by lpWideCharStr. Alternatively, this parameter can be set to -1 if the string is null-terminated. If cchWideChar is set to 0, the function fails.
> If this parameter is -1, the function processes the entire input string, including the terminating null character. Therefore, the resulting character string has a terminating null character, and the length returned by the function includes this character.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
