### PR TITLE
Remove warnings when `UnconstrainedBox` and `ConstraintsTransformBox` are clipped

### DIFF
--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -656,9 +656,9 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
   }
 }
 
-/// A [RenderBox] that applies an arbitrary transform to its [constraints]
-/// before sizing its child using the new constraints, treating any overflow as
-/// error.
+/// A [RenderBox]  that applies an arbitrary transform to its constraints,
+/// and sizes its child using the resulting [BoxConstraints], optionally
+/// clipping, or treating the overflow as an error.
 ///
 /// This [RenderBox] sizes its child using a [BoxConstraints] created by
 /// applying [constraintsTransform] to this [RenderBox]'s own [constraints].
@@ -668,9 +668,9 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
 /// the entire child, the child will be clipped if [clipBehavior] is not
 /// [Clip.none].
 ///
-/// In debug mode, if the child overflows the box, a warning will be printed on
-/// the console, and black and yellow striped areas will appear where the
-/// overflow occurs.
+/// In debug mode, if [clipBehavior] is [Clip.none] and the child overflows the
+/// container, a warning will be printed on the console, and black and yellow
+/// striped areas will appear where the overflow occurs.
 ///
 /// When [child] is null, this [RenderBox] takes the smallest possible size and
 /// never overflows.
@@ -732,7 +732,12 @@ class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugO
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// Defaults to [Clip.none], and must not be null.
+  /// In debug mode, if `clipBehavior` is [Clip.none], and the child overflows
+  /// its constraints, a warning will be printed on the console, and black and
+  /// yellow striped areas will appear where the overflow occurs. For other
+  /// values of `clipBehavior`, the contents are clipped accordingly.
+  ///
+  /// Defaults to [Clip.none].
   Clip get clipBehavior => _clipBehavior;
   Clip _clipBehavior;
   set clipBehavior(Clip value) {
@@ -830,9 +835,17 @@ class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugO
       oldLayer: _clipRectLayer.layer,
     );
 
-    // Display the overflow indicator.
+    // Display the overflow indicator if clipBehavior is Clip.none.
     assert(() {
-      paintOverflowIndicator(context, offset, _overflowContainerRect, _overflowChildRect);
+      switch (clipBehavior) {
+        case Clip.none:
+          paintOverflowIndicator(context, offset, _overflowContainerRect, _overflowChildRect);
+          break;
+        case Clip.hardEdge:
+        case Clip.antiAlias:
+        case Clip.antiAliasWithSaveLayer:
+          break;
+      }
       return true;
     }());
   }

--- a/packages/flutter/lib/src/rendering/shifted_box.dart
+++ b/packages/flutter/lib/src/rendering/shifted_box.dart
@@ -656,7 +656,7 @@ class RenderConstrainedOverflowBox extends RenderAligningShiftedBox {
   }
 }
 
-/// A [RenderBox]  that applies an arbitrary transform to its constraints,
+/// A [RenderBox] that applies an arbitrary transform to its constraints,
 /// and sizes its child using the resulting [BoxConstraints], optionally
 /// clipping, or treating the overflow as an error.
 ///
@@ -732,10 +732,7 @@ class RenderConstraintsTransformBox extends RenderAligningShiftedBox with DebugO
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
-  /// In debug mode, if `clipBehavior` is [Clip.none], and the child overflows
-  /// its constraints, a warning will be printed on the console, and black and
-  /// yellow striped areas will appear where the overflow occurs. For other
-  /// values of `clipBehavior`, the contents are clipped accordingly.
+  /// {@macro flutter.widgets.ConstraintsTransformBox.clipBehavior}
   ///
   /// Defaults to [Clip.none].
   Clip get clipBehavior => _clipBehavior;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2686,10 +2686,12 @@ class ConstraintsTransformBox extends SingleChildRenderObjectWidget {
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
+  /// {@template flutter.widgets.ConstraintsTransformBox.clipBehavior}
   /// In debug mode, if `clipBehavior` is [Clip.none], and the child overflows
   /// its constraints, a warning will be printed on the console, and black and
   /// yellow striped areas will appear where the overflow occurs. For other
   /// values of `clipBehavior`, the contents are clipped accordingly.
+  /// {@endtemplate}
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2513,8 +2513,8 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 }
 
 /// A container widget that applies an arbitrary transform to its constraints,
-/// and sizes its child using the resulting [BoxConstraints], treating any
-/// overflow as error.
+/// and sizes its child using the resulting [BoxConstraints], optionally
+/// clipping, or treating the overflow as an error.
 ///
 /// This container sizes its child using a [BoxConstraints] created by applying
 /// [constraintsTransform] to its own constraints. This container will then
@@ -2523,12 +2523,12 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 /// [alignment]. If the container cannot expand enough to accommodate the entire
 /// child, the child will be clipped if [clipBehavior] is not [Clip.none].
 ///
-/// In debug mode, if the child overflows the container, a warning will be
-/// printed on the console, and black and yellow striped areas will appear where
-/// the overflow occurs.
+/// In debug mode, if [clipBehavior] is [Clip.none] and the child overflows the
+/// container, a warning will be printed on the console, and black and yellow
+/// striped areas will appear where the overflow occurs.
 ///
 /// When [child] is null, this widget becomes as small as possible and never
-/// overflows
+/// overflows.
 ///
 /// This widget can be used to ensure some of [child]'s natural dimensions are
 /// honored, and get an early warning otherwise during development. For
@@ -2564,7 +2564,7 @@ class ConstrainedBox extends SingleChildRenderObjectWidget {
 ///  * [OverflowBox], a widget that imposes additional constraints on its child,
 ///    and allows the child to overflow itself.
 ///  * [UnconstrainedBox] which allows its children to render themselves
-///    unconstrained, expands to fit them, and considers overflow to be an error.
+///    unconstrained and expands to fit them.
 class ConstraintsTransformBox extends SingleChildRenderObjectWidget {
   /// Creates a widget that uses a function to transform the constraints it
   /// passes to its child. If the child overflows the parent's constraints, a
@@ -2685,6 +2685,11 @@ class ConstraintsTransformBox extends SingleChildRenderObjectWidget {
   final BoxConstraintsTransform constraintsTransform;
 
   /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// In debug mode, if `clipBehavior` is [Clip.none], and the child overflows
+  /// its constraints, a warning will be printed on the console, and black and
+  /// yellow striped areas will appear where the overflow occurs. For other
+  /// values of `clipBehavior`, the contents are clipped accordingly.
   ///
   /// Defaults to [Clip.none].
   final Clip clipBehavior;

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -54,40 +54,44 @@ void main() {
   TestRenderingFlutterBinding.ensureInitialized();
 
   test('RenderEditable respects clipBehavior', () {
-    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
-    final TestClipPaintingContext context = TestClipPaintingContext();
-
+    const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 1.0);
     final String longString = 'a' * 10000;
 
-    // By default, clipBehavior should be Clip.none
-    final RenderEditable defaultEditable = RenderEditable(
-      text: TextSpan(text: longString),
-      textDirection: TextDirection.ltr,
-      startHandleLayerLink: LayerLink(),
-      endHandleLayerLink: LayerLink(),
-      offset: ViewportOffset.zero(),
-      textSelectionDelegate: _FakeEditableTextState(),
-      selection: const TextSelection(baseOffset: 0, extentOffset: 0),
-    );
-    layout(defaultEditable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
-    context.paintChild(defaultEditable, Offset.zero);
-    expect(context.clipBehavior, equals(Clip.hardEdge));
-
-    context.clipBehavior = Clip.none; // Reset as Clip.none won't write into clipBehavior.
-    for (final Clip clip in Clip.values) {
-      final RenderEditable editable = RenderEditable(
-        text: TextSpan(text: longString),
-        textDirection: TextDirection.ltr,
-        startHandleLayerLink: LayerLink(),
-        endHandleLayerLink: LayerLink(),
-        offset: ViewportOffset.zero(),
-        textSelectionDelegate: _FakeEditableTextState(),
-        selection: const TextSelection(baseOffset: 0, extentOffset: 0),
-        clipBehavior: clip,
-      );
-      layout(editable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    for (final Clip? clip in <Clip?>[null, ...Clip.values]) {
+      final TestClipPaintingContext context = TestClipPaintingContext();
+      final RenderEditable editable;
+      switch (clip) {
+        case Clip.none:
+        case Clip.hardEdge:
+        case Clip.antiAlias:
+        case Clip.antiAliasWithSaveLayer:
+          editable = RenderEditable(
+            text: TextSpan(text: longString),
+            textDirection: TextDirection.ltr,
+            startHandleLayerLink: LayerLink(),
+            endHandleLayerLink: LayerLink(),
+            offset: ViewportOffset.zero(),
+            textSelectionDelegate: _FakeEditableTextState(),
+            selection: const TextSelection(baseOffset: 0, extentOffset: 0),
+            clipBehavior: clip!,
+          );
+          break;
+        case null:
+          editable = RenderEditable(
+            text: TextSpan(text: longString),
+            textDirection: TextDirection.ltr,
+            startHandleLayerLink: LayerLink(),
+            endHandleLayerLink: LayerLink(),
+            offset: ViewportOffset.zero(),
+            textSelectionDelegate: _FakeEditableTextState(),
+            selection: const TextSelection(baseOffset: 0, extentOffset: 0),
+          );
+          break;
+      }
+      layout(editable, constraints: viewport, phase: EnginePhase.composite, onErrors: expectNoFlutterErrors);
       context.paintChild(editable, Offset.zero);
-      expect(context.clipBehavior, equals(clip));
+      // By default, clipBehavior is Clip.hardEdge.
+      expect(context.clipBehavior, equals(clip ?? Clip.hardEdge), reason: 'for $clip');
     }
   });
 

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -536,19 +536,24 @@ void main() {
 
   test('RenderFittedBox respects clipBehavior', () {
     const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
-    final TestClipPaintingContext context = TestClipPaintingContext();
-
-    // By default, clipBehavior should be Clip.none
-    final RenderFittedBox defaultBox = RenderFittedBox(child: box200x200, fit: BoxFit.none);
-    layout(defaultBox, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
-    defaultBox.paint(context, Offset.zero);
-    expect(context.clipBehavior, equals(Clip.none));
-
-    for (final Clip clip in Clip.values) {
-      final RenderFittedBox box = RenderFittedBox(child: box200x200, fit: BoxFit.none, clipBehavior: clip);
-      layout(box, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    for (final Clip? clip in <Clip?>[null, ...Clip.values]) {
+      final TestClipPaintingContext context = TestClipPaintingContext();
+      final RenderFittedBox box;
+      switch (clip) {
+        case Clip.none:
+        case Clip.hardEdge:
+        case Clip.antiAlias:
+        case Clip.antiAliasWithSaveLayer:
+          box = RenderFittedBox(child: box200x200, fit: BoxFit.none, clipBehavior: clip!);
+          break;
+        case null:
+          box = RenderFittedBox(child: box200x200, fit: BoxFit.none);
+          break;
+      }
+      layout(box, constraints: viewport, phase: EnginePhase.composite, onErrors: expectNoFlutterErrors);
       box.paint(context, Offset.zero);
-      expect(context.clipBehavior, equals(clip));
+      // By default, clipBehavior should be Clip.none
+      expect(context.clipBehavior, equals(clip ?? Clip.none));
     }
   });
 

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -382,12 +382,21 @@ class TestPushLayerPaintingContext extends PaintingContext {
   }
 }
 
-void expectOverflowedErrors() {
-  final FlutterErrorDetails errorDetails = TestRenderingFlutterBinding.instance.takeFlutterErrorDetails()!;
-  final bool overflowed = errorDetails.toString().contains('overflowed');
-  if (!overflowed) {
-    FlutterError.reportError(errorDetails);
+// Absorbs errors that don't have "overflowed" in their error details.
+void absorbOverflowedErrors() {
+  final Iterable<FlutterErrorDetails> errorDetails = TestRenderingFlutterBinding.instance.takeAllFlutterErrorDetails();
+  final Iterable<FlutterErrorDetails> filtered = errorDetails.where((FlutterErrorDetails details) {
+    return !details.toString().contains('overflowed');
+  });
+  if (filtered.isNotEmpty) {
+    filtered.forEach(FlutterError.reportError);
   }
+}
+
+// Reports any FlutterErrors.
+void expectNoFlutterErrors() {
+  final Iterable<FlutterErrorDetails> errorDetails = TestRenderingFlutterBinding.instance.takeAllFlutterErrorDetails();
+  errorDetails.forEach(FlutterError.reportError);
 }
 
 RenderConstrainedBox get box200x200 =>

--- a/packages/flutter/test/rendering/wrap_test.dart
+++ b/packages/flutter/test/rendering/wrap_test.dart
@@ -208,17 +208,23 @@ void main() {
     const BoxConstraints viewport = BoxConstraints(maxHeight: 100.0, maxWidth: 100.0);
     final TestClipPaintingContext context = TestClipPaintingContext();
 
-    // By default, clipBehavior should be Clip.none
-    final RenderWrap defaultWrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200]);
-    layout(defaultWrap, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
-    context.paintChild(defaultWrap, Offset.zero);
-    expect(context.clipBehavior, equals(Clip.none));
-
-    for (final Clip clip in Clip.values) {
-      final RenderWrap wrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200], clipBehavior: clip);
-      layout(wrap, constraints: viewport, phase: EnginePhase.composite, onErrors: expectOverflowedErrors);
+    for (final Clip? clip in <Clip?>[null, ...Clip.values]) {
+      final RenderWrap wrap;
+      switch(clip){
+        case Clip.none:
+        case Clip.hardEdge:
+        case Clip.antiAlias:
+        case Clip.antiAliasWithSaveLayer:
+          wrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200], clipBehavior: clip!);
+          break;
+        case null:
+          wrap = RenderWrap(textDirection: TextDirection.ltr, children: <RenderBox>[box200x200]);
+          break;
+      }
+      layout(wrap, constraints: viewport, phase: EnginePhase.composite, onErrors: expectNoFlutterErrors);
       context.paintChild(wrap, Offset.zero);
-      expect(context.clipBehavior, equals(clip));
+      // By default, clipBehavior should be Clip.none
+      expect(context.clipBehavior, equals(clip ?? Clip.none));
     }
   });
 }


### PR DESCRIPTION
## Description

This changes the behavior of `UnconstrainedBox` and `ConstraintsTransformBox` so that when their `clipBehavior` is not `Clip.none`, they don't report overflows.

While I was writing the tests for these, I realized that there was a function in the rendering testing called `expectOverflowedErrors` that really didn't do what it said: tests using it were tests that were either expecting errors and didn't enforce that they got one, or tests that were expecting not to have errors that were using it, and would have ignored layout errors.

They also were all laid out similarly, and had a "default" section and then a loop through the values of `Clip`, so I made the loop use `Clip?`, and then the test for the default is assured of taking the same path as the non-default, and also includes a switch on the `Clip` values so that if we add a new one, we'll find it.

I also renamed the function `absorbOverflowErrors` so that it wouldn't be misleading, and made it actually filter all of the overflow errors, not just the first one.

## Tests
 - Added tests for the new behavior, and reworked existing tests that used `expectOverflowedErrors` so that they enforced whether they got errors or not.