### PR TITLE
Add documentation for `platform_view` example.

### DIFF
--- a/examples/platform_view/macos/Runner/MainFlutterWindow.swift
+++ b/examples/platform_view/macos/Runner/MainFlutterWindow.swift
@@ -5,6 +5,12 @@
 import Cocoa
 import FlutterMacOS
 
+/**
+ The main application window.
+
+ Performs Flutter app initialization, and handles channel method calls over the
+ `samples.flutter.io/platform_view` channel.
+*/
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
     let flutterViewController = FlutterViewController.init()

--- a/examples/platform_view/macos/Runner/PlatformViewController.swift
+++ b/examples/platform_view/macos/Runner/PlatformViewController.swift
@@ -4,6 +4,17 @@
 
 import Cocoa
 
+/**
+`ViewControllers` in the xib can inherit from this class to communicate with
+the flutter view for this application. ViewControllers that inherit from this
+class should be displayed as a popover or modal, with a button that binds to
+the IBAction `pop()`.
+
+To get the value of the popover during close, pass a callback function as
+the `dispose` parameter. The callback passed will have access to the
+`PlatformViewController` and all of it's properties at close so that the `count`
+can be passed back through the message channel if needed.
+*/
 class PlatformViewController: NSViewController {
     var count: Int = 0
 


### PR DESCRIPTION
When `platform_view` first landed for `macOS` there was no documentation for any of the classes added. This PR adds documentation for the `MainFlutterWindow` and the `PlatformViewController` classes.

fixes https://github.com/flutter/flutter/issues/111142


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
> [Tree Hygiene page](https://github.com/flutter/flutter/wiki/Tree-hygiene#how-to-review-code): only affect comments (including documentation).

- [x] All existing and new tests are passing.
