### PR TITLE
Remove deprecated `updateSemantics` API usage.

### DIFF
--- a/packages/flutter/lib/src/rendering/binding.dart
+++ b/packages/flutter/lib/src/rendering/binding.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:developer';
+import 'dart:ui' as ui show SemanticsUpdate;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
@@ -31,6 +32,7 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
     _pipelineOwner = PipelineOwner(
       onNeedVisualUpdate: ensureVisualUpdate,
       onSemanticsOwnerCreated: _handleSemanticsOwnerCreated,
+      onSemanticsUpdate: _handleSemanticsUpdate,
       onSemanticsOwnerDisposed: _handleSemanticsOwnerDisposed,
     );
     platformDispatcher
@@ -365,6 +367,10 @@ mixin RendererBinding on BindingBase, ServicesBinding, SchedulerBinding, Gesture
 
   void _handleSemanticsOwnerCreated() {
     renderView.scheduleInitialSemantics();
+  }
+
+  void _handleSemanticsUpdate(ui.SemanticsUpdate update) {
+    renderView.updateSemantics(update);
   }
 
   void _handleSemanticsOwnerDisposed() {

--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -4,6 +4,7 @@
 
 import 'dart:developer';
 import 'dart:ui' as ui show PictureRecorder;
+import 'dart:ui';
 
 import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
@@ -894,6 +895,7 @@ class PipelineOwner {
   PipelineOwner({
     this.onNeedVisualUpdate,
     this.onSemanticsOwnerCreated,
+    this.onSemanticsUpdate,
     this.onSemanticsOwnerDisposed,
   });
 
@@ -911,6 +913,12 @@ class PipelineOwner {
   /// Typical implementations will schedule the creation of the initial
   /// semantics tree.
   final VoidCallback? onSemanticsOwnerCreated;
+
+  /// Called whenever this pipeline owner's semantics owner emits a [SemanticsUpdate].
+  ///
+  /// Typical implementations will delegate the [SemanticsUpdate] to a [FlutterView]
+  /// that can handle the [SemanticsUpdate].
+  final SemanticsUpdateCallback? onSemanticsUpdate;
 
   /// Called whenever this pipeline owner disposes its semantics owner.
   ///
@@ -1183,7 +1191,8 @@ class PipelineOwner {
     _outstandingSemanticsHandles += 1;
     if (_outstandingSemanticsHandles == 1) {
       assert(_semanticsOwner == null);
-      _semanticsOwner = SemanticsOwner();
+      assert(onSemanticsUpdate != null, 'Attempted to open a semantics handle without an onSemanticsUpdate callback.');
+      _semanticsOwner = SemanticsOwner(onSemanticsUpdate: onSemanticsUpdate!);
       onSemanticsOwnerCreated?.call();
     }
     return SemanticsHandle._(this, listener);

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -247,8 +247,9 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     }
   }
 
-  /// Sends a [SemanticsUpdate] to the semantics tree contained within the
-  /// window of this [RenderView].
+  /// Sends the provided [SemanticsUpdate] to the [FlutterView] associated with this [RenderView].
+  ///
+  /// A [SemanticsUpdate] is produced by a [SemanticsOwner] during the [EnginePhase.flushSemantics] phase.
   void updateSemantics(ui.SemanticsUpdate update) {
     _window.updateSemantics(update);
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -247,9 +247,11 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
     }
   }
 
-  /// Sends the provided [SemanticsUpdate] to the [FlutterView] associated with this [RenderView].
+  /// Sends the provided [SemanticsUpdate] to the [FlutterView] associated with
+  /// this [RenderView].
   ///
-  /// A [SemanticsUpdate] is produced by a [SemanticsOwner] during the [EnginePhase.flushSemantics] phase.
+  /// A [SemanticsUpdate] is produced by a [SemanticsOwner] during the
+  /// [EnginePhase.flushSemantics] phase.
   void updateSemantics(ui.SemanticsUpdate update) {
     _window.updateSemantics(update);
   }

--- a/packages/flutter/lib/src/rendering/view.dart
+++ b/packages/flutter/lib/src/rendering/view.dart
@@ -4,7 +4,7 @@
 
 import 'dart:developer';
 import 'dart:io' show Platform;
-import 'dart:ui' as ui show FlutterView, Scene, SceneBuilder;
+import 'dart:ui' as ui show FlutterView, Scene, SceneBuilder, SemanticsUpdate;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
@@ -245,6 +245,12 @@ class RenderView extends RenderObject with RenderObjectWithChildMixin<RenderBox>
         Timeline.finishSync();
       }
     }
+  }
+
+  /// Sends a [SemanticsUpdate] to the semantics tree contained within the
+  /// window of this [RenderView].
+  void updateSemantics(ui.SemanticsUpdate update) {
+    _window.updateSemantics(update);
   }
 
   void _updateSystemChrome() {

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3069,7 +3069,7 @@ class SemanticsOwner extends ChangeNotifier {
     super.dispose();
   }
 
-  /// Update the semantics using [dart:ui.PlatformDispatcher.updateSemantics].
+  /// Update the semantics using [dart:ui.FlutterView.updateSemantics].
   void sendSemanticsUpdate() {
     if (_dirtyNodes.isEmpty) {
       return;

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -48,6 +48,9 @@ typedef SetTextHandler = void Function(String text);
 /// Returned by [SemanticsConfiguration.getActionHandler].
 typedef SemanticsActionHandler = void Function(Object? args);
 
+/// Signature for a function that receives a semantics update and returns no result.
+typedef SemanticsUpdateCallback = void Function(ui.SemanticsUpdate update);
+
 /// A tag for a [SemanticsNode].
 ///
 /// Tags can be interpreted by the parent of a [SemanticsNode]
@@ -3052,6 +3055,15 @@ class _TraversalSortNode implements Comparable<_TraversalSortNode> {
 /// obtain a [SemanticsHandle]. This will create a [SemanticsOwner] if
 /// necessary.
 class SemanticsOwner extends ChangeNotifier {
+  /// Creates a [SemanticsOwner] manages zero or more [SemanticsNode] objects.
+  SemanticsOwner({
+    required this.onSemanticsUpdate,
+  });
+
+  /// Updates to the internal state of the [SemanticsOwner]'s [SemanticsNode]s
+  /// are accumulted into one [SemanticsUpdate] that can be delegated with the
+  /// onSemanticsUpdate callback.
+  final SemanticsUpdateCallback onSemanticsUpdate;
   final Set<SemanticsNode> _dirtyNodes = <SemanticsNode>{};
   final Map<int, SemanticsNode> _nodes = <int, SemanticsNode>{};
   final Set<SemanticsNode> _detachedNodes = <SemanticsNode>{};
@@ -3118,7 +3130,7 @@ class SemanticsOwner extends ChangeNotifier {
       final CustomSemanticsAction action = CustomSemanticsAction.getAction(actionId)!;
       builder.updateCustomAction(id: actionId, label: action.label, hint: action.hint, overrideId: action.action?.index ?? -1);
     }
-    SemanticsBinding.instance.platformDispatcher.views.first.updateSemantics(builder.build());
+    onSemanticsUpdate(builder.build());
     notifyListeners();
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3118,9 +3118,7 @@ class SemanticsOwner extends ChangeNotifier {
       final CustomSemanticsAction action = CustomSemanticsAction.getAction(actionId)!;
       builder.updateCustomAction(id: actionId, label: action.label, hint: action.hint, overrideId: action.action?.index ?? -1);
     }
-    // TODO(a-wallen): https://github.com/flutter/flutter/issues/112221
-    // ignore: deprecated_member_use
-    SemanticsBinding.instance.platformDispatcher.updateSemantics(builder.build());
+    SemanticsBinding.instance.platformDispatcher.views.first.updateSemantics(builder.build());
     notifyListeners();
   }
 

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -49,6 +49,8 @@ typedef SetTextHandler = void Function(String text);
 typedef SemanticsActionHandler = void Function(Object? args);
 
 /// Signature for a function that receives a semantics update and returns no result.
+///
+/// Used by [SemanticsOwner.onSemanticsUpdate].
 typedef SemanticsUpdateCallback = void Function(ui.SemanticsUpdate update);
 
 /// A tag for a [SemanticsNode].
@@ -3055,14 +3057,18 @@ class _TraversalSortNode implements Comparable<_TraversalSortNode> {
 /// obtain a [SemanticsHandle]. This will create a [SemanticsOwner] if
 /// necessary.
 class SemanticsOwner extends ChangeNotifier {
-  /// Creates a [SemanticsOwner] manages zero or more [SemanticsNode] objects.
+  /// Creates a [SemanticsOwner] that manages zero or more [SemanticsNode] objects.
   SemanticsOwner({
     required this.onSemanticsUpdate,
   });
 
-  /// Updates to the internal state of the [SemanticsOwner]'s [SemanticsNode]s
-  /// are accumulted into one [SemanticsUpdate] that can be delegated with the
-  /// onSemanticsUpdate callback.
+  /// The [onSemanticsUpdate] callback is expected to dispatch [SemanticsUpdate]s
+  /// to the [FlutterView] that is associated with this [PipelineOwner] and/or
+  /// [SemanticsOwner].
+  ///
+  /// A [SemanticsOwner] calls [onSemanticsUpdate] during [sendSemanticsUpdate]
+  /// after the [SemanticsUpdate] has been build, but before the [SemanticsOwner]'s
+  /// listeners have been notified.
   final SemanticsUpdateCallback onSemanticsUpdate;
   final Set<SemanticsNode> _dirtyNodes = <SemanticsNode>{};
   final Map<int, SemanticsNode> _nodes = <int, SemanticsNode>{};
@@ -3081,7 +3087,7 @@ class SemanticsOwner extends ChangeNotifier {
     super.dispose();
   }
 
-  /// Update the semantics using [dart:ui.FlutterView.updateSemantics].
+  /// Update the semantics using [onSemanticsUpdate].
   void sendSemanticsUpdate() {
     if (_dirtyNodes.isEmpty) {
       return;

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -18,25 +18,44 @@ void main() {
     // Initialize all bindings because owner.flushSemantics() requires a window
     final TestRenderObject renderObject = TestRenderObject();
     int onNeedVisualUpdateCallCount = 0;
-    int onSemanticsUpdateCallCount = 0;
     final PipelineOwner owner = PipelineOwner(
       onNeedVisualUpdate: () {
         onNeedVisualUpdateCallCount +=1;
       },
-      onSemanticsUpdate: (ui.SemanticsUpdate update) {
-        onNeedVisualUpdateCallCount +=1;
-      },
+      onSemanticsUpdate: (ui.SemanticsUpdate update) {}
     );
     owner.ensureSemantics();
     renderObject.attach(owner);
     renderObject.layout(const BoxConstraints.tightForFinite());  // semantics are only calculated if layout information is up to date.
-    expect(onSemanticsUpdateCallCount, 0);
     owner.flushSemantics();
-    expect(onSemanticsUpdateCallCount, 1);
 
     expect(onNeedVisualUpdateCallCount, 1);
     renderObject.markNeedsSemanticsUpdate();
     expect(onNeedVisualUpdateCallCount, 2);
+  });
+
+  test('onSemanticsUpdate is called during flushSemantics.', () {
+    final TestRenderObject renderObject = TestRenderObject();
+    bool onSemanticsUpdateCallCount = false;
+    final PipelineOwner owner = PipelineOwner(
+      onSemanticsUpdate: (ui.SemanticsUpdate update) {
+        onSemanticsUpdateCallCount = true;
+      },
+    );
+    owner.ensureSemantics();
+
+    expect(onSemanticsUpdateCallCount, false);
+
+    renderObject.attach(owner);
+    renderObject.layout(const BoxConstraints.tightForFinite());
+    owner.flushSemantics();
+
+    expect(onSemanticsUpdateCallCount, true);
+  });
+
+  test('Enabling semantics without configuring onSemanticsUpdate is invalid.', () {
+    final PipelineOwner pipelineOwner = PipelineOwner();
+    expect(() => pipelineOwner.ensureSemantics(), throwsAssertionError);
   });
 
   test('detached RenderObject does not do semantics', () {

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -18,18 +18,21 @@ void main() {
     // Initialize all bindings because owner.flushSemantics() requires a window
     final TestRenderObject renderObject = TestRenderObject();
     int onNeedVisualUpdateCallCount = 0;
+    int onSemanticsUpdateCallCount = 0;
     final PipelineOwner owner = PipelineOwner(
       onNeedVisualUpdate: () {
         onNeedVisualUpdateCallCount +=1;
       },
       onSemanticsUpdate: (ui.SemanticsUpdate update) {
-
+        onNeedVisualUpdateCallCount +=1;
       },
     );
     owner.ensureSemantics();
     renderObject.attach(owner);
     renderObject.layout(const BoxConstraints.tightForFinite());  // semantics are only calculated if layout information is up to date.
+    expect(onSemanticsUpdateCallCount, 0);
     owner.flushSemantics();
+    expect(onSemanticsUpdateCallCount, 1);
 
     expect(onNeedVisualUpdateCallCount, 1);
     renderObject.markNeedsSemanticsUpdate();

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -18,9 +18,14 @@ void main() {
     // Initialize all bindings because owner.flushSemantics() requires a window
     final TestRenderObject renderObject = TestRenderObject();
     int onNeedVisualUpdateCallCount = 0;
-    final PipelineOwner owner = PipelineOwner(onNeedVisualUpdate: () {
-      onNeedVisualUpdateCallCount +=1;
-    });
+    final PipelineOwner owner = PipelineOwner(
+      onNeedVisualUpdate: () {
+        onNeedVisualUpdateCallCount +=1;
+      },
+      onSemanticsUpdate: (ui.SemanticsUpdate update) {
+
+      },
+    );
     owner.ensureSemantics();
     renderObject.attach(owner);
     renderObject.layout(const BoxConstraints.tightForFinite());  // semantics are only calculated if layout information is up to date.

--- a/packages/flutter/test/rendering/object_test.dart
+++ b/packages/flutter/test/rendering/object_test.dart
@@ -35,27 +35,46 @@ void main() {
   });
 
   test('onSemanticsUpdate is called during flushSemantics.', () {
-    final TestRenderObject renderObject = TestRenderObject();
-    bool onSemanticsUpdateCallCount = false;
+    int onSemanticsUpdateCallCount = 0;
     final PipelineOwner owner = PipelineOwner(
       onSemanticsUpdate: (ui.SemanticsUpdate update) {
-        onSemanticsUpdateCallCount = true;
+        onSemanticsUpdateCallCount += 1;
       },
     );
     owner.ensureSemantics();
 
-    expect(onSemanticsUpdateCallCount, false);
+    expect(onSemanticsUpdateCallCount, 0);
 
+    final TestRenderObject renderObject = TestRenderObject();
     renderObject.attach(owner);
     renderObject.layout(const BoxConstraints.tightForFinite());
     owner.flushSemantics();
 
-    expect(onSemanticsUpdateCallCount, true);
+    expect(onSemanticsUpdateCallCount, 1);
   });
 
   test('Enabling semantics without configuring onSemanticsUpdate is invalid.', () {
     final PipelineOwner pipelineOwner = PipelineOwner();
     expect(() => pipelineOwner.ensureSemantics(), throwsAssertionError);
+  });
+
+
+  test('onSemanticsUpdate during sendSemanticsUpdate.', () {
+    int onSemanticsUpdateCallCount = 0;
+    final SemanticsOwner owner = SemanticsOwner(
+      onSemanticsUpdate: (ui.SemanticsUpdate update) {
+        onSemanticsUpdateCallCount += 1;
+      },
+    );
+
+    final SemanticsNode node = SemanticsNode.root(owner: owner);
+    node.rect = Rect.largest;
+
+    expect(onSemanticsUpdateCallCount, 0);
+
+    owner.sendSemanticsUpdate();
+
+    expect(onSemanticsUpdateCallCount, 1);
   });
 
   test('detached RenderObject does not do semantics', () {

--- a/packages/flutter/test/semantics/semantics_test.dart
+++ b/packages/flutter/test/semantics/semantics_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui';
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -698,7 +700,9 @@ void main() {
   });
 
   test('Semantics id does not repeat', () {
-    final SemanticsOwner owner = SemanticsOwner();
+    final SemanticsOwner owner = SemanticsOwner(
+      onSemanticsUpdate: (SemanticsUpdate update) {},
+    );
     const int expectId = 1400;
     SemanticsNode? nodeToRemove;
     for (int i = 0; i < kMaxFrameworkAccessibilityIdentifier; i++) {

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -853,9 +853,7 @@ class TestPlatformDispatcher implements ui.PlatformDispatcher {
 
   @override
   void updateSemantics(ui.SemanticsUpdate update) {
-    // TODO(a-wallen): https://github.com/flutter/flutter/issues/112221
-    // ignore: deprecated_member_use
-    _platformDispatcher.updateSemantics(update);
+    _platformDispatcher.views.first.updateSemantics(update);
   }
 
   @override

--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -464,11 +464,6 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
-  void updateSemantics(ui.SemanticsUpdate update) {
-    platformDispatcher.updateSemantics(update);
-  }
-
-  @override
   void setIsolateDebugName(String name) {
     platformDispatcher.setIsolateDebugName(name);
   }
@@ -849,11 +844,6 @@ class TestPlatformDispatcher implements ui.PlatformDispatcher {
   @override
   set onAccessibilityFeaturesChanged(ui.VoidCallback? callback) {
     _platformDispatcher.onAccessibilityFeaturesChanged = callback;
-  }
-
-  @override
-  void updateSemantics(ui.SemanticsUpdate update) {
-    _platformDispatcher.views.first.updateSemantics(update);
   }
 
   @override


### PR DESCRIPTION
The tree broke after https://github.com/flutter/engine/pull/36675 which @jonahwilliams fixed by adding ignores. This PR migrates the deprecated framework APIs.

## Continues resolving https://github.com/flutter/flutter/issues/112221

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
