### PR TITLE
close async gaps (`use_build_context_synchronously` fixes)

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/gallery/demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/demo.dart
@@ -76,20 +76,22 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
     } else {
-      showDialog<void>(
-        context: context,
-        builder: (BuildContext context) {
-          return SimpleDialog(
-            title: const Text("Couldn't display URL:"),
-            children: <Widget>[
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                child: Text(url),
-              ),
-            ],
-          );
-        },
-      );
+      if (mounted) {
+        showDialog<void>(
+          context: context,
+          builder: (BuildContext context) {
+            return SimpleDialog(
+              title: const Text("Couldn't display URL:"),
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Text(url),
+                ),
+              ],
+            );
+          },
+        );
+      }
     }
   }
 

--- a/dev/integration_tests/flutter_gallery/lib/gallery/updater.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/updater.dart
@@ -35,9 +35,11 @@ class UpdaterState extends State<Updater> {
     _lastUpdateCheck = DateTime.now();
 
     final String? updateUrl = await widget.updateUrlFetcher();
-    final bool? wantsUpdate = await showDialog<bool>(context: context, builder: _buildDialog);
-    if (wantsUpdate != null && updateUrl != null && wantsUpdate) {
-      launchUrl(Uri.parse(updateUrl));
+    if (mounted) {
+      final bool? wantsUpdate = await showDialog<bool>(context: context, builder: _buildDialog);
+      if (wantsUpdate != null && updateUrl != null && wantsUpdate) {
+        launchUrl(Uri.parse(updateUrl));
+      }
     }
   }
 


### PR DESCRIPTION
https://github.com/dart-lang/linter/pull/3679 fixes the linter to detect build contexts that are passed as named arguments to async functions and that will flag these instances when we do a roll.

🚦  **HOLDING** pending discussion in: https://github.com/dart-lang/sdk/issues/58867

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
