### PR TITLE
Add warning that `RenderRepaintBoundary.toImage` and `OffsetLayer.toImage` is slow

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1450,6 +1450,8 @@ class OffsetLayer extends ContainerLayer {
   /// (the default) will give you a 1:1 mapping between logical pixels and the
   /// output pixels in the image.
   ///
+  /// This is a slow operation that is performed on a background thread.
+  ///
   /// This API functions like [toImageSync], except that it only returns after
   /// rasterization is complete.
   ///

--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1439,6 +1439,7 @@ class OffsetLayer extends ContainerLayer {
   }
 
   /// Capture an image of the current state of this layer and its children.
+  /// This is a slow operation that is performed on a background thread.
   ///
   /// The returned [ui.Image] has uncompressed raw RGBA bytes, will be offset
   /// by the top-left corner of [bounds], and have dimensions equal to the size
@@ -1449,8 +1450,6 @@ class OffsetLayer extends ContainerLayer {
   /// [dart:ui.FlutterView.devicePixelRatio] for the device, so specifying 1.0
   /// (the default) will give you a 1:1 mapping between logical pixels and the
   /// output pixels in the image.
-  ///
-  /// This is a slow operation that is performed on a background thread.
   ///
   /// This API functions like [toImageSync], except that it only returns after
   /// rasterization is complete.

--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -3398,7 +3398,7 @@ class RenderRepaintBoundary extends RenderProxyBox {
   bool get isRepaintBoundary => true;
 
   /// Capture an image of the current state of this render object and its
-  /// children.
+  /// children. This is a slow operation that is performed on a background thread.
   ///
   /// The returned [ui.Image] has uncompressed raw RGBA bytes in the dimensions
   /// of the render object, multiplied by the [pixelRatio].


### PR DESCRIPTION
Scene.toImage has doc saying: "This is a slow operation that is performed on a background thread". However, people may use `RenderRepaintBoundary.toImage` and `OffsetLayer.toImage` and never read that comment, so they are unaware of the slowness. This PR simply adds the warning to them.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
