### PR TITLE
Fix Tooltip Issue on Switch

### DIFF
--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -7,6 +7,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
+import 'feedback.dart';
 import 'material_state.dart';
 
 // Duration of the animation that moves the toggle from one state to another.
@@ -320,10 +321,10 @@ mixin ToggleableStateMixin<S extends StatefulWidget> on TickerProviderStateMixin
       mouseCursor: mouseCursor.resolve(states),
       child: GestureDetector(
         excludeFromSemantics: !isInteractive,
-        onTapDown: _handleTapDown,
-        onTap: _handleTap,
-        onTapUp: _handleTapEnd,
-        onTapCancel: _handleTapEnd,
+        onTapDown: isInteractive ? _handleTapDown : null,
+        onTap: isInteractive ? _handleTap : null,
+        onTapUp: isInteractive ? _handleTapEnd : null,
+        onTapCancel: isInteractive ? _handleTapEnd : null,
         child: Semantics(
           enabled: isInteractive,
           child: CustomPaint(

--- a/packages/flutter/lib/src/material/toggleable.dart
+++ b/packages/flutter/lib/src/material/toggleable.dart
@@ -7,7 +7,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'constants.dart';
-import 'feedback.dart';
 import 'material_state.dart';
 
 // Duration of the animation that moves the toggle from one state to another.

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/gestures/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
@@ -1445,6 +1446,57 @@ void main() {
     await tester.pumpWidget(buildApp());
     await tester.pumpAndSettle();
     expectBorder();
+  });
+
+  testWidgets('disabled checkbox shows tooltip', (WidgetTester tester) async {
+    const String longPressTooltip = 'long press tooltip';
+    const String tapTooltip = 'tap tooltip';
+    await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: Tooltip(
+              message: 'long press tooltip',
+              child: Checkbox(value: true, onChanged: null),
+            ),
+          ),
+        )
+    );
+
+    // Default tooltip shows up after long pressed.
+    final Finder tooltip0 = find.byType(Tooltip);
+    expect(find.text(longPressTooltip), findsNothing);
+
+    await tester.tap(tooltip0);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(longPressTooltip), findsNothing);
+
+    final TestGesture gestureLongPress = await tester.startGesture(tester.getCenter(tooltip0));
+    await tester.pump();
+    await tester.pump(kLongPressTimeout);
+    await gestureLongPress.up();
+    await tester.pump();
+
+    expect(find.text(longPressTooltip), findsOneWidget);
+
+    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.longPress.
+    await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: Tooltip(
+              triggerMode: TooltipTriggerMode.tap,
+              message: tapTooltip,
+              child: Checkbox(value: true, onChanged: null),
+            ),
+          ),
+        )
+    );
+
+    final Finder tooltip1 = find.byType(Tooltip);
+    expect(find.text(tapTooltip), findsNothing);
+
+    await tester.tap(tooltip1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tapTooltip), findsOneWidget);
   });
 }
 

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1452,14 +1452,14 @@ void main() {
     const String longPressTooltip = 'long press tooltip';
     const String tapTooltip = 'tap tooltip';
     await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Tooltip(
-              message: 'long press tooltip',
-              child: Checkbox(value: true, onChanged: null),
-            ),
+      const MaterialApp(
+        home: Material(
+          child: Tooltip(
+            message: longPressTooltip,
+            child: Checkbox(value: true, onChanged: null),
           ),
-        )
+        ),
+      )
     );
 
     // Default tooltip shows up after long pressed.
@@ -1478,17 +1478,17 @@ void main() {
 
     expect(find.text(longPressTooltip), findsOneWidget);
 
-    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.longPress.
+    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.tap.
     await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Tooltip(
-              triggerMode: TooltipTriggerMode.tap,
-              message: tapTooltip,
-              child: Checkbox(value: true, onChanged: null),
-            ),
+      const MaterialApp(
+        home: Material(
+          child: Tooltip(
+            triggerMode: TooltipTriggerMode.tap,
+            message: tapTooltip,
+            child: Checkbox(value: true, onChanged: null),
           ),
-        )
+        ),
+      )
     );
 
     final Finder tooltip1 = find.byType(Tooltip);

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/src/gestures/constants.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
@@ -1114,5 +1115,56 @@ void main() {
     expect(find.byKey(key), findsNothing);
     // Release pointer after widget disappeared.
     await gesture.up();
+  });
+
+  testWidgets('disabled radio shows tooltip', (WidgetTester tester) async {
+    const String longPressTooltip = 'long press tooltip';
+    const String tapTooltip = 'tap tooltip';
+    await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: Tooltip(
+              message: 'long press tooltip',
+              child: Radio<bool>(value: true, groupValue: false, onChanged: null),
+            ),
+          ),
+        )
+    );
+
+    // Default tooltip shows up after long pressed.
+    final Finder tooltip0 = find.byType(Tooltip);
+    expect(find.text(longPressTooltip), findsNothing);
+
+    await tester.tap(tooltip0);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(longPressTooltip), findsNothing);
+
+    final TestGesture gestureLongPress = await tester.startGesture(tester.getCenter(tooltip0));
+    await tester.pump();
+    await tester.pump(kLongPressTimeout);
+    await gestureLongPress.up();
+    await tester.pump();
+
+    expect(find.text(longPressTooltip), findsOneWidget);
+
+    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.longPress.
+    await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: Tooltip(
+              triggerMode: TooltipTriggerMode.tap,
+              message: tapTooltip,
+              child: Radio<bool>(value: true, groupValue: false, onChanged: null),
+            ),
+          ),
+        )
+    );
+
+    final Finder tooltip1 = find.byType(Tooltip);
+    expect(find.text(tapTooltip), findsNothing);
+
+    await tester.tap(tooltip1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tapTooltip), findsOneWidget);
   });
 }

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -1121,14 +1121,14 @@ void main() {
     const String longPressTooltip = 'long press tooltip';
     const String tapTooltip = 'tap tooltip';
     await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Tooltip(
-              message: 'long press tooltip',
-              child: Radio<bool>(value: true, groupValue: false, onChanged: null),
-            ),
+      const MaterialApp(
+        home: Material(
+          child: Tooltip(
+            message: longPressTooltip,
+            child: Radio<bool>(value: true, groupValue: false, onChanged: null),
           ),
-        )
+        ),
+      )
     );
 
     // Default tooltip shows up after long pressed.
@@ -1147,17 +1147,17 @@ void main() {
 
     expect(find.text(longPressTooltip), findsOneWidget);
 
-    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.longPress.
+    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.tap.
     await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Tooltip(
-              triggerMode: TooltipTriggerMode.tap,
-              message: tapTooltip,
-              child: Radio<bool>(value: true, groupValue: false, onChanged: null),
-            ),
+      const MaterialApp(
+        home: Material(
+          child: Tooltip(
+            triggerMode: TooltipTriggerMode.tap,
+            message: tapTooltip,
+            child: Radio<bool>(value: true, groupValue: false, onChanged: null),
           ),
-        )
+        ),
+      )
     );
 
     final Finder tooltip1 = find.byType(Tooltip);

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1721,6 +1721,63 @@ void main() {
     await gesture.up();
   });
 
+  testWidgets('disabled switch shows tooltip', (WidgetTester tester) async {
+    const String longPressTooltip = 'long press tooltip';
+    const String tapTooltip = 'tap tooltip';
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: Tooltip(
+            message: 'long press tooltip',
+            child: Switch(
+              onChanged: null,
+              value: true,
+            ),
+          ),
+        ),
+      )
+    );
+
+    // Default tooltip shows up after long pressed.
+    final Finder tooltip0 = find.byType(Tooltip);
+    expect(find.text(longPressTooltip), findsNothing);
+
+    await tester.tap(tooltip0);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(longPressTooltip), findsNothing);
+
+    final TestGesture gestureLongPress = await tester.startGesture(tester.getCenter(tooltip0));
+    await tester.pump();
+    await tester.pump(kLongPressTimeout);
+    await gestureLongPress.up();
+    await tester.pump();
+
+    expect(find.text(longPressTooltip), findsOneWidget);
+
+    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.longPress.
+    await tester.pumpWidget(
+        const MaterialApp(
+          home: Material(
+            child: Tooltip(
+              triggerMode: TooltipTriggerMode.tap,
+              message: tapTooltip,
+              child: Switch(
+                onChanged: null,
+                value: true,
+              ),
+            ),
+          ),
+        )
+    );
+
+    final Finder tooltip1 = find.byType(Tooltip);
+    expect(find.text(tapTooltip), findsNothing);
+
+    await tester.tap(tooltip1);
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(find.text(tapTooltip), findsOneWidget);
+  });
+
   group('with image', () {
     late ui.Image image;
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -1728,7 +1728,7 @@ void main() {
       const MaterialApp(
         home: Material(
           child: Tooltip(
-            message: 'long press tooltip',
+            message: longPressTooltip,
             child: Switch(
               onChanged: null,
               value: true,
@@ -1754,20 +1754,20 @@ void main() {
 
     expect(find.text(longPressTooltip), findsOneWidget);
 
-    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.longPress.
+    // Tooltip shows up after tapping when set triggerMode to TooltipTriggerMode.tap.
     await tester.pumpWidget(
-        const MaterialApp(
-          home: Material(
-            child: Tooltip(
-              triggerMode: TooltipTriggerMode.tap,
-              message: tapTooltip,
-              child: Switch(
-                onChanged: null,
-                value: true,
-              ),
+      const MaterialApp(
+        home: Material(
+          child: Tooltip(
+            triggerMode: TooltipTriggerMode.tap,
+            message: tapTooltip,
+            child: Switch(
+              onChanged: null,
+              value: true,
             ),
           ),
-        )
+        ),
+      )
     );
 
     final Finder tooltip1 = find.byType(Tooltip);


### PR DESCRIPTION
This PR fixes the iOS/Android use case when the Switch is **disabled** and the tooltip's `triggerMode` is set to `TooltipTriggerMode.tap`. The change also affects Checkbox and Radio components which are also created by the `buildToggleable` method.

For these **enabled** components, the default setting(TooltipTriggerMode.longPress) still shows a tooltip message, but if the `triggerMode` is set to `TooltipTriggerMode.tap`, the Tooltip's `GestureDetecter.onTap` will compete with other components' `GestureDetecter.onTap`, and as a result, the tooltip will not show.

https://user-images.githubusercontent.com/36861262/188039144-9fb4685e-c628-4eb6-b885-a4e92e6462a7.mov

Fixes: #110222

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
