### PR TITLE
Move android gallery_transition_perf targets to prod

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1944,7 +1944,6 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_e2e
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     presubmit: false
     timeout: 60
     properties:
@@ -1955,7 +1954,6 @@ targets:
 
   - name: Linux_build_test flutter_gallery__transition_perf_hybrid
     recipe: devicelab/devicelab_drone_build_test
-    bringup: true # New target https://github.com/flutter/flutter/issues/103542
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
This is a follow up of https://github.com/flutter/flutter/pull/110533, switching below two targets to prod.
[Linux_build_test flutter_gallery__transition_perf_e2e](https://ci.chromium.org/p/flutter/builders/staging/Linux_build_test%20flutter_gallery__transition_perf_e2e?limit=50)
[Linux_build_test flutter_gallery__transition_perf_hybrid](https://ci.chromium.org/p/flutter/builders/staging/Linux_build_test%20flutter_gallery__transition_perf_hybrid?limit=50)

They have been passing in staging, and are ready to enable in prod. Performance metrics will not be affected.