### PR TITLE
Fix Magnifier crash

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -853,7 +853,7 @@ class SelectionOverlay {
       _magnifierOverlayInfoBearer,
     );
 
-    if (builtMagnifier == null || _handles == null) {
+    if (builtMagnifier == null) {
       return;
     }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -861,7 +861,7 @@ class SelectionOverlay {
         context: context,
         below: magnifierConfiguration.shouldDisplayHandlesInMagnifier
             ? null
-            : _handles!.first,
+            : _handles?.first,
         builder: (_) => builtMagnifier);
   }
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1030,6 +1030,7 @@ void main() {
       ValueChanged<DragEndDetails>? onEndDragEnd,
       VoidCallback? onSelectionHandleTapped,
       TextSelectionControls? selectionControls,
+      TextMagnifierConfiguration? magnifierConfiguration,
     }) async {
       final UniqueKey column = UniqueKey();
       final LayerLink startHandleLayerLink = LayerLink();
@@ -1075,6 +1076,7 @@ void main() {
         selectionControls: selectionControls,
         selectionEndpoints: const <TextSelectionPoint>[],
         toolbarLayerLink: toolbarLayerLink,
+        magnifierConfiguration: magnifierConfiguration ?? TextMagnifierConfiguration.disabled,
       );
     }
 
@@ -1278,6 +1280,28 @@ void main() {
       await gesture2.up();
       await tester.pump(const Duration(milliseconds: 20));
       expect(endDragEndDetails, isNotNull);
+    });
+
+    testWidgets('can show magnifier when no handles exist', (WidgetTester tester) async {
+      final SelectionOverlay selectionOverlay = await pumpApp(
+        tester,
+        magnifierConfiguration: TextMagnifierConfiguration(
+          shouldDisplayHandlesInMagnifier: false,
+          magnifierBuilder: (BuildContext context, MagnifierController controller, ValueNotifier<MagnifierOverlayInfoBearer>? notifier) {
+            return const SizedBox.shrink();
+          },
+        ),
+      );
+
+      final MagnifierOverlayInfoBearer info = MagnifierOverlayInfoBearer(
+        globalGesturePosition: Offset.zero,
+        caretRect: Offset.zero & const Size(5.0, 20.0),
+        fieldBounds: Offset.zero & const Size(200.0, 50.0),
+        currentLineBoundaries: Offset.zero & const Size(200.0, 50.0),
+      );
+      selectionOverlay.showMagnifier(info);
+
+      expect(tester.takeException(), isNull);
     });
   });
 

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1283,15 +1283,20 @@ void main() {
     });
 
     testWidgets('can show magnifier when no handles exist', (WidgetTester tester) async {
+      final GlobalKey magnifierKey = GlobalKey();
       final SelectionOverlay selectionOverlay = await pumpApp(
         tester,
         magnifierConfiguration: TextMagnifierConfiguration(
           shouldDisplayHandlesInMagnifier: false,
           magnifierBuilder: (BuildContext context, MagnifierController controller, ValueNotifier<MagnifierOverlayInfoBearer>? notifier) {
-            return const SizedBox.shrink();
+            return SizedBox.shrink(
+              key: magnifierKey,
+            );
           },
         ),
       );
+
+      expect(find.byKey(magnifierKey), findsNothing);
 
       final MagnifierOverlayInfoBearer info = MagnifierOverlayInfoBearer(
         globalGesturePosition: Offset.zero,
@@ -1300,8 +1305,10 @@ void main() {
         currentLineBoundaries: Offset.zero & const Size(200.0, 50.0),
       );
       selectionOverlay.showMagnifier(info);
+      await tester.pump();
 
       expect(tester.takeException(), isNull);
+      expect(find.byKey(magnifierKey), findsOneWidget);
     });
   });
 


### PR DESCRIPTION
Fixes a crash that was happening when the magnifier was shown and no handles were visible.

Fixes https://github.com/flutter/flutter/issues/111301