### PR TITLE
Add bitcode deprecation note for add-to-app iOS developers

### DIFF
--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -88,7 +88,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
 
   await inDirectory(projectDir, () async {
     final StringBuffer outputError = StringBuffer();
-    final String output = await evalFlutter(
+    await evalFlutter(
       'build',
       options: <String>[
         'ios-framework',

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -87,7 +87,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
   const String outputDirectoryName = 'flutter-frameworks';
 
   await inDirectory(projectDir, () async {
-    await flutter(
+    final String output = await evalFlutter(
       'build',
       options: <String>[
         'ios-framework',
@@ -97,6 +97,9 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
         '--split-debug-info=symbols',
       ],
     );
+    if (!output.contains('Bitcode support has been deprecated.')) {
+      throw TaskResult.failure('Missing bitcode deprecation warning');
+    }
   });
 
   final String outputPath = path.join(projectDir.path, outputDirectoryName);

--- a/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
+++ b/dev/devicelab/bin/tasks/build_ios_framework_module_test.dart
@@ -87,6 +87,7 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
   const String outputDirectoryName = 'flutter-frameworks';
 
   await inDirectory(projectDir, () async {
+    final StringBuffer outputError = StringBuffer();
     final String output = await evalFlutter(
       'build',
       options: <String>[
@@ -96,8 +97,9 @@ Future<void> _testBuildIosFramework(Directory projectDir, { bool isModule = fals
         '--obfuscate',
         '--split-debug-info=symbols',
       ],
+      stderr: outputError,
     );
-    if (!output.contains('Bitcode support has been deprecated.')) {
+    if (!outputError.toString().contains('Bitcode support has been deprecated.')) {
       throw TaskResult.failure('Missing bitcode deprecation warning');
     }
   });

--- a/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios_framework.dart
@@ -300,6 +300,10 @@ class BuildIOSFrameworkCommand extends BuildFrameworkCommand {
           'See https://flutter.dev/docs/development/add-to-app/ios/add-flutter-screen#create-a-flutterengine for more information.');
     }
 
+    globals.printWarning(
+        'Bitcode support has been deprecated. Turn off the "Enable Bitcode" build setting in your Xcode project or you may encounter compilation errors.\n'
+        'See https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes for details.');
+
     return FlutterCommandResult.success();
   }
 


### PR DESCRIPTION
Bitcode has been deprecated.  Existing Flutter apps were migrated in https://github.com/flutter/flutter/pull/112828, but we have no control over iOS add-to-app host apps.  Give developers a warning that they need to turn off the build setting in the Xcode host app.

<img width="1019" alt="Screen Shot 2022-10-04 at 6 04 39 PM" src="https://user-images.githubusercontent.com/682784/193957678-eb261cfb-eb21-4c90-a751-105932c95752.png">
