### PR TITLE
Fixed the `CircularProgressIndicator` default size issue

### DIFF
--- a/dev/tools/gen_defaults/lib/progress_indicator_template.dart
+++ b/dev/tools/gen_defaults/lib/progress_indicator_template.dart
@@ -17,8 +17,6 @@ class _Circular${blockName}DefaultsM3 extends ProgressIndicatorThemeData {
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
 
-  static const double circularProgressIndicatorSize = ${tokens['md.comp.circular-progress-indicator.size']};
-
   @override
   Color get color => ${componentColor('md.comp.circular-progress-indicator.active-indicator')};
 }

--- a/packages/flutter/lib/src/material/progress_indicator.dart
+++ b/packages/flutter/lib/src/material/progress_indicator.dart
@@ -590,38 +590,26 @@ class _CircularProgressIndicatorState extends State<CircularProgressIndicator> w
       : _CircularProgressIndicatorDefaultsM2(context);
     final Color? trackColor = widget.backgroundColor ?? ProgressIndicatorTheme.of(context).circularTrackColor;
 
-    Widget progressIndicator = Container(
-      constraints: const BoxConstraints(
-        minWidth: _kMinCircularProgressIndicatorSize,
-        minHeight: _kMinCircularProgressIndicatorSize,
-      ),
-      child: CustomPaint(
-        painter: _CircularProgressIndicatorPainter(
-          backgroundColor: trackColor,
-          valueColor: widget._getValueColor(context, defaultColor: defaults.color),
-          value: widget.value, // may be null
-          headValue: headValue, // remaining arguments are ignored if widget.value is not null
-          tailValue: tailValue,
-          offsetValue: offsetValue,
-          rotationValue: rotationValue,
-          strokeWidth: widget.strokeWidth,
-        ),
-      ),
-    );
-
-    if (Theme.of(context).useMaterial3) {
-      progressIndicator = SizedBox(
-        height: _CircularProgressIndicatorDefaultsM3.circularProgressIndicatorSize,
-        width: _CircularProgressIndicatorDefaultsM3.circularProgressIndicatorSize,
-        child: Center(
-          child: progressIndicator
-        ),
-      );
-    }
-
     return widget._buildSemanticsWrapper(
       context: context,
-      child: progressIndicator,
+      child: Container(
+        constraints: const BoxConstraints(
+          minWidth: _kMinCircularProgressIndicatorSize,
+          minHeight: _kMinCircularProgressIndicatorSize,
+        ),
+        child: CustomPaint(
+          painter: _CircularProgressIndicatorPainter(
+            backgroundColor: trackColor,
+            valueColor: widget._getValueColor(context, defaultColor: defaults.color),
+            value: widget.value, // may be null
+            headValue: headValue, // remaining arguments are ignored if widget.value is not null
+            tailValue: tailValue,
+            offsetValue: offsetValue,
+            rotationValue: rotationValue,
+            strokeWidth: widget.strokeWidth,
+          ),
+        ),
+      ),
     );
   }
 
@@ -928,8 +916,6 @@ class _CircularProgressIndicatorDefaultsM3 extends ProgressIndicatorThemeData {
 
   final BuildContext context;
   late final ColorScheme _colors = Theme.of(context).colorScheme;
-
-  static const double circularProgressIndicatorSize = 48.0;
 
   @override
   Color get color => _colors.primary;

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -1000,7 +1000,7 @@ void main() {
     expect((wrappedTheme as ProgressIndicatorTheme).data, themeData);
   });
 
-  testWidgets('default size of CircularProgressIndicator is 48x48 - M3', (WidgetTester tester) async {
+  testWidgets('default size of CircularProgressIndicator is 36x36 - M3', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         theme: theme.copyWith(useMaterial3: true),
@@ -1012,7 +1012,7 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(CircularProgressIndicator)), const Size(48, 48));
+    expect(tester.getSize(find.byType(CircularProgressIndicator)), const Size(36, 36));
   });
 }
 


### PR DESCRIPTION
Fixes: #112583

Removed the SizedBox constraints so that the `CircularProgressIndicator` can be larger, and the default circle is still 36x36.

To make this CircularProgressIndicator match Material3 spec exactly which has a size of 48x48 overall, and a circle size of 36x36 inside, use `SizedBox` and `Center` to wrap the `CircularProgressIndicator`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.