### PR TITLE
Support single arch local engines for 'build macos-framework' and 'ios-framework'

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -732,6 +732,8 @@ abstract class LocalEngineArtifacts implements Artifacts {
   }) = CachedLocalEngineArtifacts;
 
   String get engineOutPath;
+
+  String get localEngineName;
 }
 
 /// Manages the artifacts of a locally built engine.
@@ -745,6 +747,7 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
     required Platform platform,
     required OperatingSystemUtils operatingSystemUtils,
   }) : _fileSystem = fileSystem,
+       localEngineName = fileSystem.path.basename(engineOutPath),
        _cache = cache,
        _processManager = processManager,
        _platform = platform,
@@ -752,6 +755,9 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
 
   @override
   final String engineOutPath;
+
+  @override
+  final String localEngineName;
 
   final String _hostEngineOutPath;
   final FileSystem _fileSystem;
@@ -1063,4 +1069,7 @@ class _TestLocalEngine extends _TestArtifacts implements LocalEngineArtifacts {
 
   @override
   final String engineOutPath;
+
+  @override
+  String get localEngineName => fileSystem.path.basename(engineOutPath);
 }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -4,6 +4,7 @@
 
 import 'package:package_config/package_config_types.dart';
 
+import 'artifacts.dart';
 import 'base/config.dart';
 import 'base/context.dart';
 import 'base/file_system.dart';
@@ -562,14 +563,40 @@ enum AndroidArch {
 
 /// The default set of iOS device architectures to build for.
 List<DarwinArch> defaultIOSArchsForEnvironment(
-    EnvironmentType environmentType) {
-  if (environmentType == EnvironmentType.simulator) {
+  EnvironmentType environmentType,
+  Artifacts artifacts,
+) {
+  // Handle single-arch local engines.
+  if (artifacts is LocalEngineArtifacts) {
+    final String localEngineName = artifacts.localEngineName;
+    if (localEngineName.contains('_arm64')) {
+      return <DarwinArch>[ DarwinArch.arm64 ];
+    }
+    if (localEngineName.contains('_sim')) {
+      return <DarwinArch>[ DarwinArch.x86_64 ];
+    }
+  } else if (environmentType == EnvironmentType.simulator) {
     return <DarwinArch>[
       DarwinArch.x86_64,
       DarwinArch.arm64,
     ];
   }
   return <DarwinArch>[
+    DarwinArch.arm64,
+  ];
+}
+
+/// The default set of macOS device architectures to build for.
+List<DarwinArch> defaultMacOSArchsForEnvironment(Artifacts artifacts) {
+  // Handle single-arch local engines.
+  if (artifacts is LocalEngineArtifacts) {
+    if (artifacts.localEngineName.contains('_arm64')) {
+      return <DarwinArch>[ DarwinArch.arm64 ];
+    }
+    return <DarwinArch>[ DarwinArch.x86_64 ];
+  }
+  return <DarwinArch>[
+    DarwinArch.x86_64,
     DarwinArch.arm64,
   ];
 }

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -422,7 +422,7 @@ end
             kTargetFile: targetFile,
             kTargetPlatform: getNameForTargetPlatform(TargetPlatform.ios),
             kBitcodeFlag: 'true',
-            kIosArchs: defaultIOSArchsForEnvironment(sdkType)
+            kIosArchs: defaultIOSArchsForEnvironment(sdkType, globals.artifacts!)
                 .map(getNameForDarwinArch)
                 .join(' '),
             kSdkRoot: await globals.xcode!.sdkLocation(sdkType),

--- a/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos_framework.dart
@@ -193,10 +193,9 @@ end
         defines: <String, String>{
           kTargetFile: targetFile,
           kTargetPlatform: getNameForTargetPlatform(TargetPlatform.darwin),
-          kDarwinArchs: <DarwinArch>[
-            DarwinArch.x86_64,
-            DarwinArch.arm64,
-          ].map(getNameForDarwinArch).join(' '),
+          kDarwinArchs: defaultMacOSArchsForEnvironment(globals.artifacts!)
+              .map(getNameForDarwinArch)
+              .join(' '),
           ...buildInfo.toBuildSystemEnvironment(),
         },
         artifacts: globals.artifacts!,

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -176,7 +176,7 @@ Future<List<String>> _xcodeBuildSettingsLines({
     final String engineOutPath = localEngineArtifacts.engineOutPath;
     xcodeBuildSettings.add('FLUTTER_ENGINE=${globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath))}');
 
-    final String localEngineName = globals.fs.path.basename(engineOutPath);
+    final String localEngineName = localEngineArtifacts.localEngineName;
     xcodeBuildSettings.add('LOCAL_ENGINE=$localEngineName');
 
     // Tell Xcode not to build universal binaries for local engines, which are

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -60,7 +60,7 @@ Future<void> buildLinux(
     final LocalEngineArtifacts localEngineArtifacts = artifacts;
     final String engineOutPath = localEngineArtifacts.engineOutPath;
     environmentConfig['FLUTTER_ENGINE'] = globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath));
-    environmentConfig['LOCAL_ENGINE'] = globals.fs.path.basename(engineOutPath);
+    environmentConfig['LOCAL_ENGINE'] = localEngineArtifacts.localEngineName;
   }
   writeGeneratedCmakeConfig(Cache.flutterRoot!, linuxProject, buildInfo, environmentConfig);
 

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -221,7 +221,7 @@ void _writeGeneratedFlutterConfig(
   if (artifacts is LocalEngineArtifacts) {
     final String engineOutPath = artifacts.engineOutPath;
     environment['FLUTTER_ENGINE'] = globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath));
-    environment['LOCAL_ENGINE'] = globals.fs.path.basename(engineOutPath);
+    environment['LOCAL_ENGINE'] = artifacts.localEngineName;
   }
   writeGeneratedCmakeConfig(Cache.flutterRoot!, windowsProject, buildInfo, environment);
 }

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/build_info.dart';
 
@@ -97,6 +98,45 @@ void main() {
     expect(getNameForTargetPlatform(TargetPlatform.ios, darwinArch: DarwinArch.armv7), 'ios-armv7');
     expect(getNameForTargetPlatform(TargetPlatform.ios, darwinArch: DarwinArch.x86_64), 'ios-x86_64');
     expect(getNameForTargetPlatform(TargetPlatform.android), isNot(contains('ios')));
+  });
+
+  testWithoutContext('defaultIOSArchsForEnvironment', () {
+    expect(defaultIOSArchsForEnvironment(
+      EnvironmentType.physical,
+      Artifacts.test(localEngine: 'ios_debug_unopt'),
+    ).single, DarwinArch.arm64);
+
+    expect(defaultIOSArchsForEnvironment(
+      EnvironmentType.simulator,
+      Artifacts.test(localEngine: 'ios_debug_sim_unopt'),
+    ).single, DarwinArch.x86_64);
+
+    expect(defaultIOSArchsForEnvironment(
+      EnvironmentType.simulator,
+      Artifacts.test(localEngine: 'ios_debug_sim_unopt_arm64'),
+    ).single, DarwinArch.arm64);
+
+    expect(defaultIOSArchsForEnvironment(
+      EnvironmentType.physical, Artifacts.test(),
+    ).single, DarwinArch.arm64);
+
+    expect(defaultIOSArchsForEnvironment(
+      EnvironmentType.simulator, Artifacts.test(),
+    ), <DarwinArch>[ DarwinArch.x86_64, DarwinArch.arm64 ]);
+  });
+
+  testWithoutContext('defaultMacOSArchsForEnvironment', () {
+    expect(defaultMacOSArchsForEnvironment(
+      Artifacts.test(localEngine: 'host_debug_unopt'),
+    ).single, DarwinArch.x86_64);
+
+    expect(defaultMacOSArchsForEnvironment(
+      Artifacts.test(localEngine: 'host_debug_unopt_arm64'),
+    ).single, DarwinArch.arm64);
+
+    expect(defaultMacOSArchsForEnvironment(
+      Artifacts.test(),
+    ), <DarwinArch>[ DarwinArch.x86_64, DarwinArch.arm64 ]);
   });
 
   testWithoutContext('getIOSArchForName on Darwin arches', () {


### PR DESCRIPTION
Pass the artifacts through these commands, if local engine then only build for a single arch.

Fixes https://github.com/flutter/flutter/issues/110335
Related to https://github.com/flutter/flutter/issues/100804 and https://github.com/flutter/flutter/pull/100811

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
