### PR TITLE
Startup `flutter` faster (cache git calls)

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -18,6 +18,7 @@ SET cache_dir=%FLUTTER_ROOT%\bin\cache
 SET snapshot_path=%cache_dir%\flutter_tools.snapshot
 SET snapshot_path_old=%cache_dir%\flutter_tools.snapshot.old
 SET stamp_path=%cache_dir%\flutter_tools.stamp
+SET git_answers_cache=%cache_dir%\git_answers_cache.json
 SET script_path=%flutter_tools_dir%\bin\flutter_tools.dart
 SET dart_sdk_path=%cache_dir%\dart-sdk
 SET engine_stamp=%cache_dir%\engine-dart-sdk.stamp
@@ -130,6 +131,7 @@ GOTO :after_subroutine
 
   :do_snapshot
     IF EXIST "%FLUTTER_ROOT%\version" DEL "%FLUTTER_ROOT%\version"
+    IF EXIST "%git_answers_cache%" DEL "%git_answers_cache%"
     ECHO: > "%cache_dir%\.dartignore"
     ECHO Building flutter tool... 1>&2
     PUSHD "%flutter_tools_dir%"

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -162,6 +162,9 @@ function upgrade_flutter () (
       mv "$SNAPSHOT_PATH" "$SNAPSHOT_PATH_OLD"
     fi
 
+    # Clean git answers cache
+    rm -f "$GIT_ANSWERS_CACHE"
+
     # Compile...
     "$DART" --verbosity=error --disable-dart-dev $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" > /dev/null
     echo "$compilekey" > "$STAMP_PATH"
@@ -192,6 +195,7 @@ function shared::execute() {
   FLUTTER_TOOLS_DIR="$FLUTTER_ROOT/packages/flutter_tools"
   SNAPSHOT_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.snapshot"
   STAMP_PATH="$FLUTTER_ROOT/bin/cache/flutter_tools.stamp"
+  GIT_ANSWERS_CACHE="$FLUTTER_ROOT/bin/cache/git_answers_cache.json"
   SCRIPT_PATH="$FLUTTER_TOOLS_DIR/bin/flutter_tools.dart"
   DART_SDK_PATH="$FLUTTER_ROOT/bin/cache/dart-sdk"
 

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -177,6 +177,8 @@ class ChannelCommand extends FlutterCommand {
         );
       }
     }
+    // Always remove the git cache - also if the switch didn't succeed.
+    FlutterVersion.resetGitCache();
     if (result != 0) {
       throwToolExit('Switching channels failed with error code $result.', exitCode: result);
     } else {

--- a/packages/flutter_tools/lib/src/commands/channel.dart
+++ b/packages/flutter_tools/lib/src/commands/channel.dart
@@ -182,7 +182,7 @@ class ChannelCommand extends FlutterCommand {
     } else {
       // Remove the version check stamp, since it could contain out-of-date
       // information that pertains to the previous channel.
-      await FlutterVersion.resetFlutterVersionFreshnessCheck();
+      await FlutterVersion.resetFlutterVersionCache();
     }
   }
 }

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -93,6 +93,7 @@ class DowngradeCommand extends FlutterCommand {
     String workingDirectory = Cache.flutterRoot!;
     if (argResults!.wasParsed('working-directory')) {
       workingDirectory = stringArgDeprecated('working-directory')!;
+      await FlutterVersion.resetFlutterVersionCache();
       _flutterVersion = FlutterVersion(workingDirectory: workingDirectory);
     }
 
@@ -174,7 +175,7 @@ class DowngradeCommand extends FlutterCommand {
         'and retry again.\nError: $error.'
       );
     }
-    await FlutterVersion.resetFlutterVersionFreshnessCheck();
+    await FlutterVersion.resetFlutterVersionCache();
     logger.printStatus('Success');
     return FlutterCommandResult.success();
   }

--- a/packages/flutter_tools/lib/src/commands/downgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/downgrade.dart
@@ -144,6 +144,9 @@ class DowngradeCommand extends FlutterCommand {
       logger.printStatus('Downgrading Flutter to version $humanReadableVersion');
     }
 
+    // Reset git cache to ensure we reset it even if the checkout doesn't succeed.
+    FlutterVersion.resetGitCache();
+
     // To downgrade the tool, we perform a git checkout --hard, and then
     // switch channels. The version recorded must have existed on that branch
     // so this operation is safe.

--- a/packages/flutter_tools/lib/src/commands/upgrade.dart
+++ b/packages/flutter_tools/lib/src/commands/upgrade.dart
@@ -171,6 +171,7 @@ class UpgradeCommandRunner {
     if (!testFlow) {
       await flutterUpgradeContinue();
     }
+    await FlutterVersion.resetFlutterVersionCache();
   }
 
   void recordState(FlutterVersion flutterVersion) {

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -292,6 +292,7 @@ class FlutterVersion {
   /// remote git repository is not reachable due to a network issue.
   static Future<String> fetchRemoteFrameworkCommitDate() async {
     try {
+      FlutterVersion.resetGitCache();
       // Fetch upstream branch's commit and tags
       await _run(<String>['git', 'fetch', '--tags']);
       return _gitCommitDate(gitRef: kGitTrackingUpstream);

--- a/packages/flutter_tools/lib/src/version.dart
+++ b/packages/flutter_tools/lib/src/version.dart
@@ -625,7 +625,7 @@ class GitAnswersCache {
   /// null if the answer is not in the cache.
   String? getCachedValue(List<String> command, String workingDirectory, Logger logger) {
     final String escapedKey = _escape(command);
-    _ansureCache(logger);
+    _ensureCache(logger);
     final dynamic cachedForCommand = _cache![escapedKey];
     if (cachedForCommand is! Map<String, Object?>) {
       return null;
@@ -641,7 +641,7 @@ class GitAnswersCache {
   /// Store the [result] from running [command] in [workingDirectory].
   void cacheResult(List<String> command, String workingDirectory, String result, Logger logger) {
     final String escapedKey = _escape(command);
-    _ansureCache(logger);
+    _ensureCache(logger);
     dynamic cachedForCommand = _cache![escapedKey];
     if (cachedForCommand is! Map<String, Object?> ) {
       cachedForCommand = _cache![escapedKey] = <String, Object?>{};
@@ -655,7 +655,7 @@ class GitAnswersCache {
     return command.map((String e) => '${e.length}:$e').join();
   }
 
-  void _ansureCache(Logger logger) {
+  void _ensureCache(Logger logger) {
     if (_cache != null) {
       return;
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
@@ -10,6 +10,7 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/upgrade.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/version.dart';
 
 import '../../src/context.dart';
@@ -40,6 +41,9 @@ void main() {
   });
 
   testUsingContext('can auto-migrate a user from dev to beta', () async {
+    // Ensure the the cache root exists so caching will work.
+    await globals.cache.getRoot().create(recursive: true);
+
     const String startingTag = '3.0.0-1.2.pre';
     flutterVersion = FakeFlutterVersion(channel: 'dev');
     const String latestUpstreamTag = '3.0.0-1.3.pre';

--- a/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/upgrade_test.dart
@@ -42,7 +42,7 @@ void main() {
 
   testUsingContext('can auto-migrate a user from dev to beta', () async {
     // Ensure the the cache root exists so caching will work.
-    await globals.cache.getRoot().create(recursive: true);
+    globals.cache.getRoot().createSync(recursive: true);
 
     const String startingTag = '3.0.0-1.2.pre';
     flutterVersion = FakeFlutterVersion(channel: 'dev');

--- a/packages/flutter_tools/test/general.shard/analytics_test.dart
+++ b/packages/flutter_tools/test/general.shard/analytics_test.dart
@@ -106,6 +106,9 @@ void main() {
     });
 
     testUsingContext('Usage records one feature in experiment setting', () async {
+      // Ensure the the cache root exists so caching will work.
+      await globals.cache.getRoot().create(recursive: true);
+
       testConfig.setValue(flutterWebFeature.configSetting!, true);
       final Usage usage = Usage(runningOnBot: true);
       usage.sendCommand('test');
@@ -124,6 +127,9 @@ void main() {
     });
 
     testUsingContext('Usage records multiple features in experiment setting', () async {
+      // Ensure the the cache root exists so caching will work.
+      await globals.cache.getRoot().create(recursive: true);
+
       testConfig.setValue(flutterWebFeature.configSetting!, true);
       testConfig.setValue(flutterLinuxDesktopFeature.configSetting!, true);
       testConfig.setValue(flutterMacOSDesktopFeature.configSetting!, true);

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -490,25 +490,27 @@ void main() {
       // (this time by modifying the cache first).
       expect(processManager, hasNoRemainingExpectations);
       final GitAnswersCache gitCache = GitAnswersCache();
+      final String root = Cache.flutterRoot!;
+      final Logger logger = BufferLogger.test();
 
       // We don't change '1234abcd' as that's referenced in other commands.
-      expect(gitCache.getCachedValue(hashCommand, Cache.flutterRoot!), '1234abcd');
+      expect(gitCache.getCachedValue(hashCommand, root, logger), '1234abcd');
 
-      expect(gitCache.getCachedValue(tagsCommand, Cache.flutterRoot!), '');
-      gitCache.cacheResult(tagsCommand, Cache.flutterRoot!, 'testtag');
-      expect(gitCache.getCachedValue(tagsCommand, Cache.flutterRoot!), 'testtag');
+      expect(gitCache.getCachedValue(tagsCommand, root, logger), '');
+      gitCache.cacheResult(tagsCommand, root, 'testtag', logger);
+      expect(gitCache.getCachedValue(tagsCommand, root, logger), 'testtag');
 
-      expect(gitCache.getCachedValue(describeCommand, Cache.flutterRoot!), '0.1.2-3-1234abcd');
-      gitCache.cacheResult(describeCommand, Cache.flutterRoot!, '0.2.1-3-1234abcd');
-      expect(gitCache.getCachedValue(describeCommand, Cache.flutterRoot!), '0.2.1-3-1234abcd');
+      expect(gitCache.getCachedValue(describeCommand, root, logger), '0.1.2-3-1234abcd');
+      gitCache.cacheResult(describeCommand, root, '0.2.1-3-1234abcd', logger);
+      expect(gitCache.getCachedValue(describeCommand, root, logger), '0.2.1-3-1234abcd');
 
-      expect(gitCache.getCachedValue(trackingBranchCommand, Cache.flutterRoot!), 'feature-branch');
-      gitCache.cacheResult(trackingBranchCommand, Cache.flutterRoot!, 'feature-branchX');
-      expect(gitCache.getCachedValue(trackingBranchCommand, Cache.flutterRoot!), 'feature-branchX');
+      expect(gitCache.getCachedValue(trackingBranchCommand, root, logger), 'feature-branch');
+      gitCache.cacheResult(trackingBranchCommand, root, 'feature-branchX', logger);
+      expect(gitCache.getCachedValue(trackingBranchCommand, root, logger), 'feature-branchX');
 
-      expect(gitCache.getCachedValue(branchCommand, Cache.flutterRoot!), 'feature-branch');
-      gitCache.cacheResult(branchCommand, Cache.flutterRoot!, 'feature-branchY');
-      expect(gitCache.getCachedValue(branchCommand, Cache.flutterRoot!), 'feature-branchY');
+      expect(gitCache.getCachedValue(branchCommand, root, logger), 'feature-branch');
+      gitCache.cacheResult(branchCommand, root, 'feature-branchY', logger);
+      expect(gitCache.getCachedValue(branchCommand, root, logger), 'feature-branchY');
 
       expect(processManager, hasNoRemainingExpectations);
       final FlutterVersion flutterVersion = FlutterVersion();

--- a/packages/flutter_tools/test/general.shard/version_test.dart
+++ b/packages/flutter_tools/test/general.shard/version_test.dart
@@ -672,7 +672,7 @@ void main() {
     }
 
     // Note that we in the below are in the future (i.e. use systemClockLater).
-    
+
     {
       // Create another FlutterVersion, make sure answers are gotten from cache
       // (i.e. we don't run any more processes).


### PR DESCRIPTION
This PR makes `flutter` (as measured with `flutter test` directly in the `flutter` directory which has no `test` directory, thus just writing "there's no `test` directory) startup faster by caching `git` calls.

When starting `flutter` a number of `git` calls are made, which is quite expensive. This PR introduces caching of these calls.
Caching is deleted when also creating a new snapshot (i.e. it's guarded by the same mechanism, which is the git hash).

This does mean that these things can change:
* Two branches on the same hash will have an undetected stale cache (in that it will think it's on one of the branch when it could be on another). I'll say this is very unlikely from having any real effect. Logically we might report crashes or whatever as if on the "main" branch when we're really on our own not-yet-committed-to copy of main, but logically this already happens when we haven't created a branch yet but have made changes to the code.
* If official tags are created for old versions where the user cached the old answer (e.g. no tags, user uses `flutter` and caches that, a tag is then created, the user fetches (but stays on the old hash) --- git would now know about the new tag, but caching isn't updated. Again I'll say this doesn't matter and any crash reports or whatever would have to handle the case anyway because not everyone has necessarily fetched.

To me, neither of these seems like big deals though.
The startup changes as measured on my machines is this:

**Linux**
| Before on master | Before not on master | With PR |
| --- | --- | --- |
| 0.614 | 0.606 | 0.484 |
| 0.655 | 0.602 | 0.482 |
| 0.69 | 0.605 | 0.489 |
| 0.669 | 0.595 | 0.474 |
| 0.647 | 0.598 | 0.493 |
| 0.672 | 0.584 | 0.483 |
| 0.638 | 0.602 | 0.483 |
| 0.67 | 0.614 | 0.489 |
| 0.67 | 0.593 | 0.48 |
| 0.677 | 0.609 | 0.489 |

While not important for this PR I'll note that it's faster to startup `flutter` when not on a branch called master:
```
Difference at 95.0% confidence
        -0.0594 +/- 0.0157866
        -8.99727% +/- 2.39118%
        (Student's t, pooled s = 0.0168015)
```

This PR improves things (compared to now on branch called master):

```
Difference at 95.0% confidence
        -0.1756 +/- 0.0151538
        -26.598% +/- 2.29533%
        (Student's t, pooled s = 0.016128)
```

This PR improves things (compared to now on branch not called master):

```
Difference at 95.0% confidence
        -0.1162 +/- 0.00681882
        -19.3409% +/- 1.13496%
        (Student's t, pooled s = 0.00725718)
```

I.e. it's somewhere from 20 to 25% faster, cutting off something like 110 to 175 ms.

**Windows** (Google issued with whatever security software)
| Before on master | Before not on master | Now |
| --- | --- | --- |
| 3.2498843 | 3.2052244 | 2.323404 |
| 3.2471592 | 3.2368394 | 2.3255623 |
| 3.2630213 | 3.2279151 | 2.3146872 |
| 3.2694762 | 3.2593181 | 2.2819018 |
| 3.2471021 | 3.2587005 | 2.3097854 |
| 3.2608728 | 3.2641268 | 2.3177364 |
| 3.2796176 | 3.2531503 | 2.2960537 |
| 3.2498695 | 3.2752845 | 2.3057254 |
| 3.2417869 | 3.2853195 | 2.3059499 |
| 3.2782214 | 3.2681917 | 2.3037698 |

This PR improves things:

```
Difference at 95.0% confidence
        -0.944949 +/- 0.0180964
        -29.0449% +/- 0.556228%
        (Student's t, pooled s = 0.0192597)
```

I.e. it's almost 30% faster, cutting off almost a full second.

A more detailed analysis is available internally at go/FlutterStartupTimeAnalysis (which also discussed future PRs).