### PR TITLE
[platform_view]retry launch if it fails to launch for xcuitest

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -26,16 +26,32 @@ static const CGFloat kStandardTimeOut = 60.0;
   [super setUp];
   self.continueAfterFailure = NO;
 
-  self.app = [[XCUIApplication alloc] init];
-  [self.app launch];
+  // Retry launching the app if it fails to launch.
+  // This is trying to fix a "failed to terminate" failure, which is likely a bug in Xcode.
+  // The solution is based on https://stackoverflow.com/questions/41872848/xctests-failing-to-launch-app-in-simulator-intermittently
+  int remainingLaunchCount = 10;
+  while (true) {
+    self.app = [[XCUIApplication alloc] init];
+    [self.app launch];
+    remainingLaunchCount -= 1;
+    [NSThread sleepForTimeInterval:3];
+    if (self.app.exists) {
+      // success launch
+      break;
+    }
+
+    if (remainingLaunchCount > 0) {
+      NSLog(@"Retry launch with remaining launch count %d", remainingLaunchCount);
+      [self.app terminate];
+      [NSThread sleepForTimeInterval:3];
+      continue;
+    }
+
+    NSLog(@"Failed to launch");
+  }
 }
 
 - (void)tearDown {
-  // This is trying to fix a "failed to terminate" failure, which is likely a bug in Xcode.
-  // In theory the terminate call is not necessary, but many has encountered this similar
-  // issue, and fixed it by terminating the app and relaunching it if needed for each test.
-  // Here we simply try terminating the app in tearDown, but if it does not work,
-  // then alternative solution is to terminate and relaunch the app.
   [self.app terminate];
   [super tearDown];
 }


### PR DESCRIPTION
Looks like we have to retry launch if it fails to launch (flaky tests [here](https://ci.chromium.org/p/flutter/builders/staging/Mac_ios%20native_platform_view_ui_tests_ios?limit=200)). I will keep this `tearDown` with "terminate" since it may provide extra safety (and some of our tests also have it). 

Related to https://github.com/flutter/flutter/pull/109720

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

https://github.com/flutter/flutter/issues/109697

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
