### PR TITLE
Show Xcode compilation errors at end of build, suppress stdout and stderr from Xcode

### DIFF
--- a/dev/devicelab/bin/tasks/module_test_ios.dart
+++ b/dev/devicelab/bin/tasks/module_test_ios.dart
@@ -548,8 +548,7 @@ end
       );
 
       if (!xcodebuildOutput.contains('flutter --verbose --local-engine-src-path=bogus assemble') || // Verbose output
-          !xcodebuildOutput.contains('Unable to detect a Flutter engine build directory in bogus') ||
-          !xcodebuildOutput.contains('Command PhaseScriptExecution failed with a nonzero exit code')) {
+          !xcodebuildOutput.contains('Unable to detect a Flutter engine build directory in bogus')) {
         return TaskResult.failure('Host Objective-C app build succeeded though flutter script failed');
       }
 

--- a/packages/flutter_tools/bin/xcode_backend.dart
+++ b/packages/flutter_tools/bin/xcode_backend.dart
@@ -97,11 +97,17 @@ class Context {
     if (verbose) {
       print((result.stdout as String).trim());
     }
-    if ((result.stderr as String).isNotEmpty) {
-      echoError((result.stderr as String).trim());
+    final String resultStderr = result.stderr.toString().trim();
+    if (resultStderr.isNotEmpty) {
+      final StringBuffer errorOutput = StringBuffer();
+      if (result.exitCode != 0) {
+        // "error:" prefix makes this show up as an Xcode compilation error.
+        errorOutput.write('error: ');
+      }
+      errorOutput.write(resultStderr);
+      echoError(errorOutput.toString());
     }
     if (!allowFail && result.exitCode != 0) {
-      stderr.write('${result.stderr}\n');
       throw Exception(
         'Command "$bin ${args.join(' ')}" exited with code ${result.exitCode}',
       );

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -871,13 +871,11 @@ class _BuildInstance {
         ErrorHandlingFileSystem.deleteIfExists(previousFile);
       }
     } on Exception catch (exception, stackTrace) {
-      // TODO(zanderso): throw specific exception for expected errors to mark
-      // as non-fatal. All others should be fatal.
       node.target.clearStamp(environment);
       succeeded = false;
       skipped = false;
       exceptionMeasurements[node.target.name] = ExceptionMeasurement(
-          node.target.name, exception, stackTrace);
+          node.target.name, exception, stackTrace, fatal: true);
     } finally {
       resource.release();
       stopwatch.stop();

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -347,7 +347,7 @@ class AssembleCommand extends FlutterCommand {
       for (final ExceptionMeasurement measurement in result.exceptions.values) {
         if (measurement.fatal || globals.logger.isVerbose) {
           globals.printError('Target ${measurement.target} failed: ${measurement.exception}',
-            stackTrace: measurement.stackTrace
+            stackTrace: globals.logger.isVerbose ? measurement.stackTrace : null,
           );
         }
       }

--- a/packages/flutter_tools/lib/src/ios/xcresult.dart
+++ b/packages/flutter_tools/lib/src/ios/xcresult.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:meta/meta.dart';
+
 import '../../src/base/process.dart';
 import '../../src/convert.dart' show json;
 import '../../src/macos/xcode.dart';
@@ -112,6 +114,20 @@ class XCResult {
     );
   }
 
+  /// Create a [XCResult] with constructed [XCResultIssue]s for testing.
+  @visibleForTesting
+  factory XCResult.test({
+    List<XCResultIssue>? issues,
+    bool? parseSuccess,
+    String? parsingErrorMessage,
+  }) {
+    return XCResult._(
+      issues: issues ?? const <XCResultIssue>[],
+      parseSuccess: parseSuccess ?? true,
+      parsingErrorMessage: parsingErrorMessage,
+    );
+  }
+
   XCResult._({
     this.issues = const <XCResultIssue>[],
     this.parseSuccess = true,
@@ -180,6 +196,24 @@ class XCResultIssue {
       }
     }
 
+    return XCResultIssue._(
+      type: type,
+      subType: subType,
+      message: message,
+      location: location,
+      warnings: warnings,
+    );
+  }
+
+  /// Create a [XCResultIssue] without JSON parsing for testing.
+  @visibleForTesting
+  factory XCResultIssue.test({
+    XCResultIssueType type = XCResultIssueType.error,
+    String? subType,
+    String? message,
+    String? location,
+    List<String> warnings = const <String>[],
+  }) {
     return XCResultIssue._(
       type: type,
       subType: subType,

--- a/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/assemble_test.dart
@@ -135,13 +135,13 @@ void main() {
   testUsingContext('flutter assemble does not log stack traces during build failure', () async {
     final CommandRunner<void> commandRunner = createTestCommandRunner(AssembleCommand(
       buildSystem: TestBuildSystem.all(BuildResult(success: false, exceptions: <String, ExceptionMeasurement>{
-        'hello': ExceptionMeasurement('hello', 'bar', stackTrace),
+        'hello': ExceptionMeasurement('hello', 'bar', stackTrace, fatal: true),
       }))
     ));
 
     await expectLater(commandRunner.run(<String>['assemble', '-o Output', 'debug_macos_bundle_flutter_assets']),
       throwsToolExit());
-    expect(testLogger.errorText, isNot(contains('bar')));
+    expect(testLogger.errorText, contains('Target hello failed: bar'));
     expect(testLogger.errorText, isNot(contains(stackTrace.toString())));
   }, overrides: <Type, Generator>{
     Cache: () => Cache.test(processManager: FakeProcessManager.any()),

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ios_test.dart
@@ -372,7 +372,7 @@ void main() {
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
     });
 
-    testUsingContext('Display xcresult issues on console if parsed.', () async {
+    testUsingContext('Display xcresult issues on console if parsed, suppress Xcode output', () async {
       final BuildCommand command = BuildCommand();
 
       createMinimalMockProjectFiles();
@@ -384,13 +384,16 @@ void main() {
 
       expect(testLogger.errorText, contains("Use of undeclared identifier 'asdas'"));
       expect(testLogger.errorText, contains('/Users/m/Projects/test_create/ios/Runner/AppDelegate.m:7:56'));
+      expect(testLogger.statusText, isNot(contains("Xcode's output")));
+      expect(testLogger.statusText, isNot(contains('Lots of spew from Xcode')));
     }, overrides: <Type, Generator>{
       FileSystem: () => fileSystem,
       ProcessManager: () => FakeProcessManager.list(<FakeCommand>[
         xattrCommand,
         setUpFakeXcodeBuildHandler(exitCode: 1, onRun: () {
           fileSystem.systemTempDirectory.childDirectory(_xcBundleFilePath).createSync();
-        }),
+        }, stdout: 'Lots of spew from Xcode',
+        ),
         setUpXCResultCommand(stdout: kSampleResultJsonWithIssues),
         setUpRsyncCommand(),
       ]),
@@ -620,7 +623,6 @@ Runner requires a provisioning profile. Select a provisioning profile in the Sig
       Platform: () => macosPlatform,
       XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(developmentTeam: null),
     });
-
 
     testUsingContext('xcresult did not detect issue but detected by stdout.', () async {
       final BuildCommand command = BuildCommand();

--- a/packages/flutter_tools/test/general.shard/ios/mac_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/mac_test.dart
@@ -13,6 +13,7 @@ import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/ios/code_signing.dart';
 import 'package:flutter_tools/src/ios/iproxy.dart';
 import 'package:flutter_tools/src/ios/mac.dart';
+import 'package:flutter_tools/src/ios/xcresult.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:test/fake.dart';
@@ -265,49 +266,8 @@ Xcode's output:
 ↳
     blah
 
-    === CLEAN TARGET url_launcher OF PROJECT Pods WITH CONFIGURATION Release ===
-
-    Check dependencies
-
-    blah
-
-    === CLEAN TARGET Pods-Runner OF PROJECT Pods WITH CONFIGURATION Release ===
-
-    Check dependencies
-
-    blah
-
-    === CLEAN TARGET Runner OF PROJECT Runner WITH CONFIGURATION Release ===
-
     Check dependencies
     [BCEROR]Signing for "Runner" requires a development team. Select a development team in the project editor.
-    [BCEROR]Code signing is required for product type 'Application' in SDK 'iOS 10.3'
-    [BCEROR]Code signing is required for product type 'Application' in SDK 'iOS 10.3'
-    [BCEROR]Code signing is required for product type 'Application' in SDK 'iOS 10.3'
-
-    blah
-
-    ** CLEAN SUCCEEDED **
-
-    === BUILD TARGET url_launcher OF PROJECT Pods WITH CONFIGURATION Release ===
-
-    Check dependencies
-
-    blah
-
-    === BUILD TARGET Pods-Runner OF PROJECT Pods WITH CONFIGURATION Release ===
-
-    Check dependencies
-
-    blah
-
-    === BUILD TARGET Runner OF PROJECT Runner WITH CONFIGURATION Release ===
-
-    Check dependencies
-    Signing for "Runner" requires a development team. Select a development team in the project editor.
-    Code signing is required for product type 'Application' in SDK 'iOS 10.3'
-    Code signing is required for product type 'Application' in SDK 'iOS 10.3'
-    Code signing is required for product type 'Application' in SDK 'iOS 10.3'
 
 Could not build the precompiled application for the device.''',
         xcodeBuildExecution: XcodeBuildExecution(
@@ -323,6 +283,47 @@ Could not build the precompiled application for the device.''',
         logger.errorText,
         contains('Building a deployable iOS app requires a selected Development Team with a \nProvisioning Profile.'),
       );
+    });
+
+    testWithoutContext('does not show no development team message when other Xcode issues detected', () async {
+      final XcodeBuildResult buildResult = XcodeBuildResult(
+        success: false,
+        stdout: '''
+Running "flutter pub get" in flutter_gallery...  0.6s
+Launching lib/main.dart on x in release mode...
+Running pod install...                                1.2s
+Running Xcode build...                                1.4s
+Failed to build iOS app
+Error output from Xcode build:
+↳
+    ** BUILD FAILED **
+
+
+    The following build commands failed:
+    	Check dependencies
+    (1 failure)
+Xcode's output:
+↳
+    blah
+
+    Check dependencies
+    [BCEROR]Signing for "Runner" requires a development team. Select a development team in the project editor.
+
+Could not build the precompiled application for the device.''',
+        xcodeBuildExecution: XcodeBuildExecution(
+          buildCommands: <String>['xcrun', 'xcodebuild', 'blah'],
+          appDirectory: '/blah/blah',
+          environmentType: EnvironmentType.physical,
+          buildSettings: buildSettings,
+        ),
+        xcResult: XCResult.test(issues: <XCResultIssue>[
+          XCResultIssue.test(message: 'Target aot_assembly_release failed', subType: 'Error'),
+        ])
+      );
+
+      await diagnoseXcodeBuildFailure(buildResult, testUsage, logger);
+      expect(logger.errorText, contains('Error (Xcode): Target aot_assembly_release failed'));
+      expect(logger.errorText, isNot(contains('Building a deployable iOS app requires a selected Development Team')));
     });
   });
 

--- a/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_build_with_compilation_error_test.dart
@@ -64,8 +64,7 @@ int x = 'String';
       ], workingDirectory: projectRoot.path);
 
       expect(
-        // iOS shows this as stdout.
-        targetPlatform == 'ios' ? result.stdout : result.stderr,
+        result.stderr,
         contains("A value of type 'String' can't be assigned to a variable of type 'int'."),
       );
       expect(result.exitCode, 1);


### PR DESCRIPTION
1. In xcode_backend prefix `assemble` stderr with `error:` to make them show up as compilation errors in the Xcode UI and the parsed XCResults.  Example dart compilation error showing in Xcode:
 <img width="346" alt="Screen Shot 2022-10-11 at 4 29 02 PM" src="https://user-images.githubusercontent.com/682784/195216738-94dd5bee-139a-4e18-9c62-a928ef971d05.png">

2. Treat `assemble` build system exceptions as fatal, but only show stack traces in verbose mode. As far as I can tell no `ExceptionMeasurement` was ever fatal, so only showing stack traces in verbose mode shouldn't suppress previously displayed stack traces, since there were none.  See https://github.com/flutter/flutter/pull/44966 and https://github.com/flutter/flutter/pull/58539 for some of the history of that TODO.

3. Stop showing the final x stderr and stdout lines of the Xcode build, unless the xcresult can't be parsed.  This should reduce the noise in the build failure.

4. Stop showing the "missing development team" message when there is a more specific error to show.

This should make triaging issues easier, since the build error will be visible and obvious without `--verbose`.

Iteration on https://github.com/flutter/flutter/issues/22536
Fixes https://github.com/flutter/flutter/issues/32755
Fixes https://github.com/flutter/flutter/issues/113203
Fixes https://github.com/flutter/flutter/issues/100721
Fixes https://github.com/flutter/flutter/issues/98298

## Compilation failure on iOS
### Before
![Screen Shot 2022-10-11 at 4 15 56 PM](https://user-images.githubusercontent.com/682784/195215312-d6e88439-5d9a-4cb0-846a-23f1b579c354.png)
<img width="353" alt="Screen Shot 2022-10-11 at 4 29 55 PM" src="https://user-images.githubusercontent.com/682784/195216824-9c068397-a8a0-44de-95c0-c6a5c4330e17.png">


### After
![Screen Shot 2022-10-11 at 4 14 39 PM](https://user-images.githubusercontent.com/682784/195215153-c8dde280-97d5-4328-b6aa-5e4a155302f8.png)
<img width="346" alt="Screen Shot 2022-10-11 at 4 29 02 PM" src="https://user-images.githubusercontent.com/682784/195216738-94dd5bee-139a-4e18-9c62-a928ef971d05.png">

## Other assemble failure on iOS
A file system exception

### Before
No indication there is a file system issue.
![Screen Shot 2022-10-11 at 4 24 06 PM](https://user-images.githubusercontent.com/682784/195216200-48b6e113-454d-4fec-bf4c-fd71c3bab55e.png)


### After
![Screen Shot 2022-10-11 at 4 21 56 PM](https://user-images.githubusercontent.com/682784/195215974-eb273090-9c4e-4166-9d4b-9a95aa1073dd.png)

## Compilation failure on Android
### Before
![Screen Shot 2022-10-11 at 4 17 31 PM](https://user-images.githubusercontent.com/682784/195215478-8d24cb63-fce5-46d3-a114-d68754c33bf6.png)

### After
There's one additional line:
```
Target kernel_snapshot failed: Exception
```

![Screen Shot 2022-10-11 at 4 19 24 PM](https://user-images.githubusercontent.com/682784/195215734-f42438b1-5e7f-4cf3-8056-9af5615b1a37.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
