### PR TITLE
Switch Linux_build_test flutter_gallery__transition_perf back to bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1935,6 +1935,7 @@ targets:
   - name: Linux_build_test flutter_gallery__transition_perf
     recipe: devicelab/devicelab_drone_build_test
     presubmit: false
+    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
Failing on CI https://ci.chromium.org/ui/p/flutter/builders/prod/Linux_build_test%20flutter_gallery__transition_perf/11/overview