### PR TITLE
Return ErrorHandlingFileSystem backed objects in ErrorHandlingFileSystem file/directory APIs

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -119,21 +119,21 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
   @override
   File file(dynamic path) => ErrorHandlingFile(
     platform: _platform,
-    fileSystem: delegate,
+    fileSystem: this,
     delegate: delegate.file(path),
   );
 
   @override
   Directory directory(dynamic path) => ErrorHandlingDirectory(
     platform: _platform,
-    fileSystem: delegate,
+    fileSystem: this,
     delegate: delegate.directory(path),
   );
 
   @override
   Link link(dynamic path) => ErrorHandlingLink(
     platform: _platform,
-    fileSystem: delegate,
+    fileSystem: this,
     delegate: delegate.link(path),
   );
 
@@ -173,7 +173,7 @@ class ErrorHandlingFile
   final io.File delegate;
 
   @override
-  final FileSystem fileSystem;
+  final ErrorHandlingFileSystem fileSystem;
 
   final Platform _platform;
 
@@ -388,7 +388,7 @@ class ErrorHandlingDirectory
   final io.Directory delegate;
 
   @override
-  final FileSystem fileSystem;
+  final ErrorHandlingFileSystem fileSystem;
 
   final Platform _platform;
 
@@ -413,20 +413,20 @@ class ErrorHandlingDirectory
     delegate: delegate,
   );
 
-  // For the childEntity methods, we first obtain an instance of the entity
-  // from the underlying file system, then invoke childEntity() on it, then
-  // wrap in the ErrorHandling version.
   @override
-  Directory childDirectory(String basename) =>
-    wrapDirectory(fileSystem.directory(delegate).childDirectory(basename));
+  Directory childDirectory(String basename) {
+    return fileSystem.directory(fileSystem.path.join(path, basename));
+  }
 
   @override
-  File childFile(String basename) =>
-    wrapFile(fileSystem.directory(delegate).childFile(basename));
+  File childFile(String basename) {
+    return fileSystem.file(fileSystem.path.join(path, basename));
+  }
 
   @override
-  Link childLink(String basename) =>
-    wrapLink(fileSystem.directory(delegate).childLink(basename));
+  Link childLink(String basename) {
+    return fileSystem.link(fileSystem.path.join(path, basename));
+  }
 
   @override
   void createSync({bool recursive = false}) {
@@ -527,7 +527,7 @@ class ErrorHandlingLink
   final io.Link delegate;
 
   @override
-  final FileSystem fileSystem;
+  final ErrorHandlingFileSystem fileSystem;
 
   final Platform _platform;
 

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -1167,7 +1167,7 @@ void main() {
       );
 
       const String expectedMessage =
-          'Flutter failed to copy source to dest due to destination location error.\n'
+          'Flutter failed to create file at "dest".\n'
           'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.';
       expect(() => fileSystem.file('source').copySync('dest'), throwsToolExit(message: expectedMessage));
     });

--- a/packages/flutter_tools/test/general.shard/config_test.dart
+++ b/packages/flutter_tools/test/general.shard/config_test.dart
@@ -117,9 +117,10 @@ void main() {
 
   testWithoutContext('Config does not error on a normally fatal file system exception', () {
     final BufferLogger bufferLogger = BufferLogger.test();
+    final Platform platform = FakePlatform();
     final File file = ErrorHandlingFile(
-      platform: FakePlatform(),
-      fileSystem: MemoryFileSystem.test(),
+      platform: platform,
+      fileSystem: ErrorHandlingFileSystem(delegate: MemoryFileSystem.test(), platform: platform),
       delegate: FakeFile('testfile'),
     );
 


### PR DESCRIPTION
The File/Directory objects returned by ErrorHandlingFileSystem must use the ErrorHandlingFileSystem itself as the fileSystem so their APIs will benefit from the wrapper's services such as caching of the path.Context.

See https://github.com/flutter/flutter/issues/112640
