### PR TITLE
Startup `flutter` faster (use app-jit snapshot)

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -163,9 +163,9 @@ GOTO :after_subroutine
     POPD
 
     IF "%FLUTTER_TOOL_ARGS%" == "" (
-      "%dart%" --verbosity=error --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%"
+      "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL
     ) else (
-      "%dart%" "%FLUTTER_TOOL_ARGS%" --verbosity=error --snapshot="%snapshot_path%" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%"
+      "%dart%" "%FLUTTER_TOOL_ARGS%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" "%script_path%" > NUL
     )
     IF "%ERRORLEVEL%" NEQ "0" (
       ECHO Error: Unable to create dart snapshot for flutter tool. 1>&2

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -155,7 +155,7 @@ function upgrade_flutter () (
     pub_upgrade_with_retry
 
     # Compile...
-    "$DART" --verbosity=error --disable-dart-dev $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH"
+    "$DART" --verbosity=error --disable-dart-dev $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" > /dev/null
     echo "$compilekey" > "$STAMP_PATH"
   fi
   # The exit here is extraneous since the function is run in a subshell, but


### PR DESCRIPTION
This PR makes `flutter` (as measured with `flutter test` directly in the `flutter` directory which has no `test` directory, thus just writing "there's no `test` directory) startup faster by caching `git` calls.

Currently when running `flutter` for the first time or after being on a new git hash, it is compiled to a kernel/dill file. Subsequent calls then just run this compiled file, and thus avoids having to compile `flutter_tools` again and again. This is good.
We also have the option to compile to to an `app-jit` snapshot though, which is better in the sense that it loads faster.

This PR does exactly that.
Note that this stacks with #111392.

The startup changes as measured on my machines is this:

**Linux**

| Before | This PR alone | This PR stacked with #111392 |
| --- | --- | --- |
| 0.583 | 0.307 | 0.158 |
| 0.583 | 0.287 | 0.16 |
| 0.574 | 0.296 | 0.171 |
| 0.593 | 0.308 | 0.164 |
| 0.589 | 0.297 | 0.177 |
| 0.618 | 0.305 | 0.164 |
| 0.579 | 0.301 | 0.164 |
| 0.59 | 0.295 | 0.167 |
| 0.604 | 0.301 | 0.16 |
| 0.572 | 0.295 | 0.161 |

I.e. this PR alone:

```
Difference at 95.0% confidence
        -0.2893 +/- 0.0102548
        -49.1589% +/- 1.74253%
        (Student's t, pooled s = 0.0109141)
```

And stacked with #111392:

```
Difference at 95.0% confidence
        -0.4239 +/- 0.0100685
        -72.0306% +/- 1.71087%
        (Student's t, pooled s = 0.0107158)
```

**Windows** (Google issued with whatever security software)

| Before | This PR alone | This PR stacked with #111392 |
| --- | --- | --- |
| 3.2045302 | 2.7633213 | 1.7806395 |
| 3.2686755 | 2.7909508 | 1.8164078 |
| 3.2457845 | 2.7613864 | 1.7898207 |
| 3.1958543 | 2.8141012 | 1.8039282 |
| 3.1954143 | 2.7816646 | 1.7866668 |
| 3.2369129 | 2.7448754 | 1.8005397 |
| 3.2849415 | 2.7315453 | 1.8290792 |
| 3.2987666 | 2.7639699 | 1.7882604 |
| 3.2835086 | 2.7211788 | 1.8032152 |
| 3.2308832 | 2.7489684 | 1.8420157 |


I.e. this PR alone:

```
Difference at 95.0% confidence
        -0.482331 +/- 0.0315589
        -14.866% +/- 0.972681%
        (Student's t, pooled s = 0.0335877)
```

And stacked with #111392:

```
Difference at 95.0% confidence
        -1.44047 +/- 0.0287394
        -44.3969% +/- 0.885781%
        (Student's t, pooled s = 0.030587)
```

The cost is the compilation taking ~7% longer (less than a second longer).
This seems like a good trade-off to me.

We can technically make it load even faster by using an aot-snapshot, but then the compilation time will increase from something like 10 seconds to something like 30 seconds, and I'm not sure that's a good trade-off.

A more detailed analysis is available internally at go/FlutterStartupTimeAnalysis (which also discussed future PRs).