### PR TITLE
Remove flutter_gallery_mac__start_up as target in .ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3127,15 +3127,6 @@ targets:
         ["devicelab", "android", "mac", "arm64"]
       task_name: run_release_test
 
-  - name: Mac_android flutter_gallery_mac__start_up
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
-    properties:
-      tags: >
-        ["devicelab", "android", "mac"]
-      task_name: flutter_gallery_mac__start_up
-
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -114,7 +114,6 @@
 /dev/devicelab/bin/tasks/fading_child_animation_perf__timeline_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/fast_scroll_large_images__memory.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/flavors_test.dart @zanderso @flutter/tool
-/dev/devicelab/bin/tasks/flutter_gallery_mac__start_up.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/flutter_view__start_up.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/fullscreen_textfield_perf__timeline_summary.dart @zanderso @flutter/engine
 /dev/devicelab/bin/tasks/hello_world_android__compile.dart @zanderso @flutter/tool


### PR DESCRIPTION
This PR removes `flutter_gallery_mac__start_up` and all references to it. Since we have other tests/benchmarks that can launch an Android app from a mac host, we can just delete flutter_gallery_mac__start_up. This will eliminate the confusion once flutter_gallery_macos__start_up is landed as a perf test for macOS.

## Fixes https://github.com/flutter/flutter/issues/111115

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.