### PR TITLE
#109455 Add post-frame update for DragTarget

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,3 +95,4 @@ Taskulu LDA <contributions@taskulu.com>
 Jonathan Joelson <jon@joelson.co>
 Elsabe Ros <hello@elsabe.dev>
 Nguyễn Phúc Lợi <nploi1998@gmail.com>
+ltOgt <omnesiaorg@gmail.com>

--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -9,6 +9,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/widgets/drag_target.dart';
 
 import 'box.dart';
 import 'debug.dart';
@@ -373,6 +374,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
   void _handlePersistentFrameCallback(Duration timeStamp) {
     drawFrame();
     _scheduleMouseTrackerUpdate();
+    _scheduleDragTargetUpdate();
   }
 
   bool _debugMouseTrackerUpdateScheduled = false;
@@ -389,6 +391,12 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
         return true;
       }());
       _mouseTracker!.updateAllDevices(renderView.hitTestMouseTrackers);
+    });
+  }
+
+   void _scheduleDragTargetUpdate() {
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      DragTargetPostFrameUpdater.instance.updateAll();
     });
   }
 


### PR DESCRIPTION
#109455 describes how `MouseRegion.onEnter` is triggered by widgets that are inserted or moved under an active pointer, without the pointer moving itself.
This is not currently the case for `DragTarget.onWillAccept`.

This PR implements the same behaviour for `DragTarget.onWillAccept`.

#109455 also gives an example for how this is needed to implement e.g. the macOS "drag-file-and-hover-over-folder-to-change-directory" UI.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

This PR does not yet implement the necessary tests, and I would much appreciate some guidance on this point.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
