### PR TITLE
unnecessary_stateful_widgets

### DIFF
--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1436,7 +1436,7 @@ class _CupertinoAlertContentSection extends StatelessWidget {
 //
 // See [_RenderCupertinoDialogActions] for details about action button sizing
 // and layout.
-class _CupertinoAlertActionSection extends StatefulWidget {
+class _CupertinoAlertActionSection extends StatelessWidget {
   const _CupertinoAlertActionSection({
     required this.children,
     this.scrollController,
@@ -1462,34 +1462,27 @@ class _CupertinoAlertActionSection extends StatefulWidget {
   final bool isActionSheet;
 
   @override
-  _CupertinoAlertActionSectionState createState() =>
-      _CupertinoAlertActionSectionState();
-}
-
-class _CupertinoAlertActionSectionState
-    extends State<_CupertinoAlertActionSection> {
-  @override
   Widget build(BuildContext context) {
     final double devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
 
     final List<Widget> interactiveButtons = <Widget>[];
-    for (int i = 0; i < widget.children.length; i += 1) {
+    for (int i = 0; i < children.length; i += 1) {
       interactiveButtons.add(
         _PressableActionButton(
-          child: widget.children[i],
+          child: children[i],
         ),
       );
     }
 
     return CupertinoScrollbar(
-      controller: widget.scrollController,
+      controller: scrollController,
       child: SingleChildScrollView(
-        controller: widget.scrollController,
+        controller: scrollController,
         child: _CupertinoDialogActionsRenderWidget(
           actionButtons: interactiveButtons,
           dividerThickness: _kDividerThickness / devicePixelRatio,
-          hasCancelButton: widget.hasCancelButton,
-          isActionSheet: widget.isActionSheet,
+          hasCancelButton: hasCancelButton,
+          isActionSheet: isActionSheet,
         ),
       ),
     );

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -2192,7 +2192,7 @@ class _RenderAppBarTitleBox extends RenderAligningShiftedBox {
 
 enum _ScrollUnderFlexibleVariant { medium, large }
 
-class _ScrollUnderFlexibleSpace extends StatefulWidget {
+class _ScrollUnderFlexibleSpace extends StatelessWidget {
   const _ScrollUnderFlexibleSpace({
     this.title,
     required this.variant,
@@ -2206,19 +2206,14 @@ class _ScrollUnderFlexibleSpace extends StatefulWidget {
   final bool primary;
 
   @override
-  State<_ScrollUnderFlexibleSpace> createState() => _ScrollUnderFlexibleSpaceState();
-}
-
-class _ScrollUnderFlexibleSpaceState extends State<_ScrollUnderFlexibleSpace> {
-  @override
   Widget build(BuildContext context) {
     late final ThemeData theme = Theme.of(context);
     final FlexibleSpaceBarSettings settings = context.dependOnInheritedWidgetOfExactType<FlexibleSpaceBarSettings>()!;
-    final double topPadding = widget.primary ? MediaQuery.of(context).viewPadding.top : 0;
+    final double topPadding = primary ? MediaQuery.of(context).viewPadding.top : 0;
     final double collapsedHeight = settings.minExtent - topPadding;
     final double scrollUnderHeight = settings.maxExtent - settings.minExtent;
     final _ScrollUnderFlexibleConfig config;
-    switch (widget.variant) {
+    switch (variant) {
       case _ScrollUnderFlexibleVariant.medium:
         config = _MediumScrollUnderFlexibleConfig(context);
         break;
@@ -2229,19 +2224,19 @@ class _ScrollUnderFlexibleSpaceState extends State<_ScrollUnderFlexibleSpace> {
 
     late final Widget? collapsedTitle;
     late final Widget? expandedTitle;
-    if (widget.title != null) {
+    if (title != null) {
       collapsedTitle = config.collapsedTextStyle != null
         ? DefaultTextStyle(
             style: config.collapsedTextStyle!,
-            child: widget.title!,
+            child: title!,
           )
-        : widget.title;
+        : title;
       expandedTitle = config.expandedTextStyle != null
         ? DefaultTextStyle(
             style: config.expandedTextStyle!,
-            child: widget.title!,
+            child: title!,
           )
-        : widget.title;
+        : title;
     }
 
     late final bool centerTitle;
@@ -2259,7 +2254,7 @@ class _ScrollUnderFlexibleSpaceState extends State<_ScrollUnderFlexibleSpace> {
             return true;
         }
       }
-      centerTitle = widget.centerCollapsedTitle
+      centerTitle = centerCollapsedTitle
         ?? theme.appBarTheme.centerTitle
         ?? platformCenter();
     }

--- a/packages/flutter/test/gestures/gesture_config_regression_test.dart
+++ b/packages/flutter/test/gestures/gesture_config_regression_test.dart
@@ -12,16 +12,10 @@ class TestResult {
   bool dragUpdate = false;
 }
 
-class NestedScrollableCase extends StatefulWidget {
+class NestedScrollableCase extends StatelessWidget {
   const NestedScrollableCase({super.key, required this.testResult});
 
   final TestResult testResult;
-
-  @override
-  State<NestedScrollableCase> createState() => _NestedScrollableCaseState();
-}
-
-class _NestedScrollableCaseState extends State<NestedScrollableCase> {
 
   @override
   Widget build(BuildContext context) {
@@ -37,10 +31,10 @@ class _NestedScrollableCaseState extends State<NestedScrollableCase> {
                   child: GestureDetector(
                     behavior: HitTestBehavior.opaque,
                     onVerticalDragDown: (DragDownDetails details) {
-                      widget.testResult.dragStarted = true;
+                      testResult.dragStarted = true;
                     },
                     onVerticalDragUpdate: (DragUpdateDetails details){
-                      widget.testResult.dragUpdate = true;
+                      testResult.dragUpdate = true;
                     },
                     onVerticalDragEnd: (_) {},
                     child: Text('List Item $index', key: ValueKey<int>(index),
@@ -56,16 +50,10 @@ class _NestedScrollableCaseState extends State<NestedScrollableCase> {
   }
 }
 
-class NestedDragableCase extends StatefulWidget {
+class NestedDragableCase extends StatelessWidget {
   const NestedDragableCase({super.key, required this.testResult});
 
   final TestResult testResult;
-
-  @override
-  State<NestedDragableCase> createState() => _NestedDragableCaseState();
-}
-
-class _NestedDragableCaseState extends State<NestedDragableCase> {
 
   @override
   Widget build(BuildContext context) {
@@ -83,10 +71,10 @@ class _NestedDragableCaseState extends State<NestedDragableCase> {
                     feedback: const Text('Dragging'),
                     child: Text('List Item $index'),
                     onDragStarted: () {
-                      widget.testResult.dragStarted = true;
+                      testResult.dragStarted = true;
                     },
                     onDragUpdate: (DragUpdateDetails details){
-                      widget.testResult.dragUpdate = true;
+                      testResult.dragUpdate = true;
                     },
                     onDragEnd: (_) {},
                   ),

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3014,7 +3014,7 @@ void main() {
   });
 }
 
-class TestApp extends StatefulWidget {
+class TestApp extends StatelessWidget {
   const TestApp({
     super.key,
     required this.textDirection,
@@ -3024,11 +3024,6 @@ class TestApp extends StatefulWidget {
   final TextDirection textDirection;
   final Widget? child;
 
-  @override
-  State<TestApp> createState() => _TestAppState();
-}
-
-class _TestAppState extends State<TestApp> {
   @override
   Widget build(BuildContext context) {
     return Localizations(
@@ -3040,14 +3035,14 @@ class _TestAppState extends State<TestApp> {
       child: MediaQuery(
         data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
         child: Directionality(
-          textDirection: widget.textDirection,
+          textDirection: textDirection,
           child: Navigator(
             onGenerateRoute: (RouteSettings settings) {
               assert(settings.name == '/');
               return MaterialPageRoute<void>(
                 settings: settings,
                 builder: (BuildContext context) => Material(
-                  child: widget.child,
+                  child: child,
                 ),
               );
             },

--- a/packages/flutter/test/material/theme_test.dart
+++ b/packages/flutter/test/material/theme_test.dart
@@ -728,14 +728,9 @@ void main() {
 }
 
 int testBuildCalled = 0;
-class Test extends StatefulWidget {
+class Test extends StatelessWidget {
   const Test({ super.key });
 
-  @override
-  State<Test> createState() => _TestState();
-}
-
-class _TestState extends State<Test> {
   @override
   Widget build(BuildContext context) {
     testBuildCalled += 1;

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13131,7 +13131,7 @@ class _CustomTextSelectionControls extends TextSelectionControls {
 }
 
 // A fake text selection toolbar with only a paste button.
-class _CustomTextSelectionToolbar extends StatefulWidget {
+class _CustomTextSelectionToolbar extends StatelessWidget {
   const _CustomTextSelectionToolbar({
     required this.anchorAbove,
     required this.anchorBelow,
@@ -13145,15 +13145,10 @@ class _CustomTextSelectionToolbar extends StatefulWidget {
   final VoidCallback? handleCut;
 
   @override
-  _CustomTextSelectionToolbarState createState() => _CustomTextSelectionToolbarState();
-}
-
-class _CustomTextSelectionToolbarState extends State<_CustomTextSelectionToolbar> {
-  @override
   Widget build(BuildContext context) {
     return TextSelectionToolbar(
-      anchorAbove: widget.anchorAbove,
-      anchorBelow: widget.anchorBelow,
+      anchorAbove: anchorAbove,
+      anchorBelow: anchorBelow,
       toolbarBuilder: (BuildContext context, Widget child) {
         return Container(
           color: Colors.pink,
@@ -13163,12 +13158,12 @@ class _CustomTextSelectionToolbarState extends State<_CustomTextSelectionToolbar
       children: <Widget>[
         TextSelectionToolbarTextButton(
           padding: TextSelectionToolbarTextButton.getPadding(0, 2),
-          onPressed: widget.handleCut,
+          onPressed: handleCut,
           child: const Text('Cut'),
         ),
         TextSelectionToolbarTextButton(
           padding: TextSelectionToolbarTextButton.getPadding(1, 2),
-          onPressed: widget.handlePaste,
+          onPressed: handlePaste,
           child: const Text('Paste'),
         ),
       ],

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -1125,7 +1125,7 @@ void main() {
   });
 }
 
-class TestList extends StatefulWidget {
+class TestList extends StatelessWidget {
   const TestList({
     super.key,
     this.textColor,
@@ -1145,23 +1145,18 @@ class TestList extends StatefulWidget {
   final void Function(int)? onReorderStart, onReorderEnd;
 
   @override
-  State<TestList> createState() => _TestListState();
-}
-
-class _TestListState extends State<TestList> {
-  @override
   Widget build(BuildContext context) {
     return MaterialApp(
       home: Scaffold(
         body: DefaultTextStyle(
-          style: TextStyle(color: widget.textColor),
+          style: TextStyle(color: textColor),
           child: IconTheme(
-            data: IconThemeData(color: widget.iconColor),
+            data: IconThemeData(color: iconColor),
             child: StatefulBuilder(
               builder: (BuildContext outerContext, StateSetter setState) {
-                final List<int> items = widget.items;
+                final List<int> items = this.items;
                 return CustomScrollView(
-                  reverse: widget.reverse,
+                  reverse: reverse,
                   slivers: <Widget>[
                     SliverReorderableList(
                       itemBuilder: (BuildContext context, int index) {
@@ -1190,9 +1185,9 @@ class _TestListState extends State<TestList> {
                           items.insert(toIndex, items.removeAt(fromIndex));
                         });
                       },
-                      proxyDecorator: widget.proxyDecorator,
-                      onReorderStart: widget.onReorderStart,
-                      onReorderEnd: widget.onReorderEnd,
+                      proxyDecorator: proxyDecorator,
+                      onReorderStart: onReorderStart,
+                      onReorderEnd: onReorderEnd,
                     ),
                   ],
                 );

--- a/packages/flutter/test/widgets/router_restoration_test.dart
+++ b/packages/flutter/test/widgets/router_restoration_test.dart
@@ -140,27 +140,22 @@ class _TestRouteInformationProvider extends RouteInformationProvider with Change
   }
 }
 
-class _TestWidget extends StatefulWidget {
+class _TestWidget extends StatelessWidget {
   const _TestWidget({this.withInformationProvider = false, this.routerKey});
 
   final bool withInformationProvider;
   final Key? routerKey;
 
   @override
-  State<_TestWidget> createState() => _TestWidgetState();
-}
-
-class _TestWidgetState extends State<_TestWidget> {
-  @override
   Widget build(BuildContext context) {
     return RootRestorationScope(
       restorationId: 'root',
       child: Router<String>(
-        key: widget.routerKey,
+        key: routerKey,
         restorationScopeId: 'router',
         routerDelegate: _TestRouterDelegate(),
         routeInformationParser: _TestRouteInformationParser(),
-        routeInformationProvider: widget.withInformationProvider ? _TestRouteInformationProvider() : null,
+        routeInformationProvider: withInformationProvider ? _TestRouteInformationProvider() : null,
       ),
     );
   }

--- a/packages/flutter/test/widgets/slivers_keepalive_test.dart
+++ b/packages/flutter/test/widgets/slivers_keepalive_test.dart
@@ -470,7 +470,7 @@ class _SwitchingChildBuilderTest extends State<SwitchingChildBuilderTest> {
   }
 }
 
-class SwitchingChildListTest extends StatefulWidget {
+class SwitchingChildListTest extends StatelessWidget {
   const SwitchingChildListTest({
     required this.children,
     this.viewportFraction = 1.0,
@@ -480,11 +480,6 @@ class SwitchingChildListTest extends StatefulWidget {
   final List<Widget> children;
   final double viewportFraction;
 
-  @override
-  State<SwitchingChildListTest> createState() => _SwitchingChildListTest();
-}
-
-class _SwitchingChildListTest extends State<SwitchingChildListTest> {
   @override
   Widget build(BuildContext context) {
     return Directionality(
@@ -496,8 +491,8 @@ class _SwitchingChildListTest extends State<SwitchingChildListTest> {
             cacheExtent: 0,
             slivers: <Widget>[
               SliverFillViewport(
-                viewportFraction: widget.viewportFraction,
-                delegate: SliverChildListDelegate(widget.children),
+                viewportFraction: viewportFraction,
+                delegate: SliverChildListDelegate(children),
               ),
             ],
           ),
@@ -507,7 +502,7 @@ class _SwitchingChildListTest extends State<SwitchingChildListTest> {
   }
 }
 
-class SwitchingSliverListTest extends StatefulWidget {
+class SwitchingSliverListTest extends StatelessWidget {
   const SwitchingSliverListTest({
     required this.children,
     this.viewportFraction = 1.0,
@@ -517,11 +512,6 @@ class SwitchingSliverListTest extends StatefulWidget {
   final List<Widget> children;
   final double viewportFraction;
 
-  @override
-  State<SwitchingSliverListTest> createState() => _SwitchingSliverListTest();
-}
-
-class _SwitchingSliverListTest extends State<SwitchingSliverListTest> {
   @override
   Widget build(BuildContext context) {
     return Directionality(
@@ -533,7 +523,7 @@ class _SwitchingSliverListTest extends State<SwitchingSliverListTest> {
             cacheExtent: 0,
             slivers: <Widget>[
               SliverList(
-                delegate: SliverChildListDelegate(widget.children),
+                delegate: SliverChildListDelegate(children),
               ),
             ],
           ),

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -29,13 +29,9 @@ import 'widget_inspector_test_utils.dart';
 // Start of block of code where widget creation location line numbers and
 // columns will impact whether tests pass.
 
-class ClockDemo extends StatefulWidget {
+class ClockDemo extends StatelessWidget {
   const ClockDemo({ super.key });
-  @override
-  State<ClockDemo> createState() => _ClockDemoState();
-}
 
-class _ClockDemoState extends State<ClockDemo> {
   @override
   Widget build(BuildContext context) {
     return Directionality(
@@ -3455,7 +3451,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       _CreationLocation location = knownLocations[id]!;
       expect(location.file, equals(file));
       // ClockText widget.
-      expect(location.line, equals(63));
+      expect(location.line, equals(59));
       expect(location.column, equals(9));
       expect(location.name, equals('ClockText'));
       expect(count, equals(1));
@@ -3465,7 +3461,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       location = knownLocations[id]!;
       expect(location.file, equals(file));
       // Text widget in _ClockTextState build method.
-      expect(location.line, equals(101));
+      expect(location.line, equals(97));
       expect(location.column, equals(12));
       expect(location.name, equals('Text'));
       expect(count, equals(1));
@@ -3492,7 +3488,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       location = knownLocations[id]!;
       expect(location.file, equals(file));
       // ClockText widget.
-      expect(location.line, equals(63));
+      expect(location.line, equals(59));
       expect(location.column, equals(9));
       expect(location.name, equals('ClockText'));
       expect(count, equals(3)); // 3 clock widget instances rebuilt.
@@ -3502,7 +3498,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       location = knownLocations[id]!;
       expect(location.file, equals(file));
       // Text widget in _ClockTextState build method.
-      expect(location.line, equals(101));
+      expect(location.line, equals(97));
       expect(location.column, equals(12));
       expect(location.name, equals('Text'));
       expect(count, equals(3)); // 3 clock widget instances rebuilt.


### PR DESCRIPTION
This PR fixes diagnostics from https://github.com/dart-lang/linter/pull/3725 to catch StatefulWidget that can be changed to StatelessWidget