### PR TITLE
[flutter_tools] reduce doctor timeout to debug 111686

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -345,7 +345,9 @@ class Doctor {
   /// Maximum allowed duration for an entire validator to take.
   ///
   /// This should only ever be reached if a process is stuck.
-  static const Duration doctorDuration = Duration(minutes: 10);
+  // Reduce this to under 5 minutes to diagnose:
+  // https://github.com/flutter/flutter/issues/111686
+  static const Duration doctorDuration = Duration(minutes: 4, seconds: 30);
 
   /// Print information about the state of installed tooling.
   ///

--- a/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/doctor_test.dart
@@ -354,7 +354,7 @@ void main() {
       FakeAsync().run<void>((FakeAsync time) {
         final Doctor doctor = FakeAsyncStuckDoctor(logger);
         doctor.diagnose(verbose: false);
-        time.elapse(Doctor.doctorDuration + const Duration(seconds: 1));
+        time.elapse(const Duration(minutes: 5));
         time.flushMicrotasks();
       });
 


### PR DESCRIPTION
Time out the doctor validators just before the luci build is timed out so that we can determine which validator is getting slow in https://github.com/flutter/flutter/issues/111686