### PR TITLE
[macOS] Add `platform_view_macos__start_up` tests devicelab test suite.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2729,6 +2729,16 @@ targets:
       - bin/**
       - .ci.yaml
 
+  - name: Mac platform_view_macos__start_up
+    bringup: true # New target https://github.com/flutter/flutter/issues/109633
+    presubmit: false
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      tags: >
+        ["devicelab", "hostonly"]
+      task_name: platform_view_macos__start_up
+
   - name: Mac plugin_dependencies_test
     recipe: devicelab/devicelab_drone
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -248,6 +248,7 @@
 /dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/flutter_gallery_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/flutter_gallery_macos__start_up.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/platform_view_macos__start_up.dart @a-wallen @flutter/desktop
 
 ## Host only framework tests
 # Linux analyze

--- a/dev/devicelab/bin/tasks/platform_view_macos__start_up.dart
+++ b/dev/devicelab/bin/tasks/platform_view_macos__start_up.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createPlatformViewStartupTest());
+}


### PR DESCRIPTION
There were very few benchmark device lab tests on macOS up until this point. See the parent issue for the list of tests we were trying to bring up now. 

Land after: https://github.com/flutter/flutter/pull/111005

#### Fixes https://github.com/flutter/flutter/issues/110086

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.