### PR TITLE
Add required dependencies for  benchmark target

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2485,7 +2485,8 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "13f17a"}
+          {"dependency": "xcode", "version": "13f17a"},
+          {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
         ["devicelab", "hostonly"]


### PR DESCRIPTION
The `flutter_gallery_macos__compile` target was missing dependencies that were required in order to run the benchmark test. To test whether the dependencies added were the bare minimum, `bringup: true` was removed to iterate against presubmit checks rather than postsubmit. The change was checked in, but was later [reverted](https://github.com/flutter/flutter/pull/110366) to ensure that a bringup test wasn't breaking the tree.

#### Issues https://github.com/flutter/flutter/issues/110126

## Pre-launch Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.