### PR TITLE
[Benchmark: platform_views_layout] show and hide more PlatformViews

### DIFF
--- a/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/platform_views_layout/test_driver/scroll_perf_test.dart
@@ -33,16 +33,18 @@ void main() {
         final SerializableFinder list = find.byValueKey(listKey);
         expect(list, isNotNull);
 
-        // Scroll down
-        for (int i = 0; i < 5; i += 1) {
-          await driver.scroll(list, 0.0, -300.0, const Duration(milliseconds: 300));
-          await Future<void>.delayed(const Duration(milliseconds: 500));
-        }
+        for (int j = 0; j < 5; j ++) {
+          // Scroll down
+          for (int i = 0; i < 5; i += 1) {
+            await driver.scroll(list, 0.0, -300.0, const Duration(milliseconds: 300));
+            await Future<void>.delayed(const Duration(milliseconds: 500));
+          }
 
-        // Scroll up
-        for (int i = 0; i < 5; i += 1) {
-          await driver.scroll(list, 0.0, 300.0, const Duration(milliseconds: 300));
-          await Future<void>.delayed(const Duration(milliseconds: 500));
+          // Scroll up
+          for (int i = 0; i < 5; i += 1) {
+            await driver.scroll(list, 0.0, 300.0, const Duration(milliseconds: 300));
+            await Future<void>.delayed(const Duration(milliseconds: 500));
+          }
         }
       });
 


### PR DESCRIPTION
This PR adds 5 times of the scrolling so more PlatformViews are shown and hidden during the test. This can potentially be more useful to caught bugs where the PlatformViews are leaking memories. 

Potentially fix: https://github.com/flutter/flutter/issues/110038

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
