### PR TITLE
Remove ali.png which doesn't exist

### DIFF
--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -129,7 +129,6 @@ flutter:
     - packages/flutter_gallery_assets/products/table.png
     - packages/flutter_gallery_assets/products/teaset.png
     - packages/flutter_gallery_assets/products/top.png
-    - packages/flutter_gallery_assets/people/ali.png
     - packages/flutter_gallery_assets/people/square/ali.png
     - packages/flutter_gallery_assets/people/square/peter.png
     - packages/flutter_gallery_assets/people/square/sandra.png


### PR DESCRIPTION
ali.png was removed from the `flutter_gallery_assets` assets here: https://github.com/flutter/flutter/commit/cb5b5c3459e0f2fca6169304d382cc3fcbe92a4a

But it is referenced here. Delete the reference since the file doesn't even exist.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
