### PR TITLE
[flutter_tools] Generate Localizations on `flutter run` for web

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -280,6 +280,7 @@ class ResidentWebRunner extends ResidentRunner {
         );
         final Uri url = await device!.devFS!.create();
         if (debuggingOptions.buildInfo.isDebug) {
+          await runSourceGenerators();
           final UpdateFSReport report = await _updateDevFS(fullRestart: true);
           if (!report.success) {
             _logger!.printError('Failed to compile application.');

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -157,7 +157,7 @@ void main() {
   late Testbed testbed;
   late FakeFlutterDevice flutterDevice;
   late FakeDevFS devFS;
-  late ResidentRunner residentRunner;
+  late ResidentRunner  residentRunner;
   late FakeDevice device;
   FakeVmServiceHost? fakeVmServiceHost;
 
@@ -1386,6 +1386,47 @@ flutter:
 
     expect(testLogger.errorText, allOf(contains('Exception')));
     expect(testLogger.statusText, isEmpty);
+  }));
+
+  testUsingContext('ResidentRunner generates files when l10n.yaml exists', () => testbed.run(() async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart'))
+      .createSync(recursive: true);
+    final File arbFile = globals.fs.file(globals.fs.path.join('lib', 'l10n', 'app_en.arb'))
+      ..createSync(recursive: true);
+    arbFile.writeAsStringSync('''
+{
+  "helloWorld": "Hello, World!",
+  "@helloWorld": {
+    "description": "Sample description"
+  }
+}''');
+    globals.fs.file('l10n.yaml').createSync();
+    globals.fs.file('pubspec.yaml').writeAsStringSync('flutter:\n  generate: true\n');
+
+    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
+    final FakeResidentCompiler residentCompiler = FakeResidentCompiler()
+      ..nextOutput = const CompilerOutput('foo', 1 ,<Uri>[]);
+    residentRunner = HotRunner(
+      <FlutterDevice>[
+        flutterDevice,
+      ],
+      stayResident: false,
+      debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
+      target: 'main.dart',
+      devtoolsHandler: createNoOpHandler,
+    );
+    flutterDevice.generator = residentCompiler;
+
+    await residentRunner.run();
+
+    final File generatedLocalizationsFile = globals.fs.directory('.dart_tool')
+      .childDirectory('flutter_gen')
+      .childDirectory('gen_l10n')
+      .childFile('app_localizations.dart');
+    expect(generatedLocalizationsFile.existsSync(), isTrue);
+
+    // Completing this future ensures that the daemon can exit correctly.
+    expect(await residentRunner.waitForAppToFinish(), 1);
   }));
 
   testUsingContext('ResidentRunner printHelpDetails hot runner', () => testbed.run(() {

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -157,7 +157,7 @@ void main() {
   late Testbed testbed;
   late FakeFlutterDevice flutterDevice;
   late FakeDevFS devFS;
-  late ResidentRunner  residentRunner;
+  late ResidentRunner residentRunner;
   late FakeDevice device;
   FakeVmServiceHost? fakeVmServiceHost;
 


### PR DESCRIPTION
Currently, when `flutter run` is run for web and `synthetic-package: false`, we don't generate localizations. They do, however, get generated when hot reloaded. This only happens on web AFAIK and this PR should fix the issue.

Reason why this doesn't affect web when `synthetic-package` is true is because of [this line](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/runner/flutter_command.dart#L1351).

Also added tests that break when l10n generation does not happen on `resident_runner.run()`.