### PR TITLE
Treat assets as variants only if they share the same filename

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -1033,16 +1033,18 @@ class _AssetDirectoryCache {
 
     final List<FileSystemEntity> entitiesInDirectory = _fileSystem.directory(directory).listSync();
 
+    final File assetFile = _fileSystem.file(assetPath);
     final List<String> pathsOfVariants = <String>[
       // It's possible that the user specifies only explicit variants (e.g. .../1x/asset.png),
       // so there does not necessarily need to be a file at the given path.
-      if (_fileSystem.file(assetPath).existsSync())
+      if (assetFile.existsSync())
         assetPath,
       ...entitiesInDirectory
         .whereType<Directory>()
         .where((Directory dir) => _assetVariantDirectoryRegExp.hasMatch(dir.basename))
         .expand((Directory dir) => dir.listSync())
         .whereType<File>()
+        .where((File file) => file.basename == assetFile.basename)
         .map((File file) => file.path),
     ];
 

--- a/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_bundle_package_test.dart
@@ -219,14 +219,18 @@ $assetsSection
       writePubspecFile(
         'p/p/pubspec.yaml',
         'test_package',
-        assets: <String>['a/foo'],
+        assets: <String>['a/foo', 'a/bar'],
       );
 
-      final List<String> assets = <String>['a/foo', 'a/2x/foo'];
+      final List<String> assets = <String>['a/foo', 'a/2x/foo', 'a/bar'];
       writeAssets('p/p/', assets);
 
-      const String expectedManifest = '{"packages/test_package/a/foo":'
-          '["packages/test_package/a/foo","packages/test_package/a/2x/foo"]}';
+      const String expectedManifest = '{'
+          '"packages/test_package/a/bar":'
+          '["packages/test_package/a/bar"],'
+          '"packages/test_package/a/foo":'
+          '["packages/test_package/a/foo","packages/test_package/a/2x/foo"]'
+          '}';
 
       await buildAndVerifyAssets(
         assets,


### PR DESCRIPTION
This fixes an issue with the asset variant matching policy introduced in https://github.com/flutter/flutter/pull/110721
