### PR TITLE
Fixed an iconTheme lerping problem with ChipThemeData.

### DIFF
--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -510,7 +510,7 @@ class ChipThemeData with Diagnosticable {
       brightness: t < 0.5 ? a?.brightness ?? Brightness.light : b?.brightness ?? Brightness.light,
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       pressElevation: lerpDouble(a?.pressElevation, b?.pressElevation, t),
-      iconTheme: a?.iconTheme != null || b?.iconTheme != null 
+      iconTheme: a?.iconTheme != null || b?.iconTheme != null
         ? IconThemeData.lerp(a?.iconTheme, b?.iconTheme, t)
         : null,
     );

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -510,7 +510,9 @@ class ChipThemeData with Diagnosticable {
       brightness: t < 0.5 ? a?.brightness ?? Brightness.light : b?.brightness ?? Brightness.light,
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
       pressElevation: lerpDouble(a?.pressElevation, b?.pressElevation, t),
-      iconTheme: IconThemeData.lerp(a?.iconTheme, b?.iconTheme, t),
+      iconTheme: a?.iconTheme != null || b?.iconTheme != null 
+        ? IconThemeData.lerp(a?.iconTheme, b?.iconTheme, t)
+        : null,
     );
   }
 

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -443,6 +443,7 @@ void main() {
     expect(lerp.elevation, 3.0);
     expect(lerp.pressElevation, 7.0);
     expect(lerp.checkmarkColor, equals(middleGrey));
+    expect(lerp.iconTheme, isNull);
 
     expect(ChipThemeData.lerp(null, null, 0.25), isNull);
 
@@ -466,6 +467,7 @@ void main() {
     expect(lerpANull25.elevation, 1.25);
     expect(lerpANull25.pressElevation, 2.5);
     expect(lerpANull25.checkmarkColor, equals(Colors.white.withAlpha(0x40)));
+    expect(lerp.iconTheme, isNull);
 
     final ChipThemeData lerpANull75 = ChipThemeData.lerp(null, chipThemeWhite, 0.75)!;
     expect(lerpANull75.backgroundColor, equals(Colors.black.withAlpha(0x17)));
@@ -508,6 +510,7 @@ void main() {
     expect(lerpBNull25.elevation, 0.75);
     expect(lerpBNull25.pressElevation, 3.0);
     expect(lerpBNull25.checkmarkColor, equals(Colors.black.withAlpha(0xbf)));
+    expect(lerp.iconTheme, isNull);
 
     final ChipThemeData lerpBNull75 = ChipThemeData.lerp(chipThemeBlack, null, 0.75)!;
     expect(lerpBNull75.backgroundColor, equals(Colors.white.withAlpha(0x08)));
@@ -529,6 +532,7 @@ void main() {
     expect(lerpBNull75.elevation, 0.25);
     expect(lerpBNull75.pressElevation, 1.0);
     expect(lerpBNull75.checkmarkColor, equals(Colors.black.withAlpha(0x40)));
+    expect(lerp.iconTheme, isNull);
   });
 
   testWidgets('Chip uses stateful color from chip theme', (WidgetTester tester) async {


### PR DESCRIPTION
The current `ChipThemeData.lerp` doesn't handle a null `iconTheme` very well. If both ChipThemeData.iconTheme's are null it creates a new default `IconThemeData` instead of null. This can cause some weird icon size and color changes during a theme lerp (like from light to dark themes). This PR fixes that.

Fixes: #111998 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
