### PR TITLE
Add regression test for TextPainter.getWordBoundary

### DIFF
--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1222,7 +1222,7 @@ void main() {
        textPainter.getWordBoundary(const TextPosition(offset: 8)),
        const TextRange(start: 8, end: 16),
      );
-   });
+   }, skip: isBrowser); // https://github.com/flutter/flutter/issues/61017
 }
 
 class MockCanvas extends Fake implements Canvas {

--- a/packages/flutter/test/painting/text_painter_test.dart
+++ b/packages/flutter/test/painting/text_painter_test.dart
@@ -1208,6 +1208,21 @@ void main() {
 
     painter.dispose();
   });
+
+   test('TextPainter.getWordBoundary works', (){
+     // Regression test for https://github.com/flutter/flutter/issues/93493 .
+     const String testCluster = '👨‍👩‍👦👨‍👩‍👦👨‍👩‍👦'; // 8 * 3
+     final TextPainter textPainter = TextPainter(
+       text: const TextSpan(text: testCluster),
+       textDirection: TextDirection.ltr,
+     );
+
+     textPainter.layout();
+     expect(
+       textPainter.getWordBoundary(const TextPosition(offset: 8)),
+       const TextRange(start: 8, end: 16),
+     );
+   });
 }
 
 class MockCanvas extends Fake implements Canvas {


### PR DESCRIPTION
Add a regression test for https://github.com/flutter/flutter/issues/93493 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
