### PR TITLE
Update `CupertinoSwitch` example

### DIFF
--- a/examples/api/lib/cupertino/switch/cupertino_switch.0.dart
+++ b/examples/api/lib/cupertino/switch/cupertino_switch.0.dart
@@ -28,7 +28,7 @@ class CupertinoSwitchExample extends StatefulWidget {
 }
 
 class _CupertinoSwitchExampleState extends State<CupertinoSwitchExample> {
-  bool wifi = true;
+  bool switchValue = true;
 
   @override
   Widget build(BuildContext context) {
@@ -37,38 +37,16 @@ class _CupertinoSwitchExampleState extends State<CupertinoSwitchExample> {
         middle: Text('CupertinoSwitch Sample'),
       ),
       child: Center(
-        // CupertinoFormRow's main axis is set to max by default.
-        // Set the intrinsic height widget to center the CupertinoFormRow.
-        child: IntrinsicHeight(
-          child: Container(
-            color: CupertinoTheme.of(context).barBackgroundColor,
-            child: CupertinoFormRow(
-              prefix: Row(
-                children: <Widget>[
-                  Icon(
-                    // Wifi icon is updated based on switch value.
-                    wifi ? CupertinoIcons.wifi : CupertinoIcons.wifi_slash,
-                    color: wifi ? CupertinoColors.systemBlue : CupertinoColors.systemRed,
-                  ),
-                  const SizedBox(width: 10),
-                  const Text('Wi-Fi')
-                ],
-              ),
-              child: CupertinoSwitch(
-                // This bool value toggles the switch.
-                value: wifi,
-                thumbColor: CupertinoColors.systemBlue,
-                trackColor: CupertinoColors.systemRed.withOpacity(0.14),
-                activeColor: CupertinoColors.systemRed.withOpacity(0.64),
-                onChanged: (bool? value) {
-                  // This is called when the user toggles the switch.
-                  setState(() {
-                    wifi = value!;
-                  });
-                },
-              ),
-            ),
-          ),
+        child: CupertinoSwitch(
+          // This bool value toggles the switch.
+          value: switchValue,
+          activeColor: CupertinoColors.activeBlue,
+          onChanged: (bool? value) {
+            // This is called when the user toggles the switch.
+            setState(() {
+              switchValue = value ?? false;
+            });
+          },
         ),
       ),
     );

--- a/examples/api/test/cupertino/switch/cupertino_switch.0_test.dart
+++ b/examples/api/test/cupertino/switch/cupertino_switch.0_test.dart
@@ -14,19 +14,11 @@ void main() {
 
     final Finder switchFinder = find.byType(CupertinoSwitch);
     CupertinoSwitch cupertinoSwitch = tester.widget<CupertinoSwitch>(switchFinder);
-    final Finder wifiOnIcon = find.byIcon(CupertinoIcons.wifi);
-    final Finder wifiOffIcon = find.byIcon(CupertinoIcons.wifi_slash);
     expect(cupertinoSwitch.value, true);
-    // When the switch is on, wifi icon should be visible.
-    expect(wifiOnIcon, findsOneWidget);
-    expect(wifiOffIcon, findsNothing);
 
     await tester.tap(switchFinder);
     await tester.pumpAndSettle();
     cupertinoSwitch = tester.widget<CupertinoSwitch>(switchFinder);
     expect(cupertinoSwitch.value, false);
-    // When the switch is off, wifi slash icon should be visible.
-    expect(wifiOnIcon, findsNothing);
-    expect(wifiOffIcon, findsOneWidget);
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/111674

`CupertinoFormRow` blocks switch from receiving focus to toggle from the keyboard when enabling full-keyboard access.

This removes `CupertinoFormRow` so `CupertinoSwitch` can be tested.

https://user-images.githubusercontent.com/48603081/191527517-34b688ea-2ee6-4914-845b-15b8167de4a1.mov




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
