### PR TITLE
[flutter_tools] Pull more arm64 artifacts on Apple Silicon

### DIFF
--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -377,7 +377,7 @@ class _MacOSUtils extends _PosixUtils {
       if (results.every((RunResult result) => result.exitCode == 0)) {
         String osName = getNameForHostPlatform(hostPlatform);
         // If the script is running in Rosetta, "uname -m" will return x86_64.
-        if (hostPlatform == HostPlatform.darwin_arm && results[3].stdout.contains('x86_64')) {
+        if (hostPlatform == HostPlatform.darwin_arm64 && results[3].stdout.contains('x86_64')) {
           osName = '$osName (Rosetta)';
         }
         _name =
@@ -415,7 +415,7 @@ class _MacOSUtils extends _PosixUtils {
       // On arm64 stdout is "sysctl hw.optional.arm64: 1"
       // On x86 hw.optional.arm64 is unavailable and exits with 1.
       if (arm64Check.exitCode == 0 && arm64Check.stdout.trim().endsWith('1')) {
-        _hostPlatform = HostPlatform.darwin_arm;
+        _hostPlatform = HostPlatform.darwin_arm64;
       } else {
         _hostPlatform = HostPlatform.darwin_x64;
       }
@@ -604,7 +604,7 @@ String? findProjectRoot(FileSystem fileSystem, [ String? directory ]) {
 
 enum HostPlatform {
   darwin_x64,
-  darwin_arm,
+  darwin_arm64,
   linux_x64,
   linux_arm64,
   windows_x64,
@@ -614,8 +614,8 @@ String getNameForHostPlatform(HostPlatform platform) {
   switch (platform) {
     case HostPlatform.darwin_x64:
       return 'darwin-x64';
-    case HostPlatform.darwin_arm:
-      return 'darwin-arm';
+    case HostPlatform.darwin_arm64:
+      return 'darwin-arm64';
     case HostPlatform.linux_x64:
       return 'linux-x64';
     case HostPlatform.linux_arm64:

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -696,7 +696,7 @@ TargetPlatform getTargetPlatformForName(String platform) {
     // For backward-compatibility and also for Tester, where it must match
     // host platform name (HostPlatform.darwin_x64)
     case 'darwin-x64':
-    case 'darwin-arm':
+    case 'darwin-arm64':
       return TargetPlatform.darwin;
     case 'linux-x64':
       return TargetPlatform.linux_x64;
@@ -1034,8 +1034,8 @@ String getNameForHostPlatformArch(HostPlatform platform) {
   switch (platform) {
     case HostPlatform.darwin_x64:
       return 'x64';
-    case HostPlatform.darwin_arm:
-      return 'arm';
+    case HostPlatform.darwin_arm64:
+      return 'arm64';
     case HostPlatform.linux_x64:
       return 'x64';
     case HostPlatform.linux_arm64:

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -234,12 +234,12 @@ class FlutterSdk extends EngineCachedArtifact {
       if (cache.includeAllPlatforms) ...<List<String>>[
         <String>['windows-x64', 'windows-x64/artifacts.zip'],
         <String>['linux-$arch', 'linux-$arch/artifacts.zip'],
-        <String>['darwin-x64', 'darwin-x64/artifacts.zip'],
+        <String>['darwin-x64', 'darwin-$arch/artifacts.zip'],
       ]
       else if (_platform.isWindows)
         <String>['windows-x64', 'windows-x64/artifacts.zip']
       else if (_platform.isMacOS)
-        <String>['darwin-x64', 'darwin-x64/artifacts.zip']
+        <String>['darwin-x64', 'darwin-$arch/artifacts.zip']
       else if (_platform.isLinux)
         <String>['linux-$arch', 'linux-$arch/artifacts.zip'],
     ];
@@ -729,7 +729,7 @@ class FontSubsetArtifacts extends EngineCachedArtifact {
     // Currently only Linux supports both arm64 and x64.
     final String arch = cache.getHostPlatformArchName();
     final Map<String, List<String>> artifacts = <String, List<String>> {
-      'macos': <String>['darwin-x64', 'darwin-x64/$artifactName.zip'],
+      'macos': <String>['darwin-x64', 'darwin-$arch/$artifactName.zip'],
       'linux': <String>['linux-$arch', 'linux-$arch/$artifactName.zip'],
       'windows': <String>['windows-x64', 'windows-x64/$artifactName.zip'],
     };

--- a/packages/flutter_tools/lib/src/ios/xcodeproj.dart
+++ b/packages/flutter_tools/lib/src/ios/xcodeproj.dart
@@ -161,7 +161,7 @@ class XcodeProjectInterpreter {
   /// to run outside the x86 Rosetta translation, which may cause crashes.
   List<String> xcrunCommand() {
     final List<String> xcrunCommand = <String>[];
-    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
+    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64) {
       // Force Xcode commands to run outside Rosetta.
       xcrunCommand.addAll(<String>[
         '/usr/bin/arch',

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -362,7 +362,7 @@ class CocoaPods {
         emphasis: true,
       );
     } else if ((stderr.contains('ffi_c.bundle') || stderr.contains('/ffi/')) &&
-        _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
+        _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64) {
       // https://github.com/flutter/flutter/issues/70796
       UsageEvent(
         'pod-install-failure',

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -52,7 +52,7 @@ class MacOSDevice extends DesktopDevice {
 
   @override
   Future<String> get targetPlatformDisplayName async {
-    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
+    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64) {
       return 'darwin-arm64';
     } else {
       return 'darwin-x64';

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -47,11 +47,11 @@ class MacOSDesignedForIPadDevice extends DesktopDevice {
   Future<TargetPlatform> get targetPlatform async => TargetPlatform.darwin;
 
   @override
-  bool isSupported() => _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm;
+  bool isSupported() => _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64;
 
   @override
   bool isSupportedForProject(FlutterProject flutterProject) {
-    return flutterProject.ios.existsSync() && _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm;
+    return flutterProject.ios.existsSync() && _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64;
   }
 
   @override
@@ -119,7 +119,7 @@ class MacOSDesignedForIPadDevices extends PollingDeviceDiscovery {
   /// and discovery is allowed for this command.
   @override
   bool get canListAnything =>
-      _iosWorkflow.canListDevices && _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm && allowDiscovery;
+      _iosWorkflow.canListDevices && _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64 && allowDiscovery;
 
   /// Set to show ARM macOS as an iOS device target.
   static bool allowDiscovery = false;

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -15,7 +15,6 @@ import 'package:stream_channel/stream_channel.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
-import '../base/os.dart';
 import '../base/platform.dart';
 import '../convert.dart';
 import '../device.dart';
@@ -47,13 +46,7 @@ class FlutterTesterTestDevice extends TestDevice {
   })  : assert(shellPath != null), // Please provide the path to the shell in the SKY_SHELL environment variable.
         assert(!debuggingOptions.startPaused || enableObservatory),
         _gotProcessObservatoryUri = enableObservatory
-            ? Completer<Uri?>() : (Completer<Uri?>()..complete()),
-        _operatingSystemUtils = OperatingSystemUtils(
-          fileSystem: fileSystem,
-          logger: logger,
-          platform: platform,
-          processManager: processManager,
-        );
+            ? Completer<Uri?>() : (Completer<Uri?>()..complete());
 
   /// Used for logging to identify the test that is currently being executed.
   final int id;
@@ -77,7 +70,6 @@ class FlutterTesterTestDevice extends TestDevice {
 
   Process? _process;
   HttpServer? _server;
-  final OperatingSystemUtils _operatingSystemUtils;
 
   /// Starts the device.
   ///
@@ -94,13 +86,6 @@ class FlutterTesterTestDevice extends TestDevice {
     _server = await bind(host, /*port*/ 0);
     logger.printTrace('test $id: test harness socket server is running at port:${_server!.port}');
     final List<String> command = <String>[
-      // Until an arm64 flutter tester binary is available, force to run in Rosetta
-      // to avoid "unexpectedly got a signal in sigtramp" crash.
-      // https://github.com/flutter/flutter/issues/88106
-      if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) ...<String>[
-        '/usr/bin/arch',
-        '-x86_64',
-      ],
       shellPath,
       if (enableObservatory) ...<String>[
         // Some systems drive the _FlutterPlatform class in an unusual way, where

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -240,7 +240,7 @@ class ChromiumLauncher {
   }
 
   Future<Process?> _spawnChromiumProcess(List<String> args, String chromeExecutable) async {
-    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm) {
+    if (_operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64) {
       final ProcessResult result = _processManager.runSync(<String>['file', chromeExecutable]);
       // Check if ARM Chrome is installed.
       // Mach-O 64-bit executable arm64

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -219,7 +219,7 @@ void main() {
 
       final OperatingSystemUtils utils =
       createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.hostPlatform, HostPlatform.darwin_arm);
+      expect(utils.hostPlatform, HostPlatform.darwin_arm64);
     });
 
     testWithoutContext('macOS 11 x86', () async {
@@ -335,7 +335,7 @@ void main() {
 
       final OperatingSystemUtils utils =
           createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.name, 'product version build darwin-arm');
+      expect(utils.name, 'product version build darwin-arm64');
     });
 
     testWithoutContext('macOS ARM on Rosetta name', () async {
@@ -385,7 +385,7 @@ void main() {
 
       final OperatingSystemUtils utils =
       createOSUtils(FakePlatform(operatingSystem: 'macos'));
-      expect(utils.name, 'product version build darwin-arm (Rosetta)');
+      expect(utils.name, 'product version build darwin-arm64 (Rosetta)');
     });
 
     testWithoutContext('macOS x86 name', () async {

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -566,9 +566,9 @@ void main() {
       cache.includeAllPlatforms = true;
 
       expect(artifacts.getBinaryDirs(), <List<String>>[
-        <String>['darwin-x64', 'darwin-x64/font-subset.zip'], // arm64 macOS hosts are not supported now
+        <String>['darwin-x64', 'darwin-arm64/font-subset.zip'],
         <String>['linux-arm64', 'linux-arm64/font-subset.zip'],
-        <String>['windows-x64', 'windows-x64/font-subset.zip'], // arm64 macOS hosts are not supported now
+        <String>['windows-x64', 'windows-x64/font-subset.zip'], // arm64 windows hosts are not supported now
       ]);
   });
 

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -48,67 +48,9 @@ void main() {
       dartEntrypointArgs: dartEntrypointArgs,
     );
 
-  testUsingContext('runs in Rosetta on arm64 Mac', () async {
-    final FakeProcessManager processManager = FakeProcessManager.empty();
-    final FlutterTesterTestDevice device = TestFlutterTesterDevice(
-      platform: FakePlatform(operatingSystem: 'macos'),
-      fileSystem: fileSystem,
-      processManager: processManager,
-      enableObservatory: false,
-      dartEntrypointArgs: const <String>[],
-    );
-    processManager.addCommands(<FakeCommand>[
-      const FakeCommand(
-        command: <String>[
-          'which',
-          'sysctl',
-        ],
-      ),
-      const FakeCommand(
-        command: <String>[
-          'sysctl',
-          'hw.optional.arm64',
-        ],
-        stdout: 'hw.optional.arm64: 1',
-      ),
-      FakeCommand(command: const <String>[
-        '/usr/bin/arch',
-        '-x86_64',
-        '/',
-        '--disable-observatory',
-        '--ipv6',
-        '--enable-checked-mode',
-        '--verify-entry-points',
-        '--enable-software-rendering',
-        '--skia-deterministic-rendering',
-        '--enable-dart-profiling',
-        '--non-interactive',
-        '--use-test-fonts',
-        '--disable-asset-fonts',
-        '--packages=.dart_tool/package_config.json',
-        'example.dill',
-      ], environment: <String, String>{
-        'FLUTTER_TEST': 'true',
-        'FONTCONFIG_FILE': device.fontConfigManager.fontConfigFile.path,
-        'SERVER_PORT': '0',
-        'APP_NAME': '',
-      }),
-    ]);
-    await device.start('example.dill');
-    expect(processManager, hasNoRemainingExpectations);
-  });
-
   group('The FLUTTER_TEST environment variable is passed to the test process', () {
     setUp(() {
-      processManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(
-          command: <String>[
-            'uname',
-            '-m',
-          ],
-          stdout: 'x86_64',
-        ),
-      ]);
+      processManager = FakeProcessManager.list(<FakeCommand>[]);
       device = createDevice();
 
       fileSystem
@@ -177,13 +119,6 @@ void main() {
       processManager = FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
           command: <String>[
-            'uname',
-            '-m',
-          ],
-          stdout: 'x86_64',
-        ),
-        const FakeCommand(
-          command: <String>[
             '/',
             '--disable-observatory',
             '--ipv6',
@@ -217,13 +152,6 @@ void main() {
   group('DDS', () {
     setUp(() {
       processManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(
-          command: <String>[
-            'uname',
-            '-m',
-          ],
-          stdout: 'x86_64',
-        ),
         const FakeCommand(
           command: <String>[
             '/',

--- a/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_device_test.dart
@@ -197,7 +197,7 @@ void main() {
   testWithoutContext('target platform display name on ARM', () async {
     final FakeOperatingSystemUtils fakeOperatingSystemUtils =
         FakeOperatingSystemUtils();
-    fakeOperatingSystemUtils.hostPlatform = HostPlatform.darwin_arm;
+    fakeOperatingSystemUtils.hostPlatform = HostPlatform.darwin_arm64;
     final MacOSDevice device = MacOSDevice(
       fileSystem: MemoryFileSystem.test(),
       logger: BufferLogger.test(),

--- a/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
@@ -32,7 +32,7 @@ void main() {
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
         fileSystem: MemoryFileSystem.test(),
-        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
         iosWorkflow: FakeIOSWorkflow(canListDevices: true),
       );
 
@@ -45,7 +45,7 @@ void main() {
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
         fileSystem: MemoryFileSystem.test(),
-        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
         iosWorkflow: FakeIOSWorkflow(canListDevices: true),
       );
       expect(discoverer.supportsPlatform, isTrue);
@@ -77,7 +77,7 @@ void main() {
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
         fileSystem: MemoryFileSystem.test(),
-        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
         iosWorkflow: FakeIOSWorkflow(canListDevices: false),
       );
       expect(discoverer.supportsPlatform, isTrue);
@@ -93,7 +93,7 @@ void main() {
         logger: BufferLogger.test(),
         processManager: FakeProcessManager.any(),
         fileSystem: MemoryFileSystem.test(),
-        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+        operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
         iosWorkflow: FakeIOSWorkflow(canListDevices: true),
       );
       expect(discoverer.supportsPlatform, isTrue);
@@ -116,7 +116,7 @@ void main() {
       logger: BufferLogger.test(),
       processManager: FakeProcessManager.any(),
       fileSystem: MemoryFileSystem.test(),
-      operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm),
+      operatingSystemUtils: FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64),
     );
     expect(device.id, 'designed-for-ipad');
     expect(await device.isLocalEmulator, isFalse);

--- a/packages/flutter_tools/test/host_cross_arch.shard/cache_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/cache_test.dart
@@ -39,7 +39,7 @@ HostPlatform _identifyMacBinaryArch(String path) {
     case 'x86_64':
       return HostPlatform.darwin_x64;
     case 'arm64':
-      return HostPlatform.darwin_arm;
+      return HostPlatform.darwin_arm64;
     default:
       fail('Unexpected architecture ${match.group(1)}');
   }

--- a/packages/flutter_tools/test/web.shard/chrome_test.dart
+++ b/packages/flutter_tools/test/web.shard/chrome_test.dart
@@ -228,7 +228,7 @@ void main() {
   });
 
   testWithoutContext('can launch x86_64 Chrome on ARM macOS', () async {
-    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm);
+    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64);
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
       platform: platform,
@@ -267,7 +267,7 @@ void main() {
   });
 
   testWithoutContext('can launch ARM Chrome natively on ARM macOS when installed', () async {
-    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm);
+    final OperatingSystemUtils macOSUtils = FakeOperatingSystemUtils(hostPlatform: HostPlatform.darwin_arm64);
     final ChromiumLauncher chromiumLauncher = ChromiumLauncher(
       fileSystem: fileSystem,
       platform: platform,


### PR DESCRIPTION
If the host is an arm64 mac, this PR causes arm64 tools to be downloaded instead of x64 tools. To avoid a large refactoring to the artifact cache, the arm64 tools are still placed in the `darwin-x64` directory. Luckily the name of the directory isn't too important. We might even consider just renaming it `darwin` instead of trying to plumb host architecture information all over the place.

Fixes: https://github.com/flutter/flutter/issues/110227 https://github.com/flutter/flutter/issues/110226 https://github.com/flutter/flutter/issues/109892