### PR TITLE
Remove x64 "tool_host_cross_arch_tests" bringup

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2843,7 +2843,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_x64 tool_host_cross_arch_tests
-    bringup: true # Mac_x64 variant https://github.com/flutter/flutter/pull/109889
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Reland half of https://github.com/flutter/flutter/pull/112311 which was reverted in https://github.com/flutter/flutter/pull/112406. Remove bringup for the x64 variant.  Keep arm off until https://github.com/flutter/flutter/issues/112130 is resolved.