### PR TITLE
Fix `floatingActionButtonAnimator` not being updated

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1305,14 +1305,14 @@ class _FloatingActionButtonTransitionState extends State<_FloatingActionButtonTr
   @override
   void didUpdateWidget(_FloatingActionButtonTransition oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.fabMotionAnimator != widget.fabMotionAnimator || oldWidget.fabMoveAnimation != widget.fabMoveAnimation) {
+      // Get the right scale and rotation animations to use for this widget.
+      _updateAnimations();
+    }
     final bool oldChildIsNull = oldWidget.child == null;
     final bool newChildIsNull = widget.child == null;
     if (oldChildIsNull == newChildIsNull && oldWidget.child?.key == widget.child?.key) {
       return;
-    }
-    if (oldWidget.fabMotionAnimator != widget.fabMotionAnimator || oldWidget.fabMoveAnimation != widget.fabMoveAnimation) {
-      // Get the right scale and rotation animations to use for this widget.
-      _updateAnimations();
     }
     if (_previousController.status == AnimationStatus.dismissed) {
       final double currentValue = widget.currentController.value;

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -607,6 +607,58 @@ void main() {
 
       expect(tester.binding.transientCallbackCount, 0);
     });
+
+    testWidgets('Animator can be updated', (WidgetTester tester) async {
+      FloatingActionButtonAnimator fabAnimator = FloatingActionButtonAnimator.scaling;
+      FloatingActionButtonLocation fabLocation = FloatingActionButtonLocation.startFloat;
+
+      final Duration animationDuration = kFloatingActionButtonSegue * 2;
+
+      await tester.pumpWidget(_singleFabScaffold(
+        fabLocation,
+        animator: fabAnimator,
+      ));
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+      expect(tester.binding.transientCallbackCount, 0);
+      expect(tester.getCenter(find.byType(FloatingActionButton)).dx, 44.0);
+
+      fabLocation = FloatingActionButtonLocation.endFloat;
+      await tester.pumpWidget(_singleFabScaffold(
+        fabLocation,
+        animator: fabAnimator,
+      ));
+
+      expect(tester.getTopLeft(find.byType(FloatingActionButton)).dx, lessThan(16.0));
+
+      await tester.pump(animationDuration * 0.25);
+      expect(tester.getTopLeft(find.byType(FloatingActionButton)).dx, greaterThan(16));
+
+      await tester.pump(animationDuration * 0.25);
+      expect(tester.getCenter(find.byType(FloatingActionButton)).dx, 756.0);
+      expect(tester.getTopRight(find.byType(FloatingActionButton)).dx, lessThan(800 - 16));
+
+      await tester.pump(animationDuration * 0.25);
+      expect(tester.getTopRight(find.byType(FloatingActionButton)).dx, lessThan(800 - 16));
+
+      await tester.pump(animationDuration * 0.25);
+      expect(tester.getTopRight(find.byType(FloatingActionButton)).dx, equals(800 - 16));
+
+      fabLocation = FloatingActionButtonLocation.startFloat;
+      fabAnimator = _NoScalingFabAnimator();
+      await tester.pumpWidget(_singleFabScaffold(
+        fabLocation,
+        animator: fabAnimator,
+      ));
+
+      await tester.pump(animationDuration * 0.25);
+      expect(tester.getCenter(find.byType(FloatingActionButton)).dx, 756.0);
+      expect(tester.getTopRight(find.byType(FloatingActionButton)).dx, equals(800 - 16));
+
+      await tester.pump(animationDuration * 0.25);
+      expect(tester.getCenter(find.byType(FloatingActionButton)).dx, 44.0);
+      expect(tester.getTopLeft(find.byType(FloatingActionButton)).dx, lessThan(16.0));
+    });
   });
 
   group('Locations account for safe interactive areas', () {
@@ -1705,6 +1757,23 @@ class _LinearMovementFabAnimator extends FloatingActionButtonAnimator {
   @override
   Offset getOffset({required Offset begin, required Offset end, required double progress}) {
     return Offset.lerp(begin, end, progress)!;
+  }
+
+  @override
+  Animation<double> getScaleAnimation({required Animation<double> parent}) {
+    return const AlwaysStoppedAnimation<double>(1.0);
+  }
+
+  @override
+  Animation<double> getRotationAnimation({required Animation<double> parent}) {
+    return const AlwaysStoppedAnimation<double>(1.0);
+  }
+}
+
+class _NoScalingFabAnimator extends FloatingActionButtonAnimator {
+  @override
+  Offset getOffset({required Offset begin, required Offset end, required double progress}) {
+    return progress < 0.5 ? begin : end;
   }
 
   @override


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/109113

This PR fixes animations not being updated in `FloatingActionButtonTransition.didUpdateWidget`. 
When the new and old child is the same the  didUpdatedWidget exits as a result animations are not updated. 

<details> 
<summary>Code Sample</summary> 

```dart
import 'dart:math' as math;

import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key, this.dark = true, this.useMaterial3 = true});

  final bool dark;
  final bool useMaterial3;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      themeMode: dark ? ThemeMode.dark : ThemeMode.light,
      theme: ThemeData(
        useMaterial3: useMaterial3,
        brightness: Brightness.light,
        colorSchemeSeed: const Color(0xff6750a4),
      ),
      darkTheme: ThemeData(
        useMaterial3: useMaterial3,
        brightness: Brightness.dark,
        colorSchemeSeed: const Color(0xff6750a4),
      ),
      home: const Example(),
    );
  }
}

class Example extends StatefulWidget {
  const Example({super.key});

  @override
  State<Example> createState() => _ExampleState();
}

class _ExampleState extends State<Example> {
  int _counter = 0;
  late bool _animateChange;
  late bool _isOnRight;

  @override
  void initState() {
    super.initState();
    _animateChange = true;
    _isOnRight = false;
  }

  void _incrementCounter() {
    setState(() {
      _counter++;
    });
  }

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('FAB'),
      ),
      body: Center(
        child: Column(
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
            const Text(
              'You have pushed the button this many times:',
            ),
            Text(
              '$_counter',
              style: Theme.of(context).textTheme.headline4,
            ),
            Row(
              mainAxisAlignment: MainAxisAlignment.center,
              children: <Widget>[
                const Text('Has Animation'),
                Checkbox(
                  value: _animateChange,
                  onChanged: (bool? v) {
                    setState(() {
                      _animateChange = v ?? false;
                    });
                  },
                ),
              ],
            ),
            Row(
              mainAxisAlignment: MainAxisAlignment.center,
              children: <Widget>[
                const Text('Button Location: Left'),
                Switch(
                  value: _isOnRight,
                  onChanged: (bool v) {
                    setState(() {
                      _isOnRight = v;
                    });
                  },
                ),
                const Text('Right'),
              ],
            ),
          ],
        ),
      ),
      floatingActionButton: FloatingActionButton(
        onPressed: _incrementCounter,
        tooltip: 'Increment',
        child: const Icon(Icons.add),
      ),
      floatingActionButtonLocation: _isOnRight
          ? FloatingActionButtonLocation.endFloat
          : FloatingActionButtonLocation.startFloat,
      floatingActionButtonAnimator: _animateChange
          ? FloatingActionButtonAnimator.scaling
          : const NoScalingFabMotionAnimator(),
    );
  }
}

class NoScalingFabMotionAnimator extends FloatingActionButtonAnimator {
  const NoScalingFabMotionAnimator();

  @override
  Offset getOffset(
      {required Offset begin, required Offset end, required double progress}) {
    return progress < 0.5 ? begin : end;
  }

  @override
  Animation<double> getScaleAnimation({required Animation<double> parent}) {
    return Tween<double>(begin: 1.0, end: 1.0).animate(parent);
  }

  @override
  Animation<double> getRotationAnimation({required Animation<double> parent}) {
    return Tween<double>(begin: 1.0, end: 1.0).animate(parent);
  }

  // If the animation was just starting, we'll continue from where we left off.
  // If the animation was finishing, we'll treat it as if we were starting at that point in reverse.
  // This avoids a size jump during the animation.
  @override
  double getAnimationRestart(double previousValue) =>
      math.min(1.0 - previousValue, previousValue);
}

``` 
	
</details>


### Fix Preview


https://user-images.githubusercontent.com/48603081/186117590-a6525e40-5ebd-4583-be76-b4518d46d87b.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
