### PR TITLE
[flutter_tools] filter "Resolving dependencies..." from dart pub get output to fix test flakiness

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3135,7 +3135,8 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
       .where((String line) {
         return line.trim().isNotEmpty &&
             !line.startsWith('Analyzing') &&
-            !line.contains('flutter pub get');
+            !line.contains('flutter pub get') &&
+            !line.contains('Resolving dependencies');
       }).map(lineParser).toList();
   expect(errors, unorderedEquals(expectedFailures));
 }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3126,18 +3126,26 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
       final String lintName = lineComponents.removeLast();
       final String location = lineComponents.removeLast();
       return '$location: $lintName';
-      // Add debugging for https://github.com/flutter/flutter/issues/111272
     } on RangeError catch (err) {
-      fail('Received "$err" while trying to parse:\n\n$line');
+      throw RangeError('Received "$err" while trying to parse: "$line".');
     }
   }
-  final List<String> errors = const LineSplitter().convert(exec.stdout.toString())
+  final String stdout = exec.stdout.toString();
+  final List<String> errors;
+  try {
+    errors = const LineSplitter().convert(stdout)
       .where((String line) {
         return line.trim().isNotEmpty &&
             !line.startsWith('Analyzing') &&
             !line.contains('flutter pub get') &&
-            !line.contains('Resolving dependencies');
+            !line.contains('Resolving dependencies') &&
+            !line.contains('Got dependencies');
       }).map(lineParser).toList();
+
+    // Add debugging for https://github.com/flutter/flutter/issues/111272
+  } on RangeError catch (err) {
+    fail('$err\n\nComplete STDOUT was:\n\n$stdout');
+  }
   expect(errors, unorderedEquals(expectedFailures));
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/111272

Example failing build: https://ci.chromium.org/p/flutter/builders/prod/Linux%20tool_tests_commands/7002

```
Received "RangeError (index): Invalid value: Valid value range is empty: -1" while trying to parse:

Resolving dependencies...
```