### PR TITLE
[platform_view]add timeout for alert buttons and a few other changes to fix a test flake

### DIFF
--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -45,10 +45,6 @@ static const CGFloat kStandardTimeOut = 60.0;
     // Pressing for 3 seconds will dismiss the context menu and make icons wiggle.
     [appIcon pressForDuration:2];
 
-    XCTAttachment *screenshotAttachment = [XCTAttachment attachmentWithScreenshot:[XCUIScreen.mainScreen screenshot]];
-    screenshotAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
-    [self addAttachment:screenshotAttachment];
-
     // The "Remove App" button in context menu.
     XCUIElement *contextMenuRemoveButton = springboard.buttons[@"Remove App"];
     XCTAssert([contextMenuRemoveButton waitForExistenceWithTimeout:kStandardTimeOut], @"The context menu remove app button must appear.");

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -45,6 +45,10 @@ static const CGFloat kStandardTimeOut = 60.0;
     // Pressing for 3 seconds will dismiss the context menu and make icons wiggle.
     [appIcon pressForDuration:2];
 
+    XCTAttachment *screenshotAttachment = [XCTAttachment attachmentWithScreenshot:[XCUIScreen.mainScreen screenshot]];
+    screenshotAttachment.lifetime = XCTAttachmentLifetimeKeepAlways;
+    [self addAttachment:screenshotAttachment];
+
     // The "Remove App" button in context menu.
     XCUIElement *contextMenuRemoveButton = springboard.buttons[@"Remove App"];
     XCTAssert([contextMenuRemoveButton waitForExistenceWithTimeout:kStandardTimeOut], @"The context menu remove app button must appear.");

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -36,17 +36,31 @@ static const CGFloat kStandardTimeOut = 60.0;
   if ([appIcon waitForExistenceWithTimeout:kStandardTimeOut]) {
     NSLog(@"Deleting previously installed app.");
 
-    // Make icons wiggle
-    [appIcon pressForDuration:3];
+    if (!appIcon.isHittable) {
+      // It's possible that app icon is not hittable yet.
+      [NSThread sleepForTimeInterval:kStandardTimeOut];
+      XCTAssert(appIcon.isHittable, @"App icon should be hittable after timeout");
+    }
 
-    // Tap the "x" button
-    [appIcon.buttons[@"DeleteButton"] tap];
+    // Pressing for 2 seconds will bring up context menu.
+    // Pressing for 3 seconds will dismiss the context menu and make icons wiggle.
+    [appIcon pressForDuration:2];
+
+    // The "Remove App" button in context menu.
+    XCUIElement *contextMenuRemoveButton = springboard.buttons[@"Remove App"];
+    XCTAssert([contextMenuRemoveButton waitForExistenceWithTimeout:kStandardTimeOut], @"The context menu remove app button must appear.");
+    [contextMenuRemoveButton tap];
+
     // Tap the delete confirmation
-    [springboard.alerts.buttons[@"Delete App"] tap];
+    XCUIElement *deleteConfirmationButton = springboard.alerts.buttons[@"Delete App"];
+    XCTAssert([deleteConfirmationButton waitForExistenceWithTimeout:kStandardTimeOut], @"The first delete confirmation button must appear.");
+    [deleteConfirmationButton tap];
+
     // Tap the second delete confirmation
-    [springboard.alerts.buttons[@"Delete"] tap];
-    // Press home button to stop wiggling
-    [XCUIDevice.sharedDevice pressButton:XCUIDeviceButtonHome];
+    XCUIElement *secondDeleteConfirmationButton = springboard.alerts.buttons[@"Delete"];
+    XCTAssert([secondDeleteConfirmationButton waitForExistenceWithTimeout:kStandardTimeOut], @"The second delete confirmation button must appear.");
+    [secondDeleteConfirmationButton tap];
+
     [NSThread sleepForTimeInterval:3];
   } else {
     NSLog(@"No previously installed app found.");

--- a/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
+++ b/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m
@@ -36,11 +36,10 @@ static const CGFloat kStandardTimeOut = 60.0;
   if ([appIcon waitForExistenceWithTimeout:kStandardTimeOut]) {
     NSLog(@"Deleting previously installed app.");
 
-    if (!appIcon.isHittable) {
-      // It's possible that app icon is not hittable yet.
-      [NSThread sleepForTimeInterval:kStandardTimeOut];
-      XCTAssert(appIcon.isHittable, @"App icon should be hittable after timeout");
-    }
+    // It's possible that app icon is not hittable yet.
+    NSPredicate *hittable = [NSPredicate predicateWithFormat:@"exists == YES AND hittable == YES"];
+    [self expectationForPredicate:hittable evaluatedWithObject:appIcon handler:nil];
+    [self waitForExpectationsWithTimeout:kStandardTimeOut handler:nil];
 
     // Pressing for 2 seconds will bring up context menu.
     // Pressing for 3 seconds will dismiss the context menu and make icons wiggle.


### PR DESCRIPTION
This is to add timeout for alert buttons, to address a new test flake. 

here's [led](https://chromium-swarm.appspot.com/task?id=5d03a3fcb379a810)

# Analysis 

## 1. `kAXErrorServerNotFound`: 

- A similar issue is [here](https://github.com/flutter/flutter/issues/83483), which is solved by calling terminate in `tearDown`. However, this is what we are doing already. 
- Another issue is [here](https://github.com/flutter/flutter/issues/61267), which seems to be resolved by bumping xcode version
- Maybe related to [this stackoverflow question](https://stackoverflow.com/questions/58757558). But the top voted answer is what we are doing already. 
- I suspect that `kAXErrorServerNotFound` is just a warning and not an error, because the test continues to run even after this error, and then we got another error about alert not found. 

## 2. "No matches found for Descendants matching type Alert"

- Here's [a list of many ways of deleting the app from springboard](https://stackoverflow.com/questions/58509372/how-to-delete-reset-an-app-from-ios-13-with-xctest). They are pretty much the same. Some answers wait for the alert, and others do not. 
- When I tested it on my machine, I did not need to explicitly wait for the alert and it worked. 
- But since it's complaining about alert not found, I think it's our best bet to wait for the alert. 

# Changes

## 1. Add the timeout for the alert
As discussed in above. Also added timeout for the initial delete button just to be extra safe. 


## 2. Use context menu's delete button instead of the "X" button
- In [this stackoverflow question](https://stackoverflow.com/questions/58509372/how-to-delete-reset-an-app-from-ios-13-with-xctest), some answers use the X button, and others use the context menu's button
- The "X" button API is undocumented, some answers use `@"DeleteButton"` name, and others use a hardcoded coordinate offset. Both aren't ideal. Very interestingly, I tried the `@"DeleteButton"` approach again on my machine today, and some times it does not work (but most of the time it works)
- For the context menu approach, some solutions uses 1.3 seconds, and others use 2 seconds. I think 2 seconds is a bit safer in case of slow hardware. 

## 3. Add a hittable check for appIcon
- It doesn't appear in any of the answers in that [stackoverflow question](https://stackoverflow.com/questions/58509372/how-to-delete-reset-an-app-from-ios-13-with-xctest), but some commented out about the app icon not being hittable.  


# Debug info 

## Full logs 

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8804511299285366417/+/u/run_native_platform_view_ui_tests_ios/test_stdout

## Logs

```

[native_platform_view_ui_tests_ios] [STDOUT] stdout: 2022-08-29 02:08:40.593596-0700 PlatformViewUITests-Runner[1932:59533] Running tests...
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Suite 'All tests' started at 2022-08-29 02:08:41.107
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Suite 'PlatformViewUITests.xctest' started at 2022-08-29 02:08:41.109
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Suite 'PlatformViewUITests' started at 2022-08-29 02:08:41.110
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Case '-[PlatformViewUITests testPlatformViewFocus]' started.
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     0.00s Start Test at 2022-08-29 02:08:41.113
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     0.03s Set Up
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     0.05s     Open com.apple.springboard
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     0.08s         Activate com.apple.springboard
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     0.09s             Wait for com.apple.springboard to idle
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     0.13s     Waiting 60.0s for "ios_platform_view_tests" Icon to exist
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.14s         Checking `Expect predicate `exists == 1` for object "ios_platform_view_tests" Icon`
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.14s             Checking existence of `"ios_platform_view_tests" Icon`
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.25s                 Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 2022-08-29 02:08:42.377445-0700 PlatformViewUITests-Runner[1932:59533] Deleting previously installed app.
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.27s     Press "ios_platform_view_tests" Icon for 3.0 seconds
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.27s         Wait for com.apple.springboard to idle
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.30s         Find the "ios_platform_view_tests" Icon
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.37s             Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.39s         Check for interrupting elements affecting "ios_platform_view_tests" Icon
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.46s             Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     1.47s         Synthesize event
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     3.64s         Wait for com.apple.springboard to idle
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     4.04s     Tap "DeleteButton" Button
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     4.04s         Wait for com.apple.springboard to idle
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     4.09s         Find the "DeleteButton" Button
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     4.25s             Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     5.26s             Find the "DeleteButton" Button (retry 1)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     5.42s                 Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     5.44s         Check for interrupting elements affecting "DeleteButton" Button
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     5.53s             Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     5.54s         Synthesize event
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     5.78s         Wait for com.apple.springboard to idle
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     6.14s     Tap "Delete App" Button
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     6.14s         Wait for com.apple.springboard to idle
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     6.17s         Find the "Delete App" Button
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     6.25s             Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     7.26s             Find the "Delete App" Button (retry 1)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     7.36s                 Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.37s             Find the "Delete App" Button (retry 2)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.47s                 Ignoring failure to get hierarchy for remote element in process 1396 (Error getting main window kAXErrorServerNotFound)
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.48s             Collecting extra data to assist test failure triage
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.48s                 Requesting snapshot of accessibility hierarchy for app with pid 62
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.58s                 Requesting snapshot of accessibility hierarchy for app with pid 62
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.68s                 Find: Descendants matching type Alert
[native_platform_view_ui_tests_ios] [STDOUT] stdout: /opt/s/w/ir/x/w/recipe_cleanup/tmpf89bzsws/flutter sdk/dev/integration_tests/ios_platform_view_tests/ios/PlatformViewUITests/PlatformViewUITests.m:45: error: -[PlatformViewUITests testPlatformViewFocus] : Failed to get matching snapshot: No matches found for Descendants matching type Alert from input {(
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     Application, pid: 62, label: ' '
[native_platform_view_ui_tests_ios] [STDOUT] stdout: )}
[native_platform_view_ui_tests_ios] [STDOUT] stdout:     t =     8.78s Tear Down
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Case '-[PlatformViewUITests testPlatformViewFocus]' failed (8.781 seconds).
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Suite 'PlatformViewUITests' failed at 2022-08-29 02:08:49.892.
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 	 Executed 1 test, with 1 failure (0 unexpected) in 8.781 (8.783) seconds
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Suite 'PlatformViewUITests.xctest' failed at 2022-08-29 02:08:49.893.
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 	 Executed 1 test, with 1 failure (0 unexpected) in 8.781 (8.784) seconds
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test Suite 'All tests' failed at 2022-08-29 02:08:49.894.
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 	 Executed 1 test, with 1 failure (0 unexpected) in 8.781 (8.787) seconds
[native_platform_view_ui_tests_ios] [STDOUT] stderr: 2022-08-29 02:08:49.991 xcodebuild[56698:249181] [MT] IDETestOperationsObserverDebug: 12.427 elapsed -- Testing started completed.
[native_platform_view_ui_tests_ios] [STDOUT] stderr: 2022-08-29 02:08:49.991 xcodebuild[56698:249181] [MT] IDETestOperationsObserverDebug: 0.000 sec, +0.000 sec -- start
[native_platform_view_ui_tests_ios] [STDOUT] stderr: 2022-08-29 02:08:49.991 xcodebuild[56698:249181] [MT] IDETestOperationsObserverDebug: 12.427 sec, +12.427 sec -- end
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 
[native_platform_view_ui_tests_ios] [STDOUT] stdout: Test session results, code coverage, and logs:
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 	/opt/s/w/ir/x/t/flutter_xcresult.GkWOcN/result
[native_platform_view_ui_tests_ios] [STDOUT] stdout: 
[native_platform_view_ui_tests_ios] [STDOUT] stderr: Failing tests:
[native_platform_view_ui_tests_ios] [STDOUT] stderr: 	PlatformViewUITests:
[native_platform_view_ui_tests_ios] [STDOUT] stderr: 		-[PlatformViewUITests testPlatformViewFocus]
[native_platform_view_ui_tests_ios] [STDOUT] stderr: 
[native_platform_view_ui_tests_ios] [STDOUT] stderr: ** TEST FAILED **
```

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/109697

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
