### PR TITLE
Fix a CupertinoScrollbar NNBD issue

### DIFF
--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -185,7 +185,10 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
   @override
   void handleThumbPressStart(Offset localPosition) {
     super.handleThumbPressStart(localPosition);
-    final Axis direction = getScrollbarDirection()!;
+    final Axis? direction = getScrollbarDirection();
+    if (direction == null) {
+     return;
+    }
     switch (direction) {
       case Axis.vertical:
         _pressStartAxisPosition = localPosition.dy;

--- a/packages/flutter/lib/src/cupertino/scrollbar.dart
+++ b/packages/flutter/lib/src/cupertino/scrollbar.dart
@@ -187,7 +187,7 @@ class _CupertinoScrollbarState extends RawScrollbarState<CupertinoScrollbar> {
     super.handleThumbPressStart(localPosition);
     final Axis? direction = getScrollbarDirection();
     if (direction == null) {
-     return;
+      return;
     }
     switch (direction) {
       case Axis.vertical:

--- a/packages/flutter/test/cupertino/scrollbar_test.dart
+++ b/packages/flutter/test/cupertino/scrollbar_test.dart
@@ -1060,6 +1060,50 @@ void main() {
     );
   });
 
+  testWidgets('Throw if interactive with the bar when no position attached', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: MediaQuery(
+          data: const MediaQueryData(),
+          child: CupertinoScrollbar(
+            controller: scrollController,
+            thumbVisibility: true,
+            child: SingleChildScrollView(
+              controller: scrollController,
+              child: const SizedBox(
+                height: 1000.0,
+                width: 1000.0,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final ScrollPosition position = scrollController.position;
+    scrollController.detach(position);
+
+    final FlutterExceptionHandler? handler = FlutterError.onError;
+    FlutterErrorDetails? error;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      error = details;
+    };
+
+    // long press the thumb
+    await tester.startGesture(const Offset(796.0, 50.0));
+    await tester.pump(kLongPressDuration);
+
+    expect(error, isNotNull);
+
+    scrollController.attach(position);
+    FlutterError.onError = handler;
+  });
+
   testWidgets('Interactive scrollbars should have a valid scroll controller', (WidgetTester tester) async {
     final ScrollController primaryScrollController = ScrollController();
     final ScrollController scrollController = ScrollController();


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/110625
I believe that the issue is an exception in production, I mean there will be assertion errors in debug mode.
I still modified some code because I wanted to be consistent with other places where `getScrollbarDirection` is used.
In fact, it's hard for test cases to test exactly what I've changed because the debug checking will fail the test first.