### PR TITLE
[flutter_test] Add createTestImageSync() method and add color to createTestImage()

### DIFF
--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -51,9 +51,9 @@ Future<ui.Image> _createImage(int width, int height, ui.Color color) {
   final Completer<ui.Image> completer = Completer<ui.Image>();
   final int pixel = color.red << 24 | color.green << 16 | color.blue << 8 | color.alpha;
   final Uint8List pixels = Uint8List(width * height * 4);
-  final ByteData = pixels.buffer.asByteData();
+  final ByteData pixelByteData = pixels.buffer.asByteData();
   for (int byteOffset = 0; byteOffset < pixels.length; byteOffset += 4) {
-    pixelData.setUint32(byteOffset, pixel); // big-endian produces RGBA
+    pixelByteData.setUint32(byteOffset, pixel); // big-endian produces RGBA
   }
   ui.decodeImageFromPixels(
     pixels,

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -51,8 +51,8 @@ Future<ui.Image> _createImage(int width, int height, ui.Color color) {
   final Completer<ui.Image> completer = Completer<ui.Image>();
   final int pixel = color.red << 24 | color.green << 16 | color.blue << 8 | color.alpha;
   final Uint8List pixels = Uint8List(width * height * 4);
-  for (int index; index < pixels.length; index += 4) {
-    pixels.buffer.setUint32(index, pixel); // big-endian produces RGBA
+  for (int byteOffset; byteOffset < pixels.length; byteOffset += 4) {
+    pixels.buffer.setUint32(byteOffset, pixel); // big-endian produces RGBA
   }
   ui.decodeImageFromPixels(
     pixels;

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -51,11 +51,12 @@ Future<ui.Image> _createImage(int width, int height, ui.Color color) {
   final Completer<ui.Image> completer = Completer<ui.Image>();
   final int pixel = color.red << 24 | color.green << 16 | color.blue << 8 | color.alpha;
   final Uint8List pixels = Uint8List(width * height * 4);
-  for (int byteOffset; byteOffset < pixels.length; byteOffset += 4) {
-    pixels.buffer.setUint32(byteOffset, pixel); // big-endian produces RGBA
+  final ByteData = pixels.buffer.asByteData();
+  for (int byteOffset = 0; byteOffset < pixels.length; byteOffset += 4) {
+    pixelData.setUint32(byteOffset, pixel); // big-endian produces RGBA
   }
   ui.decodeImageFromPixels(
-    pixels;
+    pixels,
     width,
     height,
     ui.PixelFormat.rgba8888,
@@ -91,7 +92,7 @@ ui.Image createTestImageSync({
     return _cache[cacheKey]!.clone();
   }
 
-  final ui.Image image = _createImage(width, height, color);
+  final ui.Image image = _createImageSync(width, height, color);
   if (cache) {
     _cache[cacheKey] = image.clone();
   }

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -66,7 +66,7 @@ Future<ui.Image> _createImage(int width, int height, ui.Color color) {
   return completer.future;
 }
 
-/// Creates an arbitrarily sized image for testing.
+/// Creates an arbitrarily sized image for testing synchronously.
 ///
 /// If [color] isn't provided, fully transparent black fill color is used.
 /// If the [cache] parameter is set to true, the image will be cached for the

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -106,4 +106,3 @@ ui.Image _createImageSync(int width, int height, ui.Color color) {
   final ui.Picture picture = recorder.endRecording();
   return picture.toImageSync(width, height);
 }
-

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -12,6 +12,7 @@ final Map<int, ui.Image> _cache = <int, ui.Image>{};
 
 /// Creates an arbitrarily sized image for testing.
 ///
+/// If [color] isn't provided, fully transparent black color is used.
 /// If the [cache] parameter is set to true, the image will be cached for the
 /// rest of this suite. This is normally desirable, assuming a test suite uses
 /// images with the same dimensions in most tests, as it will save on memory
@@ -27,6 +28,7 @@ final Map<int, ui.Image> _cache = <int, ui.Image>{};
 Future<ui.Image> createTestImage({
   int width = 1,
   int height = 1,
+  ui.Color color = const ui.Color(0x00000000),
   bool cache = true,
 }) => TestAsyncUtils.guard(() async {
   assert(width != null && width > 0);
@@ -38,23 +40,58 @@ Future<ui.Image> createTestImage({
     return _cache[cacheKey]!.clone();
   }
 
-  final ui.Image image = await _createImage(width, height);
+  final ui.Image image = await _createImage(width, height, color);
   if (cache) {
     _cache[cacheKey] = image.clone();
   }
   return image;
 });
 
-Future<ui.Image> _createImage(int width, int height) async {
-  final Completer<ui.Image> completer = Completer<ui.Image>();
-  ui.decodeImageFromPixels(
-    Uint8List.fromList(List<int>.filled(width * height * 4, 0)),
-    width,
-    height,
-    ui.PixelFormat.rgba8888,
-    (ui.Image image) {
-      completer.complete(image);
-    },
-  );
-  return completer.future;
+Future<ui.Image> _createImage(int width, int height, ui.Color color) {
+  final ui.PictureRecorder recorder = ui.PictureRecorder();
+  final ui.Canvas pictureCanvas = ui.Canvas(recorder);
+  pictureCanvas.drawColor(color, ui.BlendMode.src);
+  final ui.Picture picture = recorder.endRecording();
+  return picture.toImage(width, height);
 }
+
+/// Creates an arbitrarily sized image for testing.
+///
+/// If [color] isn't provided, fully transparent black color is used.
+/// If the [cache] parameter is set to true, the image will be cached for the
+/// rest of this suite. This is normally desirable, assuming a test suite uses
+/// images with the same dimensions in most tests, as it will save on memory
+/// usage and CPU time over the course of the suite. However, it should be
+/// avoided for images that are used only once in a test suite, especially if
+/// the image is large, as it will require holding on to the memory for that
+/// image for the duration of the suite.
+ui.Image createTestImageSync({
+  int width = 1,
+  int height = 1,
+  ui.Color color = const ui.Color(0x00000000),
+  bool cache = true,
+}) {
+  assert(width != null && width > 0);
+  assert(height != null && height > 0);
+  assert(cache != null);
+
+  final int cacheKey = Object.hash(width, height);
+  if (cache && _cache.containsKey(cacheKey)) {
+    return _cache[cacheKey]!.clone();
+  }
+
+  final ui.Image image = _createImage(width, height, color);
+  if (cache) {
+    _cache[cacheKey] = image.clone();
+  }
+  return image;
+}
+
+ui.Image _createImageSync(int width, int height, ui.Color color) {
+  final ui.PictureRecorder recorder = ui.PictureRecorder();
+  final ui.Canvas pictureCanvas = ui.Canvas(recorder);
+  pictureCanvas.drawColor(color, ui.BlendMode.src);
+  final ui.Picture picture = recorder.endRecording();
+  return picture.toImageSync(width, height);
+}
+

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -48,11 +48,22 @@ Future<ui.Image> createTestImage({
 });
 
 Future<ui.Image> _createImage(int width, int height, ui.Color color) {
-  final ui.PictureRecorder recorder = ui.PictureRecorder();
-  final ui.Canvas pictureCanvas = ui.Canvas(recorder);
-  pictureCanvas.drawColor(color, ui.BlendMode.src);
-  final ui.Picture picture = recorder.endRecording();
-  return picture.toImage(width, height);
+  final Completer<ui.Image> completer = Completer<ui.Image>();
+  final int pixel = color.red << 24 | color.green << 16 | color.blue << 8 | color.alpha;
+  final Uint8List pixels = Uint8List(width * height * 4);
+  for (int index; index < pixels.length; index += 4) {
+    pixels.buffer.setUint32(index, pixel); // big-endian produces RGBA
+  }
+  ui.decodeImageFromPixels(
+    pixels;
+    width,
+    height,
+    ui.PixelFormat.rgba8888,
+    (ui.Image image) {
+      completer.complete(image);
+    },
+  );
+  return completer.future;
 }
 
 /// Creates an arbitrarily sized image for testing.

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -12,7 +12,7 @@ final Map<int, ui.Image> _cache = <int, ui.Image>{};
 
 /// Creates an arbitrarily sized image for testing.
 ///
-/// If [color] isn't provided, fully transparent black color is used.
+/// If [color] isn't provided, fully transparent black fill color is used.
 /// If the [cache] parameter is set to true, the image will be cached for the
 /// rest of this suite. This is normally desirable, assuming a test suite uses
 /// images with the same dimensions in most tests, as it will save on memory
@@ -57,7 +57,7 @@ Future<ui.Image> _createImage(int width, int height, ui.Color color) {
 
 /// Creates an arbitrarily sized image for testing.
 ///
-/// If [color] isn't provided, fully transparent black color is used.
+/// If [color] isn't provided, fully transparent black fill color is used.
 /// If the [cache] parameter is set to true, the image will be cached for the
 /// rest of this suite. This is normally desirable, assuming a test suite uses
 /// images with the same dimensions in most tests, as it will save on memory


### PR DESCRIPTION
Changes in this PR:
- `createTestImageSync()` method is added for easier use in tests where HTML backend (which doesn't support `Picture.toImageSync()`) is not required
- optional `color` parameter is added for fill color for both `createTestImage ()` and `createTestImageSync()`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
