### PR TITLE
Fix UiKitView which wrongly unconditionally repaints

### DIFF
--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -322,6 +322,9 @@ class RenderUiKitView extends RenderBox {
   UiKitViewController _viewController;
   set viewController(UiKitViewController viewController) {
     assert(viewController != null);
+    if (_viewController == controller) {
+      return;
+    }
     final bool needsSemanticsUpdate = _viewController.id != viewController.id;
     _viewController = viewController;
     markNeedsPaint();

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -322,7 +322,7 @@ class RenderUiKitView extends RenderBox {
   UiKitViewController _viewController;
   set viewController(UiKitViewController viewController) {
     assert(viewController != null);
-    if (_viewController == controller) {
+    if (_viewController == viewController) {
       return;
     }
     final bool needsSemanticsUpdate = _viewController.id != viewController.id;

--- a/packages/flutter/lib/src/rendering/platform_view.dart
+++ b/packages/flutter/lib/src/rendering/platform_view.dart
@@ -320,13 +320,13 @@ class RenderUiKitView extends RenderBox {
   /// must have been created by calling [PlatformViewsService.initUiKitView].
   UiKitViewController get viewController => _viewController;
   UiKitViewController _viewController;
-  set viewController(UiKitViewController viewController) {
-    assert(viewController != null);
-    if (_viewController == viewController) {
+  set viewController(UiKitViewController value) {
+    assert(value != null);
+    if (_viewController == value) {
       return;
     }
-    final bool needsSemanticsUpdate = _viewController.id != viewController.id;
-    _viewController = viewController;
+    final bool needsSemanticsUpdate = _viewController.id != value.id;
+    _viewController = value;
     markNeedsPaint();
     if (needsSemanticsUpdate) {
       markNeedsSemanticsUpdate();

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -260,7 +260,7 @@ void main() {
       expect(renderBox.debugLayer, isNull);
     });
   });
-  
+
   test('markNeedsPaint does not get called when setting the same viewController', () {
     FakeAsync().run((FakeAsync async) {
       final Completer<void> viewCreation = Completer<void>();

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -273,7 +273,7 @@ void main() {
 
       bool futureCallbackRan = false;
 
-      PlatformViewsService.initUiKitView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).then((viewController) {
+      PlatformViewsService.initUiKitView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).then((UiKitViewController viewController) {
         final RenderUiKitView renderBox = RenderUiKitView(
           viewController: viewController,
           hitTestBehavior: PlatformViewHitTestBehavior.opaque,

--- a/packages/flutter/test/rendering/platform_view_test.dart
+++ b/packages/flutter/test/rendering/platform_view_test.dart
@@ -271,22 +271,29 @@ void main() {
         return /*textureId=*/ 0;
       });
 
-      // TODO
-      final UiKitViewController viewController =
-          await PlatformViewsService.initUiKitView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr);
-      final RenderUiKitView renderBox = RenderUiKitView(
-        viewController: viewController,
-        hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-        gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
-      );
+      bool futureCallbackRan = false;
 
-      layout(renderBox);
-      pumpFrame(phase: EnginePhase.paint);
-      expect(renderBox.debugNeedsPaint, isFalse);
+      PlatformViewsService.initUiKitView(id: 0, viewType: 'webview', layoutDirection: TextDirection.ltr).then((viewController) {
+        final RenderUiKitView renderBox = RenderUiKitView(
+          viewController: viewController,
+          hitTestBehavior: PlatformViewHitTestBehavior.opaque,
+          gestureRecognizers: <Factory<OneSequenceGestureRecognizer>>{},
+        );
 
-      renderBox.viewController = viewController;
+        layout(renderBox);
+        pumpFrame(phase: EnginePhase.paint);
+        expect(renderBox.debugNeedsPaint, isFalse);
 
-      expect(renderBox.debugNeedsPaint, isFalse);
+        renderBox.viewController = viewController;
+
+        expect(renderBox.debugNeedsPaint, isFalse);
+
+        futureCallbackRan = true;
+      });
+
+      viewCreation.complete();
+      async.flushMicrotasks();
+      expect(futureCallbackRan, true);
     });
   });
 }


### PR DESCRIPTION
### How the bug is found

This bug is surely not found by human eyes reading each and every line of Flutter code :)

I proposed the idea that a linter can be created (https://github.com/dart-code-checker/dart-code-metrics/issues/997) to validate whether RenderObject field setters have correct early-return code. @incendial implemented it and ran it (https://github.com/dart-code-checker/dart-code-metrics/pull/1003).

Thus, thanks @incendial for implementing the linter and run it through flutter framework code!

### Bug description

As we know, when implementing a setter in RenderObject, we usually early halt if the new value is equal to the old value (such as [this one](https://github.com/flutter/flutter/blob/7fba37848c9f3007795be2d67a3207067b7a0894/packages/flutter/lib/src/rendering/platform_view.dart#L115), indeed almost all fields in RenderObject child classes are examples). This is very necessary, because we are setting fields in `updateRenderObject` *unconditionally*. If we do not early return, we will execute the full logic like markNeedsPaint and so on *unconditionally* on *every* `updateRenderObject`. That will be performance penalty.

The current PR fixes one bug of such case. In more details, the `viewController` field setter lacks such early-return, and thus unconditionally calls markNeedsPaint. The setter is called from `updateRenderObject` as follows:

![image](https://user-images.githubusercontent.com/5236035/190656619-8aae1809-81f7-475e-8786-73b260c6d3b5.png)

And _UiKitPlatformView is used here:

![image](https://user-images.githubusercontent.com/5236035/190656716-04152bb1-d791-4b0a-8b6a-31f72479ae02.png)

In other words, the controller is not changed in every frame. Instead, in common cases, it should be the same one for many frames. However, it triggers repaint for each and every rebuild.

Close #111788 

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
