### PR TITLE
Fix SliverScrollingPersistentHeader not able to update stretchConfiguration

### DIFF
--- a/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
+++ b/packages/flutter/lib/src/widgets/sliver_persistent_header.dart
@@ -402,6 +402,11 @@ class _SliverScrollingPersistentHeader extends _SliverPersistentHeaderRenderObje
       stretchConfiguration: delegate.stretchConfiguration,
     );
   }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant _RenderSliverScrollingPersistentHeaderForWidgets renderObject) {
+    renderObject.stretchConfiguration = delegate.stretchConfiguration;
+  }
 }
 
 class _RenderSliverScrollingPersistentHeaderForWidgets extends RenderSliverScrollingPersistentHeader

--- a/packages/flutter/test/widgets/sliver_persistent_header_test.dart
+++ b/packages/flutter/test/widgets/sliver_persistent_header_test.dart
@@ -1,0 +1,63 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/src/rendering/sliver_persistent_header.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+      '_SliverScrollingPersistentHeader should update stretchConfiguration',
+      (WidgetTester tester) async {
+    for (final double stretchTriggerOffset in <double>[10.0, 20.0]) {
+      await tester.pumpWidget(MaterialApp(
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverPersistentHeader(
+              delegate: TestDelegate(
+                stretchConfiguration: OverScrollHeaderStretchConfiguration(
+                  stretchTriggerOffset: stretchTriggerOffset,
+                ),
+              ),
+            )
+          ],
+        ),
+      ));
+    }
+
+    expect(
+        tester.allWidgets.where((Widget w) =>
+            w.runtimeType.toString() == '_SliverScrollingPersistentHeader'),
+        isNotEmpty);
+
+    final RenderSliverScrollingPersistentHeader render = tester.allRenderObjects
+        .whereType<RenderSliverScrollingPersistentHeader>()
+        .first;
+    expect(render.stretchConfiguration?.stretchTriggerOffset, 20);
+  });
+}
+
+class TestDelegate extends SliverPersistentHeaderDelegate {
+  TestDelegate({this.stretchConfiguration, this.showOnScreenConfiguration});
+
+  @override
+  double get maxExtent => 200.0;
+
+  @override
+  double get minExtent => 200.0;
+
+  @override
+  Widget build(
+      BuildContext context, double shrinkOffset, bool overlapsContent) {
+    return Container(height: maxExtent);
+  }
+
+  @override
+  bool shouldRebuild(TestDelegate oldDelegate) => false;
+
+  @override
+  final OverScrollHeaderStretchConfiguration? stretchConfiguration;
+  @override
+  final PersistentHeaderShowOnScreenConfiguration? showOnScreenConfiguration;
+}


### PR DESCRIPTION
Close #112038. Please see description there.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
