### PR TITLE
Allow Navigator to inherit traversal policy from parent.

### DIFF
--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -5235,6 +5235,7 @@ class NavigatorState extends State<Navigator> with TickerProviderStateMixin, Res
         child: AbsorbPointer(
           absorbing: false, // it's mutated directly by _cancelActivePointers above
           child: FocusTraversalGroup(
+            policy: FocusTraversalGroup.maybeOf(context),
             child: Focus(
               focusNode: focusNode,
               autofocus: true,


### PR DESCRIPTION
## Description

When we removed the `FocusScope` from the `Navigator`, we replaced it with a `FocusTraversalGroup`, but that had the unfortunate side effect of disabling any custom traversal policies already in effect.  This adds logic to inherit the ambient policy if there is one, and supplying the default policy (`ReadingOrderTraversalPolicy`) if there isn't.

## Tests
 - Added tests for both with and without ambient policies.