### PR TITLE
add material slider secondary value

### DIFF
--- a/examples/api/lib/material/slider/slider.1.dart
+++ b/examples/api/lib/material/slider/slider.1.dart
@@ -43,7 +43,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
       children: <Widget>[
         Slider(
           value: _currentSliderPrimaryValue,
-          secondaryValue: _currentSliderSecondaryValue,
+          secondaryTrackValue: _currentSliderSecondaryValue,
           label: _currentSliderPrimaryValue.round().toString(),
           onChanged: (double value) {
             setState(() {

--- a/examples/api/lib/material/slider/slider.1.dart
+++ b/examples/api/lib/material/slider/slider.1.dart
@@ -1,0 +1,66 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for Slider
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const MyStatefulWidget(),
+      ),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({super.key});
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  double _currentSliderPrimaryValue = 0.2;
+  double _currentSliderSecondaryValue = 0.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Slider(
+          value: _currentSliderPrimaryValue,
+          secondaryValue: _currentSliderSecondaryValue,
+          label: _currentSliderPrimaryValue.round().toString(),
+          onChanged: (double value) {
+            setState(() {
+              _currentSliderPrimaryValue = value;
+            });
+          },
+        ),
+        Slider(
+          value: _currentSliderSecondaryValue,
+          label: _currentSliderSecondaryValue.round().toString(),
+          onChanged: (double value) {
+            setState(() {
+              _currentSliderSecondaryValue = value;
+            });
+          },
+        ),
+      ],
+    );
+  }
+}

--- a/examples/api/test/material/slider/slider.1_test.dart
+++ b/examples/api/test/material/slider/slider.1_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/slider/slider.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Slider shows secondary track', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    expect(find.byType(Slider), findsNWidgets(2));
+
+    final Finder slider1Finder = find.byType(Slider).at(0);
+    final Finder slider2Finder = find.byType(Slider).at(1);
+
+    Slider slider1 = tester.widget(slider1Finder);
+    Slider slider2 = tester.widget(slider2Finder);
+    expect(slider1.secondaryTrackValue, slider2.value);
+
+    const double targetValue = 0.8;
+    final Rect rect = tester.getRect(slider2Finder);
+    final Offset target = Offset(rect.left + (rect.right - rect.left) * targetValue, rect.top + (rect.bottom - rect.top) / 2);
+    await tester.tapAt(target);
+    await tester.pump();
+
+    slider1 = tester.widget(slider1Finder);
+    slider2 = tester.widget(slider2Finder);
+    expect(slider1.secondaryTrackValue, closeTo(targetValue, 0.05));
+    expect(slider1.secondaryTrackValue, slider2.value);
+  });
+}

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -48,6 +48,13 @@ enum _SliderType { material, adaptive }
 /// ** See code in examples/api/lib/material/slider/slider.0.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This example shows a [Slider] widget using the [Slider.secondaryTrackValue]
+/// to show a secondary track in the slider.
+///
+/// ** See code in examples/api/lib/material/slider/slider.1.dart **
+/// {@end-tool}
+///
 /// A slider can be used to select from either a continuous or a discrete set of
 /// values. The default is to use a continuous range of values from [min] to
 /// [max]. To use discrete values, use a non-null value for [divisions], which
@@ -188,8 +195,10 @@ class Slider extends StatefulWidget {
        assert(min != null),
        assert(max != null),
        assert(min <= max),
-       assert(value >= min && value <= max),
-       assert(secondaryTrackValue == null || (secondaryTrackValue >= min && secondaryTrackValue <= max)),
+       assert(value >= min && value <= max,
+         'Value $value is not between minimum $min and maximum $max'),
+       assert(secondaryTrackValue == null || (secondaryTrackValue >= min && secondaryTrackValue <= max),
+         'SecondaryValue $secondaryTrackValue is not between $min and $max'),
        assert(divisions == null || divisions > 0);
 
   /// The currently selected value for this slider.
@@ -197,7 +206,7 @@ class Slider extends StatefulWidget {
   /// The slider's thumb is drawn at a position that corresponds to this value.
   final double value;
 
-  /// The secondary track value for this slider
+  /// The secondary track value for this slider.
   ///
   /// If not null, a secondary track using [Slider.secondaryActiveColor] color
   /// is drawn between the thumb and this value, over the inactive track.
@@ -385,7 +394,7 @@ class Slider extends StatefulWidget {
   final Color? inactiveColor;
 
   /// The color to use for the portion of the slider track between the thumb and
-  /// the [Slider.secondaryTrackValue]
+  /// the [Slider.secondaryTrackValue].
   ///
   /// Defaults to the [SliderThemeData.secondaryActiveTrackColor] of the current
   /// [SliderTheme].

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -266,8 +266,10 @@ class SliderThemeData with Diagnosticable {
     this.trackHeight,
     this.activeTrackColor,
     this.inactiveTrackColor,
+    this.secondaryActiveTrackColor,
     this.disabledActiveTrackColor,
     this.disabledInactiveTrackColor,
+    this.disabledSecondaryActiveTrackColor,
     this.activeTickMarkColor,
     this.inactiveTickMarkColor,
     this.disabledActiveTickMarkColor,
@@ -317,8 +319,10 @@ class SliderThemeData with Diagnosticable {
     // component Colors (with opacity) from base colors.
     const int activeTrackAlpha = 0xff;
     const int inactiveTrackAlpha = 0x3d; // 24% opacity
+    const int secondaryActiveTrackAlpha = 0x8a; // 54% opacity
     const int disabledActiveTrackAlpha = 0x52; // 32% opacity
     const int disabledInactiveTrackAlpha = 0x1f; // 12% opacity
+    const int disabledSecondaryActiveTrackAlpha = 0x1f; // 12% opacity
     const int activeTickMarkAlpha = 0x8a; // 54% opacity
     const int inactiveTickMarkAlpha = 0x8a; // 54% opacity
     const int disabledActiveTickMarkAlpha = 0x1f; // 12% opacity
@@ -332,8 +336,10 @@ class SliderThemeData with Diagnosticable {
       trackHeight: 2.0,
       activeTrackColor: primaryColor.withAlpha(activeTrackAlpha),
       inactiveTrackColor: primaryColor.withAlpha(inactiveTrackAlpha),
+      secondaryActiveTrackColor: primaryColor.withAlpha(secondaryActiveTrackAlpha),
       disabledActiveTrackColor: primaryColorDark.withAlpha(disabledActiveTrackAlpha),
       disabledInactiveTrackColor: primaryColorDark.withAlpha(disabledInactiveTrackAlpha),
+      disabledSecondaryActiveTrackColor: primaryColorDark.withAlpha(disabledSecondaryActiveTrackAlpha),
       activeTickMarkColor: primaryColorLight.withAlpha(activeTickMarkAlpha),
       inactiveTickMarkColor: primaryColor.withAlpha(inactiveTickMarkAlpha),
       disabledActiveTickMarkColor: primaryColorLight.withAlpha(disabledActiveTickMarkAlpha),
@@ -368,9 +374,17 @@ class SliderThemeData with Diagnosticable {
   /// [Slider.max] position.
   final Color? inactiveTrackColor;
 
+  /// The color of the [Slider] track between the current thumb position and the
+  /// [Slider.secondaryValue] position.
+  final Color? secondaryActiveTrackColor;
+
   /// The color of the [Slider] track between the [Slider.min] position and the
   /// current thumb position when the [Slider] is disabled.
   final Color? disabledActiveTrackColor;
+
+  /// The color of the [Slider] track between the current thumb position and the
+  /// [Slider.secondaryValue] position when the [Slider] is disabled.
+  final Color? disabledSecondaryActiveTrackColor;
 
   /// The color of the [Slider] track between the current thumb position and the
   /// [Slider.max] position when the [Slider] is disabled.
@@ -573,8 +587,10 @@ class SliderThemeData with Diagnosticable {
     double? trackHeight,
     Color? activeTrackColor,
     Color? inactiveTrackColor,
+    Color? secondaryActiveTrackColor,
     Color? disabledActiveTrackColor,
     Color? disabledInactiveTrackColor,
+    Color? disabledSecondaryActiveTrackColor,
     Color? activeTickMarkColor,
     Color? inactiveTickMarkColor,
     Color? disabledActiveTickMarkColor,
@@ -603,8 +619,10 @@ class SliderThemeData with Diagnosticable {
       trackHeight: trackHeight ?? this.trackHeight,
       activeTrackColor: activeTrackColor ?? this.activeTrackColor,
       inactiveTrackColor: inactiveTrackColor ?? this.inactiveTrackColor,
+      secondaryActiveTrackColor: secondaryActiveTrackColor ?? this.secondaryActiveTrackColor,
       disabledActiveTrackColor: disabledActiveTrackColor ?? this.disabledActiveTrackColor,
       disabledInactiveTrackColor: disabledInactiveTrackColor ?? this.disabledInactiveTrackColor,
+      disabledSecondaryActiveTrackColor: disabledSecondaryActiveTrackColor ?? this.disabledSecondaryActiveTrackColor,
       activeTickMarkColor: activeTickMarkColor ?? this.activeTickMarkColor,
       inactiveTickMarkColor: inactiveTickMarkColor ?? this.inactiveTickMarkColor,
       disabledActiveTickMarkColor: disabledActiveTickMarkColor ?? this.disabledActiveTickMarkColor,
@@ -644,8 +662,10 @@ class SliderThemeData with Diagnosticable {
       trackHeight: lerpDouble(a.trackHeight, b.trackHeight, t),
       activeTrackColor: Color.lerp(a.activeTrackColor, b.activeTrackColor, t),
       inactiveTrackColor: Color.lerp(a.inactiveTrackColor, b.inactiveTrackColor, t),
+      secondaryActiveTrackColor: Color.lerp(a.secondaryActiveTrackColor, b.secondaryActiveTrackColor, t),
       disabledActiveTrackColor: Color.lerp(a.disabledActiveTrackColor, b.disabledActiveTrackColor, t),
       disabledInactiveTrackColor: Color.lerp(a.disabledInactiveTrackColor, b.disabledInactiveTrackColor, t),
+      disabledSecondaryActiveTrackColor: Color.lerp(a.disabledSecondaryActiveTrackColor, b.disabledSecondaryActiveTrackColor, t),
       activeTickMarkColor: Color.lerp(a.activeTickMarkColor, b.activeTickMarkColor, t),
       inactiveTickMarkColor: Color.lerp(a.inactiveTickMarkColor, b.inactiveTickMarkColor, t),
       disabledActiveTickMarkColor: Color.lerp(a.disabledActiveTickMarkColor, b.disabledActiveTickMarkColor, t),
@@ -677,8 +697,10 @@ class SliderThemeData with Diagnosticable {
     trackHeight,
     activeTrackColor,
     inactiveTrackColor,
+    secondaryActiveTrackColor,
     disabledActiveTrackColor,
     disabledInactiveTrackColor,
+    disabledSecondaryActiveTrackColor,
     activeTickMarkColor,
     inactiveTickMarkColor,
     disabledActiveTickMarkColor,
@@ -691,9 +713,9 @@ class SliderThemeData with Diagnosticable {
     overlayShape,
     tickMarkShape,
     thumbShape,
-    trackShape,
-    valueIndicatorShape,
     Object.hash(
+      trackShape,
+      valueIndicatorShape,
       rangeTickMarkShape,
       rangeThumbShape,
       rangeTrackShape,
@@ -718,8 +740,10 @@ class SliderThemeData with Diagnosticable {
         && other.trackHeight == trackHeight
         && other.activeTrackColor == activeTrackColor
         && other.inactiveTrackColor == inactiveTrackColor
+        && other.secondaryActiveTrackColor == secondaryActiveTrackColor
         && other.disabledActiveTrackColor == disabledActiveTrackColor
         && other.disabledInactiveTrackColor == disabledInactiveTrackColor
+        && other.disabledSecondaryActiveTrackColor == disabledSecondaryActiveTrackColor
         && other.activeTickMarkColor == activeTickMarkColor
         && other.inactiveTickMarkColor == inactiveTickMarkColor
         && other.disabledActiveTickMarkColor == disabledActiveTickMarkColor
@@ -752,8 +776,10 @@ class SliderThemeData with Diagnosticable {
     properties.add(DoubleProperty('trackHeight', trackHeight, defaultValue: defaultData.trackHeight));
     properties.add(ColorProperty('activeTrackColor', activeTrackColor, defaultValue: defaultData.activeTrackColor));
     properties.add(ColorProperty('inactiveTrackColor', inactiveTrackColor, defaultValue: defaultData.inactiveTrackColor));
+    properties.add(ColorProperty('secondaryActiveTrackColor', secondaryActiveTrackColor, defaultValue: defaultData.secondaryActiveTrackColor));
     properties.add(ColorProperty('disabledActiveTrackColor', disabledActiveTrackColor, defaultValue: defaultData.disabledActiveTrackColor));
     properties.add(ColorProperty('disabledInactiveTrackColor', disabledInactiveTrackColor, defaultValue: defaultData.disabledInactiveTrackColor));
+    properties.add(ColorProperty('disabledSecondaryActiveTrackColor', disabledSecondaryActiveTrackColor, defaultValue: defaultData.disabledSecondaryActiveTrackColor));
     properties.add(ColorProperty('activeTickMarkColor', activeTickMarkColor, defaultValue: defaultData.activeTickMarkColor));
     properties.add(ColorProperty('inactiveTickMarkColor', inactiveTickMarkColor, defaultValue: defaultData.inactiveTickMarkColor));
     properties.add(ColorProperty('disabledActiveTickMarkColor', disabledActiveTickMarkColor, defaultValue: defaultData.disabledActiveTickMarkColor));
@@ -1047,6 +1073,11 @@ abstract class SliderTrackShape {
   /// relative to the origin of the [PaintingContext.canvas]. It can be used as
   /// the point that divides the track into 2 segments.
   ///
+  /// The `secondaryOffset` argument is the offset of the secondary value
+  /// relative to the origin of the [PaintingContext.canvas].
+  ///
+  /// If not null, the track is divided into 3 segments.
+  ///
   /// {@macro flutter.material.SliderTickMarkShape.getPreferredSize.isEnabled}
   ///
   /// {@macro flutter.material.SliderComponentShape.paint.isDiscrete}
@@ -1068,6 +1099,7 @@ abstract class SliderTrackShape {
     required SliderThemeData sliderTheme,
     required Animation<double> enableAnimation,
     required Offset thumbCenter,
+    Offset? secondaryOffset,
     bool isEnabled,
     bool isDiscrete,
     required TextDirection textDirection,
@@ -1534,6 +1566,7 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
     required Animation<double> enableAnimation,
     required TextDirection textDirection,
     required Offset thumbCenter,
+    Offset? secondaryOffset,
     bool isDiscrete = false,
     bool isEnabled = false,
   }) {
@@ -1593,6 +1626,25 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
     if (!rightTrackSegment.isEmpty) {
       context.canvas.drawRect(rightTrackSegment, rightTrackPaint);
     }
+
+    final bool showMiddleTrack = (secondaryOffset != null) &&
+        ((textDirection == TextDirection.ltr)
+            ? (secondaryOffset.dx > thumbCenter.dx)
+            : (secondaryOffset.dx < thumbCenter.dx));
+
+    if (showMiddleTrack) {
+      final ColorTween middleTrackColorTween = ColorTween(begin: sliderTheme.disabledSecondaryActiveTrackColor, end: sliderTheme.secondaryActiveTrackColor);
+      final Paint middleTrackPaint = Paint()..color = middleTrackColorTween.evaluate(enableAnimation)!;
+      final Rect middleTrackSegment = Rect.fromLTRB(
+        (textDirection == TextDirection.ltr) ? thumbCenter.dx : secondaryOffset.dx,
+        trackRect.top,
+        (textDirection == TextDirection.ltr) ? secondaryOffset.dx : thumbCenter.dx,
+        trackRect.bottom,
+      );
+      if (!middleTrackSegment.isEmpty) {
+        context.canvas.drawRect(middleTrackSegment, middleTrackPaint);
+      }
+    }
   }
 }
 
@@ -1635,6 +1687,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
     required Animation<double> enableAnimation,
     required TextDirection textDirection,
     required Offset thumbCenter,
+    Offset? secondaryOffset,
     bool isDiscrete = false,
     bool isEnabled = false,
     double additionalActiveTrackHeight = 2,
@@ -1709,6 +1762,41 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
       ),
       rightTrackPaint,
     );
+
+    final bool showMiddleTrack = (secondaryOffset != null) &&
+        ((textDirection == TextDirection.ltr)
+            ? (secondaryOffset.dx > thumbCenter.dx)
+            : (secondaryOffset.dx < thumbCenter.dx));
+
+    if (showMiddleTrack) {
+      final ColorTween middleTrackColorTween = ColorTween(begin: sliderTheme.disabledSecondaryActiveTrackColor, end: sliderTheme.secondaryActiveTrackColor);
+      final Paint middleTrackPaint = Paint()..color = middleTrackColorTween.evaluate(enableAnimation)!;
+      if (textDirection == TextDirection.ltr) {
+        context.canvas.drawRRect(
+          RRect.fromLTRBAndCorners(
+            thumbCenter.dx,
+            trackRect.top,
+            secondaryOffset.dx,
+            trackRect.bottom,
+            topRight: trackRadius,
+            bottomRight: trackRadius,
+          ),
+          middleTrackPaint,
+        );
+      } else {
+        context.canvas.drawRRect(
+          RRect.fromLTRBAndCorners(
+            secondaryOffset.dx,
+            trackRect.top,
+            thumbCenter.dx,
+            trackRect.bottom,
+            topLeft: trackRadius,
+            bottomLeft: trackRadius,
+          ),
+          middleTrackPaint,
+        );
+      }
+    }
   }
 }
 

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -375,7 +375,7 @@ class SliderThemeData with Diagnosticable {
   final Color? inactiveTrackColor;
 
   /// The color of the [Slider] track between the current thumb position and the
-  /// [Slider.secondaryValue] position.
+  /// [Slider.secondaryTrackValue] position.
   final Color? secondaryActiveTrackColor;
 
   /// The color of the [Slider] track between the [Slider.min] position and the
@@ -383,7 +383,7 @@ class SliderThemeData with Diagnosticable {
   final Color? disabledActiveTrackColor;
 
   /// The color of the [Slider] track between the current thumb position and the
-  /// [Slider.secondaryValue] position when the [Slider] is disabled.
+  /// [Slider.secondaryTrackValue] position when the [Slider] is disabled.
   final Color? disabledSecondaryActiveTrackColor;
 
   /// The color of the [Slider] track between the current thumb position and the
@@ -1627,22 +1627,22 @@ class RectangularSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
       context.canvas.drawRect(rightTrackSegment, rightTrackPaint);
     }
 
-    final bool showMiddleTrack = (secondaryOffset != null) &&
+    final bool showSecondaryTrack = (secondaryOffset != null) &&
         ((textDirection == TextDirection.ltr)
             ? (secondaryOffset.dx > thumbCenter.dx)
             : (secondaryOffset.dx < thumbCenter.dx));
 
-    if (showMiddleTrack) {
-      final ColorTween middleTrackColorTween = ColorTween(begin: sliderTheme.disabledSecondaryActiveTrackColor, end: sliderTheme.secondaryActiveTrackColor);
-      final Paint middleTrackPaint = Paint()..color = middleTrackColorTween.evaluate(enableAnimation)!;
-      final Rect middleTrackSegment = Rect.fromLTRB(
+    if (showSecondaryTrack) {
+      final ColorTween secondaryTrackColorTween = ColorTween(begin: sliderTheme.disabledSecondaryActiveTrackColor, end: sliderTheme.secondaryActiveTrackColor);
+      final Paint secondaryTrackPaint = Paint()..color = secondaryTrackColorTween.evaluate(enableAnimation)!;
+      final Rect secondaryTrackSegment = Rect.fromLTRB(
         (textDirection == TextDirection.ltr) ? thumbCenter.dx : secondaryOffset.dx,
         trackRect.top,
         (textDirection == TextDirection.ltr) ? secondaryOffset.dx : thumbCenter.dx,
         trackRect.bottom,
       );
-      if (!middleTrackSegment.isEmpty) {
-        context.canvas.drawRect(middleTrackSegment, middleTrackPaint);
+      if (!secondaryTrackSegment.isEmpty) {
+        context.canvas.drawRect(secondaryTrackSegment, secondaryTrackPaint);
       }
     }
   }
@@ -1763,14 +1763,14 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
       rightTrackPaint,
     );
 
-    final bool showMiddleTrack = (secondaryOffset != null) &&
+    final bool showSecondaryTrack = (secondaryOffset != null) &&
         ((textDirection == TextDirection.ltr)
             ? (secondaryOffset.dx > thumbCenter.dx)
             : (secondaryOffset.dx < thumbCenter.dx));
 
-    if (showMiddleTrack) {
-      final ColorTween middleTrackColorTween = ColorTween(begin: sliderTheme.disabledSecondaryActiveTrackColor, end: sliderTheme.secondaryActiveTrackColor);
-      final Paint middleTrackPaint = Paint()..color = middleTrackColorTween.evaluate(enableAnimation)!;
+    if (showSecondaryTrack) {
+      final ColorTween secondaryTrackColorTween = ColorTween(begin: sliderTheme.disabledSecondaryActiveTrackColor, end: sliderTheme.secondaryActiveTrackColor);
+      final Paint secondaryTrackPaint = Paint()..color = secondaryTrackColorTween.evaluate(enableAnimation)!;
       if (textDirection == TextDirection.ltr) {
         context.canvas.drawRRect(
           RRect.fromLTRBAndCorners(
@@ -1781,7 +1781,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
             topRight: trackRadius,
             bottomRight: trackRadius,
           ),
-          middleTrackPaint,
+          secondaryTrackPaint,
         );
       } else {
         context.canvas.drawRRect(
@@ -1793,7 +1793,7 @@ class RoundedRectSliderTrackShape extends SliderTrackShape with BaseSliderTrackS
             topLeft: trackRadius,
             bottomLeft: trackRadius,
           ),
-          middleTrackPaint,
+          secondaryTrackPaint,
         );
       }
     }

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -631,6 +631,7 @@ void main() {
     try {
       const Color customColor1 = Color(0xcafefeed);
       const Color customColor2 = Color(0xdeadbeef);
+      const Color customColor3 = Color(0xdecaface);
       final ThemeData theme = ThemeData(
         platform: TargetPlatform.android,
         primarySwatch: Colors.blue,
@@ -647,6 +648,8 @@ void main() {
           overlayColor: Color(0xff000010),
           thumbColor: Color(0xff000011),
           valueIndicatorColor: Color(0xff000012),
+          disabledSecondaryActiveTrackColor: Color(0xff000013),
+          secondaryActiveTrackColor: Color(0xff000014),
         ),
       );
       final SliderThemeData sliderTheme = theme.sliderTheme;
@@ -654,6 +657,7 @@ void main() {
       Widget buildApp({
         Color? activeColor,
         Color? inactiveColor,
+        Color? secondaryActiveColor,
         int? divisions,
         bool enabled = true,
       }) {
@@ -671,10 +675,12 @@ void main() {
                   data: theme,
                   child: Slider(
                     value: value,
+                    secondaryValue: 0.75,
                     label: '$value',
                     divisions: divisions,
                     activeColor: activeColor,
                     inactiveColor: inactiveColor,
+                    secondaryActiveColor: secondaryActiveColor,
                     onChanged: onChanged,
                   ),
                 ),
@@ -690,47 +696,61 @@ void main() {
       final RenderBox valueIndicatorBox = tester.renderObject(find.byType(Overlay));
 
       // Check default theme for enabled widget.
-      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: sliderTheme.inactiveTrackColor));
+      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: sliderTheme.inactiveTrackColor)..rrect(color: sliderTheme.secondaryActiveTrackColor));
       expect(material, paints..shadow(color: const Color(0xff000000)));
       expect(material, paints..circle(color: sliderTheme.thumbColor));
       expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
       expect(material, isNot(paints..circle(color: sliderTheme.activeTickMarkColor)));
       expect(material, isNot(paints..circle(color: sliderTheme.inactiveTickMarkColor)));
 
       // Test setting only the activeColor.
       await tester.pumpWidget(buildApp(activeColor: customColor1));
-      expect(material, paints..rrect(color: customColor1)..rrect(color: sliderTheme.inactiveTrackColor));
+      expect(material, paints..rrect(color: customColor1)..rrect(color: sliderTheme.inactiveTrackColor)..rrect(color: sliderTheme.secondaryActiveTrackColor));
       expect(material, paints..shadow(color: Colors.black));
       expect(material, paints..circle(color: customColor1));
       expect(material, isNot(paints..circle(color: sliderTheme.thumbColor)));
       expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
 
       // Test setting only the inactiveColor.
       await tester.pumpWidget(buildApp(inactiveColor: customColor1));
-      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: customColor1));
+      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: customColor1)..rrect(color: sliderTheme.secondaryActiveTrackColor));
       expect(material, paints..shadow(color: Colors.black));
       expect(material, paints..circle(color: sliderTheme.thumbColor));
       expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
 
-      // Test setting both activeColor and inactiveColor.
-      await tester.pumpWidget(buildApp(activeColor: customColor1, inactiveColor: customColor2));
-      expect(material, paints..rrect(color: customColor1)..rrect(color: customColor2));
+      // Test setting only the secondaryActiveColor.
+      await tester.pumpWidget(buildApp(secondaryActiveColor: customColor1));
+      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: sliderTheme.inactiveTrackColor)..rrect(color: customColor1));
+      expect(material, paints..shadow(color: Colors.black));
+      expect(material, paints..circle(color: sliderTheme.thumbColor));
+      expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
+
+      // Test setting both activeColor, inactiveColor, and secondaryActiveColor.
+      await tester.pumpWidget(buildApp(activeColor: customColor1, inactiveColor: customColor2, secondaryActiveColor: customColor3));
+      expect(material, paints..rrect(color: customColor1)..rrect(color: customColor2)..rrect(color: customColor3));
       expect(material, paints..shadow(color: Colors.black));
       expect(material, paints..circle(color: customColor1));
       expect(material, isNot(paints..circle(color: sliderTheme.thumbColor)));
       expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
 
       // Test colors for discrete slider.
       await tester.pumpWidget(buildApp(divisions: 3));
-      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: sliderTheme.inactiveTrackColor));
+      expect(material, paints..rrect(color: sliderTheme.activeTrackColor)..rrect(color: sliderTheme.inactiveTrackColor)..rrect(color: sliderTheme.secondaryActiveTrackColor));
       expect(
         material,
         paints
@@ -744,14 +764,16 @@ void main() {
       expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
 
       // Test colors for discrete slider with inactiveColor and activeColor set.
       await tester.pumpWidget(buildApp(
         activeColor: customColor1,
         inactiveColor: customColor2,
+        secondaryActiveColor: customColor3,
         divisions: 3,
       ));
-      expect(material, paints..rrect(color: customColor1)..rrect(color: customColor2));
+      expect(material, paints..rrect(color: customColor1)..rrect(color: customColor2)..rrect(color: customColor3));
       expect(
         material,
         paints
@@ -766,6 +788,7 @@ void main() {
       expect(material, isNot(paints..circle(color: sliderTheme.disabledThumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledActiveTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.disabledInactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor)));
       expect(material, isNot(paints..circle(color: sliderTheme.activeTickMarkColor)));
       expect(material, isNot(paints..circle(color: sliderTheme.inactiveTickMarkColor)));
 
@@ -776,25 +799,29 @@ void main() {
         material,
         paints
           ..rrect(color: sliderTheme.disabledActiveTrackColor)
-          ..rrect(color: sliderTheme.disabledInactiveTrackColor),
+          ..rrect(color: sliderTheme.disabledInactiveTrackColor)
+          ..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor),
       );
       expect(material, paints..shadow(color: Colors.black)..circle(color: sliderTheme.disabledThumbColor));
       expect(material, isNot(paints..circle(color: sliderTheme.thumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.activeTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.inactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.secondaryActiveTrackColor)));
 
-      // Test setting the activeColor and inactiveColor for disabled widget.
-      await tester.pumpWidget(buildApp(activeColor: customColor1, inactiveColor: customColor2, enabled: false));
+      // Test setting the activeColor, inactiveColor and secondaryActiveColor for disabled widget.
+      await tester.pumpWidget(buildApp(activeColor: customColor1, inactiveColor: customColor2, secondaryActiveColor: customColor3, enabled: false));
       expect(
         material,
         paints
           ..rrect(color: sliderTheme.disabledActiveTrackColor)
-          ..rrect(color: sliderTheme.disabledInactiveTrackColor),
+          ..rrect(color: sliderTheme.disabledInactiveTrackColor)
+          ..rrect(color: sliderTheme.disabledSecondaryActiveTrackColor),
       );
       expect(material, paints..circle(color: sliderTheme.disabledThumbColor));
       expect(material, isNot(paints..circle(color: sliderTheme.thumbColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.activeTrackColor)));
       expect(material, isNot(paints..rrect(color: sliderTheme.inactiveTrackColor)));
+      expect(material, isNot(paints..rrect(color: sliderTheme.secondaryActiveTrackColor)));
 
       // Test that the default value indicator has the right colors.
       await tester.pumpWidget(buildApp(divisions: 3));
@@ -2813,10 +2840,12 @@ void main() {
       activeColor: Colors.blue,
       divisions: 10,
       inactiveColor: Colors.grey,
+      secondaryActiveColor: Colors.blueGrey,
       label: 'Set a value',
       max: 100.0,
       onChanged: null,
       value: 50.0,
+      secondaryValue: 75.0,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -2825,6 +2854,7 @@ void main() {
 
     expect(description, <String>[
       'value: 50.0',
+      'secondaryValue: 75.0',
       'disabled',
       'min: 0.0',
       'max: 100.0',
@@ -2832,6 +2862,7 @@ void main() {
       'label: "Set a value"',
       'activeColor: MaterialColor(primary value: Color(0xff2196f3))',
       'inactiveColor: MaterialColor(primary value: Color(0xff9e9e9e))',
+      'secondaryActiveColor: MaterialColor(primary value: Color(0xff607d8b))',
     ]);
   });
 

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -675,7 +675,7 @@ void main() {
                   data: theme,
                   child: Slider(
                     value: value,
-                    secondaryValue: 0.75,
+                    secondaryTrackValue: 0.75,
                     label: '$value',
                     divisions: divisions,
                     activeColor: activeColor,
@@ -2845,7 +2845,7 @@ void main() {
       max: 100.0,
       onChanged: null,
       value: 50.0,
-      secondaryValue: 75.0,
+      secondaryTrackValue: 75.0,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -2854,7 +2854,7 @@ void main() {
 
     expect(description, <String>[
       'value: 50.0',
-      'secondaryValue: 75.0',
+      'secondaryTrackValue: 75.0',
       'disabled',
       'min: 0.0',
       'max: 100.0',

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -34,17 +34,19 @@ void main() {
       trackHeight: 7.0,
       activeTrackColor: Color(0xFF000001),
       inactiveTrackColor: Color(0xFF000002),
-      disabledActiveTrackColor: Color(0xFF000003),
-      disabledInactiveTrackColor: Color(0xFF000004),
-      activeTickMarkColor: Color(0xFF000005),
-      inactiveTickMarkColor: Color(0xFF000006),
-      disabledActiveTickMarkColor: Color(0xFF000007),
-      disabledInactiveTickMarkColor: Color(0xFF000008),
-      thumbColor: Color(0xFF000009),
-      overlappingShapeStrokeColor: Color(0xFF000010),
-      disabledThumbColor: Color(0xFF000011),
-      overlayColor: Color(0xFF000012),
-      valueIndicatorColor: Color(0xFF000013),
+      secondaryActiveTrackColor: Color(0xFF000003),
+      disabledActiveTrackColor: Color(0xFF000004),
+      disabledInactiveTrackColor: Color(0xFF000005),
+      disabledSecondaryActiveTrackColor: Color(0xFF000006),
+      activeTickMarkColor: Color(0xFF000007),
+      inactiveTickMarkColor: Color(0xFF000008),
+      disabledActiveTickMarkColor: Color(0xFF000009),
+      disabledInactiveTickMarkColor: Color(0xFF000010),
+      thumbColor: Color(0xFF000011),
+      overlappingShapeStrokeColor: Color(0xFF000012),
+      disabledThumbColor: Color(0xFF000013),
+      overlayColor: Color(0xFF000014),
+      valueIndicatorColor: Color(0xFF000015),
       overlayShape: RoundSliderOverlayShape(),
       tickMarkShape: RoundSliderTickMarkShape(),
       thumbShape: RoundSliderThumbShape(),
@@ -68,17 +70,19 @@ void main() {
       'trackHeight: 7.0',
       'activeTrackColor: Color(0xff000001)',
       'inactiveTrackColor: Color(0xff000002)',
-      'disabledActiveTrackColor: Color(0xff000003)',
-      'disabledInactiveTrackColor: Color(0xff000004)',
-      'activeTickMarkColor: Color(0xff000005)',
-      'inactiveTickMarkColor: Color(0xff000006)',
-      'disabledActiveTickMarkColor: Color(0xff000007)',
-      'disabledInactiveTickMarkColor: Color(0xff000008)',
-      'thumbColor: Color(0xff000009)',
-      'overlappingShapeStrokeColor: Color(0xff000010)',
-      'disabledThumbColor: Color(0xff000011)',
-      'overlayColor: Color(0xff000012)',
-      'valueIndicatorColor: Color(0xff000013)',
+      'secondaryActiveTrackColor: Color(0xff000003)',
+      'disabledActiveTrackColor: Color(0xff000004)',
+      'disabledInactiveTrackColor: Color(0xff000005)',
+      'disabledSecondaryActiveTrackColor: Color(0xff000006)',
+      'activeTickMarkColor: Color(0xff000007)',
+      'inactiveTickMarkColor: Color(0xff000008)',
+      'disabledActiveTickMarkColor: Color(0xff000009)',
+      'disabledInactiveTickMarkColor: Color(0xff000010)',
+      'thumbColor: Color(0xff000011)',
+      'overlappingShapeStrokeColor: Color(0xff000012)',
+      'disabledThumbColor: Color(0xff000013)',
+      'overlayColor: Color(0xff000014)',
+      'valueIndicatorColor: Color(0xff000015)',
       "overlayShape: Instance of 'RoundSliderOverlayShape'",
       "tickMarkShape: Instance of 'RoundSliderTickMarkShape'",
       "thumbShape: Instance of 'RoundSliderThumbShape'",
@@ -103,16 +107,18 @@ void main() {
     final SliderThemeData customTheme = sliderTheme.copyWith(
       activeTrackColor: Colors.purple,
       inactiveTrackColor: Colors.purple.withAlpha(0x3d),
+      secondaryActiveTrackColor: Colors.purple.withAlpha(0x8a),
     );
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, secondaryValue: 0.75, enabled: false));
     final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
 
     expect(
       material,
       paints
         ..rrect(color: customTheme.disabledActiveTrackColor)
-        ..rrect(color: customTheme.disabledInactiveTrackColor),
+        ..rrect(color: customTheme.disabledInactiveTrackColor)
+        ..rrect(color: customTheme.disabledSecondaryActiveTrackColor),
     );
   });
 
@@ -125,16 +131,18 @@ void main() {
     final SliderThemeData customTheme = sliderTheme.copyWith(
       activeTrackColor: Colors.purple,
       inactiveTrackColor: Colors.purple.withAlpha(0x3d),
+      secondaryActiveTrackColor: Colors.purple.withAlpha(0x8a),
     );
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, secondaryValue: 0.75, enabled: false));
     final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
 
     expect(
       material,
       paints
         ..rrect(color: customTheme.disabledActiveTrackColor)
-        ..rrect(color: customTheme.disabledInactiveTrackColor),
+        ..rrect(color: customTheme.disabledInactiveTrackColor)
+        ..rrect(color: customTheme.disabledSecondaryActiveTrackColor),
     );
   });
 
@@ -153,8 +161,10 @@ void main() {
 
     expect(sliderTheme.activeTrackColor, equals(customColor1.withAlpha(0xff)));
     expect(sliderTheme.inactiveTrackColor, equals(customColor1.withAlpha(0x3d)));
+    expect(sliderTheme.secondaryActiveTrackColor, equals(customColor1.withAlpha(0x8a)));
     expect(sliderTheme.disabledActiveTrackColor, equals(customColor2.withAlpha(0x52)));
     expect(sliderTheme.disabledInactiveTrackColor, equals(customColor2.withAlpha(0x1f)));
+    expect(sliderTheme.disabledSecondaryActiveTrackColor, equals(customColor2.withAlpha(0x1f)));
     expect(sliderTheme.activeTickMarkColor, equals(customColor3.withAlpha(0x8a)));
     expect(sliderTheme.inactiveTickMarkColor, equals(customColor1.withAlpha(0x8a)));
     expect(sliderTheme.disabledActiveTickMarkColor, equals(customColor3.withAlpha(0x1f)));
@@ -209,8 +219,10 @@ void main() {
     expect(lerp.trackHeight, equals(4.0));
     expect(lerp.activeTrackColor, equals(middleGrey.withAlpha(0xff)));
     expect(lerp.inactiveTrackColor, equals(middleGrey.withAlpha(0x3d)));
+    expect(lerp.secondaryActiveTrackColor, equals(middleGrey.withAlpha(0x8a)));
     expect(lerp.disabledActiveTrackColor, equals(middleGrey.withAlpha(0x52)));
     expect(lerp.disabledInactiveTrackColor, equals(middleGrey.withAlpha(0x1f)));
+    expect(lerp.disabledSecondaryActiveTrackColor, equals(middleGrey.withAlpha(0x1f)));
     expect(lerp.activeTickMarkColor, equals(middleGrey.withAlpha(0x8a)));
     expect(lerp.inactiveTickMarkColor, equals(middleGrey.withAlpha(0x8a)));
     expect(lerp.disabledActiveTickMarkColor, equals(middleGrey.withAlpha(0x1f)));
@@ -229,7 +241,7 @@ void main() {
     );
     final SliderThemeData sliderTheme = theme.sliderTheme.copyWith(thumbColor: Colors.red.shade500);
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, secondaryValue: 0.5));
     final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
 
     const Radius radius = Radius.circular(2);
@@ -241,10 +253,11 @@ void main() {
       material,
       paints
         ..rrect(rrect: RRect.fromLTRBAndCorners(24.0, 297.0, 212.0, 303.0, topLeft: activatedRadius, bottomLeft: activatedRadius), color: sliderTheme.activeTrackColor)
-        ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 776.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.inactiveTrackColor),
+        ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 776.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.inactiveTrackColor)
+        ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 400.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.secondaryActiveTrackColor),
     );
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, secondaryValue: 0.5, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
 
     // The disabled slider thumb is the same size as the enabled thumb.
@@ -252,7 +265,8 @@ void main() {
       material,
       paints
         ..rrect(rrect: RRect.fromLTRBAndCorners(24.0, 297.0, 212.0, 303.0, topLeft: activatedRadius, bottomLeft: activatedRadius), color: sliderTheme.disabledActiveTrackColor)
-        ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 776.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.disabledInactiveTrackColor),
+        ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 776.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.disabledInactiveTrackColor)
+        ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 400.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.disabledSecondaryActiveTrackColor),
     );
   });
 
@@ -1348,17 +1362,19 @@ class RoundedRectSliderTrackShapeWithCustomAdditionalActiveTrackHeight extends R
     required Animation<double> enableAnimation,
     required TextDirection textDirection,
     required Offset thumbCenter,
+    Offset? secondaryOffset,
     bool isDiscrete = false,
     bool isEnabled = false,
     double additionalActiveTrackHeight = 2.0,
   }) {
-    super.paint(context, offset, parentBox: parentBox, sliderTheme: sliderTheme, enableAnimation: enableAnimation, textDirection: textDirection, thumbCenter: thumbCenter, additionalActiveTrackHeight: this.additionalActiveTrackHeight);
+    super.paint(context, offset, parentBox: parentBox, sliderTheme: sliderTheme, enableAnimation: enableAnimation, textDirection: textDirection, thumbCenter: thumbCenter, secondaryOffset: secondaryOffset, additionalActiveTrackHeight: this.additionalActiveTrackHeight);
   }
 }
 
 Widget _buildApp(
     SliderThemeData sliderTheme, {
       double value = 0.0,
+      double? secondaryValue,
       bool enabled = true,
       int? divisions,
     }) {
@@ -1370,6 +1386,7 @@ Widget _buildApp(
           data: sliderTheme,
           child: Slider(
             value: value,
+            secondaryValue: secondaryValue,
             label: '$value',
             onChanged: onChanged,
             divisions: divisions,

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -110,7 +110,7 @@ void main() {
       secondaryActiveTrackColor: Colors.purple.withAlpha(0x8a),
     );
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, secondaryValue: 0.75, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, secondaryTrackValue: 0.75, enabled: false));
     final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
 
     expect(
@@ -134,7 +134,7 @@ void main() {
       secondaryActiveTrackColor: Colors.purple.withAlpha(0x8a),
     );
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, secondaryValue: 0.75, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.5, secondaryTrackValue: 0.75, enabled: false));
     final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
 
     expect(
@@ -241,7 +241,7 @@ void main() {
     );
     final SliderThemeData sliderTheme = theme.sliderTheme.copyWith(thumbColor: Colors.red.shade500);
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, secondaryValue: 0.5));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, secondaryTrackValue: 0.5));
     final MaterialInkController material = Material.of(tester.element(find.byType(Slider)))!;
 
     const Radius radius = Radius.circular(2);
@@ -257,7 +257,7 @@ void main() {
         ..rrect(rrect: RRect.fromLTRBAndCorners(212.0, 298.0, 400.0, 302.0, topRight: radius, bottomRight: radius), color: sliderTheme.secondaryActiveTrackColor),
     );
 
-    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, secondaryValue: 0.5, enabled: false));
+    await tester.pumpWidget(_buildApp(sliderTheme, value: 0.25, secondaryTrackValue: 0.5, enabled: false));
     await tester.pumpAndSettle(); // wait for disable animation
 
     // The disabled slider thumb is the same size as the enabled thumb.
@@ -1374,7 +1374,7 @@ class RoundedRectSliderTrackShapeWithCustomAdditionalActiveTrackHeight extends R
 Widget _buildApp(
     SliderThemeData sliderTheme, {
       double value = 0.0,
-      double? secondaryValue,
+      double? secondaryTrackValue,
       bool enabled = true,
       int? divisions,
     }) {
@@ -1386,7 +1386,7 @@ Widget _buildApp(
           data: sliderTheme,
           child: Slider(
             value: value,
-            secondaryValue: secondaryValue,
+            secondaryTrackValue: secondaryTrackValue,
             label: '$value',
             onChanged: onChanged,
             divisions: divisions,


### PR DESCRIPTION
This PR adds the support for showing secondary value in Slider widget.

![Slider](https://user-images.githubusercontent.com/50951164/185494323-8f5217fe-daa9-4159-a2d3-ce9e47d5117b.gif) 

Fixes #64029

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
