### PR TITLE
[Windows] Fix stack corruption issues

### DIFF
--- a/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
@@ -8,7 +8,6 @@
 #include <mutex>
 
 #include <dwmapi.h>
-#include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
 
 #include "flutter/generated_plugin_registrant.h"
@@ -63,11 +62,11 @@ bool FlutterWindow::OnCreate() {
   });
 
   // Create a method channel to check the window's visibility.
-  flutter::MethodChannel<> channel(
+  channel_ = std::make_unique<flutter::MethodChannel<>>(
       flutter_controller_->engine()->messenger(), "tests.flutter.dev/windows_startup_test",
       &flutter::StandardMethodCodec::GetInstance());
 
-  channel.SetMethodCallHandler(
+  channel_->SetMethodCallHandler(
     [&](const flutter::MethodCall<>& call,
        std::unique_ptr<flutter::MethodResult<>> result) {
        std::string method = call.method_name();

--- a/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.h
+++ b/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.h
@@ -7,6 +7,7 @@
 
 #include <flutter/dart_project.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
 
 #include <memory>
 
@@ -32,6 +33,9 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // The channel used by Dart to look up native properties.
+  std::unique_ptr<flutter::MethodChannel<>> channel_;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_

--- a/examples/platform_channel/windows/runner/flutter_window.cpp
+++ b/examples/platform_channel/windows/runner/flutter_window.cpp
@@ -4,10 +4,8 @@
 
 #include "flutter_window.h"
 
-#include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
 #include <flutter/event_stream_handler_functions.h>
-#include <flutter/method_channel.h>
 #include <flutter/standard_method_codec.h>
 #include <windows.h>
 
@@ -57,10 +55,10 @@ bool FlutterWindow::OnCreate() {
   }
   RegisterPlugins(flutter_controller_->engine());
 
-  flutter::MethodChannel<> channel(
+  battery_channel_ = std::make_unique<flutter::MethodChannel<>>(
       flutter_controller_->engine()->messenger(), "samples.flutter.io/battery",
       &flutter::StandardMethodCodec::GetInstance());
-  channel.SetMethodCallHandler(
+  battery_channel_->SetMethodCallHandler(
       [](const flutter::MethodCall<>& call,
          std::unique_ptr<flutter::MethodResult<>> result) {
         if (call.method_name() == "getBatteryLevel") {
@@ -78,10 +76,10 @@ bool FlutterWindow::OnCreate() {
         }
       });
 
-  flutter::EventChannel<> charging_channel(
+  charging_channel_ = std::make_unique<flutter::EventChannel<>>(
       flutter_controller_->engine()->messenger(), "samples.flutter.io/charging",
       &flutter::StandardMethodCodec::GetInstance());
-  charging_channel.SetStreamHandler(
+  charging_channel_->SetStreamHandler(
       std::make_unique<flutter::StreamHandlerFunctions<>>(
           [this](auto arguments, auto events) {
             this->OnStreamListen(std::move(events));

--- a/examples/platform_channel/windows/runner/flutter_window.h
+++ b/examples/platform_channel/windows/runner/flutter_window.h
@@ -44,8 +44,12 @@ class FlutterWindow : public Win32Window {
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
 
+  // The channel to notify Dart of battery charging status changes.
   std::unique_ptr<flutter::EventChannel<>> charging_channel_;
+
+  // The channel used by Dart to look up the battery level.
   std::unique_ptr<flutter::MethodChannel<>> battery_channel_;
+
   std::unique_ptr<flutter::EventSink<>> event_sink_;
   HPOWERNOTIFY power_notification_handle_ = nullptr;
 };

--- a/examples/platform_channel/windows/runner/flutter_window.h
+++ b/examples/platform_channel/windows/runner/flutter_window.h
@@ -6,8 +6,10 @@
 #define RUNNER_FLUTTER_WINDOW_H_
 
 #include <flutter/dart_project.h>
+#include <flutter/event_channel.h>
 #include <flutter/event_sink.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
 #include <winuser.h>
 
 #include <memory>
@@ -42,6 +44,8 @@ class FlutterWindow : public Win32Window {
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
 
+  std::unique_ptr<flutter::EventChannel<>> charging_channel_;
+  std::unique_ptr<flutter::MethodChannel<>> battery_channel_;
   std::unique_ptr<flutter::EventSink<>> event_sink_;
   HPOWERNOTIFY power_notification_handle_ = nullptr;
 };

--- a/examples/platform_view/windows/runner/flutter_window.h
+++ b/examples/platform_view/windows/runner/flutter_window.h
@@ -7,6 +7,7 @@
 
 #include <flutter/dart_project.h>
 #include <flutter/flutter_view_controller.h>
+#include <flutter/method_channel.h>
 
 #include <memory>
 
@@ -32,6 +33,9 @@ class FlutterWindow : public Win32Window {
 
   // The Flutter instance hosted by this window.
   std::unique_ptr<flutter::FlutterViewController> flutter_controller_;
+
+  // The channel used by Dart to create native popups.
+  std::unique_ptr<flutter::MethodChannel<>> channel_;
 };
 
 #endif  // RUNNER_FLUTTER_WINDOW_H_


### PR DESCRIPTION
https://github.com/flutter/engine/pull/36538 attempted to update the engine to Visual Studio 2019, however this was reverted as it [broke the framework tree](https://ci.chromium.org/ui/p/flutter/builders/prod/Windows%20platform_channel_sample_test_windows/1804/overview).


<details>
<summary>Crash...</summary>

The crash is unrelated to the underlying issue, which made debugging this hard 😅

Crash reason: `Access violation`

Call stack:

```
flutter_windows.dll!std::_Find_unchecked1(...)
flutter_windows.dll!std::_Find_unchecked(...)
flutter_windows.dll!std::find(...)
flutter_windows.dll!flutter::TaskRunnerWindow::ProcessTasks()
flutter_windows.dll!flutter::TaskRunnerWindow::HandleMessage(...)
user32.dll!UserCallWinProcCheckWow()
user32.dll!DispatchMessageWorker()
platform_channel.exe!wWinMain(...)
platform_channel.exe!invoke_main()
platform_channel.exe!__scrt_common_main_seh()
platform_channel.exe!__scrt_common_main()
platform_channel.exe!wWinMainCRTStartup(...)
kernel32.dll!BaseThreadInitThunk()
ntdll.dll!RtlUserThreadStart()
```

</details>

The underlying issue is that the Windows samples and tests create stack-allocated `MethodChannel`s and `EventChannel`s in `FlutterWindow::OnCreate` methods. Once the `FlutterWindow::OnCreate` method exits, the `MethodChannel` and `EventChannel` are destroyed. However, the [desktop embedder keeps pointers](https://github.com/flutter/engine/blob/90815e5f75dee1c20ce6d61d5161157513d90b84/shell/platform/common/client_wrapper/core_implementations.cc#L107) to these stack-allocated objects' handlers. These handlers would then corrupt the stack if [they attempted to modify the deallocated channel](https://github.com/flutter/engine/blob/90815e5f75dee1c20ce6d61d5161157513d90b84/shell/platform/common/client_wrapper/include/flutter/event_channel.h#L64-L126). This corrupted stack may cause crashes later depending on the app's behavior.

This fix updates the samples to tie the lifetime of `MethodChannel`s and `EventChannel`s to the apps' `FlutterWindow`. In the future, we should reconsider this API to prevent lifetime issues. Perhaps destroying `MethodChannel`s/`EventChannel`s should deregister the handlers.

Part of https://github.com/flutter/flutter/issues/110948

These codebases may also be affected (found using [this](https://cs.github.com/?scopeName=All+repos&scope=&q=flutter+language%3Acpp+methodchannel)):
1. https://github.com/flutter/plugins/blob/028e7494bb0c0391ba3e3a4b065af9f52a30cde4/packages/url_launcher/url_launcher_windows/windows/url_launcher_plugin.cpp#L65-L75
2. https://github.com/flutter/samples/blob/dc50c46ef13c08feb4e4b588101ca70acf840305/experimental/federated_plugin/federated_plugin_windows/windows/federated_plugin_windows_plugin.cpp#L37-L47
3. https://github.com/flutter/plugins/blob/028e7494bb0c0391ba3e3a4b065af9f52a30cde4/packages/camera/camera_windows/windows/camera_plugin.cpp#L195-L205
4. https://github.com/flutter/plugins/blob/028e7494bb0c0391ba3e3a4b065af9f52a30cde4/packages/local_auth/local_auth_windows/windows/local_auth_plugin.cpp#L113-L124
5. https://github.com/flutter/codelabs/blob/b4c9c2cb23db3744395f93f6e4e75cbd5dce5b16/github-client/window_to_front/windows/window_to_front_plugin.cpp#L31-L43
6. https://github.com/flutter-webrtc/flutter-webrtc/blob/3e4ef91d6aa1a975ce38abf9cdcebf8e4632b5b6/common/cpp/flutter_webrtc_plugin.cc#L15-L30
7. https://github.com/juicycleff/flutter-unity-view-widget/blob/799e0ca16510422f8ed6939e9fc2ad3aa7e61eb8/windows/flutter_unity_widget_plugin.cpp#L37-L49
8. https://github.com/getsentry/sentry-dart/blob/fe217baa64bf65dac702f8ef5acd8a267f02b46c/flutter/windows/sentry_flutter_plugin.cpp#L37-L49
9. And a bunch more :(

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
