### PR TITLE
Quiet iOS native test result zipping

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -495,6 +495,7 @@ end
                 <String>[
                   '-r',
                   '-9',
+                  '-q',
                   zipPath,
                   'result.xcresult',
                 ],

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -483,7 +483,7 @@ end
           canFail: true,
         );
 
-        if (testResultExit == 0) {
+        if (testResultExit != 0) {
           final Directory? dumpDirectory = hostAgent.dumpDirectory;
           if (dumpDirectory != null) {
             // Zip the test results to the artifacts directory for upload.

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -483,7 +483,7 @@ end
           canFail: true,
         );
 
-        if (testResultExit != 0) {
+        if (testResultExit == 0) {
           final Directory? dumpDirectory = hostAgent.dumpDirectory;
           if (dumpDirectory != null) {
             // Zip the test results to the artifacts directory for upload.

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -229,6 +229,7 @@ Future<bool> runXcodeTests({
           <String>[
             '-r',
             '-9',
+            '-q',
             zipPath,
             path.basename(xcresultBundle.path),
           ],

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -216,7 +216,7 @@ Future<bool> runXcodeTests({
     canFail: true,
   );
 
-  if (testResultExit == 0) {
+  if (testResultExit != 0) {
     final Directory? dumpDirectory = hostAgent.dumpDirectory;
     final Directory xcresultBundle = Directory(path.join(resultBundleTemp, 'result.xcresult'));
     if (dumpDirectory != null) {

--- a/dev/devicelab/lib/framework/ios.dart
+++ b/dev/devicelab/lib/framework/ios.dart
@@ -216,7 +216,7 @@ Future<bool> runXcodeTests({
     canFail: true,
   );
 
-  if (testResultExit != 0) {
+  if (testResultExit == 0) {
     final Directory? dumpDirectory = hostAgent.dumpDirectory;
     final Directory xcresultBundle = Directory(path.join(resultBundleTemp, 'result.xcresult'));
     if (dumpDirectory != null) {


### PR DESCRIPTION
Avoid hundreds of lines of zipping log spew when native iOS tests fail:

Example https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8803188107419461905/+/u/run_module_test_ios/test_stdout
```
[module_test_ios] [STDOUT] Executing "zip -r -9 /opt/s/w/ir/x/w/recipe_cleanup/flutter_logs_dir/module_test_ios-objc-2022-09-12T16:06:31.734361.zip result.xcresult" in "/opt/s/w/ir/x/t/flutter_module_test_ios_xcresult.3bZOZY" with environment {BOT: true, LANG: en_US.UTF-8}
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/ (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/ (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~-zNSZqYWtgVjjRs748aDZ2mLtOdrEY4-wFu6kq3Nr0v4MtCA09bkyCLGAPToicCsfBsY8E8EP4Bh_E89p0lFOg== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~VNMXCa5_T5tUIEy60wiW3O_0_cbmY-dT0re_GWd9QtTMfbL0xvS5y54CCUOHHSzUYweOhdnvdYv-hoNWxiHm8Q== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~Gtwb4A71w8AMG-rSejDEk8J-ysaS8wMwpzWk67kcdzJjornWSBv_TKX9dBMj10mtMrKmJjwaIV5XprdC8XAcPA== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~dt2w4vMNcWhz9Csu1zoSLKwWtDurLpgoqWFkXrBkdRbbOkOV500NCoVSouMg7gTtY1Yj8A9mCAIzbmF_3be8VA== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~qK1ES2CO6sjdZeIGImfXGdE_V6-ENVtm1ReBbmBXY4JTwQkGel-6mf4lWxKh1sTSo8lwfK1w-X9JO7Xy9pzxAQ== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~-_up9ToOSuB0RqBb3_HHEksbLnIlkGI8UjLaQnO2goUQY-ArC61nmlrpscfS1GRszv8FOBAl882qWLSJClW6HQ== (deflated 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~EQZQIcJuRJz32wiTAERZAV1oT4UQpP6ydEL4yHxVCvX9oYbdCRVPqLxN-wAMQDalQujP5RoUC9TSFo5lOUIm7w== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~QSgX9uYaSMwKItFJ4YfGscvEScgrWDAUoOCtId36LKt8QdXv8rTNAxPoQh9W7B6o1y8jNNr9skl0zt0DxnMm2g== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~ce5I-SM9wDoLACe77WjmP5Bw_D-dGR6-4kVp6MxZPzSGtPx_dZa3VqAKXjqR83t2aDHwPbEe3U1xGTdkKFx5ZQ== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~rg0xDzoau2aZw2gxLscJfRjsu_AoEEECWOrqXlXxeGAgBYDVZktMlSJA_XAh0i9ZlFeqsMpYnNHyZ7KLDDY1uw== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~XdY3wh-lIBjk5vSTkXcv4KhVoqx7kgkO5bYHzDSIg5ohzzjyZDuClzp3_FhlIH2kF9JIBowlI-oTqz6wrpj2dg== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~ITx0EaCXh4iFG9UlLH0Y5JoitMA4lBiZ_9s1-rML6cosUSbHBqiz0Kh1E5rdaGXtnQoOdQphRHpYqXlqQdetdA== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~N3TQOLBabir3izVYF4ld3lWPB5RjtgoXmgoQSWS_1ZFAePO9mSbGxlCwLt2S3O4MnCbKsthbu_rtNzZxm7pKyQ== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~Q2BC4HkosXIHDqv6ZK851TxORXJPvpszoFitksc9zh29bMbf14Vh5qeLSxLOkVHfffzEm16EoSO3fRyHaKZRcQ== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~5-vxt3hjzHQXdk-lkyrztWELx0EVaBi0NUwcUcPyCMQfD-Z8B0pNc1p3e-X3WrfIxaKsm0NB5SJdWxfelT6F-Q== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~1GKerG_rygfeqwQz16FfqMNnPbSXEhfsFmJuFAJR3pYxAbqQ7zzNgrNjrYUwqmOM1duLHTc8f0vwSTHziZf79g== (deflated 1%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~eN0BVKT0amWYkXACYSymSRo0Z4Y7VPxGNGx1ZiLMlbNYPA9d5V3sLE7KpyCMFk9LyFeY9zub758uEMahIG2PNg== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~a47HflJae0O8hSNNF3BCTLIMiSAsFxM5k0C5vXDMzI4uelLO6pd5nSY6p5FBgb8YMwhJqFFUygoc4Fut8hrsow== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~V2u64lqKVdiibYjw1nObz6fYbK0RWExJ_3PPLqhru9ul3yAbrw2caS74IdTDLc82bFl13MYgeo_mk1obf7hvug== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~qkSv5TQx_EuJVDyCtPN7pxSZfLwU18GetzV5ZT1iCv6kUEb8t4E0_gsRfHwdxhhJhfV5zIGZHnce4fw_SAg2Gg== (deflated 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~Z7m5ZblnyIzSolJlLhY2v2Nj3VYbCTbDVpEEWLaCJ7OWJTMvsPUpwDscxr_JtvYEAC1d4xcy82oXVWkD_5vCFw== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~LEeXZg3P1N4HXQNBY2nI3k7-WlyfMNwwsZuOUHUmfQ5m2pw9pd7pZkYFojyNUhdjHcbSYAnvzVLRS66VwpcYKQ== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~WdjfMBrWsQKAFVgr-R--TTPpiewJtYiYh_Lt6PGJwS229HpVtCZ5agUZD6Y1QFHPJNx1lt1K2InMzlpZRmiXKw== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~nju9euYEWG9P2EkRCY5s4XBWcW_LoIn58BKeiYIJ_Px--OKTsghI6-pmjQ4EjlIJiz9IoFynjft2znVvpUXFxw== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~FtCHrtzaU--LLLGOPGSEbqZGP-dt2XP2rM0LOyOQbWTKXXrNbHnSoOhqWnErpV9bGAd2A8bMX4Kz1TbHhw8yVA== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~DJeufrPoaHZbKaexfSeG7bQgt2btsPtvYykaVWMUQfrqy5X3uDmY_fqU-1vSw2YcOECoiEPJvx3bO_lnmRde_g== (deflated 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~PAp1WI_Kj3dtKhFk7bP0HscL4aAApj28q9Lo3f970YTuiEcddhkMS1GpuVmTpF0Ky0AnO2W657GfMiE6qw5g-Q== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~xytjfQ5no3-QpcuFqggL6MdlGmAL22_p_1DEYfDNDrUtJ0GYXQEIp6XlVHvn4oZvUI1T8cwiSj5JIvRbYZbC9Q== (stored 0%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/data.0~OQtQoLyJzmwHUsF93_Aesr5YO2RF9rQqlj9Y9VwKa40eE0mbotRPR6H_LNORwNg88OI16Ju-62nrOOYmouVMaw== (deflated 1%)
[module_test_ios] [STDOUT] stdout:   adding: result.xcresult/Data/refs.0~_dVsx1XdM9XBXAPdVgjjtbxNWduqa8xtQMh8RcijFK41rqDeOy47umnaCKltT7TDf8aoVguYIAjkUsjqqN3MSQ== (stored 0%)
.....
```
After this change it looks like:
https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8803175519294956977/+/u/run_module_test_ios/test_stdout
```
[module_test_ios] [STDOUT] Executing "zip -r -9 -q /opt/s/w/ir/x/w/recipe_cleanup/flutter_logs_dir/module_test_ios-objc-2022-09-12T19:32:31.728322.zip result.xcresult" in "/opt/s/w/ir/x/t/flutter_module_test_ios_xcresult.rbmbue" with environment {BOT: true, LANG: en_US.UTF-8}
```
