### PR TITLE
Only run generateLockfiles when lockfiles are missing

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -160,7 +160,7 @@ class FlutterPlugin implements Plugin<Project> {
                 break
             }
         }
-        if (isFlutterAppProject() && lockfilesExist) {
+        if (isFlutterAppProject() && !lockfilesExist) {
             rootProject.tasks.register('generateLockfiles') {
                 rootProject.subprojects.each { subproject ->
                     def gradlew = (OperatingSystem.current().isWindows()) ?

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -152,7 +152,15 @@ class FlutterPlugin implements Plugin<Project> {
         this.project = project
 
         def rootProject = project.rootProject
-        if (isFlutterAppProject()) {
+        def lockfilesExist = true
+        rootProject.subprojects.each { subproject ->
+            if (!(subproject.file("project-{subproject.name}.lockfile").exists() &&
+                  subproject.file("buildscript-gradle.lockfile").exists())) {
+                lockfilesExist = false
+                break
+            }
+        }
+        if (isFlutterAppProject() && lockfilesExist) {
             rootProject.tasks.register('generateLockfiles') {
                 rootProject.subprojects.each { subproject ->
                     def gradlew = (OperatingSystem.current().isWindows()) ?


### PR DESCRIPTION
As reported in https://github.com/flutter/flutter/issues/110559, gradle dependency locking can take a very long time to complete. Since generating locks is not something that has to be done on every run. We should:

1. Check if there are any missing files and run task if so.
2. Check if there are any dependency changes that are meant to be locked. We may not actually have to check as it would be up to the developer to regenerate locks, which they can do so via calling this task directly or deleting an existing lockfile.