### PR TITLE
Isolate platform channels for macos

### DIFF
--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -173,7 +173,7 @@ class _TestAppState extends State<TestApp> {
     () => basicStringMessageToUnknownChannel(),
     () => basicJsonMessageToUnknownChannel(),
     () => basicStandardMessageToUnknownChannel(),
-    if (Platform.isIOS || Platform.isAndroid)
+    if (Platform.isIOS || Platform.isAndroid || Platform.isMacOS)
       () => basicBackgroundStandardEcho(123),
   ];
   Future<TestStepResult>? _result;

--- a/dev/integration_tests/channels/macos/Runner/MainFlutterWindow.swift
+++ b/dev/integration_tests/channels/macos/Runner/MainFlutterWindow.swift
@@ -99,6 +99,13 @@ class MainFlutterWindow: NSWindow {
         binaryMessenger: registrar.messenger,
         codec: FlutterStandardMethodCodec(readerWriter: ExtendedReaderWriter())))
 
+    FlutterBasicMessageChannel(
+      name: "std-echo", binaryMessenger: registrar.messenger,
+      codec: FlutterStandardMessageCodec.sharedInstance()
+    ).setMessageHandler { message, reply in
+      reply(message)
+    }
+
     super.awakeFromNib()
   }
 


### PR DESCRIPTION
Adds integration tests for isolate platform channels on macos.

engine pr: https://github.com/flutter/engine/pull/35893

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
