### PR TITLE
Enable android isolate platform channels tests

### DIFF
--- a/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
+++ b/dev/integration_tests/channels/android/app/src/main/java/com/yourcompany/channels/MainActivity.java
@@ -29,6 +29,15 @@ public class MainActivity extends FlutterActivity {
     setupMessageHandshake(new BasicMessageChannel<>(dartExecutor, "std-msg", ExtendedStandardMessageCodec.INSTANCE));
     setupMethodHandshake(new MethodChannel(dartExecutor, "json-method", JSONMethodCodec.INSTANCE));
     setupMethodHandshake(new MethodChannel(dartExecutor, "std-method", new StandardMethodCodec(ExtendedStandardMessageCodec.INSTANCE)));
+
+    BasicMessageChannel echoChannel =
+        new BasicMessageChannel(dartExecutor, "std-echo", ExtendedStandardMessageCodec.INSTANCE);
+    echoChannel.setMessageHandler(new BasicMessageChannel.MessageHandler(){
+      @Override
+      public void onMessage(final Object message, final BasicMessageChannel.Reply reply) {
+        reply.reply(message);
+      }
+    });
   }
 
   private <T> void setupMessageHandshake(final BasicMessageChannel<T> channel) {

--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -173,7 +173,7 @@ class _TestAppState extends State<TestApp> {
     () => basicStringMessageToUnknownChannel(),
     () => basicJsonMessageToUnknownChannel(),
     () => basicStandardMessageToUnknownChannel(),
-    if (Platform.isIOS)
+    if (Platform.isIOS || Platform.isAndroid)
       () => basicBackgroundStandardEcho(123),
   ];
   Future<TestStepResult>? _result;


### PR DESCRIPTION
**companion engine pr:** https://github.com/flutter/engine/pull/35804
**issue:** https://github.com/flutter/flutter/issues/13937

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
