### PR TITLE
Add missing deprecation notice for toggleableActiveColor

### DIFF
--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -413,7 +413,7 @@ class ThemeData with Diagnosticable {
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/toggleable-active-color#migration-guide. '
-      'This feature was deprecated after v2.13.0-0.4.pre.',
+      'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     Color? toggleableActiveColor,
     @Deprecated(
@@ -846,7 +846,7 @@ class ThemeData with Diagnosticable {
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/toggleable-active-color#migration-guide. '
-      'This feature was deprecated after v2.13.0-0.4.pre.',
+      'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     Color? toggleableActiveColor,
     @Deprecated(
@@ -1420,11 +1420,6 @@ class ThemeData with Diagnosticable {
   ///  * [splashFactory], which defines the appearance of the splash.
   final Color splashColor;
 
-  /// The color used to highlight the active states of toggleable widgets like
-  /// [Switch], [Radio], and [Checkbox].
-  Color get toggleableActiveColor => _toggleableActiveColor!;
-  final Color? _toggleableActiveColor;
-
   /// The color used for widgets in their inactive (but enabled)
   /// state. For example, an unchecked checkbox. See also [disabledColor].
   final Color unselectedWidgetColor;
@@ -1734,6 +1729,17 @@ class ThemeData with Diagnosticable {
   Color get backgroundColor => _backgroundColor!;
   final Color? _backgroundColor;
 
+  /// The color used to highlight the active states of toggleable widgets like
+  /// [Switch], [Radio], and [Checkbox].
+  @Deprecated(
+    'No longer used by the framework, please remove any reference to it. '
+    'For more information, consult the migration guide at '
+    'https://flutter.dev/docs/release/breaking-changes/toggleable-active-color#migration-guide. '
+    'This feature was deprecated after v3.4.0-19.0.pre.',
+  )
+  Color get toggleableActiveColor => _toggleableActiveColor!;
+  final Color? _toggleableActiveColor;
+
   /// Creates a copy of this theme but with the given fields replaced with the new values.
   ///
   /// The [brightness] value is applied to the [colorScheme].
@@ -1874,7 +1880,7 @@ class ThemeData with Diagnosticable {
       'No longer used by the framework, please remove any reference to it. '
       'For more information, consult the migration guide at '
       'https://flutter.dev/docs/release/breaking-changes/toggleable-active-color#migration-guide. '
-      'This feature was deprecated after v2.13.0-0.4.pre.',
+      'This feature was deprecated after v3.4.0-19.0.pre.',
     )
     Color? toggleableActiveColor,
     @Deprecated(


### PR DESCRIPTION
Came across this while auditing for the next batch of deprecations for removal.

This adds a deprecation to ThemeData.toggleableActiveColor. 

Originally deprecated in https://github.com/flutter/flutter/pull/97972, the deprecation lint did not catch this because in ThemeData, deprecated parameters are refactored to getters to avoid hard breaks. 

This resets the clock so all the other version tags were updated as well.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
