### PR TITLE
Reset missing deprecation for ScrollbarThemeData.copyWith(showTrackOnHover)

### DIFF
--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -17,6 +17,64 @@
 
 version: 1
 transforms:
+  # Changes made in TBD
+  - title: "Migrate to 'trackVisibility'"
+    date: 2022-09-15
+    element:
+      uris: [ 'material.dart' ]
+      field: 'showTrackOnHover'
+      inClass: 'Scrollbar'
+    changes:
+      - kind: 'rename'
+        newName: 'trackVisibility'
+
+  # Changes made in TBD
+  - title: "Migrate to 'trackVisibility'"
+    date: 2022-09-15
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'Scrollbar'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'showTrackOnHover'
+        newName: 'trackVisibility'
+
+  # Changes made in TBD
+  - title: "Migrate to 'trackVisibility'"
+    date: 2022-09-15
+    element:
+      uris: [ 'material.dart' ]
+      field: 'showTrackOnHover'
+      inClass: 'ScrollbarThemeData'
+    changes:
+      - kind: 'rename'
+        newName: 'trackVisibility'
+
+  # Changes made in TBD
+  - title: "Migrate to 'thumbVisibility'"
+    date: 2022-09-15
+    element:
+      uris: [ 'material.dart' ]
+      constructor: ''
+      inClass: 'ScrollbarThemeData'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'showTrackOnHover'
+        newName: 'trackVisibility'
+
+  # Changes made in TBD
+  - title: "Migrate to 'trackVisibility'"
+    date: 2022-09-15
+    element:
+      uris: [ 'material.dart' ]
+      method: 'copyWith'
+      inClass: 'ScrollbarThemeData'
+    changes:
+      - kind: 'renameParameter'
+        oldName: 'showTrackOnHover'
+        newName: 'trackVisibility'
+
   # Changes made in https://github.com/flutter/flutter/pull/111080
   - title: "Migrate to 'BottomAppBarTheme.color'"
     date: 2022-09-07

--- a/packages/flutter/lib/fix_data.yaml
+++ b/packages/flutter/lib/fix_data.yaml
@@ -17,7 +17,7 @@
 
 version: 1
 transforms:
-  # Changes made in TBD
+  # Changes made in https://github.com/flutter/flutter/pull/111706
   - title: "Migrate to 'trackVisibility'"
     date: 2022-09-15
     element:
@@ -28,7 +28,7 @@ transforms:
       - kind: 'rename'
         newName: 'trackVisibility'
 
-  # Changes made in TBD
+  # Changes made in https://github.com/flutter/flutter/pull/111706
   - title: "Migrate to 'trackVisibility'"
     date: 2022-09-15
     element:
@@ -40,7 +40,7 @@ transforms:
         oldName: 'showTrackOnHover'
         newName: 'trackVisibility'
 
-  # Changes made in TBD
+  # Changes made in https://github.com/flutter/flutter/pull/111706
   - title: "Migrate to 'trackVisibility'"
     date: 2022-09-15
     element:
@@ -51,7 +51,7 @@ transforms:
       - kind: 'rename'
         newName: 'trackVisibility'
 
-  # Changes made in TBD
+  # Changes made in https://github.com/flutter/flutter/pull/111706
   - title: "Migrate to 'thumbVisibility'"
     date: 2022-09-15
     element:
@@ -63,7 +63,7 @@ transforms:
         oldName: 'showTrackOnHover'
         newName: 'trackVisibility'
 
-  # Changes made in TBD
+  # Changes made in https://github.com/flutter/flutter/pull/111706
   - title: "Migrate to 'trackVisibility'"
     date: 2022-09-15
     element:

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -102,7 +102,7 @@ class Scrollbar extends StatelessWidget {
     this.isAlwaysShown,
     @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after 3.4.0-19.0.pre.',
+      'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     this.showTrackOnHover,
     @Deprecated(
@@ -168,7 +168,7 @@ class Scrollbar extends StatelessWidget {
   /// should be used instead.
   @Deprecated(
     'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-    'This feature was deprecated after 3.4.0-19.0.pre.',
+    'This feature was deprecated after v3.4.0-19.0.pre.',
   )
   final bool? showTrackOnHover;
 

--- a/packages/flutter/lib/src/material/scrollbar.dart
+++ b/packages/flutter/lib/src/material/scrollbar.dart
@@ -102,7 +102,7 @@ class Scrollbar extends StatelessWidget {
     this.isAlwaysShown,
     @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
+      'This feature was deprecated after 3.4.0-19.0.pre.',
     )
     this.showTrackOnHover,
     @Deprecated(
@@ -168,7 +168,7 @@ class Scrollbar extends StatelessWidget {
   /// should be used instead.
   @Deprecated(
     'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-    'This feature was deprecated after v2.9.0-1.0.pre.',
+    'This feature was deprecated after 3.4.0-19.0.pre.',
   )
   final bool? showTrackOnHover;
 

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -52,7 +52,7 @@ class ScrollbarThemeData with Diagnosticable {
     this.isAlwaysShown,
     @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after 3.4.0-19.0.pre.',
+      'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     this.showTrackOnHover,
   }) : assert(
@@ -82,7 +82,7 @@ class ScrollbarThemeData with Diagnosticable {
   /// descendant [Scrollbar] widgets.
   @Deprecated(
     'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-    'This feature was deprecated after 3.4.0-19.0.pre.',
+    'This feature was deprecated after v3.4.0-19.0.pre.',
   )
   final bool? showTrackOnHover;
 

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -52,7 +52,7 @@ class ScrollbarThemeData with Diagnosticable {
     this.isAlwaysShown,
     @Deprecated(
       'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-      'This feature was deprecated after v2.9.0-1.0.pre.',
+      'This feature was deprecated after 3.4.0-19.0.pre.',
     )
     this.showTrackOnHover,
   }) : assert(
@@ -82,7 +82,7 @@ class ScrollbarThemeData with Diagnosticable {
   /// descendant [Scrollbar] widgets.
   @Deprecated(
     'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
-    'This feature was deprecated after v2.9.0-1.0.pre.',
+    'This feature was deprecated after 3.4.0-19.0.pre.',
   )
   final bool? showTrackOnHover;
 
@@ -161,7 +161,6 @@ class ScrollbarThemeData with Diagnosticable {
     MaterialStateProperty<bool?>? thumbVisibility,
     MaterialStateProperty<double?>? thickness,
     MaterialStateProperty<bool?>? trackVisibility,
-    bool? showTrackOnHover,
     bool? interactive,
     Radius? radius,
     MaterialStateProperty<Color?>? thumbColor,
@@ -175,6 +174,12 @@ class ScrollbarThemeData with Diagnosticable {
       'This feature was deprecated after v2.9.0-1.0.pre.',
     )
     bool? isAlwaysShown,
+
+    @Deprecated(
+      'Use ScrollbarThemeData.trackVisibility to resolve based on the current state instead. '
+      'This feature was deprecated after v3.4.0-19.0.pre.',
+    )
+    bool? showTrackOnHover,
   }) {
     return ScrollbarThemeData(
       thumbVisibility: thumbVisibility ?? this.thumbVisibility,

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -695,7 +695,7 @@ void main() {
   themeData = ThemeData.raw(bottomAppBarColor: Colors.green);
   themeData = ThemeData.copyWith(bottomAppBarColor: Colors.green);
 
-  // Changes made in TBD
+  // Changes made in https://github.com/flutter/flutter/pull/111706
   Scrollbar scrollbar = Scrollbar(showTrackOnHover: true);
   bool nowShowing = scrollbar.showTrackOnHover;
   ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(showTrackOnHover: nowShowing);

--- a/packages/flutter/test_fixes/material.dart
+++ b/packages/flutter/test_fixes/material.dart
@@ -694,4 +694,11 @@ void main() {
   themeData = ThemeData(bottomAppBarColor: Colors.green);
   themeData = ThemeData.raw(bottomAppBarColor: Colors.green);
   themeData = ThemeData.copyWith(bottomAppBarColor: Colors.green);
+
+  // Changes made in TBD
+  Scrollbar scrollbar = Scrollbar(showTrackOnHover: true);
+  bool nowShowing = scrollbar.showTrackOnHover;
+  ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(showTrackOnHover: nowShowing);
+  scrollbarTheme.copyWith(showTrackOnHover: nowShowing);
+  scrollbarTheme.showTrackOnHover;
 }

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -899,7 +899,7 @@ void main() {
   themeData = ThemeData.raw(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
   themeData = ThemeData.copyWith(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
 
-  // Changes made in TBD
+  // Changes made in https://github.com/flutter/flutter/pull/111706
   Scrollbar scrollbar = Scrollbar(trackVisibility: true);
   bool nowShowing = scrollbar.trackVisibility;
   ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(trackVisibility: nowShowing);

--- a/packages/flutter/test_fixes/material.dart.expect
+++ b/packages/flutter/test_fixes/material.dart.expect
@@ -898,4 +898,11 @@ void main() {
   themeData = ThemeData(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
   themeData = ThemeData.raw(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
   themeData = ThemeData.copyWith(bottomAppBarTheme: BottomAppBarTheme(color: Colors.green));
+
+  // Changes made in TBD
+  Scrollbar scrollbar = Scrollbar(trackVisibility: true);
+  bool nowShowing = scrollbar.trackVisibility;
+  ScrollbarThemeData scrollbarTheme = ScrollbarThemeData(trackVisibility: nowShowing);
+  scrollbarTheme.copyWith(trackVisibility: nowShowing);
+  scrollbarTheme.trackVisibility;
 }


### PR DESCRIPTION
Found this while completing an audit for the next batch of deprecations to be removed from the framework.

Scrollbar and ScrollbarThemeData showTrackOnHover is deprecated, but the later .copyWith was not notated for it. This adds the deprecation notation and resets the clock for the bunch.

It also adds a dart fix for this deprecation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
