### PR TITLE
Reland - Fix ExpansionTile shows children background when expanded

### DIFF
--- a/packages/flutter/lib/src/material/expansion_tile.dart
+++ b/packages/flutter/lib/src/material/expansion_tile.dart
@@ -10,6 +10,7 @@ import 'expansion_tile_theme.dart';
 import 'icons.dart';
 import 'list_tile.dart';
 import 'list_tile_theme.dart';
+import 'material.dart';
 import 'theme.dart';
 
 const Duration _kExpand = Duration(milliseconds: 200);
@@ -432,11 +433,13 @@ class _ExpansionTileState extends State<ExpansionTile> with SingleTickerProvider
       offstage: closed,
       child: TickerMode(
         enabled: !closed,
-        child: Padding(
-          padding: widget.childrenPadding ?? expansionTileTheme.childrenPadding ?? EdgeInsets.zero,
-          child: Column(
-            crossAxisAlignment: widget.expandedCrossAxisAlignment ?? CrossAxisAlignment.center,
-            children: widget.children,
+        child: Material(
+          child: Padding(
+            padding: widget.childrenPadding ?? expansionTileTheme.childrenPadding ?? EdgeInsets.zero,
+            child: Column(
+              crossAxisAlignment: widget.expandedCrossAxisAlignment ?? CrossAxisAlignment.center,
+              children: widget.children,
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/material/expansion_tile_test.dart
+++ b/packages/flutter/test/material/expansion_tile_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 class TestIcon extends StatefulWidget {
   const TestIcon({super.key});
 
@@ -479,6 +481,51 @@ void main() {
     expect(columnRect.top, paddingRect.top + 8);
     expect(columnRect.right, paddingRect.right - 12);
     expect(columnRect.bottom, paddingRect.bottom - 4);
+  });
+
+  testWidgets('ExpansionTile adds a Material widget above its children when expanded', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/107030
+    const Color childColor = Color(0xff4caf50);
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Material(
+          child: Center(
+            child: ExpansionTile(
+              title: Text('title'),
+              childrenPadding: EdgeInsets.fromLTRB(10, 8, 12, 4),
+              children: <Widget>[
+                ListTile(tileColor: childColor),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Finder rootMaterialFinder = find.ancestor(
+      of: find.byType(ExpansionTile),
+      matching: find.byType(Material),
+    );
+
+    final Finder expansionTileMaterialFinder = find.descendant(
+      of: find.byType(ExpansionTile),
+      matching: find.byType(Material),
+    );
+
+    // ExpansionTile should not add a Material widget when it is not expanded
+    expect(expansionTileMaterialFinder, findsNothing);
+
+    // Expand
+    await tester.tap(find.text('title'));
+    await tester.pumpAndSettle();
+
+    // ExpansionTile adds a Material widget when it is expanded
+    expect(expansionTileMaterialFinder, findsOneWidget);
+
+    // Child color is painted on the inner Material widget
+    expect(rootMaterialFinder, isNot(paints..rect()..rect(color: childColor)));
+    expect(expansionTileMaterialFinder, paints..rect(color: childColor));
   });
 
   testWidgets('ExpansionTile.collapsedBackgroundColor', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Reland https://github.com/flutter/flutter/pull/107834, which was reverted in https://github.com/flutter/flutter/pull/108844.
(With a slight change at the end of the test due to https://github.com/flutter/flutter/pull/108648 which changed how the `Material` widget is rendered: calling `drawRect` instead of `drawPath`).

## Related issues

Fixes https://github.com/flutter/flutter/issues/107030