### PR TITLE
Enable impeller flags for iOS simulator

### DIFF
--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -442,6 +442,7 @@ class IOSSimulator extends Device {
         if (debuggingOptions.traceAllowlist != null) '--trace-allowlist="${debuggingOptions.traceAllowlist}"',
         if (debuggingOptions.traceSkiaAllowlist != null) '--trace-skia-allowlist="${debuggingOptions.traceSkiaAllowlist}"',
         if (dartVmFlags.isNotEmpty) '--dart-flags=$dartVmFlags',
+        if (debuggingOptions.enableImpeller) '--enable-impeller',
         '--observatory-port=${debuggingOptions.hostVmServicePort ?? 0}',
         if (route != null) '--route=$route',
       ],

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -976,7 +976,7 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
       Xcode: () => xcode,
     });
 
-    testUsingContext('startApp respects the enable software rendering flag', () async {
+    testUsingContext('startApp forwards all supported debugging options', () async {
       final IOSSimulator device = IOSSimulator(
         'x',
         name: 'iPhone SE',
@@ -994,10 +994,35 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
       );
 
       const BuildInfo mockInfo = BuildInfo(BuildMode.debug, 'flavor', treeShakeIcons: false);
-      final DebuggingOptions mockOptions = DebuggingOptions.enabled(mockInfo, enableSoftwareRendering: true);
-      await device.startApp(package, prebuiltApplication: true, debuggingOptions: mockOptions);
+      final DebuggingOptions mockOptions = DebuggingOptions.enabled(
+        mockInfo,
+        enableSoftwareRendering: true,
+        startPaused: true,
+        disableServiceAuthCodes: true,
+        skiaDeterministicRendering: true,
+        useTestFonts: true,
+        traceAllowlist: 'foo,bar',
+        traceSkiaAllowlist: 'skia.a,skia.b',
+        dartFlags: '--baz',
+        enableImpeller: true,
+      );
 
-      expect(simControl.requests.single.launchArgs, contains('--enable-software-rendering'));
+      await device.startApp(package, prebuiltApplication: true, debuggingOptions: mockOptions);
+      expect(simControl.requests.single.launchArgs, unorderedEquals(<String>[
+        '--enable-dart-profiling',
+        '--enable-checked-mode',
+        '--verify-entry-points',
+        '--enable-software-rendering',
+        '--start-paused',
+        '--disable-service-auth-codes',
+        '--skia-deterministic-rendering',
+        '--use-test-fonts',
+        '--trace-allowlist="foo,bar"',
+        '--trace-skia-allowlist="skia.a,skia.b"',
+        '--dart-flags=--baz',
+        '--enable-impeller',
+        '--observatory-port=0',
+      ]));
     }, overrides: <Type, Generator>{
       PlistParser: () => testPlistParser,
       FileSystem: () => fileSystem,


### PR DESCRIPTION
```
[  +12 ms] executing: xcrun simctl launch AE176D28-EC86-4472-B48D-3DC32202B267 io.flutter.examples.gallery --enable-dart-profiling --enable-checked-mode --verify-entry-points --enable-impeller --observatory-port=0
[ +397 ms] io.flutter.examples.gallery: 76484
[        ] Waiting for observatory port to be available...
[+1183 ms] [VERBOSE-2:ios_context_metal_impeller.mm(22)] Using the Impeller rendering backend.
```

Fixes https://github.com/flutter/flutter/issues/113349

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
