### PR TITLE
Remove no-longer-needed clamping of RRect radii

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -232,18 +232,7 @@ abstract class BoxBorder extends ShapeBorder {
       canvas.drawRRect(borderRadius.toRRect(rect), paint);
     } else {
       final RRect borderRect = borderRadius.toRRect(rect);
-      RRect inner = borderRect.deflate(side.strokeInset);
-      // Clamp the inner border's radii to zero, until deflate does this
-      // automatically, so that we can start asserting non-negative values
-      // in the engine without breaking the framework.
-      // TODO(gspencergoog): Remove this once https://github.com/flutter/engine/pull/36062 rolls into the framework.
-      inner = RRect.fromLTRBAndCorners(
-        inner.left, inner.top, inner.right, inner.bottom,
-        topLeft: inner.tlRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-        topRight: inner.trRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-        bottomLeft: inner.blRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-        bottomRight: inner.brRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      );
+      final RRect inner = borderRect.deflate(side.strokeInset);
       final RRect outer = borderRect.inflate(side.strokeOutset);
       canvas.drawDRRect(outer, inner, paint);
     }

--- a/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
+++ b/packages/flutter/lib/src/painting/rounded_rectangle_border.dart
@@ -132,18 +132,7 @@ class RoundedRectangleBorder extends OutlinedBorder {
           final Paint paint = Paint()
             ..color = side.color;
           final RRect borderRect = borderRadius.resolve(textDirection).toRRect(rect);
-          RRect inner = borderRect.deflate(side.strokeInset);
-          // Clamp the inner border's radii to zero, until deflate does this
-          // automatically, so that we can start asserting non-negative values
-          // in the engine without breaking the framework.
-          // TODO(gspencergoog): Remove this once https://github.com/flutter/engine/pull/36062 rolls into the framework.
-          inner = RRect.fromLTRBAndCorners(
-            inner.left, inner.top, inner.right, inner.bottom,
-            topLeft: inner.tlRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-            topRight: inner.trRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-            bottomLeft: inner.blRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-            bottomRight: inner.brRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-          );
+          final RRect inner = borderRect.deflate(side.strokeInset);
           final RRect outer = borderRect.inflate(side.strokeOutset);
           canvas.drawDRRect(outer, inner, paint);
         }

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -271,18 +271,7 @@ class TableBorder {
       paintBorder(canvas, rect, top: top, right: right, bottom: bottom, left: left);
     } else {
       final RRect outer = borderRadius.toRRect(rect);
-      RRect inner = outer.deflate(top.width);
-      // Clamp the inner border's radii to zero, until deflate does this
-      // automatically, so that we can start asserting non-negative values
-      // in the engine without breaking the framework.
-      // TODO(gspencergoog): Remove this once https://github.com/flutter/engine/pull/36062 rolls into the framework.
-      inner = RRect.fromLTRBAndCorners(
-        inner.left, inner.top, inner.right, inner.bottom,
-        topLeft: inner.tlRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-        topRight: inner.trRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-        bottomLeft: inner.blRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-        bottomRight: inner.brRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      );
+      final RRect inner = outer.deflate(top.width);
       final Paint paint = Paint()..color = top.color;
       canvas.drawDRRect(outer, inner, paint);
     }

--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -129,17 +129,6 @@ class _MulticastCanvas implements Canvas {
 
   @override
   void drawDRRect(RRect outer, RRect inner, Paint paint) {
-    // Clamp the inner border's radii to zero, until deflate does this
-    // automatically, so that we can start asserting non-negative values
-    // in the engine without breaking the framework.
-    // TODO(gspencergoog): Remove this once https://github.com/flutter/engine/pull/36062 rolls into the framework.
-    inner = RRect.fromLTRBAndCorners(
-      inner.left, inner.top, inner.right, inner.bottom,
-      topLeft: inner.tlRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      topRight: inner.trRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      bottomLeft: inner.blRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-      bottomRight: inner.brRadius.clamp(minimum: Radius.zero), // ignore_clamp_double_lint
-    );
     _main.drawDRRect(outer, inner, paint);
     _screenshot.drawDRRect(outer, inner, paint);
   }


### PR DESCRIPTION
## Description

This removes some clamping added in https://github.com/flutter/flutter/pull/111515 now that https://github.com/flutter/engine/pull/36062 has landed in the framework.

## Related Issues
 - https://github.com/flutter/flutter/issues/78855
 - https://github.com/flutter/flutter/issues/111086

## Tests
 - No tests changed here because we're removing unnecessary code.