### PR TITLE
[macOS] Add missing, required dependencies to run platform_view_macos__start_up

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2735,6 +2735,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
       tags: >
         ["devicelab", "hostonly"]
       task_name: platform_view_macos__start_up


### PR DESCRIPTION
`platform_view_macos__start_up` was brought up in https://github.com/flutter/flutter/pull/111041, but did not have the proper dependencies to actually run the test. This PR adds the dependencies required for the `platform_view` example to run on macOS.

## Fixes https://github.com/flutter/flutter/issues/111297#event-7359160787
###### Thank you, Jenn for catching this one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.