### PR TITLE
[codesign] bring up verify codesign test on release branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2978,6 +2978,7 @@ targets:
       - dev
       - beta
       - stable
+      - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
     timeout: 60
     properties:


### PR DESCRIPTION
bring up fixed verify codesign test on release branches on dashboard. This would help release engineer detect codesign problems in an earlier stage, and prevent the possibilities of merging in unsigned binaries.

context: Christopher and I invested a ton of hours on this and after eliminating a ton of possibilities, come up with https://flutter-review.googlesource.com/c/recipes/+/34180 (which is already merged) to fix https://github.com/flutter/flutter/issues/95297, tested with led.