### PR TITLE
[framework] work around to load self packages from packages/

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -964,6 +964,7 @@ Future<void> _runFrameworkTests() async {
     await _runDartTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);
     // TODO(gspencergoog): Remove the exception for fatalWarnings once https://github.com/flutter/flutter/pull/91127 has landed.
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'android_semantics_testing'), fatalWarnings: false);
+    await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'ui'));
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'manual_tests'));
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'tools', 'vitool'));
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'tools', 'gen_defaults'));

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -79,5 +79,7 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/foo.png
 
 # PUBSPEC CHECKSUM: 8eeb

--- a/dev/integration_tests/ui/test/asset_test.dart
+++ b/dev/integration_tests/ui/test/asset_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+
+// Regression test for https://github.com/flutter/flutter/issues/111285
+void main() {
+  testWidgets('Can load asset from same package without error', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(home: Scaffold(body: Image.asset('assets/foo.png', package: 'integration_ui'))));
+    await tester.pumpAndSettle();
+
+    // If this asset couldn't be loaded, the exception message would be
+    // "asset failed to load"
+    expect(tester.takeException().toString(), contains('Invalid image data'));
+  });
+}

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -266,6 +266,22 @@ class PlatformAssetBundle extends CachingAssetBundle {
       final ByteData bytes = await load(key);
       return ui.ImmutableBuffer.fromUint8List(bytes.buffer.asUint8List());
     }
+    bool debugUsePlatformChannel = false;
+    assert(() {
+      // dart:io is safe to use here since we early return for web
+      // above. If that code is changed, this needs to be gaurded on
+      // web presence. Override how assets are loaded in tests so that
+      // the old loader behavior that allows tests to load assets from
+      // the current package using the package prefix.
+      if (Platform.environment.containsKey('UNIT_TEST_ASSETS')) {
+        debugUsePlatformChannel = true;
+      }
+      return true;
+    }());
+    if (debugUsePlatformChannel) {
+      final ByteData bytes = await load(key);
+      return ui.ImmutableBuffer.fromUint8List(bytes.buffer.asUint8List());
+    }
     try {
       return await ui.ImmutableBuffer.fromAsset(key);
     } on Exception {


### PR DESCRIPTION
Restores removed feature that assets from the current package could still be loaded with a `package` prefix in unit tests. This change is designed to be cherry-picked, in the future we should make this more consistent.

Fixes https://github.com/flutter/flutter/issues/111285

FYI @andrewkolos 