### PR TITLE
Make 'Transform' widget work as expected when 'transform' param is a 2D translation

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -2604,8 +2604,7 @@ class RenderTransform extends RenderProxyBox {
     if (child != null) {
       final Matrix4 transform = _effectiveTransform!;
       if (filterQuality == null) {
-        final Offset? childOffset = MatrixUtils.getAsTranslation(transform);
-        if (childOffset == null) {
+        if (!transform.isIdentity()) {
           // if the matrix is singular the children would be compressed to a line or
           // single point, instead short-circuit and paint nothing.
           final double det = transform.determinant();
@@ -2621,7 +2620,7 @@ class RenderTransform extends RenderProxyBox {
             oldLayer: layer is TransformLayer ? layer as TransformLayer? : null,
           );
         } else {
-          super.paint(context, offset + childOffset);
+          super.paint(context, offset);
           layer = null;
         }
       } else {

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -308,11 +308,23 @@ void main() {
       ),
     );
 
-    // This should not cause a transform layer to be inserted.
     final List<Layer> layers = tester.layers
       ..retainWhere((Layer layer) => layer is TransformLayer);
-    expect(layers.length, 1); // only the render view
+    expect(layers.length, 2);
     expect(tester.getTopLeft(find.byType(Container)), const Offset(100.0, 50.0));
+  });
+
+  testWidgets('Transform with identity does not insert layers', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      Transform(
+        transform: Matrix4.identity(),
+        child: RepaintBoundary(child: Container()),
+      ),
+    );
+
+    final List<Layer> layers = tester.layers
+      ..retainWhere((Layer layer) => layer is TransformLayer);
+    expect(layers.length, 1);
   });
 
   testWidgets('Transform.scale', (WidgetTester tester) async {


### PR DESCRIPTION
fix https://github.com/flutter/flutter/issues/111855

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
