### PR TITLE
Updated the Action chip's documentation regarding disabled states.

### DIFF
--- a/packages/flutter/lib/src/material/action_chip.dart
+++ b/packages/flutter/lib/src/material/action_chip.dart
@@ -18,9 +18,10 @@ import 'theme_data.dart';
 /// content. Action chips should appear dynamically and contextually in a UI.
 ///
 /// Action chips can be tapped to trigger an action or show progress and
-/// confirmation. They cannot be disabled; if the action is not applicable, the
-/// chip should not be included in the interface. (This contrasts with buttons,
-/// where unavailable choices are usually represented as disabled controls.)
+/// confirmation. For Material 3, a disabled state is supported for Action
+/// chips and is specified with [onPressed] being null. For previous versions
+/// of Material Design, it is recommended to remove the Action chip from the
+/// the interface entirely rather than display a disabled chip.
 ///
 /// Action chips are displayed after primary content, such as below a card or
 /// persistently at the bottom of a screen.


### PR DESCRIPTION
The documentation for the `ActionChip` widget's disabled state was misleading.

Fixes: #109515

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
