### PR TITLE
Fixed an issue with FilterChips changing size when selected.

### DIFF
--- a/dev/tools/gen_defaults/lib/filter_chip_template.dart
+++ b/dev/tools/gen_defaults/lib/filter_chip_template.dart
@@ -57,7 +57,7 @@ class _${blockName}DefaultsM3 extends ChipThemeData {
     ? isEnabled
       ? ${border('$tokenGroup$variant.unselected.outline')}
       : ${border('$tokenGroup$variant.disabled.unselected.outline')}
-    : null;
+    : const BorderSide(color: Colors.transparent);
 
   @override
   IconThemeData? get iconTheme => IconThemeData(

--- a/packages/flutter/lib/src/material/choice_chip.dart
+++ b/packages/flutter/lib/src/material/choice_chip.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 
 import 'chip.dart';
 import 'chip_theme.dart';
+import 'colors.dart';
 import 'debug.dart';
 import 'theme.dart';
 import 'theme_data.dart';
@@ -148,7 +149,7 @@ class ChoiceChip extends StatelessWidget
     assert(debugCheckHasMaterial(context));
     final ChipThemeData chipTheme = ChipTheme.of(context);
     final ChipThemeData? defaults = Theme.of(context).useMaterial3
-      ? _FilterChipDefaultsM3(context, isEnabled, selected)
+      ? _ChoiceChipDefaultsM3(context, isEnabled, selected)
       : null;
     return RawChip(
       defaultProperties: defaults,
@@ -182,7 +183,7 @@ class ChoiceChip extends StatelessWidget
   }
 }
 
-// BEGIN GENERATED TOKEN PROPERTIES - FilterChip
+// BEGIN GENERATED TOKEN PROPERTIES - ChoiceChip
 
 // Do not edit by hand. The code between the "BEGIN GENERATED" and
 // "END GENERATED" comments are generated from data in the Material
@@ -191,8 +192,8 @@ class ChoiceChip extends StatelessWidget
 
 // Token database version: v0_127
 
-class _FilterChipDefaultsM3 extends ChipThemeData {
-  const _FilterChipDefaultsM3(this.context, this.isEnabled, this.isSelected)
+class _ChoiceChipDefaultsM3 extends ChipThemeData {
+  const _ChoiceChipDefaultsM3(this.context, this.isEnabled, this.isSelected)
     : super(
         elevation: 0.0,
         shape: const RoundedRectangleBorder(borderRadius: BorderRadius.only(topLeft: Radius.circular(8.0), topRight: Radius.circular(8.0), bottomLeft: Radius.circular(8.0), bottomRight: Radius.circular(8.0))),
@@ -236,7 +237,7 @@ class _FilterChipDefaultsM3 extends ChipThemeData {
     ? isEnabled
       ? BorderSide(color: Theme.of(context).colorScheme.outline)
       : BorderSide(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12))
-    : null;
+    : const BorderSide(color: Colors.transparent);
 
   @override
   IconThemeData? get iconTheme => IconThemeData(
@@ -261,4 +262,4 @@ class _FilterChipDefaultsM3 extends ChipThemeData {
   )!;
 }
 
-// END GENERATED TOKEN PROPERTIES - FilterChip
+// END GENERATED TOKEN PROPERTIES - ChoiceChip

--- a/packages/flutter/lib/src/material/filter_chip.dart
+++ b/packages/flutter/lib/src/material/filter_chip.dart
@@ -7,6 +7,7 @@ import 'package:flutter/widgets.dart';
 
 import 'chip.dart';
 import 'chip_theme.dart';
+import 'colors.dart';
 import 'debug.dart';
 import 'theme.dart';
 import 'theme_data.dart';
@@ -245,7 +246,7 @@ class _FilterChipDefaultsM3 extends ChipThemeData {
     ? isEnabled
       ? BorderSide(color: Theme.of(context).colorScheme.outline)
       : BorderSide(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12))
-    : null;
+    : const BorderSide(color: Colors.transparent);
 
   @override
   IconThemeData? get iconTheme => IconThemeData(

--- a/packages/flutter/test/material/filter_chip_test.dart
+++ b/packages/flutter/test/material/filter_chip_test.dart
@@ -172,4 +172,43 @@ void main() {
     await tester.pumpWidget(wrapForChip(child: FilterChip(label: label, onSelected: (bool b) { }, clipBehavior: Clip.antiAlias)));
     checkChipMaterialClipBehavior(tester, Clip.antiAlias);
   });
+
+  testWidgets('M3 width should not change with selection', (WidgetTester tester) async {
+    // Regression tests for: https://github.com/flutter/flutter/issues/110645
+
+    // For the text "FilterChip" the chip should default to 175 regardless of selection.
+    const int expectedWidth = 175;
+
+    // Unselected
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: Material(
+        child: Center(
+          child: FilterChip(
+            label: const Text('FilterChip'),
+            showCheckmark: false,
+            onSelected: (bool _) {},
+         )
+        ),
+      ),
+    ));
+    expect(tester.getSize(find.byType(FilterChip)).width, expectedWidth);
+
+    // Selected
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(useMaterial3: true),
+      home: Material(
+        child: Center(
+            child: FilterChip(
+              label: const Text('FilterChip'),
+              showCheckmark: false,
+              selected: true,
+              onSelected: (bool _) {},
+            )
+        ),
+      ),
+    ));
+    await tester.pumpAndSettle();
+    expect(tester.getSize(find.byType(FilterChip)).width, expectedWidth);
+  });
 }


### PR DESCRIPTION
As pointed out in #111038, the size of the `FilterChip` would change if it was selected or not. This made it hard to line up these chips in a row as they would bounce around as selection changed. 

This was due to the fact that we were not adding a border for the selected case. This meant that the size would be off by the size of the border. To fix this we are just using a transparent border of the same size to ensure it will be the same size as the unselected which do have a border.

Fixes: #111038

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
