### PR TITLE
Exposing hook for RenderObject.layout with zero overhead

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -2013,7 +2013,7 @@ abstract class RenderObject extends AbstractNode with DiagnosticableTreeMixin im
   /// Override [enableLayoutHook] in debug mode.
   static bool? debugOverrideEnableLayoutHook;
 
-  /// Whether [tickerProviderStateMixinTickerCreator] will take effect.
+  /// Whether [layoutHook] will take effect.
   bool get enableLayoutHook {
     bool? override;
     assert(() {

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -31,6 +31,24 @@ void main() {
     expect(onNeedVisualUpdateCallCount, 2);
   });
 
+  test('when enableLayoutHook, layoutHook is called', () {
+    RenderObject.debugOverrideEnableLayoutHook = true;
+    addTearDown(() => RenderObject.debugOverrideEnableLayoutHook = null);
+
+    int layoutHookCallCount = 0;
+    RenderObject.layoutHook = (RenderObject renderObject, Constraints constraints, {required bool parentUsesSize}) {
+      layoutHookCallCount++;
+    };
+
+    final TestRenderObject renderObject = TestRenderObject();
+    final PipelineOwner owner = PipelineOwner();
+    renderObject.attach(owner);
+
+    expect(layoutHookCallCount, 0);
+    renderObject.layout(const BoxConstraints.tightForFinite());
+    expect(layoutHookCallCount, 1);
+  });
+
   test('detached RenderObject does not do semantics', () {
     final TestRenderObject renderObject = TestRenderObject();
     expect(renderObject.attached, isFalse);


### PR DESCRIPTION
1. I will finish code details, refine code, add tests, make tests pass, etc, after a code review that thinks the *rough idea* is acceptable. It is because, from my past experience, reviews may request changing a lot. If the general idea is to be changed, all detailed implementation efforts are wasted :)
2. The PR has an already-working counterpart, and it produces ~60FPS smooth experimental results. The benchmark results and detailed analysis is in chapter https://cjycode.com/flutter_smooth/benchmark/. All the source code is in  https://github.com/fzyzcjy/engine/tree/flutter-smooth and https://github.com/fzyzcjy/flutter/tree/flutter-smooth.
3. Possibly useful as a context to this PR, there is a whole chapter discussing the internals - how flutter_smooth is implemented. (Link: https://cjycode.com/flutter_smooth/design/)

---



**Remark:** This PR has less priority compared with the other two (https://github.com/flutter/engine/pull/36438, https://github.com/flutter/flutter/pull/112436), because this one can be workaround, while the other two are really mandatory to implement PreemptBuilder.

---

This PR is a part for implementing the 60fps smooth rendering (#101227).

Some discussions can be seen in Discord, such as around https://discordapp.com/channels/608014603317936148/608021234516754444/1024141682377236500.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/101227

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
