### PR TITLE
Fix RangeSlider constructor reference to `[value]`

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -110,7 +110,7 @@ class RangeSlider extends StatefulWidget {
   /// The range slider widget itself does not maintain any state. Instead, when
   /// the state of the slider changes, the widget calls the [onChanged] callback.
   /// Most widgets that use a range slider will listen for the [onChanged] callback
-  /// and rebuild the slider with a new [value] to update the visual appearance of
+  /// and rebuild the slider with new [values] to update the visual appearance of
   /// the slider. To know when the value starts to change, or when it is done
   /// changing, set the optional callbacks [onChangeStart] and/or [onChangeEnd].
   ///


### PR DESCRIPTION
Right now it looks like RangeSlider's [constructor docs](https://api.flutter.dev/flutter/material/RangeSlider/RangeSlider.html) contain a code-formatted "value", and dartdoc otherwise thinks this is a fair reference. I believe that dartdoc thinks `[value]` is meant to refer to a parameter _of_ one of the parameters. Perhaps the `value` parameter of the `onChanged` parameter. I'm fixing this bad reference [here](https://github.com/dart-lang/dartdoc/pull/3166).


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
