### PR TITLE
Link `debugVisitOnstageChildren` in `Offstage`

### DIFF
--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3218,6 +3218,7 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///    subtly).
 ///  * [TickerMode], which can be used to disable animations in a subtree.
 ///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
+///  * [debugVisitOnstageChildren], for non-offstage children discoverability.
 class Offstage extends SingleChildRenderObjectWidget {
   /// Creates a widget that visually hides its child.
   const Offstage({ super.key, this.offstage = true, super.child })

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -3218,7 +3218,8 @@ class SizedOverflowBox extends SingleChildRenderObjectWidget {
 ///    subtly).
 ///  * [TickerMode], which can be used to disable animations in a subtree.
 ///  * The [catalog of layout widgets](https://flutter.dev/widgets/layout/).
-///  * [debugVisitOnstageChildren], for non-offstage children discoverability.
+///  * [Element.debugVisitOnstageChildren], for non-offstage children
+///    discoverability.
 class Offstage extends SingleChildRenderObjectWidget {
   /// Creates a widget that visually hides its child.
   const Offstage({ super.key, this.offstage = true, super.child })


### PR DESCRIPTION
The Offstage has strong relationship with debugVisitOnstageChildren: When using Offstage widget, the widget subtree of debugVisitOnstageChildren is changed, and widget testers will not find an offstage widget. In addition, when we are talking about the word "offstage", we may need to refer to both pages, because they have slightly different meanings.

This origins partially from https://github.com/flutter/flutter/pull/111479#issuecomment-1245534877. Indeed, when talking about "offstage widgets", I quickly remembered and opened Offstage page, but never realize there is another page about debugVisitOnstageChildren, which even has a bit different explanation from Offstage. This PR fixes this problem.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
