### PR TITLE
[flutter_tools] Instantiate shutdown hooks before localfilesystem

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -127,6 +127,7 @@ Future<void> main(List<String> args) async {
       },
       PreRunValidator: () => PreRunValidator(fileSystem: globals.fs),
     },
+    shutdownHooks: globals.shutdownHooks,
   );
 }
 

--- a/packages/flutter_tools/lib/runner.dart
+++ b/packages/flutter_tools/lib/runner.dart
@@ -34,6 +34,7 @@ Future<int> run(
     bool? reportCrashes,
     String? flutterVersion,
     Map<Type, Generator>? overrides,
+    required ShutdownHooks shutdownHooks,
   }) async {
   if (muteCommandLogging) {
     // Remove the verbose option; for help and doctor, users don't need to see
@@ -64,7 +65,7 @@ Future<int> run(
         // Triggering [runZoned]'s error callback does not necessarily mean that
         // we stopped executing the body.  See https://github.com/dart-lang/sdk/issues/42150.
         if (firstError == null) {
-          return await _exit(0);
+          return await _exit(0, shutdownHooks: shutdownHooks);
         }
 
         // We already hit some error, so don't return success.  The error path
@@ -74,7 +75,7 @@ Future<int> run(
         // This catches all exceptions to send to crash logging, etc.
         firstError = error;
         firstStackTrace = stackTrace;
-        return _handleToolError(error, stackTrace, verbose, args, reportCrashes!, getVersion);
+        return _handleToolError(error, stackTrace, verbose, args, reportCrashes!, getVersion, shutdownHooks);
       }
     }, onError: (Object error, StackTrace stackTrace) async { // ignore: deprecated_member_use
       // If sending a crash report throws an error into the zone, we don't want
@@ -82,7 +83,7 @@ Future<int> run(
       // to send the original error that triggered the crash report.
       firstError ??= error;
       firstStackTrace ??= stackTrace;
-      await _handleToolError(firstError!, firstStackTrace, verbose, args, reportCrashes!, getVersion);
+      await _handleToolError(firstError!, firstStackTrace, verbose, args, reportCrashes!, getVersion, shutdownHooks);
     });
   }, overrides: overrides);
 }
@@ -94,12 +95,13 @@ Future<int> _handleToolError(
   List<String> args,
   bool reportCrashes,
   String Function() getFlutterVersion,
+  ShutdownHooks shutdownHooks,
 ) async {
   if (error is UsageException) {
     globals.printError('${error.message}\n');
     globals.printError("Run 'flutter -h' (or 'flutter <command> -h') for available flutter commands and options.");
     // Argument error exit code.
-    return _exit(64);
+    return _exit(64, shutdownHooks: shutdownHooks);
   } else if (error is ToolExit) {
     if (error.message != null) {
       globals.printError(error.message!);
@@ -107,14 +109,14 @@ Future<int> _handleToolError(
     if (verbose) {
       globals.printError('\n$stackTrace\n');
     }
-    return _exit(error.exitCode ?? 1);
+    return _exit(error.exitCode ?? 1, shutdownHooks: shutdownHooks);
   } else if (error is ProcessExit) {
     // We've caught an exit code.
     if (error.immediate) {
       exit(error.exitCode);
       return error.exitCode;
     } else {
-      return _exit(error.exitCode);
+      return _exit(error.exitCode, shutdownHooks: shutdownHooks);
     }
   } else {
     // We've crashed; emit a log report.
@@ -124,7 +126,7 @@ Future<int> _handleToolError(
       // Print the stack trace on the bots - don't write a crash report.
       globals.stdio.stderrWrite('$error\n');
       globals.stdio.stderrWrite('$stackTrace\n');
-      return _exit(1);
+      return _exit(1, shutdownHooks: shutdownHooks);
     }
 
     // Report to both [Usage] and [CrashReportSender].
@@ -165,7 +167,7 @@ Future<int> _handleToolError(
       final File file = await _createLocalCrashReport(details);
       await globals.crashReporter!.informUser(details, file);
 
-      return _exit(1);
+      return _exit(1, shutdownHooks: shutdownHooks);
     // This catch catches all exceptions to ensure the message below is printed.
     } catch (error, st) { // ignore: avoid_catches_without_on_clauses
       globals.stdio.stderrWrite(
@@ -228,7 +230,7 @@ Future<File> _createLocalCrashReport(CrashDetails details) async {
   return crashFile;
 }
 
-Future<int> _exit(int code) async {
+Future<int> _exit(int code, {required ShutdownHooks shutdownHooks}) async {
   // Prints the welcome message if needed.
   globals.flutterUsage.printWelcome();
 
@@ -241,7 +243,7 @@ Future<int> _exit(int code) async {
   }
 
   // Run shutdown hooks before flushing logs
-  await globals.shutdownHooks!.runShutdownHooks();
+  await shutdownHooks.runShutdownHooks(globals.logger);
 
   final Completer<void> completer = Completer<void>();
 

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -208,7 +208,7 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
         _systemTemp?.deleteSync(recursive: true);
       }
     } on FileSystemException {
-      globals.printTrace('Failed trying to clean up temporary directory ${_systemTemp?.path}.');
+      // ignore
     }
     _systemTemp = null;
   }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -239,7 +239,7 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
       }
       // Make sure that the temporary directory is cleaned up when the tool
       // exits normally.
-      _shutdownHooks?.addShutdownHook(
+      _shutdownHooks.addShutdownHook(
         _tryToDeleteTemp,
       );
     }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -6,8 +6,6 @@ import 'package:file/file.dart';
 import 'package:file/local.dart' as local_fs;
 import 'package:meta/meta.dart';
 
-import '../globals.dart' as globals;
-
 import 'common.dart';
 import 'io.dart';
 import 'platform.dart';

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -177,7 +177,7 @@ File getUniqueFile(Directory dir, String baseName, String ext) {
 /// directories and files that the tool creates under the system temporary
 /// directory when the tool exits either normally or when killed by a signal.
 class LocalFileSystem extends local_fs.LocalFileSystem {
-  LocalFileSystem(this._signals, this._fatalSignals, this._shutdownHooks);
+  LocalFileSystem(this._signals, this._fatalSignals, this.shutdownHooks);
 
   @visibleForTesting
   LocalFileSystem.test({
@@ -187,7 +187,8 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
 
   Directory? _systemTemp;
   final Map<ProcessSignal, Object> _signalTokens = <ProcessSignal, Object>{};
-  final ShutdownHooks _shutdownHooks;
+
+  final ShutdownHooks shutdownHooks;
 
   Future<void> dispose() async {
     _tryToDeleteTemp();
@@ -239,7 +240,7 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
       }
       // Make sure that the temporary directory is cleaned up when the tool
       // exits normally.
-      _shutdownHooks.addShutdownHook(
+      shutdownHooks.addShutdownHook(
         _tryToDeleteTemp,
       );
     }

--- a/packages/flutter_tools/lib/src/base/file_system.dart
+++ b/packages/flutter_tools/lib/src/base/file_system.dart
@@ -6,6 +6,8 @@ import 'package:file/file.dart';
 import 'package:file/local.dart' as local_fs;
 import 'package:meta/meta.dart';
 
+import '../globals.dart' as globals;
+
 import 'common.dart';
 import 'io.dart';
 import 'platform.dart';
@@ -183,11 +185,11 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
   LocalFileSystem.test({
     required Signals signals,
     List<ProcessSignal> fatalSignals = Signals.defaultExitSignals,
-  }) : this(signals, fatalSignals, null);
+  }) : this(signals, fatalSignals, ShutdownHooks());
 
   Directory? _systemTemp;
   final Map<ProcessSignal, Object> _signalTokens = <ProcessSignal, Object>{};
-  final ShutdownHooks? _shutdownHooks;
+  final ShutdownHooks _shutdownHooks;
 
   Future<void> dispose() async {
     _tryToDeleteTemp();
@@ -206,7 +208,7 @@ class LocalFileSystem extends local_fs.LocalFileSystem {
         _systemTemp?.deleteSync(recursive: true);
       }
     } on FileSystemException {
-      // ignore.
+      globals.printTrace('Failed trying to clean up temporary directory ${_systemTemp?.path}.');
     }
     _systemTemp = null;
   }

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -56,7 +56,9 @@ class _DefaultShutdownHooks implements ShutdownHooks {
 
   @override
   Future<void> runShutdownHooks(Logger logger) async {
-    logger.printTrace('Running shutdown hooks');
+    logger.printTrace(
+      'Running ${_shutdownHooks.length} shutdown hook${_shutdownHooks.length == 1 ? '' : 's'}',
+    );
     _shutdownHooksRunning = true;
     try {
       final List<Future<dynamic>> futures = <Future<dynamic>>[];

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -13,7 +13,7 @@ import 'logger.dart';
 typedef StringConverter = String? Function(String string);
 
 /// A function that will be run before the VM exits.
-typedef ShutdownHook = FutureOr<dynamic> Function();
+typedef ShutdownHook = FutureOr<void> Function();
 
 // TODO(ianh): We have way too many ways to run subprocesses in this project.
 // Convert most of these into one or more lightweight wrappers around the
@@ -22,11 +22,7 @@ typedef ShutdownHook = FutureOr<dynamic> Function();
 // for more details.
 
 abstract class ShutdownHooks {
-  factory ShutdownHooks({
-    required Logger logger,
-  }) => _DefaultShutdownHooks(
-    logger: logger,
-  );
+  factory ShutdownHooks() => _DefaultShutdownHooks();
 
   /// Registers a [ShutdownHook] to be executed before the VM exits.
   void addShutdownHook(
@@ -40,15 +36,12 @@ abstract class ShutdownHooks {
   /// hooks within a given stage will be started in parallel and will be
   /// guaranteed to run to completion before shutdown hooks in the next stage are
   /// started.
-  Future<void> runShutdownHooks();
+  Future<void> runShutdownHooks(Logger logger);
 }
 
 class _DefaultShutdownHooks implements ShutdownHooks {
-  _DefaultShutdownHooks({
-    required Logger logger,
-  }) : _logger = logger;
+  _DefaultShutdownHooks();
 
-  final Logger _logger;
   final List<ShutdownHook> _shutdownHooks = <ShutdownHook>[];
 
   bool _shutdownHooksRunning = false;
@@ -62,8 +55,8 @@ class _DefaultShutdownHooks implements ShutdownHooks {
   }
 
   @override
-  Future<void> runShutdownHooks() async {
-    _logger.printTrace('Running shutdown hooks');
+  Future<void> runShutdownHooks(Logger logger) async {
+    logger.printTrace('Running shutdown hooks');
     _shutdownHooksRunning = true;
     try {
       final List<Future<dynamic>> futures = <Future<dynamic>>[];
@@ -77,7 +70,7 @@ class _DefaultShutdownHooks implements ShutdownHooks {
     } finally {
       _shutdownHooksRunning = false;
     }
-    _logger.printTrace('Shutdown hooks complete');
+    logger.printTrace('Shutdown hooks complete');
   }
 }
 

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -313,7 +313,6 @@ Future<T> runInContext<T>(
         platform: globals.platform,
         usage: globals.flutterUsage,
       ),
-      ShutdownHooks: () => ShutdownHooks(logger: globals.logger),
       Stdio: () => Stdio(),
       SystemClock: () => const SystemClock(),
       Usage: () => Usage(

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -248,6 +248,10 @@ PlistParser? _plistInstance;
 /// The global template renderer.
 TemplateRenderer get templateRenderer => context.get<TemplateRenderer>()!;
 
+/// Global [ShutdownHooks] that should be run before the tool process exits.
+///
+/// This is depended on by [localFileSystem] which is called before any
+/// [Context] is set up, and thus this cannot be a Context getter.
 final ShutdownHooks shutdownHooks = ShutdownHooks();
 
 // Unless we're in a test of this class's signal handling features, we must

--- a/packages/flutter_tools/lib/src/globals.dart
+++ b/packages/flutter_tools/lib/src/globals.dart
@@ -248,7 +248,7 @@ PlistParser? _plistInstance;
 /// The global template renderer.
 TemplateRenderer get templateRenderer => context.get<TemplateRenderer>()!;
 
-ShutdownHooks? get shutdownHooks => context.get<ShutdownHooks>();
+final ShutdownHooks shutdownHooks = ShutdownHooks();
 
 // Unless we're in a test of this class's signal handling features, we must
 // have only one instance created with the singleton LocalSignals instance

--- a/packages/flutter_tools/test/general.shard/base/process_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/process_test.dart
@@ -42,13 +42,13 @@ void main() {
       int i = 1;
       int? cleanup;
 
-      final ShutdownHooks shutdownHooks = ShutdownHooks(logger: BufferLogger.test());
+      final ShutdownHooks shutdownHooks = ShutdownHooks();
 
       shutdownHooks.addShutdownHook(() async {
         cleanup = i++;
       });
 
-      await shutdownHooks.runShutdownHooks();
+      await shutdownHooks.runShutdownHooks(BufferLogger.test());
 
       expect(cleanup, 1);
     });

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -162,17 +162,17 @@ void main() {
       // catch it in a zone.
       unawaited(runZoned<Future<void>>(
         () {
-        unawaited(runner.run(
-          <String>['crash'],
-          () => <FlutterCommand>[
-            CrashingFlutterCommand(),
-          ],
-          // This flutterVersion disables crash reporting.
-          flutterVersion: '[user-branch]/',
-          reportCrashes: true,
-          shutdownHooks: ShutdownHooks(),
-        ));
-        return null;
+          unawaited(runner.run(
+            <String>['crash'],
+            () => <FlutterCommand>[
+              CrashingFlutterCommand(),
+            ],
+            // This flutterVersion disables crash reporting.
+            flutterVersion: '[user-branch]/',
+            reportCrashes: true,
+            shutdownHooks: ShutdownHooks(),
+          ));
+          return null;
         },
         onError: (Object error, StackTrace stack) { // ignore: deprecated_member_use
           expect(firstExitCode, isNotNull);

--- a/packages/flutter_tools/test/general.shard/runner/runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/runner_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart' as io;
 import 'package:flutter_tools/src/base/net.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/process.dart';
 import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -68,6 +69,7 @@ void main() {
             // This flutterVersion disables crash reporting.
             flutterVersion: '[user-branch]/',
             reportCrashes: true,
+            shutdownHooks: ShutdownHooks(),
           ));
           return null;
         },
@@ -120,6 +122,7 @@ void main() {
             // This flutterVersion disables crash reporting.
             flutterVersion: '[user-branch]/',
             reportCrashes: true,
+            shutdownHooks: ShutdownHooks(),
           ));
           return null;
         },
@@ -167,6 +170,7 @@ void main() {
           // This flutterVersion disables crash reporting.
           flutterVersion: '[user-branch]/',
           reportCrashes: true,
+          shutdownHooks: ShutdownHooks(),
         ));
         return null;
         },

--- a/packages/flutter_tools/test/integration.shard/command_output_test.dart
+++ b/packages/flutter_tools/test/integration.shard/command_output_test.dart
@@ -68,7 +68,7 @@ void main() {
     ]);
 
     // Check for message only printed in verbose mode.
-    expect(result.stdout, contains('Running shutdown hooks'));
+    expect(result.stdout, contains('Shutdown hooks complete'));
   });
 
   testWithoutContext('flutter config contains all features', () async {

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -384,7 +384,7 @@ void main() {
             return null;
           }),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
-          Multiple(<Pattern>[RegExp(r'^Restarted application in [0-9]+ms.$'), 'called main', 'called paint'], handler: (String line) {
+          Multiple(<Pattern>[RegExp(r'^Restarted application in [0-9][0-9,]*ms.$'), 'called main', 'called paint'], handler: (String line) {
             return 'q';
           }),
           const Barrier('Application finished.'),

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -384,6 +384,7 @@ void main() {
             return null;
           }),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
+          // This could look like 'Restarted application in 1,237ms.'
           Multiple(<Pattern>[RegExp(r'^Restarted application in [0-9][0-9,]*ms.$'), 'called main', 'called paint'], handler: (String line) {
             return 'q';
           }),

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -385,7 +385,7 @@ void main() {
           }),
           Barrier('Performing hot restart...'.padRight(progressMessageWidth)),
           // This could look like 'Restarted application in 1,237ms.'
-          Multiple(<Pattern>[RegExp(r'^Restarted application in [0-9][0-9,]*ms.$'), 'called main', 'called paint'], handler: (String line) {
+          Multiple(<Pattern>[RegExp(r'^Restarted application in .+m?s.$'), 'called main', 'called paint'], handler: (String line) {
             return 'q';
           }),
           const Barrier('Application finished.'),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/84094

The core issue was that the tool was constructing the `LocalFileSystem` **BEFORE** the context runner, because it is needed to determine the `Cache.flutterRoot`, which many other objects depend on. While constructing the `LocalFileSystem`, the context getter for `ShutdownHooks` was called; this would return `null` at this point, as the context override was not set yet. This meant that later, when the `LocalFileSystem` would create the `systemTempDirectory` (which was actually a sub-directory name-spaced with `flutter_tools.`), it would try to register a shutdown hook to delete it; however, this would be a no-op since `LocalFileSystem._shutdownHooks` was always `null`.

The fix was to make `globals.shutdownHooks` a non-nullable global field and `LocalFileSystem.shutdownHooks` likewise non-nullable.

I will have a follow-up PR that will help users clean up the extra directories already created, as on Windows the OS will never garbage collect them.