### PR TITLE
Remove NavigationToolbar condition that leading widget cannot be larger than 1/3 the total space available.

### DIFF
--- a/packages/flutter/lib/src/widgets/navigation_toolbar.dart
+++ b/packages/flutter/lib/src/widgets/navigation_toolbar.dart
@@ -106,7 +106,7 @@ class _ToolbarLayout extends MultiChildLayoutDelegate {
 
     if (hasChild(_ToolbarSlot.leading)) {
       final BoxConstraints constraints = BoxConstraints(
-        maxWidth: size.width / 3.0, // The leading widget shouldn't take up more than 1/3 of the space.
+        maxWidth: size.width,
         minHeight: size.height, // The height should be exactly the height of the bar.
         maxHeight: size.height,
       );

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3680,4 +3680,34 @@ void main() {
     await tester.pumpWidget(buildApp());
     expect(tester.getTopLeft(title).dx, 16.0);
   });
+
+  testWidgets('AppBar leading widget can take up arbitrary space', (WidgetTester tester) async {
+    final Key leadingKey = UniqueKey();
+    final Key titleKey = UniqueKey();
+    late double leadingWidth;
+
+    Widget buildApp() {
+      return MaterialApp(
+        home: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            leadingWidth = constraints.maxWidth / 2;
+            return Scaffold(
+              appBar: AppBar(
+                leading: Container(
+                  key: leadingKey,
+                  width: leadingWidth,
+                ),
+                leadingWidth: leadingWidth,
+                title: Text('Title', key: titleKey),
+              ),
+            );
+          }
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    expect(tester.getTopLeft(find.byKey(titleKey)).dx, leadingWidth + 16.0);
+    expect(tester.getSize(find.byKey(leadingKey)).width, leadingWidth);
+  });
 }


### PR DESCRIPTION
Remove a constraint in NavigationToolbar that the leading widget cannot be larger than 1/3 the total space available. There's no good reason for this constraint, and there are situations where somebody may want to have a larger leading widget.

For example, in my app, on large screens we want to restrict the content area to a maximum 960dp width. The way we are doing that is by padding the leading and trailing elements with any excess width. However, this means that on screens larger than 2880dp wide, the leading element cannot actually take up as much space as we want. This leads to rendering bugs like this:

![zwWYw5hisJVu6DD](https://user-images.githubusercontent.com/4040946/192789013-1354b9e3-db62-4827-8e2c-82ef893f39ec.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
