### PR TITLE
Fix menu_anchor_test.dart's state leak

### DIFF
--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -16,6 +16,7 @@ void main() {
   final List<TestMenu> opened = <TestMenu>[];
   final List<TestMenu> closed = <TestMenu>[];
   final GlobalKey menuItemKey = GlobalKey();
+  late Size defaultSize;
 
   void onPressed(TestMenu item) {
     selected.add(item);
@@ -33,6 +34,11 @@ void main() {
     focusedMenu = primaryFocus?.debugLabel ?? primaryFocus?.toString();
   }
 
+  setUpAll(() {
+    final MediaQueryData mediaQueryData = MediaQueryData.fromWindow(TestWidgetsFlutterBinding.instance.window);
+    defaultSize = mediaQueryData.size;
+  });
+
   setUp(() {
     focusedMenu = null;
     selected.clear();
@@ -41,6 +47,13 @@ void main() {
     controller = MenuController();
     focusedMenu = null;
   });
+
+  Future<void> changeSurfaceSize(WidgetTester tester, Size size) async {
+    await tester.binding.setSurfaceSize(size);
+    addTearDown(() async {
+      await tester.binding.setSurfaceSize(defaultSize);
+    });
+  }
 
   void listenForFocusChanges() {
     FocusManager.instance.addListener(handleFocusChange);
@@ -1059,16 +1072,13 @@ void main() {
       opened.clear();
 
       const Size smallSize = Size(200, 200);
-      await tester.binding.setSurfaceSize(smallSize);
+      await changeSurfaceSize(tester, smallSize);
 
       await tester.pumpWidget(build(smallSize));
       await tester.pump();
 
       expect(opened, isEmpty);
       expect(closed, isNotEmpty);
-
-      // Reset binding when done.
-      await tester.binding.setSurfaceSize(mediaQueryData.size);
     });
   });
 
@@ -1408,7 +1418,7 @@ void main() {
     }
 
     testWidgets('unconstrained menus show up in the right place in LTR', (WidgetTester tester) async {
-      await tester.binding.setSurfaceSize(const Size(800, 600));
+      await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
@@ -1446,7 +1456,7 @@ void main() {
     });
 
     testWidgets('unconstrained menus show up in the right place in RTL', (WidgetTester tester) async {
-      await tester.binding.setSurfaceSize(const Size(800, 600));
+      await changeSurfaceSize(tester, const Size(800, 600));
       await tester.pumpWidget(
         MaterialApp(
           home: Directionality(
@@ -1487,7 +1497,7 @@ void main() {
     });
 
     testWidgets('constrained menus show up in the right place in LTR', (WidgetTester tester) async {
-      await tester.binding.setSurfaceSize(const Size(300, 300));
+      await changeSurfaceSize(tester, const Size(300, 300));
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(
@@ -1526,7 +1536,7 @@ void main() {
     });
 
     testWidgets('constrained menus show up in the right place in RTL', (WidgetTester tester) async {
-      await tester.binding.setSurfaceSize(const Size(300, 300));
+      await changeSurfaceSize(tester, const Size(300, 300));
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(


### PR DESCRIPTION
## Description

There was a state leak in the menu tests where it was setting the surface size without setting it back.  It worked fine in one order, but today's random order didn't work for it.

It caused these failures: https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20framework_tests_libraries/7492/overview

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/112714
