### PR TITLE
Revert "Marks Mac_arm64 tool_host_cross_arch_tests to be unflaky"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2867,6 +2867,7 @@ targets:
       - .ci.yaml
 
   - name: Mac_arm64 tool_host_cross_arch_tests
+    bringup: true # Mac_arm64 variant https://github.com/flutter/flutter/pull/109889
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
Reverts flutter/flutter#112558

This is passing in staging but is being hit by https://github.com/flutter/flutter/issues/112130 in prod.

@keyonghan how do we get the bot to not mark this as unflaky?  It was never flaky, but in "bringup".