### PR TITLE
Adds Tooltip to `NavigationRail`

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -14,6 +14,7 @@ import 'navigation_bar.dart';
 import 'navigation_rail_theme.dart';
 import 'text_theme.dart';
 import 'theme.dart';
+import 'tooltip.dart';
 
 /// A Material Design widget that is meant to be displayed at the left or right of an
 /// app to navigate between a small number of views, typically between three and
@@ -436,6 +437,7 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
                             selected: widget.selectedIndex == i,
                             icon: widget.selectedIndex == i ? widget.destinations[i].selectedIcon : widget.destinations[i].icon,
                             label: widget.destinations[i].label,
+                            tooltip: widget.destinations[i].tooltip,
                             destinationAnimation: _destinationAnimations[i],
                             labelType: labelType,
                             iconTheme: widget.selectedIndex == i ? selectedIconTheme : effectiveUnselectedIconTheme,
@@ -518,6 +520,7 @@ class _RailDestination extends StatelessWidget {
     required this.minExtendedWidth,
     required this.icon,
     required this.label,
+    this.tooltip,
     required this.destinationAnimation,
     required this.extendedTransitionAnimation,
     required this.labelType,
@@ -551,6 +554,7 @@ class _RailDestination extends StatelessWidget {
   final double minExtendedWidth;
   final Widget icon;
   final Widget label;
+  final String? tooltip;
   final Animation<double> destinationAnimation;
   final NavigationRailLabelType labelType;
   final bool selected;
@@ -583,7 +587,7 @@ class _RailDestination extends StatelessWidget {
       child: label,
     );
 
-    final Widget content;
+    Widget content;
 
     switch (labelType) {
       case NavigationRailLabelType.none:
@@ -734,24 +738,35 @@ class _RailDestination extends StatelessWidget {
     }
 
     final ColorScheme colors = Theme.of(context).colorScheme;
+
+    content = Material(
+      type: MaterialType.transparency,
+      child: InkResponse(
+        onTap: onTap,
+        onHover: (_) {},
+        highlightShape: BoxShape.rectangle,
+        borderRadius: material3 ? null : BorderRadius.all(Radius.circular(minWidth / 2.0)),
+        containedInkWell: true,
+        splashColor: colors.primary.withOpacity(0.12),
+        hoverColor: colors.primary.withOpacity(0.04),
+        child: content,
+      ),
+    );
+
+    if(tooltip != null && tooltip!.isNotEmpty){
+      content = Tooltip(
+        message: tooltip,
+        excludeFromSemantics: true,
+        child: content,
+      );
+    }
+
     return Semantics(
       container: true,
       selected: selected,
       child: Stack(
         children: <Widget>[
-          Material(
-            type: MaterialType.transparency,
-            child: InkResponse(
-              onTap: onTap,
-              onHover: (_) {},
-              highlightShape: BoxShape.rectangle,
-              borderRadius: material3 ? null : BorderRadius.all(Radius.circular(minWidth / 2.0)),
-              containedInkWell: true,
-              splashColor: colors.primary.withOpacity(0.12),
-              hoverColor: colors.primary.withOpacity(0.04),
-              child: content,
-            ),
-          ),
+          content,
           Semantics(
             label: indexLabel,
           ),
@@ -851,6 +866,7 @@ class NavigationRailDestination {
     Widget? selectedIcon,
     required this.label,
     this.padding,
+    this.tooltip,
   }) : selectedIcon = selectedIcon ?? icon,
        assert(icon != null),
        assert(label != null);
@@ -892,6 +908,13 @@ class NavigationRailDestination {
 
   /// The amount of space to inset the destination item.
   final EdgeInsetsGeometry? padding;
+
+  /// The text to display in the [Tooltip] for this destination.
+  ///
+  /// A [Tooltip] will only appear on this item if [tooltip] is set to a non-empty string.
+  ///
+  /// Defaults to null, in which case the tooltip is not shown.
+  final String? tooltip;
 }
 
 class _ExtendedNavigationRailAnimation extends InheritedWidget {

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -68,6 +68,51 @@ void main() {
     expect(semantics.where((Semantics s) => s.properties.selected ?? false), isEmpty);
   });
 
+
+  testWidgets('NavigationRail shows tool tips on long press when tooltips are provided', (WidgetTester tester) async {
+    await _pumpNavigationRail(
+      tester,
+      navigationRail: NavigationRail(
+        selectedIndex: null,
+        extended: true,
+        destinations: const <NavigationRailDestination>[
+          NavigationRailDestination(
+            icon: Icon(Icons.favorite_border),
+            selectedIcon: Icon(Icons.favorite),
+            label: Text('Abc'),
+            tooltip: 'Abc'
+          ),
+          NavigationRailDestination(
+            icon: Icon(Icons.bookmark_border),
+            selectedIcon: Icon(Icons.bookmark),
+            label: Text('Empty tooltip'),
+            tooltip: ''
+          ),
+          NavigationRailDestination(
+            icon: Icon(Icons.bookmark_border),
+            selectedIcon: Icon(Icons.bookmark),
+            label: Text('Null tooltip'),
+          ),
+        ],
+      ),
+    );
+
+    expect(find.text('Abc'), findsOneWidget);
+    await tester.longPress(find.text('Abc'));
+    expect(find.byTooltip('Abc'), findsOneWidget);
+
+
+    expect(find.text('Empty tooltip'), findsOneWidget);
+    await tester.longPress(find.text('Empty tooltip'));
+    expect(find.byTooltip(''), findsNothing);
+
+    expect(find.text('Null tooltip'), findsOneWidget);
+    await tester.longPress(find.text('Null tooltip'));
+    expect(find.byTooltip(''), findsNothing);
+
+  });
+
+
   testWidgets('backgroundColor can be changed', (WidgetTester tester) async {
     await _pumpNavigationRail(
       tester,

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -101,7 +101,6 @@ void main() {
     await tester.longPress(find.text('Abc'));
     expect(find.byTooltip('Abc'), findsOneWidget);
 
-
     expect(find.text('Empty tooltip'), findsOneWidget);
     await tester.longPress(find.text('Empty tooltip'));
     expect(find.byTooltip(''), findsNothing);
@@ -109,9 +108,7 @@ void main() {
     expect(find.text('Null tooltip'), findsOneWidget);
     await tester.longPress(find.text('Null tooltip'));
     expect(find.byTooltip(''), findsNothing);
-
   });
-
 
   testWidgets('backgroundColor can be changed', (WidgetTester tester) async {
     await _pumpNavigationRail(


### PR DESCRIPTION
Adds 
- Tooltip to `NavigationRailDestination`. 
- Test cases for the tooltip in `NavigationRail`
Reason: When `expanded` is false in `NavigationRail` users can't see the labels if the labels are hidden as required by design. So, we need tooltips to show labels of the Destinations. We have used the same in BottomNavigationBar.

- Previously
<img width="912" alt="image" src="https://user-images.githubusercontent.com/58727124/194626929-13ba7315-912b-4579-b2b4-78a9faa4de22.png">

- Now
<img width="912" alt="image" src="https://user-images.githubusercontent.com/58727124/194627093-79104a3f-e733-494e-8aa8-e1c64af983dc.png">

*List which issues are fixed by this PR. You must list at least one issue.*
- Fix https://github.com/flutter/flutter/issues/113103

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
