### PR TITLE
improve debugging when dart pub get call fails

### DIFF
--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -414,11 +414,15 @@ class _DefaultPub implements Pub {
       } while (output == null);
       status?.stop();
     // The exception is rethrown, so don't catch only Exceptions.
-    } catch (exception) { // ignore: avoid_catches_without_on_clauses
+    } catch (exception, stacktrace) { // ignore: avoid_catches_without_on_clauses
       status?.cancel();
       if (exception is io.ProcessException) {
         final StringBuffer buffer = StringBuffer('${exception.message}\n');
-        buffer.writeln('Working directory: "$directory"');
+        buffer.writeln(stacktrace.toString());
+        final String directoryExistsMessage = _fileSystem.directory(directory).existsSync()
+            ? 'exists'
+            : 'does not exist';
+        buffer.writeln('Working directory: "$directory" ($directoryExistsMessage)');
         final Map<String, String> env = await _createPubEnvironment(context, flutterRootOverride);
         buffer.write(_stringifyPubEnv(env));
         throw io.ProcessException(

--- a/packages/flutter_tools/lib/src/dart/pub.dart
+++ b/packages/flutter_tools/lib/src/dart/pub.dart
@@ -414,11 +414,10 @@ class _DefaultPub implements Pub {
       } while (output == null);
       status?.stop();
     // The exception is rethrown, so don't catch only Exceptions.
-    } catch (exception, stacktrace) { // ignore: avoid_catches_without_on_clauses
+    } catch (exception) { // ignore: avoid_catches_without_on_clauses
       status?.cancel();
       if (exception is io.ProcessException) {
         final StringBuffer buffer = StringBuffer('${exception.message}\n');
-        buffer.writeln(stacktrace.toString());
         final String directoryExistsMessage = _fileSystem.directory(directory).existsSync()
             ? 'exists'
             : 'does not exist';

--- a/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/pub_get_test.dart
@@ -782,7 +782,7 @@ last line of pub output: "err3"
         isA<ProcessException>().having(
           (ProcessException error) => error.message,
           'message',
-          contains('Working directory: "/"'),
+          contains('Working directory: "/" (exists)'),
         ).having(
           (ProcessException error) => error.message,
           'message',


### PR DESCRIPTION
Add debugging for https://github.com/flutter/flutter/issues/95437.

In experimenting with this locally, including deleting the working directory in the middle of tool execution, I cannot repro this. My best guess is that the working directory doesn't exist, but let's just check it and surface that in the error message.