### PR TITLE
Startup `flutter` faster (Only access globals.deviceManager if actually setting something)

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -256,7 +256,10 @@ class FlutterCommandRunner extends CommandRunner<void> {
         }
 
         // See if the user specified a specific device.
-        globals.deviceManager?.specifiedDeviceId = topLevelResults['device-id'] as String?;
+        final String? specifiedDeviceId = topLevelResults['device-id'] as String?;
+        if (specifiedDeviceId != null) {
+          globals.deviceManager?.specifiedDeviceId = specifiedDeviceId;
+        }
 
         if ((topLevelResults['version'] as bool?) ?? false) {
           globals.flutterUsage.sendCommand('version');


### PR DESCRIPTION
This PR makes `flutter` (as measured with `flutter test` directly in the `flutter` directory which has no `test` directory, thus just writing "there's no `test` directory) startup faster by caching `git` calls.

When starting `flutter` currently the user-specified "device id" is unconditionally set on the device manager.
There is nothing technically wrong with that, but when a device id has not been provided by the user, and we don't otherwise need the device manager it is created for no reason.
This wouldn't be too bad, if it wasn't because it could take quite a while to do so, but it can (because it eagerly searches for the android sdk).

This PR makes it conditional on the user having actually specified a device id.
A future PR could make the android sdk search lazy instead.

On my Linux machine - which does have an android sdk - this doesn't change much --- it removes something along the lines of 3-5 ms, but on my Windows machine - which does not have an android sdk - the change is quite significant, see below.

This PR stacks with #111392 and #111459.

**Windows** (Google issued with whatever security software --- and no android sdk)

| Before | This PR alone | This PR stacked with #111392 and #111459 |
| --- | --- | --- |
| 3.3373447 | 2.8303869 | 1.2849433 |
| 3.3226704 | 2.7771196 | 1.2759344 |
| 3.3039702 | 2.7602999 | 1.2668016 |
| 3.2984141 | 2.7172332 | 1.2741733 |
| 3.3244981 | 2.8190871 | 1.2679842 |
| 3.2896061 | 2.7742435 | 1.2899466 |
| 3.3063319 | 2.8068465 | 1.2569228 |
| 3.2715855 | 2.7997578 | 1.287999 |
| 3.3431836 | 2.7171742 | 1.2548849 |
| 3.2870784 | 2.7108063 | 1.2840665 |

I.e. this PR alone:

```
Difference at 95.0% confidence
        -0.537173 +/- 0.0330875
        -16.2363% +/- 1.00009%
        (Student's t, pooled s = 0.0352147)
```

And stacked with #111392 and #111459:

```
Difference at 95.0% confidence
        -2.0341 +/- 0.0174607
        -61.4817% +/- 0.527756%
        (Student's t, pooled s = 0.0185832)
```

A more detailed analysis is available internally at go/FlutterStartupTimeAnalysis (which also discussed future PRs).