### PR TITLE
Write crash report in temp directory if writing to CWD failed.

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -816,7 +816,7 @@ void _throwFileSystemException(String? errorMessage) {
     return;
   }
   if (ErrorHandlingFileSystem._noExitOnFailure) {
-    throw Exception(errorMessage);
+    throw FileSystemException(errorMessage);
   }
   throwToolExit(errorMessage);
 }


### PR DESCRIPTION
Based on the code, this was the original intention but is now broken because `ErrorHandlingFileSystem` throws a `ToolExit`, but the crash handler is only catching `FileSystemException`.

Wrap the filesystem calls with `ErrorHandlingFileSystem.noExitOnFailure` so that it throws the right exception, and update
`ErrorHandlingFileSystem` to throw `FileSystemException` instead of the generic `Exception`, to match the behavior described in the comments.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
