### PR TITLE
Fix microbenchmarks_impeller_ios

### DIFF
--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -32,8 +32,8 @@ TaskFunction createMicrobenchmarkTask({bool enableImpeller = false}) {
             // --release doesn't work on iOS due to code signing issues
             '--profile',
             '--no-publish-port',
-            '-d',
             if (enableImpeller) '--enable-impeller',
+            '-d',
             device.deviceId,
           ];
           options.add(benchmarkPath);


### PR DESCRIPTION
The flags were in the wrong order, confusing device discovery.