### PR TITLE
refactor: strip all local symbols from macOS and iOS App.framework - reduces app size

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -162,7 +162,7 @@ class AOTSnapshotter {
     }
 
     final String assembly = _fileSystem.path.join(outputDir.path, 'snapshot_assembly.S');
-    if (platform == TargetPlatform.ios || platform == TargetPlatform.darwin) {
+    if (targetingApplePlatform) {
       genSnapshotArgs.addAll(<String>[
         '--snapshot_kind=app-aot-assembly',
         '--assembly=$assembly',
@@ -181,7 +181,7 @@ class AOTSnapshotter {
     if (targetingApplePlatform) {
       stripAfterBuild = shouldStrip;
       if (stripAfterBuild) {
-        _logger.printTrace('Will strip AOT snapshot manual after build and dSYM generation.');
+        _logger.printTrace('Will strip AOT snapshot manually after build and dSYM generation.');
       }
     } else {
       stripAfterBuild = false;
@@ -331,7 +331,7 @@ class AOTSnapshotter {
 
       if (stripAfterBuild) {
         // See https://www.unix.com/man-page/osx/1/strip/ for arguments
-        final RunResult stripResult = await _xcode.strip(<String>['-S', appLib, '-o', appLib]);
+        final RunResult stripResult = await _xcode.strip(<String>['-x', appLib, '-o', appLib]);
         if (stripResult.exitCode != 0) {
           _logger.printError('Failed to strip debugging symbols from the generated AOT snapshot - strip terminated with exit code ${stripResult.exitCode}');
           return stripResult.exitCode;

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -262,7 +262,7 @@ void main() {
         const FakeCommand(command: <String>[
           'xcrun',
           'strip',
-          '-S',
+          '-x',
           'build/foo/App.framework/App',
           '-o',
           'build/foo/App.framework/App',
@@ -335,7 +335,7 @@ void main() {
         const FakeCommand(command: <String>[
           'xcrun',
           'strip',
-          '-S',
+          '-x',
           'build/foo/App.framework/App',
           '-o',
           'build/foo/App.framework/App',
@@ -407,7 +407,7 @@ void main() {
         const FakeCommand(command: <String>[
           'xcrun',
           'strip',
-          '-S',
+          '-x',
           'build/foo/App.framework/App',
           '-o',
           'build/foo/App.framework/App',
@@ -476,7 +476,7 @@ void main() {
         const FakeCommand(command: <String>[
           'xcrun',
           'strip',
-          '-S',
+          '-x',
           'build/foo/App.framework/App',
           '-o',
           'build/foo/App.framework/App',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/common_test.dart
@@ -529,7 +529,7 @@ void main() {
       FakeCommand(command: <String>[
         'xcrun',
         'strip',
-        '-S',
+        '-x',
         '$build/arm64/App.framework/App',
         '-o',
         '$build/arm64/App.framework/App',
@@ -619,7 +619,7 @@ void main() {
       FakeCommand(command: <String>[
         'xcrun',
         'strip',
-        '-S',
+        '-x',
         '$build/arm64/App.framework/App',
         '-o',
         '$build/arm64/App.framework/App',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/macos_test.dart
@@ -503,7 +503,7 @@ void main() {
       FakeCommand(command: <String>[
         'xcrun',
         'strip',
-        '-S',
+        '-x',
         environment.buildDir.childFile('arm64/App.framework/App').path,
         '-o',
         environment.buildDir.childFile('arm64/App.framework/App').path,
@@ -511,7 +511,7 @@ void main() {
       FakeCommand(command: <String>[
         'xcrun',
         'strip',
-        '-S',
+        '-x',
         environment.buildDir.childFile('x86_64/App.framework/App').path,
         '-o',
         environment.buildDir.childFile('x86_64/App.framework/App').path,

--- a/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/ios_content_validation_test.dart
@@ -192,19 +192,13 @@ void main() {
           expect(localNetworkUsageFound, buildMode == BuildMode.debug);
         });
 
-        const List<String> requiredSymbols = <String>[
-          '_kDartIsolateSnapshotData',
-          '_kDartIsolateSnapshotInstructions',
-          '_kDartVmSnapshotData',
-          '_kDartVmSnapshotInstructions'
-        ];
-
         testWithoutContext('check symbols', () {
-          final List<String> symbols = getExportedSymbols(outputAppFrameworkBinary.path);
+          final List<String> symbols =
+              AppleTestUtils.getExportedSymbols(outputAppFrameworkBinary.path);
           if (buildMode == BuildMode.debug) {
             expect(symbols, isEmpty);
           } else {
-            expect(symbols, equals(requiredSymbols));
+            expect(symbols, equals(AppleTestUtils.requiredSymbols));
           }
         });
 
@@ -213,8 +207,9 @@ void main() {
             // dSYM is not created for a debug build.
             expect(buildAppFrameworkDsymBinary.existsSync(), isFalse);
           } else {
-            final List<String> symbols = getExportedSymbols(buildAppFrameworkDsymBinary.path);
-            expect(symbols, containsAll(requiredSymbols));
+            final List<String> symbols =
+                AppleTestUtils.getExportedSymbols(buildAppFrameworkDsymBinary.path);
+            expect(symbols, containsAll(AppleTestUtils.requiredSymbols));
             // The actual number of symbols is going to vary but there should
             // be "many" in the dSYM. At the time of writing, it was 7656.
             expect(symbols.length, greaterThanOrEqualTo(5000));
@@ -362,20 +357,4 @@ void main() {
   }, skip: !platform.isMacOS, // [intended] only makes sense for macos platform.
      timeout: const Timeout(Duration(minutes: 7))
   );
-}
-
-List<String> getExportedSymbols(String dwarfPath) {
-  final ProcessResult nm = processManager.runSync(
-    <String>[
-      'nm',
-      '--debug-syms',  // nm docs: 'Show all symbols, even debugger only'
-      '--defined-only',
-      '--just-symbol-name',
-      dwarfPath,
-      '-arch',
-      'arm64',
-    ],
-  );
-  final String nmOutput = (nm.stdout as String).trim();
-  return nmOutput.isEmpty ? const <String>[] : nmOutput.split('\n');
 }

--- a/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
+++ b/packages/flutter_tools/test/host_cross_arch.shard/macos_content_validation_test.dart
@@ -9,7 +9,6 @@ import 'package:flutter_tools/src/base/io.dart';
 import '../integration.shard/test_utils.dart';
 import '../src/common.dart';
 import '../src/darwin_common.dart';
-import 'ios_content_validation_test.dart';
 
 void main() {
   final String flutterBin = fileSystem.path.join(
@@ -88,20 +87,13 @@ void main() {
         'App.framework',
       ));
 
-      const List<String> requiredSymbols = <String>[
-        '_kDartIsolateSnapshotData',
-        '_kDartIsolateSnapshotInstructions',
-        '_kDartVmSnapshotData',
-        '_kDartVmSnapshotInstructions'
-      ];
-
       final File libBinary = outputAppFramework.childFile('App');
       final File libDsymBinary =
         buildPath.childFile('App.framework.dSYM/Contents/Resources/DWARF/App');
 
       _checkFatBinary(libBinary, buildModeLower, 'dynamically linked shared library');
 
-      final List<String> libSymbols = getExportedSymbols(libBinary.path);
+      final List<String> libSymbols = AppleTestUtils.getExportedSymbols(libBinary.path);
 
       if (buildMode == 'Debug') {
         // dSYM is not created for a debug build.
@@ -109,9 +101,10 @@ void main() {
         expect(libSymbols, isEmpty);
       } else {
         _checkFatBinary(libDsymBinary, buildModeLower, 'dSYM companion file');
-        expect(libSymbols, equals(requiredSymbols));
-        final List<String> dSymSymbols = getExportedSymbols(libDsymBinary.path);
-        expect(dSymSymbols, containsAll(requiredSymbols));
+        expect(libSymbols, equals(AppleTestUtils.requiredSymbols));
+        final List<String> dSymSymbols =
+            AppleTestUtils.getExportedSymbols(libDsymBinary.path);
+        expect(dSymSymbols, containsAll(AppleTestUtils.requiredSymbols));
         // The actual number of symbols is going to vary but there should
         // be "many" in the dSYM. At the time of writing, it was 19195.
         expect(dSymSymbols.length, greaterThanOrEqualTo(15000));

--- a/packages/flutter_tools/test/integration.shard/test_utils.dart
+++ b/packages/flutter_tools/test/integration.shard/test_utils.dart
@@ -99,3 +99,31 @@ Future<void> pollForServiceExtensionValue<T>({
     " attempts responded with '$continuePollingValue'.",
   );
 }
+
+class AppleTestUtils {
+  // static only
+  AppleTestUtils._();
+
+  static const List<String> requiredSymbols = <String>[
+    '_kDartIsolateSnapshotData',
+    '_kDartIsolateSnapshotInstructions',
+    '_kDartVmSnapshotData',
+    '_kDartVmSnapshotInstructions'
+  ];
+
+  static List<String> getExportedSymbols(String dwarfPath) {
+    final ProcessResult nm = processManager.runSync(
+      <String>[
+        'nm',
+        '--debug-syms',  // nm docs: 'Show all symbols, even debugger only'
+        '--defined-only',
+        '--just-symbol-name',
+        dwarfPath,
+        '-arch',
+        'arm64',
+      ],
+    );
+    final String nmOutput = (nm.stdout as String).trim();
+    return nmOutput.isEmpty ? const <String>[] : nmOutput.split('\n');
+  }
+}


### PR DESCRIPTION
Follow up from https://github.com/flutter/flutter/pull/101586#discussion_r934228683

Changes striping debug symbols to striping all local symbols for iOS and macOS.

I've also manually checked sizes of `App.framework`'s `App` lib before and after the change on the integration test apps and the changes yield a nice reduction

|       	| `strip -S` 	| `strip -x` 	| Difference 	|
|-------	|-----------:	|-----------:	|-----------:	|
| iOS   	| `2903776`  	| `2638864`  	| -258.7 KiB  (9 %)	|
| macOS 	| `18272448` 	| `15835152` 	| -2.32 MiB (13 %)   	|


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
