### PR TITLE
Create enum for service extensions in services library

### DIFF
--- a/packages/flutter/lib/services.dart
+++ b/packages/flutter/lib/services.dart
@@ -37,6 +37,7 @@ export 'src/services/raw_keyboard_macos.dart';
 export 'src/services/raw_keyboard_web.dart';
 export 'src/services/raw_keyboard_windows.dart';
 export 'src/services/restoration.dart';
+export 'src/services/service_extensions.dart';
 export 'src/services/spell_check.dart';
 export 'src/services/system_channels.dart';
 export 'src/services/system_chrome.dart';

--- a/packages/flutter/lib/src/services/binding.dart
+++ b/packages/flutter/lib/src/services/binding.dart
@@ -15,6 +15,7 @@ import 'binary_messenger.dart';
 import 'hardware_keyboard.dart';
 import 'message_codec.dart';
 import 'restoration.dart';
+import 'service_extensions.dart';
 import 'system_channels.dart';
 import 'text_input.dart';
 
@@ -213,11 +214,7 @@ mixin ServicesBinding on BindingBase, SchedulerBinding {
 
     assert(() {
       registerStringServiceExtension(
-        // ext.flutter.evict value=foo.png will cause foo.png to be evicted from
-        // the rootBundle cache and cause the entire image cache to be cleared.
-        // This is used by hot reload mode to clear out the cache of resources
-        // that have changed.
-        name: 'evict',
+        name: ServicesServiceExtensions.evict.name,
         getter: () async => '',
         setter: (String value) async {
           evict(value);

--- a/packages/flutter/lib/src/services/service_extensions.dart
+++ b/packages/flutter/lib/src/services/service_extensions.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Service extension constants for the services library.
+///
+/// These constants will be used when registering service extensions in the
+/// framework, and they will also be used by tools and services that call these
+/// service extensions.
+///
+/// The String value for each of these extension names should be accessed by
+/// calling the `.name` property on the enum value.
+enum ServicesServiceExtensions {
+  /// Name of service extension that, when called, will evict an image from the
+  /// rootBundle cache and cause the image cache to be cleared.
+  ///
+  /// This is used by hot reload mode to clear out the cache of resources that
+  /// have changed. This service extension should be called with a String value
+  /// of the image path (e.g. foo.png).
+  ///
+  /// See also:
+  ///
+  /// * [ServicesBinding.initServiceExtensions], where the service extension is
+  ///   registered.
+  evict,
+}

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -563,7 +563,7 @@ void main() {
     });
     expect(data, isTrue);
     expect(completed, isFalse);
-    result = await binding.testExtension('evict', <String, String>{'value': 'test'});
+    result = await binding.testExtension(ServicesServiceExtensions.evict.name, <String, String>{'value': 'test'});
     expect(result, <String, String>{'value': ''});
     expect(completed, isFalse);
     data = await rootBundle.loadStructuredData<bool>('test', (String value) async {


### PR DESCRIPTION
Originally reviewed and approved here: https://github.com/flutter/flutter/pull/111271. Something funky happened with git and the PR was automatically-closed when I was trying to resolve the commit history.