### PR TITLE
[platform_view]delete previously installed app if needed

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -32,10 +32,10 @@ static const CGFloat kStandardTimeOut = 60.0;
   XCUIApplication *springboard = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
   [springboard activate];
   XCUIElement *appIcon = springboard.icons[@"ios_platform_view_tests"];
-  
+
   if ([appIcon waitForExistenceWithTimeout:kStandardTimeOut]) {
     NSLog(@"Deleting previously installed app.");
-    
+
     // Make icons wiggle
     [appIcon pressForDuration:3];
 
@@ -51,7 +51,7 @@ static const CGFloat kStandardTimeOut = 60.0;
   } else {
     NSLog(@"No previously installed app found.");
   }
-  
+
   self.app = [[XCUIApplication alloc] init];
   [self.app launch];
 }

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -26,29 +26,34 @@ static const CGFloat kStandardTimeOut = 60.0;
   [super setUp];
   self.continueAfterFailure = NO;
 
-  // Retry launching the app if it fails to launch.
-  // This is trying to fix a "failed to terminate" failure, which is likely a bug in Xcode.
-  // The solution is based on https://stackoverflow.com/questions/41872848/xctests-failing-to-launch-app-in-simulator-intermittently
-  int remainingLaunchCount = 10;
-  while (true) {
-    self.app = [[XCUIApplication alloc] init];
-    [self.app launch];
-    remainingLaunchCount -= 1;
+  // Delete the previously installed app if needed before running.
+  // This is to address "Failed to terminate" failure.
+  // The solution is based on https://stackoverflow.com/questions/50016018/uitest-failed-to-terminate-com-test-abc3708-after-60-0s-state-is-still-runnin
+  XCUIApplication *springboard = [[XCUIApplication alloc] initWithBundleIdentifier:@"com.apple.springboard"];
+  [springboard activate];
+  XCUIElement *appIcon = springboard.icons[@"ios_platform_view_tests"];
+  
+  if ([appIcon waitForExistenceWithTimeout:kStandardTimeOut]) {
+    NSLog(@"Deleting previously installed app.");
+    
+    // Make icons wiggle
+    [appIcon pressForDuration:3];
+
+    // Tap the "x" button
+    [appIcon.buttons[@"DeleteButton"] tap];
+    // Tap the delete confirmation
+    [springboard.alerts.buttons[@"Delete App"] tap];
+    // Tap the second delete confirmation
+    [springboard.alerts.buttons[@"Delete"] tap];
+    // Press home button to stop wiggling
+    [XCUIDevice.sharedDevice pressButton:XCUIDeviceButtonHome];
     [NSThread sleepForTimeInterval:3];
-    if (self.app.exists) {
-      // success launch
-      break;
-    }
-
-    if (remainingLaunchCount > 0) {
-      NSLog(@"Retry launch with remaining launch count %d", remainingLaunchCount);
-      [self.app terminate];
-      [NSThread sleepForTimeInterval:3];
-      continue;
-    }
-
-    NSLog(@"Failed to launch");
+  } else {
+    NSLog(@"No previously installed app found.");
   }
+  
+  self.app = [[XCUIApplication alloc] init];
+  [self.app launch];
 }
 
 - (void)tearDown {


### PR DESCRIPTION
Besides relaunching the app, [the only other solution I found](https://stackoverflow.com/questions/50016018/uitest-failed-to-terminate-com-test-abc3708-after-60-0s-state-is-still-runnin
) is to deleting the previously installed app if needed (tho that answer is not yet accepted by OP)


I have tried running it on simulator with and without previously installed app.  

led: 
https://chromium-swarm.appspot.com/task?id=5ce9e752e3912010


*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/110184

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
