### PR TITLE
Fix selection area causes small scrollables to bounce

### DIFF
--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -125,7 +125,7 @@ void main() {
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
 
-    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)));
+    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(0, 20));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(controller.offset > previousOffset, isTrue);
@@ -148,6 +148,54 @@ void main() {
     expect(paragraph96.selections[0], const TextSelection(baseOffset: 0, extentOffset: 7));
 
     await gesture.up();
+  });
+
+  testWidgets('select to scroll works for small scrollable', (WidgetTester tester) async {
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(MaterialApp(
+      home: SelectionArea(
+        selectionControls: materialTextSelectionControls,
+        child: Scaffold(
+          body: SizedBox(
+            height: 10,
+            child: ListView.builder(
+              controller: controller,
+              itemCount: 100,
+              itemBuilder: (BuildContext context, int index) {
+                return Text('Item $index');
+              },
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    final RenderParagraph paragraph1 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Item 0'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph1, 2), kind: ui.PointerDeviceKind.mouse);
+    addTearDown(gesture.removePointer);
+    await tester.pump();
+    expect(controller.offset, 0.0);
+    double previousOffset = controller.offset;
+
+    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(0, 20));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset > previousOffset, isTrue);
+    previousOffset = controller.offset;
+
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset > previousOffset, isTrue);
+    await gesture.up();
+
+    // Should not stuck if gesture is up.
+    bool hasError = false;
+    try {
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+    } on FlutterError catch (_) {
+      hasError = true;
+    }
+    expect(hasError, isFalse);
   });
 
   testWidgets('select to scroll backward', (WidgetTester tester) async {
@@ -174,7 +222,7 @@ void main() {
     expect(controller.offset, 4000);
     double previousOffset = controller.offset;
 
-    await gesture.moveTo(tester.getTopLeft(find.byType(ListView)));
+    await gesture.moveTo(tester.getTopLeft(find.byType(ListView)) + const Offset(0, -20));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(controller.offset < previousOffset, isTrue);
@@ -220,7 +268,7 @@ void main() {
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
 
-    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)));
+    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(20, 0));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(controller.offset > previousOffset, isTrue);
@@ -268,7 +316,7 @@ void main() {
     expect(controller.offset, 2080);
     double previousOffset = controller.offset;
 
-    await gesture.moveTo(tester.getTopLeft(find.byType(ListView)));
+    await gesture.moveTo(tester.getTopLeft(find.byType(ListView)) + const Offset(-10, 0));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(controller.offset < previousOffset, isTrue);
@@ -427,8 +475,7 @@ void main() {
 
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
-
-    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)));
+    await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(0, 40));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
     expect(controller.offset > previousOffset, isTrue);

--- a/packages/flutter/test/widgets/scrollable_selection_test.dart
+++ b/packages/flutter/test/widgets/scrollable_selection_test.dart
@@ -125,6 +125,7 @@ void main() {
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
 
+    // Scrollable only auto scroll if the drag passes the boundary.
     await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(0, 20));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -177,6 +178,7 @@ void main() {
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
 
+    // Scrollable only auto scroll if the drag passes the boundary
     await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(0, 20));
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 100));
@@ -188,14 +190,9 @@ void main() {
     expect(controller.offset > previousOffset, isTrue);
     await gesture.up();
 
-    // Should not stuck if gesture is up.
-    bool hasError = false;
-    try {
-      await tester.pumpAndSettle(const Duration(seconds: 1));
-    } on FlutterError catch (_) {
-      hasError = true;
-    }
-    expect(hasError, isFalse);
+    // Shouldn't be stuck if gesture is up.
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(tester.takeException(), isNull);
   });
 
   testWidgets('select to scroll backward', (WidgetTester tester) async {
@@ -268,6 +265,7 @@ void main() {
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
 
+    // Scrollable only auto scroll if the drag passes the boundary
     await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(20, 0));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));
@@ -475,6 +473,7 @@ void main() {
 
     expect(controller.offset, 0.0);
     double previousOffset = controller.offset;
+    // Scrollable only auto scroll if the drag passes the boundary
     await gesture.moveTo(tester.getBottomRight(find.byType(ListView)) + const Offset(0, 40));
     await tester.pump();
     await tester.pump(const Duration(seconds: 1));


### PR DESCRIPTION
The problem is that the Selection container of scrollable may pass rect larger than the scrollable to the auto scroller. The auto scroll attempt to scroll the scrollable to review the target rect, and it keep scrolling up and down to try to fit the target rect.

This pr fixes it by passing zero size rect to autoscroller instead.

fixes https://github.com/flutter/flutter/issues/110917
## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
