### PR TITLE
Roll gallery for devicelab tests

### DIFF
--- a/dev/devicelab/lib/versions/gallery.dart
+++ b/dev/devicelab/lib/versions/gallery.dart
@@ -3,4 +3,4 @@
 // found in the LICENSE file.
 
 /// The pinned version of flutter gallery, used for devicelab tests.
-const String galleryVersion = '221023a99dc7d4e1a6b1bd3d53e5d9551b785774';
+const String galleryVersion = '9fd4ee5cb2d280f4ddb497e17acf404cb78c96f6';


### PR DESCRIPTION
Pick up https://github.com/flutter/gallery/pull/792 (https://github.com/flutter/gallery/commit/9fd4ee5cb2d280f4ddb497e17acf404cb78c96f6) so `new_gallery_impeller_ios__transition_perf` and `new_gallery_ios__transition_perf` pass on iPhone 11 in landscape mode.

Last rolled #103993
Blocking https://github.com/flutter/flutter/issues/111131

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
