### PR TITLE
Migrate Linux android gallery `e2e` and `hybrid` tests to build+test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1940,25 +1940,29 @@ targets:
       tags: >
         ["devicelab", "android", "linux"]
       task_name: flutter_gallery__transition_perf
-      artifact: gallery_app_profile
+      artifact: gallery__transition_perf
 
-  - name: Linux_android flutter_gallery__transition_perf_e2e
-    recipe: devicelab/devicelab_drone
+  - name: Linux_build_test flutter_gallery__transition_perf_e2e
+    recipe: devicelab/devicelab_drone_build_test
+    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     presubmit: false
     timeout: 60
     properties:
       tags: >
         ["devicelab", "android", "linux"]
       task_name: flutter_gallery__transition_perf_e2e
+      artifact: gallery__transition_perf_e2e
 
-  - name: Linux_android flutter_gallery__transition_perf_hybrid
-    recipe: devicelab/devicelab_drone
+  - name: Linux_build_test flutter_gallery__transition_perf_hybrid
+    recipe: devicelab/devicelab_drone_build_test
+    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     presubmit: false
     timeout: 60
     properties:
       tags: >
         ["devicelab", "android", "linux"]
       task_name: flutter_gallery__transition_perf_hybrid
+      artifact: gallery__transition_perf_hybrid
 
   - name: Linux_android flutter_gallery__transition_perf_with_semantics
     recipe: devicelab/devicelab_drone

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_e2e.dart
@@ -6,7 +6,7 @@ import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
-  await task(createGalleryTransitionE2ETest());
+  await task(createGalleryTransitionE2EBuildTest(args));
 }

--- a/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__transition_perf_hybrid.dart
@@ -6,7 +6,7 @@ import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/tasks/gallery.dart';
 
-Future<void> main() async {
+Future<void> main(List<String> args) async {
   deviceOperatingSystem = DeviceOperatingSystem.android;
-  await task(createGalleryTransitionHybridTest());
+  await task(createGalleryTransitionHybridBuildTest(args));
 }

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -257,6 +257,7 @@ class GalleryTransitionBuildTest extends BuildTestTask {
   List<String> getTestArgs(DeviceOperatingSystem deviceOperatingSystem, String deviceId) {
     final String testDriver = driverFile ?? (semanticsEnabled ? '${testFile}_with_semantics_test' : '${testFile}_test');
     return <String>[
+      '--no-dds',
       '--profile',
       if (enableImpeller) '--enable-impeller',
       if (needFullTimeline) '--trace-startup',

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -57,6 +57,17 @@ TaskFunction createGalleryTransitionE2ETest({
   );
 }
 
+TaskFunction createGalleryTransitionHybridBuildTest(
+  List<String> args, {
+  bool semanticsEnabled = false,
+}) {
+  return GalleryTransitionBuildTest(
+    args,
+    semanticsEnabled: semanticsEnabled,
+    driverFile: semanticsEnabled ? 'transitions_perf_hybrid_with_semantics_test' : 'transitions_perf_hybrid_test',
+  );
+}
+
 TaskFunction createGalleryTransitionHybridTest({bool semanticsEnabled = false}) {
   return GalleryTransitionTest(
     semanticsEnabled: semanticsEnabled,

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -47,7 +47,9 @@ TaskFunction createGalleryTransitionE2ETest({
   bool enableImpeller = false,
 }) {
   return GalleryTransitionTest(
-    testFile: semanticsEnabled ? 'transitions_perf_e2e_with_semantics' : 'transitions_perf_e2e',
+    testFile: semanticsEnabled
+        ? 'transitions_perf_e2e_with_semantics'
+        : 'transitions_perf_e2e',
     needFullTimeline: false,
     timelineSummaryFile: 'e2e_perf_summary',
     transitionDurationFile: null,
@@ -71,7 +73,9 @@ TaskFunction createGalleryTransitionHybridBuildTest(
 TaskFunction createGalleryTransitionHybridTest({bool semanticsEnabled = false}) {
   return GalleryTransitionTest(
     semanticsEnabled: semanticsEnabled,
-    driverFile: semanticsEnabled ? 'transitions_perf_hybrid_with_semantics_test' : 'transitions_perf_hybrid_test',
+    driverFile: semanticsEnabled
+        ? 'transitions_perf_hybrid_with_semantics_test'
+        : 'transitions_perf_hybrid_test',
   );
 }
 
@@ -124,20 +128,23 @@ class GalleryTransitionTest {
         applicationBinaryPath = 'build/app/outputs/flutter-apk/app-profile.apk';
       }
 
-      final String testDriver =
-          driverFile ?? (semanticsEnabled ? '${testFile}_with_semantics_test' : '${testFile}_test');
+      final String testDriver = driverFile ?? (semanticsEnabled
+          ? '${testFile}_with_semantics_test'
+          : '${testFile}_test');
       section('DRIVE START');
       await flutter('drive', options: <String>[
         '--no-dds',
         '--profile',
         if (enableImpeller) '--enable-impeller',
-        if (needFullTimeline) '--trace-startup',
+        if (needFullTimeline)
+          '--trace-startup',
         if (applicationBinaryPath != null)
           '--use-application-binary=$applicationBinaryPath'
-        else ...<String>[
-          '-t',
-          'test_driver/$testFile.dart',
-        ],
+        else 
+          ...<String>[
+            '-t',
+            'test_driver/$testFile.dart',
+          ],
         '--driver',
         'test_driver/$testDriver.dart',
         '-d',
@@ -145,8 +152,7 @@ class GalleryTransitionTest {
       ]);
     });
 
-    final String testOutputDirectory =
-        Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
+    final String testOutputDirectory = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
     final Map<String, dynamic> summary = json.decode(
       file('$testOutputDirectory/$timelineSummaryFile.json').readAsStringSync(),
     ) as Map<String, dynamic>;
@@ -164,14 +170,16 @@ class GalleryTransitionTest {
     }
 
     final bool isAndroid = deviceOperatingSystem == DeviceOperatingSystem.android;
-    return TaskResult.success(
-      summary,
+    return TaskResult.success(summary,
       detailFiles: <String>[
-        if (transitionDurationFile != null) '$testOutputDirectory/$transitionDurationFile.json',
-        if (timelineTraceFile != null) '$testOutputDirectory/$timelineTraceFile.json',
+        if (transitionDurationFile != null)
+          '$testOutputDirectory/$transitionDurationFile.json',
+        if (timelineTraceFile != null)
+          '$testOutputDirectory/$timelineTraceFile.json',
       ],
       benchmarkScoreKeys: <String>[
-        if (transitionDurationFile != null) 'missed_transition_count',
+        if (transitionDurationFile != null)
+          'missed_transition_count',
         'average_frame_build_time_millis',
         'worst_frame_build_time_millis',
         '90th_percentile_frame_build_time_millis',
@@ -238,12 +246,11 @@ class GalleryTransitionBuildTest extends BuildTestTask {
   final String? transitionDurationFile;
   final String? driverFile;
 
-  final String testOutputDirectory =
-      Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
+  final String testOutputDirectory = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
 
   @override
   void copyArtifacts() {
-    if (applicationBinaryPath != null) {
+    if(applicationBinaryPath != null) {
       copy(
         file('${galleryDirectory.path}/build/app/outputs/flutter-apk/app-profile.apk'),
         Directory(applicationBinaryPath!),

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -80,6 +80,7 @@ TaskFunction createGalleryTransitionHybridTest({bool semanticsEnabled = false}) 
 }
 
 class GalleryTransitionTest {
+
   GalleryTransitionTest({
     this.semanticsEnabled = false,
     this.testFile = 'transitions_perf',
@@ -140,7 +141,7 @@ class GalleryTransitionTest {
           '--trace-startup',
         if (applicationBinaryPath != null)
           '--use-application-binary=$applicationBinaryPath'
-        else 
+        else
           ...<String>[
             '-t',
             'test_driver/$testFile.dart',

--- a/dev/devicelab/lib/tasks/gallery.dart
+++ b/dev/devicelab/lib/tasks/gallery.dart
@@ -25,14 +25,29 @@ TaskFunction createGalleryTransitionTest({bool semanticsEnabled = false}) {
   return GalleryTransitionTest(semanticsEnabled: semanticsEnabled);
 }
 
+TaskFunction createGalleryTransitionE2EBuildTest(
+  List<String> args, {
+  bool semanticsEnabled = false,
+  bool enableImpeller = false,
+}) {
+  return GalleryTransitionBuildTest(
+    args,
+    testFile: semanticsEnabled ? 'transitions_perf_e2e_with_semantics' : 'transitions_perf_e2e',
+    needFullTimeline: false,
+    timelineSummaryFile: 'e2e_perf_summary',
+    transitionDurationFile: null,
+    timelineTraceFile: null,
+    driverFile: 'transitions_perf_e2e_test',
+    enableImpeller: enableImpeller,
+  );
+}
+
 TaskFunction createGalleryTransitionE2ETest({
   bool semanticsEnabled = false,
   bool enableImpeller = false,
 }) {
   return GalleryTransitionTest(
-    testFile: semanticsEnabled
-        ? 'transitions_perf_e2e_with_semantics'
-        : 'transitions_perf_e2e',
+    testFile: semanticsEnabled ? 'transitions_perf_e2e_with_semantics' : 'transitions_perf_e2e',
     needFullTimeline: false,
     timelineSummaryFile: 'e2e_perf_summary',
     transitionDurationFile: null,
@@ -45,14 +60,11 @@ TaskFunction createGalleryTransitionE2ETest({
 TaskFunction createGalleryTransitionHybridTest({bool semanticsEnabled = false}) {
   return GalleryTransitionTest(
     semanticsEnabled: semanticsEnabled,
-    driverFile: semanticsEnabled
-        ? 'transitions_perf_hybrid_with_semantics_test'
-        : 'transitions_perf_hybrid_test',
+    driverFile: semanticsEnabled ? 'transitions_perf_hybrid_with_semantics_test' : 'transitions_perf_hybrid_test',
   );
 }
 
 class GalleryTransitionTest {
-
   GalleryTransitionTest({
     this.semanticsEnabled = false,
     this.testFile = 'transitions_perf',
@@ -101,23 +113,20 @@ class GalleryTransitionTest {
         applicationBinaryPath = 'build/app/outputs/flutter-apk/app-profile.apk';
       }
 
-      final String testDriver = driverFile ?? (semanticsEnabled
-          ? '${testFile}_with_semantics_test'
-          : '${testFile}_test');
+      final String testDriver =
+          driverFile ?? (semanticsEnabled ? '${testFile}_with_semantics_test' : '${testFile}_test');
       section('DRIVE START');
       await flutter('drive', options: <String>[
         '--no-dds',
         '--profile',
         if (enableImpeller) '--enable-impeller',
-        if (needFullTimeline)
-          '--trace-startup',
+        if (needFullTimeline) '--trace-startup',
         if (applicationBinaryPath != null)
           '--use-application-binary=$applicationBinaryPath'
-        else
-          ...<String>[
-            '-t',
-            'test_driver/$testFile.dart',
-          ],
+        else ...<String>[
+          '-t',
+          'test_driver/$testFile.dart',
+        ],
         '--driver',
         'test_driver/$testDriver.dart',
         '-d',
@@ -125,7 +134,8 @@ class GalleryTransitionTest {
       ]);
     });
 
-    final String testOutputDirectory = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
+    final String testOutputDirectory =
+        Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
     final Map<String, dynamic> summary = json.decode(
       file('$testOutputDirectory/$timelineSummaryFile.json').readAsStringSync(),
     ) as Map<String, dynamic>;
@@ -143,16 +153,14 @@ class GalleryTransitionTest {
     }
 
     final bool isAndroid = deviceOperatingSystem == DeviceOperatingSystem.android;
-    return TaskResult.success(summary,
+    return TaskResult.success(
+      summary,
       detailFiles: <String>[
-        if (transitionDurationFile != null)
-          '$testOutputDirectory/$transitionDurationFile.json',
-        if (timelineTraceFile != null)
-          '$testOutputDirectory/$timelineTraceFile.json',
+        if (transitionDurationFile != null) '$testOutputDirectory/$transitionDurationFile.json',
+        if (timelineTraceFile != null) '$testOutputDirectory/$timelineTraceFile.json',
       ],
       benchmarkScoreKeys: <String>[
-        if (transitionDurationFile != null)
-          'missed_transition_count',
+        if (transitionDurationFile != null) 'missed_transition_count',
         'average_frame_build_time_millis',
         'worst_frame_build_time_millis',
         '90th_percentile_frame_build_time_millis',
@@ -205,23 +213,26 @@ class GalleryTransitionBuildTest extends BuildTestTask {
     this.driverFile,
     this.measureCpuGpu = true,
     this.measureMemory = true,
+    this.enableImpeller = false,
   }) : super(workingDirectory: galleryDirectory);
 
   final bool semanticsEnabled;
   final bool needFullTimeline;
   final bool measureCpuGpu;
   final bool measureMemory;
+  final bool enableImpeller;
   final String testFile;
   final String timelineSummaryFile;
   final String? timelineTraceFile;
   final String? transitionDurationFile;
   final String? driverFile;
 
-  final String testOutputDirectory = Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
+  final String testOutputDirectory =
+      Platform.environment['FLUTTER_TEST_OUTPUTS_DIR'] ?? '${galleryDirectory.path}/build';
 
   @override
   void copyArtifacts() {
-    if(applicationBinaryPath != null) {
+    if (applicationBinaryPath != null) {
       copy(
         file('${galleryDirectory.path}/build/app/outputs/flutter-apk/app-profile.apk'),
         Directory(applicationBinaryPath!),
@@ -247,6 +258,7 @@ class GalleryTransitionBuildTest extends BuildTestTask {
     final String testDriver = driverFile ?? (semanticsEnabled ? '${testFile}_with_semantics_test' : '${testFile}_test');
     return <String>[
       '--profile',
+      if (enableImpeller) '--enable-impeller',
       if (needFullTimeline) '--trace-startup',
       '-t',
       'test_driver/$testFile.dart',


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/103542.

This migrates `flutter_gallery__transition_perf_hybrid` and `flutter_gallery__transition_perf_e2e` to build+test model. Validated via led, but marking as `bringup: true` to initiate in CI.