### PR TITLE
Add follower layer delegate

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -4823,6 +4823,53 @@ class RenderLeaderLayer extends RenderProxyBox {
   }
 }
 
+/// A class that can supply the transform used in a
+/// [RenderFollowerLayer.transformDelegate] or
+/// [CompositedTransformFollower.transformDelegate].
+///
+/// Create a subclass of this to override the default computation of the offset
+/// for a [FollowerLayer] (or [RenderFollowerLayer]) in [computeOffset].
+///
+/// {@template flutter.rendering.proxy_box.follower_layer_transform_delegate_note}
+/// This is used to provide a custom transform when calculating the transform
+/// for a [CompositedTransformFollower], which can perform transforms during the
+/// paint phase of the rendering pipeline to render objects that come later in
+/// the paint order, instead of having to wait an additional frame to update the
+/// follower's transform, as would normally have to happen if synchronizing two
+/// widgets in different parts of the tree.
+///
+/// This is often used to synchronize elements in an [Overlay] with elements in
+/// the main widget tree.
+/// {@endtemplate}
+@immutable
+class FollowerLayerTransformDelegate {
+  /// Creates a const [FollowerLayerTransformDelegate].
+  ///
+  /// This is declared as const so that subclasses may be const.
+  const FollowerLayerTransformDelegate();
+
+  /// Computes the offset of a [FollowerLayer] based on the input alignments and
+  /// sizes.
+  ///
+  /// The default implementation honors the given alignments and offsets,
+  /// aligning the `followerAnchor` point with the `leaderAnchor` point, offset
+  /// by `offset`.
+  ///
+  /// The `leaderSize` argument will only be null when `leaderAnchor` is
+  /// [Alignment.topLeft], or when no leader is linked.
+  Offset computeOffset({
+    Size? leaderSize,
+    required Rect followerRect,
+    required Alignment leaderAnchor,
+    required Alignment followerAnchor,
+    Offset offset = Offset.zero,
+  }) {
+    return leaderSize == null
+      ? offset
+      : leaderAnchor.alongSize(leaderSize) - followerAnchor.alongSize(followerRect.size) + offset;
+  }
+}
+
 /// Transform the child so that its origin is [offset] from the origin of the
 /// [RenderLeaderLayer] with the same [LayerLink].
 ///
@@ -4846,6 +4893,7 @@ class RenderFollowerLayer extends RenderProxyBox {
     Offset offset = Offset.zero,
     Alignment leaderAnchor = Alignment.topLeft,
     Alignment followerAnchor = Alignment.topLeft,
+    FollowerLayerTransformDelegate transformDelegate = const FollowerLayerTransformDelegate(),
     RenderBox? child,
   }) : assert(link != null),
        assert(showWhenUnlinked != null),
@@ -4855,6 +4903,7 @@ class RenderFollowerLayer extends RenderProxyBox {
        _offset = offset,
        _leaderAnchor = leaderAnchor,
        _followerAnchor = followerAnchor,
+       _transformDelegate = transformDelegate,
        super(child);
 
   /// The link object that connects this [RenderFollowerLayer] with a
@@ -4945,6 +4994,29 @@ class RenderFollowerLayer extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  /// A delegate that can compute the required transform given the sizes of the
+  /// leader and follower, alignments, and an offset.
+  ///
+  /// A delegate can be supplied to override the default calculation in
+  /// [FollowerLayerTransformDelegate.computeOffset] to position the follower
+  /// based on additional information.
+  ///
+  /// The default implementation of
+  /// [FollowerLayerTransformDelegate.computeOffset] honors the given alignments
+  /// and offsets, aligning the [followerAnchor] point with the [leaderAnchor]
+  /// point, offset by [offset].
+  ///
+  /// {@macro flutter.rendering.proxy_box.follower_layer_transform_delegate_note}
+  FollowerLayerTransformDelegate get transformDelegate => _transformDelegate;
+  FollowerLayerTransformDelegate _transformDelegate;
+  set transformDelegate(FollowerLayerTransformDelegate value) {
+    if (_transformDelegate == value) {
+      return;
+    }
+    _transformDelegate = value;
+    markNeedsPaint();
+  }
+
   @override
   void detach() {
     layer = null;
@@ -4996,14 +5068,18 @@ class RenderFollowerLayer extends RenderProxyBox {
   void paint(PaintingContext context, Offset offset) {
     final Size? leaderSize = link.leaderSize;
     assert(
-      link.leaderSize != null || (link.leader == null || leaderAnchor == Alignment.topLeft),
+      link.leaderSize != null || link.leader == null || leaderAnchor == Alignment.topLeft,
       '$link: layer is linked to ${link.leader} but a valid leaderSize is not set. '
       'leaderSize is required when leaderAnchor is not Alignment.topLeft '
       '(current value is $leaderAnchor).',
     );
-    final Offset effectiveLinkedOffset = leaderSize == null
-      ? this.offset
-      : leaderAnchor.alongSize(leaderSize) - followerAnchor.alongSize(size) + this.offset;
+    final Offset effectiveLinkedOffset = transformDelegate.computeOffset(
+      leaderSize: leaderSize,
+      followerRect: offset & size,
+      leaderAnchor: leaderAnchor,
+      followerAnchor: followerAnchor,
+      offset: this.offset,
+    );
     assert(showWhenUnlinked != null);
     if (layer == null) {
       layer = FollowerLayer(

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -85,7 +85,7 @@ export 'package:flutter/services.dart' show
 /// infrequently change. This provides a performance tradeoff where building
 /// the [Widget]s is faster but performing updates is slower.
 ///
-/// |                     | _UbiquitiousInheritedElement | InheritedElement |
+/// |                     | _UbiquitousInheritedElement | InheritedElement |
 /// |---------------------|------------------------------|------------------|
 /// | insert (best case)  | O(1)                         | O(1)             |
 /// | insert (worst case) | O(1)                         | O(n)             |
@@ -1604,6 +1604,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
     this.offset = Offset.zero,
     this.targetAnchor = Alignment.topLeft,
     this.followerAnchor = Alignment.topLeft,
+    this.transformDelegate = const FollowerLayerTransformDelegate(),
     super.child,
   }) : assert(link != null),
        assert(showWhenUnlinked != null),
@@ -1652,6 +1653,17 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
   /// Defaults to [Alignment.topLeft].
   final Alignment followerAnchor;
 
+  /// A delegate that can compute the required transform given the two sizes,
+  /// the two alignment points, and an offset.
+  ///
+  /// A delegate can be supplied to override the default calculation in
+  /// [FollowerLayerTransformDelegate.computeOffset] to locate the
+  /// follower based on additional information.
+  ///
+  /// If not specified, then it will use it's own instance of
+  /// [FollowerLayerTransformDelegate].
+  final FollowerLayerTransformDelegate transformDelegate;
+
   /// The additional offset to apply to the [targetAnchor] of the linked
   /// [CompositedTransformTarget] to obtain this widget's [followerAnchor]
   /// position.
@@ -1665,6 +1677,7 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
       offset: offset,
       leaderAnchor: targetAnchor,
       followerAnchor: followerAnchor,
+      transformDelegate: transformDelegate,
     );
   }
 
@@ -1675,7 +1688,8 @@ class CompositedTransformFollower extends SingleChildRenderObjectWidget {
       ..showWhenUnlinked = showWhenUnlinked
       ..offset = offset
       ..leaderAnchor = targetAnchor
-      ..followerAnchor = followerAnchor;
+      ..followerAnchor = followerAnchor
+      ..transformDelegate = transformDelegate;
   }
 }
 

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -22,27 +22,27 @@ void main() {
         child: LayoutBuilder(
           builder: (BuildContext context, BoxConstraints constraints) {
             return Stack(
-            children: <Widget>[
-              Positioned(
-                left: 123.0,
-                top: 456.0,
-                child: CompositedTransformTarget(
-                  link: linkToUse ?? link,
-                  child: const SizedBox(height: 10.0, width: 10.0),
+              children: <Widget>[
+                Positioned(
+                  left: 123.0,
+                  top: 456.0,
+                  child: CompositedTransformTarget(
+                    link: linkToUse ?? link,
+                    child: const SizedBox(height: 10.0, width: 10.0),
+                  ),
                 ),
-              ),
-              Positioned(
-                left: 787.0,
-                top: 343.0,
-                child: CompositedTransformFollower(
-                  link: linkToUse ?? link,
-                  targetAnchor: Alignment.center,
-                  followerAnchor: Alignment.center,
-                  child: SizedBox(key: key, height: 20.0, width: 20.0),
+                Positioned(
+                  left: 787.0,
+                  top: 343.0,
+                  child: CompositedTransformFollower(
+                    link: linkToUse ?? link,
+                    targetAnchor: Alignment.center,
+                    followerAnchor: Alignment.center,
+                    child: SizedBox(key: key, height: 20.0, width: 20.0),
+                  ),
                 ),
-              ),
-            ],
-          );
+              ],
+            );
           },
         ),
       );
@@ -143,6 +143,7 @@ void main() {
         ),
       );
     }
+
     testWidgets('topLeft', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
       final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
@@ -220,6 +221,7 @@ void main() {
         ),
       );
     }
+
     testWidgets('topLeft', (WidgetTester tester) async {
       await tester.pumpWidget(build(targetAlignment: Alignment.topLeft, followerAlignment: Alignment.topLeft));
       final RenderBox box1 = key1.currentContext!.findRenderObject()! as RenderBox;
@@ -273,7 +275,9 @@ void main() {
               child: GestureDetector(
                 key: key2,
                 behavior: HitTestBehavior.opaque,
-                onTap: () { tapped = true; },
+                onTap: () {
+                  tapped = true;
+                },
                 child: SizedBox(key: key3, height: 2.0, width: 2.0),
               ),
             ),
@@ -283,16 +287,20 @@ void main() {
     }
 
     const List<Alignment> alignments = <Alignment>[
-      Alignment.topLeft, Alignment.topRight,
+      Alignment.topLeft,
+      Alignment.topRight,
       Alignment.center,
-      Alignment.bottomLeft, Alignment.bottomRight,
+      Alignment.bottomLeft,
+      Alignment.bottomRight,
     ];
 
-    setUp(() { tapped = false; });
+    setUp(() {
+      tapped = false;
+    });
 
     for (final Alignment targetAlignment in alignments) {
       for (final Alignment followerAlignment in alignments) {
-        testWidgets('$targetAlignment - $followerAlignment', (WidgetTester tester) async{
+        testWidgets('$targetAlignment - $followerAlignment', (WidgetTester tester) async {
           await tester.pumpWidget(build(targetAlignment: targetAlignment, followerAlignment: followerAlignment));
           final RenderBox box2 = key2.currentContext!.findRenderObject()! as RenderBox;
           expect(box2.size, const Size(2.0, 2.0));
@@ -322,8 +330,7 @@ void main() {
     );
   });
 
-  testWidgets(
-      '`FollowerLayer` (`CompositedTransformFollower`) has null pointer error when using with some kinds of `Layer`s',
+  testWidgets('`FollowerLayer` (`CompositedTransformFollower`) has null pointer error when using with some kinds of `Layer`s',
       (WidgetTester tester) async {
     final LayerLink link = LayerLink();
     await tester.pumpWidget(
@@ -336,6 +343,108 @@ void main() {
       ),
     );
   });
+
+  group('FollowerLayerTransformDelegate', () {
+    final GlobalKey key = GlobalKey();
+
+    Widget build({
+      required Alignment targetAlignment,
+      required Alignment followerAlignment,
+      Offset offset = Offset.zero,
+      required FollowerLayerTransformDelegate delegate,
+    }) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: <Widget>[
+            Positioned(
+              left: 123.0,
+              top: 456.0,
+              child: CompositedTransformTarget(
+                link: link,
+                child: const SizedBox(height: 10.0, width: 10.0),
+              ),
+            ),
+            Positioned(
+              left: 787.0,
+              top: 343.0,
+              child: CompositedTransformFollower(
+                link: link,
+                targetAnchor: targetAlignment,
+                followerAnchor: followerAlignment,
+                offset: offset,
+                transformDelegate: delegate,
+                child: SizedBox(key: key, height: 20.0, width: 20.0),
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    testWidgets('Can override offset with delegate', (WidgetTester tester) async {
+      const Offset testOffset = Offset(100, 200);
+      await tester.pumpWidget(
+        build(
+          targetAlignment: Alignment.topLeft,
+          followerAlignment: Alignment.topLeft,
+          offset: const Offset(10, 20),
+          delegate: TestFixedLocationDelegate(testOffset),
+        ),
+      );
+      final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
+      expect(box.localToGlobal(Offset.zero), const Offset(123, 456) + testOffset);
+    });
+
+    testWidgets('Delegate is passed the correct information', (WidgetTester tester) async {
+      const Offset testOffset = Offset(100, 200);
+      final TestFixedLocationDelegate delegate = TestFixedLocationDelegate(testOffset);
+      await tester.pumpWidget(
+        build(
+          targetAlignment: Alignment.topLeft,
+          followerAlignment: Alignment.topLeft,
+          offset: const Offset(10, 20),
+          delegate: delegate,
+        ),
+      );
+      final RenderBox box = key.currentContext!.findRenderObject()! as RenderBox;
+      expect(box.localToGlobal(Offset.zero), const Offset(123, 456) + testOffset);
+      expect(delegate.leaderSize, equals(const Size(10, 10)));
+      expect(delegate.followerRect, equals(const Rect.fromLTRB(787.0, 343.0, 807.0, 363.0)));
+      expect(delegate.leaderAnchor, equals(Alignment.topLeft));
+      expect(delegate.followerAnchor, equals(Alignment.topLeft));
+      expect(delegate.offset, equals(const Offset(10, 20)));
+    });
+  });
+}
+
+// ignore: must_be_immutable
+class TestFixedLocationDelegate extends FollowerLayerTransformDelegate {
+  TestFixedLocationDelegate(this.testOffset);
+
+  final Offset testOffset;
+
+  Size? leaderSize;
+  late Rect followerRect;
+  late Alignment leaderAnchor;
+  late Alignment followerAnchor;
+  late Offset offset;
+
+  @override
+  Offset computeOffset({
+    Size? leaderSize,
+    required Rect followerRect,
+    required Alignment leaderAnchor,
+    required Alignment followerAnchor,
+    Offset offset = Offset.zero,
+  }) {
+    this.leaderSize = leaderSize;
+    this.followerRect = followerRect;
+    this.leaderAnchor = leaderAnchor;
+    this.followerAnchor = followerAnchor;
+    this.offset = offset;
+    return testOffset;
+  }
 }
 
 class _CustomWidget extends SingleChildRenderObjectWidget {


### PR DESCRIPTION
## Description

This adds a delegate class that can override the transform used by a `CompositedTransformFollower` so that it can incorporate additional information other than the alignments and leader/follower sizes at the time of the transform.

I needed this in order to do cascading menus properly so that they wouldn't be delayed by a frame when their connected menu button moved.

## Tests
 - Added a test to make sure that the delegate gets used and gets passed the correct information.