### PR TITLE
Unlock the device before running a StartupTest benchmark

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -655,6 +655,7 @@ class StartupTest {
   Future<TaskResult> run() async {
     return inDirectory<TaskResult>(testDirectory, () async {
       final Device device = await devices.workingDevice;
+      await device.unlock();
       const int iterations = 5;
       final List<Map<String, dynamic>> results = <Map<String, dynamic>>[];
 


### PR DESCRIPTION
The device's screen must be on in order to complete the frame rendering measured by StartupTest.

See https://github.com/flutter/flutter/issues/112076