### PR TITLE
Revert "[macOS] Bring up "flutter_gallery" devicelab, start up test for x86."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2478,20 +2478,6 @@ targets:
         ["devicelab", "hostonly"]
       task_name: flutter_gallery_macos__compile
 
-  - name: Mac flutter_gallery_macos__start_up
-    bringup: true # New target https://github.com/flutter/flutter/issues/109633
-    recipe: devicelab/devicelab_drone
-    timeout: 60
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "13f17a"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly"]
-      task_name: flutter_gallery_macos__compile
-
   - name: Mac framework_tests_libraries
     recipe: flutter/flutter_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -234,7 +234,6 @@
 /dev/devicelab/bin/tasks/windows_startup_test.dart @loic-sharma @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/flutter_gallery_macos__compile.dart @a-wallen @flutter/desktop
-/dev/devicelab/bin/tasks/flutter_gallery_macos__start_up.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/flutter_gallery_mac__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_mac__start_up.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/perf_tests.dart';
 
 Future<void> main() async {
-  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  // It's intended to use the Gallery startup test as a smoke test on macOS
+  // Catalina.
   await task(createFlutterGalleryStartupTest());
 }


### PR DESCRIPTION
Reverts flutter/flutter#110370

This closed the tree: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20flutter_gallery_mac__start_up/3652/overview

I'm not sure why it broke `Mac_android flutter_gallery_mac__start_up` since the breaking PR added `Mac flutter_gallery_macos__start_up`.  Maybe a naming conflict?