### PR TITLE
Fix Image's logical flow which disposes its image too early, causing errors such as "Cannot clone a disposed image"

### DIFF
--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1171,7 +1171,8 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   }
 
   void _replaceImage({required ImageInfo? info}) {
-    _imageInfo?.dispose();
+    ImageInfo? oldImageInfo = _imageInfo;
+    SchedulerBinding.instance.addPostFrameCallback((_) => oldImageInfo?.dispose());
     _imageInfo = info;
   }
 

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -1171,7 +1171,7 @@ class _ImageState extends State<Image> with WidgetsBindingObserver {
   }
 
   void _replaceImage({required ImageInfo? info}) {
-    ImageInfo? oldImageInfo = _imageInfo;
+    final ImageInfo? oldImageInfo = _imageInfo;
     SchedulerBinding.instance.addPostFrameCallback((_) => oldImageInfo?.dispose());
     _imageInfo = info;
   }

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -36,6 +36,8 @@ void main() {
   });
 
   testWidgets('Verify Image does not use disposed handles', (WidgetTester tester) async {
+    final ui.Image image100x100 = (await tester.runAsync(() async => createTestImage(width: 100, height: 100)))!;
+
     final _TestImageProvider imageProvider1 = _TestImageProvider();
     final _TestImageProvider imageProvider2 = _TestImageProvider();
 
@@ -74,7 +76,7 @@ void main() {
     imageLoaded = false;
     imageListenable.value = imageProvider2;
     innerListenable.value += 1;
-    imageProvider2.complete(image10x10);
+    imageProvider2.complete(image100x100);
     await tester.idle();
     await tester.pump();
     expect(imageLoaded, true);

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -35,7 +35,7 @@ void main() {
     imageCache.maximumSize = originalCacheSize;
   });
 
-  testWidgets('Verify Image does not use disposed handles', (tester) async {
+  testWidgets('Verify Image does not use disposed handles', (WidgetTester tester) async {
     final ValueNotifier<int> outerListenable = ValueNotifier<int>(0);
     final ValueNotifier<int> innerListenable = ValueNotifier<int>(0);
 
@@ -43,13 +43,13 @@ void main() {
     MemoryImage image = MemoryImage(Uint8List.fromList(kTransparentImage));
 
     Future<void> runAsyncAndIdle() async {
-      for (var i = 0; i < 20; ++i) {
+      for (int i = 0; i < 20; ++i) {
         await tester.runAsync(() => Future<void>.delayed(Duration.zero));
         await tester.idle();
       }
     }
 
-    await tester.pumpWidget(ValueListenableBuilder(
+    await tester.pumpWidget(ValueListenableBuilder<int>(
       valueListenable: outerListenable,
       builder: (BuildContext _, Object? __, Widget? ___) => Image(
         image: image,
@@ -58,7 +58,7 @@ void main() {
             imageLoaded = true;
           }
           return LayoutBuilder(
-            builder: (BuildContext _, BoxConstraints __) => ValueListenableBuilder(
+            builder: (BuildContext _, BoxConstraints __) => ValueListenableBuilder<int>(
               valueListenable: innerListenable,
               builder: (BuildContext _, Object? __, Widget? ___) => KeyedSubtree(
                 key: UniqueKey(),

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -81,7 +81,7 @@ void main() {
     imageLoaded = false;
     while (!imageLoaded) {
       await runAsyncAndIdle();
-      innerListenable.value++;
+      innerListenable.value += 1;
       await tester.pump();
     }
   });

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -76,7 +76,7 @@ void main() {
     }
 
     image = MemoryImage(Uint8List.fromList(kBlueSquarePng));
-    outerListenable.value++;
+    outerListenable.value += 1;
 
     imageLoaded = false;
     while (!imageLoaded) {

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -51,14 +51,16 @@ void main() {
 
     await tester.pumpWidget(ValueListenableBuilder(
       valueListenable: outerListenable,
-      builder: (_, __, ___) => Image(
+      builder: (BuildContext _, Object? __, Widget? ___) => Image(
         image: image,
-        frameBuilder: (_, child, __, ___) {
-          if (((child as Semantics).child! as RawImage).image != null) imageLoaded = true;
+        frameBuilder: (BuildContext _, Widget child, int? __, bool ___) {
+          if (((child as Semantics).child! as RawImage).image != null) {
+            imageLoaded = true;
+          }
           return LayoutBuilder(
-            builder: (_, __) => ValueListenableBuilder(
+            builder: (BuildContext _, BoxConstraints __) => ValueListenableBuilder(
               valueListenable: innerListenable,
-              builder: (_, __, ___) => KeyedSubtree(
+              builder: (BuildContext _, Object? __, Widget? ___) => KeyedSubtree(
                 key: UniqueKey(),
                 child: child,
               ),

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -73,7 +73,7 @@ void main() {
       await tester.pump();
     }
 
-    image = MemoryImage(MemoryImage(Uint8List.fromList(kBlueSquarePng));
+    image = MemoryImage(Uint8List.fromList(kBlueSquarePng));
     outerListenable.value++;
 
     imageLoaded = false;


### PR DESCRIPTION
Close #110129

Please see the issue for paragraphs about the bug cause and fix etc

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
