### PR TITLE
Allow marking a golden check as flaky

### DIFF
--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -20,7 +20,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // TODO(yjbanov): on the web text rendered with perspective produces flaky goldens: https://github.com/flutter/flutter/issues/110785
-const bool skipPerspectiveTextGoldens = isBrowser;
+const bool perspectiveTextIsFlaky = isBrowser;
 
 // A number of the hit tests below say "warnIfMissed: false". This is because
 // the way the CupertinoPicker works, the hits don't actually reach the labels,
@@ -1197,39 +1197,31 @@ void main() {
       }
 
       await tester.pumpWidget(buildApp(CupertinoDatePickerMode.time));
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.time.initial.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesGoldenFile('date_picker_test.time.initial.png', isFlaky: perspectiveTextIsFlaky),
+      );
 
       await tester.pumpWidget(buildApp(CupertinoDatePickerMode.date));
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.date.initial.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesGoldenFile('date_picker_test.date.initial.png', isFlaky: perspectiveTextIsFlaky),
+      );
 
       await tester.pumpWidget(buildApp(CupertinoDatePickerMode.dateAndTime));
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.datetime.initial.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesGoldenFile('date_picker_test.datetime.initial.png', isFlaky: perspectiveTextIsFlaky),
+      );
 
       // Slightly drag the hour component to make the current hour off-center.
       await tester.drag(find.text('4'), Offset(0, _kRowOffset.dy / 2), warnIfMissed: false); // see top of file
       await tester.pump();
 
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.datetime.drag.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesGoldenFile('date_picker_test.datetime.drag.png', isFlaky: perspectiveTextIsFlaky),
+      );
     });
 
     testWidgets('DatePicker displays the date in correct order', (WidgetTester tester) async {
@@ -1314,23 +1306,19 @@ void main() {
       ),
     );
 
-    if (!skipPerspectiveTextGoldens) {
-      await expectLater(
-        find.byType(CupertinoTimerPicker),
-        matchesGoldenFile('timer_picker_test.datetime.initial.png'),
-      );
-    }
+    await expectLater(
+      find.byType(CupertinoTimerPicker),
+      matchesGoldenFile('timer_picker_test.datetime.initial.png', isFlaky: perspectiveTextIsFlaky),
+    );
 
     // Slightly drag the minute component to make the current minute off-center.
     await tester.drag(find.text('59'), Offset(0, _kRowOffset.dy / 2), warnIfMissed: false); // see top of file
     await tester.pump();
 
-    if (!skipPerspectiveTextGoldens) {
-      await expectLater(
-        find.byType(CupertinoTimerPicker),
-        matchesGoldenFile('timer_picker_test.datetime.drag.png'),
-      );
-    }
+    await expectLater(
+      find.byType(CupertinoTimerPicker),
+      matchesGoldenFile('timer_picker_test.datetime.drag.png', isFlaky: perspectiveTextIsFlaky),
+    );
   });
 
   testWidgets('TimerPicker only changes hour label after scrolling stops', (WidgetTester tester) async {

--- a/packages/flutter_goldens/lib/flutter_goldens.dart
+++ b/packages/flutter_goldens/lib/flutter_goldens.dart
@@ -536,6 +536,8 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
     );
 
     if (isFlaky) {
+      // TODO(yjbanov): there's no way to communicate warnings to the caller https://github.com/flutter/flutter/issues/91285
+      // ignore: avoid_print
       print('Golden $golden is marked as flaky and will not fail the test.');
     }
 
@@ -547,8 +549,9 @@ class FlutterLocalFileComparator extends FlutterGoldenFileComparator with LocalC
     if (!isFlaky) {
       throw FlutterError(error);
     } else {
-      // The test was marked as flaky. Simply print the error to console, but
-      // do not fail the test.
+      // The test was marked as flaky. Do not fail the test.
+      // TODO(yjbanov): there's no way to communicate warnings to the caller https://github.com/flutter/flutter/issues/91285
+      // ignore: avoid_print
       print(error);
     }
 

--- a/packages/flutter_goldens/test/flutter_goldens_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_test.dart
@@ -1122,7 +1122,7 @@ class FakeSkiaGoldClient extends Fake implements SkiaGoldClient {
   @override
   Future<void> imgtestInit() async => initCalls += 1;
   @override
-  Future<bool> imgtestAdd(String testName, File goldenFile) async {
+  Future<bool> imgtestAdd(String testName, File goldenFile, { bool isFlaky = false }) async {
     testNames.add(testName);
     return true;
   }
@@ -1131,7 +1131,7 @@ class FakeSkiaGoldClient extends Fake implements SkiaGoldClient {
   @override
   Future<void> tryjobInit() async => tryInitCalls += 1;
   @override
-  Future<bool> tryjobAdd(String testName, File goldenFile) async => true;
+  Future<bool> tryjobAdd(String testName, File goldenFile, { bool isFlaky = false }) async => true;
 
   Map<String, List<int>> imageBytesValues = <String, List<int>>{};
   @override

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -199,7 +199,7 @@ class SkiaGoldClient {
   ///
   /// The [testName] and [goldenFile] parameters reference the current
   /// comparison being evaluated by the [FlutterPostSubmitFileComparator].
-  Future<bool> imgtestAdd(String testName, File goldenFile) async {
+  Future<bool> imgtestAdd(String testName, File goldenFile, { bool isFlaky = false }) async {
     final List<String> imgtestCommand = <String>[
       _goldctl,
       'imgtest', 'add',
@@ -209,7 +209,7 @@ class SkiaGoldClient {
       '--test-name', cleanTestName(testName),
       '--png-file', goldenFile.path,
       '--passfail',
-      ..._getPixelMatchingArguments(),
+      ..._getPixelMatchingArguments(isFlaky: isFlaky),
     ];
 
     final io.ProcessResult result = await process.run(imgtestCommand);
@@ -323,7 +323,7 @@ class SkiaGoldClient {
   ///
   /// The [testName] and [goldenFile] parameters reference the current
   /// comparison being evaluated by the [FlutterPreSubmitFileComparator].
-  Future<void> tryjobAdd(String testName, File goldenFile) async {
+  Future<void> tryjobAdd(String testName, File goldenFile, { bool isFlaky = false }) async {
     final List<String> imgtestCommand = <String>[
       _goldctl,
       'imgtest', 'add',
@@ -332,7 +332,7 @@ class SkiaGoldClient {
         .path,
       '--test-name', cleanTestName(testName),
       '--png-file', goldenFile.path,
-      ..._getPixelMatchingArguments(),
+      ..._getPixelMatchingArguments(isFlaky: isFlaky),
     ];
 
     final io.ProcessResult result = await process.run(imgtestCommand);
@@ -362,6 +362,41 @@ class SkiaGoldClient {
     }
   }
 
+  List<String> _getPixelMatchingArguments({ required bool isFlaky }) {
+    if (isFlaky) {
+      return _getNormalPixelMatchingArguments();
+    } else {
+      return _getFlakyPixelMatchingArguments();
+    }
+  }
+
+  List<String> _getFlakyPixelMatchingArguments() {
+    // The algorithm to be used when matching images. The available options are:
+    // - "fuzzy": Allows for customizing the thresholds of pixel differences.
+    // - "sobel": Same as "fuzzy" but performs edge detection before performing
+    //            a fuzzy match.
+    const String algorithm = 'fuzzy';
+
+    // The number of pixels in this image that are allowed to differ from the
+    // baseline.
+    //
+    // The chosen number - 1 billion - indicates that a flaky test should pass
+    // no matter how many pixels are different from the master golden.
+    const int maxDifferentPixels = 1000 * 1000 * 1000;
+
+    // The maximum acceptable difference per pixel.
+    //
+    // The chosen number - 1 billion - indicates that a flaky test should pass
+    // no matter how far the new pixels deviate from the master golden.
+    const int pixelDeltaThreshold = 1000 * 1000 * 1000;
+
+    return <String>[
+      '--add-test-optional-key', 'image_matching_algorithm:$algorithm',
+      '--add-test-optional-key', 'fuzzy_max_different_pixels:$maxDifferentPixels',
+      '--add-test-optional-key', 'fuzzy_pixel_delta_threshold:$pixelDeltaThreshold',
+    ];
+  }
+
   // Constructs arguments for `goldctl` for controlling how pixels are compared.
   //
   // For AOT and CanvasKit exact pixel matching is used. For the HTML renderer
@@ -369,7 +404,7 @@ class SkiaGoldClient {
   // because Chromium cannot exactly reproduce the same golden on all computers.
   // It seems to depend on the hardware/OS/driver combination. However, those
   // differences are very small (typically not noticeable to human eye).
-  List<String> _getPixelMatchingArguments() {
+  List<String> _getNormalPixelMatchingArguments() {
     // Only use fuzzy pixel matching in the HTML renderer.
     if (!_isBrowserTest || _isBrowserCanvasKitTest) {
       return const <String>[];

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -386,9 +386,10 @@ class SkiaGoldClient {
 
     // The maximum acceptable difference per pixel.
     //
-    // The chosen number - 1 billion - indicates that a flaky test should pass
-    // no matter how far the new pixels deviate from the master golden.
-    const int pixelDeltaThreshold = 1000 * 1000 * 1000;
+    // The chosen number - 1020 - is the maximum supported pixel delta and
+    // indicates that a flaky test should pass no matter how far the new pixels
+    // deviate from the master golden.
+    const int pixelDeltaThreshold = 1020;
 
     return <String>[
       '--add-test-optional-key', 'image_matching_algorithm:$algorithm',

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -364,9 +364,9 @@ class SkiaGoldClient {
 
   List<String> _getPixelMatchingArguments({ required bool isFlaky }) {
     if (isFlaky) {
-      return _getNormalPixelMatchingArguments();
-    } else {
       return _getFlakyPixelMatchingArguments();
+    } else {
+      return _getNormalPixelMatchingArguments();
     }
   }
 

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -90,17 +90,27 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
   final path.Context _path;
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, { bool isFlaky = false }) async {
     final ComparisonResult result = await GoldenFileComparator.compareLists(
       imageBytes,
       await getGoldenBytes(golden),
     );
 
+    if (isFlaky) {
+      print('Golden $golden is marked as flaky and will not fail the test.');
+    }
+
     if (!result.passed) {
       final String error = await generateFailureOutput(result, golden, basedir);
-      throw FlutterError(error);
+      if (!isFlaky) {
+        throw FlutterError(error);
+      } else {
+        // The test was marked as flaky. Simply print the error to console, but
+        // do not fail the test.
+        print(error);
+      }
     }
-    return result.passed;
+    return true;
   }
 
   @override

--- a/packages/flutter_test/lib/src/_goldens_io.dart
+++ b/packages/flutter_test/lib/src/_goldens_io.dart
@@ -97,6 +97,8 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
     );
 
     if (isFlaky) {
+      // TODO(yjbanov): there's no way to communicate warnings to the caller https://github.com/flutter/flutter/issues/91285
+      // ignore: avoid_print
       print('Golden $golden is marked as flaky and will not fail the test.');
     }
 
@@ -105,8 +107,9 @@ class LocalFileComparator extends GoldenFileComparator with LocalComparisonOutpu
       if (!isFlaky) {
         throw FlutterError(error);
       } else {
-        // The test was marked as flaky. Simply print the error to console, but
-        // do not fail the test.
+        // The test was marked as flaky. Do not fail the test.
+        // TODO(yjbanov): there's no way to communicate warnings to the caller https://github.com/flutter/flutter/issues/91285
+        // ignore: avoid_print
         print(error);
       }
     }
@@ -293,7 +296,7 @@ ByteData _invert(ByteData imageBytes) {
 /// An unsupported [WebGoldenComparator] that exists for API compatibility.
 class DefaultWebGoldenComparator extends WebGoldenComparator {
   @override
-  Future<bool> compare(double width, double height, Uri golden) {
+  Future<bool> compare(double width, double height, Uri golden, { bool isFlaky = false }) {
     throw UnsupportedError('DefaultWebGoldenComparator is only supported on the web.');
   }
 

--- a/packages/flutter_test/lib/src/_goldens_web.dart
+++ b/packages/flutter_test/lib/src/_goldens_web.dart
@@ -13,7 +13,7 @@ import 'goldens.dart';
 /// An unsupported [GoldenFileComparator] that exists for API compatibility.
 class LocalFileComparator extends GoldenFileComparator {
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, { bool isFlaky = false }) {
     throw UnsupportedError('LocalFileComparator is not supported on the web.');
   }
 

--- a/packages/flutter_test/lib/src/_goldens_web.dart
+++ b/packages/flutter_test/lib/src/_goldens_web.dart
@@ -56,7 +56,7 @@ class DefaultWebGoldenComparator extends WebGoldenComparator {
   Uri testUri;
 
   @override
-  Future<bool> compare(double width, double height, Uri golden) async {
+  Future<bool> compare(double width, double height, Uri golden, { bool isFlaky = false }) async {
     final String key = golden.toString();
     final html.HttpRequest request = await html.HttpRequest.request(
       'flutter_goldens',
@@ -66,6 +66,7 @@ class DefaultWebGoldenComparator extends WebGoldenComparator {
         'key': key,
         'width': width.round(),
         'height': height.round(),
+        'isFlaky': isFlaky,
       }),
     );
     final String response = request.response as String;

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -43,16 +43,22 @@ const bool canCaptureImage = true;
 /// test is running on a VM using conditional import.
 class MatchesGoldenFile extends AsyncMatcher {
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  const MatchesGoldenFile(this.key, this.version);
+  const MatchesGoldenFile(this.key, this.version, { this.isFlaky = false });
 
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  MatchesGoldenFile.forStringPath(String path, this.version) : key = Uri.parse(path);
+  MatchesGoldenFile.forStringPath(String path, this.version, { this.isFlaky = false }) : key = Uri.parse(path);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// Whether this matcher allows goldens that do not match the master golden to pass.
+  ///
+  /// If set to true, the underlying implementation of [goldenFileComparator]
+  /// should
+  final bool isFlaky;
 
   @override
   Future<String?> matchAsync(dynamic item) async {

--- a/packages/flutter_test/lib/src/_matchers_io.dart
+++ b/packages/flutter_test/lib/src/_matchers_io.dart
@@ -57,7 +57,8 @@ class MatchesGoldenFile extends AsyncMatcher {
   /// Whether this matcher allows goldens that do not match the master golden to pass.
   ///
   /// If set to true, the underlying implementation of [goldenFileComparator]
-  /// should
+  /// should produce a screenshot and make it available for human review but not
+  /// fail the test.
   final bool isFlaky;
 
   @override
@@ -76,7 +77,7 @@ class MatchesGoldenFile extends AsyncMatcher {
         return null;
       }
       try {
-        final bool success = await goldenFileComparator.compare(buffer, testNameUri);
+        final bool success = await goldenFileComparator.compare(buffer, testNameUri, isFlaky: isFlaky);
         return success ? null : 'does not match';
       } on TestFailure catch (ex) {
         return ex.message;
@@ -114,7 +115,7 @@ class MatchesGoldenFile extends AsyncMatcher {
         return null;
       }
       try {
-        final bool success = await goldenFileComparator.compare(bytes.buffer.asUint8List(), testNameUri);
+        final bool success = await goldenFileComparator.compare(bytes.buffer.asUint8List(), testNameUri, isFlaky: isFlaky);
         return success ? null : 'does not match';
       } on TestFailure catch (ex) {
         return ex.message;

--- a/packages/flutter_test/lib/src/_matchers_web.dart
+++ b/packages/flutter_test/lib/src/_matchers_web.dart
@@ -31,16 +31,23 @@ const bool canCaptureImage = false;
 /// test is running in a web browser using conditional import.
 class MatchesGoldenFile extends AsyncMatcher {
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  const MatchesGoldenFile(this.key, this.version);
+  const MatchesGoldenFile(this.key, this.version, { this.isFlaky = false});
 
   /// Creates an instance of [MatchesGoldenFile]. Called by [matchesGoldenFile].
-  MatchesGoldenFile.forStringPath(String path, this.version) : key = Uri.parse(path);
+  MatchesGoldenFile.forStringPath(String path, this.version, { this.isFlaky = false}) : key = Uri.parse(path);
 
   /// The [key] to the golden image.
   final Uri key;
 
   /// The [version] of the golden image.
   final int? version;
+
+  /// Whether this matcher allows goldens that do not match the master golden to pass.
+  ///
+  /// If set to true, the underlying implementation of [goldenFileComparator]
+  /// should produce a screenshot and make it available for human review but not
+  /// fail the test.
+  final bool isFlaky;
 
   @override
   Future<String?> matchAsync(dynamic item) async {
@@ -70,7 +77,7 @@ class MatchesGoldenFile extends AsyncMatcher {
         return null;
       }
       try {
-        final bool success = await webGoldenComparator.compare(size.width, size.height, key);
+        final bool success = await webGoldenComparator.compare(size.width, size.height, key, isFlaky: isFlaky);
         return success ? null : 'does not match';
       } on TestFailure catch (ex) {
         return ex.message;

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -167,8 +167,15 @@ abstract class WebGoldenComparator {
   /// rendered on the top left of the screen against the golden file identified
   /// by [golden].
   ///
-  /// The returned future completes with a boolean value that indicates whether
-  /// the pixels rendered on screen match the golden file's pixels.
+  /// If [isFlaky] is false, the returned future completes with a boolean value
+  /// that indicates whether the pixels decoded from [imageBytes] match the
+  /// golden file's pixels.
+  ///
+  /// If [isFlaky] is true, the comparison always passes. Implementations should
+  /// strive to assist developers with managing flaky golden tests effectively.
+  /// For example, the comparator could submit the screenshot to the goldens
+  /// storage and/or management system for manual review, tracking, and
+  /// alerting.
   ///
   /// In the case of comparison mismatch, the comparator may choose to throw a
   /// [TestFailure] if it wants to control the failure message, often in the
@@ -179,7 +186,7 @@ abstract class WebGoldenComparator {
   /// is left up to the implementation class. For instance, some implementations
   /// may load files from the local file system, whereas others may load files
   /// over the network or from a remote repository.
-  Future<bool> compare(double width, double height, Uri golden);
+  Future<bool> compare(double width, double height, Uri golden, { bool isFlaky = false });
 
   /// Updates the golden file identified by [golden] with rendered pixels of
   /// [width]x[height].
@@ -304,7 +311,7 @@ class _TrivialWebGoldenComparator implements WebGoldenComparator {
   const _TrivialWebGoldenComparator._();
 
   @override
-  Future<bool> compare(double width, double height, Uri golden) {
+  Future<bool> compare(double width, double height, Uri golden, { bool isFlaky = false }) {
     // Ideally we would use markTestSkipped here but in some situations,
     // comparators are called outside of tests.
     // See also: https://github.com/flutter/flutter/issues/91285

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -53,8 +53,15 @@ abstract class GoldenFileComparator {
   /// Compares the pixels of decoded png [imageBytes] against the golden file
   /// identified by [golden].
   ///
-  /// The returned future completes with a boolean value that indicates whether
-  /// the pixels decoded from [imageBytes] match the golden file's pixels.
+  /// If [isFlaky] is false, the returned future completes with a boolean value
+  /// that indicates whether the pixels decoded from [imageBytes] match the
+  /// golden file's pixels.
+  ///
+  /// If [isFlaky] is true, the comparison always passes. Implementations should
+  /// strive to assist developers with managing flaky golden tests effectively.
+  /// For example, the comparator could submit the screenshot to the goldens
+  /// storage and/or management system for manual review, tracking, and
+  /// alerting.
   ///
   /// In the case of comparison mismatch, the comparator may choose to throw a
   /// [TestFailure] if it wants to control the failure message, often in the
@@ -65,7 +72,7 @@ abstract class GoldenFileComparator {
   /// is left up to the implementation class. For instance, some implementations
   /// may load files from the local file system, whereas others may load files
   /// over the network or from a remote repository.
-  Future<bool> compare(Uint8List imageBytes, Uri golden);
+  Future<bool> compare(Uint8List imageBytes, Uri golden, { bool isFlaky = false });
 
   /// Updates the golden file identified by [golden] with [imageBytes].
   ///
@@ -273,7 +280,7 @@ class TrivialComparator implements GoldenFileComparator {
   const TrivialComparator._();
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, { bool isFlaky = false }) {
     // Ideally we would use markTestSkipped here but in some situations,
     // comparators are called outside of tests.
     // See also: https://github.com/flutter/flutter/issues/91285

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -168,8 +168,8 @@ abstract class WebGoldenComparator {
   /// by [golden].
   ///
   /// If [isFlaky] is false, the returned future completes with a boolean value
-  /// that indicates whether the pixels decoded from [imageBytes] match the
-  /// golden file's pixels.
+  /// that indicates whether the pixels of the screenshot identified by [golden]
+  /// match the golden file's pixels.
   ///
   /// If [isFlaky] is true, the comparison always passes. Implementations should
   /// strive to assist developers with managing flaky golden tests effectively.

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -452,11 +452,11 @@ Matcher coversSameAreaAs(Path expectedPath, { required Rect areaToCompare, int s
 ///    verify that two different code paths create identical images.
 ///  * [flutter_test] for a discussion of test configurations, whereby callers
 ///    may swap out the backend for this matcher.
-AsyncMatcher matchesGoldenFile(Object key, {int? version}) {
+AsyncMatcher matchesGoldenFile(Object key, { int? version, bool isFlaky = false }) {
   if (key is Uri) {
-    return MatchesGoldenFile(key, version);
+    return MatchesGoldenFile(key, version, isFlaky: isFlaky);
   } else if (key is String) {
-    return MatchesGoldenFile.forStringPath(key, version);
+    return MatchesGoldenFile.forStringPath(key, version, isFlaky: isFlaky);
   }
   throw ArgumentError('Unexpected type for golden file: ${key.runtimeType}');
 }

--- a/packages/flutter_test/test/matchers_test.dart
+++ b/packages/flutter_test/test/matchers_test.dart
@@ -1341,7 +1341,7 @@ class _FakeComparator implements GoldenFileComparator {
   Uri? golden;
 
   @override
-  Future<bool> compare(Uint8List imageBytes, Uri golden) {
+  Future<bool> compare(Uint8List imageBytes, Uri golden, { bool isFlaky = false }) {
     invocation = _ComparatorInvocation.compare;
     this.imageBytes = imageBytes;
     this.golden = golden;

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -349,6 +349,7 @@ class FlutterWebPlatform extends PlatformPlugin {
       final Uri testUri = Uri.parse(body['testUri']! as String);
       final num width = body['width']! as num;
       final num height = body['height']! as num;
+      final bool isFlaky = body['isFlaky']! as bool;
       Uint8List bytes;
 
       try {
@@ -383,7 +384,7 @@ class FlutterWebPlatform extends PlatformPlugin {
         return shelf.Response.ok('Unknown error, bytes is null');
       }
 
-      final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens);
+      final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens, isFlaky);
       return shelf.Response.ok(errorMessage ?? 'true');
     } else {
       return shelf.Response.notFound('Not Found');

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
@@ -41,13 +41,13 @@ void main() {
       final MemoryIOSink ioSink = mockProcess.stdin as MemoryIOSink;
 
       final TestGoldenComparatorProcess process = TestGoldenComparatorProcess(mockProcess, logger: BufferLogger.test());
-      process.sendCommand(imageFile, goldenKey, false);
+      process.sendCommand(imageFile, goldenKey, false, false);
 
       final Map<String, dynamic> response = await process.getResponse();
       final String stringToStdin = ioSink.getAndClear();
 
       expect(response, expectedResponse);
-      expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n');
+      expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false,"isFlaky":false}\n');
     });
 
     testWithoutContext('can handle multiple requests', () async {
@@ -64,18 +64,21 @@ void main() {
       final MemoryIOSink ioSink = mockProcess.stdin as MemoryIOSink;
 
       final TestGoldenComparatorProcess process = TestGoldenComparatorProcess(mockProcess, logger: BufferLogger.test());
-      process.sendCommand(imageFile, goldenKey, false);
+      process.sendCommand(imageFile, goldenKey, false, false);
 
       final Map<String, dynamic> response1 = await process.getResponse();
 
-      process.sendCommand(imageFile2, goldenKey2, true);
+      process.sendCommand(imageFile2, goldenKey2, true, true);
 
       final Map<String, dynamic> response2 = await process.getResponse();
       final String stringToStdin = ioSink.getAndClear();
 
       expect(response1, expectedResponse1);
       expect(response2, expectedResponse2);
-      expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n{"imageFile":"second_test_image_file","key":"file://second_golden_key/","update":true}\n');
+      expect(
+        stringToStdin,
+        '{"imageFile":"test_image_file","key":"file://golden_key/","update":false,"isFlaky":false}\n'
+        '{"imageFile":"second_test_image_file","key":"file://second_golden_key/","update":true,"isFlaky":true}\n');
     });
 
     testWithoutContext('ignores anything that does not look like JSON', () async {
@@ -94,13 +97,13 @@ Other JSON data after the initial data
       final MemoryIOSink ioSink = mockProcess.stdin as MemoryIOSink;
 
       final TestGoldenComparatorProcess process = TestGoldenComparatorProcess(mockProcess,logger: BufferLogger.test());
-      process.sendCommand(imageFile, goldenKey, false);
+      process.sendCommand(imageFile, goldenKey, false, false);
 
       final Map<String, dynamic> response = await process.getResponse();
       final String stringToStdin = ioSink.getAndClear();
 
       expect(response, expectedResponse);
-      expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n');
+      expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false,"isFlaky":false}\n');
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
@@ -61,7 +61,7 @@ void main() {
         webRenderer: WebRendererMode.html,
       );
 
-      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, false);
       expect(result, null);
     });
 
@@ -90,7 +90,7 @@ void main() {
         webRenderer: WebRendererMode.canvaskit,
       );
 
-      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, false);
       expect(result, 'some message');
     });
 
@@ -123,10 +123,10 @@ void main() {
         webRenderer: WebRendererMode.html,
       );
 
-      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, false);
       expect(result1, 'some message');
 
-      final String? result2 = await comparator.compareGoldens(testUri, imageBytes, goldenKey2, false);
+      final String? result2 = await comparator.compareGoldens(testUri, imageBytes, goldenKey2, false, false);
       expect(result2, 'some other message');
     });
 
@@ -168,10 +168,10 @@ void main() {
         webRenderer: WebRendererMode.canvaskit,
       );
 
-      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, false);
       expect(result1, 'some message');
 
-      final String? result2 = await comparator.compareGoldens(testUri2, imageBytes, goldenKey2, false);
+      final String? result2 = await comparator.compareGoldens(testUri2, imageBytes, goldenKey2, false, false);
       expect(result2, 'some other message');
     });
 
@@ -203,7 +203,7 @@ void main() {
         webRenderer: WebRendererMode.html,
       );
 
-      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, false);
       expect(result, null);
 
       await comparator.close();


### PR DESCRIPTION
Support marking a golden check as flaky. A flaky check will still generate a golden and report it to the current `GoldenFileComparator`, but it will not fail the test.

The local file comparator was updated to simply not fail on mismatch.

The Skia Gole comparator was updated to submit the golden to Skia Gold with a virtually unlimited failure threshold. The effect is that the test doesn't fail and it does not generate a triage, but it still allows Skia Gold to track generated screenshots over time. When a fix for flakiness lands, it's easy to go Skia Gold UI to confirm it and remove the `isFlaky` argument from the test.

Fixes https://github.com/flutter/flutter/issues/111325
