### PR TITLE
Allow marking a golden check as flaky

### DIFF
--- a/dev/automated_tests/flutter_test/flutter_gold_test.dart
+++ b/dev/automated_tests/flutter_test/flutter_gold_test.dart
@@ -8,7 +8,7 @@ import 'dart:typed_data';
 
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
-import 'package:flutter_goldens/flutter_goldens.dart';
+import 'package:flutter_goldens/src/flutter_goldens_io.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform/platform.dart';
 

--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -418,7 +418,7 @@ Future<void> verifyNoSyncAsyncStar(String workingDirectory, {int minimumMatches 
   }
 }
 
-final RegExp _findGoldenTestPattern = RegExp(r'matchesGoldenFile\(');
+final RegExp _findGoldenTestPattern = RegExp(r'(matchesGoldenFile|matchesFlutterGolden)\(');
 final RegExp _findGoldenDefinitionPattern = RegExp(r'matchesGoldenFile\(Object');
 final RegExp _leadingComment = RegExp(r'//');
 final RegExp _goldenTagPattern1 = RegExp(r'@Tags\(');
@@ -431,8 +431,17 @@ const String _ignoreGoldenTag = '// flutter_ignore: golden_tag (see analyze.dart
 const String _ignoreGoldenTagForFile = '// flutter_ignore_for_file: golden_tag (see analyze.dart)';
 
 Future<void> verifyGoldenTags(String workingDirectory, { int minimumMatches = 2000 }) async {
+  // Skip flutter_goldens/lib because this library uses `matchesGoldenFile`
+  // but is not itself a test that needs tags.
+  final String flutterGoldensPackageLib = path.join(flutterPackages, 'flutter_goldens', 'lib');
+  bool isWithinFlutterGoldenLib(File file) {
+    return path.isWithin(flutterGoldensPackageLib, file.path);
+  }
+
   final List<String> errors = <String>[];
-  await for (final File file in _allFiles(workingDirectory, 'dart', minimumMatches: minimumMatches)) {
+  final Stream<File> allTestFiles = _allFiles(workingDirectory, 'dart', minimumMatches: minimumMatches)
+    .where((File file) => !isWithinFlutterGoldenLib(file));
+  await for (final File file in allTestFiles) {
     bool needsTag = false;
     bool hasTagNotation = false;
     bool hasReducedTag = false;

--- a/dev/integration_tests/flutter_gallery/test/flutter_test_config.dart
+++ b/dev/integration_tests/flutter_gallery/test/flutter_test_config.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/rendering.dart';
-import 'package:flutter_goldens/flutter_goldens.dart' as flutter_goldens show testExecutable;
+import 'package:flutter_goldens/test_wrapper.dart' as flutter_goldens show testExecutable;
 import 'package:flutter_test/flutter_test.dart';
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) {

--- a/examples/api/test/goldens_io.dart
+++ b/examples/api/test/goldens_io.dart
@@ -2,4 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'package:flutter_goldens/flutter_goldens.dart' show testExecutable;
+export 'package:flutter_goldens/test_wrapper.dart' show testExecutable;

--- a/packages/flutter/test/_goldens_io.dart
+++ b/packages/flutter/test/_goldens_io.dart
@@ -1,5 +1,0 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-export 'package:flutter_goldens/flutter_goldens.dart' show testExecutable;

--- a/packages/flutter/test/_goldens_web.dart
+++ b/packages/flutter/test/_goldens_web.dart
@@ -1,8 +1,0 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-import 'dart:async';
-
-// package:flutter_goldens is not used as part of the test process for web.
-Future<void> testExecutable(FutureOr<void> Function() testMain) async => testMain();

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -17,10 +17,11 @@ import 'dart:ui';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
+import 'package:flutter_goldens/matchers.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // TODO(yjbanov): on the web text rendered with perspective produces flaky goldens: https://github.com/flutter/flutter/issues/110785
-const bool skipPerspectiveTextGoldens = isBrowser;
+const bool perspectiveTextIsFlaky = isBrowser;
 
 // A number of the hit tests below say "warnIfMissed: false". This is because
 // the way the CupertinoPicker works, the hits don't actually reach the labels,
@@ -1197,39 +1198,31 @@ void main() {
       }
 
       await tester.pumpWidget(buildApp(CupertinoDatePickerMode.time));
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.time.initial.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesFlutterGolden('date_picker_test.time.initial.png', isFlaky: perspectiveTextIsFlaky),
+      );
 
       await tester.pumpWidget(buildApp(CupertinoDatePickerMode.date));
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.date.initial.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesFlutterGolden('date_picker_test.date.initial.png', isFlaky: perspectiveTextIsFlaky),
+      );
 
       await tester.pumpWidget(buildApp(CupertinoDatePickerMode.dateAndTime));
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.datetime.initial.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesFlutterGolden('date_picker_test.datetime.initial.png', isFlaky: perspectiveTextIsFlaky),
+      );
 
       // Slightly drag the hour component to make the current hour off-center.
       await tester.drag(find.text('4'), Offset(0, _kRowOffset.dy / 2), warnIfMissed: false); // see top of file
       await tester.pump();
 
-      if (!skipPerspectiveTextGoldens) {
-        await expectLater(
-          find.byType(CupertinoDatePicker),
-          matchesGoldenFile('date_picker_test.datetime.drag.png'),
-        );
-      }
+      await expectLater(
+        find.byType(CupertinoDatePicker),
+        matchesFlutterGolden('date_picker_test.datetime.drag.png', isFlaky: perspectiveTextIsFlaky),
+      );
     });
 
     testWidgets('DatePicker displays the date in correct order', (WidgetTester tester) async {
@@ -1314,23 +1307,19 @@ void main() {
       ),
     );
 
-    if (!skipPerspectiveTextGoldens) {
-      await expectLater(
-        find.byType(CupertinoTimerPicker),
-        matchesGoldenFile('timer_picker_test.datetime.initial.png'),
-      );
-    }
+    await expectLater(
+      find.byType(CupertinoTimerPicker),
+      matchesFlutterGolden('timer_picker_test.datetime.initial.png', isFlaky: perspectiveTextIsFlaky),
+    );
 
     // Slightly drag the minute component to make the current minute off-center.
     await tester.drag(find.text('59'), Offset(0, _kRowOffset.dy / 2), warnIfMissed: false); // see top of file
     await tester.pump();
 
-    if (!skipPerspectiveTextGoldens) {
-      await expectLater(
-        find.byType(CupertinoTimerPicker),
-        matchesGoldenFile('timer_picker_test.datetime.drag.png'),
-      );
-    }
+    await expectLater(
+      find.byType(CupertinoTimerPicker),
+      matchesFlutterGolden('timer_picker_test.datetime.drag.png', isFlaky: perspectiveTextIsFlaky),
+    );
   });
 
   testWidgets('TimerPicker only changes hour label after scrolling stops', (WidgetTester tester) async {

--- a/packages/flutter/test/flutter_test_config.dart
+++ b/packages/flutter/test/flutter_test_config.dart
@@ -5,10 +5,8 @@
 import 'dart:async';
 
 import 'package:flutter/rendering.dart';
+import 'package:flutter_goldens/test_wrapper.dart' as test_wrapper;
 import 'package:flutter_test/flutter_test.dart';
-
-import '_goldens_io.dart'
-  if (dart.library.html) '_goldens_web.dart' as flutter_goldens;
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) {
   // Enable checks because there are many implementations of [RenderBox] in this
@@ -20,5 +18,9 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) {
   WidgetController.hitTestWarningShouldBeFatal = true;
 
   // Enable golden file testing using Skia Gold.
-  return flutter_goldens.testExecutable(testMain);
+  return test_wrapper.testExecutable(testMain);
+}
+
+Future<void> processBrowserCommand(dynamic command) {
+  return test_wrapper.processBrowserCommand(command);
 }

--- a/packages/flutter/test/flutter_web_test_config.dart
+++ b/packages/flutter/test/flutter_web_test_config.dart
@@ -1,0 +1,25 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'flutter_test_config.dart';
+
+/// A custom host configuration for browser tests that supports flaky golden
+/// checks.
+///
+/// See also [processBrowserCommand].
+Future<void> startWebTestHostConfiguration(String testUri) async {
+  testExecutable(() async {
+    final Stream<dynamic> commands = stdin
+      .transform<String>(utf8.decoder)
+      .transform<String>(const LineSplitter())
+      .map<dynamic>(jsonDecode);
+    await for (final dynamic command in commands) {
+      await processBrowserCommand(command);
+    }
+  });
+}

--- a/packages/flutter_goldens/lib/matchers.dart
+++ b/packages/flutter_goldens/lib/matchers.dart
@@ -1,0 +1,9 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// This library exposes the [matchesFlutterGolden] function that's similar to
+/// [matchesGoldenFile] but supports flaky goldens.
+
+export 'src/flutter_goldens_io.dart' if (dart.library.js_util) 'src/flutter_goldens_web.dart'
+  show matchesFlutterGolden;

--- a/packages/flutter_goldens/lib/src/flutter_goldens_web.dart
+++ b/packages/flutter_goldens/lib/src/flutter_goldens_web.dart
@@ -1,0 +1,121 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async' show FutureOr;
+import 'dart:convert' show json;
+import 'dart:html' as html;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_api/src/expect/async_matcher.dart' show AsyncMatcher; // ignore: implementation_imports
+
+export 'package:flutter_goldens_client/skia_client.dart';
+
+/// See documentation in `flutter_goldens_io.dart`.
+AsyncMatcher matchesFlutterGolden(Object key, { int? version, bool isFlaky = false }) {
+  assert(
+    webGoldenComparator is _FlutterWebGoldenComparator,
+    'matchesFlutterGolden can only be used with FlutterGoldenFileComparator '
+    'but found ${goldenFileComparator.runtimeType}.'
+  );
+
+  if (isFlaky) {
+    (webGoldenComparator as _FlutterWebGoldenComparator).enableFlakyMode();
+  }
+
+  return matchesGoldenFile(key, version: version);
+}
+
+/// Wraps a web test, supplying a custom comparator that supports flaky goldens.
+Future<void> testExecutable(FutureOr<void> Function() testMain, {String? namePrefix}) async {
+  webGoldenComparator = _FlutterWebGoldenComparator(webTestUri);
+  await testMain();
+}
+
+/// See the io implementation of this function.
+Future<void> processBrowserCommand(dynamic command) async {
+  throw UnimplementedError('processCommand is not used inside the browser');
+}
+
+/// Same as [DefaultWebGoldenComparator] but supports flaky golden checks.
+class _FlutterWebGoldenComparator extends WebGoldenComparator {
+  /// Creates a new [_FlutterWebGoldenComparator] for the specified [testUri].
+  ///
+  /// Golden file keys will be interpreted as file paths relative to the
+  /// directory in which [testUri] resides.
+  ///
+  /// The [testUri] URL must represent a file.
+  _FlutterWebGoldenComparator(this.testUri);
+
+  /// The test file currently being executed.
+  ///
+  /// Golden file keys will be interpreted as file paths relative to the
+  /// directory in which this file resides.
+  Uri testUri;
+
+  /// Whether this comparator allows flaky goldens.
+  ///
+  /// If set to true, concrete implementations of this class are expected to
+  /// generate the golden and submit it for review, but not fail the test.
+  bool _isFlakyModeEnabled = false;
+
+  /// Puts this comparator into flaky comparison mode.
+  ///
+  /// After calling this method the next invocation of [compare] will allow
+  /// incorrect golden to pass the check.
+  ///
+  /// Concrete implementations of [compare] must call [getAndResetFlakyMode] so
+  /// that subsequent tests can run in non-flaky mode. If a subsequent test
+  /// needs to run in a flaky mode, it must call this method again.
+  void enableFlakyMode() {
+    assert(
+      !_isFlakyModeEnabled,
+      'Test is already marked as flaky. Call `getAndResetFlakyMode` to reset the '
+      'flag before calling this method again.',
+    );
+    _isFlakyModeEnabled = true;
+  }
+
+  /// Returns whether flaky comparison mode was enabled via [enableFlakyMode],
+  /// and if it was, resets the comparator back to non-flaky mode.
+  bool getAndResetFlakyMode() {
+    if (!_isFlakyModeEnabled) {
+      // Not in flaky mode. Nothing to do.
+      return false;
+    }
+
+    // In flaky mode. Reset it and return true.
+    _isFlakyModeEnabled = false;
+    return true;
+  }
+
+  @override
+  Future<bool> compare(double width, double height, Uri golden) async {
+    final bool isFlaky = getAndResetFlakyMode();
+    final String key = golden.toString();
+    final html.HttpRequest request = await html.HttpRequest.request(
+      'flutter_goldens',
+      method: 'POST',
+      sendData: json.encode(<String, Object>{
+        'testUri': testUri.toString(),
+        'key': key,
+        'width': width.round(),
+        'height': height.round(),
+        'customProperties': <String, dynamic>{
+          'isFlaky': isFlaky,
+        },
+      }),
+    );
+    final String response = request.response as String;
+    if (response == 'true') {
+      return true;
+    }
+    fail(response);
+  }
+
+  @override
+  Future<void> update(double width, double height, Uri golden) async {
+    // Update is handled on the server side, just use the same logic here
+    await compare(width, height, golden);
+  }
+}

--- a/packages/flutter_goldens/lib/test_wrapper.dart
+++ b/packages/flutter_goldens/lib/test_wrapper.dart
@@ -1,0 +1,9 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// This library exposes functions that enhance the test with custom golden
+/// configuration for the Flutter repository.
+
+export 'src/flutter_goldens_io.dart' if (dart.library.js_util) 'src/flutter_goldens_web.dart'
+  show processBrowserCommand, testExecutable;

--- a/packages/flutter_goldens/test/flutter_goldens_io_test.dart
+++ b/packages/flutter_goldens/test/flutter_goldens_io_test.dart
@@ -10,7 +10,7 @@ import 'dart:io' hide Directory;
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter_goldens/flutter_goldens.dart';
+import 'package:flutter_goldens/src/flutter_goldens_io.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:platform/platform.dart';
 import 'package:process/process.dart';
@@ -1122,7 +1122,7 @@ class FakeSkiaGoldClient extends Fake implements SkiaGoldClient {
   @override
   Future<void> imgtestInit() async => initCalls += 1;
   @override
-  Future<bool> imgtestAdd(String testName, File goldenFile) async {
+  Future<bool> imgtestAdd(String testName, File goldenFile, { bool isFlaky = false }) async {
     testNames.add(testName);
     return true;
   }
@@ -1131,7 +1131,7 @@ class FakeSkiaGoldClient extends Fake implements SkiaGoldClient {
   @override
   Future<void> tryjobInit() async => tryInitCalls += 1;
   @override
-  Future<bool> tryjobAdd(String testName, File goldenFile) async => true;
+  Future<bool> tryjobAdd(String testName, File goldenFile, { bool isFlaky = false }) async => true;
 
   Map<String, List<int>> imageBytesValues = <String, List<int>>{};
   @override

--- a/packages/flutter_goldens_client/lib/skia_client.dart
+++ b/packages/flutter_goldens_client/lib/skia_client.dart
@@ -199,7 +199,7 @@ class SkiaGoldClient {
   ///
   /// The [testName] and [goldenFile] parameters reference the current
   /// comparison being evaluated by the [FlutterPostSubmitFileComparator].
-  Future<bool> imgtestAdd(String testName, File goldenFile) async {
+  Future<bool> imgtestAdd(String testName, File goldenFile, { bool isFlaky = false }) async {
     final List<String> imgtestCommand = <String>[
       _goldctl,
       'imgtest', 'add',
@@ -209,7 +209,7 @@ class SkiaGoldClient {
       '--test-name', cleanTestName(testName),
       '--png-file', goldenFile.path,
       '--passfail',
-      ..._getPixelMatchingArguments(),
+      ..._getPixelMatchingArguments(isFlaky: isFlaky),
     ];
 
     final io.ProcessResult result = await process.run(imgtestCommand);
@@ -323,7 +323,7 @@ class SkiaGoldClient {
   ///
   /// The [testName] and [goldenFile] parameters reference the current
   /// comparison being evaluated by the [FlutterPreSubmitFileComparator].
-  Future<void> tryjobAdd(String testName, File goldenFile) async {
+  Future<void> tryjobAdd(String testName, File goldenFile, { bool isFlaky = false }) async {
     final List<String> imgtestCommand = <String>[
       _goldctl,
       'imgtest', 'add',
@@ -332,7 +332,7 @@ class SkiaGoldClient {
         .path,
       '--test-name', cleanTestName(testName),
       '--png-file', goldenFile.path,
-      ..._getPixelMatchingArguments(),
+      ..._getPixelMatchingArguments(isFlaky: isFlaky),
     ];
 
     final io.ProcessResult result = await process.run(imgtestCommand);
@@ -362,6 +362,42 @@ class SkiaGoldClient {
     }
   }
 
+  List<String> _getPixelMatchingArguments({ required bool isFlaky }) {
+    if (isFlaky) {
+      return _getFlakyPixelMatchingArguments();
+    } else {
+      return _getNormalPixelMatchingArguments();
+    }
+  }
+
+  List<String> _getFlakyPixelMatchingArguments() {
+    // The algorithm to be used when matching images. The available options are:
+    // - "fuzzy": Allows for customizing the thresholds of pixel differences.
+    // - "sobel": Same as "fuzzy" but performs edge detection before performing
+    //            a fuzzy match.
+    const String algorithm = 'fuzzy';
+
+    // The number of pixels in this image that are allowed to differ from the
+    // baseline.
+    //
+    // The chosen number - 1 billion - indicates that a flaky test should pass
+    // no matter how many pixels are different from the master golden.
+    const int maxDifferentPixels = 1000 * 1000 * 1000;
+
+    // The maximum acceptable difference per pixel.
+    //
+    // The chosen number - 1020 - is the maximum supported pixel delta and
+    // indicates that a flaky test should pass no matter how far the new pixels
+    // deviate from the master golden.
+    const int pixelDeltaThreshold = 1020;
+
+    return <String>[
+      '--add-test-optional-key', 'image_matching_algorithm:$algorithm',
+      '--add-test-optional-key', 'fuzzy_max_different_pixels:$maxDifferentPixels',
+      '--add-test-optional-key', 'fuzzy_pixel_delta_threshold:$pixelDeltaThreshold',
+    ];
+  }
+
   // Constructs arguments for `goldctl` for controlling how pixels are compared.
   //
   // For AOT and CanvasKit exact pixel matching is used. For the HTML renderer
@@ -369,7 +405,7 @@ class SkiaGoldClient {
   // because Chromium cannot exactly reproduce the same golden on all computers.
   // It seems to depend on the hardware/OS/driver combination. However, those
   // differences are very small (typically not noticeable to human eye).
-  List<String> _getPixelMatchingArguments() {
+  List<String> _getNormalPixelMatchingArguments() {
     // Only use fuzzy pixel matching in the HTML renderer.
     if (!_isBrowserTest || _isBrowserCanvasKitTest) {
       return const <String>[];

--- a/packages/flutter_test/lib/src/_goldens_web.dart
+++ b/packages/flutter_test/lib/src/_goldens_web.dart
@@ -41,12 +41,12 @@ Future<ComparisonResult> compareLists(List<int> test, List<int> master) async {
 ///   * [matchesGoldenFile], the function from [flutter_test] that invokes the
 ///    comparator.
 class DefaultWebGoldenComparator extends WebGoldenComparator {
-  /// Creates a new [DefaultWebGoldenComparator] for the specified [testFile].
+  /// Creates a new [DefaultWebGoldenComparator] for the specified [testUri].
   ///
   /// Golden file keys will be interpreted as file paths relative to the
-  /// directory in which [testFile] resides.
+  /// directory in which [testUri] resides.
   ///
-  /// The [testFile] URL must represent a file.
+  /// The [testUri] URL must represent a file.
   DefaultWebGoldenComparator(this.testUri);
 
   /// The test file currently being executed.

--- a/packages/flutter_test/lib/src/goldens.dart
+++ b/packages/flutter_test/lib/src/goldens.dart
@@ -238,6 +238,14 @@ set webGoldenComparator(WebGoldenComparator value) {
   _webGoldenComparator = value;
 }
 
+/// The URI of the test file currently being executed.
+///
+/// This variable is populated by the Flutter Tool automatically.
+///
+/// Golden file keys will be interpreted as file paths relative to the directory
+/// in which this file resides.
+late Uri webTestUri;
+
 /// Whether golden files should be automatically updated during tests rather
 /// than compared to the image bytes recorded by the tests.
 ///

--- a/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
@@ -98,14 +98,14 @@ class TestGoldenComparator {
     return _processManager!.start(command, environment: environment);
   }
 
-  Future<String?> compareGoldens(Uri testUri, Uint8List bytes, Uri goldenKey, bool? updateGoldens) async {
+  Future<String?> compareGoldens(Uri testUri, Uint8List bytes, Uri goldenKey, bool? updateGoldens, Map<String, dynamic>? customProperties) async {
     final File imageFile = await (await tempDir.createTemp('image')).childFile('image').writeAsBytes(bytes);
     final TestGoldenComparatorProcess? process = await _processForTestFile(testUri);
     if (process == null) {
       return 'process was null';
     }
 
-    process.sendCommand(imageFile, goldenKey, updateGoldens);
+    process.sendCommand(imageFile, goldenKey, updateGoldens, customProperties);
 
     final Map<String, dynamic> result = await process.getResponse();
 
@@ -152,11 +152,13 @@ class TestGoldenComparatorProcess {
     await process.exitCode;
   }
 
-  void sendCommand(File imageFile, Uri? goldenKey, bool? updateGoldens) {
+  void sendCommand(File imageFile, Uri? goldenKey, bool? updateGoldens, Map<String, dynamic>? customProperties) {
     final Object command = jsonEncode(<String, dynamic>{
       'imageFile': imageFile.path,
       'key': goldenKey.toString(),
       'update': updateGoldens,
+      if (customProperties != null)
+        'customProperties': customProperties,
     });
     _logger.printTrace('Preparing to send command: $command');
     process.stdin.writeln(command);
@@ -168,7 +170,22 @@ class TestGoldenComparatorProcess {
     return streamIterator.current;
   }
 
+  /// Generates the source code for the comparator process for the test file.
+  ///
+  /// If a test configuation exists for the tested package, uses its
+  /// implementation. Otherwise, uses the default implementation.
   static String generateBootstrap(File testFile, Uri testUri, {required Logger logger}) {
+    final File? webTestConfigFile = findWebTestConfigFile(testFile, logger);
+    if (webTestConfigFile != null) {
+      return _generateBootstrapWithWebTestConfig(webTestConfigFile, testFile, testUri);
+    } else {
+      return _generateBasicBootstrap(testFile, testUri, logger: logger);
+    }
+  }
+
+  // Generates the bootstrap used by tests that either don't have a test
+  // configuration file, or don't have a `flutter_web_test_config.dart`.
+  static String _generateBasicBootstrap(File testFile, Uri testUri, {required Logger logger}) {
     final File? testConfigFile = findTestConfigFile(testFile, logger);
     // Generate comparator process for the file.
     return '''
@@ -211,6 +228,19 @@ void main() async {
     }
   }
   ${testConfigFile != null ? '});' : ''}
+}
+    ''';
+  }
+
+  // Generates the bootstrap used by tests that have a `flutter_web_test_config.dart`.
+  static String _generateBootstrapWithWebTestConfig(File webTestConfigFile, File testFile, Uri testUri) {
+    return '''
+import 'package:flutter_test/flutter_test.dart';
+import '${Uri.file(webTestConfigFile.path)}' as web_test_config;
+void main() async {
+  final String testUri = '$testUri';
+  goldenFileComparator = LocalFileComparator(Uri.parse(testUri));
+  await web_test_config.startWebTestHostConfiguration(testUri);
 }
     ''';
   }

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -343,10 +343,9 @@ class FlutterWebPlatform extends PlatformPlugin {
   }
 
   Future<shelf.Response> _goldenFileHandler(shelf.Request request) async {
-    if (request.url.path.contains('flutter_goldens')) {
-      final Map<String, Object?> body = json.decode(await request.readAsString()) as Map<String, Object?>;
-      final Uri goldenKey = Uri.parse(body['key']! as String);
-      final Uri testUri = Uri.parse(body['testUri']! as String);
+    if (request.method == 'POST' && request.url.path.contains('flutter_goldens')) {
+      final String requestJson = await request.readAsString();
+      final Map<String, Object?> body = json.decode(requestJson) as Map<String, Object?>;
       final num width = body['width']! as num;
       final num height = body['height']! as num;
       Uint8List bytes;
@@ -383,7 +382,10 @@ class FlutterWebPlatform extends PlatformPlugin {
         return shelf.Response.ok('Unknown error, bytes is null');
       }
 
-      final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens);
+      final Uri goldenKey = Uri.parse(body['key']! as String);
+      final Uri testUri = Uri.parse(body['testUri']! as String);
+      final Map<String, dynamic>? customProperties = body['customProperties'] as Map<String, dynamic>?;
+      final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens, customProperties);
       return shelf.Response.ok(errorMessage ?? 'true');
     } else {
       return shelf.Response.notFound('Not Found');

--- a/packages/flutter_tools/lib/src/test/test_config.dart
+++ b/packages/flutter_tools/lib/src/test/test_config.dart
@@ -9,23 +9,36 @@ import '../base/logger.dart';
 /// test harness if it exists in the project directory hierarchy.
 const String _kTestConfigFileName = 'flutter_test_config.dart';
 
+/// The name of the web test configuration file that will be discovered by the
+/// test harness if it exists in the project directory hierarchy.
+const String _kWebTestConfigFileName = 'flutter_web_test_config.dart';
+
 /// The name of the file that signals the root of the project and that will
 /// cause the test harness to stop scanning for configuration files.
 const String _kProjectRootSentinel = 'pubspec.yaml';
 
 /// Find the `flutter_test_config.dart` file for a specific test file.
 File? findTestConfigFile(File testFile, Logger logger) {
+  return _findConfigFile(testFile, _kTestConfigFileName, logger);
+}
+
+/// Find the `flutter_web_test_config.dart` file for a specific test file.
+File? findWebTestConfigFile(File testFile, Logger logger) {
+  return _findConfigFile(testFile, _kWebTestConfigFileName, logger);
+}
+
+File? _findConfigFile(File testFile, String configFileName, Logger logger) {
   File? testConfigFile;
   Directory directory = testFile.parent;
   while (directory.path != directory.parent.path) {
-    final File configFile = directory.childFile(_kTestConfigFileName);
+    final File configFile = directory.childFile(configFileName);
     if (configFile.existsSync()) {
-      logger.printTrace('Discovered $_kTestConfigFileName in ${directory.path}');
+      logger.printTrace('Discovered $configFileName in ${directory.path}');
       testConfigFile = configFile;
       break;
     }
     if (directory.childFile(_kProjectRootSentinel).existsSync()) {
-      logger.printTrace('Stopping scan for $_kTestConfigFileName; '
+      logger.printTrace('Stopping scan for $configFileName; '
           'found project root at ${directory.path}');
       break;
     }

--- a/packages/flutter_tools/lib/src/web/bootstrap.dart
+++ b/packages/flutter_tools/lib/src/web/bootstrap.dart
@@ -224,7 +224,8 @@ String generateTestEntrypoint({
   Future<void> main() async {
     ui.debugEmulateFlutterTesterEnvironment = true;
     await ui.webOnlyInitializePlatform();
-    webGoldenComparator = DefaultWebGoldenComparator(Uri.parse('${Uri.file(absolutePath)}'));
+    webTestUri = Uri.parse('${Uri.file(absolutePath)}');
+    webGoldenComparator = DefaultWebGoldenComparator(webTestUri);
     (ui.window as dynamic).debugOverrideDevicePixelRatio(3.0);
     (ui.window as dynamic).webOnlyDebugPhysicalSizeOverride = const ui.Size(2400, 1800);
 

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_process_test.dart
@@ -41,7 +41,7 @@ void main() {
       final MemoryIOSink ioSink = mockProcess.stdin as MemoryIOSink;
 
       final TestGoldenComparatorProcess process = TestGoldenComparatorProcess(mockProcess, logger: BufferLogger.test());
-      process.sendCommand(imageFile, goldenKey, false);
+      process.sendCommand(imageFile, goldenKey, false, null);
 
       final Map<String, dynamic> response = await process.getResponse();
       final String stringToStdin = ioSink.getAndClear();
@@ -64,18 +64,21 @@ void main() {
       final MemoryIOSink ioSink = mockProcess.stdin as MemoryIOSink;
 
       final TestGoldenComparatorProcess process = TestGoldenComparatorProcess(mockProcess, logger: BufferLogger.test());
-      process.sendCommand(imageFile, goldenKey, false);
+      process.sendCommand(imageFile, goldenKey, false, null);
 
       final Map<String, dynamic> response1 = await process.getResponse();
 
-      process.sendCommand(imageFile2, goldenKey2, true);
+      process.sendCommand(imageFile2, goldenKey2, true, null);
 
       final Map<String, dynamic> response2 = await process.getResponse();
       final String stringToStdin = ioSink.getAndClear();
 
       expect(response1, expectedResponse1);
       expect(response2, expectedResponse2);
-      expect(stringToStdin, '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n{"imageFile":"second_test_image_file","key":"file://second_golden_key/","update":true}\n');
+      expect(
+        stringToStdin,
+        '{"imageFile":"test_image_file","key":"file://golden_key/","update":false}\n'
+        '{"imageFile":"second_test_image_file","key":"file://second_golden_key/","update":true}\n');
     });
 
     testWithoutContext('ignores anything that does not look like JSON', () async {
@@ -94,7 +97,7 @@ Other JSON data after the initial data
       final MemoryIOSink ioSink = mockProcess.stdin as MemoryIOSink;
 
       final TestGoldenComparatorProcess process = TestGoldenComparatorProcess(mockProcess,logger: BufferLogger.test());
-      process.sendCommand(imageFile, goldenKey, false);
+      process.sendCommand(imageFile, goldenKey, false, null);
 
       final Map<String, dynamic> response = await process.getResponse();
       final String stringToStdin = ioSink.getAndClear();

--- a/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/golden_comparator_test.dart
@@ -61,7 +61,7 @@ void main() {
         webRenderer: WebRendererMode.html,
       );
 
-      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, null);
       expect(result, null);
     });
 
@@ -90,7 +90,7 @@ void main() {
         webRenderer: WebRendererMode.canvaskit,
       );
 
-      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, null);
       expect(result, 'some message');
     });
 
@@ -123,10 +123,10 @@ void main() {
         webRenderer: WebRendererMode.html,
       );
 
-      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, null);
       expect(result1, 'some message');
 
-      final String? result2 = await comparator.compareGoldens(testUri, imageBytes, goldenKey2, false);
+      final String? result2 = await comparator.compareGoldens(testUri, imageBytes, goldenKey2, false, null);
       expect(result2, 'some other message');
     });
 
@@ -168,10 +168,10 @@ void main() {
         webRenderer: WebRendererMode.canvaskit,
       );
 
-      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result1 = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, null);
       expect(result1, 'some message');
 
-      final String? result2 = await comparator.compareGoldens(testUri2, imageBytes, goldenKey2, false);
+      final String? result2 = await comparator.compareGoldens(testUri2, imageBytes, goldenKey2, false, null);
       expect(result2, 'some other message');
     });
 
@@ -203,7 +203,7 @@ void main() {
         webRenderer: WebRendererMode.html,
       );
 
-      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false);
+      final String? result = await comparator.compareGoldens(testUri, imageBytes, goldenKey, false, null);
       expect(result, null);
 
       await comparator.close();


### PR DESCRIPTION
(this is a non-breaking non-API-changing variant of https://github.com/flutter/flutter/pull/111595)

Support marking a golden check as flaky. A flaky check will still generate a golden and report it to the current `GoldenFileComparator`, but it will not fail the test.

## Public API changes

In order to keep the concept of "flaky golden" private to the Flutter repo, the public golden test API was extended in the following non-breaking ways:

* `MatchesGoldenFile` now takes an optional `comparator` argument. This allows the test to instruct the matcher to use a flaky comparator rather than always use the default one (the default API has no notion of "flaky golden").
  * https://github.com/flutter/flutter/pull/113396/files#diff-503cfe6d62ac4cd45c0b021f709e278bc212e3e185027e50dbecae7a4bc3417d
* Introduce `flutter_web_test_config.dart`, an optional sibling to `flutter_test_config.dart`. Because on the web the golden comparator is split into two parts, one that runs in the browser, and on that runs outside the browser, in order to keep the concept of flaky golden private to the Flutter repo, that logic goes into `flutter_web_test_config.dart` rather than being hard-coded into any of the public tool or package code.
  * https://github.com/flutter/flutter/pull/113396/files#diff-331e9cbbfbec535700e20268c037352a820584d2efcd04a7e0099814cb752937

## Private changes

The following changes do not affect the public API:

* The Skia Gold client was updated with new API that submits the golden to Skia Gold with a virtually unlimited failure threshold. The effect is that the test doesn't fail and it does not generate a triage, but it still allows Skia Gold to track generated screenshots over time. When a fix for flakiness lands, it's easy to go Skia Gold UI to confirm it and remove the `isFlaky` argument from the test.
  * https://github.com/flutter/flutter/pull/113396/files#diff-672b414f234faa47812f9af289e8a9d1072d8f0b225c757575a965a27c29bccf
* `package:flutter_goldens` acquired a new function `matchesFlutterGolden` that's similar to `matchesGoldenFile` but supports flaky goldens.
  * https://github.com/flutter/flutter/pull/113396/files#diff-57dd08efb172adaa80f3c0c5f03dd5a8ab9d6bc3025c0a3ed69ff0dd0ffd62feR25
* `package:flutter_goldens` provides a command handler for web tests that implements the `isFlaky` option.
  * https://github.com/flutter/flutter/pull/113396/files#diff-57dd08efb172adaa80f3c0c5f03dd5a8ab9d6bc3025c0a3ed69ff0dd0ffd62feR73
* `package:flutter_goldens` now implements a `testExecutable` for web tests providing flaky functionality (previously the web version was empty).
  * https://github.com/flutter/flutter/pull/113396/files#diff-8fa5d39f0c9a57621d61e4f9618715b392d509032919174103407f33cf5a1082R50

## TODO

- [x] We have a check in the analyzer that ensures every matchesGoldenFile has a Tag at the top of the test file. It should probably be updated to ensure uses of matchesFlutterGolden are accounted for.
- [ ] We'd probably want to migrate all uses of matchesGoldenFile in the framework tests to use this one for consistency, and have the analyzer enforce it.
- [ ] Document the new `flutter_web_test_config.dart` file.
- [ ] Add tests for `isFlaky` and new public API.

Fixes https://github.com/flutter/flutter/issues/111325
