### PR TITLE
Use UriConverter from context for test

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -6,6 +6,7 @@
 
 import 'dart:async';
 
+import 'package:dds/dds.dart';
 import 'package:meta/meta.dart';
 import 'package:package_config/package_config.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -65,6 +66,7 @@ FlutterPlatform installHook({
   Device? integrationTestDevice,
   String? integrationTestUserIdentifier,
   TestTimeRecorder? testTimeRecorder,
+  UriConverter? uriConverter,
 }) {
   assert(testWrapper != null);
   assert(enableObservatory || (!debuggingOptions.startPaused && debuggingOptions.hostVmServicePort == null));
@@ -95,6 +97,7 @@ FlutterPlatform installHook({
     integrationTestDevice: integrationTestDevice,
     integrationTestUserIdentifier: integrationTestUserIdentifier,
     testTimeRecorder: testTimeRecorder,
+    uriConverter: uriConverter,
   );
   platformPluginRegistration(platform);
   return platform;
@@ -290,6 +293,7 @@ class FlutterPlatform extends PlatformPlugin {
     this.integrationTestDevice,
     this.integrationTestUserIdentifier,
     this.testTimeRecorder,
+    this.uriConverter,
   }) : assert(shellPath != null);
 
   final String shellPath;
@@ -306,6 +310,7 @@ class FlutterPlatform extends PlatformPlugin {
   final FlutterProject? flutterProject;
   final String? icudtlPath;
   final TestTimeRecorder? testTimeRecorder;
+  final UriConverter? uriConverter;
 
   /// The device to run the test on for Integration Tests.
   ///
@@ -428,7 +433,8 @@ class FlutterPlatform extends PlatformPlugin {
       flutterProject: flutterProject,
       icudtlPath: icudtlPath,
       compileExpression: _compileExpressionService,
-      fontConfigManager: _fontConfigManager
+      fontConfigManager: _fontConfigManager,
+      uriConverter: uriConverter,
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -310,6 +310,8 @@ class FlutterPlatform extends PlatformPlugin {
   final FlutterProject? flutterProject;
   final String? icudtlPath;
   final TestTimeRecorder? testTimeRecorder;
+
+  // This can be used by internal projects that require custom logic for converting package: URIs to local paths.
   final UriConverter? uriConverter;
 
   /// The device to run the test on for Integration Tests.

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -12,6 +12,7 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
 
+import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -162,7 +163,7 @@ class FlutterTesterTestDevice extends TestDevice {
         Uri? forwardingUri;
         if (debuggingOptions.enableDds) {
           logger.printTrace('test $id: Starting Dart Development Service');
-          final DartDevelopmentService dds = await startDds(detectedUri);
+          final DartDevelopmentService dds = await startDds(detectedUri, uriConverter: context.get<UriConverter>());
           forwardingUri = dds.uri;
           logger.printTrace('test $id: Dart Development Service started at ${dds.uri}, forwarding to VM service at ${dds.remoteVmServiceUri}.');
         } else {
@@ -239,12 +240,13 @@ class FlutterTesterTestDevice extends TestDevice {
 
   @visibleForTesting
   @protected
-  Future<DartDevelopmentService> startDds(Uri uri) {
+  Future<DartDevelopmentService> startDds(Uri uri, {UriConverter? uriConverter}) {
     return DartDevelopmentService.startDartDevelopmentService(
       uri,
       serviceUri: _ddsServiceUri,
       enableAuthCodes: !debuggingOptions.disableServiceAuthCodes,
       ipv6: host!.type == InternetAddressType.IPv6,
+      uriConverter: uriConverter,
     );
   }
 

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -12,7 +12,6 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:stream_channel/stream_channel.dart';
 
-import '../base/context.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -44,6 +43,7 @@ class FlutterTesterTestDevice extends TestDevice {
     required this.icudtlPath,
     required this.compileExpression,
     required this.fontConfigManager,
+    required this.uriConverter,
   })  : assert(shellPath != null), // Please provide the path to the shell in the SKY_SHELL environment variable.
         assert(!debuggingOptions.startPaused || enableObservatory),
         _gotProcessObservatoryUri = enableObservatory
@@ -65,6 +65,7 @@ class FlutterTesterTestDevice extends TestDevice {
   final String? icudtlPath;
   final CompileExpression? compileExpression;
   final FontConfigManager fontConfigManager;
+  final UriConverter? uriConverter;
 
   final Completer<Uri?> _gotProcessObservatoryUri;
   final Completer<int> _exitCode = Completer<int>();
@@ -163,7 +164,10 @@ class FlutterTesterTestDevice extends TestDevice {
         Uri? forwardingUri;
         if (debuggingOptions.enableDds) {
           logger.printTrace('test $id: Starting Dart Development Service');
-          final DartDevelopmentService dds = await startDds(detectedUri, uriConverter: context.get<UriConverter>());
+          final DartDevelopmentService dds = await startDds(
+            detectedUri,
+            uriConverter: uriConverter,
+          );
           forwardingUri = dds.uri;
           logger.printTrace('test $id: Dart Development Service started at ${dds.uri}, forwarding to VM service at ${dds.remoteVmServiceUri}.');
         } else {

--- a/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_platform_test.dart
@@ -97,7 +97,9 @@ void main() {
         icudtlPath: 'ghi',
         platformPluginRegistration: (FlutterPlatform platform) {
           capturedPlatform = platform;
-        });
+        },
+        uriConverter: (String input) => '$input/test',
+      );
 
       expect(identical(capturedPlatform, flutterPlatform), equals(true));
       expect(flutterPlatform.shellPath, equals('abc'));
@@ -113,6 +115,7 @@ void main() {
       expect(flutterPlatform.updateGoldens, equals(true));
       expect(flutterPlatform.testAssetDirectory, '/build/test');
       expect(flutterPlatform.icudtlPath, equals('ghi'));
+      expect(flutterPlatform.uriConverter?.call('hello'), 'hello/test');
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -188,8 +188,8 @@ void main() {
       await device.start('example.dill');
       await device.observatoryUri;
 
-      final FakeDartDevelopmentService dds = ((device as TestFlutterTesterDevice).dds
-      as FakeDartDevelopmentService);
+      final FakeDartDevelopmentService dds = (device as TestFlutterTesterDevice).dds
+      as FakeDartDevelopmentService;
       final String? result = dds
           .uriConverter
           ?.call('test');

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -46,6 +46,7 @@ void main() {
       processManager: processManager,
       enableObservatory: enableObservatory,
       dartEntrypointArgs: dartEntrypointArgs,
+      uriConverter: (String input) => '$input/converted',
     );
 
   group('The FLUTTER_TEST environment variable is passed to the test process', () {
@@ -187,12 +188,13 @@ void main() {
       await device.start('example.dill');
       await device.observatoryUri;
 
-      final String? result = ((device as TestFlutterTesterDevice).dds
-              as FakeDartDevelopmentService)
+      final FakeDartDevelopmentService dds = ((device as TestFlutterTesterDevice).dds
+      as FakeDartDevelopmentService);
+      final String? result = dds
           .uriConverter
           ?.call('test');
       expect(result, 'test/converted');
-    }, overrides: <Type, Generator>{UriConverter: () => (String input) => '$input/converted'});
+    });
   });
 }
 
@@ -206,6 +208,7 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
     required super.processManager,
     required super.enableObservatory,
     required List<String> dartEntrypointArgs,
+    required UriConverter uriConverter,
   }) : super(
     id: 999,
     shellPath: '/',
@@ -226,6 +229,7 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
     icudtlPath: null,
     compileExpression: null,
     fontConfigManager: FontConfigManager(),
+    uriConverter: uriConverter,
   );
   late DartDevelopmentService dds;
 

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -238,9 +238,16 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
   Future<Uri> ddsServiceUriFuture() => _ddsServiceUriCompleter.future;
 
   @override
-  Future<DartDevelopmentService> startDds(Uri uri, {UriConverter? uriConverter}) async {
+  Future<DartDevelopmentService> startDds(
+    Uri uri, {
+    UriConverter? uriConverter,
+  }) async {
     _ddsServiceUriCompleter.complete(uri);
-    dds = FakeDartDevelopmentService(Uri.parse('http://localhost:${debuggingOptions.hostVmServicePort}'), Uri.parse('http://localhost:8080'), uriConverter: uriConverter);
+    dds = FakeDartDevelopmentService(
+      Uri.parse('http://localhost:${debuggingOptions.hostVmServicePort}'),
+      Uri.parse('http://localhost:8080'),
+      uriConverter: uriConverter,
+    );
     return dds;
   }
 

--- a/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_tester_device_test.dart
@@ -248,7 +248,7 @@ class TestFlutterTesterDevice extends FlutterTesterTestDevice {
 }
 
 class FakeDartDevelopmentService extends Fake implements DartDevelopmentService {
-  FakeDartDevelopmentService(this.uri, this.original, {UriConverter? this.uriConverter});
+  FakeDartDevelopmentService(this.uri, this.original, {this.uriConverter});
 
   final Uri original;
   final UriConverter? uriConverter;


### PR DESCRIPTION
This will allow internal tests to pass a UriConverter to DDS that will provide package: URI to local file conversions during test debugging.

CC @chingjun @jwren 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above. (issue is internal)
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
