### PR TITLE
fix a CupertinoDatePicker bug

### DIFF
--- a/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
+++ b/packages/flutter/lib/src/rendering/list_wheel_viewport.dart
@@ -681,10 +681,14 @@ class RenderListWheelViewport
   /// by [childManager].
   @override
   void performLayout() {
-    // Apply the dimensions first in case it changes the scroll offset which
-    // determines what should be shown.
     offset.applyViewportDimension(_viewportExtent);
-    offset.applyContentDimensions(_minEstimatedScrollExtent, _maxEstimatedScrollExtent);
+    // Apply the content dimensions first if it has exact dimensions in case it
+    // changes the scroll offset which determines what should be shown. Such as
+    // if the child count decrease, we should correct the pixels first, otherwise,
+    // it may be shown blank null children.
+    if (childManager.childCount != null) {
+      offset.applyContentDimensions(_minEstimatedScrollExtent, _maxEstimatedScrollExtent);
+    }
 
     // The height, in pixel, that children will be visible and might be laid out
     // and painted.


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/112526
This bug was introduced by #96102, which wants to update the pixels before determining what should be shown when the children's count changes.

The root cause of this issue,
If the children's count is indeterminate, it will apply unboundary dimensions which may break the BouncingScrollPhysics boundary.