### PR TITLE
Added backgroundDecoration property to Scaffold

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1590,6 +1590,7 @@ class Scaffold extends StatefulWidget {
     this.drawerEnableOpenDragGesture = true,
     this.endDrawerEnableOpenDragGesture = true,
     this.restorationId,
+    this.backgroundDecoration,
   }) : assert(primary != null),
        assert(extendBody != null),
        assert(extendBodyBehindAppBar != null),
@@ -1848,6 +1849,15 @@ class Scaffold extends StatefulWidget {
   ///  * [RestorationManager], which explains how state restoration works in
   ///    Flutter.
   final String? restorationId;
+
+  /// Defines the background decoration of the [Scaffold]. This property may
+  /// be used to customize the Scaffold background, for example, to provide a
+  /// custom border or shape. The [BoxDecoration.color] property, if set, paints
+  /// on top of [backgroundColor]. As such, the [backgroundColor] color is only
+  /// visible if the Scaffold has a different shape, say [BoxShape.circle] or the
+  /// [BoxDecoration.color] has some alpha value which makes the background behind
+  /// the [backgroundDecoration] visible.
+  final ShapeDecoration? backgroundDecoration;
 
   /// Finds the [ScaffoldState] from the closest instance of this class that
   /// encloses the given context.
@@ -2963,6 +2973,25 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
     // extendBody locked when keyboard is open
     final bool extendBody = minInsets.bottom <= 0 && widget.extendBody;
 
+    final Widget scaffoldChildren = CustomMultiChildLayout(
+      delegate: _ScaffoldLayout(
+        extendBody: extendBody,
+        extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
+        minInsets: minInsets,
+        minViewPadding: minViewPadding,
+        currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
+        floatingActionButtonMoveAnimationProgress: _floatingActionButtonMoveController.value,
+        floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
+        geometryNotifier: _geometryNotifier,
+        previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,
+        textDirection: textDirection,
+        isSnackBarFloating: isSnackBarFloating,
+        extendBodyBehindMaterialBanner: extendBodyBehindMaterialBanner,
+        snackBarWidth: snackBarWidth,
+      ),
+      children: children,
+    );
+
     return _ScaffoldScope(
       hasDrawer: hasDrawer,
       geometryNotifier: _geometryNotifier,
@@ -2974,23 +3003,9 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
               actions: <Type, Action<Intent>>{
                 DismissIntent: _DismissDrawerAction(context),
               },
-              child: CustomMultiChildLayout(
-                delegate: _ScaffoldLayout(
-                  extendBody: extendBody,
-                  extendBodyBehindAppBar: widget.extendBodyBehindAppBar,
-                  minInsets: minInsets,
-                  minViewPadding: minViewPadding,
-                  currentFloatingActionButtonLocation: _floatingActionButtonLocation!,
-                  floatingActionButtonMoveAnimationProgress: _floatingActionButtonMoveController.value,
-                  floatingActionButtonMotionAnimator: _floatingActionButtonAnimator,
-                  geometryNotifier: _geometryNotifier,
-                  previousFloatingActionButtonLocation: _previousFloatingActionButtonLocation!,
-                  textDirection: textDirection,
-                  isSnackBarFloating: isSnackBarFloating,
-                  extendBodyBehindMaterialBanner: extendBodyBehindMaterialBanner,
-                  snackBarWidth: snackBarWidth,
-                ),
-                children: children,
+              child: widget.backgroundDecoration == null ? scaffoldChildren : DecoratedBox(
+                decoration: widget.backgroundDecoration!,
+                child: scaffoldChildren,
               ),
             );
           }),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
 import '../widgets/semantics_tester.dart';
 
 void main() {
@@ -2620,6 +2621,27 @@ void main() {
       // ignore: avoid_redundant_argument_values
       matchesSemantics(label: 'BottomSheet', hasDismissAction: false),
     );
+  });
+
+  testWidgets('backgroundDecoration works as expected', (WidgetTester tester) async {
+    const Color decorationColor = Color(0xFF00FF00);
+    const double decorationBorder = 2.0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          backgroundDecoration: ShapeDecoration(
+            shape: Border.all(
+              width: decorationBorder,
+              color: decorationColor,
+            ),
+          ),
+        ),
+      )
+    );
+
+    final Finder mainContainer = find.ancestor(of: find.byType(CustomMultiChildLayout), matching: find.byType(DecoratedBox));
+    expect(mainContainer, paints..rect(color: decorationColor, style: PaintingStyle.stroke, strokeWidth: decorationBorder));
   });
 }
 


### PR DESCRIPTION
This PR adds backgroundDecoration property to Scaffold enabling additional customization to the background of Scaffold.

Fixes: #109223 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
