### PR TITLE
Copy artifacts to `applicationBinaryPath` when specified for build+test separation

### DIFF
--- a/dev/devicelab/lib/tasks/build_test_task.dart
+++ b/dev/devicelab/lib/tasks/build_test_task.dart
@@ -59,6 +59,7 @@ abstract class BuildTestTask {
       }
       section('BUILDING APPLICATION');
       await flutter('build', options: getBuildArgs(deviceOperatingSystem));
+      copyArtifacts();
     });
 
   }
@@ -83,6 +84,11 @@ abstract class BuildTestTask {
   /// Args passed to flutter drive to test the built application.
   List<String> getTestArgs(DeviceOperatingSystem deviceOperatingSystem, String deviceId) => throw UnimplementedError('getTestArgs is not implemented');
 
+  /// Copy artifacts to [applicationBinaryPath] if specified.
+  /// 
+  /// This is needed when running from CI, so that LUCI recipes know where to locate and upload artifacts to GCS.
+  void copyArtifacts() => throw UnimplementedError('copyArtifacts is not implemented');
+  
   /// Logic to construct [TaskResult] from this test's results.
   Future<TaskResult> parseTaskResult() => throw UnimplementedError('parseTaskResult is not implemented');
 
@@ -98,10 +104,6 @@ abstract class BuildTestTask {
   Future<TaskResult> call() async {
     if (buildOnly && testOnly) {
       throw Exception('Both build and test should not be passed. Pass only one.');
-    }
-
-    if (buildOnly && applicationBinaryPath != null) {
-      throw Exception('Application binary path is only used for tests');
     }
 
     if (!testOnly) {

--- a/dev/devicelab/lib/tasks/build_test_task.dart
+++ b/dev/devicelab/lib/tasks/build_test_task.dart
@@ -85,10 +85,10 @@ abstract class BuildTestTask {
   List<String> getTestArgs(DeviceOperatingSystem deviceOperatingSystem, String deviceId) => throw UnimplementedError('getTestArgs is not implemented');
 
   /// Copy artifacts to [applicationBinaryPath] if specified.
-  /// 
+  ///
   /// This is needed when running from CI, so that LUCI recipes know where to locate and upload artifacts to GCS.
   void copyArtifacts() => throw UnimplementedError('copyArtifacts is not implemented');
-  
+
   /// Logic to construct [TaskResult] from this test's results.
   Future<TaskResult> parseTaskResult() => throw UnimplementedError('parseTaskResult is not implemented');
 

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -6,6 +6,8 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:path/path.dart' as path;
+
 import '../framework/devices.dart';
 import '../framework/framework.dart';
 import '../framework/task_result.dart';
@@ -213,6 +215,16 @@ class GalleryTransitionBuildTest extends BuildTestTask {
   final String testOutputDirectory = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
 
   @override
+  void copyArtifacts() {
+    if(applicationBinaryPath != null) {
+      copy(
+        file('${galleryDirectory.path}/build/app/outputs/flutter-apk/app-profile.apk'),
+        Directory(applicationBinaryPath!),
+      );
+    }
+  }
+
+  @override
   List<String> getBuildArgs(DeviceOperatingSystem deviceOperatingSystem) {
     return <String>[
       'apk',
@@ -310,7 +322,7 @@ class GalleryTransitionBuildTest extends BuildTestTask {
   @override
   String getApplicationBinaryPath() {
     if (applicationBinaryPath != null) {
-      return applicationBinaryPath!;
+      return '${applicationBinaryPath!}/app-profile.apk';
     }
 
     return 'build/app/outputs/flutter-apk/app-profile.apk';

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -6,8 +6,6 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:path/path.dart' as path;
-
 import '../framework/devices.dart';
 import '../framework/framework.dart';
 import '../framework/task_result.dart';

--- a/dev/devicelab/test/tasks/build_test_task_test.dart
+++ b/dev/devicelab/test/tasks/build_test_task_test.dart
@@ -78,13 +78,13 @@ void main() {
     expect(result.message, 'Task failed: Exception: Both build and test should not be passed. Pass only one.');
   });
 
-  test('throws exception when build and application binary arg are given', () async {
+  test('copies artifacts when build and application binary arg are given', () async {
     final TaskResult result = await runTask(
       'smoke_test_build_test',
-      taskArgs: <String>['--build', '--application-binary-path=test.apk'],
+      taskArgs: <String>['--build', '--application-binary-path=test'],
       deviceId: 'FAKE_SUCCESS',
       isolateParams: isolateParams,
     );
-    expect(result.message, 'Task failed: Exception: Application binary path is only used for tests');
+    expect(result.message, 'No tests run');
   });
 }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/103542.

Support artifact path:
1) for build, copy artifacts to the specified path after building
2) for test, obtain artifacts from the specified path