### PR TITLE
Switch `Linux_build_test flutter_gallery__transition_perf` to prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1935,7 +1935,6 @@ targets:
   - name: Linux_build_test flutter_gallery__transition_perf
     recipe: devicelab/devicelab_drone_build_test
     presubmit: false
-    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     timeout: 60
     properties:
       tags: >


### PR DESCRIPTION
There were a couple of revert and reland of builder `Linux_build_test flutter_gallery__transition_perf`:
https://github.com/flutter/flutter/pull/110702
https://github.com/flutter/flutter/pull/110734
https://github.com/flutter/flutter/pull/110804

The root cause has been fixed (details: https://github.com/flutter/flutter/issues/103542): inject correct builder (parent builder) to test drone so that datastore can be updated correctly.

Validation: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux_build_test%20flutter_gallery__transition_perf/31/overview

Considering no flake in staging, and infra ready, it's the time to bring it up in prod.
