### PR TITLE
Switched `Element.renderObject` to iterative implementation.

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3419,17 +3419,20 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// until it finds a [RenderObjectElement].
   RenderObject? get renderObject {
     RenderObject? result;
-    void visit(Element element) {
-      assert(result == null); // this verifies that there's only one child
-      if (element._lifecycleState == _ElementLifecycle.defunct) {
-        return;
-      } else if (element is RenderObjectElement) {
-        result = element.renderObject;
+    final Queue<Element> elements = Queue<Element>();
+    elements.addFirst(this);
+    void adder(Element x) => elements.addLast(x);
+    while (elements.isNotEmpty) {
+      final Element current = elements.removeFirst();
+      if (current._lifecycleState == _ElementLifecycle.defunct) {
+        break;
+      } else if (current is RenderObjectElement) {
+        result = current.renderObject;
+        break;
       } else {
-        element.visitChildren(visit);
+        current.visitChildren(adder);
       }
     }
-    visit(this);
     return result;
   }
 

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3421,7 +3421,6 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
     RenderObject? result;
     final Queue<Element> elements = Queue<Element>();
     elements.addFirst(this);
-    void adder(Element x) => elements.addLast(x);
     while (elements.isNotEmpty) {
       final Element current = elements.removeFirst();
       if (current._lifecycleState == _ElementLifecycle.defunct) {
@@ -3430,7 +3429,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
         result = current.renderObject;
         break;
       } else {
-        current.visitChildren(adder);
+        current.visitChildren(elements.addLast);
       }
     }
     return result;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3418,16 +3418,19 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// this location in the tree. Otherwise, this getter will walk down the tree
   /// until it finds a [RenderObjectElement].
   RenderObject? get renderObject {
-    final Queue<Element> elements = Queue<Element>();
-    elements.addFirst(this);
-    while (elements.isNotEmpty) {
-      final Element current = elements.removeFirst();
+    Element? current = this;
+    while (current != null) {
       if (current._lifecycleState == _ElementLifecycle.defunct) {
         break;
       } else if (current is RenderObjectElement) {
         return current.renderObject;
       } else {
-        current.visitChildren(elements.addLast);
+        Element? next;
+        current.visitChildren((Element child) {
+          assert(next == null);  // This verifies that there's only one child.
+          next = child;
+        });
+        current = next;
       }
     }
     return null;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -3418,7 +3418,6 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// this location in the tree. Otherwise, this getter will walk down the tree
   /// until it finds a [RenderObjectElement].
   RenderObject? get renderObject {
-    RenderObject? result;
     final Queue<Element> elements = Queue<Element>();
     elements.addFirst(this);
     while (elements.isNotEmpty) {
@@ -3426,13 +3425,12 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
       if (current._lifecycleState == _ElementLifecycle.defunct) {
         break;
       } else if (current is RenderObjectElement) {
-        result = current.renderObject;
-        break;
+        return current.renderObject;
       } else {
         current.visitChildren(elements.addLast);
       }
     }
-    return result;
+    return null;
   }
 
   @override


### PR DESCRIPTION
issue: https://github.com/flutter/flutter/issues/112888

The iterative implementation is 30% faster in local testing on x86_64 AOT where `Element is RenderObjectElement`.  (97% faster with JIT).

Benchmark:
```dart
// @dart=2.12
import 'dart:collection';

enum _ElementLifecycle {
  other,
  defunct,
}

class RenderObject {
  int count = 0;
}

class Element {
  _ElementLifecycle _lifecycleState = _ElementLifecycle.other;

  RenderObject? get renderObject {
    RenderObject? result;
    final Queue<Element> elements = Queue<Element>();
    elements.addFirst(this);
    void adder(Element x) => elements.addLast(x);
    while (elements.isNotEmpty) {
      final Element current = elements.removeFirst();
      if (current._lifecycleState == _ElementLifecycle.defunct) {
        break;
      } else if (current is RenderObjectElement) {
        result = current.renderObject;
        break;
      } else {
        current.visitChildren(adder);
      }
    }
    return result;
  }

  RenderObject? get renderObject2 {
    RenderObject? result;
    void visit(Element element) {
      if (element._lifecycleState == _ElementLifecycle.defunct) {
        return;
      } else if (element is RenderObjectElement) {
        result = element.renderObject;
      } else {
        element.visitChildren(visit);
      }
    }
    visit(this);
    return result;
  }

  void visitChildren(void Function(Element) func) {}
}

class RenderObjectElement extends Element {
  final RenderObject? _renderObject = RenderObject();

  @override
  RenderObject? get renderObject => _renderObject;
}

void main() {
  RenderObjectElement foo = RenderObjectElement();
  int numIterations = 1000000000;
  int count = 0;
  {
    Stopwatch stopWatch = Stopwatch();
    stopWatch.start();
    for (int i = 0; i < numIterations; ++i) {
      count += foo.renderObject!.count;
    }
    stopWatch.stop();
    print('$count renderObject ${stopWatch.elapsedMicroseconds / numIterations.toDouble()} µs');
  }
  {
    Stopwatch stopWatch = Stopwatch();
    stopWatch.start();
    for (int i = 0; i < numIterations; ++i) {
      count += foo.renderObject2!.count;
    }
    stopWatch.stop();
    print('$count renderObject2 ${stopWatch.elapsedMicroseconds / numIterations.toDouble()} µs');
  }
}
```

ouput
```
0 renderObject 0.000530598 µs
0 renderObject2 0.000766342 µs
```

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
