### PR TITLE
Always run plugin_lint_mac test on arm and x64

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2763,7 +2763,7 @@ targets:
 
   - name: Mac_x64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
-    bringup: true # Mac_x64 variant https://github.com/flutter/flutter/issues/112130
+    bringup: true # Mac_x64 variant https://github.com/flutter/flutter/pull/112131
     timeout: 60
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2761,8 +2761,9 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac plugin_lint_mac
+  - name: Mac_x64 plugin_lint_mac
     recipe: devicelab/devicelab_drone
+    bringup: true # Mac_x64 variant https://github.com/flutter/flutter/issues/112130
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
This test should be running on both x64 and arm machines.
arm version at:
https://github.com/flutter/flutter/blob/0cd381015965aef25344a17605078acbee73f920/.ci.yaml#L2783

https://github.com/flutter/flutter/pull/109889 changed `Mac plugin_lint_mac` from "run on x64" to "run on any machine".

I'm not sure why there's a cdn issue on the arm macs when `Mac_arm64_ios plugin_lint_mac` seems to always be passing without issue.

Fixes https://github.com/flutter/flutter/issues/112130

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
