### PR TITLE
Migrated `Checkbox` to Material 3 - Added Error State

### DIFF
--- a/dev/tools/gen_defaults/lib/checkbox_template.dart
+++ b/dev/tools/gen_defaults/lib/checkbox_template.dart
@@ -23,55 +23,13 @@ class _${blockName}DefaultsM3 extends CheckboxThemeData {
   MaterialStateProperty<Color> get fillColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
-        if (states.contains(MaterialState.selected)) {
-          return ${componentColor('md.comp.checkbox.selected.disabled.container')};
-        }
-        return ${componentColor('md.comp.checkbox.unselected.disabled.outline')}.withOpacity(${opacity('md.comp.checkbox.unselected.disabled.container.opacity')});
-      }
-      if (states.contains(MaterialState.selected)) {
-        if (states.contains(MaterialState.error)) {
-          if (states.contains(MaterialState.pressed)) {
-            return ${componentColor('md.comp.checkbox.selected.error.pressed.container')};
-          }
-          if (states.contains(MaterialState.hovered)) {
-            return ${componentColor('md.comp.checkbox.selected.error.hover.container')};
-          }
-          if (states.contains(MaterialState.focused)) {
-            return ${componentColor('md.comp.checkbox.selected.error.focus.container')};
-          }
-          return ${componentColor('md.comp.checkbox.selected.error.container')};
-        }
-        if (states.contains(MaterialState.pressed)) {
-          return ${componentColor('md.comp.checkbox.selected.pressed.container')};
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return ${componentColor('md.comp.checkbox.selected.hover.container')};
-        }
-        if (states.contains(MaterialState.focused)) {
-          return ${componentColor('md.comp.checkbox.selected.focus.container')};
-        }
-        return ${componentColor('md.comp.checkbox.selected.container')};
+        return ${componentColor('md.comp.checkbox.selected.disabled.container')};
       }
       if (states.contains(MaterialState.error)) {
-        if (states.contains(MaterialState.pressed)) {
-          return ${componentColor('md.comp.checkbox.unselected.error.pressed.outline')};
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return ${componentColor('md.comp.checkbox.unselected.error.hover.outline')};
-        }
-        if (states.contains(MaterialState.focused)) {
-          return ${componentColor('md.comp.checkbox.unselected.error.focus.outline')};
-        }
         return ${componentColor('md.comp.checkbox.unselected.error.outline')};
       }
-      if (states.contains(MaterialState.pressed)) {
-        return ${componentColor('md.comp.checkbox.unselected.pressed.outline')};
-      }
-      if (states.contains(MaterialState.hovered)) {
-        return ${componentColor('md.comp.checkbox.unselected.hover.outline')};
-      }
-      if (states.contains(MaterialState.focused)) {
-        return ${componentColor('md.comp.checkbox.unselected.focus.outline')};
+      if (states.contains(MaterialState.selected)) {
+        return ${componentColor('md.comp.checkbox.selected.container')};
       }
       return ${componentColor('md.comp.checkbox.unselected.outline')};
     });
@@ -88,25 +46,7 @@ class _${blockName}DefaultsM3 extends CheckboxThemeData {
       }
       if (states.contains(MaterialState.selected)) {
         if (states.contains(MaterialState.error)) {
-          if (states.contains(MaterialState.pressed)) {
-            return ${componentColor('md.comp.checkbox.selected.error.pressed.icon')};
-          }
-          if (states.contains(MaterialState.hovered)) {
-            return ${componentColor('md.comp.checkbox.selected.error.hover.icon')};
-          }
-          if (states.contains(MaterialState.focused)) {
-            return ${componentColor('md.comp.checkbox.selected.error.focus.icon')};
-          }
           return ${componentColor('md.comp.checkbox.selected.error.icon')};
-        }
-        if (states.contains(MaterialState.pressed)) {
-          return ${componentColor('md.comp.checkbox.selected.pressed.icon')};
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return ${componentColor('md.comp.checkbox.selected.hover.icon')};
-        }
-        if (states.contains(MaterialState.focused)) {
-          return ${componentColor('md.comp.checkbox.selected.focus.icon')};
         }
         return ${componentColor('md.comp.checkbox.selected.icon')};
       }

--- a/dev/tools/gen_defaults/lib/checkbox_template.dart
+++ b/dev/tools/gen_defaults/lib/checkbox_template.dart
@@ -29,6 +29,18 @@ class _${blockName}DefaultsM3 extends CheckboxThemeData {
         return ${componentColor('md.comp.checkbox.unselected.disabled.outline')}.withOpacity(${opacity('md.comp.checkbox.unselected.disabled.container.opacity')});
       }
       if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.error)) {
+          if (states.contains(MaterialState.pressed)) {
+            return ${componentColor('md.comp.checkbox.selected.error.pressed.container')};
+          }
+          if (states.contains(MaterialState.hovered)) {
+            return ${componentColor('md.comp.checkbox.selected.error.hover.container')};
+          }
+          if (states.contains(MaterialState.focused)) {
+            return ${componentColor('md.comp.checkbox.selected.error.focus.container')};
+          }
+          return ${componentColor('md.comp.checkbox.selected.error.container')};
+        }
         if (states.contains(MaterialState.pressed)) {
           return ${componentColor('md.comp.checkbox.selected.pressed.container')};
         }
@@ -39,6 +51,18 @@ class _${blockName}DefaultsM3 extends CheckboxThemeData {
           return ${componentColor('md.comp.checkbox.selected.focus.container')};
         }
         return ${componentColor('md.comp.checkbox.selected.container')};
+      }
+      if (states.contains(MaterialState.error)) {
+        if (states.contains(MaterialState.pressed)) {
+          return ${componentColor('md.comp.checkbox.unselected.error.pressed.outline')};
+        }
+        if (states.contains(MaterialState.hovered)) {
+          return ${componentColor('md.comp.checkbox.unselected.error.hover.outline')};
+        }
+        if (states.contains(MaterialState.focused)) {
+          return ${componentColor('md.comp.checkbox.unselected.error.focus.outline')};
+        }
+        return ${componentColor('md.comp.checkbox.unselected.error.outline')};
       }
       if (states.contains(MaterialState.pressed)) {
         return ${componentColor('md.comp.checkbox.unselected.pressed.outline')};
@@ -63,6 +87,18 @@ class _${blockName}DefaultsM3 extends CheckboxThemeData {
         return Colors.transparent; // No icons available when the checkbox is unselected.
       }
       if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.error)) {
+          if (states.contains(MaterialState.pressed)) {
+            return ${componentColor('md.comp.checkbox.selected.error.pressed.icon')};
+          }
+          if (states.contains(MaterialState.hovered)) {
+            return ${componentColor('md.comp.checkbox.selected.error.hover.icon')};
+          }
+          if (states.contains(MaterialState.focused)) {
+            return ${componentColor('md.comp.checkbox.selected.error.focus.icon')};
+          }
+          return ${componentColor('md.comp.checkbox.selected.error.icon')};
+        }
         if (states.contains(MaterialState.pressed)) {
           return ${componentColor('md.comp.checkbox.selected.pressed.icon')};
         }
@@ -81,6 +117,17 @@ class _${blockName}DefaultsM3 extends CheckboxThemeData {
   @override
   MaterialStateProperty<Color> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.error)) {
+        if (states.contains(MaterialState.pressed)) {
+          return ${componentColor('md.comp.checkbox.error.pressed.state-layer')};
+        }
+        if (states.contains(MaterialState.hovered)) {
+          return ${componentColor('md.comp.checkbox.error.hover.state-layer')};
+        }
+        if (states.contains(MaterialState.focused)) {
+          return ${componentColor('md.comp.checkbox.error.focus.state-layer')}.withOpacity(0.12);
+        }
+      }
       if (states.contains(MaterialState.selected)) {
         if (states.contains(MaterialState.pressed)) {
           return ${componentColor('md.comp.checkbox.selected.pressed.state-layer')};

--- a/examples/api/lib/material/checkbox/checkbox.1.dart
+++ b/examples/api/lib/material/checkbox/checkbox.1.dart
@@ -1,0 +1,74 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for M3 Checkbox with error state
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  static const String _title = 'Flutter Code Sample';
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: const Color(0xff6750a4)),
+      title: _title,
+      home: Scaffold(
+        appBar: AppBar(title: const Text(_title)),
+        body: const Center(
+          child: MyStatefulWidget(),
+        ),
+      ),
+    );
+  }
+}
+
+class MyStatefulWidget extends StatefulWidget {
+  const MyStatefulWidget({super.key});
+
+  @override
+  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+}
+
+class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  bool? isChecked = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Checkbox(
+          tristate: true,
+          value: isChecked,
+          onChanged: (bool? value) {
+            setState(() {
+              isChecked = value;
+            });
+          }
+        ),
+        Checkbox(
+          isError: true,
+          tristate: true,
+          value: isChecked,
+          onChanged: (bool? value) {
+            setState(() {
+              isChecked = value;
+            });
+          }
+        ),
+        Checkbox(
+          isError: true,
+          tristate: true,
+          value: isChecked,
+          onChanged: null,
+        ),
+      ]
+    );
+  }
+}

--- a/examples/api/lib/material/checkbox/checkbox.1.dart
+++ b/examples/api/lib/material/checkbox/checkbox.1.dart
@@ -50,7 +50,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
             setState(() {
               isChecked = value;
             });
-          }
+          },
         ),
         Checkbox(
           isError: true,
@@ -60,7 +60,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
             setState(() {
               isChecked = value;
             });
-          }
+          },
         ),
         Checkbox(
           isError: true,
@@ -68,7 +68,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget> {
           value: isChecked,
           onChanged: null,
         ),
-      ]
+      ],
     );
   }
 }

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -87,6 +87,7 @@ class Checkbox extends StatefulWidget {
     this.autofocus = false,
     this.shape,
     this.side,
+    this.isError = false,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(autofocus != null);
@@ -332,6 +333,14 @@ class Checkbox extends StatefulWidget {
   /// will be width 2.
   final BorderSide? side;
 
+  /// True if this checkbox wants to show an error state.
+  ///
+  /// The checkbox will have different default container color and check color when
+  /// this is true. This is only used when [ThemeData.useMaterial3] is set to true.
+  ///
+  /// Must not be null. Defaults to false.
+  final bool isError;
+
   /// The width of a checkbox widget.
   static const double width = 18.0;
 
@@ -427,8 +436,9 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
 
     // Colors need to be resolved in selected and non selected states separately
     // so that they can be lerped between.
-    final Set<MaterialState> activeStates = states..add(MaterialState.selected);
-    final Set<MaterialState> inactiveStates = states..remove(MaterialState.selected);
+    final Set<MaterialState> errorState = states..add(MaterialState.error);
+    final Set<MaterialState> activeStates = widget.isError ? (errorState..add(MaterialState.selected)) : states..add(MaterialState.selected);
+    final Set<MaterialState> inactiveStates = widget.isError ? (errorState..remove(MaterialState.selected)) : states..remove(MaterialState.selected);
     final Color? activeColor = widget.fillColor?.resolve(activeStates)
       ?? _widgetFillColor.resolve(activeStates)
       ?? checkboxTheme.fillColor?.resolve(activeStates);
@@ -440,13 +450,13 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
     final Color effectiveInactiveColor = inactiveColor
       ?? defaults.fillColor!.resolve(inactiveStates)!;
 
-    final Set<MaterialState> focusedStates = states..add(MaterialState.focused);
+    final Set<MaterialState> focusedStates = widget.isError ? (errorState..add(MaterialState.focused)) : states..add(MaterialState.focused);
     final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
       ?? widget.focusColor
       ?? checkboxTheme.overlayColor?.resolve(focusedStates)
       ?? defaults.overlayColor!.resolve(focusedStates)!;
 
-    final Set<MaterialState> hoveredStates = states..add(MaterialState.hovered);
+    final Set<MaterialState> hoveredStates = widget.isError ? (errorState..add(MaterialState.hovered)) : states..add(MaterialState.hovered);
     final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
       ?? widget.hoverColor
       ?? checkboxTheme.overlayColor?.resolve(hoveredStates)
@@ -464,9 +474,10 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
       ?? inactiveColor?.withAlpha(kRadialReactionAlpha)
       ?? defaults.overlayColor!.resolve(inactivePressedStates)!;
 
+    final Set<MaterialState> checkStates = widget.isError ? (states..add(MaterialState.error)) : states;
     final Color effectiveCheckColor = widget.checkColor
-      ?? checkboxTheme.checkColor?.resolve(states)
-      ?? defaults.checkColor!.resolve(states)!;
+      ?? checkboxTheme.checkColor?.resolve(checkStates)
+      ?? defaults.checkColor!.resolve(checkStates)!;
 
     final double effectiveSplashRadius = widget.splashRadius
       ?? checkboxTheme.splashRadius
@@ -486,8 +497,8 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
           ..reactionHoverFade = reactionHoverFade
           ..inactiveReactionColor = effectiveInactivePressedOverlayColor
           ..reactionColor = effectiveActivePressedOverlayColor
-          ..hoverColor = effectiveHoverOverlayColor
-          ..focusColor = effectiveFocusOverlayColor
+          ..hoverColor = downPosition != null ? effectiveActivePressedOverlayColor : effectiveHoverOverlayColor
+          ..focusColor = downPosition != null ? effectiveActivePressedOverlayColor : effectiveFocusOverlayColor
           ..splashRadius = effectiveSplashRadius
           ..downPosition = downPosition
           ..isFocused = states.contains(MaterialState.focused)
@@ -763,6 +774,18 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
         return _colors.onSurface.withOpacity(0.38);
       }
       if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.error)) {
+          if (states.contains(MaterialState.pressed)) {
+            return _colors.error;
+          }
+          if (states.contains(MaterialState.hovered)) {
+            return _colors.error;
+          }
+          if (states.contains(MaterialState.focused)) {
+            return _colors.error;
+          }
+          return _colors.error;
+        }
         if (states.contains(MaterialState.pressed)) {
           return _colors.primary;
         }
@@ -773,6 +796,18 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
           return _colors.primary;
         }
         return _colors.primary;
+      }
+      if (states.contains(MaterialState.error)) {
+        if (states.contains(MaterialState.pressed)) {
+          return _colors.error;
+        }
+        if (states.contains(MaterialState.hovered)) {
+          return _colors.error;
+        }
+        if (states.contains(MaterialState.focused)) {
+          return _colors.error;
+        }
+        return _colors.error;
       }
       if (states.contains(MaterialState.pressed)) {
         return _colors.onSurface;
@@ -797,6 +832,18 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
         return Colors.transparent; // No icons available when the checkbox is unselected.
       }
       if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.error)) {
+          if (states.contains(MaterialState.pressed)) {
+            return _colors.onError;
+          }
+          if (states.contains(MaterialState.hovered)) {
+            return _colors.onError;
+          }
+          if (states.contains(MaterialState.focused)) {
+            return _colors.onError;
+          }
+          return _colors.onError;
+        }
         if (states.contains(MaterialState.pressed)) {
           return _colors.onPrimary;
         }
@@ -815,6 +862,17 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
   @override
   MaterialStateProperty<Color> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.error)) {
+        if (states.contains(MaterialState.pressed)) {
+          return _colors.error.withOpacity(0.24);
+        }
+        if (states.contains(MaterialState.hovered)) {
+          return _colors.error.withOpacity(0.08);
+        }
+        if (states.contains(MaterialState.focused)) {
+          return _colors.error.withOpacity(0.12);
+        }
+      }
       if (states.contains(MaterialState.selected)) {
         if (states.contains(MaterialState.pressed)) {
           return _colors.onSurface.withOpacity(0.12);

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -451,13 +451,13 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
       ?? defaults.fillColor!.resolve(inactiveStates)!;
 
     final Set<MaterialState> focusedStates = widget.isError ? (errorState..add(MaterialState.focused)) : states..add(MaterialState.focused);
-    final Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
+    Color effectiveFocusOverlayColor = widget.overlayColor?.resolve(focusedStates)
       ?? widget.focusColor
       ?? checkboxTheme.overlayColor?.resolve(focusedStates)
       ?? defaults.overlayColor!.resolve(focusedStates)!;
 
     final Set<MaterialState> hoveredStates = widget.isError ? (errorState..add(MaterialState.hovered)) : states..add(MaterialState.hovered);
-    final Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
+    Color effectiveHoverOverlayColor = widget.overlayColor?.resolve(hoveredStates)
       ?? widget.hoverColor
       ?? checkboxTheme.overlayColor?.resolve(hoveredStates)
       ?? defaults.overlayColor!.resolve(hoveredStates)!;
@@ -473,6 +473,15 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
       ?? checkboxTheme.overlayColor?.resolve(inactivePressedStates)
       ?? inactiveColor?.withAlpha(kRadialReactionAlpha)
       ?? defaults.overlayColor!.resolve(inactivePressedStates)!;
+
+    if (downPosition != null) {
+      effectiveHoverOverlayColor = states.contains(MaterialState.selected)
+        ? effectiveActivePressedOverlayColor
+        : effectiveInactivePressedOverlayColor;
+      effectiveFocusOverlayColor = states.contains(MaterialState.selected)
+        ? effectiveActivePressedOverlayColor
+        : effectiveInactivePressedOverlayColor;
+    }
 
     final Set<MaterialState> checkStates = widget.isError ? (states..add(MaterialState.error)) : states;
     final Color effectiveCheckColor = widget.checkColor
@@ -497,8 +506,8 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
           ..reactionHoverFade = reactionHoverFade
           ..inactiveReactionColor = effectiveInactivePressedOverlayColor
           ..reactionColor = effectiveActivePressedOverlayColor
-          ..hoverColor = downPosition != null ? effectiveActivePressedOverlayColor : effectiveHoverOverlayColor
-          ..focusColor = downPosition != null ? effectiveActivePressedOverlayColor : effectiveFocusOverlayColor
+          ..hoverColor = effectiveHoverOverlayColor
+          ..focusColor = effectiveFocusOverlayColor
           ..splashRadius = effectiveSplashRadius
           ..downPosition = downPosition
           ..isFocused = states.contains(MaterialState.focused)
@@ -768,55 +777,13 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
   MaterialStateProperty<Color> get fillColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.disabled)) {
-        if (states.contains(MaterialState.selected)) {
-          return _colors.onSurface.withOpacity(0.38);
-        }
         return _colors.onSurface.withOpacity(0.38);
       }
-      if (states.contains(MaterialState.selected)) {
-        if (states.contains(MaterialState.error)) {
-          if (states.contains(MaterialState.pressed)) {
-            return _colors.error;
-          }
-          if (states.contains(MaterialState.hovered)) {
-            return _colors.error;
-          }
-          if (states.contains(MaterialState.focused)) {
-            return _colors.error;
-          }
-          return _colors.error;
-        }
-        if (states.contains(MaterialState.pressed)) {
-          return _colors.primary;
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return _colors.primary;
-        }
-        if (states.contains(MaterialState.focused)) {
-          return _colors.primary;
-        }
-        return _colors.primary;
-      }
       if (states.contains(MaterialState.error)) {
-        if (states.contains(MaterialState.pressed)) {
-          return _colors.error;
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return _colors.error;
-        }
-        if (states.contains(MaterialState.focused)) {
-          return _colors.error;
-        }
         return _colors.error;
       }
-      if (states.contains(MaterialState.pressed)) {
-        return _colors.onSurface;
-      }
-      if (states.contains(MaterialState.hovered)) {
-        return _colors.onSurface;
-      }
-      if (states.contains(MaterialState.focused)) {
-        return _colors.onSurface;
+      if (states.contains(MaterialState.selected)) {
+        return _colors.primary;
       }
       return _colors.onSurface;
     });
@@ -833,25 +800,7 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
       }
       if (states.contains(MaterialState.selected)) {
         if (states.contains(MaterialState.error)) {
-          if (states.contains(MaterialState.pressed)) {
-            return _colors.onError;
-          }
-          if (states.contains(MaterialState.hovered)) {
-            return _colors.onError;
-          }
-          if (states.contains(MaterialState.focused)) {
-            return _colors.onError;
-          }
           return _colors.onError;
-        }
-        if (states.contains(MaterialState.pressed)) {
-          return _colors.onPrimary;
-        }
-        if (states.contains(MaterialState.hovered)) {
-          return _colors.onPrimary;
-        }
-        if (states.contains(MaterialState.focused)) {
-          return _colors.onPrimary;
         }
         return _colors.onPrimary;
       }
@@ -864,7 +813,7 @@ class _CheckboxDefaultsM3 extends CheckboxThemeData {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.error)) {
         if (states.contains(MaterialState.pressed)) {
-          return _colors.error.withOpacity(0.24);
+          return _colors.error.withOpacity(0.12);
         }
         if (states.contains(MaterialState.hovered)) {
           return _colors.error.withOpacity(0.08);

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1252,6 +1252,7 @@ class ThemeData with Diagnosticable {
   ///     - [ActionChip] (used for Assist and Suggestion chips),
   ///     - [FilterChip], [ChoiceChip] (used for single selection filter chips),
   ///     - [InputChip]
+  ///   * Checkbox: [Checkbox]
   ///   * Dialogs: [Dialog], [AlertDialog]
   ///   * Lists: [ListTile]
   ///   * Navigation bar: [NavigationBar] (new, replacing [BottomNavigationBar])

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1036,6 +1036,7 @@ void main() {
       reason: 'Default active pressed Checkbox should have overlay color from default fillColor',
     );
 
+    await tester.pumpWidget(Container()); // reset test
     await tester.pumpWidget(buildCheckbox(focused: true));
     await tester.pumpAndSettle();
 
@@ -1168,6 +1169,7 @@ void main() {
       reason: 'Active pressed Checkbox should have overlay color: $activePressedOverlayColor',
     );
 
+    await tester.pumpWidget(Container()); // reset test
     await tester.pumpWidget(buildCheckbox(focused: true));
     await tester.pumpAndSettle();
 
@@ -1563,7 +1565,7 @@ void main() {
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
       paints
-        ..circle(color: theme.colorScheme.error.withOpacity(0.24))
+        ..circle(color: theme.colorScheme.error.withOpacity(0.12))
         ..path(color: theme.colorScheme.error)
     );
     await gestureLongPress.up();

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1543,7 +1543,7 @@ void main() {
     expect(focusNode.hasPrimaryFocus, isFalse);
     expect(
       Material.of(tester.element(find.byType(Checkbox))),
-        paints..path(color: theme.colorScheme.error)..path(color: theme.colorScheme.onError)
+      paints..path(color: theme.colorScheme.error)..path(color: theme.colorScheme.onError)
     );
 
     // Start hovering

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -1498,6 +1498,77 @@ void main() {
     await tester.pump(const Duration(milliseconds: 10));
     expect(find.text(tapTooltip), findsOneWidget);
   });
+
+  testWidgets('Checkbox has default error color when isError is set to true - M3', (WidgetTester tester) async {
+    final FocusNode focusNode = FocusNode(debugLabel: 'Checkbox');
+    tester.binding.focusManager.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
+    bool? value = true;
+    Widget buildApp({bool autoFocus = true}) {
+      return MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: Material(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return Checkbox(
+                isError: true,
+                value: value,
+                onChanged: (bool? newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                },
+                autofocus: autoFocus,
+                focusNode: focusNode,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    // Focused
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isTrue);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints..circle(color: theme.colorScheme.error.withOpacity(0.12))..path(color: theme.colorScheme.error)..path(color: theme.colorScheme.onError)
+    );
+
+    // Default color
+    await tester.pumpWidget(Container());
+    await tester.pumpWidget(buildApp(autoFocus: false));
+    await tester.pumpAndSettle();
+    expect(focusNode.hasPrimaryFocus, isFalse);
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+        paints..path(color: theme.colorScheme.error)..path(color: theme.colorScheme.onError)
+    );
+
+    // Start hovering
+    final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer();
+    await gesture.moveTo(tester.getCenter(find.byType(Checkbox)));
+    await tester.pumpAndSettle();
+
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..circle(color: theme.colorScheme.error.withOpacity(0.08))
+        ..path(color: theme.colorScheme.error)
+    );
+
+    // Start pressing
+    final TestGesture gestureLongPress = await tester.startGesture(tester.getCenter(find.byType(Checkbox)));
+    await tester.pump();
+    expect(
+      Material.of(tester.element(find.byType(Checkbox))),
+      paints
+        ..circle(color: theme.colorScheme.error.withOpacity(0.24))
+        ..path(color: theme.colorScheme.error)
+    );
+    await gestureLongPress.up();
+    await tester.pump();
+  });
 }
 
 class _SelectedGrabMouseCursor extends MaterialStateMouseCursor {


### PR DESCRIPTION
This PR added an error state for the Checkbox. Fixes #104446

<img width="180" alt="Screen Shot 2022-09-07 at 4 31 42 PM" src="https://user-images.githubusercontent.com/36861262/189000737-66f2ad2e-cc5b-474b-a4f2-2318770bdc11.png"><img width="177" alt="Screen Shot 2022-09-07 at 4 32 34 PM" src="https://user-images.githubusercontent.com/36861262/189000823-1c308007-1295-45eb-b6ad-fc68594d575e.png">

In order to use the Checkbox with the new Material 3 defaults, turn on the useMaterial3 flag in the ThemeData:
```dart
  return MaterialApp(
    theme: ThemeData(useMaterial3: true),
    // ...
  );
```

This PR adds a new property `isError` for `Checkbox`. To show a checkbox in an error state, set `isError` to true.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
