### PR TITLE
[macOS] Add `flutter_view_macos__start_up` tests devicelab test suite.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2529,6 +2529,16 @@ targets:
         ["devicelab", "hostonly"]
       task_name: flutter_gallery_macos__start_up
 
+  - name: Mac flutter_view_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: flutter_view_macos__start_up
+
   - name: Mac framework_tests_libraries
     recipe: flutter/flutter_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -250,6 +250,9 @@
 /dev/devicelab/bin/tasks/web_benchmarks_html.dart @yjbanov @flutter/web
 /dev/devicelab/bin/tasks/windows_home_scroll_perf__timeline_summary.dart @jonahwilliams @flutter/engine
 /dev/devicelab/bin/tasks/windows_startup_test.dart @loic-sharma @flutter/desktop
+/dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/flutter_gallery_macos__compile.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/flutter_view_macos__start_up.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/flutter_view_macos__start_up.dart
+++ b/dev/devicelab/bin/tasks/flutter_view_macos__start_up.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createFlutterViewStartupTest());
+}


### PR DESCRIPTION
There were very little benchmark devicelab tests on macOS up until this point. See the parent issue for the list of tests that we were trying to bring up at this time. 

**this PR requires that the flutter_view example is implemented**

#### Issue https://github.com/flutter/flutter/issues/110085

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.