### PR TITLE
[flutter_tools] change the way version is calculated on master

### DIFF
--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -812,9 +812,9 @@ class GitTagVersion {
       return '$x.$y.$z+hotfix.${hotfix! + 1}.pre.$commits';
     }
     if (devPatch != null && devVersion != null) {
-      // The next published release this commit will appear in will be a beta
-      // release, thus increment [y].
-      return '$x.${y! + 1}.0-0.0.pre.$commits';
+      // The next tag that will contain this commit will be the next candidate
+      // branch, which will increment the devVersion.
+      return '$x.$y.0-${devVersion! + 1}.0.pre.$commits';
     }
     return '$x.$y.${z! + 1}-0.0.pre.$commits';
   }

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -440,9 +440,9 @@ void main() {
     GitTagVersion gitTagVersion;
 
     // Master channel
-    gitTagVersion = GitTagVersion.parse('1.2.3-4.5.pre-13-g$hash');
-    expect(gitTagVersion.frameworkVersionFor(hash), '1.3.0-0.0.pre.13');
-    expect(gitTagVersion.gitTag, '1.2.3-4.5.pre');
+    gitTagVersion = GitTagVersion.parse('1.2.0-4.5.pre-13-g$hash');
+    expect(gitTagVersion.frameworkVersionFor(hash), '1.2.0-5.0.pre.13');
+    expect(gitTagVersion.gitTag, '1.2.0-4.5.pre');
     expect(gitTagVersion.devVersion, 4);
     expect(gitTagVersion.devPatch, 5);
 
@@ -543,7 +543,7 @@ void main() {
   });
 
   testUsingContext('determine reports correct git describe version if HEAD is not at a tag', () {
-    const String devTag = '1.2.3-2.0.pre';
+    const String devTag = '1.2.0-2.0.pre';
     const String headRevision = 'abcd1234';
     const String commitsAhead = '12';
     final FakeProcessManager fakeProcessManager = FakeProcessManager.list(
@@ -565,8 +565,8 @@ void main() {
     final FakePlatform platform = FakePlatform();
 
     final GitTagVersion gitTagVersion = GitTagVersion.determine(processUtils, platform, workingDirectory: '.');
-    // reported version should increment the y
-    expect(gitTagVersion.frameworkVersionFor(headRevision), '1.3.0-0.0.pre.12');
+    // reported version should increment the m
+    expect(gitTagVersion.frameworkVersionFor(headRevision), '1.2.0-3.0.pre.12');
   });
 
   testUsingContext('determine does not call fetch --tags', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/110536

In https://github.com/flutter/flutter/commit/1d59d8d341a82ae9c7c4fef1b4a20fa7c756e347 I changed the way we calculate the Flutter SDK version on the master channel to increment the `y` from the last tag, since we were getting the tag from a beta release, and the next release the HEAD commit would appear in would be the NEXT beta release, which would increment `y`.

However, with internal b/244592409, we will add tags to each candidate branch branch point, the way we did when we had dev releases. Thus, change this logic back to increment the m.