### PR TITLE
Reland "Migrate android_semantics_testing to null safety (#111420)"

### DIFF
--- a/dev/integration_tests/android_semantics_testing/lib/main.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/main.dart
@@ -23,11 +23,11 @@ void main() {
 
 const MethodChannel kSemanticsChannel = MethodChannel('semantics');
 
-Future<String> dataHandler(String message) async {
-  if (message.contains('getSemanticsNode')) {
+Future<String> dataHandler(String? message) async {
+  if (message != null && message.contains('getSemanticsNode')) {
     final Completer<String> completer = Completer<String>();
     final int id = int.tryParse(message.split('#')[1]) ?? 0;
-    Future<void> completeSemantics([Object _]) async {
+    Future<void> completeSemantics([Object? _]) async {
       final dynamic result = await kSemanticsChannel.invokeMethod<dynamic>('getSemanticsNode', <String, dynamic>{
         'id': id,
       });
@@ -40,10 +40,10 @@ Future<String> dataHandler(String message) async {
     }
     return completer.future;
   }
-  if (message.contains('setClipboard')) {
+  if (message != null && message.contains('setClipboard')) {
     final Completer<String> completer = Completer<String>();
     final String str = message.split('#')[1];
-    Future<void> completeSetClipboard([Object _]) async {
+    Future<void> completeSetClipboard([Object? _]) async {
       await kSemanticsChannel.invokeMethod<dynamic>('setClipboard', <String, dynamic>{
         'message': str,
       });
@@ -67,7 +67,7 @@ Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
 };
 
 class TestApp extends StatelessWidget {
-  const TestApp({Key key}) : super(key: key);
+  const TestApp({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/dev/integration_tests/android_semantics_testing/lib/src/common.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/common.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: avoid_dynamic_calls
+
 import 'dart:convert';
 
 import 'package:meta/meta.dart';
@@ -53,13 +55,13 @@ class AndroidSemanticsNode {
   ///       ]
   ///     }
   factory AndroidSemanticsNode.deserialize(String value) {
-    return AndroidSemanticsNode._(json.decode(value) as Map<String, Object>);
+    return AndroidSemanticsNode._(json.decode(value));
   }
 
-  final Map<String, Object> _values;
+  final dynamic _values;
   final List<AndroidSemanticsNode> _children = <AndroidSemanticsNode>[];
 
-  Map<String, Object> get _flags => _values['flags'] as Map<String, Object>;
+  dynamic get _flags => _values['flags'];
 
   /// The text value of the semantics node.
   ///
@@ -132,13 +134,12 @@ class AndroidSemanticsNode {
 
   /// Gets a [Rect] which defines the position and size of the semantics node.
   Rect getRect() {
-    final Map<String, Object> rawRect = _values['rect'] as Map<String, Object>;
-    final Map<String, int> rect = rawRect.cast<String, int>();
+    final dynamic rawRect = _values['rect'];
     return Rect.fromLTRB(
-      rect['left'].toDouble(),
-      rect['top'].toDouble(),
-      rect['right'].toDouble(),
-      rect['bottom'].toDouble(),
+      (rawRect['left']! as int).toDouble(),
+      (rawRect['top']! as int).toDouble(),
+      (rawRect['right']! as int).toDouble(),
+      (rawRect['bottom']! as int).toDouble(),
     );
   }
 
@@ -150,7 +151,7 @@ class AndroidSemanticsNode {
 
   /// Gets a list of [AndroidSemanticsActions] which are defined for the node.
   List<AndroidSemanticsAction> getActions() => <AndroidSemanticsAction>[
-    for (final int id in (_values['actions'] as List<dynamic>).cast<int>()) AndroidSemanticsAction.deserialize(id),
+    for (final int id in (_values['actions']! as List<dynamic>).cast<int>()) AndroidSemanticsAction.deserialize(id)!,
   ];
 
   @override

--- a/dev/integration_tests/android_semantics_testing/lib/src/common.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/common.dart
@@ -67,7 +67,7 @@ class AndroidSemanticsNode {
   ///
   /// This is produced by combining the value, label, and hint fields from
   /// the Flutter [SemanticsNode].
-  String get text => _values['text'] as String;
+  String? get text => _values['text'] as String?;
 
   /// The contentDescription of the semantics node.
   ///
@@ -77,7 +77,7 @@ class AndroidSemanticsNode {
   ///
   /// This is produced by combining the value, label, and hint fields from
   /// the Flutter [SemanticsNode].
-  String get contentDescription => _values['contentDescription'] as String;
+  String? get contentDescription => _values['contentDescription'] as String?;
 
   /// The className of the semantics node.
   ///
@@ -86,10 +86,10 @@ class AndroidSemanticsNode {
   ///
   /// If a more specific value isn't provided, it defaults to
   /// "android.view.View".
-  String get className => _values['className'] as String;
+  String? get className => _values['className'] as String?;
 
   /// The identifier for this semantics node.
-  int get id => _values['id'] as int;
+  int? get id => _values['id'] as int?;
 
   /// The children of this semantics node.
   List<AndroidSemanticsNode> get children => _children;
@@ -97,44 +97,47 @@ class AndroidSemanticsNode {
   /// Whether the node is currently in a checked state.
   ///
   /// Equivalent to [SemanticsFlag.isChecked].
-  bool get isChecked => _flags['isChecked'] as bool;
+  bool? get isChecked => _flags['isChecked'] as bool?;
 
   /// Whether the node can be in a checked state.
   ///
   /// Equivalent to [SemanticsFlag.hasCheckedState]
-  bool get isCheckable => _flags['isCheckable'] as bool;
+  bool? get isCheckable => _flags['isCheckable'] as bool?;
 
   /// Whether the node is editable.
   ///
   /// This is usually only applied to text fields, which map
   /// to "android.widget.EditText".
-  bool get isEditable => _flags['isEditable'] as bool;
+  bool? get isEditable => _flags['isEditable'] as bool?;
 
   /// Whether the node is enabled.
-  bool get isEnabled => _flags['isEnabled'] as bool;
+  bool? get isEnabled => _flags['isEnabled'] as bool?;
 
   /// Whether the node is focusable.
-  bool get isFocusable => _flags['isFocusable'] as bool;
+  bool? get isFocusable => _flags['isFocusable'] as bool?;
 
   /// Whether the node is focused.
-  bool get isFocused => _flags['isFocused'] as bool;
+  bool? get isFocused => _flags['isFocused'] as bool?;
 
   /// Whether the node is considered a heading.
-  bool get isHeading => _flags['isHeading'] as bool;
+  bool? get isHeading => _flags['isHeading'] as bool?;
 
   /// Whether the node represents a password field.
   ///
   /// Equivalent to [SemanticsFlag.isObscured].
-  bool get isPassword => _flags['isPassword'] as bool;
+  bool? get isPassword => _flags['isPassword'] as bool?;
 
   /// Whether the node is long clickable.
   ///
   /// Equivalent to having [SemanticsAction.longPress].
-  bool get isLongClickable => _flags['isLongClickable'] as bool;
+  bool? get isLongClickable => _flags['isLongClickable'] as bool?;
 
   /// Gets a [Rect] which defines the position and size of the semantics node.
   Rect getRect() {
     final dynamic rawRect = _values['rect'];
+    if (rawRect == null) {
+      return const Rect.fromLTRB(0.0, 0.0, 0.0, 0.0);
+    }
     return Rect.fromLTRB(
       (rawRect['left']! as int).toDouble(),
       (rawRect['top']! as int).toDouble(),
@@ -150,9 +153,20 @@ class AndroidSemanticsNode {
   }
 
   /// Gets a list of [AndroidSemanticsActions] which are defined for the node.
-  List<AndroidSemanticsAction> getActions() => <AndroidSemanticsAction>[
-    for (final int id in (_values['actions']! as List<dynamic>).cast<int>()) AndroidSemanticsAction.deserialize(id)!,
-  ];
+  List<AndroidSemanticsAction> getActions() {
+    final List<int>? actions = (_values['actions'] as List<dynamic>?)?.cast<int>();
+    if (actions == null) {
+      return const <AndroidSemanticsAction>[];
+    }
+    final List<AndroidSemanticsAction> convertedActions = <AndroidSemanticsAction>[];
+    for (final int id in actions) {
+      final AndroidSemanticsAction? action = AndroidSemanticsAction.deserialize(id);
+      if (action != null) {
+        convertedActions.add(action);
+      }
+    }
+    return convertedActions;
+  }
 
   @override
   String toString() {

--- a/dev/integration_tests/android_semantics_testing/lib/src/constants.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/constants.dart
@@ -168,7 +168,7 @@ class AndroidSemanticsAction {
       case _kSetText:
         return 'AndroidSemanticsAction.setText';
       default:
-        return null;
+        throw UnimplementedError();
     }
   }
 
@@ -211,7 +211,7 @@ class AndroidSemanticsAction {
   /// Creates a new [AndroidSemanticsAction] from an integer `value`.
   ///
   /// Returns `null` if the id is not a known Android accessibility action.
-  static AndroidSemanticsAction deserialize(int value) {
+  static AndroidSemanticsAction? deserialize(int value) {
     return _kActionById[value];
   }
 }

--- a/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
@@ -18,24 +18,24 @@ import 'constants.dart';
 /// the Android accessibility bridge, and not the semantics object created by
 /// the Flutter framework.
 Matcher hasAndroidSemantics({
-  String text,
-  String contentDescription,
-  String className,
-  int id,
-  Rect rect,
-  Size size,
-  List<AndroidSemanticsAction> actions,
-  List<AndroidSemanticsAction> ignoredActions,
-  List<AndroidSemanticsNode> children,
-  bool isChecked,
-  bool isCheckable,
-  bool isEditable,
-  bool isEnabled,
-  bool isFocusable,
-  bool isFocused,
-  bool isHeading,
-  bool isPassword,
-  bool isLongClickable,
+  String? text,
+  String? contentDescription,
+  String? className,
+  int? id,
+  Rect? rect,
+  Size? size,
+  List<AndroidSemanticsAction>? actions,
+  List<AndroidSemanticsAction>? ignoredActions,
+  List<AndroidSemanticsNode>? children,
+  bool? isChecked,
+  bool? isCheckable,
+  bool? isEditable,
+  bool? isEnabled,
+  bool? isFocusable,
+  bool? isFocused,
+  bool? isHeading,
+  bool? isPassword,
+  bool? isLongClickable,
 }) {
   return _AndroidSemanticsMatcher(
     text: text,
@@ -79,23 +79,23 @@ class _AndroidSemanticsMatcher extends Matcher {
     this.isLongClickable,
   });
 
-  final String text;
-  final String className;
-  final String contentDescription;
-  final int id;
-  final List<AndroidSemanticsAction> actions;
-  final List<AndroidSemanticsAction> ignoredActions;
-  final Rect rect;
-  final Size size;
-  final bool isChecked;
-  final bool isCheckable;
-  final bool isEditable;
-  final bool isEnabled;
-  final bool isFocusable;
-  final bool isFocused;
-  final bool isHeading;
-  final bool isPassword;
-  final bool isLongClickable;
+  final String? text;
+  final String? className;
+  final String? contentDescription;
+  final int? id;
+  final List<AndroidSemanticsAction>? actions;
+  final List<AndroidSemanticsAction>? ignoredActions;
+  final Rect? rect;
+  final Size? size;
+  final bool? isChecked;
+  final bool? isCheckable;
+  final bool? isEditable;
+  final bool? isEnabled;
+  final bool? isFocusable;
+  final bool? isFocused;
+  final bool? isHeading;
+  final bool? isPassword;
+  final bool? isLongClickable;
 
   @override
   Description describe(Description description) {
@@ -149,7 +149,7 @@ class _AndroidSemanticsMatcher extends Matcher {
   }
 
   @override
-  bool matches(covariant AndroidSemanticsNode item, Map<Object, Object> matchState) {
+  bool matches(covariant AndroidSemanticsNode item, Map<dynamic, dynamic> matchState) {
     if (text != null && text != item.text) {
       return _failWithMessage('Expected text: $text', matchState);
     }
@@ -170,13 +170,13 @@ class _AndroidSemanticsMatcher extends Matcher {
     }
     if (actions != null) {
       final List<AndroidSemanticsAction> itemActions = item.getActions();
-      if (!unorderedEquals(actions).matches(itemActions, matchState)) {
-        final List<String> actionsString = actions.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
+      if (!unorderedEquals(actions!).matches(itemActions, matchState)) {
+        final List<String> actionsString = actions!.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
         final List<String> itemActionsString = itemActions.map<String>((AndroidSemanticsAction action) => action.toString()).toList()..sort();
-        final Set<AndroidSemanticsAction> unexpected = itemActions.toSet().difference(actions.toSet());
+        final Set<AndroidSemanticsAction> unexpected = itemActions.toSet().difference(actions!.toSet());
         final Set<String> unexpectedInString = itemActionsString.toSet().difference(actionsString.toSet());
         final Set<String> missingInString = actionsString.toSet().difference(itemActionsString.toSet());
-        if (missingInString.isEmpty && ignoredActions != null && unexpected.every(ignoredActions.contains)) {
+        if (missingInString.isEmpty && ignoredActions != null && unexpected.every(ignoredActions!.contains)) {
           return true;
         }
         return _failWithMessage('Expected actions: $actionsString\nActual actions: $itemActionsString\nUnexpected: $unexpectedInString\nMissing: $missingInString', matchState);
@@ -214,8 +214,8 @@ class _AndroidSemanticsMatcher extends Matcher {
   }
 
   @override
-  Description describeMismatch(Object item, Description mismatchDescription,
-      Map<Object, Object> matchState, bool verbose) {
+  Description describeMismatch(dynamic item, Description mismatchDescription,
+      Map<dynamic, dynamic> matchState, bool verbose) {
     return mismatchDescription.add(matchState['failure'] as String);
   }
 

--- a/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/matcher.dart
@@ -216,7 +216,11 @@ class _AndroidSemanticsMatcher extends Matcher {
   @override
   Description describeMismatch(dynamic item, Description mismatchDescription,
       Map<dynamic, dynamic> matchState, bool verbose) {
-    return mismatchDescription.add(matchState['failure'] as String);
+    final String? failure = matchState['failure'] as String?;
+    if (failure == null) {
+      return mismatchDescription.add('hasAndroidSemantics matcher does not complete successfully');
+    }
+    return mismatchDescription.add(failure);
   }
 
   bool _failWithMessage(String value, Map<dynamic, dynamic> matchState) {

--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/controls_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/controls_page.dart
@@ -9,7 +9,7 @@ export 'controls_constants.dart';
 
 /// A test page with a checkbox, three radio buttons, and a switch.
 class SelectionControlsPage extends StatefulWidget {
-  const SelectionControlsPage({Key key}) : super(key: key);
+  const SelectionControlsPage({super.key});
 
   @override
   State<StatefulWidget> createState() => _SelectionControlsPageState();
@@ -28,15 +28,15 @@ class _SelectionControlsPageState extends State<SelectionControlsPage> {
   bool _isLabeledOn = false;
   int _radio = 0;
 
-  void _updateCheckbox(bool newValue) {
+  void _updateCheckbox(bool? newValue) {
     setState(() {
-      _isChecked = newValue;
+      _isChecked = newValue!;
     });
   }
 
-  void _updateRadio(int newValue) {
+  void _updateRadio(int? newValue) {
     setState(() {
-      _radio = newValue;
+      _radio = newValue!;
     });
   }
 

--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/headings_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/headings_page.dart
@@ -9,7 +9,7 @@ export 'headings_constants.dart';
 
 /// A test page with an app bar and some body text for testing heading flags.
 class HeadingsPage extends StatelessWidget {
-  const HeadingsPage({Key key}) : super(key: key);
+  const HeadingsPage({super.key});
 
   static const ValueKey<String> _appBarTitleKey = ValueKey<String>(appBarTitleKeyValue);
   static const ValueKey<String> _bodyTextKey = ValueKey<String>(bodyTextKeyValue);

--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
@@ -10,7 +10,7 @@ export 'popup_constants.dart';
 
 /// A page with a popup menu, a dropdown menu, and a modal alert.
 class PopupControlsPage extends StatefulWidget {
-  const PopupControlsPage({Key key}) : super(key: key);
+  const PopupControlsPage({super.key});
 
   @override
   State<StatefulWidget> createState() => _PopupControlsPageState();
@@ -60,9 +60,9 @@ class _PopupControlsPageState extends State<PopupControlsPage> {
                     child: Text(item),
                   );
                 }).toList(),
-                onChanged: (String value) {
+                onChanged: (String? value) {
                   setState(() {
-                    dropdownValue = value;
+                    dropdownValue = value!;
                   });
                 },
               ),

--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/text_field_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/text_field_page.dart
@@ -10,7 +10,7 @@ export 'text_field_constants.dart';
 
 /// A page with a normal text field and a password field.
 class TextFieldPage extends StatefulWidget {
-  const TextFieldPage({Key key}) : super(key: key);
+  const TextFieldPage({super.key});
 
   @override
   State<StatefulWidget> createState() => _TextFieldPageState();

--- a/dev/integration_tests/android_semantics_testing/pubspec.yaml
+++ b/dev/integration_tests/android_semantics_testing/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_semantics_testing
 description: Integration testing library for Android semantics
 environment:
-  sdk: '>=2.9.0 <3.0.0'
+  sdk: '>=2.17.0-0 <3.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -20,7 +20,7 @@ const List<AndroidSemanticsAction> ignoredAccessibilityFocusActions = <AndroidSe
 ];
 
 String adbPath() {
-  final String androidHome = io.Platform.environment['ANDROID_HOME'] ?? io.Platform.environment['ANDROID_SDK_ROOT'];
+  final String androidHome = io.Platform.environment['ANDROID_HOME'] ?? io.Platform.environment['ANDROID_SDK_ROOT']!;
   if (androidHome == null) {
     return 'adb';
   } else {
@@ -30,7 +30,7 @@ String adbPath() {
 
 void main() {
   group('AccessibilityBridge', () {
-    FlutterDriver driver;
+    late FlutterDriver driver;
     Future<AndroidSemanticsNode> getSemantics(SerializableFinder finder) async {
       final int id = await driver.getSemanticsId(finder);
       final String data = await driver.requestData('getSemanticsNode#$id');
@@ -38,7 +38,7 @@ void main() {
     }
 
     // The version of TalkBack running on the device.
-    Version talkbackVersion;
+    Version? talkbackVersion;
 
     Future<Version> getTalkbackVersion() async {
       final io.ProcessResult result = await io.Process.run(adbPath(), const <String>[
@@ -51,7 +51,7 @@ void main() {
         throw Exception('Failed to get TalkBack version: ${result.stdout as String}\n${result.stderr as String}');
       }
       final List<String> lines = (result.stdout as String).split('\n');
-      String version;
+      String? version;
       for (final String line in lines) {
         if (line.contains('versionName')) {
           version = line.replaceAll(RegExp(r'\s*versionName='), '');
@@ -64,14 +64,14 @@ void main() {
 
       // Android doesn't quite use semver, so convert the version string to semver form.
       final RegExp startVersion = RegExp(r'(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(\.(?<build>\d+))?');
-      final RegExpMatch match = startVersion.firstMatch(version);
+      final RegExpMatch? match = startVersion.firstMatch(version);
       if (match == null) {
         return Version(0, 0, 0);
       }
       return Version(
-        int.parse(match.namedGroup('major')),
-        int.parse(match.namedGroup('minor')),
-        int.parse(match.namedGroup('patch')),
+        int.parse(match.namedGroup('major')!),
+        int.parse(match.namedGroup('minor')!),
+        int.parse(match.namedGroup('patch')!),
         build: match.namedGroup('build'),
       );
     }
@@ -104,7 +104,7 @@ void main() {
         'null',
       ]);
       await run.exitCode;
-      driver?.close();
+      driver.close();
     });
 
     group('TextField', () {


### PR DESCRIPTION
The error message seems to indicate there is exception thrown when running the matcher. The error message gets swallowed because the describeMismatch assumes the matchState always contains the failure message, which may not be the case if the match does no finish successfully.

This pr add two things:
1. makes describeMismatch more robust to handle cases there matcher doesn't complete successfully.
2. make AndroidSemanticsNode to expect nullable fields which may be the reason matcher crashes.

The AndroidSemanticsNode.isHeader is only available above certain Android version, and it is likely the motog4 in devices lab is below the android version, which may be the reason the matcher crash in the first place.

The changes are in the second commit.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
