### PR TITLE
Avoid sending zero transform semantic nodes to the engine

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4433,7 +4433,7 @@ class _SemanticsGeometry {
   /// by this object can be dropped from the semantics tree without losing
   /// semantics information.
   bool get dropFromTree {
-    return _rect.isEmpty;
+    return _rect.isEmpty || _transform.isZero();
   }
 
   /// Whether the [SemanticsNode] annotated with the geometric information

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -1634,9 +1634,10 @@ void main() {
   });
 
   testWidgets('Semantics with zero transform gets dropped', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/110671.
     // Construct a widget tree that will end up with a fitted box that applies
     // a zero transform because it does not actually draw its children.
-    // Assert that this subtree gets dropped from the
+    // Assert that this subtree gets dropped (the root node has no children).
     await tester.pumpWidget(Column(
       children: <Widget>[
         SizedBox(

--- a/packages/flutter/test/widgets/semantics_test.dart
+++ b/packages/flutter/test/widgets/semantics_test.dart
@@ -1632,6 +1632,32 @@ void main() {
       textDirection: TextDirection.ltr,
     ));
   });
+
+  testWidgets('Semantics with zero transform gets dropped', (WidgetTester tester) async {
+    // Construct a widget tree that will end up with a fitted box that applies
+    // a zero transform because it does not actually draw its children.
+    // Assert that this subtree gets dropped from the
+    await tester.pumpWidget(Column(
+      children: <Widget>[
+        SizedBox(
+          height: 0,
+          width: 500,
+          child: FittedBox(
+            child: SizedBox(
+              height: 55,
+              width: 266,
+              child: SingleChildScrollView(child: Column()),
+            ),
+          ),
+        ),
+      ],
+    ));
+
+    final SemanticsNode node = RendererBinding.instance.renderView.debugSemantics!;
+
+    expect(node.transform, null); // Make sure the zero transform didn't end up on the root somehow.
+    expect(node.childrenCount, 0);
+  });
 }
 
 class CustomSortKey extends OrdinalSortKey {


### PR DESCRIPTION
Addresses framework side of https://github.com/flutter/flutter/issues/110671

We should still fix this on the engine side - it's valid (but inefficient) for someone to send up a zero transform to the engine.