### PR TITLE
Fix long text disappears when TextField height is small

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -2570,10 +2570,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   void paint(PaintingContext context, Offset offset) {
     _computeTextMetricsIfNeeded();
     if (_hasVisualOverflow && clipBehavior != Clip.none) {
+      final double minClipHeight = math.max(size.height, preferredLineHeight);
       _clipRectLayer.layer = context.pushClipRect(
         needsCompositing,
         offset,
-        Offset.zero & size,
+        Offset.zero & Size(size.width, minClipHeight),
         _paintContents,
         clipBehavior: clipBehavior,
         oldLayer: _clipRectLayer.layer,


### PR DESCRIPTION
## Description

As reported in https://github.com/flutter/flutter/issues/78622, when using a small TextField height, a short text is entirely visible but a longer one could partially (or fully) disappear.
This is related to `RenderEditable.paint` adding clipping only when the text overflows. 

This PR changes the height of the clip to use `RenderEditable.preferredLineHeight` as a minimal value.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/78622

## Tests

Updates 1 test.