### PR TITLE
[macOS] Bring up "flutter_gallery" devicelab, compilation test for x86

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2425,6 +2425,15 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Mac flutter_gallery_macos__compile
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: flutter_gallery_macos__compile
+
   - name: Mac framework_tests_libraries
     recipe: flutter/flutter_drone
     timeout: 60

--- a/dev/devicelab/bin/tasks/flutter_gallery_macos__compile.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_macos__compile.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createFlutterGalleryCompileTest());
+}


### PR DESCRIPTION
From https://github.com/flutter/flutter/issues/109633
> The initial desktop integration tests are running now, but they need to be expanded beyond the initial gallery build test; filing this to make sure that planned work is captured in the issue tracker. This should be much more straightforward that getting the first one running was, since the bot work is all complete.

> In particular we should ensure we are testing building a freshly created project to catch errors in template changes. (I haven't checked where that test lives on existing platforms; it may be a device lab test, which still needs desktop bring-up).

Fixes https://github.com/flutter/flutter/issues/110080

## Pre-launch Checklist
- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.