### PR TITLE
110598: expect() in semantic test producing unhelpful output

### DIFF
--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -2272,10 +2272,10 @@ class _MatchesSemanticsData extends Matcher {
         .toList();
 
       if (expectedActions.isNotEmpty) {
-        description.add(' with actions: ').addDescriptionOf(expectedActions);
+        description.add(' with actions: ${_createEnumsSummary(expectedActions)} ');
       }
       if (notExpectedActions.isNotEmpty) {
-        description.add(' without actions: ').addDescriptionOf(notExpectedActions);
+        description.add(' without actions: ${_createEnumsSummary(notExpectedActions)} ');
       }
     }
     if (flags.isNotEmpty) {
@@ -2289,10 +2289,10 @@ class _MatchesSemanticsData extends Matcher {
         .toList();
 
       if (expectedFlags.isNotEmpty) {
-        description.add(' with flags: ').addDescriptionOf(expectedFlags);
+        description.add(' with flags: ${_createEnumsSummary(expectedFlags)} ');
       }
       if (notExpectedFlags.isNotEmpty) {
-        description.add(' without flags: ').addDescriptionOf(notExpectedFlags);
+        description.add(' without flags: ${_createEnumsSummary(notExpectedFlags)} ');
       }
     }
     if (textDirection != null) {
@@ -2434,17 +2434,23 @@ class _MatchesSemanticsData extends Matcher {
       return failWithDescription(matchState, 'maxValueLength was: ${data.maxValueLength}');
     }
     if (actions.isNotEmpty) {
+      final List<SemanticsAction> unexpectedActions = <SemanticsAction>[];
+      final List<SemanticsAction> missingActions = <SemanticsAction>[];
       for (final MapEntry<ui.SemanticsAction, bool> actionEntry in actions.entries) {
         final ui.SemanticsAction action = actionEntry.key;
         final bool actionExpected = actionEntry.value;
         final bool actionPresent = (action.index & data.actions) == action.index;
         if (actionPresent != actionExpected) {
-          final List<String> actionSummary = <String>[
-            for (final SemanticsAction action in SemanticsAction.values.values)
-              if ((data.actions & action.index) != 0) describeEnum(action),
-          ];
-          return failWithDescription(matchState, 'actions were: $actionSummary');
+          if(actionExpected) {
+            missingActions.add(action);
+          } else {
+            unexpectedActions.add(action);
+          }
         }
+      }
+
+      if (unexpectedActions.isNotEmpty || missingActions.isNotEmpty) {
+        return failWithDescription(matchState, 'missing actions: ${_createEnumsSummary(missingActions)} unexpected actions: ${_createEnumsSummary(unexpectedActions)}');
       }
     }
     if (customActions != null || hintOverrides != null) {
@@ -2473,17 +2479,23 @@ class _MatchesSemanticsData extends Matcher {
       }
     }
     if (flags.isNotEmpty) {
+      final List<SemanticsFlag> unexpectedFlags = <SemanticsFlag>[];
+      final List<SemanticsFlag> missingFlags = <SemanticsFlag>[];
       for (final MapEntry<ui.SemanticsFlag, bool> flagEntry in flags.entries) {
         final ui.SemanticsFlag flag = flagEntry.key;
         final bool flagExpected = flagEntry.value;
         final bool flagPresent = flag.index & data.flags == flag.index;
         if (flagPresent != flagExpected) {
-          final List<String> flagSummary = <String>[
-            for (final SemanticsFlag flag in SemanticsFlag.values.values)
-              if ((data.flags & flag.index) != 0) describeEnum(flag),
-          ];
-          return failWithDescription(matchState, 'flags were: $flagSummary');
+          if(flagExpected) {
+            missingFlags.add(flag);
+          } else {
+            unexpectedFlags.add(flag);
+          }
         }
+      }
+
+      if (unexpectedFlags.isNotEmpty || missingFlags.isNotEmpty) {
+        return failWithDescription(matchState, 'missing flags: ${_createEnumsSummary(missingFlags)} unexpected flags: ${_createEnumsSummary(unexpectedFlags)}');
       }
     }
     bool allMatched = true;
@@ -2511,6 +2523,11 @@ class _MatchesSemanticsData extends Matcher {
     bool verbose,
   ) {
     return mismatchDescription.add(matchState['failure'] as String);
+  }
+
+  static String _createEnumsSummary<T extends Object>(List<T> enums) {
+    assert(T == SemanticsAction || T == SemanticsFlag, 'This method is only intended for lists of SemanticsActions or SemanticsFlags.');
+    return '[${enums.map(describeEnum).join(', ')}]';
   }
 }
 

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -2440,8 +2440,8 @@ class _MatchesSemanticsData extends Matcher {
         final bool actionPresent = (action.index & data.actions) == action.index;
         if (actionPresent != actionExpected) {
           final List<String> actionSummary = <String>[
-            for (final int action in SemanticsAction.values.keys)
-              if ((data.actions & action) != 0) describeEnum(action),
+            for (final SemanticsAction action in SemanticsAction.values.values)
+              if ((data.actions & action.index) != 0) describeEnum(action),
           ];
           return failWithDescription(matchState, 'actions were: $actionSummary');
         }
@@ -2479,8 +2479,8 @@ class _MatchesSemanticsData extends Matcher {
         final bool flagPresent = flag.index & data.flags == flag.index;
         if (flagPresent != flagExpected) {
           final List<String> flagSummary = <String>[
-            for (final int flag in SemanticsFlag.values.keys)
-              if ((data.flags & flag) != 0) describeEnum(flag),
+            for (final SemanticsFlag flag in SemanticsFlag.values.values)
+              if ((data.flags & flag.index) != 0) describeEnum(flag),
           ];
           return failWithDescription(matchState, 'flags were: $flagSummary');
         }

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -764,6 +764,9 @@ void main() {
       // This should fail due to the mis-match between the `namesRoute` value.
       void failedExpectation() => expect(tester.getSemantics(find.byKey(key)),
         matchesSemantics(
+          // Adding the explicit `false` for test readability
+          // ignore: avoid_redundant_argument_values
+          namesRoute: false,
           label: 'foo',
           hint: 'bar',
           value: 'baz',
@@ -775,7 +778,6 @@ void main() {
           isButton: true,
           isLink: true,
           isHeader: true,
-          namesRoute: false,
           onTapHint: 'scan',
           onLongPressHint: 'fill',
           customActions: <CustomSemanticsAction>[
@@ -785,7 +787,7 @@ void main() {
         ),
       );
 
-      expect(failedExpectation, throwsA(isA<TestFailure>()));//.having((TestFailure failure) => failure., description, matcher)))
+      expect(failedExpectation, throwsA(isA<TestFailure>()));
     });
   });
 

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -733,6 +733,60 @@ void main() {
       ));
       handle.dispose();
     });
+
+    testWidgets('failure does not throw unexpected errors', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      addTearDown(() => handle.dispose());
+
+      const Key key = Key('semantics');
+      await tester.pumpWidget(Semantics(
+        key: key,
+        namesRoute: true,
+        header: true,
+        button: true,
+        link: true,
+        onTap: () { },
+        onLongPress: () { },
+        label: 'foo',
+        hint: 'bar',
+        value: 'baz',
+        increasedValue: 'a',
+        decreasedValue: 'b',
+        textDirection: TextDirection.rtl,
+        onTapHint: 'scan',
+        onLongPressHint: 'fill',
+        customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+          const CustomSemanticsAction(label: 'foo'): () { },
+          const CustomSemanticsAction(label: 'bar'): () { },
+        },
+      ));
+
+      // This should fail due to the mis-match between the `namesRoute` value.
+      void failedExpectation() => expect(tester.getSemantics(find.byKey(key)),
+        matchesSemantics(
+          label: 'foo',
+          hint: 'bar',
+          value: 'baz',
+          increasedValue: 'a',
+          decreasedValue: 'b',
+          textDirection: TextDirection.rtl,
+          hasTapAction: true,
+          hasLongPressAction: true,
+          isButton: true,
+          isLink: true,
+          isHeader: true,
+          namesRoute: false,
+          onTapHint: 'scan',
+          onLongPressHint: 'fill',
+          customActions: <CustomSemanticsAction>[
+            const CustomSemanticsAction(label: 'foo'),
+            const CustomSemanticsAction(label: 'bar'),
+          ],
+        ),
+      );
+
+      expect(failedExpectation, throwsA(isA<TestFailure>()));//.having((TestFailure failure) => failure., description, matcher)))
+    });
   });
 
   group('containsSemantics', () {
@@ -1172,6 +1226,60 @@ void main() {
       final _FakeSemanticsNode node = _FakeSemanticsNode(data);
 
       expect(node, containsSemantics(customActions: <CustomSemanticsAction>[action]));
+    });
+
+    testWidgets('failure does not throw unexpected errors', (WidgetTester tester) async {
+      final SemanticsHandle handle = tester.ensureSemantics();
+      addTearDown(() => handle.dispose());
+
+      const Key key = Key('semantics');
+      await tester.pumpWidget(Semantics(
+        key: key,
+        namesRoute: true,
+        header: true,
+        button: true,
+        link: true,
+        onTap: () { },
+        onLongPress: () { },
+        label: 'foo',
+        hint: 'bar',
+        value: 'baz',
+        increasedValue: 'a',
+        decreasedValue: 'b',
+        textDirection: TextDirection.rtl,
+        onTapHint: 'scan',
+        onLongPressHint: 'fill',
+        customSemanticsActions: <CustomSemanticsAction, VoidCallback>{
+          const CustomSemanticsAction(label: 'foo'): () { },
+          const CustomSemanticsAction(label: 'bar'): () { },
+        },
+      ));
+
+      // This should fail due to the mis-match between the `namesRoute` value.
+      void failedExpectation() => expect(tester.getSemantics(find.byKey(key)),
+        containsSemantics(
+          label: 'foo',
+          hint: 'bar',
+          value: 'baz',
+          increasedValue: 'a',
+          decreasedValue: 'b',
+          textDirection: TextDirection.rtl,
+          hasTapAction: true,
+          hasLongPressAction: true,
+          isButton: true,
+          isLink: true,
+          isHeader: true,
+          namesRoute: false,
+          onTapHint: 'scan',
+          onLongPressHint: 'fill',
+          customActions: <CustomSemanticsAction>[
+            const CustomSemanticsAction(label: 'foo'),
+            const CustomSemanticsAction(label: 'bar'),
+          ],
+        ),
+      );
+
+      expect(failedExpectation, throwsA(isA<TestFailure>()));
     });
   });
 


### PR DESCRIPTION
Fixed issue with usage of `describeEnum` in `_MatchesSemanticsData` and added tests to prevent regressions.

Resolves #110598 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
