### PR TITLE
Remove deprecated drag anchor

### DIFF
--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -120,34 +120,6 @@ Offset pointerDragAnchorStrategy(Draggable<Object> draggable, BuildContext conte
   return Offset.zero;
 }
 
-/// Where the [Draggable] should be anchored during a drag.
-///
-/// This has been replaced by the more configurable [DragAnchorStrategy].
-@Deprecated(
-  'Use dragAnchorStrategy instead. '
-  'This feature was deprecated after v2.1.0-10.0.pre.',
-)
-enum DragAnchor {
-  /// Display the feedback anchored at the position of the original child.
-  ///
-  /// Replaced by [childDragAnchorStrategy].
-  @Deprecated(
-    'Use childDragAnchorStrategy instead. '
-    'This feature was deprecated after v2.1.0-10.0.pre.',
-  )
-  child,
-
-  /// Display the feedback anchored at the position of the touch that started
-  /// the drag.
-  ///
-  /// Replaced by [pointerDragAnchorStrategy].
-  @Deprecated(
-    'Use pointerDragAnchorStrategy instead. '
-    'This feature was deprecated after v2.1.0-10.0.pre.',
-  )
-  pointer,
-}
-
 /// A widget that can be dragged from to a [DragTarget].
 ///
 /// When a draggable widget recognizes the start of a drag gesture, it displays
@@ -197,13 +169,6 @@ class Draggable<T extends Object> extends StatefulWidget {
     this.axis,
     this.childWhenDragging,
     this.feedbackOffset = Offset.zero,
-    @Deprecated(
-      'Use dragAnchorStrategy instead. '
-      'Replace "dragAnchor: DragAnchor.child" with "dragAnchorStrategy: childDragAnchorStrategy". '
-      'Replace "dragAnchor: DragAnchor.pointer" with "dragAnchorStrategy: pointerDragAnchorStrategy". '
-      'This feature was deprecated after v2.1.0-10.0.pre.',
-    )
-    this.dragAnchor = DragAnchor.child,
     this.dragAnchorStrategy,
     this.affinity,
     this.maxSimultaneousDrags,
@@ -275,17 +240,6 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// purposes of finding a drag target. It is especially useful if the feedback
   /// is transformed compared to the child.
   final Offset feedbackOffset;
-
-  /// Where this widget should be anchored during a drag.
-  ///
-  /// This property is overridden by the [dragAnchorStrategy] if the latter is provided.
-  ///
-  /// Defaults to [DragAnchor.child].
-  @Deprecated(
-    'Use dragAnchorStrategy instead. '
-    'This feature was deprecated after v2.1.0-10.0.pre.',
-  )
-  final DragAnchor dragAnchor;
 
   /// A strategy that is used by this draggable to get the anchor offset when it
   /// is dragged.
@@ -447,13 +401,6 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
     super.axis,
     super.childWhenDragging,
     super.feedbackOffset,
-    @Deprecated(
-      'Use dragAnchorStrategy instead. '
-      'Replace "dragAnchor: DragAnchor.child" with "dragAnchorStrategy: childDragAnchorStrategy". '
-      'Replace "dragAnchor: DragAnchor.pointer" with "dragAnchorStrategy: pointerDragAnchorStrategy". '
-      'This feature was deprecated after v2.1.0-10.0.pre.',
-    )
-    super.dragAnchor,
     super.dragAnchorStrategy,
     super.maxSimultaneousDrags,
     super.onDragStarted,
@@ -539,18 +486,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
       return null;
     }
     final Offset dragStartPoint;
-    if (widget.dragAnchorStrategy == null) {
-      switch (widget.dragAnchor) {
-        case DragAnchor.child:
-          dragStartPoint = childDragAnchorStrategy(widget, context, position);
-          break;
-        case DragAnchor.pointer:
-          dragStartPoint = pointerDragAnchorStrategy(widget, context, position);
-          break;
-      }
-    } else {
-      dragStartPoint = widget.dragAnchorStrategy!(widget, context, position);
-    }
+    dragStartPoint = widget.dragAnchorStrategy!(widget, context, position);
     setState(() {
       _activeCount += 1;
     });

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -86,7 +86,7 @@ typedef DragAnchorStrategy = Offset Function(Draggable<Object> draggable, BuildC
 /// If feedback is identical to the child, then this means the feedback will
 /// exactly overlap the original child when the drag starts.
 ///
-/// This is the default [DragAnchorStrategy] and replaces [DragAnchor.child].
+/// This is the default [DragAnchorStrategy].
 ///
 /// See also:
 ///
@@ -109,8 +109,6 @@ Offset childDragAnchorStrategy(Draggable<Object> draggable, BuildContext context
 /// finger down makes the touch feedback appear above the finger. (It feels
 /// weird for it to appear offset from the original child if it's anchored to
 /// the child and not the finger.)
-///
-/// This replaces [DragAnchor.pointer], which has been deprecated.
 ///
 /// See also:
 ///
@@ -169,7 +167,7 @@ class Draggable<T extends Object> extends StatefulWidget {
     this.axis,
     this.childWhenDragging,
     this.feedbackOffset = Offset.zero,
-    this.dragAnchorStrategy,
+    this.dragAnchorStrategy = childDragAnchorStrategy,
     this.affinity,
     this.maxSimultaneousDrags,
     this.onDragStarted,
@@ -185,7 +183,8 @@ class Draggable<T extends Object> extends StatefulWidget {
        assert(feedback != null),
        assert(ignoringFeedbackSemantics != null),
        assert(ignoringFeedbackPointer != null),
-       assert(maxSimultaneousDrags == null || maxSimultaneousDrags >= 0);
+       assert(maxSimultaneousDrags == null || maxSimultaneousDrags >= 0),
+       assert(dragAnchorStrategy != null);
 
   /// The data that will be dropped by this draggable.
   final T? data;
@@ -256,10 +255,8 @@ class Draggable<T extends Object> extends StatefulWidget {
   ///  * [pointerDragAnchorStrategy], which displays the feedback anchored at the
   ///    position of the touch that started the drag.
   ///
-  /// Defaults to [childDragAnchorStrategy] if the deprecated [dragAnchor]
-  /// property is set to [DragAnchor.child], and [pointerDragAnchorStrategy] if
-  /// the [dragAnchor] is set to [DragAnchor.pointer].
-  final DragAnchorStrategy? dragAnchorStrategy;
+  /// Defaults to [childDragAnchorStrategy].
+  final DragAnchorStrategy dragAnchorStrategy;
 
   /// Whether the semantics of the [feedback] widget is ignored when building
   /// the semantics tree.
@@ -486,7 +483,7 @@ class _DraggableState<T extends Object> extends State<Draggable<T>> {
       return null;
     }
     final Offset dragStartPoint;
-    dragStartPoint = widget.dragAnchorStrategy!(widget, context, position);
+    dragStartPoint = widget.dragAnchorStrategy(widget, context, position);
     setState(() {
       _activeCount += 1;
     });

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -3192,8 +3192,6 @@ void main() {
     expect(const LongPressDraggable<int>(feedback: widget2, child: widget1), isA<Draggable<int>>());
     expect(const LongPressDraggable<int>(feedback: widget2, child: widget1).child, widget1);
     expect(const LongPressDraggable<int>(feedback: widget2, child: widget1).feedback, widget2);
-    expect(const LongPressDraggable<int>(feedback: widget2, child: widget1).dragAnchor, DragAnchor.child);
-    expect(const LongPressDraggable<int>(feedback: widget2, dragAnchor: DragAnchor.pointer, child: widget1).dragAnchor, DragAnchor.pointer);
     expect(LongPressDraggable<int>(feedback: widget2, dragAnchorStrategy: dummyStrategy, child: widget1).dragAnchorStrategy, dummyStrategy);
   });
 }


### PR DESCRIPTION
This removes 
- `Draggable.dragAnchor`
- `LongPressDraggable.dragAnchor`
- `DragAnchor` enum

This deprecated class has reached end of life after the release of Flutter 3.3

- The replacement is to use `dragAnchorStrategy` instead.
-  ✅  Migration via dart fix is supported
- 🕐 This API was deprecated in
  - https://github.com/flutter/flutter/pull/79160, tagged v2.1


Part of https://github.com/flutter/flutter/issues/111708
For the full list of deprecations being removed in this batch, see [flutter.dev/go/deprecations-removed-after-3-3](https://github.com/flutter/flutter/pull/flutter.dev/go/deprecations-removed-after-3-3)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
