### PR TITLE
Add Xcode as dependency of flutter_view_macos__start_up in .ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3731,7 +3731,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "13f17a"},
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2495,7 +2495,7 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "13f17a"},
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2508,6 +2508,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
       tags: >
         ["devicelab", "hostonly"]
       task_name: flutter_view_macos__start_up


### PR DESCRIPTION
`flutter_view_macos__start_up` test landed in https://github.com/flutter/flutter/pull/111326, but lacked the dependencies that it needed to run successfully in postsubmit. This change adds Xcode as a dependency so that the `flutter_view_macos__start_up` test can be run in postsubmit.

There's no filed issue for this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
> only affect code inside the .github directory, .cirrus.yml or .ci.yaml config files.
- [x] All existing and new tests are passing.
