### PR TITLE
[flutter_tools] Fix type error in ChromiumDevice.startApp

### DIFF
--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -118,7 +118,7 @@ abstract class ChromiumDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant WebApplicationPackage package, {
+    WebApplicationPackage? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -454,7 +454,7 @@ class WebServerDevice extends Device {
   Future<String> get sdkNameAndVersion async => 'Flutter Tools';
 
   @override
-  Future<LaunchResult> startApp(ApplicationPackage package, {
+  Future<LaunchResult> startApp(ApplicationPackage? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -340,7 +340,7 @@ void main() {
     fakeVmServiceHost =
         FakeVmServiceHost(requests: kAttachExpectations.toList());
     setupMocks();
-    fileSystem.file(fileSystem.path.join('web', 'index.html')).deleteSync();
+    fileSystem.directory('web').deleteSync(recursive: true);
     final ResidentWebRunner residentWebRunner = ResidentWebRunner(
       flutterDevice,
       flutterProject:

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -112,6 +112,37 @@ void main() {
     expect(device.supportsRuntimeMode(BuildMode.jitRelease), false);
 });
 
+  testWithoutContext('ChromiumDevice accepts null package', () async {
+    final MemoryFileSystem fs = MemoryFileSystem.test();
+    final FakePlatform platform = FakePlatform();
+    final FakeProcessManager pm = FakeProcessManager.any();
+    final BufferLogger logger = BufferLogger.test();
+    final GoogleChromeDevice device = GoogleChromeDevice(
+      fileSystem: fs,
+      processManager: pm,
+      platform: platform,
+      chromiumLauncher: ChromiumLauncher(
+        fileSystem: fs,
+        platform: platform,
+        processManager: pm,
+        operatingSystemUtils: FakeOperatingSystemUtils(),
+        browserFinder: findChromeExecutable,
+        logger: logger,
+      ),
+      logger: logger,
+    );
+    await expectLater(
+      () => device.startApp(
+        null,
+        debuggingOptions: DebuggingOptions.disabled(BuildInfo.debug),
+        platformArgs: <String, Object?>{'uri': 'localhost:1234'},
+      ),
+      // The tool exit here is irrelevant, this test simply ensures ChromiumDevice.startApp
+      // will accept a null value for a package.
+      throwsToolExit(message: 'Failed to launch browser'),
+    );
+  });
+
   testWithoutContext('Chrome device is listed when Chrome can be run', () async {
     final WebDevices webDevices = WebDevices(
       featureFlags: TestFeatureFlags(isWebEnabled: true),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/111877

The issue was that the method declaration in the super class (`Device.startApp`) specifies `covariant ApplicationPackage?`, while the sub-class (`ChromiumDevice.startApp`) declares it `covariant WebApplicationPackage`, which is non-nullable. However, because of https://github.com/flutter/flutter/pull/55531, it is possible to run a Flutter app on a browser device even if the project does not specify a web target; thus, package could legitimately be null. However, `ChromiumDevice.startApp` specifies a non-nullable parameter, it is a runtime error. This was likely introduced during a null-safety migration, so this restores this functionality by making the parameter nullable (note that `ChromiumDevice.startApp` does not even reference the argument).