### PR TITLE
Run Mac hostonly tests on any available arch

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2358,6 +2358,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2377,6 +2378,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2396,6 +2398,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2415,6 +2418,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2698,6 +2702,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2784,10 +2789,6 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "arm64ruby", "version": "version:311_3"}
-        ]
       tags: >
         ["devicelab", "ios", "mac", "arm64"]
       task_name: plugin_lint_mac
@@ -2840,7 +2841,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2887,6 +2887,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2912,6 +2913,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2937,6 +2939,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2962,6 +2965,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3038,6 +3042,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: x86 # https://github.com/flutter/flutter/issues/110113
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2308,8 +2308,7 @@ targets:
       - .ci.yaml
 
   - name: Mac basic_material_app_macos__compile
-    bringup: true # New target https://github.com/flutter/flutter/issues/109633
-    presubmit: false
+    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2325,6 +2324,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2434,11 +2434,11 @@ targets:
         ["framework", "hostonly", "shard"]
 
   - name: Mac complex_layout_macos__compile
-    bringup: true # New target https://github.com/flutter/flutter/issues/109633
-    presubmit: false
+    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2492,8 +2492,7 @@ targets:
       - .ci.yaml
 
   - name: Mac flutter_gallery_macos__compile
-    bringup: true # New target https://github.com/flutter/flutter/issues/109633
-    presubmit: false
+    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2564,6 +2563,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
@@ -2632,8 +2632,7 @@ targets:
       - .ci.yaml
 
   - name: Mac hello_world_macos__compile
-    bringup: true # New target https://github.com/flutter/flutter/issues/109633
-    presubmit: false
+    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2750,6 +2749,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2353,11 +2353,12 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 build_tests_1_4
+  - name: Mac build_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2372,11 +2373,12 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
-  - name: Mac_x64 build_tests_2_4
+  - name: Mac build_tests_2_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2391,11 +2393,12 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
-  - name: Mac_x64 build_tests_3_4
+  - name: Mac build_tests_3_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2410,11 +2413,12 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
-  - name: Mac_x64 build_tests_4_4
+  - name: Mac build_tests_4_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2468,10 +2472,11 @@ targets:
       tags: >
         ["framework", "hostonly"]
 
-  - name: Mac_x64 dart_plugin_registry_test
+  - name: Mac dart_plugin_registry_test
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2694,10 +2699,11 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 module_test_ios
+  - name: Mac module_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2760,10 +2766,11 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 plugin_lint_mac
+  - name: Mac plugin_lint_mac
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2816,10 +2823,11 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 plugin_test_ios
+  - name: Mac plugin_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2835,10 +2843,12 @@ targets:
       - .ci.yaml
 
   - name: Mac_x64 tool_host_cross_arch_tests
+    bringup: true # Mac_x64 variant https://github.com/flutter/flutter/pull/109889
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2855,10 +2865,12 @@ targets:
       - .ci.yaml
 
   - name: Mac_arm64 tool_host_cross_arch_tests
+    bringup: true # Mac_arm64 variant https://github.com/flutter/flutter/pull/109889
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: arm64
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2879,11 +2891,12 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 tool_integration_tests_1_4
+  - name: Mac tool_integration_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2904,11 +2917,12 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 tool_integration_tests_2_4
+  - name: Mac tool_integration_tests_2_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2929,11 +2943,12 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 tool_integration_tests_3_4
+  - name: Mac tool_integration_tests_3_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2954,11 +2969,12 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac_x64 tool_integration_tests_4_4
+  - name: Mac tool_integration_tests_4_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3031,10 +3047,11 @@ targets:
       validation: verify_binaries_codesigned
       validation_name: Verify binaries codesigned
 
-  - name: Mac_x64 web_tool_tests
+  - name: Mac web_tool_tests
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3745,10 +3762,11 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios_sksl_warmup__transition_perf
 
-  - name: Mac_x64 native_ui_tests_macos
+  - name: Mac native_ui_tests_macos
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -76,7 +76,6 @@ platform_properties:
         []
       os: Mac-12
       device_type: none
-      cpu: arm64
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_arm64:
     properties:
@@ -2308,7 +2307,7 @@ targets:
       - .ci.yaml
 
   - name: Mac basic_material_app_macos__compile
-    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2434,7 +2433,7 @@ targets:
         ["framework", "hostonly", "shard"]
 
   - name: Mac complex_layout_macos__compile
-    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2634,7 +2633,7 @@ targets:
       - .ci.yaml
 
   - name: Mac hello_world_macos__compile
-    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -76,6 +76,7 @@ platform_properties:
         []
       os: Mac-12
       device_type: none
+      cpu: arm64
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_arm64:
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -77,7 +77,7 @@ platform_properties:
       os: Mac-12
       device_type: none
       xcode: 14a5294e # xcode 14.0 beta 5
-  mac_arm:
+  mac_arm64:
     properties:
       dependencies: >-
         []
@@ -2352,7 +2352,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac build_tests_1_4
+  - name: Mac_x64 build_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2371,7 +2371,7 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
-  - name: Mac build_tests_2_4
+  - name: Mac_x64 build_tests_2_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2390,7 +2390,7 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
-  - name: Mac build_tests_3_4
+  - name: Mac_x64 build_tests_3_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2409,7 +2409,7 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
-  - name: Mac build_tests_4_4
+  - name: Mac_x64 build_tests_4_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2467,7 +2467,7 @@ targets:
       tags: >
         ["framework", "hostonly"]
 
-  - name: Mac dart_plugin_registry_test
+  - name: Mac_x64 dart_plugin_registry_test
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2693,7 +2693,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac module_test_ios
+  - name: Mac_x64 module_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2759,7 +2759,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac plugin_lint_mac
+  - name: Mac_x64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2815,7 +2815,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac plugin_test_ios
+  - name: Mac_x64 plugin_test_ios
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2833,7 +2833,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac tool_host_cross_arch_tests
+  - name: Mac_x64 tool_host_cross_arch_tests
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2853,7 +2853,32 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac tool_integration_tests_1_4
+  - name: Mac_arm64 tool_host_cross_arch_tests
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      add_recipes_cq: "true"
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"},
+          {"dependency": "arm64ruby", "version": "version:311_3"}
+        ]
+      runtime_versions: >-
+        [
+          "ios-16-0_14a5294e"
+        ]
+      shard: tool_host_cross_arch_tests
+      tags: >
+        ["framework", "hostonly", "shard"]
+      test_timeout_secs: "2700"
+    runIf:
+      - dev/**
+      - packages/flutter_tools/**
+      - bin/**
+      - .ci.yaml
+
+  - name: Mac_x64 tool_integration_tests_1_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2878,7 +2903,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac tool_integration_tests_2_4
+  - name: Mac_x64 tool_integration_tests_2_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2903,7 +2928,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac tool_integration_tests_3_4
+  - name: Mac_x64 tool_integration_tests_3_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2928,7 +2953,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac tool_integration_tests_4_4
+  - name: Mac_x64 tool_integration_tests_4_4
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3005,7 +3030,7 @@ targets:
       validation: verify_binaries_codesigned
       validation_name: Verify binaries codesigned
 
-  - name: Mac web_tool_tests
+  - name: Mac_x64 web_tool_tests
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -3719,7 +3744,7 @@ targets:
         ["devicelab", "ios", "mac"]
       task_name: flutter_gallery_ios_sksl_warmup__transition_perf
 
-  - name: Mac native_ui_tests_macos
+  - name: Mac_x64 native_ui_tests_macos
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -76,6 +76,21 @@ platform_properties:
         []
       os: Mac-12
       device_type: none
+      xcode: 14a5294e # xcode 14.0 beta 5
+  mac_arm:
+    properties:
+      dependencies: >-
+        []
+      os: Mac-12
+      device_type: none
+      cpu: arm64
+      xcode: 14a5294e # xcode 14.0 beta 5
+  mac_x64:
+    properties:
+      dependencies: >-
+        []
+      os: Mac-12
+      device_type: none
       cpu: x86
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_android:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -76,7 +76,6 @@ platform_properties:
         []
       os: Mac-12
       device_type: none
-      cpu: arm64
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_arm64:
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2453,6 +2453,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2492,10 +2493,11 @@ targets:
       - .ci.yaml
 
   - name: Mac flutter_gallery_macos__compile
-    # bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2701,7 +2701,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
+      cpu: x86 # Codesigning fails on ARM https://github.com/flutter/flutter/issues/112033
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2866,10 +2866,6 @@ targets:
         [
           {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      runtime_versions: >-
-        [
-          "ios-16-0_14a5294e"
         ]
       shard: tool_host_cross_arch_tests
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -76,6 +76,7 @@ platform_properties:
         []
       os: Mac-12
       device_type: none
+      cpu: arm64
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_arm64:
     properties:
@@ -2308,6 +2309,7 @@ targets:
 
   - name: Mac basic_material_app_macos__compile
     bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2323,7 +2325,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2357,7 +2358,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2377,7 +2377,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2397,7 +2396,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2417,7 +2415,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2434,10 +2431,10 @@ targets:
 
   - name: Mac complex_layout_macos__compile
     bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2452,7 +2449,6 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2476,7 +2472,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2493,10 +2488,10 @@ targets:
 
   - name: Mac flutter_gallery_macos__compile
     bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2564,7 +2559,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
@@ -2634,6 +2628,7 @@ targets:
 
   - name: Mac hello_world_macos__compile
     bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2703,7 +2698,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2750,7 +2744,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2771,7 +2764,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2828,7 +2820,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2875,8 +2866,7 @@ targets:
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "arm64ruby", "version": "version:311_3"}
+          {"dependency": "gems", "version": "v3.3.14"}
         ]
       runtime_versions: >-
         [
@@ -2897,7 +2887,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2923,7 +2912,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2949,7 +2937,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2975,7 +2962,6 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3052,7 +3038,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3767,7 +3752,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},


### PR DESCRIPTION
Allow Mac hostonly (not devicelab or benchmark) tests to run on any available architecture, not just x64 Intel machines.

Example expands available bots for this category of tests from
https://chromium-swarm.appspot.com/botlist?c=id&c=task&c=cpu&c=os&c=status&d=asc&f=pool%3Aluci.flutter.prod&f=os%3AMac-12&f=cpu%3Ax86&f=device_type%3Anone&s=id
to
https://chromium-swarm.appspot.com/botlist?c=id&c=task&c=cpu&c=os&c=status&d=asc&f=pool%3Aluci.flutter.prod&f=os%3AMac-12&f=device_type%3Anone&s=id

Also run `tool_host_cross_arch_tests` on both archs, as that's the intention of that shard.

Remove `arm64ruby` dependency, unnecessary as of https://github.com/flutter/flutter/issues/110561.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
