### PR TITLE
Tighten asset variant detection criteria to only include device-pixel-ratio variants

### DIFF
--- a/dev/integration_tests/flutter_gallery/pubspec.yaml
+++ b/dev/integration_tests/flutter_gallery/pubspec.yaml
@@ -169,7 +169,6 @@ flutter:
     - packages/flutter_gallery_assets/products/table.png
     - packages/flutter_gallery_assets/products/teaset.png
     - packages/flutter_gallery_assets/products/top.png
-    - packages/flutter_gallery_assets/people/ali.png
     - packages/flutter_gallery_assets/people/square/ali.png
     - packages/flutter_gallery_assets/people/square/peter.png
     - packages/flutter_gallery_assets/people/square/sandra.png

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -843,7 +843,6 @@ class ManifestAssetBundle implements AssetBundle {
     final Iterable<Directory> nonVariantSubDirectories = entities
       .whereType<Directory>()
       .where((Directory directory) => !_assetVariantDirectoryRegExp.hasMatch(directory.basename));
-
     for (final Directory dir in nonVariantSubDirectories) {
       final String relativePath = _fileSystem.path.relative(dir.path, from: assetBase);
       final Uri relativePathsUri = Uri.directory(relativePath, windows: _platform.isWindows);

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1067,8 +1067,7 @@ class _AssetDirectoryCache {
       ...entitiesInDirectory
         .whereType<Directory>()
         .where((Directory dir) => _assetVariantDirectoryRegExp.hasMatch(dir.basename))
-        .map((Directory dir) => dir.listSync())
-        .flatten()
+        .expand((Directory dir) => dir.listSync())
         .whereType<File>()
         .map((File file) => file.path),
     ];
@@ -1081,11 +1080,5 @@ class _AssetDirectoryCache {
 
     _cache[assetPath] = result;
     return result;
-  }
-}
-
-extension IterableFlattening <T> on Iterable<Iterable<T>> {
-  List<T> flatten() {
-    return expand((Iterable<T> subList) => subList).toList();
   }
 }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1036,7 +1036,8 @@ class _AssetDirectoryCache {
     final List<String> pathsOfVariants = <String>[
       // It's possible that the user specifies only explicit variants (e.g. .../1x/asset.png),
       // so there does not necessarily need to be a file at the given path.
-      if (_fileSystem.file(assetPath).existsSync()) assetPath,
+      if (_fileSystem.file(assetPath).existsSync())
+        assetPath,
       ...entitiesInDirectory
         .whereType<Directory>()
         .where((Directory dir) => _assetVariantDirectoryRegExp.hasMatch(dir.basename))

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -121,7 +121,6 @@ Future<AssetBundle?> buildAssets({
   final AssetBundle assetBundle = AssetBundleFactory.instance.createBundle();
   final int result = await assetBundle.build(
     manifestPath: manifestPath,
-    assetDirPath: assetDirPath,
     packagesPath: packagesPath,
     targetPlatform: targetPlatform,
   );

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -222,11 +222,11 @@ $assetsSection
         assets: <String>['a/foo'],
       );
 
-      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+      final List<String> assets = <String>['a/foo', 'a/2x/foo'];
       writeAssets('p/p/', assets);
 
       const String expectedManifest = '{"packages/test_package/a/foo":'
-          '["packages/test_package/a/foo","packages/test_package/a/v/foo"]}';
+          '["packages/test_package/a/foo","packages/test_package/a/2x/foo"]}';
 
       await buildAndVerifyAssets(
         assets,
@@ -251,11 +251,11 @@ $assetsSection
         'test_package',
       );
 
-      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+      final List<String> assets = <String>['a/foo', 'a/2x/foo'];
       writeAssets('p/p/lib/', assets);
 
       const String expectedManifest = '{"packages/test_package/a/foo":'
-          '["packages/test_package/a/foo","packages/test_package/a/v/foo"]}';
+          '["packages/test_package/a/foo","packages/test_package/a/2x/foo"]}';
 
       await buildAndVerifyAssets(
         assets,
@@ -344,15 +344,15 @@ $assetsSection
         assets: <String>['a/foo'],
       );
 
-      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+      final List<String> assets = <String>['a/foo', 'a/2x/foo'];
       writeAssets('p/p/', assets);
       writeAssets('p2/p/', assets);
 
       const String expectedAssetManifest =
           '{"packages/test_package/a/foo":'
-          '["packages/test_package/a/foo","packages/test_package/a/v/foo"],'
+          '["packages/test_package/a/foo","packages/test_package/a/2x/foo"],'
           '"packages/test_package2/a/foo":'
-          '["packages/test_package2/a/foo","packages/test_package2/a/v/foo"]}';
+          '["packages/test_package2/a/foo","packages/test_package2/a/2x/foo"]}';
 
       await buildAndVerifyAssets(
         assets,
@@ -384,15 +384,15 @@ $assetsSection
         'test_package2',
       );
 
-      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+      final List<String> assets = <String>['a/foo', 'a/2x/foo'];
       writeAssets('p/p/lib/', assets);
       writeAssets('p2/p/lib/', assets);
 
       const String expectedAssetManifest =
           '{"packages/test_package/a/foo":'
-          '["packages/test_package/a/foo","packages/test_package/a/v/foo"],'
+          '["packages/test_package/a/foo","packages/test_package/a/2x/foo"],'
           '"packages/test_package2/a/foo":'
-          '["packages/test_package2/a/foo","packages/test_package2/a/v/foo"]}';
+          '["packages/test_package2/a/foo","packages/test_package2/a/2x/foo"]}';
 
       await buildAndVerifyAssets(
         assets,
@@ -421,12 +421,12 @@ $assetsSection
         'test_package2',
       );
 
-      final List<String> assets = <String>['a/foo', 'a/v/foo'];
+      final List<String> assets = <String>['a/foo', 'a/2x/foo'];
       writeAssets('p2/p/lib/', assets);
 
       const String expectedAssetManifest =
           '{"packages/test_package2/a/foo":'
-          '["packages/test_package2/a/foo","packages/test_package2/a/v/foo"]}';
+          '["packages/test_package2/a/foo","packages/test_package2/a/2x/foo"]}';
 
       await buildAndVerifyAssets(
         assets,
@@ -553,7 +553,7 @@ $assetsSection
       writePubspecFile('pubspec.yaml', 'test');
       writePackagesFile('test_package:p/p/lib/');
 
-      final List<String> assetsOnDisk = <String>['a/foo','a/b/foo'];
+      final List<String> assetsOnDisk = <String>['a/foo','a/2x/foo'];
       final List<String> assetOnManifest = <String>['a/',];
 
       writePubspecFile(
@@ -564,7 +564,7 @@ $assetsSection
 
       writeAssets('p/p/', assetsOnDisk);
       const String expectedAssetManifest =
-          '{"packages/test_package/a/foo":["packages/test_package/a/foo","packages/test_package/a/b/foo"]}';
+          '{"packages/test_package/a/foo":["packages/test_package/a/foo","packages/test_package/a/2x/foo"]}';
 
       await buildAndVerifyAssets(
         assetsOnDisk,
@@ -580,7 +580,7 @@ $assetsSection
       writePubspecFile('pubspec.yaml', 'test');
       writePackagesFile('test_package:p/p/lib/');
 
-      final List<String> assetsOnDisk = <String>['a/foo', 'a/b/foo'];
+      final List<String> assetsOnDisk = <String>['a/foo', 'a/2x/foo'];
       final List<String> assetOnManifest = <String>[];
 
       writePubspecFile(

--- a/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_test.dart
@@ -643,7 +643,7 @@ name: example
 
 flutter:
   assets:
-    - foo.txt
+    - assets/foo.txt
 ''');
     globals.fs.file('assets/foo.txt').createSync(recursive: true);
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -36,9 +36,13 @@ void main() {
     late final Platform platform;
     late final FileSystem fs;
 
-    setUp(() {
+    setUpAll(() {
       platform = FakePlatform();
-      fs = MemoryFileSystem.test();
+      fs = MemoryFileSystem.test(
+        style: io.Platform.isWindows
+          ? FileSystemStyle.windows
+          : FileSystemStyle.posix
+      );
       Cache.flutterRoot = Cache.defaultFlutterRoot(
         platform: platform,
         fileSystem: fs,

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -21,7 +21,6 @@ import '../src/common.dart';
 
 void main() {
 
-
   Future<Map<String, List<String>>> extractAssetManifestFromBundle(ManifestAssetBundle bundle) async {
     final String manifestJson = utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes());
     final Map<String, dynamic> parsedJson = json.decode(manifestJson) as Map<String, dynamic>;
@@ -36,8 +35,14 @@ void main() {
     late final Platform platform;
     late final FileSystem fs;
 
+    String correctPathSeparators(String path) {
+      // The in-memory file system is strict about slashes on Windows being the
+      // correct way. See https://github.com/google/file.dart/issues/112.
+      return path.replaceAll('/', fs.path.separator);
+    }
+
     setUpAll(() {
-      platform = FakePlatform();
+      platform = FakePlatform(operatingSystem: io.Platform.operatingSystem);
       fs = MemoryFileSystem.test(
         style: io.Platform.isWindows
           ? FileSystemStyle.windows
@@ -65,7 +70,6 @@ flutter:
     });
 
     testWithoutContext('Only images in folders named with device pixel ratios (e.g. 2x, 3.0x) should be considered as variants of other images', () async {
-
       const String image = 'assets/image.jpg';
       const String image2xVariant = 'assets/2x/image.jpg';
       const String imageNonVariant = 'assets/notAVariant/image.jpg';
@@ -77,7 +81,7 @@ flutter:
       ];
 
       for (final String asset in assets) {
-        final File assetFile = fs.file(asset);
+        final File assetFile = fs.file(correctPathSeparators(asset));
         await assetFile.create(recursive: true);
         await assetFile.writeAsString(asset);
       }
@@ -113,7 +117,7 @@ flutter:
       ];
 
       for (final String asset in assets) {
-        final File assetFile = fs.file(asset);
+        final File assetFile = fs.file(correctPathSeparators(asset));
         await assetFile.create(recursive: true);
         await assetFile.writeAsString(asset);
       }

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -83,7 +83,6 @@ flutter:
 
       await bundle.build(
         packagesPath: '.packages',
-        assetDirPath: './build/flutter_assets',
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
@@ -119,7 +118,6 @@ flutter:
 
       await bundle.build(
         packagesPath: '.packages',
-        assetDirPath: './build/flutter_assets',
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
@@ -192,7 +190,6 @@ flutter:
 
       await bundle.build(
         packagesPath: '.packages',
-        assetDirPath: correctPathSeparators('./build/flutter_assets'),
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
@@ -228,7 +225,6 @@ flutter:
 
       await bundle.build(
         packagesPath: '.packages',
-        assetDirPath: correctPathSeparators('./build/flutter_assets'),
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -192,7 +192,7 @@ flutter:
 
       await bundle.build(
         packagesPath: '.packages',
-        assetDirPath: './build/flutter_assets',
+        assetDirPath: correctPathSeparators('./build/flutter_assets'),
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 
@@ -228,7 +228,7 @@ flutter:
 
       await bundle.build(
         packagesPath: '.packages',
-        assetDirPath: './build/flutter_assets',
+        assetDirPath: correctPathSeparators('./build/flutter_assets'),
         flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
       );
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_variant_test.dart
@@ -3,43 +3,51 @@
 // found in the LICENSE file.
 
 import 'dart:convert';
+import 'dart:io' as io;
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/logger.dart';
+import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/base/user_messages.dart';
+import 'package:flutter_tools/src/cache.dart';
 
-import 'package:flutter_tools/src/globals.dart' as globals;
+import 'package:flutter_tools/src/project.dart';
 
 import '../src/common.dart';
-import '../src/context.dart';
 
 void main() {
-  String fixPath(String path) {
-    // The in-memory file system is strict about slashes on Windows being the
-    // correct way so until https://github.com/google/file.dart/issues/112 is
-    // fixed we fix them here.
-    // TODO(dantup): Remove this function once the above issue is fixed and
-    // rolls into Flutter.
-    return path.replaceAll('/', globals.fs.path.separator);
+
+
+  Future<Map<String, List<String>>> extractAssetManifestFromBundle(ManifestAssetBundle bundle) async {
+    final String manifestJson = utf8.decode(await bundle.entries['AssetManifest.json']!.contentsAsBytes());
+    final Map<String, dynamic> parsedJson = json.decode(manifestJson) as Map<String, dynamic>;
+    final Iterable<String> keys = parsedJson.keys;
+    final Map<String, List<String>> parsedManifest = <String, List<String>> {
+      for (final String key in keys) key: List<String>.from(parsedJson[key] as List<dynamic>),
+    };
+    return parsedManifest;
   }
 
   group('AssetBundle asset variants', () {
-    late FileSystem testFileSystem;
-    setUp(() async {
-      testFileSystem = MemoryFileSystem(
-        style: globals.platform.isWindows
-          ? FileSystemStyle.windows
-          : FileSystemStyle.posix,
-      );
-      testFileSystem.currentDirectory = testFileSystem.systemTempDirectory.createTempSync('flutter_asset_bundle_variant_test.');
-    });
+    late final Platform platform;
+    late final FileSystem fs;
 
-    testUsingContext('main asset and variants', () async {
-      globals.fs.file('pubspec.yaml')
-        ..createSync()
-        ..writeAsStringSync(
+    setUp(() {
+      platform = FakePlatform();
+      fs = MemoryFileSystem.test();
+      Cache.flutterRoot = Cache.defaultFlutterRoot(
+        platform: platform,
+        fileSystem: fs,
+        userMessages: UserMessages()
+      );
+
+      fs.file('.packages').createSync();
+
+      fs.file('pubspec.yaml').writeAsStringSync(
 '''
 name: test
 dependencies:
@@ -47,46 +55,83 @@ dependencies:
     sdk: flutter
 flutter:
   assets:
-    - a/b/c/foo
+    - assets/
 '''
       );
-      globals.fs.file('.packages').createSync();
+    });
+
+    testWithoutContext('Only images in folders named with device pixel ratios (e.g. 2x, 3.0x) should be considered as variants of other images', () async {
+
+      const String image = 'assets/image.jpg';
+      const String image2xVariant = 'assets/2x/image.jpg';
+      const String imageNonVariant = 'assets/notAVariant/image.jpg';
 
       final List<String> assets = <String>[
-        'a/b/c/foo',
-        'a/b/c/var1/foo',
-        'a/b/c/var2/foo',
-        'a/b/c/var3/foo',
+        image,
+        image2xVariant,
+        imageNonVariant
       ];
+
       for (final String asset in assets) {
-        globals.fs.file(fixPath(asset))
-          ..createSync(recursive: true)
-          ..writeAsStringSync(asset);
+        final File assetFile = fs.file(asset);
+        await assetFile.create(recursive: true);
+        await assetFile.writeAsString(asset);
       }
 
-      AssetBundle bundle = AssetBundleFactory.instance.createBundle();
-      await bundle.build(packagesPath: '.packages');
+      final ManifestAssetBundle bundle = ManifestAssetBundle(
+        logger: BufferLogger.test(),
+        fileSystem: fs,
+        platform: platform,
+      );
 
-      // The main asset file, /a/b/c/foo, and its variants exist.
+      await bundle.build(
+        packagesPath: '.packages',
+        assetDirPath: './build/flutter_assets',
+        flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
+      );
+
+      final Map<String, List<String>> manifest = await extractAssetManifestFromBundle(bundle);
+      final List<String> variantsForImage = manifest[image]!;
+
+      expect(variantsForImage, contains(image2xVariant));
+      expect(variantsForImage, isNot(contains(imageNonVariant)));
+    });
+
+    testWithoutContext('Asset directories are recursively searched for assets', () async {
+      const String topLevelImage = 'assets/image.jpg';
+      const String secondLevelImage = 'assets/folder/secondLevel.jpg';
+      const String secondLevel2xVariant = 'assets/folder/2x/secondLevel.jpg';
+
+      final List<String> assets = <String>[
+        topLevelImage,
+        secondLevelImage,
+        secondLevel2xVariant
+      ];
+
       for (final String asset in assets) {
-        expect(bundle.entries.containsKey(asset), true);
-        expect(utf8.decode(await bundle.entries[asset]!.contentsAsBytes()), asset);
+        final File assetFile = fs.file(asset);
+        await assetFile.create(recursive: true);
+        await assetFile.writeAsString(asset);
       }
 
-      globals.fs.file(fixPath('a/b/c/foo')).deleteSync();
-      bundle = AssetBundleFactory.instance.createBundle();
-      await bundle.build(packagesPath: '.packages');
+      final ManifestAssetBundle bundle = ManifestAssetBundle(
+        logger: BufferLogger.test(),
+        fileSystem: fs,
+        platform: platform,
+      );
 
-      // Now the main asset file, /a/b/c/foo, does not exist. This is OK because
-      // the /a/b/c/*/foo variants do exist.
-      expect(bundle.entries.containsKey('a/b/c/foo'), false);
-      for (final String asset in assets.skip(1)) {
-        expect(bundle.entries.containsKey(asset), true);
-        expect(utf8.decode(await bundle.entries[asset]!.contentsAsBytes()), asset);
-      }
-    }, overrides: <Type, Generator>{
-      FileSystem: () => testFileSystem,
-      ProcessManager: () => FakeProcessManager.any(),
+      await bundle.build(
+        packagesPath: '.packages',
+        assetDirPath: './build/flutter_assets',
+        flutterProject:  FlutterProject.fromDirectoryTest(fs.currentDirectory),
+      );
+
+      final Map<String, List<String>> manifest = await extractAssetManifestFromBundle(bundle);
+      expect(manifest, contains(secondLevelImage));
+      expect(manifest, contains(topLevelImage));
+      expect(manifest[secondLevelImage], hasLength(2));
+      expect(manifest[secondLevelImage], contains(secondLevelImage));
+      expect(manifest[secondLevelImage], contains(secondLevel2xVariant));
     });
   });
 }


### PR DESCRIPTION
Fixes #69388

## Background

If unfamiliar with the concept of asset variants, see [Asset variants]. Also see #69388.

Currently, when Flutter finds an asset file to use, it will scan adjacent directories for files that have the same filename and consider these files to be variants of the first file (also, the first file is considered to be a variant of itself).

For example, take this pubspec.yaml

```
...
flutter:
  assets:
    - assets/
```
and this application directory
```
.../pubspec.yaml
.../assets/my_icon.jpg
.../assets/2x/my_icon.jpg
.../assets/dark/my_icon.jpg
...etc.
```
In this scenario, `assets/my_icon.jpg`, `assets/2x/my_icon.png`, and `assets/dark/my_icon.jpg` are considered to be _variants_ of `assets/my_icon.jpg`. Currently, this behavior is only utilized when looking for higher-resolution versions of images for devices with high pixel ratios (see [Declaring resolution-aware image assets]).

However, there are scenarios where an image file could be detected as a variant of another when the user meant for them to be two distinct assets. Using the same pubspec from before, suppose we have this application directory:
```
...
.../assets/icon.jpg
.../assets/foo_screen/icon.jpg
.../assets/bar_screen/icon.jpg
```
In this scenario, attempts to load `icon.jpg` will result in one of the other two variants being loaded instead.
This is because all three of these files are considered to be variants of `icon.jpg`, and the [implementation will just happen to pick the last one it encountered when going through the list of candidates](https://github.com/flutter/flutter/blob/4dd7065244d59e068e2bcb6d6191e45963067b28/packages/flutter/lib/src/painting/image_resolution.dart#L352). Specifically, all three files are considered to be 1x device-pixel-ratio (i.e. the default) variants of `icon.jpg` ([code](https://github.com/flutter/flutter/blob/4dd7065244d59e068e2bcb6d6191e45963067b28/packages/flutter/lib/src/painting/image_resolution.dart#L413)).

## Change
Flutter will now consider an image asset to be a variant of one in its grandparent directory if and only if the parent directory matches the pattern for a device-pixel-ratio (e.g. `2x`, `3.0x`, etc.). Example:
```
.../assets/my_icon.jpg
.../assets/2x/my_icon.jpg // 2x device-pixel-ratio variant of /assets/my_icon.jpg
.../assets/dark/my_icon.jpg // No longer a variant of /assets/my_icon.jpg
...etc.
```

**This change would call for a documentation change/overhaul of the [Asset variants] documentation.** In particular, the `dark` variant example should be removed/replaced.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[Asset variants]: https://docs.flutter.dev/development/ui/assets-and-images#asset-variants
[Declaring resolution-aware image assets]: https://docs.flutter.dev/development/ui/assets-and-images#resolution-aware
