### PR TITLE
[flutter_tool] Don't download CanvasKit if it's already in flutter_web_sdk

### DIFF
--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -206,13 +206,18 @@ class FlutterWebSdk extends CachedArtifact {
       }
     }
 
-    final String canvasKitVersion = cache.getVersionFor('canvaskit')!;
-    final String canvasKitUrl = '${cache.cipdBaseUrl}/flutter/web/canvaskit_bundle/+/$canvasKitVersion';
-    return artifactUpdater.downloadZipArchive(
-      'Downloading CanvasKit...',
-      Uri.parse(canvasKitUrl),
-      location,
-    );
+    // If the flutter_web_sdk folder doesn't already contain CanvasKit, then
+    // download it from CIPD.
+    final File expectedCanvasKitFile = fileSystem.file(fileSystem.path.join(location.path, 'canvaskit', 'canvaskit.wasm'));
+    if (!expectedCanvasKitFile.existsSync()) {
+      final String canvasKitVersion = cache.getVersionFor('canvaskit')!;
+      final String canvasKitUrl = '${cache.cipdBaseUrl}/flutter/web/canvaskit_bundle/+/$canvasKitVersion';
+      return artifactUpdater.downloadZipArchive(
+        'Downloading CanvasKit...',
+        Uri.parse(canvasKitUrl),
+        location,
+      );
+    }
   }
 }
 

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -208,6 +208,8 @@ class FlutterWebSdk extends CachedArtifact {
 
     // If the flutter_web_sdk folder doesn't already contain CanvasKit, then
     // download it from CIPD.
+    // TODO(hterkelsen): This whole section can be removed when we are always building
+    //   CanvasKit as past of flutter_web_sdk. See https://github.com/flutter/flutter/issues/113073
     final File expectedCanvasKitFile = fileSystem.file(fileSystem.path.join(location.path, 'canvaskit', 'canvaskit.wasm'));
     if (!expectedCanvasKitFile.existsSync()) {
       final String canvasKitVersion = cache.getVersionFor('canvaskit')!;

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -209,7 +209,7 @@ class FlutterWebSdk extends CachedArtifact {
     // If the flutter_web_sdk folder doesn't already contain CanvasKit, then
     // download it from CIPD.
     // TODO(hterkelsen): This whole section can be removed when we are always building
-    //   CanvasKit as past of flutter_web_sdk. See https://github.com/flutter/flutter/issues/113073
+    //   CanvasKit as part of flutter_web_sdk. See https://github.com/flutter/flutter/issues/113073
     final File expectedCanvasKitFile = fileSystem.file(fileSystem.path.join(location.path, 'canvaskit', 'canvaskit.wasm'));
     if (!expectedCanvasKitFile.existsSync()) {
       final String canvasKitVersion = cache.getVersionFor('canvaskit')!;

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -840,6 +840,56 @@ void main() {
     ]);
   });
 
+  testWithoutContext('FlutterWebSdk does not download CanvasKit if it is already in flutter_web_sdk', () async {
+    final MemoryFileSystem fileSystem = MemoryFileSystem.test();
+    final Directory internalDir = fileSystem.currentDirectory
+      .childDirectory('cache')
+      .childDirectory('bin')
+      .childDirectory('internal');
+    final File canvasKitVersionFile = internalDir.childFile('canvaskit.version');
+    canvasKitVersionFile.createSync(recursive: true);
+    canvasKitVersionFile.writeAsStringSync('abcdefg');
+
+    final File engineVersionFile = internalDir.childFile('engine.version');
+    engineVersionFile.createSync(recursive: true);
+    engineVersionFile.writeAsStringSync('hijklmnop');
+
+    final Cache cache = Cache.test(processManager: FakeProcessManager.any(), fileSystem: fileSystem);
+    final Directory webCacheDirectory = cache.getWebSdkDirectory();
+    final FakeArtifactUpdater artifactUpdater = FakeArtifactUpdater();
+    final FlutterWebSdk webSdk = FlutterWebSdk(cache, platform: FakePlatform());
+
+    final List<String> messages = <String>[];
+    final List<String> downloads = <String>[];
+    final List<String> locations = <String>[];
+    artifactUpdater.onDownloadZipArchive = (String message, Uri uri, Directory location) {
+      messages.add(message);
+      downloads.add(uri.toString());
+      locations.add(location.path);
+      location.createSync(recursive: true);
+      location.childDirectory('canvaskit').createSync();
+      location.childDirectory('canvaskit').childFile('canvaskit.js').createSync();
+      location.childDirectory('canvaskit').childFile('canvaskit.wasm').createSync();
+      location.childDirectory('canvaskit').childDirectory('profiling').createSync();
+      location.childDirectory('canvaskit').childDirectory('profiling').childFile('canvaskit.js').createSync();
+      location.childDirectory('canvaskit').childDirectory('profiling').childFile('canvaskit.wasm').createSync();
+    };
+
+    await webSdk.updateInner(artifactUpdater, fileSystem, FakeOperatingSystemUtils());
+
+    expect(messages, <String>[
+      'Downloading Web SDK...',
+    ]);
+
+    expect(downloads, <String>[
+      'https://storage.googleapis.com/flutter_infra_release/flutter/hijklmnop/flutter-web-sdk-linux-x64.zip',
+    ]);
+
+    expect(locations, <String>[
+      'cache/bin/cache/flutter_web_sdk',
+    ]);
+  });
+
   testWithoutContext('FlutterWebSdk uses tryToDelete to handle directory edge cases', () async {
     final FileExceptionHandler handler = FileExceptionHandler();
     final MemoryFileSystem fileSystem = MemoryFileSystem.test(opHandle: handler.opHandle);

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -855,7 +855,6 @@ void main() {
     engineVersionFile.writeAsStringSync('hijklmnop');
 
     final Cache cache = Cache.test(processManager: FakeProcessManager.any(), fileSystem: fileSystem);
-    final Directory webCacheDirectory = cache.getWebSdkDirectory();
     final FakeArtifactUpdater artifactUpdater = FakeArtifactUpdater();
     final FlutterWebSdk webSdk = FlutterWebSdk(cache, platform: FakePlatform());
 


### PR DESCRIPTION
Don't download CanvasKit from CIPD if it's already included in the `flutter_web_sdk` engine artifacts.

We are building CanvasKit locally in the Flutter engine now, and soon will be bundling it with `flutter_web_sdk`. This change causes flutter_tool to use the built version rather than the one from CIPD when the built version is available.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
