### PR TITLE
Switch to build+test model for `flutter_gallery__transition_perf`

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -29,6 +29,17 @@ platform_properties:
       os: Ubuntu
       cores: "8"
       device_type: none
+  linux_build_test:
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "android_sdk", "version": "version:33v6"},
+          {"dependency": "open_jdk", "version": "version:11"},
+          {"dependency": "curl", "version": "version:7.64.0"}
+        ]
+      os: Ubuntu
+      cores: "8"
+      device_type: none
   linux_android:
     properties:
       dependencies: >-
@@ -1922,14 +1933,16 @@ targets:
         ["devicelab", "android", "linux"]
       task_name: new_gallery__transition_perf
 
-  - name: Linux_android flutter_gallery__transition_perf
-    recipe: devicelab/devicelab_drone
+  - name: Linux_build_test flutter_gallery__transition_perf
+    recipe: devicelab/devicelab_drone_build_test
+    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     presubmit: false
     timeout: 60
     properties:
       tags: >
         ["devicelab", "android", "linux"]
       task_name: flutter_gallery__transition_perf
+      artifact: gallery_app_profile
 
   - name: Linux_android flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/103542.

This PR 
- adds a new platform: `linux_build_test`, which will be used for targets that are suitable for build+test model (context: go/devicelab-build-test)
- switched `flutter_gallery__transition_perf` to `linux_build_test`
  - Instead of running both `build` and `test` in a `devicelab` bot, this will put `build` in a `VM` and the `test` in a `devicelab` bot


Successful led runs: 

- [both build and test](https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/keyonghan_google.com/126201d564ee70ecf3c4d0887a8da7a473d48a51f7cc3f3794d6d202068b2bc6/+/build.proto?server=chromium-swarm.appspot.com) (when artifacts are not available)
- [only test](https://ci.chromium.org/raw/build/logs.chromium.org/flutter/led/keyonghan_google.com/5d6c057e7e3922cd87d55e6eb3592936215d6727d193a6c6429d3f014aeed23c/+/build.proto?server=chromium-swarm.appspot.com) (when artfacts are available)

I do not expect this to affect benchmark metrics. 