### PR TITLE
[macOS] Bring up "hello_world" devicelab, compilation test for x86 and arm64.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2558,6 +2558,15 @@ targets:
         ["devicelab", "hostonly"]
       task_name: hello_world_macos__compile
 
+  - name: Mac_arm64 hello_world_macos__compile
+    bringup: true
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: hello_world_macos__compile
+
   - name: Mac module_custom_host_app_name_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2549,6 +2549,15 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Mac hello_world_macos__compile
+    bringup: true
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: hello_world_macos__compile
+
   - name: Mac module_custom_host_app_name_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2567,6 +2567,15 @@ targets:
         ["devicelab", "hostonly"]
       task_name: hello_world_macos__compile
 
+  - name: Mac basic_material_app_macos__compile
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: basic_material_app_macos__compile
+
   - name: Mac module_custom_host_app_name_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -226,6 +226,7 @@
 /dev/devicelab/bin/tasks/complex_layout_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/flutter_view_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/platform_view_win_desktop__start_up.dart @schectman @flutter/desktop
+/dev/devicelab/bin/tasks/hello_world_macos__compile.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -227,6 +227,7 @@
 /dev/devicelab/bin/tasks/flutter_view_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/platform_view_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/hello_world_macos__compile.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/basic_material_app_macos__compile.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/basic_material_app_macos__compile.dart
+++ b/dev/devicelab/bin/tasks/basic_material_app_macos__compile.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createBasicMaterialCompileTest());
+}

--- a/dev/devicelab/bin/tasks/hello_world_macos__compile.dart
+++ b/dev/devicelab/bin/tasks/hello_world_macos__compile.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createHelloWorldCompileTest());
+}

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -62,6 +62,13 @@ enum DeviceOperatingSystem {
   windows,
 }
 
+extension Darwin on DeviceOperatingSystem {
+  bool get isDarwin {
+    return this == DeviceOperatingSystem.ios
+      || this == DeviceOperatingSystem.macos;
+  }
+}
+
 /// Device OS to test on.
 DeviceOperatingSystem deviceOperatingSystem = DeviceOperatingSystem.android;
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -696,7 +696,7 @@ class StartupTest {
             '--profile',
             '--target=$target',
           ]);
-          applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
+          applicationBinaryPath = _findDarwinAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
         case DeviceOperatingSystem.fake:
         case DeviceOperatingSystem.fuchsia:
@@ -830,7 +830,7 @@ class DevtoolsStartupTest {
              '-v',
             '--profile',
           ]);
-          applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
+          applicationBinaryPath = _findDarwinAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
         case DeviceOperatingSystem.fake:
         case DeviceOperatingSystem.fuchsia:
@@ -1480,7 +1480,7 @@ class CompileTest {
           'Release',
         );
         final String? appBundlePath =
-            _findIosAppInBuildDirectory(buildDirectoryPath);
+            _findDarwinAppInBuildDirectory(buildDirectoryPath);
         if (appBundlePath == null) {
           throw 'Failed to find app bundle in $buildDirectoryPath';
         }
@@ -1977,7 +1977,7 @@ Future<File> waitForFile(String path) async {
   throw StateError('Did not find vmservice out file after 1 hour');
 }
 
-String? _findIosAppInBuildDirectory(String searchDirectory) {
+String? _findDarwinAppInBuildDirectory(String searchDirectory) {
   for (final FileSystemEntity entity in Directory(searchDirectory).listSync()) {
     if (entity.path.endsWith('.app')) {
       return entity.path;

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1553,7 +1553,9 @@ class CompileTest {
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
       case DeviceOperatingSystem.macos:
-        throw Exception('Unsupported option for Fuchsia devices');
+        unawaited(stderr.flush());
+        options.insert(0, 'macos');
+        break;
       case DeviceOperatingSystem.windows:
         unawaited(stderr.flush());
         options.insert(0, 'windows');

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1978,7 +1978,8 @@ Future<File> waitForFile(String path) async {
 }
 
 String? _findDarwinAppInBuildDirectory(String searchDirectory) {
-  for (final FileSystemEntity entity in Directory(searchDirectory).listSync()) {
+  for (final FileSystemEntity entity in Directory(searchDirectory)
+    .listSync(recursive: true)) {
     if (entity.path.endsWith('.app')) {
       return entity.path;
     }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -7,7 +7,6 @@ import 'dart:convert' show LineSplitter, json, utf8;
 import 'dart:io';
 import 'dart:math' as math;
 
-import 'package:archive/archive.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
@@ -1400,34 +1399,6 @@ class CompileTest {
     final Map<String, dynamic> metrics = <String, dynamic>{};
 
     switch (deviceOperatingSystem) {
-      case DeviceOperatingSystem.ios:
-        options.insert(0, 'ios');
-        options.add('--tree-shake-icons');
-        options.add('--split-debug-info=infos/');
-        watch.start();
-        await flutter('build', options: options);
-        watch.stop();
-        final Directory appBuildDirectory = dir(path.join(cwd, 'build/ios/Release-iphoneos'));
-        final Directory? appBundle = appBuildDirectory
-            .listSync()
-            .whereType<Directory?>()
-            .singleWhere((Directory? directory) =>
-              directory != null && path.extension(directory.path) == '.app',
-              orElse: () => null);
-        if (appBundle == null) {
-          throw 'Failed to find app bundle in ${appBuildDirectory.path}';
-        }
-        final String appPath =  appBundle.path;
-        // IPAs are created manually, https://flutter.dev/ios-release/
-        await exec('tar', <String>['-zcf', 'build/app.ipa', appPath]);
-        releaseSizeInBytes = await file('$cwd/build/app.ipa').length();
-        if (reportPackageContentSizes) {
-          metrics.addAll(await getSizesFromDarwinApp(
-            appPath: appBuildDirectory.path,
-            operatingSystem: DeviceOperatingSystem.ios,
-          ));
-        }
-        break;
       case DeviceOperatingSystem.android:
       case DeviceOperatingSystem.androidArm:
         options.insert(0, 'apk');
@@ -1463,39 +1434,48 @@ class CompileTest {
         throw Exception('Unsupported option for fake devices');
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
+      case DeviceOperatingSystem.ios:
       case DeviceOperatingSystem.macos:
         unawaited(stderr.flush());
-        options.insert(0, 'macos');
+        late final String deviceId;
+        if(deviceOperatingSystem == DeviceOperatingSystem.ios) {
+          deviceId = 'ios';
+        } else if (deviceOperatingSystem == DeviceOperatingSystem.macos) {
+          deviceId = 'macos';
+        } else {
+          throw Exception('Attempted to run darwin compile workflow with $deviceOperatingSystem');
+        }
+
+        options.insert(0, deviceId);
         options.add('--tree-shake-icons');
         options.add('--split-debug-info=infos/');
         watch.start();
         await flutter('build', options: options);
         watch.stop();
-        final String buildDirectoryPath = path.join(
+        final Directory buildDirectory = dir(path.join(
           cwd,
           'build',
-          'macos',
-          'Build',
-          'Products',
-          'Release',
-        );
+        ));
         final String? appBundlePath =
-            _findDarwinAppInBuildDirectory(buildDirectoryPath);
+            _findDarwinAppInBuildDirectory(buildDirectory.path);
         if (appBundlePath == null) {
-          throw 'Failed to find app bundle in $buildDirectoryPath';
+          throw 'Failed to find app bundle in ${buildDirectory.path}';
         }
         final Directory appBundle = Directory(appBundlePath);
-        final Archive archive = Archive();
-        await appBundle
+        releaseSizeInBytes = await appBundle
             .list(recursive: true)
             .where((FileSystemEntity e) => e.runtimeType == File)
-            .map<ArchiveFile>((FileSystemEntity e) {
+            .fold<int>(0, (int totalSize, FileSystemEntity e) {
               assert(e.runtimeType == File);
-              final File file = e as File;
-              return ArchiveFile(file.path, file.statSync().size, file.readAsBytesSync());
-            })
-            .forEach((ArchiveFile file) => archive.addFile(file));
-        releaseSizeInBytes = TarEncoder().encode(archive).length;
+              return totalSize + e.statSync().size;
+            });
+        if (reportPackageContentSizes) {
+          final Map<String, dynamic> sizeMetrics = await getSizesFromDarwinApp(
+              appPath: appBundlePath,
+              operatingSystem: deviceOperatingSystem,
+          );
+          metrics.addAll(sizeMetrics);
+        }
         break;
       case DeviceOperatingSystem.windows:
         unawaited(stderr.flush());

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -7,6 +7,7 @@ import 'dart:convert' show LineSplitter, json, utf8;
 import 'dart:io';
 import 'dart:math' as math;
 
+import 'package:archive/archive.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 
@@ -1460,7 +1461,39 @@ class CompileTest {
       case DeviceOperatingSystem.fuchsia:
         throw Exception('Unsupported option for Fuchsia devices');
       case DeviceOperatingSystem.macos:
-        throw Exception('Unsupported option for macOS devices');
+        unawaited(stderr.flush());
+        options.insert(0, 'macos');
+        options.add('--tree-shake-icons');
+        options.add('--split-debug-info=infos/');
+        watch.start();
+        await flutter('build', options: options);
+        watch.stop();
+        final String buildDirectoryPath = path.join(
+          cwd,
+          'build',
+          'macos',
+          'Build',
+          'Products',
+          'Release',
+        );
+        final String? appBundlePath =
+            _findIosAppInBuildDirectory(buildDirectoryPath);
+        if (appBundlePath == null) {
+          throw 'Failed to find app bundle in $buildDirectoryPath';
+        }
+        final Directory appBundle = Directory(appBundlePath);
+        final Archive archive = Archive();
+        await appBundle
+            .list(recursive: true)
+            .where((FileSystemEntity e) => e.runtimeType == File)
+            .map<ArchiveFile>((FileSystemEntity e) {
+              assert(e.runtimeType == File);
+              final File file = e as File;
+              return ArchiveFile(file.path, file.statSync().size, file.readAsBytesSync());
+            })
+            .forEach((ArchiveFile file) => archive.addFile(file));
+        releaseSizeInBytes = TarEncoder().encode(archive).length;
+        break;
       case DeviceOperatingSystem.windows:
         unawaited(stderr.flush());
         options.insert(0, 'windows');


### PR DESCRIPTION
#### Reason
> The initial desktop integration tests are running now, but they need to be expanded beyond the initial gallery build test; filing this to make sure that planned work is captured in the issue tracker. This should be much more straightforward that getting the first one running was, since the bot work is all complete.
> 
> In particular we should ensure we are testing building a freshly created project to catch errors in template changes. (I haven't checked where that test lives on existing platforms; it may be a device lab test, which still needs desktop bring-up).

#### Related
fixes https://github.com/flutter/flutter/issues/110082

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.