### PR TITLE
BufferLogger should log stacktrace

### DIFF
--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -790,8 +790,13 @@ class BufferLogger extends Logger {
     bool? wrap,
   }) {
     hadErrorOutput = true;
+    final StringBuffer errorMessage = StringBuffer();
+    errorMessage.writeln(message);
+    if (stackTrace != null) {
+      errorMessage.writeln(stackTrace);
+    }
     _error.writeln(terminal.color(
-      wrapText(message,
+      wrapText(errorMessage.toString(),
         indent: indent,
         hangingIndent: hangingIndent,
         shouldWrap: wrap ?? _outputPreferences.wrapText,

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -791,9 +791,10 @@ class BufferLogger extends Logger {
   }) {
     hadErrorOutput = true;
     final StringBuffer errorMessage = StringBuffer();
-    errorMessage.writeln(message);
+    errorMessage.write(message);
     if (stackTrace != null) {
-      errorMessage.writeln(stackTrace);
+      errorMessage.writeln();
+      errorMessage.write(stackTrace);
     }
     _error.writeln(terminal.color(
       wrapText(errorMessage.toString(),

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -1256,7 +1256,7 @@ void main() {
 
       expect(mockLogger.statusText, 'Hey Hey Hey Hey\n');
       expect(mockLogger.traceText, 'Oooh, I do I do I do\n');
-      expect(mockLogger.errorText, 'Helpless!\n$stackTrace\n\n');
+      expect(mockLogger.errorText, 'Helpless!\n$stackTrace\n');
     });
   });
 }

--- a/packages/flutter_tools/test/general.shard/base/logger_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/logger_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_tools/executable.dart';
@@ -246,12 +247,15 @@ void main() {
 
       verboseLogger.printStatus('Hey Hey Hey Hey');
       verboseLogger.printTrace('Oooh, I do I do I do');
-      verboseLogger.printError('Helpless!');
+      final StackTrace stackTrace = StackTrace.current;
+      verboseLogger.printError('Helpless!', stackTrace: stackTrace);
 
       expect(mockLogger.statusText, matches(r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Hey Hey Hey Hey\n'
                                              r'\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Oooh, I do I do I do\n$'));
       expect(mockLogger.traceText, '');
-      expect(mockLogger.errorText, matches( r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Helpless!\n$'));
+      expect(mockLogger.errorText, matches( r'^\[ (?: {0,2}\+[0-9]{1,4} ms|       )\] Helpless!\n'));
+      final String lastLine = LineSplitter.split(stackTrace.toString()).toList().last;
+      expect(mockLogger.errorText, endsWith('$lastLine\n\n'));
     });
 
     testWithoutContext('ANSI colored errors', () async {
@@ -1238,6 +1242,21 @@ void main() {
       logger.startProgress('BBB').stop();
 
       expect(logger.statusText, 'AAA\nBBB\n');
+    });
+
+    testWithoutContext('BufferLogger prints status, trace, error', () async {
+      final BufferLogger mockLogger = BufferLogger.test(
+        outputPreferences: OutputPreferences.test(),
+      );
+
+      mockLogger.printStatus('Hey Hey Hey Hey');
+      mockLogger.printTrace('Oooh, I do I do I do');
+      final StackTrace stackTrace = StackTrace.current;
+      mockLogger.printError('Helpless!', stackTrace: stackTrace);
+
+      expect(mockLogger.statusText, 'Hey Hey Hey Hey\n');
+      expect(mockLogger.traceText, 'Oooh, I do I do I do\n');
+      expect(mockLogger.errorText, 'Helpless!\n$stackTrace\n\n');
     });
   });
 }


### PR DESCRIPTION
In `BufferLogger` simulate `StdoutLogger` printing the stacktrace
https://github.com/flutter/flutter/blob/492bfddd9fdb5143c3fadbd5b1dea049253d17cd/packages/flutter_tools/lib/src/base/logger.dart#L466-L469


This came up because I couldn't get this test to fail, realized it isn't validating anything since `BufferLogger` never prints the `stackTrace`.
https://github.com/flutter/flutter/blob/492bfddd9fdb5143c3fadbd5b1dea049253d17cd/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart#L145

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
