### PR TITLE
Re-land [macOS] Bring up "flutter_gallery" devicelab, start up test for x86.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2516,6 +2516,7 @@ targets:
 
   - name: Mac flutter_gallery_macos__start_up
     bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2514,6 +2514,20 @@ targets:
         ["devicelab", "hostonly"]
       task_name: flutter_gallery_macos__compile
 
+  - name: Mac flutter_gallery_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "13f17a"},
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: flutter_gallery_macos__start_up
+
   - name: Mac framework_tests_libraries
     recipe: flutter/flutter_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -247,6 +247,7 @@
 /dev/devicelab/bin/tasks/windows_startup_test.dart @loic-sharma @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/flutter_gallery_macos__compile.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/flutter_gallery_macos__start_up.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/flutter_gallery_macos__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_macos__start_up.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createFlutterGalleryStartupTest());
+}


### PR DESCRIPTION
#### Reason 
> The initial desktop integration tests are running now, but they need to be expanded beyond the initial gallery build test; filing this to make sure that planned work is captured in the issue tracker. This should be much more straightforward that getting the first one running was, since the bot work is all complete.
> 
> In particular we should ensure we are testing building a freshly created project to catch errors in template changes. (I haven't checked where that test lives on existing platforms; it may be a device lab test, which still needs desktop bring-up).

#### Related
fixes https://github.com/flutter/flutter/issues/110084

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.