### PR TITLE
Fix typo of PrimaryScrollController documentation

### DIFF
--- a/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
+++ b/packages/flutter/lib/src/widgets/primary_scroll_controller.dart
@@ -22,7 +22,7 @@ const Set<TargetPlatform> _kMobilePlatforms = <TargetPlatform>{
 /// subtree.
 ///
 /// A ScrollView that doesn't have a controller or the primary flag set will
-/// inherit the PrimarySCrollController, if [shouldInherit] allows it. By
+/// inherit the PrimaryScrollController, if [shouldInherit] allows it. By
 /// default [shouldInherit] is true for mobile platforms when the ScrollView has
 /// a scroll direction of [Axis.vertical]. This automatic inheritance can be
 /// configured with [automaticallyInheritForPlatforms] and [scrollDirection].


### PR DESCRIPTION
Fix typo of PrimaryScrollController documentation.

<img width="537" alt="Screen Shot 2022-10-13 at 15 25 26" src="https://user-images.githubusercontent.com/1255062/195518364-e8d66c36-8659-4c8b-980e-2b27352454c9.png">


*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
