### PR TITLE
Revert "`AutomatedTestWidgetsFlutterBinding.pump` provides wrong pump time stamp, probably because of forgetting the precision"

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -1090,7 +1090,7 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
         addTime(const Duration(milliseconds: 500));
         _currentFakeAsync!.flushMicrotasks();
         handleBeginFrame(Duration(
-          microseconds: _clock!.now().microsecondsSinceEpoch,
+          milliseconds: _clock!.now().millisecondsSinceEpoch,
         ));
         _currentFakeAsync!.flushMicrotasks();
         handleDrawFrame();

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -10,7 +10,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // ignore: deprecated_member_use
@@ -55,18 +55,6 @@ void main() {
     assert(order == 2);
     expect(binding.testTextInput.isRegistered, isFalse);
     order += 1;
-  });
-
-  testWidgets('timeStamp should be accurate', (WidgetTester tester) async {
-    final WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
-
-    await tester.pumpWidget(const CircularProgressIndicator());
-
-    final Duration timeStampBefore = widgetsBinding.currentSystemFrameTimeStamp;
-    await tester.pump(const Duration(microseconds: 12345));
-    final Duration timeStampAfter = widgetsBinding.currentSystemFrameTimeStamp;
-
-    expect(timeStampAfter - timeStampBefore, const Duration(microseconds: 12345));
   });
 
   group('elapseBlocking', () {

--- a/packages/flutter_test/test/widget_tester_test.dart
+++ b/packages/flutter_test/test/widget_tester_test.dart
@@ -170,12 +170,12 @@ void main() {
 
       await tester.pumpFrames(target, const Duration(milliseconds: 55));
 
-      expect(logPaints, <int>[0, 16683, 33366, 50049]);
+      expect(logPaints, <int>[0, 17000, 34000, 50000]);
       logPaints.clear();
 
       await tester.pumpFrames(target, const Duration(milliseconds: 30), const Duration(milliseconds: 10));
 
-      expect(logPaints, <int>[60049, 70049, 80049]);
+      expect(logPaints, <int>[60000, 70000, 80000]);
     });
   });
 


### PR DESCRIPTION
Reverts flutter/flutter#112609. context: this is causing flaky tests in the current roll, and is difficult to get a g3fix in for.