### PR TITLE
Deprecate `AnimatedListItemBuilder` and `AnimatedListRemovedItemBuilder` 

### DIFF
--- a/examples/api/lib/widgets/animated_list/animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list.0.dart
@@ -50,6 +50,8 @@ class _AnimatedListSampleState extends State<AnimatedListSample> {
     );
   }
 
+  /// The builder function used to build items that have been removed.
+  ///
   /// Used to build an item after it has been removed from the list. This method
   /// is needed because a removed item remains visible until its animation has
   /// completed (even though it's gone as far as this ListModel is concerned).

--- a/examples/api/lib/widgets/animated_list/animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list.0.dart
@@ -50,11 +50,11 @@ class _AnimatedListSampleState extends State<AnimatedListSample> {
     );
   }
 
-  // Used to build an item after it has been removed from the list. This method
-  // is needed because a removed item remains visible until its animation has
-  // completed (even though it's gone as far as this ListModel is concerned).
-  // The widget will be used by the [AnimatedListState.removeItem] method's
-  // [AnimatedListRemovedItemBuilder] parameter.
+  /// Used to build an item after it has been removed from the list. This method
+  /// is needed because a removed item remains visible until its animation has
+  /// completed (even though it's gone as far as this ListModel is concerned).
+  /// The widget will be used by the [AnimatedListState.removeItem] method's
+  /// [AnimatedRemovedItemBuilder] parameter.
   Widget _buildRemovedItem(
       int item, BuildContext context, Animation<double> animation) {
     return CardItem(

--- a/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
@@ -53,6 +53,8 @@ class _SliverAnimatedListSampleState extends State<SliverAnimatedListSample> {
     );
   }
 
+  /// The builder function used to build items that have been removed.
+  ///
   /// Used to build an item after it has been removed from the list. This method
   /// is needed because a removed item remains visible until its animation has
   /// completed (even though it's gone as far this ListModel is concerned). The

--- a/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
@@ -53,12 +53,11 @@ class _SliverAnimatedListSampleState extends State<SliverAnimatedListSample> {
     );
   }
 
-  // Used to build an item after it has been removed from the list. This
-  // method is needed because a removed item remains visible until its
-  // animation has completed (even though it's gone as far this ListModel is
-  // concerned). The widget will be used by the
-  // [AnimatedListState.removeItem] method's
-  // [AnimatedListRemovedItemBuilder] parameter.
+  /// Used to build an item after it has been removed from the list. This method
+  /// is needed because a removed item remains visible until its animation has
+  /// completed (even though it's gone as far this ListModel is concerned). The
+  /// widget will be used by the [AnimatedListState.removeItem] method's
+  /// [AnimatedRemovedItemBuilder] parameter.
   Widget _buildRemovedItem(
       int item, BuildContext context, Animation<double> animation) {
     return CardItem(

--- a/packages/flutter/lib/src/widgets/animated_grid.dart
+++ b/packages/flutter/lib/src/widgets/animated_grid.dart
@@ -20,7 +20,9 @@ import 'ticker_provider.dart';
 /// `animation` is an [Animation] that should be used to animate an entry
 /// transition for the widget that is built.
 ///
-/// - [AnimatedRemovedItemBuilder], a builder that is for removing items with
+/// See also:
+///
+/// * [AnimatedRemovedItemBuilder], a builder that is for removing items with
 ///   animations instead of adding them.
 typedef AnimatedItemBuilder = Widget Function(BuildContext context, int index, Animation<double> animation);
 
@@ -34,7 +36,7 @@ typedef AnimatedItemBuilder = Widget Function(BuildContext context, int index, A
 ///
 /// See also:
 ///
-/// - [AnimatedItemBuilder], a builder that is for adding items with animations
+/// * [AnimatedItemBuilder], a builder that is for adding items with animations
 ///   instead of removing them.
 typedef AnimatedRemovedItemBuilder = Widget Function(BuildContext context, Animation<double> animation);
 

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -15,18 +15,19 @@ import 'ticker_provider.dart';
 
 /// Signature for the builder callback used by [AnimatedList].
 ///
-/// This is deprecated, use [AnimatedItemBuilder] instead.
+/// This is deprecated, use the identical [AnimatedItemBuilder] instead.
 @Deprecated(
-  'Use AnimatedItemBuilder instead '
+  'Use AnimatedItemBuilder instead. '
   'This feature was deprecated after v3.5.0-4.0.pre.',
 )
 typedef AnimatedListItemBuilder = Widget Function(BuildContext context, int index, Animation<double> animation);
 
 /// Signature for the builder callback used by [AnimatedListState.removeItem].
 ///
-/// This is deprecated, use [AnimatedRemovedItemBuilder] instead.
+/// This is deprecated, use the identical [AnimatedRemovedItemBuilder]
+/// instead.
 @Deprecated(
-  'Use AnimatedRemovedItemBuilder instead '
+  'Use AnimatedRemovedItemBuilder instead. '
   'This feature was deprecated after v3.5.0-4.0.pre.',
 )
 typedef AnimatedListRemovedItemBuilder = Widget Function(BuildContext context, Animation<double> animation);

--- a/packages/flutter/lib/src/widgets/animated_list.dart
+++ b/packages/flutter/lib/src/widgets/animated_list.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import 'animated_grid.dart';
 import 'basic.dart';
 import 'framework.dart';
 import 'scroll_controller.dart';
@@ -13,9 +14,21 @@ import 'sliver.dart';
 import 'ticker_provider.dart';
 
 /// Signature for the builder callback used by [AnimatedList].
+///
+/// This is deprecated, use [AnimatedItemBuilder] instead.
+@Deprecated(
+  'Use AnimatedItemBuilder instead '
+  'This feature was deprecated after v3.5.0-4.0.pre.',
+)
 typedef AnimatedListItemBuilder = Widget Function(BuildContext context, int index, Animation<double> animation);
 
 /// Signature for the builder callback used by [AnimatedListState.removeItem].
+///
+/// This is deprecated, use [AnimatedRemovedItemBuilder] instead.
+@Deprecated(
+  'Use AnimatedRemovedItemBuilder instead '
+  'This feature was deprecated after v3.5.0-4.0.pre.',
+)
 typedef AnimatedListRemovedItemBuilder = Widget Function(BuildContext context, Animation<double> animation);
 
 // The default insert/remove animation duration.
@@ -30,7 +43,7 @@ class _ActiveItem implements Comparable<_ActiveItem> {
       removedItemBuilder = null;
 
   final AnimationController? controller;
-  final AnimatedListRemovedItemBuilder? removedItemBuilder;
+  final AnimatedRemovedItemBuilder? removedItemBuilder;
   int itemIndex;
 
   @override
@@ -84,7 +97,7 @@ class AnimatedList extends StatefulWidget {
   ///
   /// List items are only built when they're scrolled into view.
   ///
-  /// The [AnimatedListItemBuilder] index parameter indicates the item's
+  /// The [AnimatedItemBuilder] index parameter indicates the item's
   /// position in the list. The value of the index parameter will be between 0
   /// and [initialItemCount] plus the total number of items that have been
   /// inserted with [AnimatedListState.insertItem] and less the total number of
@@ -92,7 +105,7 @@ class AnimatedList extends StatefulWidget {
   ///
   /// Implementations of this callback should assume that
   /// [AnimatedListState.removeItem] removes an item immediately.
-  final AnimatedListItemBuilder itemBuilder;
+  final AnimatedItemBuilder itemBuilder;
 
   /// {@template flutter.widgets.animatedList.initialItemCount}
   /// The number of items the list will start with.
@@ -305,7 +318,7 @@ class AnimatedListState extends State<AnimatedList> with TickerProviderStateMixi
   /// This method's semantics are the same as Dart's [List.remove] method:
   /// it decreases the length of the list by one and shifts all items at or
   /// before [index] towards the beginning of the list.
-  void removeItem(int index, AnimatedListRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
     _sliverAnimatedListKey.currentState!.removeItem(index, builder, duration: duration);
   }
 
@@ -371,7 +384,7 @@ class SliverAnimatedList extends StatefulWidget {
   ///
   /// List items are only built when they're scrolled into view.
   ///
-  /// The [AnimatedListItemBuilder] index parameter indicates the item's
+  /// The [AnimatedItemBuilder] index parameter indicates the item's
   /// position in the list. The value of the index parameter will be between 0
   /// and [initialItemCount] plus the total number of items that have been
   /// inserted with [SliverAnimatedListState.insertItem] and less the total
@@ -380,7 +393,7 @@ class SliverAnimatedList extends StatefulWidget {
   ///
   /// Implementations of this callback should assume that
   /// [SliverAnimatedListState.removeItem] removes an item immediately.
-  final AnimatedListItemBuilder itemBuilder;
+  final AnimatedItemBuilder itemBuilder;
 
   /// {@macro flutter.widgets.SliverChildBuilderDelegate.findChildIndexCallback}
   final ChildIndexGetter? findChildIndexCallback;
@@ -620,7 +633,7 @@ class SliverAnimatedListState extends State<SliverAnimatedList> with TickerProvi
   /// This method's semantics are the same as Dart's [List.remove] method:
   /// it decreases the length of the list by one and shifts all items at or
   /// before [index] towards the beginning of the list.
-  void removeItem(int index, AnimatedListRemovedItemBuilder builder, { Duration duration = _kDuration }) {
+  void removeItem(int index, AnimatedRemovedItemBuilder builder, { Duration duration = _kDuration }) {
     assert(index != null && index >= 0);
     assert(builder != null);
     assert(duration != null);


### PR DESCRIPTION
## Description

Deprecate `AnimatedListItemBuilder` and `AnimatedListRemovedItemBuilder` in favor of `AnimatedItemBuilder` and `AnimatedRemovedItemBuilder`, since they have the same signature, and just need a new, more appropriate, name.

## Tests
 - No tests needed: just a refactor without a semantic difference.