### PR TITLE
corrected the chip file names in gen_defaults.dart

### DIFF
--- a/dev/tools/gen_defaults/bin/gen_defaults.dart
+++ b/dev/tools/gen_defaults/bin/gen_defaults.dart
@@ -110,10 +110,10 @@ Future<void> main(List<String> args) async {
   ButtonTemplate('md.comp.text-button', 'TextButton', '$materialLib/text_button.dart', tokens).updateFile();
   CardTemplate('Card', '$materialLib/card.dart', tokens).updateFile();
   CheckboxTemplate('Checkbox', '$materialLib/checkbox.dart', tokens).updateFile();
-  ChipActionTemplate('ActionChip', '$materialLib/chip_action.dart', tokens).updateFile();
-  ChipFilterTemplate('FilterChip', '$materialLib/chip_filter.dart', tokens).updateFile();
-  ChipFilterTemplate('FilterChip', '$materialLib/chip_choice.dart', tokens).updateFile();
-  ChipInputTemplate('InputChip', '$materialLib/chip_input.dart', tokens).updateFile();
+  ActionChipTemplate('ActionChip', '$materialLib/action_chip.dart', tokens).updateFile();
+  FilterChipTemplate('FilterChip', '$materialLib/filter_chip.dart', tokens).updateFile();
+  FilterChipTemplate('FilterChip', '$materialLib/choice_chip.dart', tokens).updateFile();
+  InputChipTemplate('InputChip', '$materialLib/input_chip.dart', tokens).updateFile();
   DialogTemplate('Dialog', '$materialLib/dialog.dart', tokens).updateFile();
   FABTemplate('FAB', '$materialLib/floating_action_button.dart', tokens).updateFile();
   IconButtonTemplate('IconButton', '$materialLib/icon_button.dart', tokens).updateFile();

--- a/dev/tools/gen_defaults/lib/chip_action_template.dart
+++ b/dev/tools/gen_defaults/lib/chip_action_template.dart
@@ -4,9 +4,9 @@
 
 import 'template.dart';
 
-class ChipActionTemplate extends TokenTemplate {
+class ActionChipTemplate extends TokenTemplate {
 
-  const ChipActionTemplate(super.blockName, super.fileName, super.tokens);
+  const ActionChipTemplate(super.blockName, super.fileName, super.tokens);
 
   static const String tokenGroup = 'md.comp.assist-chip';
   static const String variant = '.flat';

--- a/dev/tools/gen_defaults/lib/chip_filter_template.dart
+++ b/dev/tools/gen_defaults/lib/chip_filter_template.dart
@@ -4,8 +4,8 @@
 
 import 'template.dart';
 
-class ChipFilterTemplate extends TokenTemplate {
-  const ChipFilterTemplate(super.blockName, super.fileName, super.tokens);
+class FilterChipTemplate extends TokenTemplate {
+  const FilterChipTemplate(super.blockName, super.fileName, super.tokens);
 
   static const String tokenGroup = 'md.comp.filter-chip';
   static const String variant = '.flat';

--- a/dev/tools/gen_defaults/lib/chip_input_template.dart
+++ b/dev/tools/gen_defaults/lib/chip_input_template.dart
@@ -4,8 +4,8 @@
 
 import 'template.dart';
 
-class ChipInputTemplate extends TokenTemplate {
-  const ChipInputTemplate(super.blockName, super.fileName, super.tokens);
+class InputChipTemplate extends TokenTemplate {
+  const InputChipTemplate(super.blockName, super.fileName, super.tokens);
 
   static const String tokenGroup = 'md.comp.input-chip';
   static const String variant = '';


### PR DESCRIPTION
when https://github.com/flutter/flutter/pull/108538 renamed the `chip_*.dart` files to `*_chip.dart`, the file names in `gen_defaults.dart` became incorrect. this PR fixes those file and template names.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
