### PR TITLE
Avoid copying Strings in TextBoundary classes

### DIFF
--- a/packages/flutter/lib/src/services/text_boundary.dart
+++ b/packages/flutter/lib/src/services/text_boundary.dart
@@ -56,20 +56,21 @@ class CharacterBoundary extends TextBoundary {
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
-    if (position.offset > _textEditingValue.text.length ||
-        (position.offset == _textEditingValue.text.length && position.affinity == TextAffinity.downstream)) {
-      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
+    int length = _textEditingValue.text.length;
+    if (position.offset > length ||
+        (position.offset == length && position.affinity == TextAffinity.downstream)) {
+      return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
     final int endOffset;
     final int startOffset;
     switch (position.affinity) {
       case TextAffinity.upstream:
-        startOffset = math.min(position.offset - 1, _textEditingValue.text.length);
-        endOffset = math.min(position.offset, _textEditingValue.text.length);
+        startOffset = math.min(position.offset - 1, length);
+        endOffset = math.min(position.offset, length);
         break;
       case TextAffinity.downstream:
-        startOffset = math.min(position.offset, _textEditingValue.text.length);
-        endOffset = math.min(position.offset + 1, _textEditingValue.text.length);
+        startOffset = math.min(position.offset, length);
+        endOffset = math.min(position.offset + 1, length);
         break;
     }
     return TextPosition(
@@ -83,19 +84,20 @@ class CharacterBoundary extends TextBoundary {
         (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       return const TextPosition(offset: 0);
     }
-    if (position.offset >= _textEditingValue.text.length) {
-      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
+    int length = _textEditingValue.text.length;
+    if (position.offset >= length) {
+      return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
     final int endOffset;
     final int startOffset;
     switch (position.affinity) {
       case TextAffinity.upstream:
-        startOffset = math.min(position.offset - 1, _textEditingValue.text.length);
-        endOffset = math.min(position.offset, _textEditingValue.text.length);
+        startOffset = math.min(position.offset - 1, length);
+        endOffset = math.min(position.offset, length);
         break;
       case TextAffinity.downstream:
-        startOffset = math.min(position.offset, _textEditingValue.text.length);
-        endOffset = math.min(position.offset + 1, _textEditingValue.text.length);
+        startOffset = math.min(position.offset, length);
+        endOffset = math.min(position.offset + 1, length);
         break;
     }
     final CharacterRange range = CharacterRange.at(_textEditingValue.text, startOffset, endOffset);

--- a/packages/flutter/lib/src/services/text_boundary.dart
+++ b/packages/flutter/lib/src/services/text_boundary.dart
@@ -166,7 +166,7 @@ class LineBreak extends TextBoundary {
 /// position.
 class DocumentBoundary extends TextBoundary {
   /// Creates a [CharacterBoundary] with the text
-  const DocumentBoundary(this._textEditingValue.);
+  const DocumentBoundary(this._textEditingValue);
 
   final TextEditingValue _textEditingValue;
 

--- a/packages/flutter/lib/src/services/text_boundary.dart
+++ b/packages/flutter/lib/src/services/text_boundary.dart
@@ -56,7 +56,7 @@ class CharacterBoundary extends TextBoundary {
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
-    int length = _textEditingValue.text.length;
+    final int length = _textEditingValue.text.length;
     if (position.offset > length ||
         (position.offset == length && position.affinity == TextAffinity.downstream)) {
       return TextPosition(offset: length, affinity: TextAffinity.upstream);
@@ -84,7 +84,7 @@ class CharacterBoundary extends TextBoundary {
         (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       return const TextPosition(offset: 0);
     }
-    int length = _textEditingValue.text.length;
+    final int length = _textEditingValue.text.length;
     if (position.offset >= length) {
       return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }

--- a/packages/flutter/lib/src/services/text_boundary.dart
+++ b/packages/flutter/lib/src/services/text_boundary.dart
@@ -7,6 +7,7 @@ import 'dart:ui';
 
 import 'package:characters/characters.dart' show CharacterRange;
 
+import 'text_input.dart' show TextEditingValue;
 import 'text_layout_metrics.dart';
 
 /// An interface for retrieving the logical text boundary (left-closed-right-open)
@@ -42,37 +43,37 @@ abstract class TextBoundary {
 
 /// A text boundary that uses characters as logical boundaries.
 ///
-/// This class takes grapheme clusters into account and avoid creating
-/// boundaries that generate malformed utf-16 characters.
+/// This class takes grapheme clusters into account and avoids creating
+/// boundaries that generate malformed UTF-16 characters.
 class CharacterBoundary extends TextBoundary {
   /// Creates a [CharacterBoundary] with the text.
-  const CharacterBoundary(this._text);
+  const CharacterBoundary(this._textEditingValue);
 
-  final String _text;
+  final TextEditingValue _textEditingValue;
 
   @override
   TextPosition getLeadingTextBoundaryAt(TextPosition position) {
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
-    if (position.offset > _text.length ||
-        (position.offset == _text.length && position.affinity == TextAffinity.downstream)) {
-      return TextPosition(offset: _text.length, affinity: TextAffinity.upstream);
+    if (position.offset > _textEditingValue.text.length ||
+        (position.offset == _textEditingValue.text.length && position.affinity == TextAffinity.downstream)) {
+      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
     }
     final int endOffset;
     final int startOffset;
     switch (position.affinity) {
       case TextAffinity.upstream:
-        startOffset = math.min(position.offset - 1, _text.length);
-        endOffset = math.min(position.offset, _text.length);
+        startOffset = math.min(position.offset - 1, _textEditingValue.text.length);
+        endOffset = math.min(position.offset, _textEditingValue.text.length);
         break;
       case TextAffinity.downstream:
-        startOffset = math.min(position.offset, _text.length);
-        endOffset = math.min(position.offset + 1, _text.length);
+        startOffset = math.min(position.offset, _textEditingValue.text.length);
+        endOffset = math.min(position.offset + 1, _textEditingValue.text.length);
         break;
     }
     return TextPosition(
-      offset: CharacterRange.at(_text, startOffset, endOffset).stringBeforeLength,
+      offset: CharacterRange.at(_textEditingValue.text, startOffset, endOffset).stringBeforeLength,
     );
   }
 
@@ -82,24 +83,24 @@ class CharacterBoundary extends TextBoundary {
         (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       return const TextPosition(offset: 0);
     }
-    if (position.offset >= _text.length) {
-      return TextPosition(offset: _text.length, affinity: TextAffinity.upstream);
+    if (position.offset >= _textEditingValue.text.length) {
+      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
     }
     final int endOffset;
     final int startOffset;
     switch (position.affinity) {
       case TextAffinity.upstream:
-        startOffset = math.min(position.offset - 1, _text.length);
-        endOffset = math.min(position.offset, _text.length);
+        startOffset = math.min(position.offset - 1, _textEditingValue.text.length);
+        endOffset = math.min(position.offset, _textEditingValue.text.length);
         break;
       case TextAffinity.downstream:
-        startOffset = math.min(position.offset, _text.length);
-        endOffset = math.min(position.offset + 1, _text.length);
+        startOffset = math.min(position.offset, _textEditingValue.text.length);
+        endOffset = math.min(position.offset + 1, _textEditingValue.text.length);
         break;
     }
-    final CharacterRange range = CharacterRange.at(_text, startOffset, endOffset);
+    final CharacterRange range = CharacterRange.at(_textEditingValue.text, startOffset, endOffset);
     return TextPosition(
-      offset: _text.length - range.stringAfterLength,
+      offset: _textEditingValue.text.length - range.stringAfterLength,
       affinity: TextAffinity.upstream,
     );
   }
@@ -163,16 +164,16 @@ class LineBreak extends TextBoundary {
 /// position.
 class DocumentBoundary extends TextBoundary {
   /// Creates a [CharacterBoundary] with the text
-  const DocumentBoundary(this._text);
+  const DocumentBoundary(this._textEditingValue.);
 
-  final String _text;
+  final TextEditingValue _textEditingValue;
 
   @override
   TextPosition getLeadingTextBoundaryAt(TextPosition position) => const TextPosition(offset: 0);
   @override
   TextPosition getTrailingTextBoundaryAt(TextPosition position) {
     return TextPosition(
-      offset: _text.length,
+      offset: _textEditingValue.text.length,
       affinity: TextAffinity.upstream,
     );
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4236,15 +4236,16 @@ class _CodeUnitBoundary extends TextBoundary {
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
-    if (position.offset > _textEditingValue.text.length ||
-        (position.offset == _textEditingValue.text.length && position.affinity == TextAffinity.downstream)) {
-      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
+    int length = _textEditingValue.text.length;
+    if (position.offset > length ||
+        (position.offset == length && position.affinity == TextAffinity.downstream)) {
+      return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
     switch (position.affinity) {
       case TextAffinity.upstream:
-        return TextPosition(offset: math.min(position.offset - 1, _textEditingValue.text.length));
+        return TextPosition(offset: math.min(position.offset - 1, length));
       case TextAffinity.downstream:
-        return TextPosition(offset: math.min(position.offset, _textEditingValue.text.length));
+        return TextPosition(offset: math.min(position.offset, length));
     }
   }
 
@@ -4254,14 +4255,15 @@ class _CodeUnitBoundary extends TextBoundary {
         (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       return const TextPosition(offset: 0);
     }
-    if (position.offset >= _textEditingValue.text.length) {
-      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
+    int length = _textEditingValue.text.length;
+    if (position.offset >= length) {
+      return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
     switch (position.affinity) {
       case TextAffinity.upstream:
-        return TextPosition(offset: math.min(position.offset, _textEditingValue.text.length), affinity: TextAffinity.upstream);
+        return TextPosition(offset: math.min(position.offset, length), affinity: TextAffinity.upstream);
       case TextAffinity.downstream:
-        return TextPosition(offset: math.min(position.offset + 1, _textEditingValue.text.length), affinity: TextAffinity.upstream);
+        return TextPosition(offset: math.min(position.offset + 1, length), affinity: TextAffinity.upstream);
     }
   }
 }
@@ -4282,12 +4284,13 @@ class _WhitespaceBoundary extends TextBoundary {
 
   @override
   TextPosition getLeadingTextBoundaryAt(TextPosition position) {
-    // Handles outside of right bound.
-    if (position.offset > _textEditingValue.text.length
-        || (position.offset == _textEditingValue.length && position.affinity == TextAffinity.downstream)) {
+    // Position outside of the right bound.
+    int length = _textEditingValue.text.length;
+    if (position.offset > length
+        || (position.offset == length && position.affinity == TextAffinity.downstream)) {
       position = TextPosition(offset: _text.length, affinity: TextAffinity.upstream);
     }
-    // Handles outside of left bound.
+    // Position outside of the left bound.
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
@@ -4307,11 +4310,12 @@ class _WhitespaceBoundary extends TextBoundary {
 
   @override
   TextPosition getTrailingTextBoundaryAt(TextPosition position) {
-    // Handles outside of right bound.
-    if (position.offset >= _textEditingValue.text.length) {
-      return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
+    // Position outside of the right bound.
+    int length = _textEditingValue.text.length;
+    if (position.offset >= length) {
+      return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
-    // Handles outside of left bound.
+    // Position outside of the left bound.
     if (position.offset < 0 || (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       position = const TextPosition(offset: 0);
     }
@@ -4322,12 +4326,12 @@ class _WhitespaceBoundary extends TextBoundary {
       return position;
     }
 
-    for (index += 1; index < _textEditingValue.text.length; index += 1) {
+    for (index += 1; index < length; index += 1) {
       if (!TextLayoutMetrics.isWhitespace(_textEditingValue.text.codeUnitAt(index))) {
         return TextPosition(offset: index);
       }
     }
-    return TextPosition(offset: _textEditingValue.text.length, affinity: TextAffinity.upstream);
+    return TextPosition(offset: length, affinity: TextAffinity.upstream);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3494,7 +3494,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       final TextEditingValue textEditingValue = _textEditingValueforTextLayoutMetrics;
       atomicTextBoundary = CharacterBoundary(textEditingValue);
       // This isn't enough. Newline characters.
-      boundary = _ExpandedTextBoundary(_WhitespaceBoundary(textEditingValue.text), WordBoundary(renderEditable));
+      boundary = _ExpandedTextBoundary(_WhitespaceBoundary(textEditingValue), WordBoundary(renderEditable));
     }
 
     final _MixedBoundary mixedBoundary = intent.forward
@@ -3528,7 +3528,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       : _MixedBoundary(boundary, _PushTextPosition(atomicTextBoundary, false));
   }
 
-  TextBoundary _documentBoundary(DirectionalTextEditingIntent intent) => DocumentBoundary(_value.text);
+  TextBoundary _documentBoundary(DirectionalTextEditingIntent intent) => DocumentBoundary(_value);
 
   Action<T> _makeOverridable<T extends Intent>(Action<T> defaultAction) {
     return Action<T>.overridable(context: context, defaultAction: defaultAction);
@@ -4288,7 +4288,7 @@ class _WhitespaceBoundary extends TextBoundary {
     int length = _textEditingValue.text.length;
     if (position.offset > length
         || (position.offset == length && position.affinity == TextAffinity.downstream)) {
-      position = TextPosition(offset: _text.length, affinity: TextAffinity.upstream);
+      position = TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
     // Handle position outside of the left bound.
     if (position.offset <= 0) {

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4236,7 +4236,7 @@ class _CodeUnitBoundary extends TextBoundary {
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
-    int length = _textEditingValue.text.length;
+    final int length = _textEditingValue.text.length;
     if (position.offset > length ||
         (position.offset == length && position.affinity == TextAffinity.downstream)) {
       return TextPosition(offset: length, affinity: TextAffinity.upstream);
@@ -4255,7 +4255,7 @@ class _CodeUnitBoundary extends TextBoundary {
         (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       return const TextPosition(offset: 0);
     }
-    int length = _textEditingValue.text.length;
+    final int length = _textEditingValue.text.length;
     if (position.offset >= length) {
       return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
@@ -4285,7 +4285,7 @@ class _WhitespaceBoundary extends TextBoundary {
   @override
   TextPosition getLeadingTextBoundaryAt(TextPosition position) {
     // Handle position outside of the right bound.
-    int length = _textEditingValue.text.length;
+    final int length = _textEditingValue.text.length;
     if (position.offset > length
         || (position.offset == length && position.affinity == TextAffinity.downstream)) {
       position = TextPosition(offset: length, affinity: TextAffinity.upstream);
@@ -4311,7 +4311,7 @@ class _WhitespaceBoundary extends TextBoundary {
   @override
   TextPosition getTrailingTextBoundaryAt(TextPosition position) {
     // Handle position outside of the right bound.
-    int length = _textEditingValue.text.length;
+    final int length = _textEditingValue.text.length;
     if (position.offset >= length) {
       return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4284,13 +4284,13 @@ class _WhitespaceBoundary extends TextBoundary {
 
   @override
   TextPosition getLeadingTextBoundaryAt(TextPosition position) {
-    // Position outside of the right bound.
+    // Handle position outside of the right bound.
     int length = _textEditingValue.text.length;
     if (position.offset > length
         || (position.offset == length && position.affinity == TextAffinity.downstream)) {
       position = TextPosition(offset: _text.length, affinity: TextAffinity.upstream);
     }
-    // Position outside of the left bound.
+    // Handle position outside of the left bound.
     if (position.offset <= 0) {
       return const TextPosition(offset: 0);
     }
@@ -4310,12 +4310,12 @@ class _WhitespaceBoundary extends TextBoundary {
 
   @override
   TextPosition getTrailingTextBoundaryAt(TextPosition position) {
-    // Position outside of the right bound.
+    // Handle position outside of the right bound.
     int length = _textEditingValue.text.length;
     if (position.offset >= length) {
       return TextPosition(offset: length, affinity: TextAffinity.upstream);
     }
-    // Position outside of the left bound.
+    // Handle position outside of the left bound.
     if (position.offset < 0 || (position.offset == 0 && position.affinity == TextAffinity.upstream)) {
       position = const TextPosition(offset: 0);
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -4222,7 +4222,7 @@ class _ScribblePlaceholder extends WidgetSpan {
 
 /// A text boundary that uses code units as logical boundaries.
 ///
-/// This text boundary treats every character in input string as an utf-16 code
+/// This text boundary treats every character in the input text value as an UTF-16 code
 /// unit. This can be useful when handling text without any grapheme cluster,
 /// e.g. the obscure string in [EditableText]. If you are handling text that may
 /// include grapheme clusters, consider using [CharacterBoundary].

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3479,7 +3479,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
   // --------------------------- Text Editing Actions ---------------------------
 
   TextBoundary _characterBoundary(DirectionalTextEditingIntent intent) {
-    final TextBoundary atomicTextBoundary = widget.obscureText ? _CodeUnitBoundary(_value.text) : CharacterBoundary(_value);
+    final TextBoundary atomicTextBoundary = widget.obscureText ? _CodeUnitBoundary(_value) : CharacterBoundary(_value);
     return _PushTextPosition(atomicTextBoundary, intent.forward);
   }
 
@@ -3488,7 +3488,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     final TextBoundary boundary;
 
     if (widget.obscureText) {
-      atomicTextBoundary = _CodeUnitBoundary(_value.text);
+      atomicTextBoundary = _CodeUnitBoundary(_value);
       boundary = DocumentBoundary(_value);
     } else {
       final TextEditingValue textEditingValue = _textEditingValueforTextLayoutMetrics;
@@ -3510,7 +3510,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     final TextBoundary boundary;
 
     if (widget.obscureText) {
-      atomicTextBoundary = _CodeUnitBoundary(_value.text);
+      atomicTextBoundary = _CodeUnitBoundary(_value);
       boundary = DocumentBoundary(_value);
     } else {
       final TextEditingValue textEditingValue = _textEditingValueforTextLayoutMetrics;
@@ -4441,8 +4441,8 @@ class _DeleteTextAction<T extends DirectionalTextEditingIntent> extends ContextA
     assert(selection.isValid);
     assert(!selection.isCollapsed);
     final TextBoundary atomicBoundary = state.widget.obscureText
-      ? _CodeUnitBoundary(value.text)
-      : CharacterBoundary(value.text);
+      ? _CodeUnitBoundary(value)
+      : CharacterBoundary(value);
 
     return TextRange(
       start: atomicBoundary.getLeadingTextBoundaryAt(TextPosition(offset: selection.start)).offset,

--- a/packages/flutter/test/services/text_boundary_test.dart
+++ b/packages/flutter/test/services/text_boundary_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('Character boundary works', () {
-    const CharacterBoundary boundary = CharacterBoundary('abc');
+    const CharacterBoundary boundary = CharacterBoundary(TextEditingValue('abc'));
     const TextPosition midPosition = TextPosition(offset: 1);
     expect(boundary.getLeadingTextBoundaryAt(midPosition), const TextPosition(offset: 1));
     expect(boundary.getTrailingTextBoundaryAt(midPosition), const TextPosition(offset: 2, affinity: TextAffinity.upstream));
@@ -23,7 +23,7 @@ void main() {
 
   test('Character boundary works with grapheme', () {
     const String text = 'a❄︎c';
-    const CharacterBoundary boundary = CharacterBoundary(text);
+    const CharacterBoundary boundary = CharacterBoundary(TextEditingValue(text));
     TextPosition position = const TextPosition(offset: 1);
     expect(boundary.getLeadingTextBoundaryAt(position), const TextPosition(offset: 1));
     // The `❄` takes two character length.
@@ -58,7 +58,7 @@ void main() {
 
   test('document boundary works', () {
     const String text = 'abcd efg hi\njklmno\npqrstuv';
-    const DocumentBoundary boundary = DocumentBoundary(text);
+    const DocumentBoundary boundary = DocumentBoundary(TextEditingValue(text));
     const TextPosition position = TextPosition(offset: 10);
     expect(boundary.getLeadingTextBoundaryAt(position), const TextPosition(offset: 0));
     expect(boundary.getTrailingTextBoundaryAt(position), const TextPosition(offset: text.length, affinity: TextAffinity.upstream));

--- a/packages/flutter/test/services/text_boundary_test.dart
+++ b/packages/flutter/test/services/text_boundary_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('Character boundary works', () {
-    const CharacterBoundary boundary = CharacterBoundary(TextEditingValue('abc'));
+    const CharacterBoundary boundary = CharacterBoundary(TextEditingValue(text: 'abc'));
     const TextPosition midPosition = TextPosition(offset: 1);
     expect(boundary.getLeadingTextBoundaryAt(midPosition), const TextPosition(offset: 1));
     expect(boundary.getTrailingTextBoundaryAt(midPosition), const TextPosition(offset: 2, affinity: TextAffinity.upstream));
@@ -23,7 +23,7 @@ void main() {
 
   test('Character boundary works with grapheme', () {
     const String text = 'a❄︎c';
-    const CharacterBoundary boundary = CharacterBoundary(TextEditingValue(text));
+    const CharacterBoundary boundary = CharacterBoundary(TextEditingValue(text: text));
     TextPosition position = const TextPosition(offset: 1);
     expect(boundary.getLeadingTextBoundaryAt(position), const TextPosition(offset: 1));
     // The `❄` takes two character length.
@@ -58,7 +58,7 @@ void main() {
 
   test('document boundary works', () {
     const String text = 'abcd efg hi\njklmno\npqrstuv';
-    const DocumentBoundary boundary = DocumentBoundary(TextEditingValue(text));
+    const DocumentBoundary boundary = DocumentBoundary(TextEditingValue(text: text));
     const TextPosition position = TextPosition(offset: 10);
     expect(boundary.getLeadingTextBoundaryAt(position), const TextPosition(offset: 0));
     expect(boundary.getTrailingTextBoundaryAt(position), const TextPosition(offset: text.length, affinity: TextAffinity.upstream));


### PR DESCRIPTION
This PR updates the classes extending `TextBoundary` to pass text via `TextEditingValue` in order to avoid creating copies of `String`s which may be large.

Test exempt: memory & CPU optimisation only.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
