### PR TITLE
`PerformanceOverlay`'s multiple fields are not updated when the user wants to update it

### DIFF
--- a/packages/flutter/lib/src/widgets/performance_overlay.dart
+++ b/packages/flutter/lib/src/widgets/performance_overlay.dart
@@ -115,6 +115,8 @@ class PerformanceOverlay extends LeafRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderPerformanceOverlay renderObject) {
     renderObject
       ..optionsMask = optionsMask
-      ..rasterizerThreshold = rasterizerThreshold;
+      ..rasterizerThreshold = rasterizerThreshold
+      ..checkerboardRasterCacheImages = checkerboardRasterCacheImages
+      ..checkerboardOffscreenLayers = checkerboardOffscreenLayers;
   }
 }

--- a/packages/flutter/test/widgets/performance_overlay_test.dart
+++ b/packages/flutter/test/widgets/performance_overlay_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/src/rendering/performance_overlay.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -9,5 +10,31 @@ void main() {
   testWidgets('Performance overlay smoke test', (WidgetTester tester) async {
     await tester.pumpWidget(const PerformanceOverlay());
     await tester.pumpWidget(PerformanceOverlay.allEnabled());
+  });
+
+  testWidgets('update widget field checkerboardRasterCacheImages',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const PerformanceOverlay());
+    await tester.pumpWidget(
+        const PerformanceOverlay(checkerboardRasterCacheImages: true));
+    final Finder finder = find.byType(PerformanceOverlay);
+    expect(
+        tester
+            .renderObject<RenderPerformanceOverlay>(finder)
+            .checkerboardRasterCacheImages,
+        true);
+  });
+
+  testWidgets('update widget field checkerboardOffscreenLayers',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(const PerformanceOverlay());
+    await tester.pumpWidget(
+        const PerformanceOverlay(checkerboardOffscreenLayers: true));
+    final Finder finder = find.byType(PerformanceOverlay);
+    expect(
+        tester
+            .renderObject<RenderPerformanceOverlay>(finder)
+            .checkerboardOffscreenLayers,
+        true);
   });
 }


### PR DESCRIPTION
Close #112038. Please see description there.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
