### PR TITLE
[conductor codesign] update remote upstream url in codesign

### DIFF
--- a/dev/conductor/core/lib/src/codesign.dart
+++ b/dev/conductor/core/lib/src/codesign.dart
@@ -41,6 +41,10 @@ class CodesignCommand extends Command<void> {
         processManager = checkouts.processManager {
     if (framework != null) {
       _framework = framework;
+      _framework!.upstreamRemote = const Remote(
+        name: RemoteName.upstream,
+        url: FrameworkRepository.defaultUpstream,
+      );
     }
     argParser.addFlag(
       kVerify,

--- a/dev/conductor/core/lib/src/repository.dart
+++ b/dev/conductor/core/lib/src/repository.dart
@@ -80,7 +80,7 @@ abstract class Repository {
         assert(upstreamRemote.url.isNotEmpty);
 
   final String name;
-  final Remote upstreamRemote;
+  Remote upstreamRemote;
 
   /// Branches that must exist locally in this [Repository].
   ///


### PR DESCRIPTION
I traced through recipes and conductor code. My understanding is that the error from https://ci.chromium.org/ui/p/flutter/builders/prod/Mac%20beta%20verify_binaries_codesigned/361/overview which aligns with https://cs.opensource.google/flutter/flutter/+/master:dev/conductor/core/lib/src/repository.dart;l=191, originates from a passed down `frameworkRepository` to  conductor codeSign. Its upstream url wasn't set correctly and was not overridden, otherwise the upstream would have been caught by https://cs.opensource.google/flutter/flutter/+/master:dev/conductor/core/lib/src/codesign.dart;l=77 which sets the correct upstream. Might not be the most optimal solution, in this pr I force set upstream of a passed down `frameworkRepository` to be the default upstream repository.

A question I have (unrelated to the error above) is that, in recipe we set the $REVISION variable, and passed it to conductor codesign. But looking at the environment variables at all the steps on https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8827827793264604241/+/u/Verify_binaries_codesigned/verify_binaries_codesigned/execution_details , looks like there were no environment variable $REVISION set. Would be great if someone could instruct on where $REVISION was determined in recipe and why it did not show up in the env variables in code sign. Thank you!                                                                                         