### PR TITLE
Use raw fontFamilyFallback values without packages when constructing a merged TextStyle

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1059,7 +1059,7 @@ class TextStyle with Diagnosticable {
       decorationThickness: other.decorationThickness,
       debugLabel: mergedDebugLabel,
       fontFamily: other._fontFamily,
-      fontFamilyFallback: other.fontFamilyFallback,
+      fontFamilyFallback: other._fontFamilyFallback,
       package: other._package,
       overflow: other.overflow,
     );
@@ -1116,7 +1116,7 @@ class TextStyle with Diagnosticable {
         decorationThickness: t < 0.5 ? null : b.decorationThickness,
         debugLabel: lerpDebugLabel,
         fontFamily: t < 0.5 ? null : b._fontFamily,
-        fontFamilyFallback: t < 0.5 ? null : b.fontFamilyFallback,
+        fontFamilyFallback: t < 0.5 ? null : b._fontFamilyFallback,
         package: t < 0.5 ? null : b._package,
         overflow: t < 0.5 ? null : b.overflow,
       );
@@ -1147,7 +1147,7 @@ class TextStyle with Diagnosticable {
         decorationThickness: t < 0.5 ? a.decorationThickness : null,
         debugLabel: lerpDebugLabel,
         fontFamily: t < 0.5 ? a._fontFamily : null,
-        fontFamilyFallback: t < 0.5 ? a.fontFamilyFallback : null,
+        fontFamilyFallback: t < 0.5 ? a._fontFamilyFallback : null,
         package: t < 0.5 ? a._package : null,
         overflow: t < 0.5 ? a.overflow : null,
       );
@@ -1185,7 +1185,7 @@ class TextStyle with Diagnosticable {
       decorationThickness: ui.lerpDouble(a.decorationThickness ?? b.decorationThickness, b.decorationThickness ?? a.decorationThickness, t),
       debugLabel: lerpDebugLabel,
       fontFamily: t < 0.5 ? a._fontFamily : b._fontFamily,
-      fontFamilyFallback: t < 0.5 ? a.fontFamilyFallback : b.fontFamilyFallback,
+      fontFamilyFallback: t < 0.5 ? a._fontFamilyFallback : b._fontFamilyFallback,
       package: t < 0.5 ? a._package : b._package,
       overflow: t < 0.5 ? a.overflow : b.overflow,
     );

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -304,6 +304,23 @@ void main() {
     expect(s10.fontFamilyFallback, <String>[]);
   });
 
+  test('TextStyle package font merge', () {
+    const TextStyle s1 = TextStyle(package: 'p', fontFamily: 'font1', fontFamilyFallback: <String>['fallback1']);
+    const TextStyle s2 = TextStyle(package: 'p', fontFamily: 'font2', fontFamilyFallback: <String>['fallback2']);
+
+    final TextStyle emptyMerge = const TextStyle().merge(s1);
+    expect(emptyMerge.fontFamily, 'packages/p/font1');
+    expect(emptyMerge.fontFamilyFallback, <String>['packages/p/fallback1']);
+
+    final TextStyle lerp1 = TextStyle.lerp(s1, s2, 0)!;
+    expect(lerp1.fontFamily, 'packages/p/font1');
+    expect(lerp1.fontFamilyFallback, <String>['packages/p/fallback1']);
+
+    final TextStyle lerp2 = TextStyle.lerp(s1, s2, 1.0)!;
+    expect(lerp2.fontFamily, 'packages/p/font2');
+    expect(lerp2.fontFamilyFallback, <String>['packages/p/fallback2']);
+  });
+
   test('TextStyle font family fallback', () {
     const TextStyle s1 = TextStyle(fontFamilyFallback: <String>['Roboto', 'test']);
     expect(s1.fontFamilyFallback![0], 'Roboto');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/110843
