### PR TITLE
Refactor `DeviceManager.findTargetDevices()` and `FlutterCommand.findAllTargetDevices()`, and add a flag to not show prompt.

### DIFF
--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -205,7 +205,6 @@ Future<T> runInContext<T>(
         ),
         fuchsiaSdk: globals.fuchsiaSdk!,
         operatingSystemUtils: globals.os,
-        terminal: globals.terminal,
         customDevicesConfig: globals.customDevicesConfig,
       ),
       DevtoolsLauncher: () => DevtoolsServerLauncher(

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -235,7 +235,15 @@ abstract class DeviceManager {
   ///
   /// * If [flutterProject] is null, then assume the project supports all
   /// device types.
-  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, { Duration? timeout }) async {
+  ///
+  /// * If [promptUserToChooseDevice] is true, and there are more than one
+  /// device after the aforementioned filters, and the user is connected to a
+  /// terminal, then show a prompt asking the user to choose one.
+  Future<List<Device>> findTargetDevices(
+    FlutterProject? flutterProject, {
+    Duration? timeout,
+    bool promptUserToChooseDevice = true,
+  }) async {
     if (timeout != null) {
       // Reset the cache with the specified timeout.
       await refreshAllConnectedDevices(timeout: timeout);
@@ -296,7 +304,7 @@ abstract class DeviceManager {
       // has two active Android devices running, then we request the user to
       // choose one. If the user has two nonEphemeral devices running, we also
       // request input to choose one.
-      if (devices.length > 1 && _terminal.stdinHasTerminal) {
+      if (devices.length > 1 && promptUserToChooseDevice && _terminal.stdinHasTerminal) {
         _logger.printStatus(_userMessages.flutterMultipleDevicesFound);
         await Device.printDevices(devices, _logger);
         final Device chosenDevice = await _chooseOneOfAvailableDevices(devices);

--- a/packages/flutter_tools/lib/src/flutter_device_manager.dart
+++ b/packages/flutter_tools/lib/src/flutter_device_manager.dart
@@ -11,6 +11,7 @@ import 'artifacts.dart';
 import 'base/file_system.dart';
 import 'base/os.dart';
 import 'base/platform.dart';
+import 'base/user_messages.dart';
 import 'custom_devices/custom_device.dart';
 import 'custom_devices/custom_devices_config.dart';
 import 'device.dart';
@@ -51,10 +52,9 @@ class FlutterDeviceManager extends DeviceManager {
     required Artifacts artifacts,
     required MacOSWorkflow macOSWorkflow,
     required FuchsiaSdk fuchsiaSdk,
-    required super.userMessages,
+    required UserMessages userMessages,
     required OperatingSystemUtils operatingSystemUtils,
     required WindowsWorkflow windowsWorkflow,
-    required super.terminal,
     required CustomDevicesConfig customDevicesConfig,
   }) : deviceDiscoverers =  <DeviceDiscovery>[
     AndroidDevices(

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1408,54 +1408,15 @@ abstract class FlutterCommand extends Command<void> {
       return null;
     }
     final DeviceManager deviceManager = globals.deviceManager!;
-    List<Device> devices = await deviceManager.findTargetDevices(
+    final List<Device>? devices = await deviceManager.findTargetDevices(
       includeUnsupportedDevices ? null : FlutterProject.current(),
       timeout: deviceDiscoveryTimeout,
     );
 
-    if (devices.isEmpty && deviceManager.hasSpecifiedDeviceId) {
-      globals.printStatus(userMessages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId!));
-      final List<Device> allDevices = await deviceManager.getAllConnectedDevices();
-      if (allDevices.isNotEmpty) {
-        globals.printStatus('');
-        globals.printStatus('The following devices were found:');
-        await Device.printDevices(allDevices, globals.logger);
-      }
-      return null;
-    } else if (devices.isEmpty) {
-      if (deviceManager.hasSpecifiedAllDevices) {
-        globals.printStatus(userMessages.flutterNoDevicesFound);
-      } else {
-        globals.printStatus(userMessages.flutterNoSupportedDevices);
-      }
-      final List<Device> unsupportedDevices = await deviceManager.getDevices();
-      if (unsupportedDevices.isNotEmpty) {
-        final StringBuffer result = StringBuffer();
-        result.writeln(userMessages.flutterFoundButUnsupportedDevices);
-        result.writeAll(
-          (await Device.descriptions(unsupportedDevices))
-              .map((String desc) => desc)
-              .toList(),
-          '\n',
-        );
-        result.writeln();
-        result.writeln(userMessages.flutterMissPlatformProjects(
-          Device.devicesPlatformTypes(unsupportedDevices),
-        ));
-        globals.printStatus(result.toString());
-      }
-      return null;
-    } else if (devices.length > 1 && !deviceManager.hasSpecifiedAllDevices) {
-      if (deviceManager.hasSpecifiedDeviceId) {
-       globals.printStatus(userMessages.flutterFoundSpecifiedDevices(devices.length, deviceManager.specifiedDeviceId!));
-      } else {
-        globals.printStatus(userMessages.flutterSpecifyDeviceWithAllOption);
-        devices = await deviceManager.getAllConnectedDevices();
-      }
-      globals.printStatus('');
-      await Device.printDevices(devices, globals.logger);
+    if (devices == null || devices.isEmpty) {
       return null;
     }
+
     return devices;
   }
 

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1408,16 +1408,108 @@ abstract class FlutterCommand extends Command<void> {
       return null;
     }
     final DeviceManager deviceManager = globals.deviceManager!;
-    final List<Device>? devices = await deviceManager.findTargetDevices(
+    List<Device> devices = await deviceManager.findTargetDevices(
       includeUnsupportedDevices ? null : FlutterProject.current(),
       timeout: deviceDiscoveryTimeout,
     );
 
-    if (devices == null || devices.isEmpty) {
-      return null;
+    if (devices.isEmpty) {
+      if (deviceManager.hasSpecifiedDeviceId) {
+        globals.logger.printStatus(userMessages.flutterNoMatchingDevice(deviceManager.specifiedDeviceId!));
+        final List<Device> allDevices = await deviceManager.getAllConnectedDevices();
+        if (allDevices.isNotEmpty) {
+          globals.logger.printStatus('');
+          globals.logger.printStatus('The following devices were found:');
+          await Device.printDevices(allDevices, globals.logger);
+        }
+        return null;
+      } else if (deviceManager.hasSpecifiedAllDevices) {
+        globals.logger.printStatus(userMessages.flutterNoDevicesFound);
+        await _printUnsupportedDevice(deviceManager);
+        return null;
+      } else {
+        globals.logger.printStatus(userMessages.flutterNoSupportedDevices);
+        await _printUnsupportedDevice(deviceManager);
+        return null;
+      }
+    } else if (devices.length > 1) {
+      if (deviceManager.hasSpecifiedDeviceId) {
+        globals.logger.printStatus(userMessages.flutterFoundSpecifiedDevices(devices.length, deviceManager.specifiedDeviceId!));
+        return null;
+      } else if (!deviceManager.hasSpecifiedAllDevices) {
+        if (globals.terminal.stdinHasTerminal) {
+          // If DeviceManager was not able to prioritize a device. For example, if the user
+          // has two active Android devices running, then we request the user to
+          // choose one. If the user has two nonEphemeral devices running, we also
+          // request input to choose one.
+          globals.logger.printStatus(userMessages.flutterMultipleDevicesFound);
+          await Device.printDevices(devices, globals.logger);
+          final Device chosenDevice = await _chooseOneOfAvailableDevices(devices);
+
+          // Update the [DeviceManager.specifiedDeviceId] so that we will not be prompted again.
+          deviceManager.specifiedDeviceId = chosenDevice.id;
+
+          devices = <Device>[chosenDevice];
+        } else {
+          // Show an error message asking the user to specify `-d all` if they
+          // want to run on multiple devices.
+          final List<Device> allDevices = await deviceManager.getAllConnectedDevices();
+          globals.logger.printStatus(userMessages.flutterSpecifyDeviceWithAllOption);
+          globals.logger.printStatus('');
+          await Device.printDevices(allDevices, globals.logger);
+          return null;
+        }
+      }
     }
 
     return devices;
+  }
+
+  Future<void> _printUnsupportedDevice(DeviceManager deviceManager) async {
+    final List<Device> unsupportedDevices = await deviceManager.getDevices();
+    if (unsupportedDevices.isNotEmpty) {
+      final StringBuffer result = StringBuffer();
+      result.writeln(userMessages.flutterFoundButUnsupportedDevices);
+      result.writeAll(
+        (await Device.descriptions(unsupportedDevices))
+            .map((String desc) => desc)
+            .toList(),
+        '\n',
+      );
+      result.writeln();
+      result.writeln(userMessages.flutterMissPlatformProjects(
+        Device.devicesPlatformTypes(unsupportedDevices),
+      ));
+      globals.logger.printStatus(result.toString());
+    }
+  }
+
+  Future<Device> _chooseOneOfAvailableDevices(List<Device> devices) async {
+    _displayDeviceOptions(devices);
+    final String userInput =  await _readUserInput(devices.length);
+    if (userInput.toLowerCase() == 'q') {
+      throwToolExit('');
+    }
+    return devices[int.parse(userInput) - 1];
+  }
+
+  void _displayDeviceOptions(List<Device> devices) {
+    int count = 1;
+    for (final Device device in devices) {
+      globals.logger.printStatus(userMessages.flutterChooseDevice(count, device.name, device.id));
+      count++;
+    }
+  }
+
+  Future<String> _readUserInput(int deviceCount) async {
+    globals.terminal.usesTerminalUi = true;
+    final String result = await globals.terminal.promptForCharInput(
+      <String>[ for (int i = 0; i < deviceCount; i++) '${i + 1}', 'q', 'Q'],
+      displayAcceptedCharacters: false,
+      logger: globals.logger,
+      prompt: userMessages.flutterChooseOne,
+    );
+    return result;
   }
 
   /// Find and return the target [Device] based upon currently connected

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -14,7 +14,6 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
@@ -34,6 +33,7 @@ import 'package:multicast_dns/multicast_dns.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
+import '../../general.shard/runner/flutter_command_test.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_devices.dart';
@@ -417,7 +417,7 @@ void main() {
         createTestCommandRunner(command).run(<String>['attach']),
         throwsToolExit(),
       );
-      expect(testDeviceManager.logger.statusText, containsIgnoringWhitespace('No supported devices connected'));
+      expect(testLogger.statusText, containsIgnoringWhitespace('No supported devices connected'));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
@@ -448,14 +448,15 @@ void main() {
         createTestCommandRunner(command).run(<String>['attach']),
         throwsToolExit(),
       );
-      expect(testDeviceManager.logger.statusText, containsIgnoringWhitespace('More than one device'));
-      expect(testDeviceManager.logger.statusText, contains('xx1'));
-      expect(testDeviceManager.logger.statusText, contains('yy2'));
+      expect(testLogger.statusText, containsIgnoringWhitespace('More than one device'));
+      expect(testLogger.statusText, contains('xx1'));
+      expect(testLogger.statusText, contains('yy2'));
       expect(MacOSDesignedForIPadDevices.allowDiscovery, isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
       DeviceManager: () => testDeviceManager,
+      AnsiTerminal: () => FakeTerminal(stdinHasTerminal: false),
     });
 
     testUsingContext('Catches service disappeared error', () async {
@@ -918,11 +919,7 @@ class FakeMDnsClient extends Fake implements MDnsClient {
 }
 
 class TestDeviceManager extends DeviceManager {
-  TestDeviceManager({required this.logger}) : super(
-    logger: logger,
-    terminal: Terminal.test(),
-    userMessages: UserMessages(),
-  );
+  TestDeviceManager({required this.logger}) : super(logger: logger);
   List<Device> devices = <Device>[];
 
   final BufferLogger logger;

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -14,6 +14,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/terminal.dart';
+import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/attach.dart';
@@ -46,6 +47,7 @@ void main() {
   group('attach', () {
     late StreamLogger logger;
     late FileSystem testFileSystem;
+    late TestDeviceManager testDeviceManager;
 
     setUp(() {
       Cache.disableLocking();
@@ -57,6 +59,7 @@ void main() {
       );
       testFileSystem.directory('lib').createSync();
       testFileSystem.file(testFileSystem.path.join('lib', 'main.dart')).createSync();
+      testDeviceManager = TestDeviceManager(logger: BufferLogger.test());
     });
 
     group('with one device and no specified target file', () {
@@ -92,7 +95,7 @@ void main() {
           },
         );
 
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
           if (message == '[verbose] Observatory URL on device: http://127.0.0.1:$devicePort') {
@@ -113,6 +116,7 @@ void main() {
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
         MDnsObservatoryDiscovery: () => MDnsObservatoryDiscovery(
           mdnsClient: FakeMDnsClient(<PtrResourceRecord>[], <String, List<SrvResourceRecord>>{}),
           logger: logger,
@@ -126,7 +130,7 @@ void main() {
           fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
           if (message == '[verbose] Observatory URL on device: http://127.0.0.1:$devicePort') {
@@ -147,6 +151,7 @@ void main() {
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
       });
 
       testUsingContext('Fails with tool exit on bad Observatory uri', () async {
@@ -156,12 +161,13 @@ void main() {
           fakeLogReader.dispose();
           return fakeLogReader;
         };
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
         expect(() => createTestCommandRunner(AttachCommand()).run(<String>['attach']), throwsToolExit());
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
       });
 
       testUsingContext('accepts filesystem parameters', () async {
@@ -170,7 +176,7 @@ void main() {
           fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         const String filesystemScheme = 'foo';
         const String filesystemRoot = '/build-output/';
@@ -221,10 +227,11 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
+        DeviceManager: () => testDeviceManager,
       });
 
       testUsingContext('exits when ipv6 is specified and debug-port is not', () async {
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         final AttachCommand command = AttachCommand();
         await expectLater(
@@ -237,6 +244,7 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
+        DeviceManager: () => testDeviceManager,
       },);
 
       testUsingContext('exits when observatory-port is specified and debug-port is not', () async {
@@ -245,7 +253,7 @@ void main() {
           fakeLogReader.addLine('The Dart VM service is listening on http://127.0.0.1:$devicePort');
           return fakeLogReader;
         };
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         final AttachCommand command = AttachCommand();
         await expectLater(
@@ -258,6 +266,7 @@ void main() {
       }, overrides: <Type, Generator>{
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
+        DeviceManager: () => testDeviceManager,
       },);
     });
 
@@ -276,7 +285,7 @@ void main() {
       });
 
       testUsingContext('succeeds in ipv4 mode', () async {
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
@@ -298,10 +307,11 @@ void main() {
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
       });
 
       testUsingContext('succeeds in ipv6 mode', () async {
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
@@ -324,10 +334,11 @@ void main() {
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
       });
 
       testUsingContext('skips in ipv4 mode with a provided observatory port', () async {
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
@@ -359,10 +370,11 @@ void main() {
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
       });
 
       testUsingContext('skips in ipv6 mode with a provided observatory port', () async {
-        testDeviceManager.addDevice(device);
+        testDeviceManager.devices = <Device>[device];
 
         final Completer<void> completer = Completer<void>();
         final StreamSubscription<String> loggerSubscription = logger.stream.listen((String message) {
@@ -395,6 +407,7 @@ void main() {
         FileSystem: () => testFileSystem,
         ProcessManager: () => FakeProcessManager.any(),
         Logger: () => logger,
+        DeviceManager: () => testDeviceManager,
       });
     });
 
@@ -404,15 +417,16 @@ void main() {
         createTestCommandRunner(command).run(<String>['attach']),
         throwsToolExit(),
       );
-      expect(testLogger.statusText, containsIgnoringWhitespace('No supported devices connected'));
+      expect(testDeviceManager.logger.statusText, containsIgnoringWhitespace('No supported devices connected'));
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => testDeviceManager,
     });
 
     testUsingContext('fails when targeted device is not Android with --device-user', () async {
       final FakeIOSDevice device = FakeIOSDevice();
-      testDeviceManager.addDevice(device);
+      testDeviceManager.devices = <Device>[device];
       expect(createTestCommandRunner(AttachCommand()).run(<String>[
         'attach',
         '--device-user',
@@ -421,23 +435,27 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => testDeviceManager,
     });
 
     testUsingContext('exits when multiple devices connected', () async {
       final AttachCommand command = AttachCommand();
-      testDeviceManager.addDevice(FakeAndroidDevice(id: 'xx1'));
-      testDeviceManager.addDevice(FakeAndroidDevice(id: 'yy2'));
+      testDeviceManager.devices = <Device>[
+        FakeAndroidDevice(id: 'xx1'),
+        FakeAndroidDevice(id: 'yy2'),
+      ];
       await expectLater(
         createTestCommandRunner(command).run(<String>['attach']),
         throwsToolExit(),
       );
-      expect(testLogger.statusText, containsIgnoringWhitespace('More than one device'));
-      expect(testLogger.statusText, contains('xx1'));
-      expect(testLogger.statusText, contains('yy2'));
+      expect(testDeviceManager.logger.statusText, containsIgnoringWhitespace('More than one device'));
+      expect(testDeviceManager.logger.statusText, contains('xx1'));
+      expect(testDeviceManager.logger.statusText, contains('yy2'));
       expect(MacOSDesignedForIPadDevices.allowDiscovery, isTrue);
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => testDeviceManager,
     });
 
     testUsingContext('Catches service disappeared error', () async {
@@ -457,7 +475,7 @@ void main() {
         throw vm_service.RPCError('flutter._listViews', RPCErrorCodes.kServiceDisappeared, '');
       };
 
-      testDeviceManager.addDevice(device);
+      testDeviceManager.devices = <Device>[device];
       testFileSystem.file('lib/main.dart').createSync();
 
       final AttachCommand command = AttachCommand(hotRunnerFactory: hotRunnerFactory);
@@ -467,6 +485,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => testDeviceManager,
     });
 
     testUsingContext('Does not catch generic RPC error', () async {
@@ -487,7 +506,7 @@ void main() {
         throw vm_service.RPCError('flutter._listViews', RPCErrorCodes.kInvalidParams, '');
       };
 
-      testDeviceManager.addDevice(device);
+      testDeviceManager.devices = <Device>[device];
       testFileSystem.file('lib/main.dart').createSync();
 
       final AttachCommand command = AttachCommand(hotRunnerFactory: hotRunnerFactory);
@@ -497,6 +516,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => testFileSystem,
       ProcessManager: () => FakeProcessManager.any(),
+      DeviceManager: () => testDeviceManager,
     });
   });
 }
@@ -791,6 +811,9 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   Category get category => Category.mobile;
+
+  @override
+  bool get ephemeral => true;
 }
 
 // Unfortunately Device, despite not being immutable, has an `operator ==`.
@@ -840,6 +863,12 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
   @override
   final PlatformType platformType = PlatformType.ios;
+
+  @override
+  bool isSupported() => true;
+
+  @override
+  bool isSupportedForProject(FlutterProject project) => true;
 }
 
 class FakeMDnsClient extends Fake implements MDnsClient {
@@ -886,4 +915,22 @@ class FakeMDnsClient extends Fake implements MDnsClient {
 
   @override
   void stop() {}
+}
+
+class TestDeviceManager extends DeviceManager {
+  TestDeviceManager({required this.logger}) : super(
+    logger: logger,
+    terminal: Terminal.test(),
+    userMessages: UserMessages(),
+  );
+  List<Device> devices = <Device>[];
+
+  final BufferLogger logger;
+
+  @override
+  List<DeviceDiscovery> get deviceDiscoverers {
+    final FakePollingDeviceDiscovery discoverer = FakePollingDeviceDiscovery();
+    devices.forEach(discoverer.addDevice);
+    return <DeviceDiscovery>[discoverer];
+  }
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -33,7 +33,6 @@ import 'package:multicast_dns/multicast_dns.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
-import '../../general.shard/runner/flutter_command_test.dart';
 import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_devices.dart';
@@ -930,4 +929,11 @@ class TestDeviceManager extends DeviceManager {
     devices.forEach(discoverer.addDevice);
     return <DeviceDiscovery>[discoverer];
   }
+}
+
+class FakeTerminal extends Fake implements AnsiTerminal {
+  FakeTerminal({this.stdinHasTerminal = true});
+
+  @override
+  final bool stdinHasTerminal;
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/devices_test.dart
@@ -6,8 +6,6 @@ import 'dart:convert';
 
 import 'package:flutter_tools/src/android/android_sdk.dart';
 import 'package:flutter_tools/src/artifacts.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/devices.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -133,7 +131,7 @@ webby (mobile)     • webby     • web-javascript • Web SDK (1.2.4) (emulato
 }
 
 class _FakeDeviceManager extends DeviceManager {
-  _FakeDeviceManager() : super(logger: testLogger, terminal: Terminal.test(), userMessages: userMessages);
+  _FakeDeviceManager() : super(logger: testLogger);
 
   @override
   Future<List<Device>> getAllConnectedDevices() =>
@@ -153,7 +151,7 @@ class _FakeDeviceManager extends DeviceManager {
 }
 
 class NoDevicesManager extends DeviceManager {
-  NoDevicesManager() : super(logger: testLogger, terminal: Terminal.test(), userMessages: userMessages);
+  NoDevicesManager() : super(logger: testLogger);
 
   @override
   Future<List<Device>> getAllConnectedDevices() async => <Device>[];

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -328,7 +328,7 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   Future<List<Device>> getDevices() async => devices;
 
   @override
-  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, {Duration? timeout}) async => devices;
+  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, {Duration? timeout, bool promptUserToChooseDevice = true}) async => devices;
 }
 
 class FailingFakeFlutterDriverFactory extends Fake implements FlutterDriverFactory {

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -46,11 +46,9 @@ void main() {
   group('run', () {
     late TestDeviceManager testDeviceManager;
     late FileSystem fileSystem;
-    late BufferLogger logger;
 
     setUp(() {
-      logger = BufferLogger.test();
-      testDeviceManager = TestDeviceManager(logger: logger);
+      testDeviceManager = TestDeviceManager(logger: BufferLogger.test());
       fileSystem = MemoryFileSystem.test();
     });
 
@@ -63,7 +61,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => logger,
+      Logger: () => BufferLogger.test(),
     });
 
     testUsingContext('does not support "--use-application-binary" and "--fast-start"', () async {
@@ -89,7 +87,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => logger,
+      Logger: () => BufferLogger.test(),
     });
 
     testUsingContext('Walks upward looking for a pubspec.yaml and succeeds if found', () async {
@@ -117,7 +115,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => logger,
+      Logger: () => BufferLogger.test(),
     });
 
     testUsingContext('Walks upward looking for a pubspec.yaml and exits if missing', () async {
@@ -137,7 +135,7 @@ void main() {
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.any(),
-      Logger: () => logger,
+      Logger: () => BufferLogger.test(),
     });
 
     group('run app', () {
@@ -180,7 +178,7 @@ void main() {
         );
 
         expect(
-          logger.statusText,
+          testLogger.statusText,
           containsIgnoringWhitespace(userMessages.flutterNoSupportedDevices),
         );
       }, overrides: <Type, Generator>{
@@ -207,9 +205,9 @@ void main() {
           ]),
           throwsToolExit(),
         );
-        expect(logger.statusText, contains("No supported devices found with name or id matching 'invalid-device-id'"));
-        expect(logger.statusText, contains('The following devices were found:'));
-        expect(logger.statusText, contains('FakeDevice (mobile) • fake_device • ios •  (simulator)'));
+        expect(testLogger.statusText, contains("No supported devices found with name or id matching 'invalid-device-id'"));
+        expect(testLogger.statusText, contains('The following devices were found:'));
+        expect(testLogger.statusText, contains('FakeDevice (mobile) • fake_device • ios •  (simulator)'));
       }, overrides: <Type, Generator>{
         DeviceManager: () => testDeviceManager,
         FileSystem: () => fs,
@@ -356,15 +354,15 @@ void main() {
         );
 
         expect(
-          logger.statusText,
+          testLogger.statusText,
           containsIgnoringWhitespace(userMessages.flutterNoSupportedDevices),
         );
         expect(
-          logger.statusText,
+          testLogger.statusText,
           containsIgnoringWhitespace(userMessages.flutterFoundButUnsupportedDevices),
         );
         expect(
-          logger.statusText,
+          testLogger.statusText,
           containsIgnoringWhitespace(
             userMessages.flutterMissPlatformProjects(
               Device.devicesPlatformTypes(<Device>[mockDevice]),
@@ -466,7 +464,7 @@ void main() {
           ProcessManager: () => FakeProcessManager.any(),
           Usage: () => usage,
           Stdio: () => FakeStdio(),
-          Logger: () => AppRunLogger(parent: logger),
+          Logger: () => AppRunLogger(parent: BufferLogger.test()),
         });
 
         testUsingContext('can disable multidex with --no-multidex', () async {
@@ -494,7 +492,7 @@ void main() {
           ProcessManager: () => FakeProcessManager.any(),
           Usage: () => usage,
           Stdio: () => FakeStdio(),
-          Logger: () => AppRunLogger(parent: logger),
+          Logger: () => AppRunLogger(parent: BufferLogger.test()),
         });
 
         testUsingContext('can pass --device-user', () async {
@@ -523,7 +521,7 @@ void main() {
           ProcessManager: () => FakeProcessManager.any(),
           Usage: () => usage,
           Stdio: () => FakeStdio(),
-          Logger: () => AppRunLogger(parent: logger),
+          Logger: () => AppRunLogger(parent: BufferLogger.test()),
         });
       });
     });
@@ -859,11 +857,7 @@ void main() {
 }
 
 class TestDeviceManager extends DeviceManager {
-  TestDeviceManager({required this.logger}) : super(
-    logger: logger,
-    terminal: Terminal.test(),
-    userMessages: UserMessages(),
-  );
+  TestDeviceManager({required this.logger}) : super(logger: logger);
   List<Device> devices = <Device>[];
 
   final Logger logger;

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -900,7 +900,7 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   }
 
   @override
-  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, {Duration? timeout}) async {
+  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, {Duration? timeout, bool promptUserToChooseDevice = true}) async {
     return targetDevices;
   }
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -10,8 +10,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/terminal.dart';
-import 'package:flutter_tools/src/base/user_messages.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/test.dart';
 import 'package:flutter_tools/src/device.dart';
@@ -851,7 +849,7 @@ class FakePackageTest implements TestWrapper {
 }
 
 class _FakeDeviceManager extends DeviceManager {
-  _FakeDeviceManager(this._connectedDevices) : super(logger: testLogger, terminal: Terminal.test(), userMessages: userMessages);
+  _FakeDeviceManager(this._connectedDevices) : super(logger: testLogger);
 
   final List<Device> _connectedDevices;
 

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -331,6 +331,58 @@ void main() {
       );
     });
 
+    testWithoutContext('returns all devices when stdin is not attached to a terminal', () async {
+      final List<Device> devices = <Device>[
+        ephemeralOne,
+        ephemeralTwo,
+        nonEphemeralOne,
+        nonEphemeralTwo,
+      ];
+
+      final FakeTerminal terminal = FakeTerminal(stdinHasTerminal: false);
+
+      final DeviceManager deviceManager = TestDeviceManager(
+        devices,
+        logger: BufferLogger.test(),
+        terminal: terminal,
+      );
+
+      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+
+      expect(filtered, <Device>[
+        ephemeralOne,
+        ephemeralTwo,
+        nonEphemeralOne,
+        nonEphemeralTwo,
+      ]);
+    });
+
+    testWithoutContext('returns all devices when promptUserToChooseDevice is false', () async {
+      final List<Device> devices = <Device>[
+        ephemeralOne,
+        ephemeralTwo,
+        nonEphemeralOne,
+        nonEphemeralTwo,
+      ];
+
+      final FakeTerminal terminal = FakeTerminal();
+
+      final DeviceManager deviceManager = TestDeviceManager(
+        devices,
+        logger: BufferLogger.test(),
+        terminal: terminal,
+      );
+
+      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject(), promptUserToChooseDevice: false);
+
+      expect(filtered, <Device>[
+        ephemeralOne,
+        ephemeralTwo,
+        nonEphemeralOne,
+        nonEphemeralTwo,
+      ]);
+    });
+
     testWithoutContext('Unsupported devices listed in all connected devices', () async {
       final List<Device> devices = <Device>[
         unsupported,
@@ -652,8 +704,10 @@ class ThrowingPollingDeviceDiscovery extends PollingDeviceDiscovery {
 }
 
 class FakeTerminal extends Fake implements Terminal {
+  FakeTerminal({this.stdinHasTerminal = true});
+
   @override
-  bool stdinHasTerminal = true;
+  final bool stdinHasTerminal;
 
   @override
   bool usesTerminalUi = true;

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -201,9 +201,9 @@ void main() {
         logger: BufferLogger.test(),
         terminal: Terminal.test(),
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
-      expect(filtered.single, ephemeralOne);
+      expect(filtered!.single, ephemeralOne);
     });
 
     testWithoutContext('choose first non-ephemeral device', () async {
@@ -219,7 +219,7 @@ void main() {
         logger: BufferLogger.test(),
         terminal: terminal,
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         nonEphemeralOne,
@@ -239,7 +239,7 @@ void main() {
         logger: BufferLogger.test(),
         terminal: terminal,
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         nonEphemeralTwo,
@@ -260,7 +260,7 @@ void main() {
         logger: BufferLogger.test(),
         terminal: terminal,
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         ephemeralOne,
@@ -280,7 +280,7 @@ void main() {
         logger: BufferLogger.test(),
         terminal: terminal,
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         ephemeralTwo,
@@ -304,7 +304,7 @@ void main() {
         terminal: terminal,
       );
 
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         nonEphemeralOne,
@@ -331,7 +331,7 @@ void main() {
       );
     });
 
-    testWithoutContext('returns all devices when stdin is not attached to a terminal', () async {
+    testWithoutContext('returns null with an error message when stdin is not attached to a terminal', () async {
       final List<Device> devices = <Device>[
         ephemeralOne,
         ephemeralTwo,
@@ -340,24 +340,21 @@ void main() {
       ];
 
       final FakeTerminal terminal = FakeTerminal(stdinHasTerminal: false);
+      final BufferLogger logger = BufferLogger.test();
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
-        logger: BufferLogger.test(),
+        logger: logger,
         terminal: terminal,
       );
 
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
-      expect(filtered, <Device>[
-        ephemeralOne,
-        ephemeralTwo,
-        nonEphemeralOne,
-        nonEphemeralTwo,
-      ]);
+      expect(filtered, null);
+      expect(logger.statusText, contains(UserMessages().flutterSpecifyDeviceWithAllOption));
     });
 
-    testWithoutContext('returns all devices when promptUserToChooseDevice is false', () async {
+    testWithoutContext('returns null with an error message when promptUserToChooseDevice is false', () async {
       final List<Device> devices = <Device>[
         ephemeralOne,
         ephemeralTwo,
@@ -366,21 +363,18 @@ void main() {
       ];
 
       final FakeTerminal terminal = FakeTerminal();
+      final BufferLogger logger = BufferLogger.test();
 
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
-        logger: BufferLogger.test(),
+        logger: logger,
         terminal: terminal,
       );
 
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject(), promptUserToChooseDevice: false);
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject(), promptUserToChooseDevice: false);
 
-      expect(filtered, <Device>[
-        ephemeralOne,
-        ephemeralTwo,
-        nonEphemeralOne,
-        nonEphemeralTwo,
-      ]);
+      expect(filtered, null);
+      expect(logger.statusText, contains(UserMessages().flutterSpecifyDeviceWithAllOption));
     });
 
     testWithoutContext('Unsupported devices listed in all connected devices', () async {
@@ -408,14 +402,19 @@ void main() {
         unsupportedForProject,
       ];
 
+      final BufferLogger logger = BufferLogger.test();
+
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
-        logger: BufferLogger.test(),
+        logger: logger,
         terminal: Terminal.test(),
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
-      expect(filtered, <Device>[]);
+      expect(filtered, null);
+      expect(logger.statusText, contains(UserMessages().flutterNoSupportedDevices));
+      expect(logger.statusText, contains('The following devices were found, but are not supported by this project:'));
+      expect(logger.statusText, contains('unsupportedForProject (mobile) • unsupportedForProject • android-arm • Test SDK (1.2.3) (emulator)'));
     });
 
     testWithoutContext('Retains devices unsupported by the project if FlutterProject is null', () async {
@@ -429,7 +428,7 @@ void main() {
         logger: BufferLogger.test(),
         terminal: Terminal.test(),
       );
-      final List<Device> filtered = await deviceManager.findTargetDevices(null);
+      final List<Device>? filtered = await deviceManager.findTargetDevices(null);
 
       expect(filtered, <Device>[unsupportedForProject]);
     });
@@ -439,16 +438,20 @@ void main() {
         webDevice,
         fuchsiaDevice,
       ];
+
+      final BufferLogger logger = BufferLogger.test();
+
       final DeviceManager deviceManager = TestDeviceManager(
         devices,
-        logger: BufferLogger.test(),
+        logger: logger,
         terminal: Terminal.test(),
       );
       deviceManager.specifiedDeviceId = 'all';
 
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
-      expect(filtered, <Device>[]);
+      expect(filtered, null);
+      expect(logger.statusText, contains(UserMessages().flutterNoDevicesFound));
     });
 
     testWithoutContext('Removes devices unsupported by the project from --all', () async {
@@ -465,12 +468,69 @@ void main() {
       );
       deviceManager.specifiedDeviceId = 'all';
 
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         nonEphemeralOne,
         nonEphemeralTwo,
       ]);
+    });
+
+    testWithoutContext('Returns device with the specified id', () async {
+      final List<Device> devices = <Device>[
+        nonEphemeralOne,
+      ];
+      final DeviceManager deviceManager = TestDeviceManager(
+        devices,
+        logger: BufferLogger.test(),
+        terminal: Terminal.test(),
+      );
+      deviceManager.specifiedDeviceId = nonEphemeralOne.id;
+
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+
+      expect(filtered, <Device>[
+        nonEphemeralOne,
+      ]);
+    });
+
+    testWithoutContext('Returns null and show warning when multiple devices matches the specified id', () async {
+      final List<Device> devices = <Device>[
+        nonEphemeralOne,
+        nonEphemeralTwo,
+      ];
+      final BufferLogger logger = BufferLogger.test();
+      final DeviceManager deviceManager = TestDeviceManager(
+        devices,
+        logger: logger,
+        terminal: Terminal.test(),
+      );
+      deviceManager.specifiedDeviceId = 'nonEphemeral'; // This prefix matches both devices
+
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+
+      expect(filtered, null);
+      expect(logger.statusText, contains(UserMessages().flutterFoundSpecifiedDevices(2, 'nonEphemeral')));
+    });
+
+    testWithoutContext('Returns null and show warning when device of specified id is not found', () async {
+      final List<Device> devices = <Device>[
+        nonEphemeralOne,
+      ];
+      final BufferLogger logger = BufferLogger.test();
+      final DeviceManager deviceManager = TestDeviceManager(
+        devices,
+        logger: logger,
+        terminal: Terminal.test(),
+      );
+      deviceManager.specifiedDeviceId = nonEphemeralTwo.id;
+
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+
+      expect(filtered, null);
+      expect(logger.statusText, contains(UserMessages().flutterNoMatchingDevice(nonEphemeralTwo.id)));
+      expect(logger.statusText, contains('The following devices were found:'));
+      expect(logger.statusText, contains('nonEphemeralOne (mobile) • nonEphemeralOne • android-arm • Test SDK (1.2.3) (emulator)'));
     });
 
     testWithoutContext('uses DeviceManager.isDeviceSupportedForProject instead of device.isSupportedForProject', () async {
@@ -485,7 +545,7 @@ void main() {
       );
       deviceManager.isAlwaysSupportedForProjectOverride = true;
 
-      final List<Device> filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
+      final List<Device>? filtered = await deviceManager.findTargetDevices(FakeFlutterProject());
 
       expect(filtered, <Device>[
         unsupportedForProject,
@@ -508,11 +568,11 @@ void main() {
         terminal: Terminal.test(),
       );
       deviceManager.specifiedDeviceId = ephemeralOne.id;
-      final List<Device> filtered = await deviceManager.findTargetDevices(
+      final List<Device>? filtered = await deviceManager.findTargetDevices(
         FakeFlutterProject(),
       );
 
-      expect(filtered.single, ephemeralOne);
+      expect(filtered!.single, ephemeralOne);
       expect(deviceDiscovery.devicesCalled, 1);
       expect(deviceDiscovery.discoverDevicesCalled, 0);
     });
@@ -534,12 +594,12 @@ void main() {
         terminal: Terminal.test(),
       );
       deviceManager.specifiedDeviceId = ephemeralOne.id;
-      final List<Device> filtered = await deviceManager.findTargetDevices(
+      final List<Device>? filtered = await deviceManager.findTargetDevices(
         FakeFlutterProject(),
         timeout: timeout,
       );
 
-      expect(filtered.single, ephemeralOne);
+      expect(filtered!.single, ephemeralOne);
       expect(deviceDiscovery.devicesCalled, 1);
       expect(deviceDiscovery.discoverDevicesCalled, 1);
     });

--- a/packages/flutter_tools/test/src/context.dart
+++ b/packages/flutter_tools/test/src/context.dart
@@ -241,7 +241,7 @@ class FakeDeviceManager implements DeviceManager {
   }
 
   @override
-  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, { Duration? timeout }) async {
+  Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, { Duration? timeout, bool promptUserToChooseDevice = true }) async {
     return devices;
   }
 }


### PR DESCRIPTION
Refactor `DeviceManager.findTargetDevices()` and `FlutterCommand.findAllTargetDevices()`, and add a flag to not show prompt in `DeviceManager.findTargetDevices()`.

Move the device selection logic from `DeviceManager.findTargetDevices()` to `FlutterCommand.findAllTargetDevices()`, and keep `FlutterCommand.findAllTargetDevices()` for all error reporting.

### Original PR description below.
Original title: Add a flag to not show prompt in findTargetDevices

Also added tests for when stdin is not attached to a terminal.

The new parameter will be used internally. And I always thought that it's weird to ask for user interaction in a function called `deviceManager.findTargetDevices()`