### PR TITLE
Turn off bitcode in existing iOS Xcode projects

### DIFF
--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -129,7 +129,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     XcodeProjectObjectVersionMigration(app.project, globals.logger),
     HostAppInfoPlistMigration(app.project, globals.logger),
     XcodeScriptBuildPhaseMigration(app.project, globals.logger),
-    RemoveBitcodeMigration(app.project, globals.xcode!, globals.logger),
+    RemoveBitcodeMigration(app.project, globals.logger),
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -31,6 +31,7 @@ import 'migrations/host_app_info_plist_migration.dart';
 import 'migrations/ios_deployment_target_migration.dart';
 import 'migrations/project_base_configuration_migration.dart';
 import 'migrations/project_build_location_migration.dart';
+import 'migrations/remove_bitcode_migration.dart';
 import 'migrations/remove_framework_link_and_embedding_migration.dart';
 import 'migrations/xcode_build_system_migration.dart';
 import 'xcode_build_settings.dart';
@@ -128,6 +129,7 @@ Future<XcodeBuildResult> buildXcodeProject({
     XcodeProjectObjectVersionMigration(app.project, globals.logger),
     HostAppInfoPlistMigration(app.project, globals.logger),
     XcodeScriptBuildPhaseMigration(app.project, globals.logger),
+    RemoveBitcodeMigration(app.project, globals.xcode!, globals.logger),
   ];
 
   final ProjectMigration migration = ProjectMigration(migrators);

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_bitcode_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_bitcode_migration.dart
@@ -4,31 +4,23 @@
 
 import '../../base/file_system.dart';
 import '../../base/project_migrator.dart';
-import '../../base/version.dart';
-import '../../macos/xcode.dart';
 import '../../xcode_project.dart';
 
 /// Remove deprecated bitcode build setting.
 class RemoveBitcodeMigration extends ProjectMigrator {
   RemoveBitcodeMigration(
     IosProject project,
-    Xcode xcode,
     super.logger,
-  )   : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
-        _xcodeVersion = xcode.currentVersion;
+  )   : _xcodeProjectInfoFile = project.xcodeProjectInfoFile;
 
   final File _xcodeProjectInfoFile;
-  final Version? _xcodeVersion;
 
   @override
   bool migrate() {
-    final Version? xcodeVersion = _xcodeVersion;
-    if (xcodeVersion == null || xcodeVersion.major < 14) {
-      logger.printTrace('Xcode version < 14, skipping removing bitcode migration.');
-    } else if (!_xcodeProjectInfoFile.existsSync()) {
-      logger.printTrace('Xcode project not found, skipping removing bitcode migration.');
-    } else {
+    if (_xcodeProjectInfoFile.existsSync()) {
       processFileLines(_xcodeProjectInfoFile);
+    } else {
+      logger.printTrace('Xcode project not found, skipping removing bitcode migration.');
     }
 
     return true;
@@ -41,7 +33,7 @@ class RemoveBitcodeMigration extends ProjectMigrator {
         // Only print for the first discovered change found.
         logger.printWarning('Disabling deprecated bitcode Xcode build setting. See https://github.com/flutter/flutter/issues/107887 for additional details.');
       }
-      return null;
+      return line.replaceAll('ENABLE_BITCODE = YES', 'ENABLE_BITCODE = NO');
     }
 
     return line;

--- a/packages/flutter_tools/lib/src/ios/migrations/remove_bitcode_migration.dart
+++ b/packages/flutter_tools/lib/src/ios/migrations/remove_bitcode_migration.dart
@@ -1,0 +1,49 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../base/file_system.dart';
+import '../../base/project_migrator.dart';
+import '../../base/version.dart';
+import '../../macos/xcode.dart';
+import '../../xcode_project.dart';
+
+/// Remove deprecated bitcode build setting.
+class RemoveBitcodeMigration extends ProjectMigrator {
+  RemoveBitcodeMigration(
+    IosProject project,
+    Xcode xcode,
+    super.logger,
+  )   : _xcodeProjectInfoFile = project.xcodeProjectInfoFile,
+        _xcodeVersion = xcode.currentVersion;
+
+  final File _xcodeProjectInfoFile;
+  final Version? _xcodeVersion;
+
+  @override
+  bool migrate() {
+    final Version? xcodeVersion = _xcodeVersion;
+    if (xcodeVersion == null || xcodeVersion.major < 14) {
+      logger.printTrace('Xcode version < 14, skipping removing bitcode migration.');
+    } else if (!_xcodeProjectInfoFile.existsSync()) {
+      logger.printTrace('Xcode project not found, skipping removing bitcode migration.');
+    } else {
+      processFileLines(_xcodeProjectInfoFile);
+    }
+
+    return true;
+  }
+
+  @override
+  String? migrateLine(String line) {
+    if (line.contains('ENABLE_BITCODE = YES;')) {
+      if (!migrationRequired) {
+        // Only print for the first discovered change found.
+        logger.printWarning('Disabling deprecated bitcode Xcode build setting. See https://github.com/flutter/flutter/issues/107887 for additional details.');
+      }
+      return null;
+    }
+
+    return line;
+  }
+}

--- a/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/ios_project_migration_test.dart
@@ -6,7 +6,6 @@ import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/project_migrator.dart';
-import 'package:flutter_tools/src/base/version.dart';
 import 'package:flutter_tools/src/ios/migrations/host_app_info_plist_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/ios_deployment_target_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/project_base_configuration_migration.dart';
@@ -14,8 +13,6 @@ import 'package:flutter_tools/src/ios/migrations/project_build_location_migratio
 import 'package:flutter_tools/src/ios/migrations/remove_bitcode_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/remove_framework_link_and_embedding_migration.dart';
 import 'package:flutter_tools/src/ios/migrations/xcode_build_system_migration.dart';
-import 'package:flutter_tools/src/ios/xcodeproj.dart';
-import 'package:flutter_tools/src/macos/xcode.dart';
 import 'package:flutter_tools/src/migrations/xcode_project_object_version_migration.dart';
 import 'package:flutter_tools/src/migrations/xcode_script_build_phase_migration.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
@@ -23,7 +20,6 @@ import 'package:flutter_tools/src/xcode_project.dart';
 import 'package:test/fake.dart';
 
 import '../../src/common.dart';
-import '../../src/fake_process_manager.dart';
 
 void main () {
   group('iOS migration', () {
@@ -832,8 +828,6 @@ platform :ios, '11.0'
       late BufferLogger testLogger;
       late FakeIosProject project;
       late File xcodeProjectInfoFile;
-      late Xcode xcode13;
-      late Xcode xcode14;
 
       setUp(() {
         memoryFileSystem = MemoryFileSystem();
@@ -841,45 +835,17 @@ platform :ios, '11.0'
         project = FakeIosProject();
         xcodeProjectInfoFile = memoryFileSystem.file('project.pbxproj');
         project.xcodeProjectInfoFile = xcodeProjectInfoFile;
-        final FakeProcessManager processManager = FakeProcessManager.any();
-        xcode13 = Xcode.test(
-          processManager: processManager,
-          xcodeProjectInterpreter: XcodeProjectInterpreter.test(
-            processManager: processManager,
-            version: Version(13, 14, 14),
-          ),
-        );
-        xcode14 = Xcode.test(
-          processManager: processManager,
-          xcodeProjectInterpreter: XcodeProjectInterpreter.test(
-            processManager: processManager,
-            version: Version(14, 0, 0),
-          ),
-        );
       });
 
       testWithoutContext('skipped if files are missing', () {
         final RemoveBitcodeMigration migration = RemoveBitcodeMigration(
           project,
-          xcode14,
           testLogger,
         );
         expect(migration.migrate(), isTrue);
         expect(xcodeProjectInfoFile.existsSync(), isFalse);
 
         expect(testLogger.traceText, contains('Xcode project not found, skipping removing bitcode migration'));
-        expect(testLogger.statusText, isEmpty);
-      });
-
-      testWithoutContext('skipped Xcode version too low', () {
-        final RemoveBitcodeMigration migration = RemoveBitcodeMigration(
-          project,
-          xcode13,
-          testLogger,
-        );
-        expect(migration.migrate(), isTrue);
-
-        expect(testLogger.traceText, contains('Xcode version < 14, skipping removing bitcode migration'));
         expect(testLogger.statusText, isEmpty);
       });
 
@@ -890,7 +856,6 @@ platform :ios, '11.0'
 
         final RemoveBitcodeMigration migration = RemoveBitcodeMigration(
           project,
-          xcode14,
           testLogger,
         );
         expect(migration.migrate(), isTrue);
@@ -912,15 +877,16 @@ platform :ios, '11.0'
 
         final RemoveBitcodeMigration migration = RemoveBitcodeMigration(
           project,
-          xcode14,
           testLogger,
         );
         expect(migration.migrate(), isTrue);
 
         expect(xcodeProjectInfoFile.readAsStringSync(), '''
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
 
+				ENABLE_BITCODE = NO;
 ''');
         // Only print once even though 2 lines were changed.
         expect('Disabling deprecated bitcode Xcode build setting'.allMatches(testLogger.warningText).length, 1);


### PR DESCRIPTION
> Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.

https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes

Ensure Flutter apps have `ENABLE_BITCODE` set to `NO`.  We never turned bitcode on by default in our template, but it's possible the user turned it on manually.  It it is on, then give the user a warning and remove the build setting.

```
$ flutter build ios --config-only
Building com.example.testCreate for device (ios-release)...
Disabling deprecated bitcode Xcode build setting. See https://github.com/flutter/flutter/issues/107887 for additional details.
Upgrading project.pbxproj
Automatically signing iOS for device deployment using specified development team in Xcode project: S8QB4VV633
```

Confirmed this worked and removed the build setting in the test project where I manually turned it on:
```diff
				DEVELOPMENT_TEAM = S8QB4VV633;
-				ENABLE_BITCODE = YES;
				INFOPLIST_FILE = Runner/Info.plist;
```

Fixes https://github.com/flutter/flutter/issues/111776

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
