### PR TITLE
ui.PointerSignalKind forwards compatibility for scale

### DIFF
--- a/packages/flutter/lib/src/gestures/converter.dart
+++ b/packages/flutter/lib/src/gestures/converter.dart
@@ -268,6 +268,8 @@ class PointerEventConverter {
                 embedderId: datum.embedderId,
               );
             case ui.PointerSignalKind.unknown:
+            default: // ignore: no_default_cases, to allow adding new [PointerSignalKind]
+                     // TODO(moffatman): Remove after landing https://github.com/flutter/engine/pull/36342
               // This branch should already have 'unknown' filtered out, but
               // we don't want to return anything or miss if someone adds a new
               // enumeration to PointerSignalKind.


### PR DESCRIPTION
Allow adding `ui.PointerSignalKind.scale` in a subsequent engine PR.

Part of #112103

## Sequence

1. This PR
2. https://github.com/flutter/engine/pull/36342
3. https://github.com/flutter/flutter/pull/112172
4. https://github.com/flutter/engine/pull/36348

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

