### PR TITLE
Add `allowedButtonsFilter` to prevent Draggable from appearing with secondary click.

### DIFF
--- a/packages/flutter/lib/src/gestures/eager.dart
+++ b/packages/flutter/lib/src/gestures/eager.dart
@@ -24,6 +24,7 @@ class EagerGestureRecognizer extends OneSequenceGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   @override

--- a/packages/flutter/lib/src/gestures/force_press.dart
+++ b/packages/flutter/lib/src/gestures/force_press.dart
@@ -133,6 +133,7 @@ class ForcePressGestureRecognizer extends OneSequenceGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   }) : assert(startPressure != null),
        assert(peakPressure != null),
        assert(interpolation != null),

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -247,13 +247,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   /// The [duration] argument can be used to overwrite the default duration
   /// after which the long press will be recognized.
   ///
-  /// The [allowedButtonsFilter] argument only gives this recognizer the
-  /// ability to limit the buttons it accepts. It does not provide the
-  /// ability to recognize any buttons beyond the ones it already accepts:
-  /// kPrimaryButton, kSecondaryButton or kTertiaryButton. Therefore, a
-  /// combined value of `kPrimaryButton & kSecondaryButton` would be ignored,
-  /// but `kPrimaryButton | kSecondaryButton` would be allowed, as long as
-  /// only one of them is long pressed at a time.
+  /// {@macro flutter.gestures.tap.TapGestureRecognizer.allowedButtonsFilter}
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
   LongPressGestureRecognizer({

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -247,6 +247,14 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   /// The [duration] argument can be used to overwrite the default duration
   /// after which the long press will be recognized.
   ///
+  /// The [allowedButtonsFilter] argument only gives this recognizer the
+  /// ability to limit the buttons it accepts. It does not provide the
+  /// ability to recognize any buttons beyond the ones it already accepts:
+  /// kPrimaryButton, kSecondaryButton or kTertiaryButton. Therefore, a
+  /// combined value of `kPrimaryButton & kSecondaryButton` would be ignored,
+  /// but `kPrimaryButton | kSecondaryButton` would be allowed, as long as
+  /// only one of them is long pressed at a time.
+  ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
   LongPressGestureRecognizer({
     Duration? duration,

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -258,7 +258,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     super.kind,
     super.supportedDevices,
     super.debugOwner,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
+    super.allowedButtonsFilter,
   }) : super(
          deadline: duration ?? kLongPressTimeout,
        );
@@ -268,12 +268,6 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   // The buttons sent by `PointerDownEvent`. If a `PointerMoveEvent` comes with a
   // different set of buttons, the gesture is canceled.
   int? _initialButtons;
-
-  // Accept the input when a single button is pressed.
-  static bool _defaultButtonAcceptBehavior(int buttons) =>
-      buttons == kPrimaryButton ||
-      buttons == kSecondaryButton ||
-      buttons == kTertiaryButton;
 
   /// Called when a pointer has contacted the screen at a particular location
   /// with a primary button, which might be the start of a long-press.
@@ -611,7 +605,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         }
         break;
       default:
-        break;
+        return false;
     }
     return super.isPointerAllowed(event);
   }
@@ -671,71 +665,54 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
       localPosition: _longPressOrigin!.local,
       kind: getKindForPointer(event.pointer),
     );
-
-    _switchButtons(
-      onPrimaryButton: () {
+    switch (_initialButtons) {
+      case kPrimaryButton:
         if (onLongPressDown != null) {
           invokeCallback<void>('onLongPressDown', () => onLongPressDown!(details));
         }
-      },
-      onSecondaryButton: () {
+        break;
+      case kSecondaryButton:
         if (onSecondaryLongPressDown != null) {
           invokeCallback<void>('onSecondaryLongPressDown', () => onSecondaryLongPressDown!(details));
         }
-      },
-      onTertiaryButton: () {
+        break;
+      case kTertiaryButton:
         if (onTertiaryLongPressDown != null) {
           invokeCallback<void>('onTertiaryLongPressDown', () => onTertiaryLongPressDown!(details));
         }
-      },
-    );
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
+    }
   }
 
   void _checkLongPressCancel() {
     if (state == GestureRecognizerState.possible) {
-      _switchButtons(
-        onPrimaryButton: () {
+      switch (_initialButtons) {
+        case kPrimaryButton:
           if (onLongPressCancel != null) {
             invokeCallback<void>('onLongPressCancel', onLongPressCancel!);
           }
-        },
-        onSecondaryButton: () {
+          break;
+        case kSecondaryButton:
           if (onSecondaryLongPressCancel != null) {
             invokeCallback<void>('onSecondaryLongPressCancel', onSecondaryLongPressCancel!);
           }
-        },
-        onTertiaryButton: () {
+          break;
+        case kTertiaryButton:
           if (onTertiaryLongPressCancel != null) {
             invokeCallback<void>('onTertiaryLongPressCancel', onTertiaryLongPressCancel!);
           }
-        },
-      );
-    }
-  }
-
-  void _switchButtons({
-    required void Function() onPrimaryButton,
-    required void Function() onSecondaryButton,
-    required void Function() onTertiaryButton,
-  }) {
-    // This method uses bitwise operations to determine which button was
-    // pressed, in case more than one button was pressed at the same time.
-    if (_initialButtons != null) {
-      if (_initialButtons! & kPrimaryButton != 0) {
-        onPrimaryButton();
-      }
-      if (_initialButtons! & kSecondaryButton != 0) {
-        onSecondaryButton();
-      }
-      if (_initialButtons! & kTertiaryButton != 0) {
-        onTertiaryButton();
+          break;
+        default:
+          assert(false, 'Unhandled button $_initialButtons');
       }
     }
   }
 
   void _checkLongPressStart() {
-  _switchButtons(
-      onPrimaryButton: () {
+    switch (_initialButtons) {
+      case kPrimaryButton:
         if (onLongPressStart != null) {
           final LongPressStartDetails details = LongPressStartDetails(
             globalPosition: _longPressOrigin!.global,
@@ -746,8 +723,8 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onLongPress != null) {
           invokeCallback<void>('onLongPress', onLongPress!);
         }
-      },
-      onSecondaryButton: () {
+        break;
+      case kSecondaryButton:
         if (onSecondaryLongPressStart != null) {
           final LongPressStartDetails details = LongPressStartDetails(
             globalPosition: _longPressOrigin!.global,
@@ -758,8 +735,8 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onSecondaryLongPress != null) {
           invokeCallback<void>('onSecondaryLongPress', onSecondaryLongPress!);
         }
-      },
-      onTertiaryButton: () {
+        break;
+      case kTertiaryButton:
         if (onTertiaryLongPressStart != null) {
           final LongPressStartDetails details = LongPressStartDetails(
             globalPosition: _longPressOrigin!.global,
@@ -770,8 +747,10 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
         if (onTertiaryLongPress != null) {
           invokeCallback<void>('onTertiaryLongPress', onTertiaryLongPress!);
         }
-      },
-    );
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
+    }
   }
 
   void _checkLongPressMoveUpdate(PointerEvent event) {
@@ -781,23 +760,25 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
       offsetFromOrigin: event.position - _longPressOrigin!.global,
       localOffsetFromOrigin: event.localPosition - _longPressOrigin!.local,
     );
-    _switchButtons(
-      onPrimaryButton: () {
+    switch (_initialButtons) {
+      case kPrimaryButton:
         if (onLongPressMoveUpdate != null) {
           invokeCallback<void>('onLongPressMoveUpdate', () => onLongPressMoveUpdate!(details));
         }
-      },
-      onSecondaryButton: () {
+        break;
+      case kSecondaryButton:
         if (onSecondaryLongPressMoveUpdate != null) {
           invokeCallback<void>('onSecondaryLongPressMoveUpdate', () => onSecondaryLongPressMoveUpdate!(details));
         }
-      },
-      onTertiaryButton: () {
+        break;
+      case kTertiaryButton:
         if (onTertiaryLongPressMoveUpdate != null) {
           invokeCallback<void>('onTertiaryLongPressMoveUpdate', () => onTertiaryLongPressMoveUpdate!(details));
         }
-      },
-    );
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
+    }
   }
 
   void _checkLongPressEnd(PointerEvent event) {
@@ -812,33 +793,34 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     );
 
     _velocityTracker = null;
-    _switchButtons(
-      onPrimaryButton: () {
+    switch (_initialButtons) {
+      case kPrimaryButton:
         if (onLongPressEnd != null) {
           invokeCallback<void>('onLongPressEnd', () => onLongPressEnd!(details));
         }
         if (onLongPressUp != null) {
           invokeCallback<void>('onLongPressUp', onLongPressUp!);
         }
-      },
-      onSecondaryButton: () {
+        break;
+      case kSecondaryButton:
         if (onSecondaryLongPressEnd != null) {
           invokeCallback<void>('onSecondaryLongPressEnd', () => onSecondaryLongPressEnd!(details));
         }
         if (onSecondaryLongPressUp != null) {
-          invokeCallback<void>(
-              'onSecondaryLongPressUp', onSecondaryLongPressUp!);
+          invokeCallback<void>('onSecondaryLongPressUp', onSecondaryLongPressUp!);
         }
-      },
-      onTertiaryButton: () {
+        break;
+      case kTertiaryButton:
         if (onTertiaryLongPressEnd != null) {
           invokeCallback<void>('onTertiaryLongPressEnd', () => onTertiaryLongPressEnd!(details));
         }
         if (onTertiaryLongPressUp != null) {
           invokeCallback<void>('onTertiaryLongPressUp', onTertiaryLongPressUp!);
         }
-      },
-    );
+        break;
+      default:
+        assert(false, 'Unhandled button $_initialButtons');
+    }
   }
 
   void _reset() {

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -258,7 +258,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     super.kind,
     super.supportedDevices,
     super.debugOwner,
-    super.allowedButtonsFilter,
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
   }) : super(
          deadline: duration ?? kLongPressTimeout,
        );
@@ -268,6 +268,12 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
   // The buttons sent by `PointerDownEvent`. If a `PointerMoveEvent` comes with a
   // different set of buttons, the gesture is canceled.
   int? _initialButtons;
+
+  // Accept the input if, and only if, a single button is pressed.
+  static bool _defaultButtonAcceptBehavior(int buttons) =>
+      buttons == kPrimaryButton ||
+      buttons == kSecondaryButton ||
+      buttons == kTertiaryButton;
 
   /// Called when a pointer has contacted the screen at a particular location
   /// with a primary button, which might be the start of a long-press.

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -257,8 +257,8 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.allowedButtonsFilter,
     super.debugOwner,
+    super.allowedButtonsFilter,
   }) : super(
          deadline: duration ?? kLongPressTimeout,
        );

--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -257,6 +257,7 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
     super.debugOwner,
   }) : super(
          deadline: duration ?? kLongPressTimeout,

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -645,8 +645,10 @@ class PanGestureRecognizer extends DragGestureRecognizer {
   PanGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
-    super.allowedButtonsFilter,
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
   });
+
+  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -59,9 +59,8 @@ typedef GestureVelocityTrackerBuilder = VelocityTracker Function(PointerEvent ev
 /// consider using one of its subclasses to recognize specific types for drag
 /// gestures.
 ///
-/// [DragGestureRecognizer] competes on pointer events of [kPrimaryButton]
-/// only when it has at least one non-null callback. If it has no callbacks, it
-/// is a no-op.
+/// [DragGestureRecognizer] competes on pointer events only when it has at
+/// least one non-null callback. If it has no callbacks, it is a no-op.
 ///
 /// See also:
 ///
@@ -123,7 +122,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [DragDownDetails], which is passed as an argument to this callback.
   GestureDragDownCallback? onDown;
 
@@ -138,7 +137,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [DragStartDetails], which is passed as an argument to this callback.
   GestureDragStartCallback? onStart;
 
@@ -152,7 +151,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [DragUpdateDetails], which is passed as an argument to this callback.
   GestureDragUpdateCallback? onUpdate;
 
@@ -167,7 +166,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [DragEndDetails], which is passed as an argument to this callback.
   GestureDragEndCallback? onEnd;
 
@@ -175,7 +174,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   GestureDragCancelCallback? onCancel;
 
   /// The minimum distance an input pointer drag must have moved to
@@ -252,18 +251,12 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   @override
   bool isPointerAllowed(PointerEvent event) {
     if (_initialButtons == null) {
-      switch (event.buttons) {
-        case kPrimaryButton:
-          if (onDown == null &&
-              onStart == null &&
-              onUpdate == null &&
-              onEnd == null &&
-              onCancel == null) {
-            return false;
-          }
-          break;
-        default:
-          return false;
+      if (onDown == null &&
+          onStart == null &&
+          onUpdate == null &&
+          onEnd == null &&
+          onCancel == null) {
+        return false;
       }
     } else {
       // There can be multiple drags simultaneously. Their effects are combined.
@@ -303,7 +296,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     super.addAllowedPointerPanZoom(event);
     startTrackingPointer(event.pointer, event.transform);
     if (_state == _DragState.ready) {
-      _initialButtons = kPrimaryButton;
+      _initialButtons = event.buttons;
     }
     _addPointer(event);
   }
@@ -450,7 +443,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _checkDown() {
-    assert(_initialButtons == kPrimaryButton);
     if (onDown != null) {
       final DragDownDetails details = DragDownDetails(
         globalPosition: _initialPosition.global,
@@ -461,7 +453,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _checkStart(Duration timestamp, int pointer) {
-    assert(_initialButtons == kPrimaryButton);
     if (onStart != null) {
       final DragStartDetails details = DragStartDetails(
         sourceTimeStamp: timestamp,
@@ -480,7 +471,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     required Offset globalPosition,
     Offset? localPosition,
   }) {
-    assert(_initialButtons == kPrimaryButton);
     if (onUpdate != null) {
       final DragUpdateDetails details = DragUpdateDetails(
         sourceTimeStamp: sourceTimeStamp,
@@ -494,7 +484,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _checkEnd(int pointer) {
-    assert(_initialButtons == kPrimaryButton);
     if (onEnd == null) {
       return;
     }
@@ -531,7 +520,6 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
   }
 
   void _checkCancel() {
-    assert(_initialButtons == kPrimaryButton);
     if (onCancel != null) {
       invokeCallback<void>('onCancel', onCancel!);
     }

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -84,6 +84,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   }) : assert(dragStartBehavior != null);
 
   static VelocityTracker _defaultBuilder(PointerEvent event) => VelocityTracker.withKind(event.kind);
@@ -570,6 +571,7 @@ class VerticalDragGestureRecognizer extends DragGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   @override
@@ -616,6 +618,7 @@ class HorizontalDragGestureRecognizer extends DragGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   @override
@@ -654,6 +657,7 @@ class PanGestureRecognizer extends DragGestureRecognizer {
   PanGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   @override

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -83,10 +83,13 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
     super.supportedDevices,
-    super.allowedButtonsFilter,
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
   }) : assert(dragStartBehavior != null);
 
   static VelocityTracker _defaultBuilder(PointerEvent event) => VelocityTracker.withKind(event.kind);
+
+  // Accept the input if, and only if, [kPrimaryButton] is pressed.
+  static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
 
   /// Configure the behavior of offsets passed to [onStart].
   ///
@@ -296,7 +299,7 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     super.addAllowedPointerPanZoom(event);
     startTrackingPointer(event.pointer, event.transform);
     if (_state == _DragState.ready) {
-      _initialButtons = event.buttons;
+      _initialButtons = kPrimaryButton;
     }
     _addPointer(event);
   }
@@ -645,10 +648,8 @@ class PanGestureRecognizer extends DragGestureRecognizer {
   PanGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
+    super.allowedButtonsFilter,
   });
-
-  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   @override
   bool isFlingGesture(VelocityEstimate estimate, PointerDeviceKind kind) {

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -26,10 +26,10 @@ export 'gesture_settings.dart' show DeviceGestureSettings;
 /// Signature for when [MultiDragGestureRecognizer] recognizes the start of a drag gesture.
 typedef GestureMultiDragStartCallback = Drag? Function(Offset position);
 
-/// Signature for `buttonsEventFilter` in [MultiDragGestureRecognizer].
+/// Signature for `allowedButtonsFilter` in [MultiDragGestureRecognizer].
 /// Used to filter the input buttons of the pointer event.
-/// The parameter `int buttons` comes from [PointerEvent.buttons].
-typedef ButtonsEventFilter = bool Function(int buttons);
+/// The parameter `buttons` comes from [PointerEvent.buttons].
+typedef AllowedButtonsFilter = bool Function(int buttons);
 
 /// Per-pointer state for a [MultiDragGestureRecognizer].
 ///
@@ -228,8 +228,8 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    ButtonsEventFilter? buttonsEventFilter,
-  }): _buttonsEventFilter = buttonsEventFilter ?? _defaultButtonAcceptBehavior;
+    AllowedButtonsFilter? allowedButtonsFilter,
+  }): _allowedButtonsFilter = allowedButtonsFilter ?? _defaultButtonAcceptBehavior;
 
   /// Called when this class recognizes the start of a drag gesture.
   ///
@@ -237,7 +237,7 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
   /// [Drag] object returned by this callback.
   GestureMultiDragStartCallback? onStart;
 
-  /// {@template flutter.gestures.multidrag._buttonsEventFilter}
+  /// {@template flutter.gestures.multidrag._allowedButtonsFilter}
   /// Called when interaction starts. This limits the dragging behavior
   /// for custom clicks (such as scroll click). Its parameter comes
   /// from [PointerEvent.buttons].
@@ -254,9 +254,9 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
   ///
   /// Defaults to primary button only.
   /// {@endtemplate}
-  final ButtonsEventFilter _buttonsEventFilter;
+  final AllowedButtonsFilter _allowedButtonsFilter;
 
-  // The default value for [buttonsEventFilter].
+  // The default value for [allowedButtonsFilter].
   // Accept the input if, and only if, [kPrimaryButton] is pressed.
   static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
 
@@ -362,7 +362,7 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
   @protected
   bool isPointerAllowed(PointerDownEvent event) {
     // Check for mouse button, then device kind.
-    return _buttonsEventFilter(event.buttons) && super.isPointerAllowed(event);
+    return _allowedButtonsFilter(event.buttons) && super.isPointerAllowed(event);
   }
 
   @override
@@ -419,7 +419,7 @@ class ImmediateMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.buttonsEventFilter,
+    super.allowedButtonsFilter,
   });
 
   @override
@@ -477,7 +477,7 @@ class HorizontalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.buttonsEventFilter,
+    super.allowedButtonsFilter,
   });
 
   @override
@@ -535,7 +535,7 @@ class VerticalMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.buttonsEventFilter,
+    super.allowedButtonsFilter,
   });
 
   @override
@@ -646,7 +646,7 @@ class DelayedMultiDragGestureRecognizer extends MultiDragGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.buttonsEventFilter,
+    super.allowedButtonsFilter,
   }) : assert(delay != null);
 
   /// The amount of time the pointer must remain in the same place for the drag

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -26,11 +26,6 @@ export 'gesture_settings.dart' show DeviceGestureSettings;
 /// Signature for when [MultiDragGestureRecognizer] recognizes the start of a drag gesture.
 typedef GestureMultiDragStartCallback = Drag? Function(Offset position);
 
-/// Signature for `allowedButtonsFilter` in [MultiDragGestureRecognizer].
-/// Used to filter the input buttons of the pointer event.
-/// The parameter `buttons` comes from [PointerEvent.buttons].
-typedef AllowedButtonsFilter = bool Function(int buttons);
-
 /// Per-pointer state for a [MultiDragGestureRecognizer].
 ///
 /// A [MultiDragGestureRecognizer] tracks each pointer separately. The state for
@@ -228,37 +223,14 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    AllowedButtonsFilter? allowedButtonsFilter,
-  }): _allowedButtonsFilter = allowedButtonsFilter ?? _defaultButtonAcceptBehavior;
+    super.allowedButtonsFilter,
+  });
 
   /// Called when this class recognizes the start of a drag gesture.
   ///
   /// The remaining notifications for this drag gesture are delivered to the
   /// [Drag] object returned by this callback.
   GestureMultiDragStartCallback? onStart;
-
-  /// {@template flutter.gestures.multidrag._allowedButtonsFilter}
-  /// Called when interaction starts. This limits the dragging behavior
-  /// for custom clicks (such as scroll click). Its parameter comes
-  /// from [PointerEvent.buttons].
-  ///
-  /// Due to how [kPrimaryButton], [kSecondaryButton], etc., use integers,
-  /// bitwise operations can help filter how buttons are pressed.
-  /// For example, if someone simultaneously presses the primary and secondary
-  /// buttons, the default behavior will return false. The following code
-  /// accepts any button press with primary:
-  /// `(int buttons) => buttons & kPrimaryButton != 0`.
-  ///
-  /// When value is `(int buttons) => false`, allow no interactions.
-  /// When value is `(int buttons) => true`, allow all interactions.
-  ///
-  /// Defaults to primary button only.
-  /// {@endtemplate}
-  final AllowedButtonsFilter _allowedButtonsFilter;
-
-  // The default value for [allowedButtonsFilter].
-  // Accept the input if, and only if, [kPrimaryButton] is pressed.
-  static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
 
   Map<int, MultiDragPointerState>? _pointers = <int, MultiDragPointerState>{};
 
@@ -361,8 +333,8 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
   @override
   @protected
   bool isPointerAllowed(PointerDownEvent event) {
-    // Check for mouse button, then device kind.
-    return _allowedButtonsFilter(event.buttons) && super.isPointerAllowed(event);
+    // Check for mouse button, then device kind and button type.
+    return super.isPointerAllowed(event);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -223,8 +223,11 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.allowedButtonsFilter,
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
   });
+
+  // Accept the input if, and only if, [kPrimaryButton] is pressed.
+  static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
 
   /// Called when this class recognizes the start of a drag gesture.
   ///
@@ -327,14 +330,6 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
     assert(_pointers!.containsKey(pointer));
     GestureBinding.instance.pointerRouter.removeRoute(pointer, _handleEvent);
     _pointers!.remove(pointer)!.dispose();
-  }
-
-  /// Checks whether or not a pointer is allowed to be tracked by this recognizer.
-  @override
-  @protected
-  bool isPointerAllowed(PointerDownEvent event) {
-    // Check for mouse button, then device kind and button type.
-    return super.isPointerAllowed(event);
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -128,6 +128,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   // Implementation notes:
@@ -492,6 +493,7 @@ class MultiTapGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   /// A pointer that might cause a tap has contacted the screen at a particular
@@ -813,6 +815,7 @@ class SerialTapGestureRecognizer extends GestureRecognizer {
   SerialTapGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
+    super.allowedButtonsFilter
   });
 
   /// A pointer has contacted the screen at a particular location, which might

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -815,11 +815,8 @@ class SerialTapGestureRecognizer extends GestureRecognizer {
   SerialTapGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior
+    super.allowedButtonsFilter,
   });
-
-  /// SerialTap gestures are accepted regardless of the button state.
-  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   /// A pointer has contacted the screen at a particular location, which might
   /// be the start of a serial tap.

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -113,8 +113,8 @@ class _TapTracker {
 /// Recognizes when the user has tapped the screen at the same location twice in
 /// quick succession.
 ///
-/// [DoubleTapGestureRecognizer] competes on pointer events of [kPrimaryButton]
-/// only when it has a non-null callback. If it has no callbacks, it is a no-op.
+/// [DoubleTapGestureRecognizer] competes on pointer events when it
+/// has a non-null callback. If it has no callbacks, it is a no-op.
 ///
 class DoubleTapGestureRecognizer extends GestureRecognizer {
   /// Create a gesture recognizer for double taps.
@@ -128,8 +128,12 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
-    super.allowedButtonsFilter,
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
   });
+
+  // The default value for [allowedButtonsFilter].
+  // Accept the input if, and only if, [kPrimaryButton] is pressed.
+  static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
 
   // Implementation notes:
   //
@@ -166,7 +170,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [TapDownDetails], which is passed as an argument to this callback.
   ///  * [GestureDetector.onDoubleTapDown], which exposes this callback.
   GestureTapDownCallback? onDoubleTapDown;
@@ -179,7 +183,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [GestureDetector.onDoubleTap], which exposes this callback.
   GestureDoubleTapCallback? onDoubleTap;
 
@@ -193,7 +197,7 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   ///
   /// See also:
   ///
-  ///  * [kPrimaryButton], the button this callback responds to.
+  ///  * [allowedButtonsFilter], which decides which button will be allowed.
   ///  * [GestureDetector.onDoubleTapCancel], which exposes this callback.
   GestureTapCancelCallback? onDoubleTapCancel;
 
@@ -204,16 +208,10 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   @override
   bool isPointerAllowed(PointerDownEvent event) {
     if (_firstTap == null) {
-      switch (event.buttons) {
-        case kPrimaryButton:
-          if (onDoubleTapDown == null &&
-              onDoubleTap == null &&
-              onDoubleTapCancel == null) {
-            return false;
-          }
-          break;
-        default:
-          return false;
+      if (onDoubleTapDown == null &&
+          onDoubleTap == null &&
+          onDoubleTapCancel == null) {
+        return false;
       }
     }
 
@@ -374,7 +372,6 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   }
 
   void _checkUp(int buttons) {
-    assert(buttons == kPrimaryButton);
     if (onDoubleTap != null) {
       invokeCallback<void>('onDoubleTap', onDoubleTap!);
     }

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -815,8 +815,11 @@ class SerialTapGestureRecognizer extends GestureRecognizer {
   SerialTapGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
-    super.allowedButtonsFilter
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior
   });
+
+  /// SerialTap gestures are accepted regardless of the button state.
+  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   /// A pointer has contacted the screen at a particular location, which might
   /// be the start of a serial tap.

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -216,7 +216,13 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
           return false;
       }
     }
-    return super.isPointerAllowed(event);
+
+    // If second tap is not allowed, reset the state.
+    final bool isPointerAllowed = super.isPointerAllowed(event);
+    if (isPointerAllowed == false) {
+      _reset();
+    }
+    return isPointerAllowed;
   }
 
   @override

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -544,7 +544,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
     )
     super.kind,
     super.supportedDevices,
-    super.allowedButtonsFilter,
+    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
   }) : assert(
          preAcceptSlopTolerance == null || preAcceptSlopTolerance >= 0,
          'The preAcceptSlopTolerance must be positive or null',
@@ -553,6 +553,9 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
          postAcceptSlopTolerance == null || postAcceptSlopTolerance >= 0,
          'The postAcceptSlopTolerance must be positive or null',
        );
+
+  /// PrimaryPointerGestureRecognizer gestures are accepted regardless of the button state.
+  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   /// If non-null, the recognizer will call [didExceedDeadline] after this
   /// amount of time has elapsed since starting to track the primary pointer.

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -84,7 +84,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
     )
     PointerDeviceKind? kind,
     Set<PointerDeviceKind>? supportedDevices,
-    required AllowedButtonsFilter? allowedButtonsFilter,
+    AllowedButtonsFilter? allowedButtonsFilter,
   }) : assert(kind == null || supportedDevices == null),
        _supportedDevices = kind == null ? supportedDevices : <PointerDeviceKind>{ kind },
        _allowedButtonsFilter = allowedButtonsFilter ?? _defaultButtonAcceptBehavior;
@@ -217,8 +217,8 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   bool isPointerAllowed(PointerDownEvent event) {
     // Currently, it only checks for device kind. But in the future we could check
     // for other things e.g. mouse button.
-    return _supportedDevices == null ||
-        _supportedDevices!.contains(event.kind) ||
+    return (_supportedDevices == null ||
+            _supportedDevices!.contains(event.kind)) &&
         _allowedButtonsFilter(event.buttons);
   }
 

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -48,6 +48,11 @@ enum DragStartBehavior {
   start,
 }
 
+/// Signature for `allowedButtonsFilter` in [GestureRecognizer].
+/// Used to filter the input buttons of the pointer event.
+/// The parameter `buttons` comes from [PointerEvent.buttons].
+typedef AllowedButtonsFilter = bool Function(int buttons);
+
 /// The base class that all gesture recognizers inherit from.
 ///
 /// Provides a basic API that can be used by classes that work with
@@ -79,8 +84,10 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
     )
     PointerDeviceKind? kind,
     Set<PointerDeviceKind>? supportedDevices,
+    required AllowedButtonsFilter? allowedButtonsFilter,
   }) : assert(kind == null || supportedDevices == null),
-       _supportedDevices = kind == null ? supportedDevices : <PointerDeviceKind>{ kind };
+       _supportedDevices = kind == null ? supportedDevices : <PointerDeviceKind>{ kind },
+       _allowedButtonsFilter = allowedButtonsFilter ?? _defaultButtonAcceptBehavior;
 
   /// The recognizer's owner.
   ///
@@ -97,6 +104,29 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// These cannot both be set. If both are null, events from all device kinds will be
   /// tracked and recognized.
   final Set<PointerDeviceKind>? _supportedDevices;
+
+    /// {@template flutter.gestures.multidrag._allowedButtonsFilter}
+  /// Called when interaction starts. This limits the dragging behavior
+  /// for custom clicks (such as scroll click). Its parameter comes
+  /// from [PointerEvent.buttons].
+  ///
+  /// Due to how [kPrimaryButton], [kSecondaryButton], etc., use integers,
+  /// bitwise operations can help filter how buttons are pressed.
+  /// For example, if someone simultaneously presses the primary and secondary
+  /// buttons, the default behavior will return false. The following code
+  /// accepts any button press with primary:
+  /// `(int buttons) => buttons & kPrimaryButton != 0`.
+  ///
+  /// When value is `(int buttons) => false`, allow no interactions.
+  /// When value is `(int buttons) => true`, allow all interactions.
+  ///
+  /// Defaults to primary button only.
+  /// {@endtemplate}
+  final AllowedButtonsFilter _allowedButtonsFilter;
+
+  // The default value for [allowedButtonsFilter].
+  // Accept the input if, and only if, [kPrimaryButton] is pressed.
+  static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
 
   /// Holds a mapping between pointer IDs and the kind of devices they are
   /// coming from.
@@ -187,7 +217,9 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   bool isPointerAllowed(PointerDownEvent event) {
     // Currently, it only checks for device kind. But in the future we could check
     // for other things e.g. mouse button.
-    return _supportedDevices == null || _supportedDevices!.contains(event.kind);
+    return _supportedDevices == null ||
+        _supportedDevices!.contains(event.kind) ||
+        _allowedButtonsFilter(event.buttons);
   }
 
   /// Handles a pointer pan/zoom being added that's not allowed by this recognizer.
@@ -298,6 +330,7 @@ abstract class OneSequenceGestureRecognizer extends GestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   });
 
   final Map<int, GestureArenaEntry> _entries = <int, GestureArenaEntry>{};
@@ -511,6 +544,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   }) : assert(
          preAcceptSlopTolerance == null || preAcceptSlopTolerance >= 0,
          'The preAcceptSlopTolerance must be positive or null',

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -125,8 +125,8 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   final AllowedButtonsFilter _allowedButtonsFilter;
 
   // The default value for [allowedButtonsFilter].
-  // Accept the input if, and only if, [kPrimaryButton] is pressed.
-  static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;
+  // Accept any input.
+  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   /// Holds a mapping between pointer IDs and the kind of devices they are
   /// coming from.
@@ -544,7 +544,7 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
     )
     super.kind,
     super.supportedDevices,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
+    super.allowedButtonsFilter,
   }) : assert(
          preAcceptSlopTolerance == null || preAcceptSlopTolerance >= 0,
          'The preAcceptSlopTolerance must be positive or null',
@@ -553,9 +553,6 @@ abstract class PrimaryPointerGestureRecognizer extends OneSequenceGestureRecogni
          postAcceptSlopTolerance == null || postAcceptSlopTolerance >= 0,
          'The postAcceptSlopTolerance must be positive or null',
        );
-
-  /// PrimaryPointerGestureRecognizer gestures are accepted regardless of the button state.
-  static bool _defaultButtonAcceptBehavior(int buttons) => true;
 
   /// If non-null, the recognizer will call [didExceedDeadline] after this
   /// amount of time has elapsed since starting to track the primary pointer.

--- a/packages/flutter/lib/src/gestures/recognizer.dart
+++ b/packages/flutter/lib/src/gestures/recognizer.dart
@@ -49,7 +49,7 @@ enum DragStartBehavior {
 }
 
 /// Signature for `allowedButtonsFilter` in [GestureRecognizer].
-/// Used to filter the input buttons of the pointer event.
+/// Used to filter the input buttons of incoming pointer events.
 /// The parameter `buttons` comes from [PointerEvent.buttons].
 typedef AllowedButtonsFilter = bool Function(int buttons);
 
@@ -105,7 +105,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// tracked and recognized.
   final Set<PointerDeviceKind>? _supportedDevices;
 
-    /// {@template flutter.gestures.multidrag._allowedButtonsFilter}
+  /// {@template flutter.gestures.multidrag._allowedButtonsFilter}
   /// Called when interaction starts. This limits the dragging behavior
   /// for custom clicks (such as scroll click). Its parameter comes
   /// from [PointerEvent.buttons].
@@ -120,7 +120,7 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// When value is `(int buttons) => false`, allow no interactions.
   /// When value is `(int buttons) => true`, allow all interactions.
   ///
-  /// Defaults to primary button only.
+  /// Defaults to all buttons.
   /// {@endtemplate}
   final AllowedButtonsFilter _allowedButtonsFilter;
 
@@ -215,8 +215,6 @@ abstract class GestureRecognizer extends GestureArenaMember with DiagnosticableT
   /// Checks whether or not a pointer is allowed to be tracked by this recognizer.
   @protected
   bool isPointerAllowed(PointerDownEvent event) {
-    // Currently, it only checks for device kind. But in the future we could check
-    // for other things e.g. mouse button.
     return (_supportedDevices == null ||
             _supportedDevices!.contains(event.kind)) &&
         _allowedButtonsFilter(event.buttons);

--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -334,6 +334,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
     )
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
     this.dragStartBehavior = DragStartBehavior.down,
     this.trackpadScrollCausesScale = false,
     this.trackpadScrollToScaleFactor = kDefaultTrackpadScrollToScaleFactor,

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -366,7 +366,11 @@ class TapGestureRecognizer extends BaseTapGestureRecognizer {
   /// Creates a tap gesture recognizer.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
-  TapGestureRecognizer({ super.debugOwner, super.supportedDevices });
+  TapGestureRecognizer({
+    super.debugOwner,
+    super.supportedDevices,
+    super.allowedButtonsFilter,
+  });
 
   /// {@template flutter.gestures.tap.TapGestureRecognizer.onTapDown}
   /// A pointer has contacted the screen at a particular location with a primary

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -149,7 +149,11 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
   /// Creates a tap gesture recognizer.
   ///
   /// {@macro flutter.gestures.GestureRecognizer.supportedDevices}
-  BaseTapGestureRecognizer({ super.debugOwner, super.supportedDevices })
+  BaseTapGestureRecognizer({
+    super.debugOwner,
+    super.supportedDevices,
+    super.allowedButtonsFilter,
+  })
     : super(deadline: kPressTimeout);
 
   bool _sentTapDown = false;

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -358,13 +358,16 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
 /// one non-null `onTertiaryTap*` callback. If it has no callbacks, it is a
 /// no-op.
 ///
+/// {@template flutter.gestures.tap.TapGestureRecognizer.allowedButtonsFilter}
 /// The [allowedButtonsFilter] argument only gives this recognizer the
 /// ability to limit the buttons it accepts. It does not provide the
 /// ability to recognize any buttons beyond the ones it already accepts:
 /// kPrimaryButton, kSecondaryButton or kTertiaryButton. Therefore, a
 /// combined value of `kPrimaryButton & kSecondaryButton` would be ignored,
 /// but `kPrimaryButton | kSecondaryButton` would be allowed, as long as
-/// only one of them is tapped at a time.
+/// only one of them is selected at a time.
+/// {@endtemplate}
+///
 /// See also:
 ///
 ///  * [GestureDetector.onTap], which uses this recognizer.

--- a/packages/flutter/lib/src/gestures/tap.dart
+++ b/packages/flutter/lib/src/gestures/tap.dart
@@ -358,6 +358,13 @@ abstract class BaseTapGestureRecognizer extends PrimaryPointerGestureRecognizer 
 /// one non-null `onTertiaryTap*` callback. If it has no callbacks, it is a
 /// no-op.
 ///
+/// The [allowedButtonsFilter] argument only gives this recognizer the
+/// ability to limit the buttons it accepts. It does not provide the
+/// ability to recognize any buttons beyond the ones it already accepts:
+/// kPrimaryButton, kSecondaryButton or kTertiaryButton. Therefore, a
+/// combined value of `kPrimaryButton & kSecondaryButton` would be ignored,
+/// but `kPrimaryButton | kSecondaryButton` would be allowed, as long as
+/// only one of them is tapped at a time.
 /// See also:
 ///
 ///  * [GestureDetector.onTap], which uses this recognizer.

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -179,6 +179,7 @@ class Draggable<T extends Object> extends StatefulWidget {
     this.ignoringFeedbackPointer = true,
     this.rootOverlay = false,
     this.hitTestBehavior = HitTestBehavior.deferToChild,
+    this.buttonsEventFilter,
   }) : assert(child != null),
        assert(feedback != null),
        assert(ignoringFeedbackSemantics != null),
@@ -359,6 +360,9 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// Defaults to [HitTestBehavior.deferToChild].
   final HitTestBehavior hitTestBehavior;
 
+  /// {@macro flutter.gestures.multidrag._buttonsEventFilter}
+  final ButtonsEventFilter? buttonsEventFilter;
+
   /// Creates a gesture recognizer that recognizes the start of the drag.
   ///
   /// Subclasses can override this function to customize when they start
@@ -367,11 +371,11 @@ class Draggable<T extends Object> extends StatefulWidget {
   MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
     switch (affinity) {
       case Axis.horizontal:
-        return HorizontalMultiDragGestureRecognizer()..onStart = onStart;
+        return HorizontalMultiDragGestureRecognizer(buttonsEventFilter: buttonsEventFilter)..onStart = onStart;
       case Axis.vertical:
-        return VerticalMultiDragGestureRecognizer()..onStart = onStart;
+        return VerticalMultiDragGestureRecognizer(buttonsEventFilter: buttonsEventFilter)..onStart = onStart;
       case null:
-        return ImmediateMultiDragGestureRecognizer()..onStart = onStart;
+        return ImmediateMultiDragGestureRecognizer(buttonsEventFilter: buttonsEventFilter)..onStart = onStart;
     }
   }
 
@@ -409,6 +413,7 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
     super.ignoringFeedbackSemantics,
     super.ignoringFeedbackPointer,
     this.delay = kLongPressTimeout,
+    super.buttonsEventFilter,
   });
 
   /// Whether haptic feedback should be triggered on drag start.
@@ -421,7 +426,7 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
 
   @override
   DelayedMultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
-    return DelayedMultiDragGestureRecognizer(delay: delay)
+    return DelayedMultiDragGestureRecognizer(delay: delay, buttonsEventFilter: buttonsEventFilter)
       ..onStart = (Offset position) {
         final Drag? result = onStart(position);
         if (result != null && hapticFeedbackOnStart) {

--- a/packages/flutter/lib/src/widgets/drag_target.dart
+++ b/packages/flutter/lib/src/widgets/drag_target.dart
@@ -179,7 +179,7 @@ class Draggable<T extends Object> extends StatefulWidget {
     this.ignoringFeedbackPointer = true,
     this.rootOverlay = false,
     this.hitTestBehavior = HitTestBehavior.deferToChild,
-    this.buttonsEventFilter,
+    this.allowedButtonsFilter,
   }) : assert(child != null),
        assert(feedback != null),
        assert(ignoringFeedbackSemantics != null),
@@ -360,8 +360,8 @@ class Draggable<T extends Object> extends StatefulWidget {
   /// Defaults to [HitTestBehavior.deferToChild].
   final HitTestBehavior hitTestBehavior;
 
-  /// {@macro flutter.gestures.multidrag._buttonsEventFilter}
-  final ButtonsEventFilter? buttonsEventFilter;
+  /// {@macro flutter.gestures.multidrag._allowedButtonsFilter}
+  final AllowedButtonsFilter? allowedButtonsFilter;
 
   /// Creates a gesture recognizer that recognizes the start of the drag.
   ///
@@ -371,11 +371,11 @@ class Draggable<T extends Object> extends StatefulWidget {
   MultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
     switch (affinity) {
       case Axis.horizontal:
-        return HorizontalMultiDragGestureRecognizer(buttonsEventFilter: buttonsEventFilter)..onStart = onStart;
+        return HorizontalMultiDragGestureRecognizer(allowedButtonsFilter: allowedButtonsFilter)..onStart = onStart;
       case Axis.vertical:
-        return VerticalMultiDragGestureRecognizer(buttonsEventFilter: buttonsEventFilter)..onStart = onStart;
+        return VerticalMultiDragGestureRecognizer(allowedButtonsFilter: allowedButtonsFilter)..onStart = onStart;
       case null:
-        return ImmediateMultiDragGestureRecognizer(buttonsEventFilter: buttonsEventFilter)..onStart = onStart;
+        return ImmediateMultiDragGestureRecognizer(allowedButtonsFilter: allowedButtonsFilter)..onStart = onStart;
     }
   }
 
@@ -413,7 +413,7 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
     super.ignoringFeedbackSemantics,
     super.ignoringFeedbackPointer,
     this.delay = kLongPressTimeout,
-    super.buttonsEventFilter,
+    super.allowedButtonsFilter,
   });
 
   /// Whether haptic feedback should be triggered on drag start.
@@ -426,7 +426,7 @@ class LongPressDraggable<T extends Object> extends Draggable<T> {
 
   @override
   DelayedMultiDragGestureRecognizer createRecognizer(GestureMultiDragStartCallback onStart) {
-    return DelayedMultiDragGestureRecognizer(delay: delay, buttonsEventFilter: buttonsEventFilter)
+    return DelayedMultiDragGestureRecognizer(delay: delay, allowedButtonsFilter: allowedButtonsFilter)
       ..onStart = (Offset position) {
         final Drag? result = onStart(position);
         if (result != null && hapticFeedbackOnStart) {

--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -702,6 +702,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
     super.debugOwner,
     super.kind,
     super.supportedDevices,
+    super.allowedButtonsFilter,
   }) : _deadline = kPressTimeout,
       dragStartBehavior = DragStartBehavior.start,
       slopTolerance = kTouchSlop;

--- a/packages/flutter/test/gestures/double_tap_test.dart
+++ b/packages/flutter/test/gestures/double_tap_test.dart
@@ -493,6 +493,56 @@ void main() {
       expect(doubleTapCanceled, isFalse);
     });
 
+    testGesture('Button change with allowedButtonsFilter should interrupt existing sequence', (GestureTester tester) {
+      final DoubleTapGestureRecognizer tapPrimary = DoubleTapGestureRecognizer(
+        allowedButtonsFilter: (int buttons) => buttons == kPrimaryButton,
+      );
+      tapPrimary.onDoubleTap = () {
+        doubleTapRecognized = true;
+      };
+      tapPrimary.onDoubleTapDown = (TapDownDetails details) {
+        doubleTapDownDetails = details;
+      };
+      tapPrimary.onDoubleTapCancel = () {
+        doubleTapCanceled = true;
+      };
+
+      // Down1 -> down6 (different button from 1) -> down2 (same button as 1)
+      // Down1 and down2 could've been a double tap, but is interrupted by down 6.
+      // Down6 gets ignored because it's not a primary button. Regardless, the state
+      // is reset.
+      const Duration interval = Duration(milliseconds: 100);
+      assert(interval * 2 < kDoubleTapTimeout);
+      assert(interval > kDoubleTapMinTime);
+
+      tapPrimary.addPointer(down1);
+      tester.closeArena(1);
+      tester.route(down1);
+      tester.route(up1);
+      GestureBinding.instance.gestureArena.sweep(1);
+
+      tester.async.elapse(interval);
+
+      tapPrimary.addPointer(down6);
+      tester.closeArena(6);
+      tester.route(down6);
+      tester.route(up6);
+      GestureBinding.instance.gestureArena.sweep(6);
+
+      tester.async.elapse(interval);
+      expect(doubleTapRecognized, isFalse);
+
+      tapPrimary.addPointer(down2);
+      tester.closeArena(2);
+      tester.route(down2);
+      tester.route(up2);
+      GestureBinding.instance.gestureArena.sweep(2);
+
+      expect(doubleTapRecognized, isFalse);
+      expect(doubleTapDownDetails, isNull);
+      expect(doubleTapCanceled, isFalse);
+    });
+
     testGesture('Button change should start a valid sequence', (GestureTester tester) {
       // Down6 -> down1 (different button from 6) -> down2 (same button as 1)
 
@@ -618,6 +668,44 @@ void main() {
     tester.closeArena(7);
     tester.route(down7);
     tester.route(up7);
+    expect(recognized, <String>[]);
+
+    recognized.clear();
+    doubleTap.dispose();
+  });
+
+  testGesture('Buttons filter should cancel invalid taps', (GestureTester tester) {
+    final List<String> recognized = <String>[];
+    final DoubleTapGestureRecognizer doubleTap = DoubleTapGestureRecognizer(
+      allowedButtonsFilter: (int buttons) => false,
+    )
+      ..onDoubleTap = () {
+        recognized.add('primary');
+      };
+
+    // Down/up pair 7: normal tap sequence close to pair 6
+    const PointerDownEvent down7 = PointerDownEvent(
+      pointer: 7,
+      position: Offset(10.0, 10.0),
+    );
+
+    const PointerUpEvent up7 = PointerUpEvent(
+      pointer: 7,
+      position: Offset(11.0, 9.0),
+    );
+
+    doubleTap.addPointer(down7);
+    tester.closeArena(7);
+    tester.route(down7);
+    tester.route(up7);
+    GestureBinding.instance.gestureArena.sweep(7);
+
+    tester.async.elapse(const Duration(milliseconds: 100));
+    doubleTap.addPointer(down6);
+    tester.closeArena(6);
+    tester.route(down6);
+    tester.route(up6);
+
     expect(recognized, <String>[]);
 
     recognized.clear();

--- a/packages/flutter/test/gestures/double_tap_test.dart
+++ b/packages/flutter/test/gestures/double_tap_test.dart
@@ -152,6 +152,54 @@ void main() {
     expect(doubleTapCanceled, isFalse);
   });
 
+  testGesture('Should recognize double tap with secondaryButton', (GestureTester tester) {
+    final DoubleTapGestureRecognizer tapSecondary = DoubleTapGestureRecognizer(
+      allowedButtonsFilter: (int buttons) => buttons == kSecondaryButton,
+    );
+    tapSecondary.onDoubleTap = () {
+      doubleTapRecognized = true;
+    };
+    tapSecondary.onDoubleTapDown = (TapDownDetails details) {
+      doubleTapDownDetails = details;
+    };
+    tapSecondary.onDoubleTapCancel = () {
+      doubleTapCanceled = true;
+    };
+
+    // Down/up pair 7: normal tap sequence close to pair 6
+    const PointerDownEvent down7 = PointerDownEvent(
+      pointer: 7,
+      position: Offset(10.0, 10.0),
+      buttons: kSecondaryMouseButton,
+    );
+
+    const PointerUpEvent up7 = PointerUpEvent(
+      pointer: 7,
+      position: Offset(11.0, 9.0),
+    );
+
+    tapSecondary.addPointer(down6);
+    tester.closeArena(6);
+    tester.route(down6);
+    tester.route(up6);
+    GestureBinding.instance.gestureArena.sweep(6);
+    expect(doubleTapDownDetails, isNull);
+
+    tester.async.elapse(const Duration(milliseconds: 100));
+    tapSecondary.addPointer(down7);
+    tester.closeArena(7);
+    expect(doubleTapDownDetails, isNotNull);
+    expect(doubleTapDownDetails!.globalPosition, down7.position);
+    expect(doubleTapDownDetails!.localPosition, down7.localPosition);
+    tester.route(down7);
+    expect(doubleTapRecognized, isFalse);
+
+    tester.route(up7);
+    expect(doubleTapRecognized, isTrue);
+    GestureBinding.instance.gestureArena.sweep(2);
+    expect(doubleTapCanceled, isFalse);
+  });
+
   testGesture('Inter-tap distance cancels double tap', (GestureTester tester) {
     tap.addPointer(down1);
     tester.closeArena(1);

--- a/packages/flutter/test/gestures/long_press_test.dart
+++ b/packages/flutter/test/gestures/long_press_test.dart
@@ -332,35 +332,6 @@ void main() {
       expect(recognized, const <String>['down', 'start']);
     });
 
-    testGesture('Should recognize long press with multiple buttons', (GestureTester tester) {
-      const PointerDownEvent multipleButtonsDown = PointerDownEvent(
-        pointer: 5,
-        position: Offset(10, 10),
-        buttons: kPrimaryButton | kSecondaryButton,
-      );
-
-      final LongPressGestureRecognizer customGesture =
-          LongPressGestureRecognizer(allowedButtonsFilter: (int buttons) => true)
-            ..onLongPressDown = (LongPressDownDetails details) {
-              recognized.add('down');
-            }
-            ..onLongPress = () {
-              recognized.add('start');
-            }
-            ..addPointer(multipleButtonsDown);
-
-      tester.closeArena(5);
-      expect(recognized, const <String>[]);
-      tester.route(multipleButtonsDown);
-      expect(recognized, const <String>['down']);
-      tester.async.elapse(const Duration(milliseconds: 300));
-      expect(recognized, const <String>['down']);
-      tester.async.elapse(const Duration(milliseconds: 700));
-      expect(recognized, const <String>['down', 'start']);
-      customGesture.dispose();
-      expect(recognized, const <String>['down', 'start']);
-    });
-
     testGesture('Short up cancels long press', (GestureTester tester) {
       gesture.addPointer(down);
       tester.closeArena(5);

--- a/packages/flutter/test/gestures/long_press_test.dart
+++ b/packages/flutter/test/gestures/long_press_test.dart
@@ -332,6 +332,35 @@ void main() {
       expect(recognized, const <String>['down', 'start']);
     });
 
+    testGesture('Should recognize long press with multiple buttons', (GestureTester tester) {
+      const PointerDownEvent multipleButtonsDown = PointerDownEvent(
+        pointer: 5,
+        position: Offset(10, 10),
+        buttons: kPrimaryButton | kSecondaryButton,
+      );
+
+      final LongPressGestureRecognizer customGesture =
+          LongPressGestureRecognizer(allowedButtonsFilter: (int buttons) => true)
+            ..onLongPressDown = (LongPressDownDetails details) {
+              recognized.add('down');
+            }
+            ..onLongPress = () {
+              recognized.add('start');
+            }
+            ..addPointer(multipleButtonsDown);
+
+      tester.closeArena(5);
+      expect(recognized, const <String>[]);
+      tester.route(multipleButtonsDown);
+      expect(recognized, const <String>['down']);
+      tester.async.elapse(const Duration(milliseconds: 300));
+      expect(recognized, const <String>['down']);
+      tester.async.elapse(const Duration(milliseconds: 700));
+      expect(recognized, const <String>['down', 'start']);
+      customGesture.dispose();
+      expect(recognized, const <String>['down', 'start']);
+    });
+
     testGesture('Short up cancels long press', (GestureTester tester) {
       gesture.addPointer(down);
       tester.closeArena(5);

--- a/packages/flutter/test/gestures/monodrag_test.dart
+++ b/packages/flutter/test/gestures/monodrag_test.dart
@@ -78,6 +78,57 @@ void main() {
       ),
     );
   });
+
+  group('Recognizers on different button filters:', () {
+    final List<String> recognized = <String>[];
+    late HorizontalDragGestureRecognizer primaryRecognizer;
+    late HorizontalDragGestureRecognizer secondaryRecognizer;
+    setUp(() {
+      primaryRecognizer = HorizontalDragGestureRecognizer(
+          allowedButtonsFilter: (int buttons) => kPrimaryButton == buttons)
+        ..onStart = (DragStartDetails details) {
+          recognized.add('onStartPrimary');
+        };
+      secondaryRecognizer = HorizontalDragGestureRecognizer(
+          allowedButtonsFilter: (int buttons) => kSecondaryButton == buttons)
+        ..onStart = (DragStartDetails details) {
+          recognized.add('onStartSecondary');
+        };
+    });
+
+    tearDown(() {
+      recognized.clear();
+      primaryRecognizer.dispose();
+      secondaryRecognizer.dispose();
+    });
+
+    testGesture('Primary button works', (GestureTester tester) {
+      const PointerDownEvent down1 = PointerDownEvent(
+        pointer: 6,
+        position: Offset(10.0, 10.0),
+      );
+
+      primaryRecognizer.addPointer(down1);
+      secondaryRecognizer.addPointer(down1);
+      tester.closeArena(down1.pointer);
+      tester.route(down1);
+      expect(recognized, <String>['onStartPrimary']);
+    });
+
+    testGesture('Secondary button works', (GestureTester tester) {
+      const PointerDownEvent down1 = PointerDownEvent(
+        pointer: 6,
+        position: Offset(10.0, 10.0),
+        buttons: kSecondaryMouseButton,
+      );
+
+      primaryRecognizer.addPointer(down1);
+      secondaryRecognizer.addPointer(down1);
+      tester.closeArena(down1.pointer);
+      tester.route(down1);
+      expect(recognized, <String>['onStartSecondary']);
+    });
+  });
 }
 
 class MockHitTestTarget implements HitTestTarget {

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -3195,6 +3195,48 @@ void main() {
     expect(const LongPressDraggable<int>(feedback: widget2, child: widget1).feedback, widget2);
     expect(LongPressDraggable<int>(feedback: widget2, dragAnchorStrategy: dummyStrategy, child: widget1).dragAnchorStrategy, dummyStrategy);
   });
+
+  testWidgets('Test buttonsEventFilter', (WidgetTester tester) async {
+    Widget build(bool Function(int buttons)? buttonsEventFilter) {
+      return MaterialApp(
+        home: Draggable<int>(
+          key: UniqueKey(),
+          buttonsEventFilter: buttonsEventFilter,
+          feedback: const Text('Dragging'),
+          child: const Text('Source'),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(build(null));
+    final Offset firstLocation = tester.getCenter(find.text('Source'));
+    expect(find.text('Dragging'), findsNothing);
+    final TestGesture gesture = await tester.startGesture(firstLocation, pointer: 7);
+    await tester.pump();
+    expect(find.text('Dragging'), findsOneWidget);
+    await gesture.up();
+
+    await tester.pumpWidget(build((int buttons) => buttons == kSecondaryButton));
+    expect(find.text('Dragging'), findsNothing);
+    final TestGesture gesture1 = await tester.startGesture(firstLocation, pointer: 8);
+    await tester.pump();
+    expect(find.text('Dragging'), findsNothing);
+    await gesture1.up();
+
+    await tester.pumpWidget(build((int buttons) => buttons & kTertiaryButton != 0 || buttons & kPrimaryButton != 0));
+    expect(find.text('Dragging'), findsNothing);
+    final TestGesture gesture2 = await tester.startGesture(firstLocation, pointer: 8);
+    await tester.pump();
+    expect(find.text('Dragging'), findsOneWidget);
+    await gesture2.up();
+
+    await tester.pumpWidget(build((int buttons) => false));
+    expect(find.text('Dragging'), findsNothing);
+    final TestGesture gesture3 = await tester.startGesture(firstLocation, pointer: 8);
+    await tester.pump();
+    expect(find.text('Dragging'), findsNothing);
+    await gesture3.up();
+  });
 }
 
 Future<void> _testLongPressDraggableHapticFeedback({ required WidgetTester tester, required bool hapticFeedbackOnStart, required int expectedHapticFeedbackCount }) async {

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -3196,12 +3196,12 @@ void main() {
     expect(LongPressDraggable<int>(feedback: widget2, dragAnchorStrategy: dummyStrategy, child: widget1).dragAnchorStrategy, dummyStrategy);
   });
 
-  testWidgets('Test buttonsEventFilter', (WidgetTester tester) async {
-    Widget build(bool Function(int buttons)? buttonsEventFilter) {
+  testWidgets('Test allowedButtonsFilter', (WidgetTester tester) async {
+    Widget build(bool Function(int buttons)? allowedButtonsFilter) {
       return MaterialApp(
         home: Draggable<int>(
           key: UniqueKey(),
-          buttonsEventFilter: buttonsEventFilter,
+          allowedButtonsFilter: allowedButtonsFilter,
           feedback: const Text('Dragging'),
           child: const Text('Source'),
         ),


### PR DESCRIPTION
This changes the default Draggable behavior without breaking any test. It _doesn't need_ to change the default behavior, but I think "left click" should be the default to prevent interfering with right-click and scroll-click. This is specially important given people using right click to show options. So, the current behavior feels like a bug.

`allowListPointer` is a new parameter:
- null (allow every value, current behavior)
- [] (allow no value)
- [kPrimaryButton] (what most people will use).

Fixes: https://github.com/flutter/flutter/issues/111850
Fixes: https://github.com/flutter/flutter/issues/89962
