### PR TITLE
Add Xcode dependencies to `Mac hello_world_macos__compile`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2526,6 +2526,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "13f17a"}
+        ]
       tags: >
         ["devicelab", "hostonly"]
       task_name: hello_world_macos__compile


### PR DESCRIPTION
## Fixes https://github.com/flutter/flutter/issues/110277

> Yesterday, https://github.com/flutter/flutter/pull/110090 landed and brought up `hello_world_macos__compile` benchmark tests. Those tests ran successfully, locally because Xcode was installed. Running in the devicelab causes the test to fail due to a missing Xcode dependency in `.ci.yaml`.
> ...

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.