### PR TITLE
allow passing --file-reporter option to test runner

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -205,6 +205,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           'json':     'A machine-readable format. See: https://dart.dev/go/test-docs/json_reporter.md',
         },
       )
+      ..addOption('file-reporter',
+        help: 'Enable an additional reporter writing test results to a file.\n'
+          'Should be in the form <reporter>:<filepath>, '
+          'Example: "json:reports/tests.json"'
+      )
       ..addOption('timeout',
         help: 'The default test timeout, specified either '
               'in seconds (e.g. "60s"), '
@@ -457,6 +462,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       web: stringArgDeprecated('platform') == 'chrome',
       randomSeed: stringArgDeprecated('test-randomize-ordering-seed'),
       reporter: stringArgDeprecated('reporter'),
+      fileReporter: stringArg('file-reporter'),
       timeout: stringArgDeprecated('timeout'),
       runSkipped: boolArgDeprecated('run-skipped'),
       shardIndex: shardIndex,

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -46,6 +46,7 @@ abstract class FlutterTestRunner {
     bool web = false,
     String? randomSeed,
     String? reporter,
+    String? fileReporter,
     String? timeout,
     bool runSkipped = false,
     int? shardIndex,
@@ -83,6 +84,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     bool web = false,
     String? randomSeed,
     String? reporter,
+    String? fileReporter,
     String? timeout,
     bool runSkipped = false,
     int? shardIndex,
@@ -104,6 +106,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['-r', 'json']
       else
         ...<String>['-r', reporter ?? 'compact'],
+      if (fileReporter != null)
+        '--file-reporter=$fileReporter',
       if (timeout != null)
         ...<String>['--timeout', timeout],
       '--concurrency=$concurrency',

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -782,6 +782,40 @@ dev_dependencies:
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
+
+  group('File Reporter', () {
+    testUsingContext('defaults to unset null value', () async {
+      final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+      final TestCommand testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+      ]);
+      expect(testRunner.lastFileReporterValue, null);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+    testUsingContext('when set --file-reporter value is passed on', () async {
+      final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+      final TestCommand testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+        '--file-reporter=json:out.jsonl'
+      ]);
+      expect(testRunner.lastFileReporterValue, 'json:out.jsonl');
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
 }
 
 class FakeFlutterTestRunner implements FlutterTestRunner {
@@ -791,6 +825,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
   Duration? leastRunTime;
   bool? lastEnableObservatoryValue;
   late DebuggingOptions lastDebuggingOptionsValue;
+  String? lastFileReporterValue;
 
   @override
   Future<int> runTests(
@@ -816,6 +851,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     bool web = false,
     String? randomSeed,
     String? reporter,
+    String? fileReporter,
     String? timeout,
     bool runSkipped = false,
     int? shardIndex,
@@ -826,6 +862,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     lastDebuggingOptionsValue = debuggingOptions;
+    lastFileReporterValue = fileReporter;
 
     if (leastRunTime != null) {
       await Future<void>.delayed(leastRunTime!);


### PR DESCRIPTION
Allow passing --file-reporter option to test runner so that both machine and human readable output can be observed in a CI setting. 

This has been [supported in test runner](https://github.com/dart-lang/test/blob/master/pkgs/test/doc/json_reporter.md) for some time.

fixes #69425

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
