### PR TITLE
[flutter_tools] Generate localizations on `flutter pub get`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -6,13 +6,17 @@ import 'package:args/args.dart';
 
 import '../base/common.dart';
 import '../base/os.dart';
+import '../base/utils.dart';
 import '../build_info.dart';
 import '../build_system/build_system.dart';
+import '../build_system/targets/localizations.dart';
 import '../cache.dart';
 import '../dart/generate_synthetic_packages.dart';
 import '../dart/pub.dart';
 import '../flutter_plugins.dart';
 import '../globals.dart' as globals;
+import '../localizations/gen_l10n.dart';
+import '../localizations/localizations_utils.dart';
 import '../plugins.dart';
 import '../project.dart';
 import '../reporting/reporting.dart';
@@ -341,6 +345,35 @@ class PackagesInteractiveGetCommand extends FlutterCommand {
         await generateLocalizationsSyntheticPackage(
           environment: environment,
           buildSystem: globals.buildSystem,
+        );
+      }
+    } else if (flutterProject!.directory.childFile('l10n.yaml').existsSync()) {
+      final Environment environment = Environment(
+        artifacts: globals.artifacts!,
+        logger: globals.logger,
+        cacheDir: globals.cache.getRoot(),
+        engineVersion: globals.flutterVersion.engineRevision,
+        fileSystem: globals.fs,
+        flutterRootDir: globals.fs.directory(Cache.flutterRoot),
+        outputDir: globals.fs.directory(getBuildDirectory()),
+        processManager: globals.processManager,
+        platform: globals.platform,
+        usage: globals.flutterUsage,
+        projectDir: flutterProject.directory,
+        generateDartPluginRegistry: true,
+      );
+      final BuildResult result = await globals.buildSystem.build(
+        const GenerateLocalizationsTarget(),
+        environment,
+      );
+      if (result == null) {
+        throwToolExit('Generating synthetic localizations package failed: result is null.');
+      }
+      if (result.hasException) {
+        throwToolExit(
+          'Generating synthetic localizations package failed with ${result.exceptions.length} ${pluralize('error', result.exceptions.length)}:'
+          '\n\n'
+          '${result.exceptions.values.map<Object?>((ExceptionMeasurement e) => e.exception).join('\n\n')}',
         );
       }
     }

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -237,6 +237,32 @@ void main() {
       ),
     });
 
+    testUsingContext('get generates synthetic package when l10n.yaml has synthetic-package: true', () {
+
+    }, overrides: <Type, Generator>{
+      Pub: () => Pub(
+        fileSystem: globals.fs,
+        logger: globals.logger,
+        processManager: globals.processManager,
+        usage: globals.flutterUsage,
+        botDetector: globals.botDetector,
+        platform: globals.platform,
+      ),
+    });
+
+    testUsingContext('get generates normal files when l10n.yaml has synthetic-package: false', () {
+
+    }, overrides: <Type, Generator>{
+      Pub: () => Pub(
+        fileSystem: globals.fs,
+        logger: globals.logger,
+        processManager: globals.processManager,
+        usage: globals.flutterUsage,
+        botDetector: globals.botDetector,
+        platform: globals.platform,
+      ),
+    });
+
     testUsingContext('set no plugins as usage value', () async {
       final String projectPath = await createProject(tempDir,
         arguments: <String>['--no-pub', '--template=module']);


### PR DESCRIPTION
Currently, `flutter pub get` generates localizations if there exists an `l10n.yaml` file where `synthetic-package` is not false. However, for any user who needs to turn off `synthetic-package`, their localizations are not generated. This PR should make the behavior more consistent. (Also it seems good to make it so that running `flutter pub get` once resolves all the dependencies so that people can get to work without running `flutter gen-l10n` manually.)

Fixes https://github.com/flutter/flutter/issues/84979.

// TODO: Need to add tests.