### PR TITLE
Document that TooltipTriggerMode has no impact on hovering

### DIFF
--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -299,6 +299,15 @@ class TooltipTheme extends InheritedTheme {
 
 /// The method of interaction that will trigger a tooltip.
 /// Used in [Tooltip.triggerMode] and [TooltipThemeData.triggerMode].
+///
+/// On desktop, a tooltip will be shown when a pointer hovers it
+/// whatever the value of trigger mode is.
+///
+/// See also:
+///
+///   * [Tooltip.waitDuration], which defines the length of time that
+///     a pointer must hover over a tooltip's widget before the tooltip
+///     will be shown.
 enum TooltipTriggerMode {
   /// Tooltip will only be shown by calling `ensureTooltipVisible`.
   manual,

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -300,8 +300,8 @@ class TooltipTheme extends InheritedTheme {
 /// The method of interaction that will trigger a tooltip.
 /// Used in [Tooltip.triggerMode] and [TooltipThemeData.triggerMode].
 ///
-/// On desktop, a tooltip will be shown when a pointer hovers it
-/// whatever the value of trigger mode is.
+/// On desktop, a tooltip will be shown as soon as a pointer hovers over
+/// the widget, regardless of the value of [Tooltip.triggerMode].
 ///
 /// See also:
 ///


### PR DESCRIPTION
## Description

This PR updates `TooltipTriggerMode` documentation to mention it has no impact on hovering and to emphasize `Tooltip.waitDuration`.

## Motivation: 
- @gspencergoog following comment https://github.com/flutter/flutter/issues/107036#issuecomment-1178024207 
- https://github.com/flutter/flutter/issues/113310

## Related Issue

Fixes https://github.com/flutter/flutter/issues/113310

## Tests

Test exempt (documentation only).
