### PR TITLE
Revert "Bump android SDK to 33"

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -30,13 +30,13 @@ import org.gradle.util.VersionNumber
 /** For apps only. Provides the flutter extension used in app/build.gradle. */
 class FlutterExtension {
     /** Sets the compileSdkVersion used by default in Flutter app projects. */
-    static int compileSdkVersion = 33
+    static int compileSdkVersion = 31
 
     /** Sets the minSdkVersion used by default in Flutter app projects. */
     static int minSdkVersion = 16
 
     /** Sets the targetSdkVersion used by default in Flutter app projects. */
-    static int targetSdkVersion = 33
+    static int targetSdkVersion = 31
 
     /**
      * Sets the ndkVersion used by default in Flutter app projects.


### PR DESCRIPTION
Reverts flutter/flutter#109583

Failing consistently on CI. One example:
https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_android%20run_release_test/6379/overview