### PR TITLE
Fix an exception in `StarBorder`s that are scaled to small or infinite sizes

### DIFF
--- a/packages/flutter/lib/src/painting/star_border.dart
+++ b/packages/flutter/lib/src/painting/star_border.dart
@@ -514,7 +514,6 @@ class _StarGenerator {
     } else {
       scale = Offset(squash * scale.dx + (1 - squash) * scale.dy, scale.dy);
     }
-
     // Scale the border so that it matches the size of the widget rectangle, so
     // that "rotation" of the shape doesn't affect how much of the rectangle it
     // covers.
@@ -610,10 +609,12 @@ class _StarGenerator {
     }
 
     // The rounding added to the valley radius can sometimes push it outside of
-    // the rounding of the point, since the rounding amount can be different, so
-    // we have to evaluate both the valley and the point radii, and pick the
-    // largest.
-    return math.max(valleyRadius, pointRadius);
+    // the rounding of the point, since the rounding amount can be different
+    // between the points and the valleys, so we have to evaluate both the
+    // valley and the point radii, and pick the largest. Also, since this value
+    // is used later to determine the scale, we need to keep it finite and
+    // non-zero.
+    return clampDouble(math.max(valleyRadius, pointRadius), double.minPositive, double.maxFinite);
   }
 
   void _drawPoints(Path path, List<_PointInfo> points) {

--- a/packages/flutter/test/painting/star_border_test.dart
+++ b/packages/flutter/test/painting/star_border_test.dart
@@ -132,6 +132,34 @@ void main() {
         const StarBorder.polygon(side: BorderSide(color: Color(0xffff0000), strokeAlign: BorderSide.strokeAlignOutside)));
   });
 
+  testWidgets("StarBorder doesn't try to scale an infinite scale matrix", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Center(
+          child: SizedBox(
+            width: 100,
+            height: 100,
+            child: Stack(
+              children: <Widget> [
+                Positioned.fromRelativeRect(
+                  rect: const RelativeRect.fromLTRB(100, 100, 100, 100),
+                  child: Container(
+                    decoration: const ShapeDecoration(
+                      color: Colors.green,
+                      shape: StarBorder(),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    expect(tester.takeException(), isNull);
+  });
+
   testWidgets('StarBorder lerped with StarBorder', (WidgetTester tester) async {
     const StarBorder from = StarBorder();
     const ShapeBorder otherBorder = StarBorder(


### PR DESCRIPTION
## Description

This fixes an unreported bug in `StarBorder` that can cause it to throw in circumstances where it gets scaled to very small sizes.

## Tests
 - Added a test to prevent regression.