### PR TITLE
Revert "Remove `tool_host_cross_arch_tests` bringup"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2843,6 +2843,7 @@ targets:
       - .ci.yaml
 
   - name: Mac_x64 tool_host_cross_arch_tests
+    bringup: true # Mac_x64 variant https://github.com/flutter/flutter/pull/109889
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -2863,6 +2864,7 @@ targets:
       - .ci.yaml
 
   - name: Mac_arm64 tool_host_cross_arch_tests
+    bringup: true # Mac_arm64 variant https://github.com/flutter/flutter/pull/109889
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Reverts flutter/flutter#112311

Causes test failure: https://ci.chromium.org/ui/p/flutter/builders/prod/Mac_arm64%20tool_host_cross_arch_tests/3/overview