### PR TITLE
Switched closure to method in flushLayout for performance.

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -966,7 +966,7 @@ class PipelineOwner {
   bool _debugDoingLayout = false;
 
   // This is a method instead of a closure for optimization.
-  int _sortRenderObjects(RenderObject a, RenderObject b) => a.depth - b.depth;
+  static int _sortRenderObjects(RenderObject a, RenderObject b) => a.depth - b.depth;
 
   /// Update the layout information for all dirty render objects.
   ///

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -965,6 +965,9 @@ class PipelineOwner {
   bool get debugDoingLayout => _debugDoingLayout;
   bool _debugDoingLayout = false;
 
+  // This is a method instead of a closure for optimization.
+  int _sortRenderObjects(RenderObject a, RenderObject b) => a.depth - b.depth;
+
   /// Update the layout information for all dirty render objects.
   ///
   /// This function is one of the core stages of the rendering pipeline. Layout
@@ -998,7 +1001,7 @@ class PipelineOwner {
         assert(!_shouldMergeDirtyNodes);
         final List<RenderObject> dirtyNodes = _nodesNeedingLayout;
         _nodesNeedingLayout = <RenderObject>[];
-        dirtyNodes.sort((RenderObject a, RenderObject b) => a.depth - b.depth);
+        dirtyNodes.sort(_sortRenderObjects);
         for (int i = 0; i < dirtyNodes.length; i++) {
           if (_shouldMergeDirtyNodes) {
             _shouldMergeDirtyNodes = false;


### PR DESCRIPTION
Comparison: https://godbolt.org/z/hqMbKGorb

By looking at the AOT output of Dart we can see that it is faster to use a function / method in lieu of a closure.  Notice that in test2 there is no `call   9a048 <Stub__iso_stub_AllocateClosureStub>`.  It goes directly from allocating the array to calling sort.

Typically this would not be a big deal, but since this is guaranteed to be executed each frame, it is an easy improvement.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
