### PR TITLE
Add `clipBehavior`  and apply `borderRadius` to DataTable's Material

### DIFF
--- a/packages/flutter/lib/src/material/data_table.dart
+++ b/packages/flutter/lib/src/material/data_table.dart
@@ -406,6 +406,7 @@ class DataTable extends StatelessWidget {
     required this.rows,
     this.checkboxHorizontalMargin,
     this.border,
+    this.clipBehavior = Clip.none,
   }) : assert(columns != null),
        assert(columns.isNotEmpty),
        assert(sortColumnIndex == null || (sortColumnIndex >= 0 && sortColumnIndex < columns.length)),
@@ -414,6 +415,7 @@ class DataTable extends StatelessWidget {
        assert(rows != null),
        assert(!rows.any((DataRow row) => row.cells.length != columns.length)),
        assert(dividerThickness == null || dividerThickness >= 0),
+       assert(clipBehavior != null),
        _onlyTextColumn = _initOnlyTextColumn(columns);
 
   /// The configuration and labels for the columns in the table.
@@ -637,6 +639,13 @@ class DataTable extends StatelessWidget {
 
   /// The style to use when painting the boundary and interior divisions of the table.
   final TableBorder? border;
+
+  /// {@macro flutter.material.Material.clipBehavior}
+  ///
+  /// This can be used to clip the content within the border of the [DataTable].
+  ///
+  /// Defaults to [Clip.none], and must not be null.
+  final Clip clipBehavior;
 
   // Set by the constructor to the index of the only Column that is
   // non-numeric, if there is exactly one, otherwise null.
@@ -1056,6 +1065,8 @@ class DataTable extends StatelessWidget {
       decoration: decoration ?? dataTableTheme.decoration ?? theme.dataTableTheme.decoration,
       child: Material(
         type: MaterialType.transparency,
+        borderRadius: border?.borderRadius,
+        clipBehavior: clipBehavior,
         child: Table(
           columnWidths: tableColumns.asMap(),
           children: tableRows,

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -74,6 +74,8 @@ class TableBorder {
   final BorderSide verticalInside;
 
   /// The [BorderRadius] to use when painting the corners of this border.
+  ///
+  /// It is also applied to [DataTable]'s [Material].
   final BorderRadius borderRadius;
 
   /// The widths of the sides of this border represented as an [EdgeInsets].

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1895,4 +1895,52 @@ void main() {
     // Go without crashes.
 
   });
+
+  testWidgets('DataTable clip behavior', (WidgetTester tester) async {
+    const Color selectedColor = Colors.green;
+    const Color defaultColor = Colors.red;
+
+    Widget buildTable({bool selected = false, required Clip clipBehavior}) {
+      return Material(
+        child: DataTable(
+          clipBehavior: clipBehavior,
+          border: TableBorder.all(
+            borderRadius: const BorderRadius.all(Radius.circular(30)),
+          ),
+          columns: const <DataColumn>[
+            DataColumn(
+              label: Text('Column1'),
+            ),
+          ],
+          rows: <DataRow>[
+            DataRow(
+              selected: selected,
+              color: MaterialStateProperty.resolveWith<Color>(
+                    (Set<MaterialState> states) {
+                  if (states.contains(MaterialState.selected)) {
+                    return selectedColor;
+                  }
+                  return defaultColor;
+                },
+              ),
+              cells: const <DataCell>[
+                DataCell(Text('Content1')),
+              ],
+            ),
+          ],
+        ),
+      );
+    }
+
+    // Test default clip behavior.
+    await tester.pumpWidget(MaterialApp(home: buildTable(clipBehavior: Clip.none)));
+
+    Material material = tester.widget<Material>(find.byType(Material).last);
+    expect(material.clipBehavior, Clip.none);
+
+    await tester.pumpWidget(MaterialApp(home: buildTable(clipBehavior: Clip.hardEdge)));
+
+    material = tester.widget<Material>(find.byType(Material).last);
+    expect(material.clipBehavior, Clip.hardEdge);
+  });
 }

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1899,14 +1899,13 @@ void main() {
   testWidgets('DataTable clip behavior', (WidgetTester tester) async {
     const Color selectedColor = Colors.green;
     const Color defaultColor = Colors.red;
+    const BorderRadius borderRadius = BorderRadius.all(Radius.circular(30));
 
     Widget buildTable({bool selected = false, required Clip clipBehavior}) {
       return Material(
         child: DataTable(
           clipBehavior: clipBehavior,
-          border: TableBorder.all(
-            borderRadius: const BorderRadius.all(Radius.circular(30)),
-          ),
+          border: TableBorder.all(borderRadius: borderRadius),
           columns: const <DataColumn>[
             DataColumn(
               label: Text('Column1'),
@@ -1937,10 +1936,12 @@ void main() {
 
     Material material = tester.widget<Material>(find.byType(Material).last);
     expect(material.clipBehavior, Clip.none);
+    expect(material.borderRadius, borderRadius);
 
     await tester.pumpWidget(MaterialApp(home: buildTable(clipBehavior: Clip.hardEdge)));
 
     material = tester.widget<Material>(find.byType(Material).last);
     expect(material.clipBehavior, Clip.hardEdge);
+    expect(material.borderRadius, borderRadius);
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/113025

This PR add `borderRadius` property to the `DataTable` and applies `borderRadius` from `borderRadius` to Material for clipping.

<details> 
<summary>code sample</summary> 

```dart

import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return const MaterialApp(
      debugShowCheckedModeBanner: false,
      home: Example(),
    );
  }
}

class Example extends StatelessWidget {
  const Example({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('DataTable'),
      ),
      body: Padding(
        padding: const EdgeInsets.all(20.0),
        child: DataTable(
          border: TableBorder.all(
            borderRadius: const BorderRadius.all(Radius.circular(30)),
          ),
          headingRowColor: MaterialStateProperty.all(
            Theme.of(context).primaryColor.withOpacity(.5),
          ),
          dataRowColor: MaterialStateProperty.all(
            Theme.of(context).primaryColor.withOpacity(.5),
          ),
          columns: const <DataColumn>[
            DataColumn(label: Text('Column')),
          ],
          rows: <DataRow>[
            for (int i = 0; i < 10; ++i)
              const DataRow(
                cells: [
                  DataCell(
                    SelectableText('Row'),
                  ),
                ],
              ),
          ],
        ),
      ),
    );
  }
}

``` 
	
</details>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
