### PR TITLE
Do not codesign transitive dependency iOS pod resource bundles

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -157,11 +157,12 @@ Future<void> main() async {
       String content = await pubspec.readAsString();
       content = content.replaceFirst(
         '\ndependencies:\n',
-        // One framework, one Dart-only, and one that does not support iOS.
+        // One framework, one Dart-only, one that does not support iOS, and one with a resource bundle.
         '''
 dependencies:
   url_launcher: 6.0.20
   android_alarm_manager: 0.4.5+11
+  google_sign_in_ios: 5.5.0
   $dartPluginName:
     path: ../$dartPluginName
 ''',
@@ -201,6 +202,8 @@ dependencies:
       }
 
       checkFileExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'url_launcher_ios.framework', 'url_launcher_ios'));
+      // Resources should be embedded.
+      checkDirectoryExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'GoogleSignIn.framework', 'GoogleSignIn.bundle'));
       checkFileExists(path.join(ephemeralIOSHostApp.path, 'Frameworks', 'Flutter.framework', 'Flutter'));
 
       // Android-only, no embedded framework.
@@ -297,7 +300,7 @@ end
             'CODE_SIGNING_REQUIRED=NO',
             'CODE_SIGN_IDENTITY=-',
             'EXPANDED_CODE_SIGN_IDENTITY=-',
-            'CONFIGURATION_BUILD_DIR=${objectiveCBuildDirectory.path}',
+            'BUILD_DIR=${objectiveCBuildDirectory.path}',
             'COMPILER_INDEX_STORE_ENABLE=NO',
           ],
           environment: <String, String> {
@@ -306,27 +309,33 @@ end
         );
       });
 
-      final bool existingAppBuilt = exists(File(path.join(
+      final String hostAppDirectory = path.join(
         objectiveCBuildDirectory.path,
+        'Debug-iphoneos',
         'Host.app',
+      );
+
+      final bool existingAppBuilt = exists(File(path.join(
+        hostAppDirectory,
         'Host',
       )));
       if (!existingAppBuilt) {
         return TaskResult.failure('Failed to build existing Objective-C app .app');
       }
 
-      checkFileExists(path.join(
-        objectiveCBuildDirectory.path,
-        'Host.app',
+      final String hostFrameworksDirectory = path.join(
+        hostAppDirectory,
         'Frameworks',
+      );
+
+      checkFileExists(path.join(
+        hostFrameworksDirectory,
         'Flutter.framework',
         'Flutter',
       ));
 
       checkFileExists(path.join(
-        objectiveCBuildDirectory.path,
-        'Host.app',
-        'Frameworks',
+        hostFrameworksDirectory,
         'App.framework',
         'flutter_assets',
         'isolate_snapshot_data',
@@ -335,9 +344,7 @@ end
       section('Check the NOTICE file is correct');
 
       final String licenseFilePath = path.join(
-        objectiveCBuildDirectory.path,
-        'Host.app',
-        'Frameworks',
+        hostFrameworksDirectory,
         'App.framework',
         'flutter_assets',
         'NOTICES.Z',
@@ -524,7 +531,7 @@ end
             'CODE_SIGNING_REQUIRED=NO',
             'CODE_SIGN_IDENTITY=-',
             'EXPANDED_CODE_SIGN_IDENTITY=-',
-            'CONFIGURATION_BUILD_DIR=${objectiveCBuildDirectory.path}',
+            'BUILD_DIR=${objectiveCBuildDirectory.path}',
             'COMPILER_INDEX_STORE_ENABLE=NO',
           ],
           canFail: true,
@@ -570,7 +577,7 @@ end
             'CODE_SIGNING_REQUIRED=NO',
             'CODE_SIGN_IDENTITY=-',
             'EXPANDED_CODE_SIGN_IDENTITY=-',
-            'CONFIGURATION_BUILD_DIR=${swiftBuildDirectory.path}',
+            'BUILD_DIR=${swiftBuildDirectory.path}',
             'COMPILER_INDEX_STORE_ENABLE=NO',
           ],
           environment: <String, String> {
@@ -581,6 +588,7 @@ end
 
       final bool existingSwiftAppBuilt = exists(File(path.join(
         swiftBuildDirectory.path,
+        'Debug-iphoneos',
         'Host.app',
         'Host',
       )));

--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -18,6 +18,15 @@ import 'package:path/path.dart' as path;
 /// adding Flutter to an existing iOS app.
 Future<void> main() async {
   await task(() async {
+    // Update pod repo.
+    await eval(
+      'pod',
+      <String>['repo', 'update'],
+      environment: <String, String>{
+        'LANG': 'en_US.UTF-8',
+      },
+    );
+
     // this variable cannot be `late`, as we reference it in the `finally` block
     // which may execute before this field has been initialized
     String? simulatorDeviceId;

--- a/packages/flutter_tools/bin/podhelper.rb
+++ b/packages/flutter_tools/bin/podhelper.rb
@@ -45,12 +45,22 @@ def flutter_additional_ios_build_settings(target)
   end
 
   release_framework_dir = File.expand_path(File.join(artifacts_dir, 'ios-release', 'Flutter.xcframework'), __FILE__)
+  # Bundles are com.apple.product-type.bundle, frameworks are com.apple.product-type.framework.
+  target_is_resource_bundle = target.respond_to?(:product_type) && target.product_type == 'com.apple.product-type.bundle'
 
   target.build_configurations.each do |build_configuration|
     # Build both x86_64 and arm64 simulator archs for all dependencies. If a single plugin does not support arm64 simulators,
     # the app and all frameworks will fall back to x86_64. Unfortunately that case is not detectable in this script.
     # Therefore all pods must have a x86_64 slice available, or linking a x86_64 app will fail.
     build_configuration.build_settings['ONLY_ACTIVE_ARCH'] = 'NO' if build_configuration.type == :debug
+
+    # Workaround https://github.com/CocoaPods/CocoaPods/issues/11402, do not sign resource bundles.
+    if target_is_resource_bundle
+      build_configuration.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+      build_configuration.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+      build_configuration.build_settings['CODE_SIGNING_IDENTITY'] = '-'
+      build_configuration.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = '-'
+    end
 
     # Skip other updates if it's not a Flutter plugin (transitive dependency).
     next unless target.dependencies.any? { |dependency| dependency.name == 'Flutter' }


### PR DESCRIPTION
Bundles can contain resources like images and localization files.  They are embedded in the framework and should not be codesigned. Xcode 14 changed behavior and is erroneously codesigning these.  CocoaPods has not yet added a workaround on their side https://github.com/CocoaPods/CocoaPods/issues/11402.

Confirms this also works for add-to-app hosts.

Fixes https://github.com/flutter/flutter/issues/111475

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
