### PR TITLE
Fix flutter tool crash on upgrade caused by app-jit

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -16,6 +16,7 @@ SETLOCAL
 SET flutter_tools_dir=%FLUTTER_ROOT%\packages\flutter_tools
 SET cache_dir=%FLUTTER_ROOT%\bin\cache
 SET snapshot_path=%cache_dir%\flutter_tools.snapshot
+SET snapshot_path_old=%cache_dir%\flutter_tools.snapshot.old
 SET stamp_path=%cache_dir%\flutter_tools.stamp
 SET script_path=%flutter_tools_dir%\bin\flutter_tools.dart
 SET dart_sdk_path=%cache_dir%\dart-sdk
@@ -177,7 +178,6 @@ GOTO :after_subroutine
     REM is in use. For downloading a new dart sdk the folder is moved, so we take the same
     REM approach of moving the file here.
     SET /A snapshot_path_suffix=1
-    SET snapshot_path_old="%snapshot_path%.old"
     :move_old_snapshot
       IF EXIST "%snapshot_path_old%%snapshot_path_suffix%" (
         ECHO "%snapshot_path_old%%snapshot_path_suffix% already exists..." 2>&1

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -170,14 +170,17 @@ GOTO :after_subroutine
 
     POPD
 
+    ECHO Moving snapshots debug text... 1>&2
+
     REM Move the old snapshot - we can't just overwrite it as the VM might currently have it
     REM memory mapped (e.g. on flutter upgrade), and deleting it might not work if the file
     REM is in use. For downloading a new dart sdk the folder is moved, so we take the same
     REM approach of moving the file here.
     SET /A snapshot_path_suffix=1
-    set snapshot_path_old="%snapshot_path%.old"
+    SET snapshot_path_old="%snapshot_path%.old"
     :move_old_snapshot
       IF EXIST "%snapshot_path_old%%snapshot_path_suffix%" (
+        ECHO %snapshot_path_suffix% already exists... 1>&2
         SET /A snapshot_path_suffix+=1
         GOTO move_old_snapshot
       ) ELSE (
@@ -185,6 +188,8 @@ GOTO :after_subroutine
           MOVE "%snapshot_path%" "%snapshot_path_old%%snapshot_path_suffix%" 2> NUL > NUL
         )
       )
+
+    ECHO Compiling flutter tool debug text... 1>&2
 
     IF "%FLUTTER_TOOL_ARGS%" == "" (
       "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -170,6 +170,22 @@ GOTO :after_subroutine
 
     POPD
 
+    REM Move the old snapshot - we can't just overwrite it as the VM might currently have it
+    REM memory mapped (e.g. on flutter upgrade), and deleting it might not work if the file
+    REM is in use. For downloading a new dart sdk the folder is moved, so we take the same
+    REM approach of moving the file here.
+    SET /A snapshot_path_suffix=1
+    set snapshot_path_old="%snapshot_path%.old"
+    :move_old_snapshot
+      IF EXIST "%snapshot_path_old%%snapshot_path_suffix%" (
+        SET /A snapshot_path_suffix+=1
+        GOTO move_old_snapshot
+      ) ELSE (
+        IF EXIST "%snapshot_path%" (
+          MOVE "%snapshot_path%" "%snapshot_path_old%%snapshot_path_suffix%" 2> NUL > NUL
+        )
+      )
+
     IF "%FLUTTER_TOOL_ARGS%" == "" (
       "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL
     ) else (
@@ -181,6 +197,9 @@ GOTO :after_subroutine
       GOTO :final_exit
     )
     >"%stamp_path%" ECHO %compilekey%
+
+    REM Try to delete any old snapshots now. Swallow any errors though.
+    DEL "%snapshot_path%.old*" 2> NUL > NUL
 
   REM Exit Subroutine
   EXIT /B

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -171,8 +171,6 @@ GOTO :after_subroutine
 
     POPD
 
-    ECHO Moving snapshots debug text... 1>&2
-
     REM Move the old snapshot - we can't just overwrite it as the VM might currently have it
     REM memory mapped (e.g. on flutter upgrade), and deleting it might not work if the file
     REM is in use. For downloading a new dart sdk the folder is moved, so we take the same
@@ -180,7 +178,6 @@ GOTO :after_subroutine
     SET /A snapshot_path_suffix=1
     :move_old_snapshot
       IF EXIST "%snapshot_path_old%%snapshot_path_suffix%" (
-        ECHO "%snapshot_path_old%%snapshot_path_suffix% already exists..." 2>&1
         SET /A snapshot_path_suffix+=1
         GOTO move_old_snapshot
       ) ELSE (
@@ -188,8 +185,6 @@ GOTO :after_subroutine
           MOVE "%snapshot_path%" "%snapshot_path_old%%snapshot_path_suffix%" 2> NUL > NUL
         )
       )
-
-    ECHO Compiling flutter tool debug text... 1>&2
 
     IF "%FLUTTER_TOOL_ARGS%" == "" (
       "%dart%" --verbosity=error --snapshot="%snapshot_path%" --snapshot-kind="app-jit" --packages="%flutter_tools_dir%\.dart_tool\package_config.json" --no-enable-mirrors "%script_path%" > NUL

--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -180,7 +180,7 @@ GOTO :after_subroutine
     SET snapshot_path_old="%snapshot_path%.old"
     :move_old_snapshot
       IF EXIST "%snapshot_path_old%%snapshot_path_suffix%" (
-        ECHO %snapshot_path_suffix% already exists... 1>&2
+        ECHO "%snapshot_path_old%%snapshot_path_suffix% already exists..." 2>&1
         SET /A snapshot_path_suffix+=1
         GOTO move_old_snapshot
       ) ELSE (

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -154,9 +154,22 @@ function upgrade_flutter () (
     fi
     pub_upgrade_with_retry
 
+    # Move the old snapshot - we can't just overwrite it as the VM might currently have it
+    # memory mapped (e.g. on flutter upgrade). For downloading a new dart sdk the folder is moved,
+    # so we take the same approach of moving the file here.
+    SNAPSHOT_PATH_OLD="$SNAPSHOT_PATH.old"
+    if [ -f "$SNAPSHOT_PATH" ]; then
+      mv "$SNAPSHOT_PATH" "$SNAPSHOT_PATH_OLD"
+    fi
+
     # Compile...
     "$DART" --verbosity=error --disable-dart-dev $FLUTTER_TOOL_ARGS --snapshot="$SNAPSHOT_PATH" --snapshot-kind="app-jit" --packages="$FLUTTER_TOOLS_DIR/.dart_tool/package_config.json" --no-enable-mirrors "$SCRIPT_PATH" > /dev/null
     echo "$compilekey" > "$STAMP_PATH"
+
+    # Delete any temporary snapshot path.
+    if [ -f "$SNAPSHOT_PATH_OLD" ]; then
+      rm -f "$SNAPSHOT_PATH_OLD"
+    fi
   fi
   # The exit here is extraneous since the function is run in a subshell, but
   # this serves as documentation that running the function in a subshell is


### PR DESCRIPTION
In #111459 we started using app-jit for flutter_tool to improve startup performance. In the PR there was talks about it having been tried before, but been reverted for some reason no one remembered.

I digged a bit and found the revert #30204 which pointed me to #30203 saying that `flutter upgrade` crashed.

And sure enough that is still the case (at least on Linux):

```
Building flutter tool...

===== CRASH =====
si_signo=Bus error(7), si_code=2, si_addr=0x7f8ac18b6210
version=2.19.0-215.0.dev (dev) (Sun Sep 18 20:34:31 2022 -0700) on "linux_x64"
pid=156885, thread=157284, isolate_group=main(0x56110610a000), isolate=main(0x561106164800)
os=linux, arch=x64, comp=no, sim=no
isolate_instructions=7f8ac1783000, vm_instructions=56110306f160
  pc 0x00007f8ac18b6210 fp 0x00007f8abddfe4b0 Unknown symbol
  pc 0x00005611031ea73d fp 0x00007f8abddfe550 dart::DartEntry::InvokeCode(dart::Code const&, unsigned long, dart::Array const&, dart::Array const&, dart::Thread*)+0x14d
  pc 0x00005611031ea58c fp 0x00007f8abddfe5b0 dart::DartEntry::InvokeFunction(dart::Function const&, dart::Array const&, dart::Array const&, unsigned long)+0x14c
  pc 0x00005611031ec9ac fp 0x00007f8abddfe600 dart::DartLibraryCalls::HandleMessage(long, dart::Instance const&)+0x14c
  pc 0x0000561103212910 fp 0x00007f8abddfeba0 dart::IsolateMessageHandler::HandleMessage(std::__2::unique_ptr<dart::Message, std::__2::default_delete<dart::Message> >)+0x350
  pc 0x000056110323b22d fp 0x00007f8abddfec10 dart::MessageHandler::HandleMessages(dart::MonitorLocker*, bool, bool)+0x14d
  pc 0x000056110323b90f fp 0x00007f8abddfec60 dart::MessageHandler::TaskCallback()+0x1df
  pc 0x0000561103363f58 fp 0x00007f8abddfece0 dart::ThreadPool::WorkerLoop(dart::ThreadPool::Worker*)+0x148
  pc 0x00005611033643ad fp 0x00007f8abddfed10 dart::ThreadPool::Worker::Main(unsigned long)+0x6d
  pc 0x00005611032d8178 fp 0x00007f8abddfedd0 /path/to/flutter/bin/cache/dart-sdk/bin/dart+0x217f178
-- End of DumpStackTrace
Aborted
```

What's happening is this:

1. We run `flutter upgrade`
2. It goes to a new commit via git
3. It then launches another instance of `flutter`. Notice how this is after git has fetched the new data, so a new tool snapshot is built; also notice how the "original" ("top-most" if you will) `flutter` is still running.
4. Dart - when running from an app-jit snapshot - memory maps the snapshot. Step 3 changed the snapshot by replacing the content of the file. Now when it tries to read more it either reads what is essentially "garbage" for this process (maybe a new snapshot version, maybe another place, who knows) and crashes.

This PR fixes the issue by applying the same strategy as is applied for the dart_sdk path when upgrading dart: nothing is overwritten, it's moved and then later deleted. (technically just deleting it seems to work too, but if - for whatever reason - the file should be in use we don't want it to fail).

This way the data dart is currently using to run the "top most" `flutter` still exists and the process doesn't crash.