### PR TITLE
Startup flutter faster (faster wrapper script on Windows)

### DIFF
--- a/bin/flutter.bat
+++ b/bin/flutter.bat
@@ -22,8 +22,7 @@ REM If available, add location of bundled mingit to PATH
 SET mingit_path=%FLUTTER_ROOT%\bin\mingit\cmd
 IF EXIST "%mingit_path%" SET PATH=%PATH%;%mingit_path%
 
-REM Test if Git is available on the Host
-where /q git || ECHO Error: Unable to find git in your PATH. && EXIT /B 1
+REM We test if Git is available on the Host as we run git in shared.bat
 REM  Test if the flutter directory is a git clone, otherwise git rev-parse HEAD would fail
 IF NOT EXIST "%flutter_root%\.git" (
   ECHO Error: The Flutter directory is not a clone of the GitHub project.


### PR DESCRIPTION
This PR makes `flutter` (as measured with `flutter test` directly in the `flutter` directory which has no `test` directory, thus just writing "there's no `test` directory) startup faster by improving the Windows wrapper script.

When executing `flutter` in Windows, really it's the bat script `flutter.bat` that's executed.
This makes sure the user has git installed, there's a git checkout etc.
Specifically it does these things which it doesn't really need to:

* It checks that `git` is installed and runs a `git` command. These can be merged because a `git` command will fail if there is no git.
* It finds powershell even if not used --- and it's only used if updating flutter. This can be postponed until needed.

This PR does exactly that, improving startup time quite significant, see below.

This PR stacks with #111392, #111459 and #111461.

**Windows** (Google issued with whatever security software)

| Before | This PR alone | This PR stacked with #111392 and #111459 and #111461 |
| --- | --- | --- |
| 3.2412228 | 2.5419131 | 0.5639745 |
| 3.227448 | 2.5378603 | 0.5685186 |
| 3.2171123 | 2.5162029 | 0.5723001 |
| 3.2685162 | 2.4710732 | 0.5772019 |
| 3.2795393 | 2.4941931 | 0.5611621 |
| 3.2631289 | 2.4916417 | 0.562229 |
| 3.2584517 | 2.5167137 | 0.5630581 |
| 3.3043421 | 2.5189702 | 0.5841847 |
| 3.2826378 | 2.4690379 | 0.5808589 |
| 3.3444306 | 2.4868829 | 0.5743246 |

I.e. this PR alone:

```
Difference at 95.0% confidence
        -0.764234 +/- 0.030152
        -23.3805% +/- 0.922452%
        (Student's t, pooled s = 0.0320904)
```

And stacked with #111392, #111459 and #111461:

```
Difference at 95.0% confidence
        -2.6979 +/- 0.0254303
        -82.5379% +/- 0.777999%
        (Student's t, pooled s = 0.0270652)
```

A more detailed analysis is available internally at go/FlutterStartupTimeAnalysis.