### PR TITLE
Send progress notifications to clients during hot reload / hot restart

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -140,6 +140,13 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   Future<void> attachImpl() async {
     final FlutterAttachRequestArguments args = this.args as FlutterAttachRequestArguments;
 
+    final DapProgressReporter progress = startProgressNotification(
+      'launch',
+      'Flutter',
+      message: 'Attaching…',
+    );
+    unawaited(appStartedCompleter.future.then((_) => progress.end()));
+
     final String? vmServiceUri = args.vmServiceUri;
     final List<String> toolArgs = <String>[
       'attach',
@@ -254,6 +261,13 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
   @override
   Future<void> launchImpl() async {
     final FlutterLaunchRequestArguments args = this.args as FlutterLaunchRequestArguments;
+
+    final DapProgressReporter progress = startProgressNotification(
+      'launch',
+      'Flutter',
+      message: 'Launching…',
+    );
+    unawaited(appStartedCompleter.future.then((_) => progress.end()));
 
     final List<String> toolArgs = <String>[
       'run',
@@ -593,6 +607,14 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     bool fullRestart, [
     String? reason,
   ]) async {
+    final String progressId = fullRestart ? 'hotRestart' : 'hotReload';
+    final String progressMessage = fullRestart ? 'Hot restarting…' : 'Hot reloading…';
+    final DapProgressReporter progress = startProgressNotification(
+      progressId,
+      'Flutter',
+      message: progressMessage,
+    );
+
     try {
       await sendFlutterRequest('app.restart', <String, Object?>{
         'appId': appId,
@@ -604,6 +626,9 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     } on DebugAdapterException catch (error) {
       final String action = fullRestart ? 'Hot Restart' : 'Hot Reload';
       sendOutput('console', 'Failed to $action: $error');
+    }
+    finally {
+      progress.end();
     }
   }
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -27,6 +27,7 @@ class FlutterAttachRequestArguments
     super.evaluateGettersInDebugViews,
     super.evaluateToStringInDebugViews,
     super.sendLogsToClient,
+    super.sendCustomProgressEvents,
   });
 
   FlutterAttachRequestArguments.fromMap(super.obj)
@@ -99,6 +100,7 @@ class FlutterLaunchRequestArguments
     super.evaluateGettersInDebugViews,
     super.evaluateToStringInDebugViews,
     super.sendLogsToClient,
+    super.sendCustomProgressEvents,
   });
 
   FlutterLaunchRequestArguments.fromMap(super.obj)

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -83,6 +83,12 @@ class DapTestClient {
     return _eventController.stream.where((Event e) => e.event == event);
   }
 
+  /// Returns a stream of progress events.
+  Stream<Event> progressEvents() {
+    const Set<String> progressEvents = <String>{'progressStart', 'progressUpdate', 'progressEnd'};
+    return _eventController.stream.where((Event e) => progressEvents.contains(e.event));
+  }
+
   /// Returns a stream of custom 'dart.serviceExtensionAdded' events.
   Stream<Map<String, Object?>> get serviceExtensionAddedEvents =>
       events('dart.serviceExtensionAdded')
@@ -116,12 +122,14 @@ class DapTestClient {
   Future<Response> initialize({
     String exceptionPauseMode = 'None',
     bool? supportsRunInTerminalRequest,
+    bool? supportsProgressReporting,
   }) async {
     final List<ProtocolMessage> responses = await Future.wait(<Future<ProtocolMessage>>[
       event('initialized'),
       sendRequest(InitializeRequestArguments(
         adapterID: 'test',
         supportsRunInTerminalRequest: supportsRunInTerminalRequest,
+        supportsProgressReporting: supportsProgressReporting,
       )),
       sendRequest(
         SetExceptionBreakpointsArguments(


### PR DESCRIPTION
This send progress notifications from the DAP server to the client for launch operations and hot reload/restart. This provides some visual feedback to the user (in particular, if they don't have the Debug Console visible and save to hot reload, there is no other indicator that a reload/restart occurred).

The old DAP already had these, but they were missed from the original implementation of the new SDK ones.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
