### PR TITLE
Fixed the default color of the trailing widget on app bar

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -942,11 +942,13 @@ class _AppBarState extends State<AppBar> {
         ?? appBarTheme.iconTheme
         ?? defaults.iconTheme!.copyWith(color: foregroundColor);
 
+    final Color? actionForegroundColor = widget.foregroundColor
+      ?? appBarTheme.foregroundColor;
     IconThemeData actionsIconTheme = widget.actionsIconTheme
       ?? appBarTheme.actionsIconTheme
       ?? widget.iconTheme
       ?? appBarTheme.iconTheme
-      ?? defaults.actionsIconTheme?.copyWith(color: foregroundColor)
+      ?? defaults.actionsIconTheme?.copyWith(color: actionForegroundColor)
       ?? overallIconTheme;
 
     TextStyle? toolbarTextStyle = backwardsCompatibility

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2876,6 +2876,36 @@ void main() {
     expect(actionIconColor(), foregroundColor);
   });
 
+  testWidgets('Leading, title, and actions default color match M3 spec', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData.from(
+        colorScheme: const ColorScheme.light(onSurface: Colors.red, onSurfaceVariant: Colors.yellow),
+        useMaterial3: true);
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          appBar: AppBar(
+            leading: const Icon(Icons.add_circle),
+            title: const Text('title'),
+            actions: const <Widget>[
+              Icon(Icons.ac_unit)
+            ],
+          ),
+        ),
+      ),
+    );
+
+    Color textColor() {
+      return tester.renderObject<RenderParagraph>(find.text('title')).text.style!.color!;
+    }
+    Color? leadingIconColor() => iconStyle(tester, Icons.add_circle)?.color;
+    Color? actionIconColor() => iconStyle(tester, Icons.ac_unit)?.color;
+
+    expect(textColor(), Colors.red);
+    expect(leadingIconColor(), Colors.red);
+    expect(actionIconColor(), Colors.yellow);
+  });
+
   // Regression test for https://github.com/flutter/flutter/issues/107305
   group('Icons are colored correctly by IconTheme and ActionIconTheme in M3', () {
     testWidgets('Icons and IconButtons are colored by IconTheme in M3', (WidgetTester tester) async {

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -2876,10 +2876,14 @@ void main() {
     expect(actionIconColor(), foregroundColor);
   });
 
-  testWidgets('Leading, title, and actions default color match M3 spec', (WidgetTester tester) async {
+  testWidgets('Leading, title, and actions show correct default colors', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData.from(
-        colorScheme: const ColorScheme.light(onSurface: Colors.red, onSurfaceVariant: Colors.yellow),
-        useMaterial3: true);
+      colorScheme: const ColorScheme.light(
+        onPrimary: Colors.blue,
+        onSurface: Colors.red,
+        onSurfaceVariant: Colors.yellow),
+    );
+    final bool material3 = themeData.useMaterial3;
     await tester.pumpWidget(
       MaterialApp(
         theme: themeData,
@@ -2901,9 +2905,11 @@ void main() {
     Color? leadingIconColor() => iconStyle(tester, Icons.add_circle)?.color;
     Color? actionIconColor() => iconStyle(tester, Icons.ac_unit)?.color;
 
-    expect(textColor(), Colors.red);
-    expect(leadingIconColor(), Colors.red);
-    expect(actionIconColor(), Colors.yellow);
+    // M2 default color are onPrimary, and M3 has onSurface for leading and title,
+    // onSurfaceVariant for actions.
+    expect(textColor(), material3 ? Colors.red : Colors.blue);
+    expect(leadingIconColor(), material3 ? Colors.red : Colors.blue);
+    expect(actionIconColor(), material3 ? Colors.yellow : Colors.blue);
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/107305


### PR DESCRIPTION
Fixes: #109971

The default color of actions on AppBar should be `onSurfaceVariant`, but the default `foregroundColor` originally overrides the color in the default `actionIconTheme`. Therefore, the action color shows `onSurface` by default. This pr fixes the issue and only allows customized `foregroundColor` to override the color of `actionIconTheme`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.