### PR TITLE
Support for FilterQuality in FadeInImage

### DIFF
--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -309,7 +309,7 @@ class FadeInImage extends StatefulWidget {
   ///
   /// If not value set, it will fallback to [fit].
   final BoxFit? placeholderFit;
-  
+
   /// The rendering quality of the image.
   ///
   /// If the image is of a high quality and its pixels are perfectly aligned
@@ -327,7 +327,7 @@ class FadeInImage extends StatefulWidget {
   ///  * [FilterQuality], the enum containing all possible filter quality
   ///    options.
   final FilterQuality? filterQuality;
-  
+
   /// The rendering quality of the placeholder image.
   ///
   /// If the placeholder image is of a high quality and its pixels are perfectly aligned

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -428,7 +428,7 @@ class _FadeInImageState extends State<FadeInImage> {
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
     BoxFit? fit,
-    FilterQuality filterQuality,
+    required FilterQuality filterQuality,
     required Animation<double> opacity,
   }) {
     assert(image != null);

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -65,10 +65,10 @@ class FadeInImage extends StatefulWidget {
   /// The [placeholder] and [image] may be composed in a [ResizeImage] to provide
   /// a custom decode/cache size.
   ///
-  /// The [placeholder] and [image] may be have their own BoxFit settings via [fit]
+  /// The [placeholder] and [image] may have their own BoxFit settings via [fit]
   /// and [placeholderFit].
   ///
-  /// The [placeholder] and [image] may be have their own FilterQuality settings via [filterQuality]
+  /// The [placeholder] and [image] may have their own FilterQuality settings via [filterQuality]
   /// and [placeholderFilterQuality].
   ///
   /// The [placeholder], [image], [fadeOutDuration], [fadeOutCurve],
@@ -322,11 +322,13 @@ class FadeInImage extends StatefulWidget {
   /// improve the rendered image quality in this case. Pixels may be misaligned
   /// with the screen pixels as a result of transforms or scaling.
   ///
+  /// The default is [FilterQuality.low].
+  ///
   /// See also:
   ///
   ///  * [FilterQuality], the enum containing all possible filter quality
   ///    options.
-  final FilterQuality? filterQuality;
+  final FilterQuality filterQuality = FilterQuality.low;
 
   /// The rendering quality of the placeholder image.
   ///
@@ -426,7 +428,7 @@ class _FadeInImageState extends State<FadeInImage> {
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
     BoxFit? fit,
-    FilterQuality? filterQuality,
+    FilterQuality filterQuality,
     required Animation<double> opacity,
   }) {
     assert(image != null);
@@ -438,7 +440,7 @@ class _FadeInImageState extends State<FadeInImage> {
       width: widget.width,
       height: widget.height,
       fit: fit,
-      filterQuality: filterQuality ?? FilterQuality.low,
+      filterQuality: filterQuality,
       alignment: widget.alignment,
       repeat: widget.repeat,
       matchTextDirection: widget.matchTextDirection,

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -310,44 +310,10 @@ class FadeInImage extends StatefulWidget {
   /// If not value set, it will fallback to [fit].
   final BoxFit? placeholderFit;
 
-  /// The rendering quality of the image.
-  ///
-  /// If the image is of a high quality and its pixels are perfectly aligned
-  /// with the physical screen pixels, extra quality enhancement may not be
-  /// necessary. If so, then [FilterQuality.none] would be the most efficient.
-  ///
-  /// If the pixels are not perfectly aligned with the screen pixels, or if the
-  /// image itself is of a low quality, [FilterQuality.none] may produce
-  /// undesirable artifacts. Consider using other [FilterQuality] values to
-  /// improve the rendered image quality in this case. Pixels may be misaligned
-  /// with the screen pixels as a result of transforms or scaling.
-  ///
-  /// The default is [FilterQuality.low].
-  ///
-  /// See also:
-  ///
-  ///  * [FilterQuality], the enum containing all possible filter quality
-  ///    options.
+  /// {@macro flutter.widgets.image.filterQuality}
   final FilterQuality filterQuality;
 
-  /// The rendering quality of the placeholder image.
-  ///
-  /// If the placeholder image is of a high quality and its pixels are perfectly aligned
-  /// with the physical screen pixels, extra quality enhancement may not be
-  /// necessary. If so, then [FilterQuality.none] would be the most efficient.
-  ///
-  /// If the pixels are not perfectly aligned with the screen pixels, or if the
-  /// placeholder image itself is of a low quality, [FilterQuality.none] may produce
-  /// undesirable artifacts. Consider using other [FilterQuality] values to
-  /// improve the rendered image quality in this case. Pixels may be misaligned
-  /// with the screen pixels as a result of transforms or scaling.
-  ///
-  /// If not value set, it will fallback to [filterQuality].
-  ///
-  /// See also:
-  ///
-  ///  * [FilterQuality], the enum containing all possible filter quality
-  ///    options.
+  /// {@macro flutter.widgets.image.filterQuality}
   final FilterQuality? placeholderFilterQuality;
 
   /// How to align the image within its bounds.

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -68,6 +68,9 @@ class FadeInImage extends StatefulWidget {
   /// The [placeholder] and [image] may be have their own BoxFit settings via [fit]
   /// and [placeholderFit].
   ///
+  /// The [placeholder] and [image] may be have their own FilterQuality settings via [filterQuality]
+  /// and [placeholderFilterQuality].
+  ///
   /// The [placeholder], [image], [fadeOutDuration], [fadeOutCurve],
   /// [fadeInDuration], [fadeInCurve], [alignment], [repeat], and
   /// [matchTextDirection] arguments must not be null.
@@ -89,6 +92,8 @@ class FadeInImage extends StatefulWidget {
     this.height,
     this.fit,
     this.placeholderFit,
+    this.filterQuality,
+    this.placeholderFilterQuality,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
@@ -148,6 +153,8 @@ class FadeInImage extends StatefulWidget {
     this.height,
     this.fit,
     this.placeholderFit,
+    this.filterQuality,
+    this.placeholderFilterQuality,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
@@ -219,6 +226,8 @@ class FadeInImage extends StatefulWidget {
     this.height,
     this.fit,
     this.placeholderFit,
+    this.filterQuality,
+    this.placeholderFilterQuality,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
     this.matchTextDirection = false,
@@ -300,6 +309,44 @@ class FadeInImage extends StatefulWidget {
   ///
   /// If not value set, it will fallback to [fit].
   final BoxFit? placeholderFit;
+  
+  /// The rendering quality of the image.
+  ///
+  /// If the image is of a high quality and its pixels are perfectly aligned
+  /// with the physical screen pixels, extra quality enhancement may not be
+  /// necessary. If so, then [FilterQuality.none] would be the most efficient.
+  ///
+  /// If the pixels are not perfectly aligned with the screen pixels, or if the
+  /// image itself is of a low quality, [FilterQuality.none] may produce
+  /// undesirable artifacts. Consider using other [FilterQuality] values to
+  /// improve the rendered image quality in this case. Pixels may be misaligned
+  /// with the screen pixels as a result of transforms or scaling.
+  ///
+  /// See also:
+  ///
+  ///  * [FilterQuality], the enum containing all possible filter quality
+  ///    options.
+  final FilterQuality? filterQuality;
+  
+  /// The rendering quality of the placeholder image.
+  ///
+  /// If the placeholder image is of a high quality and its pixels are perfectly aligned
+  /// with the physical screen pixels, extra quality enhancement may not be
+  /// necessary. If so, then [FilterQuality.none] would be the most efficient.
+  ///
+  /// If the pixels are not perfectly aligned with the screen pixels, or if the
+  /// placeholder image itself is of a low quality, [FilterQuality.none] may produce
+  /// undesirable artifacts. Consider using other [FilterQuality] values to
+  /// improve the rendered image quality in this case. Pixels may be misaligned
+  /// with the screen pixels as a result of transforms or scaling.
+  ///
+  /// If not value set, it will fallback to [filterQuality].
+  ///
+  /// See also:
+  ///
+  ///  * [FilterQuality], the enum containing all possible filter quality
+  ///    options.
+  final FilterQuality? placeholderFilterQuality;
 
   /// How to align the image within its bounds.
   ///
@@ -379,6 +426,7 @@ class _FadeInImageState extends State<FadeInImage> {
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
     BoxFit? fit,
+    FilterQuality? filterQuality,
     required Animation<double> opacity,
   }) {
     assert(image != null);
@@ -390,6 +438,7 @@ class _FadeInImageState extends State<FadeInImage> {
       width: widget.width,
       height: widget.height,
       fit: fit,
+      filterQuality: filterQuality,
       alignment: widget.alignment,
       repeat: widget.repeat,
       matchTextDirection: widget.matchTextDirection,
@@ -405,6 +454,7 @@ class _FadeInImageState extends State<FadeInImage> {
       errorBuilder: widget.imageErrorBuilder,
       opacity: _imageAnimation,
       fit: widget.fit,
+      filterQuality: widget.filterQuality,
       frameBuilder: (BuildContext context, Widget child, int? frame, bool wasSynchronouslyLoaded) {
         if (wasSynchronouslyLoaded || frame != null) {
           targetLoaded = true;
@@ -417,6 +467,7 @@ class _FadeInImageState extends State<FadeInImage> {
             errorBuilder: widget.placeholderErrorBuilder,
             opacity: _placeholderAnimation,
             fit: widget.placeholderFit ?? widget.fit,
+            filterQuality: widget.placeholderFilterQuality ?? widget.filterQuality,
           ),
           placeholderProxyAnimation: _placeholderAnimation,
           isTargetLoaded: targetLoaded,

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -310,9 +310,13 @@ class FadeInImage extends StatefulWidget {
   /// If not value set, it will fallback to [fit].
   final BoxFit? placeholderFit;
 
+  /// The rendering quality of the image.
+  ///
   /// {@macro flutter.widgets.image.filterQuality}
   final FilterQuality filterQuality;
 
+  /// The rendering quality of the placeholder image.
+  ///
   /// {@macro flutter.widgets.image.filterQuality}
   final FilterQuality? placeholderFilterQuality;
 

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -92,7 +92,7 @@ class FadeInImage extends StatefulWidget {
     this.height,
     this.fit,
     this.placeholderFit,
-    this.filterQuality,
+    this.filterQuality = FilterQuality.low,
     this.placeholderFilterQuality,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
@@ -153,7 +153,7 @@ class FadeInImage extends StatefulWidget {
     this.height,
     this.fit,
     this.placeholderFit,
-    this.filterQuality,
+    this.filterQuality = FilterQuality.low,
     this.placeholderFilterQuality,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
@@ -226,7 +226,7 @@ class FadeInImage extends StatefulWidget {
     this.height,
     this.fit,
     this.placeholderFit,
-    this.filterQuality,
+    this.filterQuality = FilterQuality.low,
     this.placeholderFilterQuality,
     this.alignment = Alignment.center,
     this.repeat = ImageRepeat.noRepeat,
@@ -328,7 +328,7 @@ class FadeInImage extends StatefulWidget {
   ///
   ///  * [FilterQuality], the enum containing all possible filter quality
   ///    options.
-  final FilterQuality filterQuality = FilterQuality.low;
+  final FilterQuality filterQuality;
 
   /// The rendering quality of the placeholder image.
   ///

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -426,7 +426,7 @@ class _FadeInImageState extends State<FadeInImage> {
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
     BoxFit? fit,
-    FilterQuality? filterQuality,
+    FilterQuality filterQuality = FilterQuality.low,
     required Animation<double> opacity,
   }) {
     assert(image != null);

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -426,7 +426,7 @@ class _FadeInImageState extends State<FadeInImage> {
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
     BoxFit? fit,
-    FilterQuality? filterQuality = FilterQuality.low,
+    FilterQuality? filterQuality,
     required Animation<double> opacity,
   }) {
     assert(image != null);
@@ -438,7 +438,7 @@ class _FadeInImageState extends State<FadeInImage> {
       width: widget.width,
       height: widget.height,
       fit: fit,
-      filterQuality: filterQuality,
+      filterQuality: filterQuality ?? FilterQuality.low,
       alignment: widget.alignment,
       repeat: widget.repeat,
       matchTextDirection: widget.matchTextDirection,

--- a/packages/flutter/lib/src/widgets/fade_in_image.dart
+++ b/packages/flutter/lib/src/widgets/fade_in_image.dart
@@ -426,7 +426,7 @@ class _FadeInImageState extends State<FadeInImage> {
     ImageErrorWidgetBuilder? errorBuilder,
     ImageFrameBuilder? frameBuilder,
     BoxFit? fit,
-    FilterQuality filterQuality = FilterQuality.low,
+    FilterQuality? filterQuality = FilterQuality.low,
     required Animation<double> opacity,
   }) {
     assert(image != null);

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -868,6 +868,7 @@ class Image extends StatefulWidget {
   ///    from a single opacity value.
   final Animation<double>? opacity;
 
+  /// {@template flutter.widgets.image.filterQuality}
   /// The rendering quality of the image.
   ///
   /// If the image is of a high quality and its pixels are perfectly aligned
@@ -884,6 +885,7 @@ class Image extends StatefulWidget {
   ///
   ///  * [FilterQuality], the enum containing all possible filter quality
   ///    options.
+  /// {@endtemplate}
   final FilterQuality filterQuality;
 
   /// Used to combine [color] with this image.

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -868,9 +868,9 @@ class Image extends StatefulWidget {
   ///    from a single opacity value.
   final Animation<double>? opacity;
 
-  /// {@template flutter.widgets.image.filterQuality}
   /// The rendering quality of the image.
   ///
+  /// {@template flutter.widgets.image.filterQuality}
   /// If the image is of a high quality and its pixels are perfectly aligned
   /// with the physical screen pixels, extra quality enhancement may not be
   /// necessary. If so, then [FilterQuality.none] would be the most efficient.

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -52,6 +52,7 @@ class FadeInImageElements {
   RawImage get rawImage => rawImageElement.widget as RawImage;
   double get opacity => rawImage.opacity?.value ?? 1.0;
   BoxFit? get fit => rawImage.fit;
+  FilterQuality? get filterQuality => rawImage.filterQuality;
 }
 
 class LoadTestImageProvider extends ImageProvider<Object> {
@@ -515,6 +516,37 @@ Future<void> main() async {
 
         expect(findFadeInImage(tester).target.fit, equals(BoxFit.cover));
         expect(findFadeInImage(tester).placeholder!.fit, equals(BoxFit.fill));
+      });
+    });
+    
+    group("placeholder's FilterQuality", () {
+      testWidgets("should be the image's FilterQuality when not set", (WidgetTester tester) async {
+        final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+        final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(FadeInImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          filterQuality: FilterQuality.medium,
+        ));
+
+        expect(findFadeInImage(tester).placeholder!.filterQuality, equals(findFadeInImage(tester).target.filterQuality));
+        expect(findFadeInImage(tester).placeholder!.filterQuality, equals(FilterQuality.medium));
+      });
+
+      testWidgets('should be the given value when set', (WidgetTester tester) async {
+        final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);
+        final TestImageProvider imageProvider = TestImageProvider(targetImage);
+
+        await tester.pumpWidget(FadeInImage(
+          placeholder: placeholderProvider,
+          image: imageProvider,
+          filterQuality: FilterQuality.medium,
+          placeholderFilterQuality: FilterQuality.high,
+        ));
+
+        expect(findFadeInImage(tester).target.filterQuality, equals(FilterQuality.medium));
+        expect(findFadeInImage(tester).placeholder!.filterQuality, equals(FilterQuality.high));
       });
     });
   });

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -518,7 +518,7 @@ Future<void> main() async {
         expect(findFadeInImage(tester).placeholder!.fit, equals(BoxFit.fill));
       });
     });
-    
+
     group("placeholder's FilterQuality", () {
       testWidgets("should be the image's FilterQuality when not set", (WidgetTester tester) async {
         final TestImageProvider placeholderProvider = TestImageProvider(placeholderImage);


### PR DESCRIPTION
This PR modifies `FadeInImage` to accept an invididual `filterQuality` for both the image as well as the placeholder image, heavily inspired by https://github.com/flutter/flutter/pull/90739 for the test.

Related issue: https://github.com/flutter/flutter/issues/28993.

- Adds parameters `filterQuality` and `placeholderFilterQuality` to the FadeInImage constructor as well as the factory methods FadeInImage.memoryNetwork, FadeInImage.assetNetwork and passes them inside the build method similarly to `fit` and `placeholderFit`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
