### PR TITLE
Add test where white text on white background fails contrast.

### DIFF
--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -43,6 +43,40 @@ void main() {
       handle.dispose();
     });
 
+    testWidgets('White text on white background fails contrast test',
+      (WidgetTester tester) async {
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(
+      _boilerplate(
+        Container(
+          width: 200.0,
+          height: 200.0,
+          color: Colors.white,
+          child: Column(
+            children: const <Widget>[
+              Text(
+                'this is a white text',
+                style: TextStyle(fontSize: 14.0, color: Colors.white),
+              ),
+              SizedBox(height: 50),
+              Text(
+                'this is a black text test1',
+                style: TextStyle(fontSize: 14.0, color: Colors.black),
+              ),
+              SizedBox(height: 50),
+              Text(
+                'this is a black text test2',
+                style: TextStyle(fontSize: 14.0, color: Colors.black),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await expectLater(tester, doesNotMeetGuideline(textContrastGuideline));
+    handle.dispose();
+  });
+
     const Color surface = Color(0xFFF0F0F0);
 
     /// Shades of blue with contrast ratio of 2.9, 4.4, 4.5 from [surface].

--- a/packages/flutter_test/test/accessibility_test.dart
+++ b/packages/flutter_test/test/accessibility_test.dart
@@ -50,7 +50,7 @@ void main() {
       _boilerplate(
         Container(
           width: 200.0,
-          height: 200.0,
+          height: 300.0,
           color: Colors.white,
           child: Column(
             children: const <Widget>[


### PR DESCRIPTION
Add a test to check contrast for white text on white.

#109465 Improve flutter contrast test coverage
#103235 meetsGuideline(textContrastGuideline) passes with white text on almost-white background

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
