### PR TITLE
Add persistent frame callback removal method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -95,3 +95,4 @@ Taskulu LDA <contributions@taskulu.com>
 Jonathan Joelson <jon@joelson.co>
 Elsabe Ros <hello@elsabe.dev>
 Nguyễn Phúc Lợi <nploi1998@gmail.com>
+Amir Panahandeh <amirpanahandeh@gmail.com>

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -654,10 +654,20 @@ mixin SchedulerBinding on BindingBase {
   /// executed after the transient frame callbacks they can drive the
   /// rendering pipeline.
   ///
-  /// Persistent frame callbacks cannot be unregistered. Once registered, they
-  /// are called for every frame for the lifetime of the application.
+  /// If the same callback is added twice, it will be executed twice.
+  ///
+  /// See also:
+  ///
+  ///  * [removePersistentFrameCallback], which can be used to remove a callback
+  ///    added using this method.
   void addPersistentFrameCallback(FrameCallback callback) {
     _persistentCallbacks.add(callback);
+  }
+
+  /// Removes a callback that was earlier added by [addPersistentFrameCallback].
+  void removePersistentFrameCallback(FrameCallback callback) {
+    assert(_persistentCallbacks.contains(callback));
+    _persistentCallbacks.remove(callback);
   }
 
   final List<FrameCallback> _postFrameCallbacks = <FrameCallback>[];

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -250,6 +250,23 @@ void main() {
     warmUpDrawFrame();
     expect(scheduler.hasScheduledFrame, isTrue);
   });
+
+  test('Persistent frame callback is called', () {
+    bool isCalled = false;
+    void callback(_) => isCalled = true;
+    SchedulerBinding.instance.addPersistentFrameCallback(callback);
+    tick(Duration.zero);
+    expect(isCalled, true);
+  });
+
+  test('Persistent frame callback is not called after being removed', () {
+    bool isCalled = false;
+    void callback(_) => isCalled = true;
+    SchedulerBinding.instance.addPersistentFrameCallback(callback);
+    SchedulerBinding.instance.removePersistentFrameCallback(callback);
+    tick(Duration.zero);
+    expect(isCalled, false);
+  });
 }
 
 class DummyTimer implements Timer {


### PR DESCRIPTION
This PR attempts to add a method named `removePersistentFrameCallback` to remove added persistent frame callback. Right now it's not possible to remove a persistent frame callback and I couldn't find much about its design decisions. There is an open issue #110574 for that but since it was easy to do I decided to open this PR too.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
