### PR TITLE
Change default text color of CupertinoAlertDialog to theme primary color

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1713,7 +1713,7 @@ class CupertinoDialogAction extends StatelessWidget {
   Widget build(BuildContext context) {
     TextStyle style = _kCupertinoDialogActionStyle.copyWith(
       color: CupertinoDynamicColor.resolve(
-        isDestructiveAction ? CupertinoColors.systemRed : CupertinoColors.systemBlue,
+        isDestructiveAction ? CupertinoColors.systemRed : CupertinoTheme.of(context).primaryColor,
         context,
       ),
     );

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -125,6 +125,16 @@ void main() {
     expect(widget.style.color!.withAlpha(255), CupertinoColors.systemRed.color);
   });
 
+  testWidgets('Dialog default action style', (WidgetTester tester) async {
+    await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
+      child: Text('Ok'),
+    )));
+
+    final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
+
+    expect(widget.style.color!.withAlpha(255), CupertinoColors.systemBlue.color);
+  });
+
   testWidgets('Dialog dark theme', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -126,13 +126,20 @@ void main() {
   });
 
   testWidgets('Dialog default action style', (WidgetTester tester) async {
-    await tester.pumpWidget(boilerplate(const CupertinoDialogAction(
-      child: Text('Ok'),
-    )));
+    await tester.pumpWidget(
+      CupertinoTheme(
+      data: const CupertinoThemeData(
+        primaryColor: CupertinoColors.systemGreen,
+      ),
+      child: boilerplate(const CupertinoDialogAction(
+        child: Text('Ok'),
+      )),
+      ),
+    );
 
     final DefaultTextStyle widget = tester.widget(find.byType(DefaultTextStyle));
 
-    expect(widget.style.color!.withAlpha(255), CupertinoColors.systemBlue.color);
+    expect(widget.style.color!.withAlpha(255), CupertinoColors.systemGreen.color);
   });
 
   testWidgets('Dialog dark theme', (WidgetTester tester) async {


### PR DESCRIPTION
Addresses issue #111097, by making it so that when the `isDestructiveAction` of a `CupertinoAlertDialog` is set to `false`, the text color is set to the primary theme color, rather than the system blue color. This matches behavior with `CupertinoActionSheet`.

Old Golden image:
![98088ae546116f527261e3203cb4c90a](https://user-images.githubusercontent.com/58190796/192343155-ffcdaef0-8cd1-45fb-acf8-c67f6fdc7bbb.png)

New Golden image with different colors from theme (the blues at the bottom are a darker shade):
![906450517714fc68742bf1b204d9c377](https://user-images.githubusercontent.com/58190796/192343243-2306064f-ed1d-46c0-a81b-5e37040a54bd.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
