### PR TITLE
Cupertino picker tap

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -503,11 +503,8 @@ class _RenderCupertinoPickerSemantics extends RenderProxyBox {
     final SemanticsNode scrollable = children.first;
     final Map<int, SemanticsNode> indexedChildren = <int, SemanticsNode>{};
     scrollable.visitChildren((SemanticsNode child) {
-      child.visitChildren((SemanticsNode child) {
-        assert(child.indexInParent != null);
-        indexedChildren[child.indexInParent!] = child;
-        return true;
-      });
+      assert(child.indexInParent != null);
+      indexedChildren[child.indexInParent!] = child;
       return true;
     });
     if (indexedChildren[_currentIndex] == null) {
@@ -546,6 +543,7 @@ class _CupertinoPickerListWheelChildDelegateWrapper implements ListWheelChildDel
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
+      excludeFromSemantics: true,
       onTap: () => onTappedChild(index),
       child: child,
     );

--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -1039,7 +1039,7 @@ class RenderListWheelViewport
   @override
   void applyPaintTransform(RenderBox child, Matrix4 transform) {
     final ListWheelParentData parentData = child.parentData! as ListWheelParentData;
-    transform.translate(0.0, _getUntransformedPaintingCoordinateY(parentData.offset.dy));
+    transform.translate(parentData.offset.dx, _getUntransformedPaintingCoordinateY(parentData.offset.dy));
   }
 
   @override
@@ -1051,7 +1051,23 @@ class RenderListWheelViewport
   }
 
   @override
-  bool hitTestChildren(BoxHitTestResult result, { required Offset position }) => false;
+  bool hitTestChildren(BoxHitTestResult result, { required Offset position }) {
+    RenderBox? child = firstChild;
+    while (child != null) {
+      final ListWheelParentData parentData = child.parentData! as ListWheelParentData;
+      final double top = _getUntransformedPaintingCoordinateY(parentData.offset.dy);
+      final double bottom = top + itemExtent;
+      if (position.dy > top && position.dy < bottom) {
+        return child.hitTest(
+          result,
+          position: position.translate(-parentData.offset.dx, -top),
+        );
+      }
+      child = childAfter(child);
+    }
+    return false;
+  }
+
 
   @override
   RevealedOffset getOffsetToReveal(RenderObject target, double alignment, { Rect? rect }) {

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -335,13 +335,18 @@ void main() {
       );
 
       // Drag it by a bit but not enough to move to the next item.
-      await tester.drag(find.text('10'), const Offset(0.0, 30.0), touchSlopY: 0.0, warnIfMissed: false); // has an IgnorePointer
+      TestGesture gesture = await tester.startGesture(tester.getCenter(find.text('10')));
+      // Use custom gesture to work around the DragStartBehavior.start.
+      // First 20 initiates the drag, next 30 is the actual drag.
+      await gesture.moveBy(const Offset(0.0, 20.0)); // has an IgnorePointer
+      await gesture.moveBy(const Offset(0.0, 30.0)); // has an IgnorePointer
 
       // The item that was in the center now moved a bit.
       expect(
         tester.getTopLeft(find.widgetWithText(SizedBox, '10')),
         const Offset(200.0, 280.0),
       );
+      await gesture.up();
 
       await tester.pumpAndSettle();
 
@@ -352,8 +357,13 @@ void main() {
       expect(selectedItems.isEmpty, true);
 
       // Drag it by enough to move to the next item.
-      await tester.drag(find.text('10'), const Offset(0.0, 70.0), touchSlopY: 0.0, warnIfMissed: false); // has an IgnorePointer
+      gesture = await tester.startGesture(tester.getCenter(find.text('10')));
+      await gesture.moveBy(const Offset(0.0, 20.0)); // has an IgnorePointer
+      // Use custom gesture to work around the DragStartBehavior.start.
+      // First 20 initiates the drag, next 70 is the actual drag.
+      await gesture.moveBy(const Offset(0.0, 70.0)); // has an IgnorePointer
 
+      await gesture.up();
       await tester.pumpAndSettle();
 
       expect(

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -487,4 +487,32 @@ void main() {
       expect(borderRadius, isA<BorderRadiusDirectional>());
     });
   });
+
+  testWidgets('Picker children should be hittable', (WidgetTester tester) async {
+    int taps = 0;
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(brightness: Brightness.light),
+        home: CupertinoPicker(
+          itemExtent: 15.0,
+          onSelectedItemChanged: (int i) {},
+          selectionOverlay: const CupertinoPickerDefaultSelectionOverlay(
+              background: Color(0x12345678)),
+          children: <Widget>[
+            const Text('2'),
+            GestureDetector(
+              onTap: () => taps++,
+              behavior: HitTestBehavior.opaque,
+              child: const Text('1'),
+            ),
+          ],
+        ),
+      ),
+    );
+    expect(taps, equals(0));
+    await tester.tap(find.text('1'));
+    expect(taps, equals(1));
+    await tester.tap(find.text('2'));
+    expect(taps, equals(1));
+  });
 }

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -515,4 +515,30 @@ void main() {
     await tester.tap(find.text('2'));
     expect(taps, equals(1));
   });
+
+  testWidgets('Tapping on child in a CupertinoPicker selects that child', (WidgetTester tester) async {
+    int selectedItem = 0;
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(brightness: Brightness.light),
+        home: CupertinoPicker(
+          itemExtent: 15.0,
+          onSelectedItemChanged: (int i) {
+            selectedItem = i;
+          },
+          selectionOverlay: const CupertinoPickerDefaultSelectionOverlay(
+              background: Color(0x12345678)),
+          children: const <Widget>[
+             Text('2'),
+             Text('1'),
+          ],
+        ),
+      ),
+    );
+
+    expect(selectedItem, equals(0));
+    await tester.tap(find.text('1'));
+    await tester.pumpAndSettle();
+    expect(selectedItem, equals(1));
+  });
 }


### PR DESCRIPTION
Adds support for tapping on items in a cupertino picker
To do so I simply implemented hit testing for the ListWheelScrollView and added a gesture recogniser around all the children.

Drag gestures in the date_picker tests are failing because they need to be converted to custom gestures (the drag is not triggered because of the `DragStartBehaviour.start`).
I can convert those but would first like some feedback on the approach before sinking in that time.

Fixes #38803
Fixes #24089

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
