### PR TITLE
Make module tests pass on Xcode 14

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -421,7 +421,6 @@ end
         if ((await fileType(builtFlutterBinary)).contains('armv7')) {
           throw TaskResult.failure('Unexpected armv7 architecture slice in $builtFlutterBinary');
         }
-        await checkContainsBitcode(builtFlutterBinary);
 
         final String builtAppBinary = path.join(
           archivedAppPath,
@@ -433,7 +432,6 @@ end
         if ((await fileType(builtAppBinary)).contains('armv7')) {
           throw TaskResult.failure('Unexpected armv7 architecture slice in $builtAppBinary');
         }
-        await checkContainsBitcode(builtAppBinary);
 
         // The host app example builds plugins statically, url_launcher_ios.framework
         // should not exist.

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 
 import 'host_agent.dart';
-import 'task_result.dart';
 import 'utils.dart';
 
 typedef SimulatorFunction = Future<void> Function(String deviceId);

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -85,12 +85,6 @@ Future<bool> containsBitcode(String pathToBinary) async {
   return !emptyBitcodeMarkerFound;
 }
 
-Future<void> checkContainsBitcode(String pathToBinary) async {
-  if (!await containsBitcode(pathToBinary)) {
-    throw TaskResult.failure('Expected bitcode in $pathToBinary');
-  }
-}
-
 /// Creates and boots a new simulator, passes the new simulator's identifier to
 /// `testFunction`.
 ///


### PR DESCRIPTION
Remove `arm64_armv7` directories and bitcode checks for built/embedded frameworks.  Leave the bitcode checks for Flutter.framework and App.framework, to be removed later as part of https://github.com/flutter/flutter/issues/107887.

Tested locally on Xcode 14 beta 5.  

Fixes https://github.com/flutter/flutter/issues/110555
Fixes https://github.com/flutter/flutter/issues/110553
Reverts the unnecessary armv7 checks from #101592 post-https://github.com/flutter/flutter/issues/97327.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
