### PR TITLE
Update issue reference for skipped hot restart tests

### DIFF
--- a/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
+++ b/packages/flutter_tools/test/web.shard/hot_reload_web_test.dart
@@ -77,5 +77,5 @@ Future<void> _testProject(HotReloadProject project, {String name = 'Default'}) a
     } finally {
       await subscription.cancel();
     }
-  }, skip: true); // Skipping for https://github.com/flutter/flutter/issues/85043.
+  }, skip: true); // Skipped for https://github.com/flutter/flutter/issues/110879.
 }


### PR DESCRIPTION
Update issue reference for skipped hot restart tests with canvas kit.

Related: https://github.com/flutter/flutter/issues/110879
