### PR TITLE
Fix DraggableScrollableSheet rebuilding during drag

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -21,6 +21,7 @@ import 'scroll_physics.dart';
 import 'scroll_position.dart';
 import 'scroll_position_with_single_context.dart';
 import 'scroll_simulation.dart';
+import 'value_listenable_builder.dart';
 
 /// The signature of a method that provides a [BuildContext] and
 /// [ScrollController] for building a widget that may overflow the draggable
@@ -488,7 +489,6 @@ class _DraggableSheetExtent {
     required this.snap,
     required this.snapSizes,
     required this.initialSize,
-    required this.onSizeChanged,
     this.snapAnimationDuration,
     ValueNotifier<double>? currentSize,
     bool? hasDragged,
@@ -500,8 +500,7 @@ class _DraggableSheetExtent {
         assert(maxSize <= 1),
         assert(minSize <= initialSize),
         assert(initialSize <= maxSize),
-        _currentSize = (currentSize ?? ValueNotifier<double>(initialSize))
-          ..addListener(onSizeChanged),
+        _currentSize = currentSize ?? ValueNotifier<double>(initialSize),
         availablePixels = double.infinity,
         hasDragged = hasDragged ?? false,
         hasChanged = hasChanged ?? false;
@@ -515,7 +514,6 @@ class _DraggableSheetExtent {
   final Duration? snapAnimationDuration;
   final double initialSize;
   final ValueNotifier<double> _currentSize;
-  final VoidCallback onSizeChanged;
   double availablePixels;
 
   // Used to disable snapping until the user has dragged on the sheet.
@@ -595,17 +593,12 @@ class _DraggableSheetExtent {
     return size / maxSize * availablePixels;
   }
 
-  void dispose() {
-    _currentSize.removeListener(onSizeChanged);
-  }
-
   _DraggableSheetExtent copyWith({
     required double minSize,
     required double maxSize,
     required bool snap,
     required List<double> snapSizes,
     required double initialSize,
-    required VoidCallback onSizeChanged,
     Duration? snapAnimationDuration,
   }) {
     return _DraggableSheetExtent(
@@ -615,7 +608,6 @@ class _DraggableSheetExtent {
       snapSizes: snapSizes,
       snapAnimationDuration: snapAnimationDuration,
       initialSize: initialSize,
-      onSizeChanged: onSizeChanged,
       // Set the current size to the possibly updated initial size if the sheet
       // hasn't changed yet.
       currentSize: ValueNotifier<double>(hasChanged
@@ -641,7 +633,6 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       snapSizes: _impliedSnapSizes(),
       snapAnimationDuration: widget.snapAnimationDuration,
       initialSize: widget.initialChildSize,
-      onSizeChanged: _setExtent,
     );
     _scrollController = _DraggableScrollableSheetScrollController(extent: _extent);
     widget.controller?._attach(_scrollController);
@@ -683,24 +674,22 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
     }
   }
 
-  void _setExtent() {
-    setState(() {
-      // _extent has been updated when this is called.
-    });
-  }
-
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (BuildContext context, BoxConstraints constraints) {
-        _extent.availablePixels = widget.maxChildSize * constraints.biggest.height;
-        final Widget sheet = FractionallySizedBox(
-          heightFactor: _extent.currentSize,
-          alignment: Alignment.bottomCenter,
-          child: widget.builder(context, _scrollController),
-        );
-        return widget.expand ? SizedBox.expand(child: sheet) : sheet;
-      },
+    return ValueListenableBuilder<double>(
+      valueListenable: _extent._currentSize,
+      builder: (BuildContext context, double currentSize, Widget? child) => LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints constraints) {
+          _extent.availablePixels = widget.maxChildSize * constraints.biggest.height;
+          final Widget sheet = FractionallySizedBox(
+            heightFactor: currentSize,
+            alignment: Alignment.bottomCenter,
+            child: child,
+          );
+          return widget.expand ? SizedBox.expand(child: sheet) : sheet;
+        },
+      ),
+      child: widget.builder(context, _scrollController),
     );
   }
 
@@ -708,13 +697,11 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
   void dispose() {
     widget.controller?._detach();
     _scrollController.dispose();
-    _extent.dispose();
     super.dispose();
   }
 
   void _replaceExtent(covariant DraggableScrollableSheet oldWidget) {
     final _DraggableSheetExtent previousExtent = _extent;
-    _extent.dispose();
     _extent = _extent.copyWith(
       minSize: widget.minChildSize,
       maxSize: widget.maxChildSize,
@@ -722,14 +709,15 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
       snapSizes: _impliedSnapSizes(),
       snapAnimationDuration: widget.snapAnimationDuration,
       initialSize: widget.initialChildSize,
-      onSizeChanged: _setExtent,
     );
     // Modify the existing scroll controller instead of replacing it so that
     // developers listening to the controller do not have to rebuild their listeners.
     _scrollController.extent = _extent;
     // If an external facing controller was provided, let it know that the
     // extent has been replaced.
-    widget.controller?._onExtentReplaced(previousExtent);
+    if (widget.controller?.isAttached ?? false) {
+      widget.controller?._onExtentReplaced(previousExtent);
+    }
     if (widget.snap
         && (widget.snap != oldWidget.snap || widget.snapSizes != oldWidget.snapSizes)
         && _scrollController.hasClients

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -715,9 +715,7 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
     _scrollController.extent = _extent;
     // If an external facing controller was provided, let it know that the
     // extent has been replaced.
-    if (widget.controller?.isAttached ?? false) {
-      widget.controller?._onExtentReplaced(previousExtent);
-    }
+    widget.controller?._onExtentReplaced(previousExtent);
     if (widget.snap
         && (widget.snap != oldWidget.snap || widget.snapSizes != oldWidget.snapSizes)
         && _scrollController.hasClients

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1455,4 +1455,55 @@ void main() {
       closeTo(.6, precisionErrorTolerance),
     );
   });
+
+  testWidgets('DraggableScrollableSheet should not rebuild every frame while dragging', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/67219
+    DraggableScrollableController controller = DraggableScrollableController();
+    int buildCount = 0;
+    await tester.pumpWidget(MaterialApp(
+      home: StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) => Scaffold(
+          body: DraggableScrollableSheet(
+            initialChildSize: 0.25,
+            snap: true,
+            snapSizes: const <double>[0.25, 0.5, 1.0],
+            controller: controller,
+            builder: (BuildContext context, ScrollController scrollController) {
+              buildCount++;
+              return ListView(
+                controller: scrollController,
+                children: <Widget>[
+                  const Text('Drag me!'),
+                  ElevatedButton(
+                    onPressed: () => setState(() {
+                      controller = DraggableScrollableController();
+                    }),
+                    child: const Text('Regenerate controller'),
+                  ),
+                  Container(
+                    height: 10000,
+                    color: Colors.blue,
+                  ),
+                ],
+              );
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(buildCount, 1);
+
+    await tester.fling(find.text('Drag me!'), const Offset(0, -300), 300);
+    await tester.pumpAndSettle();
+
+    // No need to rebuild the scrollable sheet, as only position has changed.
+    expect(buildCount, 1);
+
+    await tester.tap(find.text('Regenerate controller'));
+    await tester.pump();
+
+    // DraggableScrollableSheet has rebuilt, so expect the builder to be called.
+    expect(buildCount, 2);
+  });
 }

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1458,7 +1458,6 @@ void main() {
 
   testWidgets('DraggableScrollableSheet should not rebuild every frame while dragging', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/67219
-    DraggableScrollableController controller = DraggableScrollableController();
     int buildCount = 0;
     await tester.pumpWidget(MaterialApp(
       home: StatefulBuilder(
@@ -1467,7 +1466,6 @@ void main() {
             initialChildSize: 0.25,
             snap: true,
             snapSizes: const <double>[0.25, 0.5, 1.0],
-            controller: controller,
             builder: (BuildContext context, ScrollController scrollController) {
               buildCount++;
               return ListView(
@@ -1475,10 +1473,8 @@ void main() {
                 children: <Widget>[
                   const Text('Drag me!'),
                   ElevatedButton(
-                    onPressed: () => setState(() {
-                      controller = DraggableScrollableController();
-                    }),
-                    child: const Text('Regenerate controller'),
+                    onPressed: () => setState(() {}),
+                    child: const Text('Rebuild'),
                   ),
                   Container(
                     height: 10000,
@@ -1500,7 +1496,7 @@ void main() {
     // No need to rebuild the scrollable sheet, as only position has changed.
     expect(buildCount, 1);
 
-    await tester.tap(find.text('Regenerate controller'));
+    await tester.tap(find.text('Rebuild'));
     await tester.pump();
 
     // DraggableScrollableSheet has rebuilt, so expect the builder to be called.


### PR DESCRIPTION
`DraggableScrollableSheet` was rebuilding every time the size of the child changed, which meant every frame during a drag. Now it will only rebuild when it gets changed parameters from the parent widget. 

Also inadvertent fix to an exception thrown while rebuilding `DraggableScrollableSheet` with a new controller.

Fixes #67219

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

