### PR TITLE
Revert "Temporarily disable docs tests."

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -242,7 +242,6 @@ targets:
       - master
     recipe: flutter/flutter
     presubmit: false
-    bringup: true # Marking as flaky to reopen the tree. https://github.com/flutter/flutter/issues/111193
     timeout: 60
     properties:
       dependencies: >-
@@ -259,8 +258,6 @@ targets:
 
   - name: Linux docs_test
     recipe: flutter/flutter
-    presubmit: false
-    bringup: true # Marking as flaky to reopen the tree. https://github.com/flutter/flutter/issues/111193
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
Reverts flutter/flutter#111237

A fix for generating obj-c was landed in recipes and we can now re-enable the tests.