### PR TITLE
Add clipBehavior to Card+InkWell example

### DIFF
--- a/examples/api/lib/material/card/card.1.dart
+++ b/examples/api/lib/material/card/card.1.dart
@@ -32,6 +32,11 @@ class MyStatelessWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Center(
       child: Card(
+        // clipBehavior is necessary because, without it, the InkWell's animation
+        // will extend beyond the rounded edges of the [Card] (see https://github.com/flutter/flutter/issues/109776)
+        // This introduces a small performance cost, and you should not set [clipBehavior]
+        // unless you need it.
+        clipBehavior: Clip.hardEdge,
         child: InkWell(
           splashColor: Colors.blue.withAlpha(30),
           onTap: () {

--- a/examples/api/lib/material/card/card.1.dart
+++ b/examples/api/lib/material/card/card.1.dart
@@ -34,7 +34,7 @@ class MyStatelessWidget extends StatelessWidget {
       child: Card(
         // clipBehavior is necessary because, without it, the InkWell's animation
         // will extend beyond the rounded edges of the [Card] (see https://github.com/flutter/flutter/issues/109776)
-        // This introduces a small performance cost, and you should not set [clipBehavior]
+        // This comes with a small performance cost, and you should not set [clipBehavior]
         // unless you need it.
         clipBehavior: Clip.hardEdge,
         child: InkWell(

--- a/examples/api/test/material/card/card.1_test.dart
+++ b/examples/api/test/material/card/card.1_test.dart
@@ -1,0 +1,16 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/card/card.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Card has clip applied', (WidgetTester tester) async {
+    await tester.pumpWidget(const example.MyApp());
+
+    final Card card = tester.firstWidget(find.byType(Card));
+    expect(card.clipBehavior, Clip.hardEdge);
+  });
+}


### PR DESCRIPTION
The second example on https://api.flutter.dev/flutter/material/Card-class.html that demonstrates how to make an entire card tappable exhibits https://github.com/flutter/flutter/issues/109776. This is almost certainly not what a user wants, so we should communicate how to make this work as expected.

Before:
![image](https://user-images.githubusercontent.com/581764/185687891-59430e27-3db7-44c0-bd62-728b2846e109.png)

After (with Clip.hardEdge):
![Simulator Screen Shot - iPhone 13 - 2022-08-19 at 14 59 53](https://user-images.githubusercontent.com/581764/185688784-61d7f7f5-0537-48b8-b0e9-be86ca4a5ec9.png)

After (with Clip.antiAlias. Not what's in the code, but for comparison):
![antiAlias](https://user-images.githubusercontent.com/581764/185688982-69b5d1e8-3740-4669-958a-bb472e550ec6.png)

Fixes https://github.com/flutter/flutter/issues/109776