### PR TITLE
fix overflow error in `CupertinoListTile`

### DIFF
--- a/packages/flutter/lib/src/cupertino/list_tile.dart
+++ b/packages/flutter/lib/src/cupertino/list_tile.dart
@@ -353,18 +353,19 @@ class _CupertinoListTileState extends State<CupertinoListTile> {
               SizedBox(width: widget.leadingToTitle),
             ] else
               SizedBox(height: widget.leadingSize),
-            Column(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                title,
-                if (subtitle != null) ...<Widget>[
-                  const SizedBox(height: _kNotchedTitleToSubtitle),
-                  subtitle,
+            Expanded(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  title,
+                  if (subtitle != null) ...<Widget>[
+                    const SizedBox(height: _kNotchedTitleToSubtitle),
+                    subtitle,
+                  ],
                 ],
-              ],
+              ),
             ),
-            const Spacer(),
             if (additionalInfo != null) ...<Widget>[
               additionalInfo,
               if (widget.trailing != null)

--- a/packages/flutter/lib/src/cupertino/list_tile.dart
+++ b/packages/flutter/lib/src/cupertino/list_tile.dart
@@ -283,6 +283,7 @@ class _CupertinoListTileState extends State<CupertinoListTile> {
     final Widget title = DefaultTextStyle(
       style: titleTextStyle,
       maxLines: 1,
+      overflow: TextOverflow.ellipsis,
       child: widget.title,
     );
 
@@ -303,6 +304,7 @@ class _CupertinoListTileState extends State<CupertinoListTile> {
       subtitle = DefaultTextStyle(
         style: subtitleTextStyle,
         maxLines: 1,
+        overflow: TextOverflow.ellipsis,
         child: widget.subtitle!,
       );
     }

--- a/packages/flutter/test/cupertino/list_tile_test.dart
+++ b/packages/flutter/test/cupertino/list_tile_test.dart
@@ -519,4 +519,33 @@ void main() {
     await tester.pumpAndSettle(const Duration(seconds: 5));
     expect(tester.takeException(), null);
   });
+
+  testWidgets('title does not overflow', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CupertinoListTile(
+            title: Text('CupertinoListTile' * 10),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), null);
+  });
+
+  testWidgets('subtitle does not overflow', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CupertinoListTile(
+            title: const Text(''),
+            subtitle: Text('CupertinoListTile' * 10),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), null);
+  });
 }


### PR DESCRIPTION
See https://github.com/flutter/flutter/pull/78732#issuecomment-1177482082 for more details.

This PR fixes an overflow error in the `CupertinoListTile` widget.

Closes #108910.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

## Before

![before](https://user-images.githubusercontent.com/29122935/194497156-ea399055-a6a6-4082-a6dc-32c2f054411a.png)

## After

![after](https://user-images.githubusercontent.com/29122935/194497177-e4e1f38a-333f-4519-a50d-e0823f7c016a.png)


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
