### PR TITLE
Make `'Hello, world.'` visible in `examples/layers/raw/hello_world.dart` sample

### DIFF
--- a/examples/layers/raw/hello_world.dart
+++ b/examples/layers/raw/hello_world.dart
@@ -12,26 +12,37 @@ void beginFrame(Duration timeStamp) {
   final ui.Size logicalSize = ui.window.physicalSize / devicePixelRatio;
 
   final ui.ParagraphBuilder paragraphBuilder = ui.ParagraphBuilder(
-    ui.ParagraphStyle(textDirection: ui.TextDirection.ltr),
+    ui.ParagraphStyle(
+      textDirection: ui.TextDirection.ltr,
+      fontSize: 20,
+      fontWeight: ui.FontWeight.bold,
+    ),
   )
+    ..pushStyle(
+        ui.TextStyle(color: const ui.Color.fromARGB(0xFF, 0x33, 0x33, 0x66)))
     ..addText('Hello, world.');
   final ui.Paragraph paragraph = paragraphBuilder.build()
     ..layout(ui.ParagraphConstraints(width: logicalSize.width));
 
-  final ui.Rect physicalBounds = ui.Offset.zero & (logicalSize * devicePixelRatio);
+  final ui.Rect physicalBounds =
+      ui.Offset.zero & (logicalSize * devicePixelRatio);
   final ui.PictureRecorder recorder = ui.PictureRecorder();
   final ui.Canvas canvas = ui.Canvas(recorder, physicalBounds);
   canvas.scale(devicePixelRatio, devicePixelRatio);
-  canvas.drawParagraph(paragraph, ui.Offset(
-    (logicalSize.width - paragraph.maxIntrinsicWidth) / 2.0,
-    (logicalSize.height - paragraph.height) / 2.0,
-  ));
+  canvas.drawParagraph(
+    paragraph,
+    ui.Offset(
+      logicalSize.width > paragraph.maxIntrinsicWidth
+          ? (logicalSize.width - paragraph.maxIntrinsicWidth) / 2.0
+          : 0,
+      logicalSize.height > paragraph.height
+          ? (logicalSize.height - paragraph.height) / 2.0
+          : 0,
+    ),
+  );
   final ui.Picture picture = recorder.endRecording();
 
   final ui.SceneBuilder sceneBuilder = ui.SceneBuilder()
-    // TODO(abarth): We should be able to add a picture without pushing a
-    // container layer first.
-    ..pushClipRect(physicalBounds)
     ..addPicture(ui.Offset.zero, picture)
     ..pop();
 


### PR DESCRIPTION
Before:
<img width="503" alt="Screen Shot 2022-09-10 at 12 40 56 pm" src="https://user-images.githubusercontent.com/30503/189465772-a62e4005-759b-45e9-b657-3206a881aca6.png">

After:
<img width="503" alt="Screen Shot 2022-09-10 at 12 40 31 pm" src="https://user-images.githubusercontent.com/30503/189465774-b79d60e5-dc80-454f-8184-208c77b5a56e.png">

Fixes: https://github.com/flutter/flutter/issues/111332

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
