### PR TITLE
fix for flakey analyze test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3135,13 +3135,14 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
   try {
     bool analyzeLineFound = false;
     const LineSplitter().convert(stdout).forEach((String line) {
+      // Conditional to filter out any stdout from `pub get`
       if (!analyzeLineFound && line.startsWith('Analyzing flutter_project')) {
         analyzeLineFound = true;
         return;
       }
 
-      if (analyzeLineFound && line.isNotEmpty) {
-        errors.add(lineParser(line));
+      if (analyzeLineFound && line.trim().isNotEmpty) {
+        errors.add(lineParser(line.trim()));
       }
     });
     

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -40,6 +40,7 @@ const String _kNoPlatformsMessage = "You've created a plugin project that doesn'
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 const String _kDisabledPlatformRequestedMessage = 'currently not supported on your local environment.';
+const String _kLintingErrorPattern = r"^\s*(?<type>error|info)(\s*•\s*)(?<desc>[\(\)`@\w\s'-]+)(\s*•\s*)(?<path>[\w\s'-\/:]+)(\s*•\s*)(?<lint>[\w'-]+)$";
 
 // This needs to be created from the local platform due to re-entrant flutter calls made in this test.
 FakePlatform _kNoColorTerminalPlatform() => FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false;
@@ -3132,18 +3133,14 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
   }
   final String stdout = exec.stdout.toString();
   final List<String> errors;
+  final RegExp regex = RegExp(_kLintingErrorPattern, multiLine: true);
   try {
-    errors = const LineSplitter().convert(stdout)
-      .where((String line) {
-        return line.trim().isNotEmpty &&
-            !line.startsWith('Analyzing') &&
-            !line.contains('flutter pub get') &&
-            !line.contains('Resolving dependencies') &&
-            !line.contains('Got dependencies');
-      }).map(lineParser).toList();
-
-    // Add debugging for https://github.com/flutter/flutter/issues/111272
-  } on RangeError catch (err) {
+    errors = const LineSplitter()
+        .convert(stdout)
+        .where((String line) => regex.hasMatch(line))
+        .map(lineParser)
+        .toList();
+  } on Exception catch (err) {
     fail('$err\n\nComplete STDOUT was:\n\n$stdout');
   }
   expect(errors, unorderedEquals(expectedFailures));

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3136,7 +3136,7 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
     bool analyzeLineFound = false;
     const LineSplitter().convert(stdout).forEach((String line) {
       // Conditional to filter out any stdout from `pub get`
-      if (!analyzeLineFound && line.startsWith('Analyzing flutter_project')) {
+      if (!analyzeLineFound && line.startsWith('Analyzing')) {
         analyzeLineFound = true;
         return;
       }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3145,7 +3145,6 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
         errors.add(lineParser(line.trim()));
       }
     });
-    
   } on Exception catch (err) {
     fail('$err\n\nComplete STDOUT was:\n\n$stdout');
   }

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -40,7 +40,7 @@ const String _kNoPlatformsMessage = "You've created a plugin project that doesn'
 const String frameworkRevision = '12345678';
 const String frameworkChannel = 'omega';
 const String _kDisabledPlatformRequestedMessage = 'currently not supported on your local environment.';
-const String _kLintingErrorPattern = r"^\s*(?<type>error|info)(\s*•\s*)(?<desc>[\(\)`@\w\s'-]+)(\s*•\s*)(?<path>[\w\s'-\/:]+)(\s*•\s*)(?<lint>[\w'-]+)$";
+const String _kLintingErrorPattern = r"^\s*(?<type>error|info)(\s*[•|-]\s*)(?<desc>[\(\)`@\w\s'-]+)(\s*[•|-]\s*)(?<path>[\\\w'-\/:]+)(\s*[•|-]\s*)(?<lint>[\w'-]+)$";
 
 // This needs to be created from the local platform due to re-entrant flutter calls made in this test.
 FakePlatform _kNoColorTerminalPlatform() => FakePlatform.fromPlatform(const LocalPlatform())..stdoutSupportsAnsi = false;

--- a/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/create_test.dart
@@ -3143,7 +3143,8 @@ Future<void> _analyzeProject(String workingDir, { List<String> expectedFailures 
   } on Exception catch (err) {
     fail('$err\n\nComplete STDOUT was:\n\n$stdout');
   }
-  expect(errors, unorderedEquals(expectedFailures));
+  expect(errors, unorderedEquals(expectedFailures),
+      reason: 'Failed with stdout:\n\n$stdout');
 }
 
 Future<void> _getPackages(Directory workingDir) async {


### PR DESCRIPTION
This PR fixes #111272 by improving how we parse the stdout from `flutter analyze` to find only the relevant lines

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
