### PR TITLE
Update null safety warnings in prep for Dart 3

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -722,6 +722,7 @@ class WindowsStdoutLogger extends StdoutLogger {
                .replaceAll('✓', '√')
                .replaceAll('🔨', '')
                .replaceAll('💪', '')
+               .replaceAll('⚠️', '!')
                .replaceAll('✏️', '');
     _stdio.stdoutWrite(windowsMessage);
   }

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -88,11 +88,11 @@ abstract class BuildSubCommand extends FlutterCommand {
       );
     } else {
       globals.printStatus(
-        'Building without sound null safety',
+        '⚠️ Building without sound null safety ⚠️',
         emphasis: true,
       );
       globals.printStatus(
-        'For more information see https://dart.dev/null-safety/unsound-null-safety',
+        'Dart 3 will only support sound null safety, see https://dart.dev/null-safety',
       );
     }
     globals.printStatus('');

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -88,7 +88,7 @@ abstract class BuildSubCommand extends FlutterCommand {
       );
     } else {
       globals.printStatus(
-        '⚠️ Building without sound null safety ⚠️',
+        'Building without sound null safety ⚠️',
         emphasis: true,
       );
       globals.printStatus(

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -615,7 +615,7 @@ class ResidentWebRunner extends ResidentRunner {
         _logger!.printStatus('💪 Running with sound null safety 💪', emphasis: true);
       } else {
         _logger!.printStatus(
-          '⚠️ Running without sound null safety ⚠️',
+          'Running without sound null safety ⚠️',
           emphasis: true,
         );
         _logger!.printStatus(

--- a/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
+++ b/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart
@@ -615,11 +615,11 @@ class ResidentWebRunner extends ResidentRunner {
         _logger!.printStatus('💪 Running with sound null safety 💪', emphasis: true);
       } else {
         _logger!.printStatus(
-          'Running with unsound null safety',
+          '⚠️ Running without sound null safety ⚠️',
           emphasis: true,
         );
         _logger!.printStatus(
-          'For more information see https://dart.dev/null-safety/unsound-null-safety',
+          'Dart 3 will only support sound null safety, see https://dart.dev/null-safety',
         );
       }
     }

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1026,11 +1026,11 @@ class HotRunner extends ResidentRunner {
       globals.printStatus('💪 Running with sound null safety 💪', emphasis: true);
     } else {
       globals.printStatus(
-        'Running with unsound null safety',
+        '⚠️ Running without sound null safety ⚠️',
         emphasis: true,
       );
       globals.printStatus(
-        'For more information see https://dart.dev/null-safety/unsound-null-safety',
+        'Dart 3 will only support sound null safety, see https://dart.dev/null-safety',
       );
     }
     globals.printStatus('');

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1026,7 +1026,7 @@ class HotRunner extends ResidentRunner {
       globals.printStatus('💪 Running with sound null safety 💪', emphasis: true);
     } else {
       globals.printStatus(
-        '⚠️ Running without sound null safety ⚠️',
+        'Running without sound null safety ⚠️',
         emphasis: true,
       );
       globals.printStatus(

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -70,7 +70,7 @@ void main() {
 
     FakeBuildSubCommand().test(unsound);
     expect(testLogger.statusText,
-        contains('⚠️ Building without sound null safety ⚠️'));
+        contains('Building without sound null safety ⚠️'));
 
     testLogger.clear();
     FakeBuildSubCommand().test(sound);

--- a/packages/flutter_tools/test/general.shard/commands/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/commands/build_test.dart
@@ -69,8 +69,8 @@ void main() {
     );
 
     FakeBuildSubCommand().test(unsound);
-    expect(
-        testLogger.statusText, contains('Building without sound null safety'));
+    expect(testLogger.statusText,
+        contains('⚠️ Building without sound null safety ⚠️'));
 
     testLogger.clear();
     FakeBuildSubCommand().test(sound);


### PR DESCRIPTION
*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

In Dart 3 [only sound null safety will be allowed](https://github.com/dart-lang/sdk/issues/49530). This PR updates the output of `flutter run` and `flutter build` to provide a warning about this ahead of time. The messages link to the dart.dev nulls safety page, which is being updated to state this in https://github.com/dart-lang/site-www/pull/4211.

*List which issues are fixed by this PR. You must list at least one issue.*

Contributes to https://github.com/dart-lang/sdk/issues/49530, fixes https://github.com/flutter/flutter/issues/111116

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
