### PR TITLE
Actually add example templates

### DIFF
--- a/examples/api/lib/sample_templates/cupertino.0.dart
+++ b/examples/api/lib/sample_templates/cupertino.0.dart
@@ -18,12 +18,12 @@
 //
 //   examples/api/lib/cupertino/baz/foo_bar.2.dart
 //
-// and it's associated test should be in:
+// and its associated test should be in:
 //
 //   examples/api/test/cupertino/baz/foo_bar.2_test.dart
 //
 // The following doc comment should remain, and be a doc comment so that the
-// symbol will be linked in the IDE. Don't put the whole description of the
+// symbol will be linked in the IDE. Don't use the whole description of the
 // example, since that should already be in the API docs where this example is
 // referenced, and we don't want the two descriptions to diverge. If this sample
 // is referenced more than once, link back to the instance the example file is
@@ -33,7 +33,9 @@
 
 import 'package:flutter/cupertino.dart';
 
-void main() => runApp(const SampleApp());
+void main() {
+  runApp(const SampleApp());
+}
 
 class SampleApp extends StatelessWidget {
   const SampleApp({super.key});

--- a/examples/api/lib/sample_templates/cupertino.0.dart
+++ b/examples/api/lib/sample_templates/cupertino.0.dart
@@ -1,0 +1,63 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This is a template file for illustrating best practices when creating a
+// Flutter API example that uses the Cupertino library. To use it, copy the file
+// to your destination filename, search/replace 'Placeholder' with the name of
+// the class this is an example for, delete this block, and implement your
+// example.
+//
+// The name and location of this file should be:
+//
+//   examples/api/lib/<library>/<filename_without_dart>/<lower_snake_symbol>.<index>.dart
+//
+// So, if your example is the third example of the Foo.bar function in the
+// "baz.dart" file in the cupertino library, then the filename for your example
+// should be:
+//
+//   examples/api/lib/cupertino/baz/foo_bar.2.dart
+//
+// and it's associated test should be in:
+//
+//   examples/api/test/cupertino/baz/foo_bar.2_test.dart
+//
+// The following doc comment should remain, and be a doc comment so that the
+// symbol will be linked in the IDE. Don't put the whole description of the
+// example, since that should already be in the API docs where this example is
+// referenced, and we don't want the two descriptions to diverge. If this sample
+// is referenced more than once, link back to the instance the example file is
+// named for.
+
+/// Flutter code sample for [Placeholder].
+
+import 'package:flutter/cupertino.dart';
+
+void main() => runApp(const SampleApp());
+
+class SampleApp extends StatelessWidget {
+  const SampleApp({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return const CupertinoApp(
+      home: PlaceholderExample(),
+    );
+  }
+}
+
+/// Include comments about each class, and make them dartdoc comments, so that
+/// links (e.g. [Placeholder]) are active in IDEs.
+class PlaceholderExample extends StatelessWidget {
+  const PlaceholderExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Since this is an example, add plenty of comments, explaining things that
+    // both a newcomer and an experienced user might want to know.
+    //
+    // TRY THIS: Prefix things with "TRY THIS" in places in the example that
+    // might be interesting to modify when exploring what the widget/function
+    // does.
+    return const Placeholder();
+  }
+}

--- a/examples/api/lib/sample_templates/material.0.dart
+++ b/examples/api/lib/sample_templates/material.0.dart
@@ -18,12 +18,12 @@
 //
 //   examples/api/lib/material/baz/foo_bar.2.dart
 //
-// and it's associated test should be in:
+// and its associated test should be in:
 //
 //   examples/api/test/material/baz/foo_bar.2_test.dart
 //
 // The following doc comment should remain, and be a doc comment so that the
-// symbol will be linked in the IDE. Don't put the whole description of the
+// symbol will be linked in the IDE. Don't use the whole description of the
 // example, since that should already be in the API docs where this example is
 // referenced, and we don't want the two descriptions to diverge. If this sample
 // is referenced more than once, link back to the instance the example file is
@@ -33,7 +33,9 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const SampleApp());
+void main() {
+  runApp(const SampleApp());
+}
 
 class SampleApp extends StatelessWidget {
   const SampleApp({super.key});

--- a/examples/api/lib/sample_templates/material.0.dart
+++ b/examples/api/lib/sample_templates/material.0.dart
@@ -1,0 +1,65 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This is a template file for illustrating best practices when creating a
+// Flutter API example that uses the Material library. To use it, copy the file
+// to your destination filename, search/replace 'Placeholder' with the name of
+// the class this is an example for, delete this block, and implement your
+// example.
+//
+// The name and location of this file should be:
+//
+//   examples/api/lib/<library>/<filename_without_dart>/<lower_snake_symbol>.<index>.dart
+//
+// So, if your example is the third example of the Foo.bar function in the
+// "baz.dart" file in the material library, then the filename for your example
+// should be:
+//
+//   examples/api/lib/material/baz/foo_bar.2.dart
+//
+// and it's associated test should be in:
+//
+//   examples/api/test/material/baz/foo_bar.2_test.dart
+//
+// The following doc comment should remain, and be a doc comment so that the
+// symbol will be linked in the IDE. Don't put the whole description of the
+// example, since that should already be in the API docs where this example is
+// referenced, and we don't want the two descriptions to diverge. If this sample
+// is referenced more than once, link back to the instance the example file is
+// named for.
+
+/// Flutter code sample for [Placeholder].
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const SampleApp());
+
+class SampleApp extends StatelessWidget {
+  const SampleApp({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: PlaceholderExample(),
+      ),
+    );
+  }
+}
+
+/// Include comments about each class, and make them dartdoc comments, so that
+/// links (e.g. [Placeholder]) are active in IDEs.
+class PlaceholderExample extends StatelessWidget {
+  const PlaceholderExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Since this is an example, add plenty of comments, explaining things that
+    // both a newcomer and an experienced user might want to know.
+    //
+    // TRY THIS: Prefix things with "TRY THIS" in places in the example that
+    // might be interesting to modify when exploring what the widget/function
+    // does.
+    return const Placeholder();
+  }
+}

--- a/examples/api/lib/sample_templates/widgets.0.dart
+++ b/examples/api/lib/sample_templates/widgets.0.dart
@@ -18,12 +18,12 @@
 //
 //   examples/api/lib/widgets/baz/foo_bar.2.dart
 //
-// and it's (required) associated test should be in:
+// and its (required) associated test should be in:
 //
 //   examples/api/test/widgets/baz/foo_bar.2_test.dart
 //
 // The following doc comment should remain, and be a doc comment so that the
-// symbol will be linked in the IDE. Don't put the whole description of the
+// symbol will be linked in the IDE. Don't use the whole description of the
 // example, since that should already be in the API docs where this example is
 // referenced, and we don't want the two descriptions to diverge. If this sample
 // is referenced more than once, link back to the instance the example file is
@@ -33,7 +33,9 @@
 
 import 'package:flutter/widgets.dart';
 
-void main() => runApp(const SampleApp());
+void main() {
+  runApp(const SampleApp());
+}
 
 class SampleApp extends StatelessWidget {
   const SampleApp({super.key});

--- a/examples/api/lib/sample_templates/widgets.0.dart
+++ b/examples/api/lib/sample_templates/widgets.0.dart
@@ -1,0 +1,64 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This is a template file for illustrating best practices when creating a
+// Flutter API example that uses the Widgets library. To use it, copy the file
+// to your destination filename, search/replace 'Placeholder' with the name of
+// the class this is an example for, delete this block, and implement your
+// example.
+//
+// The name and location of this file should be:
+//
+//   examples/api/lib/<library>/<filename_without_dart>/<lower_snake_symbol>.<index>.dart
+//
+// So, if your example is the third example of the Foo.bar function in the
+// "baz.dart" file in the widgets library, then the filename for your example
+// should be:
+//
+//   examples/api/lib/widgets/baz/foo_bar.2.dart
+//
+// and it's (required) associated test should be in:
+//
+//   examples/api/test/widgets/baz/foo_bar.2_test.dart
+//
+// The following doc comment should remain, and be a doc comment so that the
+// symbol will be linked in the IDE. Don't put the whole description of the
+// example, since that should already be in the API docs where this example is
+// referenced, and we don't want the two descriptions to diverge. If this sample
+// is referenced more than once, link back to the instance the example file is
+// named for.
+
+/// Flutter code sample for [Placeholder].
+
+import 'package:flutter/widgets.dart';
+
+void main() => runApp(const SampleApp());
+
+class SampleApp extends StatelessWidget {
+  const SampleApp({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return WidgetsApp(
+      color: const Color(0xffffffff),
+      home: const PlaceholderExample(),
+    );
+  }
+}
+
+/// Include comments about each class, and make them dartdoc comments, so that
+/// links (e.g. [Placeholder]) are active in IDEs.
+class PlaceholderExample extends StatelessWidget {
+  const PlaceholderExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Since this is an example, add plenty of comments, explaining things that
+    // both a newcomer and an experienced user might want to know.
+    //
+    // TRY THIS: Prefix things with "TRY THIS" in places in the example that
+    // might be interesting to modify when exploring what the widget/function
+    // does.
+    return const Placeholder();
+  }
+}

--- a/examples/api/test/sample_templates/cupertino.0_test.dart
+++ b/examples/api/test/sample_templates/cupertino.0_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter_api_samples/sample_templates/cupertino.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+// This is an example of a test for API example code.
+//
+// It only tests that the example is presenting what it is supposed to, but you
+// should also test the basic functionality of the example to make sure that it
+// functions as expected.
+
+void main() {
+  testWidgets('Example app has a placeholder', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SampleApp(),
+    );
+
+    expect(find.byType(Placeholder), findsOneWidget);
+  });
+}

--- a/examples/api/test/sample_templates/material.0_test.dart
+++ b/examples/api/test/sample_templates/material.0_test.dart
@@ -1,0 +1,24 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/sample_templates/material.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+// This is an example of a test for API example code.
+//
+// It only tests that the example is presenting what it is supposed to, but you
+// should also test the basic functionality of the example to make sure that it
+// functions as expected.
+
+void main() {
+  testWidgets('Example app has a placeholder', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SampleApp(),
+    );
+
+    expect(find.byType(Scaffold), findsOneWidget);
+    expect(find.byType(Placeholder), findsOneWidget);
+  });
+}

--- a/examples/api/test/sample_templates/widgets.0_test.dart
+++ b/examples/api/test/sample_templates/widgets.0_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_api_samples/sample_templates/widgets.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+// This is an example of a test for API example code.
+//
+// It only tests that the example is presenting what it is supposed to, but you
+// should also test the basic functionality of the example to make sure that it
+// functions as expected.
+
+void main() {
+  testWidgets('Example app has a placeholder', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SampleApp(),
+    );
+
+    expect(find.byType(Placeholder), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Description

Whoops.  In https://github.com/flutter/flutter/pull/111276, I meant to include these templates for starting a sample.  The directory is linked from the README, but I forgot to add the files to the PR.

These are not meant to be linked from anywhere other than the README.md about creating samples.

## Related Issues
 - https://github.com/flutter/flutter/issues/96492

## Tests
 - added test templates too.