### PR TITLE
[codesign] remove beta, stable, dev references in ci.yaml

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2972,9 +2972,6 @@ targets:
 
   - name: Mac verify_binaries_codesigned
     enabled_branches:
-      - dev
-      - beta
-      - stable
       - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
     timeout: 60


### PR DESCRIPTION
context: https://github.com/flutter/flutter/pull/112096#discussion_r976939310
