### PR TITLE
Adds API in semanticsconfiguration to decide how to merge child semanticsConfigurations

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2261,11 +2261,11 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     );
 
     final bool hasPrefix = decoration.prefix != null || decoration.prefixText != null;
-    final bool hasSuffix = decoration.prefix != null || decoration.prefixText != null;
+    final bool hasSuffix = decoration.suffix != null || decoration.suffixText != null;
 
     Widget? input = widget.child;
-    // If at least two out of the three will not be null, it needs semantics
-    // sort order.
+    // If at least two out of the three are not null, it needs semantics sort
+    // order.
     final bool needsSemanticsSortOrder = input != null ? (hasPrefix || hasSuffix) : (hasPrefix && hasSuffix);
 
     final Widget? prefix = hasPrefix
@@ -2290,7 +2290,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         )
       : null;
 
-    if (needsSemanticsSortOrder) {
+    if (input != null && needsSemanticsSortOrder) {
       input = Semantics(
         sortKey: _kInputSemanticsSortOrder,
         child: input,

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1327,7 +1327,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     return Size.zero;
   }
 
-  SemanticsMergeResult _semanticsMerger(Map<AbstractNode, List<SemanticsConfiguration>> childConfigs) {
+  SemanticsMergeResult _semanticsMerger(Map<Object, List<SemanticsConfiguration>> childConfigs) {
     List<List<SemanticsConfiguration>>? siblingMergeGroup;
     if (prefix != null) {
       final List<SemanticsConfiguration>? prefixMergeGroup = childConfigs.remove(prefix);

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2266,7 +2266,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     Widget? input = widget.child;
     // If at least two out of the three will not be null, it needs semantics
     // sort order.
-    final bool needsSemanticsSortOrder = (hasPrefix && hasSuffix) || (hasPrefix && input != null) || (hasSuffix && input != null);
+    final bool needsSemanticsSortOrder = input != null ? (hasPrefix || hasSuffix) : (hasPrefix && hasSuffix);
 
     final Widget? prefix = hasPrefix
       ? _AffixText(

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -1326,15 +1326,15 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
     return Size.zero;
   }
 
-  ChildSemanticsConfigsResult _semanticsMerger(List<SemanticsConfiguration> childConfigs) {
-    final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+  ChildSemanticsConfigurationsResult _childSemanticsConfigurationDelegate(List<SemanticsConfiguration> childConfigs) {
+    final ChildSemanticsConfigurationsResultBuilder builder = ChildSemanticsConfigurationsResultBuilder();
     List<SemanticsConfiguration>? prefixMergeGroup;
     List<SemanticsConfiguration>? suffixMergeGroup;
     for (final SemanticsConfiguration childConfig in childConfigs) {
-      if (childConfig.isChildrenTagged(_InputDecoratorState._kPrefixSemanticsTag)) {
+      if (childConfig.tagsChildrenWith(_InputDecoratorState._kPrefixSemanticsTag)) {
         prefixMergeGroup ??= <SemanticsConfiguration>[];
         prefixMergeGroup.add(childConfig);
-      } else if (childConfig.isChildrenTagged(_InputDecoratorState._kSuffixSemanticsTag)) {
+      } else if (childConfig.tagsChildrenWith(_InputDecoratorState._kSuffixSemanticsTag)) {
         suffixMergeGroup ??= <SemanticsConfiguration>[];
         suffixMergeGroup.add(childConfig);
       } else {
@@ -1352,7 +1352,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
-    config.childConfigsDelegate = _semanticsMerger;
+    config.childConfigurationsDelegate = _childSemanticsConfigurationDelegate;
   }
 
   @override
@@ -1742,7 +1742,7 @@ class _AffixText extends StatelessWidget {
     this.text,
     this.style,
     this.child,
-    required this.ordinalKey,
+    required this.semanticsSortKey,
     required this.semanticsTag,
   });
 
@@ -1750,7 +1750,7 @@ class _AffixText extends StatelessWidget {
   final String? text;
   final TextStyle? style;
   final Widget? child;
-  final SemanticsSortKey ordinalKey;
+  final SemanticsSortKey semanticsSortKey;
   final SemanticsTag semanticsTag;
 
   @override
@@ -1762,7 +1762,7 @@ class _AffixText extends StatelessWidget {
         curve: _kTransitionCurve,
         opacity: labelIsFloating ? 1.0 : 0.0,
         child: Semantics(
-          sortKey: ordinalKey,
+          sortKey: semanticsSortKey,
           tagForChildren: semanticsTag,
           child: child ?? (text == null ? null : Text(text!, style: style)),
         ),
@@ -2267,7 +2267,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         labelIsFloating: widget._labelShouldWithdraw,
         text: decoration.prefixText,
         style: MaterialStateProperty.resolveAs(decoration.prefixStyle, materialState) ?? hintStyle,
-        ordinalKey: _kPrefixSemanticsSortOrder,
+        semanticsSortKey: _kPrefixSemanticsSortOrder,
         semanticsTag: _kPrefixSemanticsTag,
         child: decoration.prefix,
       );
@@ -2277,7 +2277,7 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
         labelIsFloating: widget._labelShouldWithdraw,
         text: decoration.suffixText,
         style: MaterialStateProperty.resolveAs(decoration.suffixStyle, materialState) ?? hintStyle,
-        ordinalKey: _kSuffixSemanticsSortOrder,
+        semanticsSortKey: _kSuffixSemanticsSortOrder,
         semanticsTag: _kSuffixSemanticsTag,
         child: decoration.suffix,
       );

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -2264,9 +2264,9 @@ class _InputDecoratorState extends State<InputDecorator> with TickerProviderStat
     final bool hasSuffix = decoration.suffix != null || decoration.suffixText != null;
 
     Widget? input = widget.child;
-    // If at least two out of the three are not null, it needs semantics sort
+    // If at least two out of the three are visible, it needs semantics sort
     // order.
-    final bool needsSemanticsSortOrder = input != null ? (hasPrefix || hasSuffix) : (hasPrefix && hasSuffix);
+    final bool needsSemanticsSortOrder = widget._labelShouldWithdraw && (input != null ? (hasPrefix || hasSuffix) : (hasPrefix && hasSuffix));
 
     final Widget? prefix = hasPrefix
       ? _AffixText(

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4296,6 +4296,10 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
       Rect? semanticsClipRect;
       Rect? paintClipRect;
       SemanticsConfiguration? configuration;
+      // Use empty set because the _tagsForChildren may not contains all of the
+      // tags if this fragment is not explicit. The _tagsForChildren are added
+      // to sibling nodes at the end of compileChildren if this fragment is
+      // explicit.
       final Set<SemanticsTag> tags = <SemanticsTag>{};
       SemanticsNode? node;
       for (final _InterestingSemanticsFragment fragment in group) {
@@ -4493,6 +4497,10 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
       siblingNode
         ..transform = node.transform
         ..isMergedIntoParent = node.isMergedIntoParent;
+      if (_tagsForChildren != null) {
+        siblingNode.tags ??= <SemanticsTag>{};
+        siblingNode.tags!.addAll(_tagsForChildren!);
+      }
     }
     result.addAll(siblingNodes);
     siblingNodes.clear();

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3161,7 +3161,12 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
     final bool wasSemanticsBoundary = _semantics != null && (_cachedSemanticsConfiguration?.isSemanticBoundary ?? false);
     _cachedSemanticsConfiguration = null;
-    bool isEffectiveSemanticsBoundary = _semanticsConfiguration.isSemanticBoundary && wasSemanticsBoundary;
+    // Merger may produce sibling node to be attached to the parent of this
+    // semantics node, thus it can't be a semantics boundary.
+    bool isEffectiveSemanticsBoundary =
+      _semanticsConfiguration.merger == null &&
+      _semanticsConfiguration.isSemanticBoundary &&
+      wasSemanticsBoundary;
     RenderObject node = this;
 
     while (!isEffectiveSemanticsBoundary && node.parent is RenderObject) {
@@ -3213,11 +3218,13 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     assert(fragment is _InterestingSemanticsFragment);
     final _InterestingSemanticsFragment interestingFragment = fragment as _InterestingSemanticsFragment;
     final List<SemanticsNode> result = <SemanticsNode>[];
+    final List<SemanticsNode> siblingNodes = <SemanticsNode>[];
     interestingFragment.compileChildren(
       parentSemanticsClipRect: _semantics?.parentSemanticsClipRect,
       parentPaintClipRect: _semantics?.parentPaintClipRect,
       elevationAdjustment: _semantics?.elevationAdjustment ?? 0.0,
       result: result,
+      siblingNodes: siblingNodes,
     );
     final SemanticsNode node = result.single;
     // Fragment only wants to add this node's SemanticsNode to the parent.
@@ -3235,70 +3242,97 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     bool dropSemanticsOfPreviousSiblings = config.isBlockingSemanticsOfPreviouslyPaintedNodes;
 
     final bool producesForkingFragment = !config.hasBeenAnnotated && !config.isSemanticBoundary;
-    final List<_InterestingSemanticsFragment> fragments = <_InterestingSemanticsFragment>[];
-    final Set<_InterestingSemanticsFragment> toBeMarkedExplicit = <_InterestingSemanticsFragment>{};
     final bool childrenMergeIntoParent = mergeIntoParent || config.isMergingSemanticsOfDescendants;
-
+    final Map<RenderObject, List<SemanticsConfiguration>> childConfigurations = <RenderObject, List<SemanticsConfiguration>>{};
+    final bool explicitChildNode = config.explicitChildNodes || parent is! RenderObject;
+    final bool hasSemanticsMerger = config.merger != null;
+    final Map<SemanticsConfiguration, _InterestingSemanticsFragment> configToFragment = <SemanticsConfiguration, _InterestingSemanticsFragment>{};
+    final List<_InterestingSemanticsFragment> mergeUpFragments = <_InterestingSemanticsFragment>[];
+    final List<List<_InterestingSemanticsFragment>> siblingMergeFragmentGroups = <List<_InterestingSemanticsFragment>>[];
     visitChildrenForSemantics((RenderObject renderChild) {
       assert(!_needsLayout);
       final _SemanticsFragment parentFragment = renderChild._getSemanticsForParent(
         mergeIntoParent: childrenMergeIntoParent,
       );
       if (parentFragment.dropsSemanticsOfPreviousSiblings) {
-        fragments.clear();
-        toBeMarkedExplicit.clear();
+        childConfigurations.clear();
+        mergeUpFragments.clear();
+        siblingMergeFragmentGroups.clear();
         if (!config.isSemanticBoundary) {
           dropSemanticsOfPreviousSiblings = true;
         }
       }
-      // Figure out which child fragments are to be made explicit.
-      for (final _InterestingSemanticsFragment fragment in parentFragment.interestingFragments) {
-        fragments.add(fragment);
+      final List<SemanticsConfiguration> configurations = <SemanticsConfiguration>[];
+      for (final _InterestingSemanticsFragment fragment in parentFragment.mergeUpFragments) {
         fragment.addAncestor(this);
         fragment.addTags(config.tagsForChildren);
-        if (config.explicitChildNodes || parent is! RenderObject) {
-          fragment.markAsExplicit();
-          continue;
-        }
-        if (!fragment.hasConfigForParent || producesForkingFragment) {
-          continue;
-        }
-        if (!config.isCompatibleWith(fragment.config)) {
-          toBeMarkedExplicit.add(fragment);
-        }
-        final int siblingLength = fragments.length - 1;
-        for (int i = 0; i < siblingLength; i += 1) {
-          final _InterestingSemanticsFragment siblingFragment = fragments[i];
-          if (!fragment.config!.isCompatibleWith(siblingFragment.config)) {
-            toBeMarkedExplicit.add(fragment);
-            toBeMarkedExplicit.add(siblingFragment);
-          }
+        if (hasSemanticsMerger && fragment.config != null) {
+          // This fragment need to go through merger to determine whether it
+          // merge up or not.
+          configurations.add(fragment.config!);
+          configToFragment[fragment.config!] = fragment;
+        } else {
+          mergeUpFragments.add(fragment);
         }
       }
+      if (parentFragment is _ContainerSemanticsFragment) {
+        // Container fragments needs to propagate sibling merge group to be
+        // compiled by _SwitchableSemanticsFragment.
+        for (final List<_InterestingSemanticsFragment> siblingMergeGroup in parentFragment.siblingMergeGroups) {
+          for (final _InterestingSemanticsFragment siblingMergingFragment in siblingMergeGroup) {
+            siblingMergingFragment.addAncestor(this);
+            siblingMergingFragment.addTags(config.tagsForChildren);
+          }
+          siblingMergeFragmentGroups.add(siblingMergeGroup);
+        }
+      }
+      childConfigurations[renderChild] = configurations;
     });
 
-    for (final _InterestingSemanticsFragment fragment in toBeMarkedExplicit) {
-      fragment.markAsExplicit();
+    assert(hasSemanticsMerger || configToFragment.isEmpty);
+
+    if (explicitChildNode) {
+      assert(!hasSemanticsMerger, 'A Semantics with `explicitChildNode = true` cannot have a merger');
+      for (final _InterestingSemanticsFragment fragment in mergeUpFragments) {
+        fragment.markAsExplicit();
+      }
+    } else if (hasSemanticsMerger) {
+      final SemanticsMergeRule rule = config.merger!(childConfigurations);
+      mergeUpFragments.addAll(
+        rule.mergeUp.map<_InterestingSemanticsFragment>((SemanticsConfiguration config) => configToFragment[config]!),
+      );
+      for (final List<SemanticsConfiguration> group in rule.siblingMergeGroups) {
+        siblingMergeFragmentGroups.add(
+          group.map<_InterestingSemanticsFragment>((SemanticsConfiguration config) => configToFragment[config]!).toList()
+        );
+      }
     }
 
     _needsSemanticsUpdate = false;
 
-    _SemanticsFragment result;
+    final _SemanticsFragment result;
     if (parent is! RenderObject) {
       assert(!config.hasBeenAnnotated);
       assert(!mergeIntoParent);
+      assert(siblingMergeFragmentGroups.isEmpty);
+      _marksExplicitInMergeGroup(mergeUpFragments, isMergeUp: true);
+      siblingMergeFragmentGroups.forEach(_marksExplicitInMergeGroup);
       result = _RootSemanticsFragment(
         owner: this,
         dropsSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
       );
     } else if (producesForkingFragment) {
       result = _ContainerSemanticsFragment(
+        siblingMergeGroups: siblingMergeFragmentGroups,
         dropsSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
       );
     } else {
+      _marksExplicitInMergeGroup(mergeUpFragments, isMergeUp: true);
+      siblingMergeFragmentGroups.forEach(_marksExplicitInMergeGroup);
       result = _SwitchableSemanticsFragment(
         config: config,
         mergeIntoParent: mergeIntoParent,
+        siblingMergeGroups: siblingMergeFragmentGroups,
         owner: this,
         dropsSemanticsOfPreviousSiblings: dropSemanticsOfPreviousSiblings,
       );
@@ -3307,10 +3341,32 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
         fragment.markAsExplicit();
       }
     }
-
-    result.addAll(fragments);
-
+    result.addAll(mergeUpFragments);
     return result;
+  }
+
+  void _marksExplicitInMergeGroup(List<_InterestingSemanticsFragment> mergeGroup, {bool isMergeUp = false}) {
+    final Set<_InterestingSemanticsFragment> toBeExplicit = <_InterestingSemanticsFragment>{};
+    for (int i = 0; i < mergeGroup.length; i += 1) {
+      final _InterestingSemanticsFragment fragment = mergeGroup[i];
+      if (!fragment.hasConfigForParent) {
+        continue;
+      }
+      if (isMergeUp && !_semanticsConfiguration.isCompatibleWith(fragment.config)) {
+        toBeExplicit.add(fragment);
+      }
+      final int siblingLength = i;
+      for (int j = 0; j < siblingLength; j += 1) {
+        final _InterestingSemanticsFragment siblingFragment = mergeGroup[j];
+        if (!fragment.config!.isCompatibleWith(siblingFragment.config)) {
+          toBeExplicit.add(fragment);
+          toBeExplicit.add(siblingFragment);
+        }
+      }
+    }
+    for (final _InterestingSemanticsFragment fragment in toBeExplicit) {
+      fragment.markAsExplicit();
+    }
   }
 
   /// Called when collecting the semantics of this node.
@@ -3985,8 +4041,9 @@ mixin RelayoutWhenSystemFontsChangeMixin on RenderObject {
 ///  * [_ContainerSemanticsFragment]: a container class to transport the semantic
 ///    information of multiple [_InterestingSemanticsFragment] to a parent.
 abstract class _SemanticsFragment {
-  _SemanticsFragment({ required this.dropsSemanticsOfPreviousSiblings })
-    : assert (dropsSemanticsOfPreviousSiblings != null);
+  _SemanticsFragment({
+    required this.dropsSemanticsOfPreviousSiblings,
+  }) : assert (dropsSemanticsOfPreviousSiblings != null);
 
   /// Incorporate the fragments of children into this fragment.
   void addAll(Iterable<_InterestingSemanticsFragment> fragments);
@@ -4002,25 +4059,29 @@ abstract class _SemanticsFragment {
 
   /// Returns [_InterestingSemanticsFragment] describing the actual semantic
   /// information that this fragment wants to add to the parent.
-  List<_InterestingSemanticsFragment> get interestingFragments;
+  List<_InterestingSemanticsFragment> get mergeUpFragments;
 }
 
 /// A container used when a [RenderObject] wants to add multiple independent
 /// [_InterestingSemanticsFragment] to its parent.
 ///
 /// The [_InterestingSemanticsFragment] to be added to the parent can be
-/// obtained via [interestingFragments].
+/// obtained via [mergeUpFragments].
 class _ContainerSemanticsFragment extends _SemanticsFragment {
+  _ContainerSemanticsFragment({
+    required super.dropsSemanticsOfPreviousSiblings,
+    required this.siblingMergeGroups,
+  });
 
-  _ContainerSemanticsFragment({ required super.dropsSemanticsOfPreviousSiblings });
+  final List<List<_InterestingSemanticsFragment>> siblingMergeGroups;
 
   @override
   void addAll(Iterable<_InterestingSemanticsFragment> fragments) {
-    interestingFragments.addAll(fragments);
+    mergeUpFragments.addAll(fragments);
   }
 
   @override
-  final List<_InterestingSemanticsFragment> interestingFragments = <_InterestingSemanticsFragment>[];
+  final List<_InterestingSemanticsFragment> mergeUpFragments = <_InterestingSemanticsFragment>[];
 }
 
 /// A [_SemanticsFragment] that describes which concrete semantic information
@@ -4057,6 +4118,7 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
     required Rect? parentPaintClipRect,
     required double elevationAdjustment,
     required List<SemanticsNode> result,
+    required List<SemanticsNode> siblingNodes,
   });
 
   /// The [SemanticsConfiguration] the child wants to merge into the parent's
@@ -4086,7 +4148,7 @@ abstract class _InterestingSemanticsFragment extends _SemanticsFragment {
   bool get hasConfigForParent => config != null;
 
   @override
-  List<_InterestingSemanticsFragment> get interestingFragments => <_InterestingSemanticsFragment>[this];
+  List<_InterestingSemanticsFragment> get mergeUpFragments => <_InterestingSemanticsFragment>[this];
 
   Set<SemanticsTag>? _tagsForChildren;
 
@@ -4124,7 +4186,13 @@ class _RootSemanticsFragment extends _InterestingSemanticsFragment {
   });
 
   @override
-  void compileChildren({ Rect? parentSemanticsClipRect, Rect? parentPaintClipRect, required double elevationAdjustment, required List<SemanticsNode> result }) {
+  void compileChildren({
+    Rect? parentSemanticsClipRect,
+    Rect? parentPaintClipRect,
+    required double elevationAdjustment,
+    required List<SemanticsNode> result,
+    required List<SemanticsNode> siblingNodes,
+  }) {
     assert(_tagsForChildren == null || _tagsForChildren!.isEmpty);
     assert(parentSemanticsClipRect == null);
     assert(parentPaintClipRect == null);
@@ -4150,8 +4218,11 @@ class _RootSemanticsFragment extends _InterestingSemanticsFragment {
         parentPaintClipRect: parentPaintClipRect,
         elevationAdjustment: 0.0,
         result: children,
+        siblingNodes: siblingNodes,
       );
     }
+    // Root node does not have a parent and thus can't attach sibling nodes.
+    assert(siblingNodes.isEmpty);
     node.updateWith(config: null, childrenInInversePaintOrder: children);
 
     // The root node is the only semantics node allowed to be invisible. This
@@ -4201,9 +4272,11 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
   _SwitchableSemanticsFragment({
     required bool mergeIntoParent,
     required SemanticsConfiguration config,
+    required List<List<_InterestingSemanticsFragment>> siblingMergeGroups,
     required super.owner,
     required super.dropsSemanticsOfPreviousSiblings,
-  }) : _mergeIntoParent = mergeIntoParent,
+  }) : _siblingMergeGroups = siblingMergeGroups,
+       _mergeIntoParent = mergeIntoParent,
        _config = config,
        assert(mergeIntoParent != null),
        assert(config != null);
@@ -4211,14 +4284,122 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
   final bool _mergeIntoParent;
   SemanticsConfiguration _config;
   bool _isConfigWritable = false;
+  bool _mergesToSibling = false;
+
+  final List<List<_InterestingSemanticsFragment>> _siblingMergeGroups;
+
+  void _mergeSiblingGroup(Rect? parentSemanticsClipRect, Rect? parentPaintClipRect, List<SemanticsNode> result, Set<int> usedSemanticsIds) {
+    for (final List<_InterestingSemanticsFragment> group in _siblingMergeGroups) {
+      Rect? rect;
+      Rect? semanticsClipRect;
+      Rect? paintClipRect;
+      SemanticsConfiguration? configuration;
+      final Set<SemanticsTag> tags = <SemanticsTag>{};
+      SemanticsNode? node;
+      for (final _InterestingSemanticsFragment fragment in group) {
+        if (fragment.config != null) {
+          final _SwitchableSemanticsFragment switchableFragment = fragment as _SwitchableSemanticsFragment;
+          switchableFragment._mergesToSibling = true;
+          node ??= fragment.owner._semantics;
+          if (configuration == null) {
+            switchableFragment._ensureConfigIsWritable();
+            configuration = switchableFragment.config;
+          } else {
+            configuration.absorb(switchableFragment.config!);
+          }
+          // It is a child fragment of a _SwitchableFragment, it must have a
+          // geometry.
+          final _SemanticsGeometry geometry = switchableFragment._computeSemanticsGeometry(
+            parentSemanticsClipRect: parentSemanticsClipRect,
+            parentPaintClipRect: parentPaintClipRect,
+          )!;
+          final Rect fragmentRect = MatrixUtils.transformRect(geometry.transform, geometry.rect);
+          if (rect == null) {
+            rect = fragmentRect;
+          } else {
+            rect = rect.expandToInclude(fragmentRect);
+          }
+          if (geometry.semanticsClipRect != null) {
+            final Rect rect = MatrixUtils.transformRect(geometry.transform, geometry.semanticsClipRect!);
+            if (semanticsClipRect == null) {
+              semanticsClipRect = rect;
+            } else {
+              semanticsClipRect = semanticsClipRect.intersect(rect);
+            }
+          }
+          if (geometry.paintClipRect != null) {
+            final Rect rect = MatrixUtils.transformRect(geometry.transform, geometry.paintClipRect!);
+            if (paintClipRect == null) {
+              paintClipRect = rect;
+            } else {
+              paintClipRect = paintClipRect.intersect(rect);
+            }
+          }
+          if (switchableFragment._tagsForChildren != null) {
+            tags.addAll(switchableFragment._tagsForChildren!);
+          }
+        }
+      }
+      // Can be null if all fragments in group are marked as explicit.
+      if (configuration != null && !rect!.isEmpty) {
+        if (node == null || usedSemanticsIds.contains(node.id)) {
+          node = SemanticsNode(showOnScreen: owner.showOnScreen);
+        }
+        usedSemanticsIds.add(node.id);
+        node
+          ..tags = tags
+          ..rect = rect
+          ..transform = null // Will be set when compiling immediate parent node.
+          ..parentSemanticsClipRect = semanticsClipRect
+          ..parentPaintClipRect = paintClipRect;
+        for (final _InterestingSemanticsFragment fragment in group) {
+          if (fragment.config != null) {
+            fragment.owner._semantics = node;
+          }
+        }
+        node.updateWith(config: configuration);
+        result.add(node);
+      }
+    }
+  }
+
   final List<_InterestingSemanticsFragment> _children = <_InterestingSemanticsFragment>[];
 
   @override
-  void compileChildren({ Rect? parentSemanticsClipRect, Rect? parentPaintClipRect, required double elevationAdjustment, required List<SemanticsNode> result }) {
+  void compileChildren({
+    Rect? parentSemanticsClipRect,
+    Rect? parentPaintClipRect,
+    required double elevationAdjustment,
+    required List<SemanticsNode> result,
+    required List<SemanticsNode> siblingNodes,
+  }) {
+    final Set<int> usedSemanticsIds = <int>{};
+    Iterable<_InterestingSemanticsFragment> compilingFragments = _children;
+    for (final List<_InterestingSemanticsFragment> siblingGroup in _siblingMergeGroups) {
+      compilingFragments = compilingFragments.followedBy(siblingGroup);
+    }
     if (!_isExplicit) {
-      owner._semantics = null;
-      for (final _InterestingSemanticsFragment fragment in _children) {
+      if (!_mergesToSibling) {
+        owner._semantics = null;
+      }
+      _mergeSiblingGroup(
+        parentSemanticsClipRect,
+        parentPaintClipRect,
+        siblingNodes,
+        usedSemanticsIds,
+      );
+      for (final _InterestingSemanticsFragment fragment in compilingFragments) {
         assert(_ancestorChain.first == fragment._ancestorChain.last);
+        if (fragment is _SwitchableSemanticsFragment) {
+          // Cached semantics node may be part of sibling merging group prior
+          // to this update. In this case, the semantics node may continue to
+          // be reused in that sibling merging group.
+          if (fragment._isExplicit &&
+              fragment.owner._semantics != null &&
+              usedSemanticsIds.contains(fragment.owner._semantics!.id)) {
+            fragment.owner._semantics = null;
+          }
+        }
         fragment._ancestorChain.addAll(_ancestorChain.skip(1));
         fragment.compileChildren(
           parentSemanticsClipRect: parentSemanticsClipRect,
@@ -4228,14 +4409,16 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
           // its children are placed at the elevation dictated by this config.
           elevationAdjustment: elevationAdjustment + _config.elevation,
           result: result,
+          siblingNodes: siblingNodes,
         );
       }
       return;
     }
 
-    final _SemanticsGeometry? geometry = _needsGeometryUpdate
-        ? _SemanticsGeometry(parentSemanticsClipRect: parentSemanticsClipRect, parentPaintClipRect: parentPaintClipRect, ancestors: _ancestorChain)
-        : null;
+    final _SemanticsGeometry? geometry = _computeSemanticsGeometry(
+      parentSemanticsClipRect: parentSemanticsClipRect,
+      parentPaintClipRect: parentPaintClipRect,
+    );
 
     if (!_mergeIntoParent && (geometry?.dropFromTree ?? false)) {
       return; // Drop the node, it's not going to be visible.
@@ -4264,22 +4447,62 @@ class _SwitchableSemanticsFragment extends _InterestingSemanticsFragment {
         _config.isHidden = true;
       }
     }
-
     final List<SemanticsNode> children = <SemanticsNode>[];
-    for (final _InterestingSemanticsFragment fragment in _children) {
+    _mergeSiblingGroup(
+      node.parentSemanticsClipRect,
+      node.parentPaintClipRect,
+      siblingNodes,
+      usedSemanticsIds,
+    );
+    for (final _InterestingSemanticsFragment fragment in compilingFragments) {
+      if (fragment is _SwitchableSemanticsFragment) {
+        // Cached semantics node may be part of sibling merging group prior
+        // to this update. In this case, the semantics node may continue to
+        // be reused in that sibling merging group.
+        if (fragment._isExplicit &&
+            fragment.owner._semantics != null &&
+            usedSemanticsIds.contains(fragment.owner._semantics!.id)) {
+          fragment.owner._semantics = null;
+        }
+      }
+      final List<SemanticsNode> childSiblingNodes = <SemanticsNode>[];
       fragment.compileChildren(
         parentSemanticsClipRect: node.parentSemanticsClipRect,
         parentPaintClipRect: node.parentPaintClipRect,
         elevationAdjustment: 0.0,
         result: children,
+        siblingNodes: childSiblingNodes,
       );
+      siblingNodes.addAll(childSiblingNodes);
     }
+
     if (_config.isSemanticBoundary) {
       owner.assembleSemanticsNode(node, _config, children);
     } else {
       node.updateWith(config: _config, childrenInInversePaintOrder: children);
     }
     result.add(node);
+    // Sibling node needs to attach to the parent of an explicit node.
+    for (final SemanticsNode siblingNode in siblingNodes) {
+      // sibling nodes are in the same coordinate of the immediate explicit node.
+      // They need to share the same transform if they are going to attach to the
+      // parent of the immediate explicit node.
+      assert(siblingNode.transform == null);
+      siblingNode
+        ..transform = node.transform
+        ..isMergedIntoParent = node.isMergedIntoParent;
+    }
+    result.addAll(siblingNodes);
+    siblingNodes.clear();
+  }
+
+  _SemanticsGeometry? _computeSemanticsGeometry({
+    required Rect? parentSemanticsClipRect,
+    required Rect? parentPaintClipRect,
+  }) {
+    return _needsGeometryUpdate
+      ? _SemanticsGeometry(parentSemanticsClipRect: parentSemanticsClipRect, parentPaintClipRect: parentPaintClipRect, ancestors: _ancestorChain)
+      : null;
   }
 
   @override

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3101,7 +3101,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       _cachedSemanticsConfiguration = SemanticsConfiguration();
       describeSemanticsConfiguration(_cachedSemanticsConfiguration!);
       assert(
-        !_cachedSemanticsConfiguration!.explicitChildNodes || _cachedSemanticsConfiguration!.childConfigsDelegate == null,
+        !_cachedSemanticsConfiguration!.explicitChildNodes || _cachedSemanticsConfiguration!.childConfigurationsDelegate == null,
         'A SemanticsConfiguration with explicitChildNode set to true cannot have a non-null childConfigsDelegate.',
       );
     }
@@ -3165,10 +3165,11 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
     final bool wasSemanticsBoundary = _semantics != null && (_cachedSemanticsConfiguration?.isSemanticBoundary ?? false);
     _cachedSemanticsConfiguration = null;
-    // Merger may produce sibling node to be attached to the parent of this
-    // semantics node, thus it can't be a semantics boundary.
+    // The childConfigurationsDelegate may produce sibling node to be attached
+    // to the parent of this semantics node, thus it can't be a semantics
+    // boundary.
     bool isEffectiveSemanticsBoundary =
-      _semanticsConfiguration.childConfigsDelegate == null &&
+      _semanticsConfiguration.childConfigurationsDelegate == null &&
       _semanticsConfiguration.isSemanticBoundary &&
       wasSemanticsBoundary;
     RenderObject node = this;
@@ -3249,7 +3250,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     final bool childrenMergeIntoParent = mergeIntoParent || config.isMergingSemanticsOfDescendants;
     final List<SemanticsConfiguration> childConfigurations = <SemanticsConfiguration>[];
     final bool explicitChildNode = config.explicitChildNodes || parent is! RenderObject;
-    final bool hasSemanticsMerger = config.childConfigsDelegate != null;
+    final bool hasChildConfigurationsDelegate = config.childConfigurationsDelegate != null;
     final Map<SemanticsConfiguration, _InterestingSemanticsFragment> configToFragment = <SemanticsConfiguration, _InterestingSemanticsFragment>{};
     final List<_InterestingSemanticsFragment> mergeUpFragments = <_InterestingSemanticsFragment>[];
     final List<List<_InterestingSemanticsFragment>> siblingMergeFragmentGroups = <List<_InterestingSemanticsFragment>>[];
@@ -3269,7 +3270,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       for (final _InterestingSemanticsFragment fragment in parentFragment.mergeUpFragments) {
         fragment.addAncestor(this);
         fragment.addTags(config.tagsForChildren);
-        if (hasSemanticsMerger && fragment.config != null) {
+        if (hasChildConfigurationsDelegate && fragment.config != null) {
           // This fragment need to go through delegate to determine whether it
           // merge up or not.
           childConfigurations.add(fragment.config!);
@@ -3291,14 +3292,14 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
       }
     });
 
-    assert(hasSemanticsMerger || configToFragment.isEmpty);
+    assert(hasChildConfigurationsDelegate || configToFragment.isEmpty);
 
     if (explicitChildNode) {
       for (final _InterestingSemanticsFragment fragment in mergeUpFragments) {
         fragment.markAsExplicit();
       }
-    } else if (hasSemanticsMerger && childConfigurations.isNotEmpty) {
-      final ChildSemanticsConfigsResult result = config.childConfigsDelegate!(childConfigurations);
+    } else if (hasChildConfigurationsDelegate && childConfigurations.isNotEmpty) {
+      final ChildSemanticsConfigurationsResult result = config.childConfigurationsDelegate!(childConfigurations);
       mergeUpFragments.addAll(
         result.mergeUp.map<_InterestingSemanticsFragment>((SemanticsConfiguration config) => configToFragment[config]!),
       );

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3100,6 +3100,10 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
     if (_cachedSemanticsConfiguration == null) {
       _cachedSemanticsConfiguration = SemanticsConfiguration();
       describeSemanticsConfiguration(_cachedSemanticsConfiguration!);
+      assert(
+        !_cachedSemanticsConfiguration!.explicitChildNodes || _cachedSemanticsConfiguration!.merger == null,
+        'A Semantics with `explicitChildNode = true` cannot have a merger',
+      );
     }
     return _cachedSemanticsConfiguration!;
   }
@@ -3286,18 +3290,19 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
           siblingMergeFragmentGroups.add(siblingMergeGroup);
         }
       }
-      childConfigurations[renderChild] = configurations;
+      if (configurations.isNotEmpty) {
+        childConfigurations[renderChild] = configurations;
+      }
     });
 
     assert(hasSemanticsMerger || configToFragment.isEmpty);
 
     if (explicitChildNode) {
-      assert(!hasSemanticsMerger, 'A Semantics with `explicitChildNode = true` cannot have a merger');
       for (final _InterestingSemanticsFragment fragment in mergeUpFragments) {
         fragment.markAsExplicit();
       }
-    } else if (hasSemanticsMerger) {
-      final SemanticsMergeRule rule = config.merger!(childConfigurations);
+    } else if (hasSemanticsMerger && childConfigurations.isNotEmpty) {
+      final SemanticsMergeResult rule = config.merger!(childConfigurations);
       mergeUpFragments.addAll(
         rule.mergeUp.map<_InterestingSemanticsFragment>((SemanticsConfiguration config) => configToFragment[config]!),
       );

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -3165,7 +3165,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
 
     final bool wasSemanticsBoundary = _semantics != null && (_cachedSemanticsConfiguration?.isSemanticBoundary ?? false);
     _cachedSemanticsConfiguration = null;
-    // The childConfigurationsDelegate may produce sibling node to be attached
+    // The childConfigurationsDelegate may produce sibling nodes to be attached
     // to the parent of this semantics node, thus it can't be a semantics
     // boundary.
     bool isEffectiveSemanticsBoundary =

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -36,7 +36,7 @@ typedef SemanticsNodeVisitor = bool Function(SemanticsNode node);
 /// [SemanticsConfiguration]s. The list of each value is always non-empty.
 ///
 /// The return value is a [SemanticsMergeResult].
-typedef SemanticsConfigMerger = SemanticsMergeResult Function(Map<AbstractNode, List<SemanticsConfiguration>>);
+typedef SemanticsConfigMerger = SemanticsMergeResult Function(Map<Object, List<SemanticsConfiguration>>);
 
 /// Signature for [SemanticsAction]s that move the cursor.
 ///

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -4375,6 +4375,47 @@ void main() {
     expect(prefixText.style, prefixStyle);
   });
 
+  testWidgets('TextField prefix and suffix create a sibling node', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    await tester.pumpWidget(
+      overlay(
+        child: TextField(
+          controller: TextEditingController(text: 'some text'),
+          decoration: const InputDecoration(
+            prefixText: 'Prefix',
+            suffixText: 'Suffix',
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          id: 2,
+          textDirection: TextDirection.ltr,
+          label: 'Prefix',
+        ),
+        TestSemantics.rootChild(
+          id: 1,
+          textDirection: TextDirection.ltr,
+          value: 'some text',
+          actions: <SemanticsAction>[
+            SemanticsAction.tap,
+          ],
+          flags: <SemanticsFlag>[
+            SemanticsFlag.isTextField,
+          ],
+        ),
+        TestSemantics.rootChild(
+          id: 3,
+          textDirection: TextDirection.ltr,
+          label: 'Suffix',
+        ),
+      ],
+    ), ignoreTransform: true, ignoreRect: true));
+  });
+
   testWidgets('TextField with specified suffixStyle', (WidgetTester tester) async {
     final TextStyle suffixStyle = TextStyle(
       color: Colors.pink[500],

--- a/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
+++ b/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
@@ -1,0 +1,259 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'semantics_tester.dart';
+
+void main() {
+  testWidgets('Semantics can merge sibling group', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    const SemanticsTag first = SemanticsTag('1');
+    const SemanticsTag second = SemanticsTag('2');
+    const SemanticsTag third = SemanticsTag('3');
+    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
+      expect(configs.length, 3);
+      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+      final List<SemanticsConfiguration> sibling = <SemanticsConfiguration>[];
+      // Merge first and third
+      for (final SemanticsConfiguration config in configs) {
+        if (config.isChildrenTagged(first) || config.isChildrenTagged(third)) {
+          sibling.add(config);
+        } else {
+          builder.markAsMergeUp(config);
+        }
+      }
+      builder.markAsSiblingMergeGroup(sibling);
+      return builder.build();
+    }
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          label: 'parent',
+          child: TestConfigDelegate(
+            delegate: delegate,
+            child: Column(
+              children: <Widget>[
+                Semantics(
+                  label: '1',
+                  tagForChildren: first,
+                  child: const SizedBox(width: 100, height: 100),
+                  // this tests that empty nodes disappear
+                ),
+                Semantics(
+                  label: '2',
+                  tagForChildren: second,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+                Semantics(
+                  label: '3',
+                  tagForChildren: third,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          label: 'parent\n2',
+        ),
+        TestSemantics.rootChild(
+          label: '1\n3',
+        ),
+      ],
+    ), ignoreId: true, ignoreRect: true, ignoreTransform: true));
+  });
+
+  testWidgets('Semantics can drop semantics config', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
+    const SemanticsTag first = SemanticsTag('1');
+    const SemanticsTag second = SemanticsTag('2');
+    const SemanticsTag third = SemanticsTag('3');
+    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
+      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+      // Merge first and third
+      for (final SemanticsConfiguration config in configs) {
+        if (config.isChildrenTagged(first) || config.isChildrenTagged(third)) {
+          continue;
+        }
+        builder.markAsMergeUp(config);
+      }
+      return builder.build();
+    }
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          label: 'parent',
+          child: TestConfigDelegate(
+            delegate: delegate,
+            child: Column(
+              children: <Widget>[
+                Semantics(
+                  label: '1',
+                  tagForChildren: first,
+                  child: const SizedBox(width: 100, height: 100),
+                  // this tests that empty nodes disappear
+                ),
+                Semantics(
+                  label: '2',
+                  tagForChildren: second,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+                Semantics(
+                  label: '3',
+                  tagForChildren: third,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(semantics, hasSemantics(TestSemantics.root(
+      children: <TestSemantics>[
+        TestSemantics.rootChild(
+          label: 'parent\n2',
+        ),
+      ],
+    ), ignoreId: true, ignoreRect: true, ignoreTransform: true));
+  });
+
+  testWidgets('Semantics throws when mark the same config twice case 1', (WidgetTester tester) async {
+    const SemanticsTag first = SemanticsTag('1');
+    const SemanticsTag second = SemanticsTag('2');
+    const SemanticsTag third = SemanticsTag('3');
+    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
+      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+      // Marks the same one twice.
+      builder.markAsMergeUp(configs.first);
+      builder.markAsMergeUp(configs.first);
+      return builder.build();
+    }
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          label: 'parent',
+          child: TestConfigDelegate(
+            delegate: delegate,
+            child: Column(
+              children: <Widget>[
+                Semantics(
+                  label: '1',
+                  tagForChildren: first,
+                  child: const SizedBox(width: 100, height: 100),
+                  // this tests that empty nodes disappear
+                ),
+                Semantics(
+                  label: '2',
+                  tagForChildren: second,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+                Semantics(
+                  label: '3',
+                  tagForChildren: third,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isAssertionError);
+  });
+
+  testWidgets('Semantics throws when mark the same config twice case 2', (WidgetTester tester) async {
+    const SemanticsTag first = SemanticsTag('1');
+    const SemanticsTag second = SemanticsTag('2');
+    const SemanticsTag third = SemanticsTag('3');
+    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
+      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+      // Marks the same one twice.
+      builder.markAsMergeUp(configs.first);
+      builder.markAsSiblingMergeGroup(<SemanticsConfiguration>[configs.first]);
+      return builder.build();
+    }
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Semantics(
+          label: 'parent',
+          child: TestConfigDelegate(
+            delegate: delegate,
+            child: Column(
+              children: <Widget>[
+                Semantics(
+                  label: '1',
+                  tagForChildren: first,
+                  child: const SizedBox(width: 100, height: 100),
+                  // this tests that empty nodes disappear
+                ),
+                Semantics(
+                  label: '2',
+                  tagForChildren: second,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+                Semantics(
+                  label: '3',
+                  tagForChildren: third,
+                  child: const SizedBox(width: 100, height: 100),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isAssertionError);
+  });
+}
+
+class TestConfigDelegate extends SingleChildRenderObjectWidget {
+  const TestConfigDelegate({super.key, required this.delegate, super.child});
+  final ChildSemanticsConfigsDelegate delegate;
+
+  @override
+  RenderTestConfigDelegate createRenderObject(BuildContext context) => RenderTestConfigDelegate(
+    delegate: delegate,
+  );
+
+  @override
+  void updateRenderObject(BuildContext context, RenderTestConfigDelegate renderObject) {
+    renderObject.delegate = delegate;
+  }
+}
+
+class RenderTestConfigDelegate extends RenderProxyBox {
+  RenderTestConfigDelegate({
+    ChildSemanticsConfigsDelegate? delegate,
+  }) : _delegate = delegate;
+
+  ChildSemanticsConfigsDelegate? get delegate => _delegate;
+  ChildSemanticsConfigsDelegate? _delegate;
+  set delegate(ChildSemanticsConfigsDelegate? value) {
+    if (value != _delegate) {
+      markNeedsSemanticsUpdate();
+    }
+    _delegate = value;
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    config.childConfigsDelegate = _delegate;
+  }
+}

--- a/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
+++ b/packages/flutter/test/widgets/semantics_child_configs_delegate_test.dart
@@ -14,13 +14,13 @@ void main() {
     const SemanticsTag first = SemanticsTag('1');
     const SemanticsTag second = SemanticsTag('2');
     const SemanticsTag third = SemanticsTag('3');
-    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
+    ChildSemanticsConfigurationsResult delegate(List<SemanticsConfiguration> configs) {
       expect(configs.length, 3);
-      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+      final ChildSemanticsConfigurationsResultBuilder builder = ChildSemanticsConfigurationsResultBuilder();
       final List<SemanticsConfiguration> sibling = <SemanticsConfiguration>[];
       // Merge first and third
       for (final SemanticsConfiguration config in configs) {
-        if (config.isChildrenTagged(first) || config.isChildrenTagged(third)) {
+        if (config.tagsChildrenWith(first) || config.tagsChildrenWith(third)) {
           sibling.add(config);
         } else {
           builder.markAsMergeUp(config);
@@ -78,11 +78,11 @@ void main() {
     const SemanticsTag first = SemanticsTag('1');
     const SemanticsTag second = SemanticsTag('2');
     const SemanticsTag third = SemanticsTag('3');
-    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
-      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+    ChildSemanticsConfigurationsResult delegate(List<SemanticsConfiguration> configs) {
+      final ChildSemanticsConfigurationsResultBuilder builder = ChildSemanticsConfigurationsResultBuilder();
       // Merge first and third
       for (final SemanticsConfiguration config in configs) {
-        if (config.isChildrenTagged(first) || config.isChildrenTagged(third)) {
+        if (config.tagsChildrenWith(first) || config.tagsChildrenWith(third)) {
           continue;
         }
         builder.markAsMergeUp(config);
@@ -134,8 +134,8 @@ void main() {
     const SemanticsTag first = SemanticsTag('1');
     const SemanticsTag second = SemanticsTag('2');
     const SemanticsTag third = SemanticsTag('3');
-    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
-      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+    ChildSemanticsConfigurationsResult delegate(List<SemanticsConfiguration> configs) {
+      final ChildSemanticsConfigurationsResultBuilder builder = ChildSemanticsConfigurationsResultBuilder();
       // Marks the same one twice.
       builder.markAsMergeUp(configs.first);
       builder.markAsMergeUp(configs.first);
@@ -180,8 +180,8 @@ void main() {
     const SemanticsTag first = SemanticsTag('1');
     const SemanticsTag second = SemanticsTag('2');
     const SemanticsTag third = SemanticsTag('3');
-    ChildSemanticsConfigsResult delegate(List<SemanticsConfiguration> configs) {
-      final ChildSemanticsConfigsResultBuilder builder = ChildSemanticsConfigsResultBuilder();
+    ChildSemanticsConfigurationsResult delegate(List<SemanticsConfiguration> configs) {
+      final ChildSemanticsConfigurationsResultBuilder builder = ChildSemanticsConfigurationsResultBuilder();
       // Marks the same one twice.
       builder.markAsMergeUp(configs.first);
       builder.markAsSiblingMergeGroup(<SemanticsConfiguration>[configs.first]);
@@ -225,7 +225,7 @@ void main() {
 
 class TestConfigDelegate extends SingleChildRenderObjectWidget {
   const TestConfigDelegate({super.key, required this.delegate, super.child});
-  final ChildSemanticsConfigsDelegate delegate;
+  final ChildSemanticsConfigurationsDelegate delegate;
 
   @override
   RenderTestConfigDelegate createRenderObject(BuildContext context) => RenderTestConfigDelegate(
@@ -240,12 +240,12 @@ class TestConfigDelegate extends SingleChildRenderObjectWidget {
 
 class RenderTestConfigDelegate extends RenderProxyBox {
   RenderTestConfigDelegate({
-    ChildSemanticsConfigsDelegate? delegate,
+    ChildSemanticsConfigurationsDelegate? delegate,
   }) : _delegate = delegate;
 
-  ChildSemanticsConfigsDelegate? get delegate => _delegate;
-  ChildSemanticsConfigsDelegate? _delegate;
-  set delegate(ChildSemanticsConfigsDelegate? value) {
+  ChildSemanticsConfigurationsDelegate? get delegate => _delegate;
+  ChildSemanticsConfigurationsDelegate? _delegate;
+  set delegate(ChildSemanticsConfigurationsDelegate? value) {
     if (value != _delegate) {
       markNeedsSemanticsUpdate();
     }
@@ -254,6 +254,6 @@ class RenderTestConfigDelegate extends RenderProxyBox {
 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
-    config.childConfigsDelegate = _delegate;
+    config.childConfigurationsDelegate = _delegate;
   }
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/110158

The goal of this pr is to let _RenderDecoration to be able to choose which children to merge together without merging upward. 

The requirements are:

1. A render object can decide which children to merge and form a node.
2. a render object must be able to control the order of the merged nodes, including the one the render object itself formed
3. TextField must remain mergeable if wrapped with a semantics widget

The new API SemanticsConfiguration.merger let renderobject to decide which of its children can merge together. The formed semantics node will attach to the **parent** of the semantics node the renderobject created or merged to, so they will be siblings.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
