### PR TITLE
Fix runtime type comparison

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -711,7 +711,7 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
 
     if (notification is OverscrollNotification) {
       _lastOverscrollNotification = notification;
-      if (_lastNotification.runtimeType is! OverscrollNotification) {
+      if (_lastNotification is! OverscrollNotification) {
         final OverscrollIndicatorNotification confirmationNotification = OverscrollIndicatorNotification(leading: notification.overscroll < 0.0);
         confirmationNotification.dispatch(context);
         _accepted = confirmationNotification.accepted;


### PR DESCRIPTION
I was looking for wrong `something.runtimeType is` comparisons in our codebase and the search matched this line in the vendored flutter sdk.

I'm not 100% sure this MR results in correct behavior. But since `.runtimeType` always returns `Type` which can never match `OverscrollNotification`, the current code must be wrong?