### PR TITLE
Remove controller listener on CupertinoPicker dispose

### DIFF
--- a/packages/flutter/lib/src/cupertino/picker.dart
+++ b/packages/flutter/lib/src/cupertino/picker.dart
@@ -513,4 +513,10 @@ class _RenderCupertinoPickerSemantics extends RenderProxyBox {
     }
     node.updateWith(config: config);
   }
+
+  @override
+  void dispose() {
+    super.dispose();
+    controller.removeListener(_handleScrollUpdate);
+  }
 }

--- a/packages/flutter/test/cupertino/picker_test.dart
+++ b/packages/flutter/test/cupertino/picker_test.dart
@@ -10,6 +10,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
 
+class SpyFixedExtentScrollController extends FixedExtentScrollController {
+  /// Override for test visibility only.
+  @override
+  bool get hasListeners => super.hasListeners;
+}
+
 void main() {
   testWidgets('Picker respects theme styling', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -487,4 +493,36 @@ void main() {
       expect(borderRadius, isA<BorderRadiusDirectional>());
     });
   });
+
+  testWidgets('Scroll controller is detached upon dispose', (WidgetTester tester) async {
+    final SpyFixedExtentScrollController controller = SpyFixedExtentScrollController();
+    expect(controller.hasListeners, false);
+    expect(controller.positions.length, 0);
+
+    await tester.pumpWidget(CupertinoApp(
+      home: Align(
+        alignment: Alignment.topLeft,
+        child: Center(
+          child: CupertinoPicker(
+            scrollController: controller,
+            itemExtent: 50.0,
+            onSelectedItemChanged: (_) { },
+            children: List<Widget>.generate(3, (int index) {
+              return SizedBox(
+                width: 300.0,
+                child: Text(index.toString()),
+              );
+            }),
+          ),
+        ),
+      ),
+    ));
+    expect(controller.hasListeners, true);
+    expect(controller.positions.length, 1);
+
+    await tester.pumpWidget(const SizedBox.expand());
+    expect(controller.hasListeners, false);
+    expect(controller.positions.length, 0);
+  });
+
 }


### PR DESCRIPTION
`_RenderCupertinoPickerSemantics` was forgetting to unsubscribe from `ScrollController` events upon dispose. It appeared as an error about `!_debugDisposed` upon reuse of that controller, which was misidentified as use of `ScrollController` after dispose, see #90123. In fact, the `_RenderCupertinoPickerSemantics` is the object which was used after dispose. 

Fixes #110731

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
