### PR TITLE
[macOS] Bring up "flutter_view" devicelab, startup tests for x86 and arm64.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2444,6 +2444,15 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Mac flutter_view_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: flutter_view_macos__start_up
+
   - name: Mac framework_tests_libraries
     recipe: flutter/flutter_drone
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2398,6 +2398,15 @@ targets:
       tags: >
         ["framework", "hostonly", "shard"]
 
+  - name: Mac complex_layout_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: complex_layout_macos__start_up
+
   - name: Mac customer_testing
     recipe: flutter/flutter
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2453,6 +2453,15 @@ targets:
         ["devicelab", "hostonly"]
       task_name: flutter_view_macos__start_up
 
+  - name: Mac_arm64 flutter_view_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: flutter_view_macos__start_up
+
   - name: Mac framework_tests_libraries
     recipe: flutter/flutter_drone
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2407,6 +2407,15 @@ targets:
         ["devicelab", "hostonly"]
       task_name: complex_layout_macos__start_up
 
+  - name: Mac_arm64 complex_layout_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: complex_layout_macos__start_up
+
   - name: Mac customer_testing
     recipe: flutter/flutter
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -226,6 +226,7 @@
 /dev/devicelab/bin/tasks/complex_layout_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/flutter_view_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/platform_view_win_desktop__start_up.dart @schectman @flutter/desktop
+/dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -227,6 +227,7 @@
 /dev/devicelab/bin/tasks/flutter_view_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/platform_view_win_desktop__start_up.dart @schectman @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/flutter_view_macos__start_up.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createComplexLayoutStartupTest());
+}

--- a/dev/devicelab/bin/tasks/flutter_view_macos__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view_macos__start_up.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.ios;
+  await task(createFlutterViewStartupTest());
+}

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -671,7 +671,7 @@ class StartupTest {
             '--profile',
             '--target=$target',
           ]);
-          applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
+          applicationBinaryPath = _findDarwinAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
         case DeviceOperatingSystem.fake:
         case DeviceOperatingSystem.fuchsia:
@@ -805,7 +805,7 @@ class DevtoolsStartupTest {
              '-v',
             '--profile',
           ]);
-          applicationBinaryPath = _findIosAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
+          applicationBinaryPath = _findDarwinAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
           break;
         case DeviceOperatingSystem.fake:
         case DeviceOperatingSystem.fuchsia:
@@ -1884,7 +1884,7 @@ Future<File> waitForFile(String path) async {
   throw StateError('Did not find vmservice out file after 1 hour');
 }
 
-String? _findIosAppInBuildDirectory(String searchDirectory) {
+String? _findDarwinAppInBuildDirectory(String searchDirectory) {
   for (final FileSystemEntity entity in Directory(searchDirectory).listSync()) {
     if (entity.path.endsWith('.app')) {
       return entity.path;

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1885,7 +1885,8 @@ Future<File> waitForFile(String path) async {
 }
 
 String? _findDarwinAppInBuildDirectory(String searchDirectory) {
-  for (final FileSystemEntity entity in Directory(searchDirectory).listSync()) {
+  for (final FileSystemEntity entity in Directory(searchDirectory)
+    .listSync(recursive: true)) {
     if (entity.path.endsWith('.app')) {
       return entity.path;
     }

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -664,18 +664,26 @@ class StartupTest {
           ]);
           applicationBinaryPath = '$testDirectory/build/app/outputs/flutter-apk/app-profile.apk';
           break;
+        case DeviceOperatingSystem.fake:
+        case DeviceOperatingSystem.fuchsia:
+          break;
         case DeviceOperatingSystem.ios:
+        case DeviceOperatingSystem.macos:
+          final String? deviceName = <DeviceOperatingSystem, String>{
+            DeviceOperatingSystem.macos: 'macos',
+            DeviceOperatingSystem.ios: 'ios',
+          }[deviceOperatingSystem];
+          if(deviceName == null) {
+            throw Exception('$deviceOperatingSystem is not a valid Darwin platform.');
+          }
           await flutter('build', options: <String>[
-            'ios',
+            deviceName,
              '-v',
             '--profile',
             '--target=$target',
           ]);
-          applicationBinaryPath = _findDarwinAppInBuildDirectory('$testDirectory/build/ios/iphoneos');
-          break;
-        case DeviceOperatingSystem.fake:
-        case DeviceOperatingSystem.fuchsia:
-        case DeviceOperatingSystem.macos:
+          final String buildRoot = path.join(testDirectory, 'build');
+          applicationBinaryPath = _findDarwinAppInBuildDirectory(buildRoot);
           break;
         case DeviceOperatingSystem.windows:
           await flutter('build', options: <String>[


### PR DESCRIPTION
#### Reason
> The initial desktop integration tests are running now, but they need to be expanded beyond the initial gallery build test; filing this to make sure that planned work is captured in the issue tracker. This should be much more straightforward that getting the first one running was, since the bot work is all complete.
> 
> In particular we should ensure we are testing building a freshly created project to catch errors in template changes. (I haven't checked where that test lives on existing platforms; it may be a device lab test, which still needs desktop bring-up).

#### Related
fixes https://github.com/flutter/flutter/issues/110085

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.