### PR TITLE
fix for upcoming use_build_context_synchronously changes

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/gallery/demo.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/demo.dart
@@ -41,7 +41,7 @@ class ComponentDemoTabData {
   int get hashCode => Object.hash(tabName, description, documentationUrl);
 }
 
-class TabbedComponentDemoScaffold extends StatelessWidget {
+class TabbedComponentDemoScaffold extends StatefulWidget {
   const TabbedComponentDemoScaffold({
     super.key,
     this.title,
@@ -57,8 +57,13 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
   final bool isScrollable;
   final bool showExampleCodeAction;
 
+  @override
+  State<TabbedComponentDemoScaffold> createState() => _TabbedComponentDemoScaffoldState();
+}
+
+class _TabbedComponentDemoScaffoldState extends State<TabbedComponentDemoScaffold> {
   void _showExampleCode(BuildContext context) {
-    final String? tag = demos![DefaultTabController.of(context)!.index].exampleCodeTag;
+    final String? tag = widget.demos![DefaultTabController.of(context)!.index].exampleCodeTag;
     if (tag != null) {
       Navigator.push(context, MaterialPageRoute<FullScreenCodeDialog>(
         builder: (BuildContext context) => FullScreenCodeDialog(exampleCodeTag: tag)
@@ -67,7 +72,7 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
   }
 
   Future<void> _showApiDocumentation(BuildContext context) async {
-    final String? url = demos![DefaultTabController.of(context)!.index].documentationUrl;
+    final String? url = widget.demos![DefaultTabController.of(context)!.index].documentationUrl;
     if (url == null) {
       return;
     }
@@ -75,7 +80,7 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
     final Uri uri = Uri.parse(url);
     if (await canLaunchUrl(uri)) {
       await launchUrl(uri);
-    } else {
+    } else if (mounted) {
       showDialog<void>(
         context: context,
         builder: (BuildContext context) {
@@ -96,12 +101,12 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DefaultTabController(
-      length: demos!.length,
+      length: widget.demos!.length,
       child: Scaffold(
         appBar: AppBar(
-          title: Text(title!),
+          title: Text(widget.title!),
           actions: <Widget>[
-            ...?actions,
+            ...?widget.actions,
             Builder(
               builder: (BuildContext context) {
                 return IconButton(
@@ -110,7 +115,7 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
                 );
               },
             ),
-            if (showExampleCodeAction)
+            if (widget.showExampleCodeAction)
               Builder(
                 builder: (BuildContext context) {
                   return IconButton(
@@ -122,12 +127,12 @@ class TabbedComponentDemoScaffold extends StatelessWidget {
               ),
           ],
           bottom: TabBar(
-            isScrollable: isScrollable,
-            tabs: demos!.map<Widget>((ComponentDemoTabData data) => Tab(text: data.tabName)).toList(),
+            isScrollable: widget.isScrollable,
+            tabs: widget.demos!.map<Widget>((ComponentDemoTabData data) => Tab(text: data.tabName)).toList(),
           ),
         ),
         body: TabBarView(
-          children: demos!.map<Widget>((ComponentDemoTabData demo) {
+          children: widget.demos!.map<Widget>((ComponentDemoTabData demo) {
             return SafeArea(
               top: false,
               bottom: false,

--- a/dev/integration_tests/flutter_gallery/lib/gallery/updater.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/updater.dart
@@ -35,9 +35,11 @@ class UpdaterState extends State<Updater> {
     _lastUpdateCheck = DateTime.now();
 
     final String? updateUrl = await widget.updateUrlFetcher();
-    final bool? wantsUpdate = await showDialog<bool>(context: context, builder: _buildDialog);
-    if (wantsUpdate != null && updateUrl != null && wantsUpdate) {
-      launchUrl(Uri.parse(updateUrl));
+    if (mounted) {
+      final bool? wantsUpdate = await showDialog<bool>(context: context, builder: _buildDialog);
+      if (wantsUpdate != null && updateUrl != null && wantsUpdate) {
+        launchUrl(Uri.parse(updateUrl));
+      }
     }
   }
 


### PR DESCRIPTION
A recent fix to `use_build_context_synchronously` (https://github.com/dart-lang/linter/pull/3679) is flagging a few places that need addressing before publishing the new linter.

Fixes dart-lang/sdk#58867 