### PR TITLE
Added statesController to the button icon constructors.

### DIFF
--- a/packages/flutter/lib/src/material/elevated_button.dart
+++ b/packages/flutter/lib/src/material/elevated_button.dart
@@ -95,6 +95,7 @@ class ElevatedButton extends ButtonStyleButton {
     FocusNode? focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    MaterialStatesController? statesController,
     required Widget icon,
     required Widget label,
   }) = _ElevatedButtonWithIcon;
@@ -482,6 +483,7 @@ class _ElevatedButtonWithIcon extends ElevatedButton {
     super.focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    super.statesController,
     required Widget icon,
     required Widget label,
   }) : assert(icon != null),

--- a/packages/flutter/lib/src/material/filled_button.dart
+++ b/packages/flutter/lib/src/material/filled_button.dart
@@ -96,6 +96,7 @@ class FilledButton extends ButtonStyleButton {
     FocusNode? focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    MaterialStatesController? statesController,
     required Widget icon,
     required Widget label,
   }) = _FilledButtonWithIcon;
@@ -138,6 +139,7 @@ class FilledButton extends ButtonStyleButton {
     FocusNode? focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    MaterialStatesController? statesController,
     required Widget icon,
     required Widget label,
   }) {
@@ -151,6 +153,7 @@ class FilledButton extends ButtonStyleButton {
       focusNode: focusNode,
       autofocus: autofocus,
       clipBehavior: clipBehavior,
+      statesController: statesController,
       icon: icon,
       label: label,
     );
@@ -430,6 +433,7 @@ class _FilledButtonWithIcon extends FilledButton {
     super.focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    super.statesController,
     required Widget icon,
     required Widget label,
   }) : assert(icon != null),
@@ -450,6 +454,7 @@ class _FilledButtonWithIcon extends FilledButton {
     super.focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    super.statesController,
     required Widget icon,
     required Widget label,
   }) : assert(icon != null),

--- a/packages/flutter/lib/src/material/outlined_button.dart
+++ b/packages/flutter/lib/src/material/outlined_button.dart
@@ -98,6 +98,7 @@ class OutlinedButton extends ButtonStyleButton {
     FocusNode? focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    MaterialStatesController? statesController,
     required Widget icon,
     required Widget label,
   }) = _OutlinedButtonWithIcon;
@@ -413,6 +414,7 @@ class _OutlinedButtonWithIcon extends OutlinedButton {
     super.focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    super.statesController,
     required Widget icon,
     required Widget label,
   }) : assert(icon != null),

--- a/packages/flutter/lib/src/material/text_button.dart
+++ b/packages/flutter/lib/src/material/text_button.dart
@@ -107,6 +107,7 @@ class TextButton extends ButtonStyleButton {
     FocusNode? focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    MaterialStatesController? statesController,
     required Widget icon,
     required Widget label,
   }) = _TextButtonWithIcon;
@@ -448,6 +449,7 @@ class _TextButtonWithIcon extends TextButton {
     super.focusNode,
     bool? autofocus,
     Clip? clipBehavior,
+    super.statesController,
     required Widget icon,
     required Widget label,
   }) : assert(icon != null),

--- a/packages/flutter/test/material/elevated_button_test.dart
+++ b/packages/flutter/test/material/elevated_button_test.dart
@@ -1624,7 +1624,7 @@ void main() {
     expect(material.textStyle!.color, Colors.white);
   });
 
-  testWidgets('ElevatedButton statesController', (WidgetTester tester) async {
+  Future<void> testStatesController(Widget? icon, WidgetTester tester) async {
     int count = 0;
     void valueChanged() {
       count += 1;
@@ -1635,11 +1635,18 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: ElevatedButton(
-            statesController: controller,
-            onPressed: () { },
-            child: const Text('button'),
-          ),
+          child: icon == null
+            ? ElevatedButton(
+                statesController: controller,
+                onPressed: () { },
+                child: const Text('button'),
+              )
+            : ElevatedButton.icon(
+                statesController: controller,
+                onPressed: () { },
+                icon: icon,
+                label: const Text('button'),
+              ),
         ),
       ),
     );
@@ -1647,7 +1654,7 @@ void main() {
     expect(controller.value, <MaterialState>{});
     expect(count, 0);
 
-    final Offset center = tester.getCenter(find.byType(ElevatedButton));
+    final Offset center = tester.getCenter(find.byType(Text));
     final TestGesture gesture = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
     );
@@ -1698,11 +1705,18 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: ElevatedButton(
-            statesController: controller,
-            onPressed: null,
-            child: const Text('button'),
-          ),
+        child: icon == null
+          ? ElevatedButton(
+              statesController: controller,
+              onPressed: null,
+              child: const Text('button'),
+            )
+          : ElevatedButton.icon(
+              statesController: controller,
+              onPressed: null,
+              icon: icon,
+              label: const Text('button'),
+            ),
         ),
       ),
     );
@@ -1714,6 +1728,14 @@ void main() {
     expect(controller.value, <MaterialState>{MaterialState.disabled});
     expect(count, 11);
     await gesture.removePointer();
+  }
+
+  testWidgets('ElevatedButton statesController', (WidgetTester tester) async {
+    testStatesController(null, tester);
+  });
+
+  testWidgets('ElevatedButton.icon statesController', (WidgetTester tester) async {
+    testStatesController(const Icon(Icons.add), tester);
   });
 
   testWidgets('Disabled ElevatedButton statesController', (WidgetTester tester) async {

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2014 The Flutter Authors. All rights reserved.
+  // Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -1628,7 +1628,7 @@ void main() {
     expect(material.textStyle!.color, Colors.white);
   });
 
-  testWidgets('FilledButton statesController', (WidgetTester tester) async {
+  Future<void> testStatesController(Widget? icon, WidgetTester tester) async {
     int count = 0;
     void valueChanged() {
       count += 1;
@@ -1639,11 +1639,18 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: FilledButton(
-            statesController: controller,
-            onPressed: () { },
-            child: const Text('button'),
-          ),
+          child: icon == null
+            ? FilledButton(
+                statesController: controller,
+                onPressed: () { },
+                child: const Text('button'),
+              )
+            : FilledButton.icon(
+                statesController: controller,
+                onPressed: () { },
+                icon: icon,
+                label: const Text('button'),
+              ),
         ),
       ),
     );
@@ -1651,7 +1658,7 @@ void main() {
     expect(controller.value, <MaterialState>{});
     expect(count, 0);
 
-    final Offset center = tester.getCenter(find.byType(FilledButton));
+    final Offset center = tester.getCenter(find.byType(Text));
     final TestGesture gesture = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
     );
@@ -1702,11 +1709,18 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: FilledButton(
-            statesController: controller,
-            onPressed: null,
-            child: const Text('button'),
-          ),
+        child: icon == null
+          ? FilledButton(
+              statesController: controller,
+              onPressed: null,
+              child: const Text('button'),
+            )
+          : FilledButton.icon(
+              statesController: controller,
+              onPressed: null,
+              icon: icon,
+              label: const Text('button'),
+            ),
         ),
       ),
     );
@@ -1718,6 +1732,14 @@ void main() {
     expect(controller.value, <MaterialState>{MaterialState.disabled});
     expect(count, 11);
     await gesture.removePointer();
+  }
+
+  testWidgets('FilledButton statesController', (WidgetTester tester) async {
+    testStatesController(null, tester);
+  });
+
+  testWidgets('FilledButton.icon statesController', (WidgetTester tester) async {
+    testStatesController(const Icon(Icons.add), tester);
   });
 
   testWidgets('Disabled FilledButton statesController', (WidgetTester tester) async {

--- a/packages/flutter/test/material/filled_button_test.dart
+++ b/packages/flutter/test/material/filled_button_test.dart
@@ -1,4 +1,4 @@
-  // Copyright 2014 The Flutter Authors. All rights reserved.
+// Copyright 2014 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/flutter/test/material/outlined_button_test.dart
+++ b/packages/flutter/test/material/outlined_button_test.dart
@@ -1742,7 +1742,7 @@ void main() {
     expect(material.textStyle!.color, Colors.white);
   });
 
-  testWidgets('OutlinedButton statesController', (WidgetTester tester) async {
+  Future<void> testStatesController(Widget? icon, WidgetTester tester) async {
     int count = 0;
     void valueChanged() {
       count += 1;
@@ -1753,11 +1753,18 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: OutlinedButton(
-            statesController: controller,
-            onPressed: () { },
-            child: const Text('button'),
-          ),
+          child: icon == null
+            ? OutlinedButton(
+                statesController: controller,
+                onPressed: () { },
+                child: const Text('button'),
+              )
+            : OutlinedButton.icon(
+                statesController: controller,
+                onPressed: () { },
+                icon: icon,
+                label: const Text('button'),
+              ),
         ),
       ),
     );
@@ -1765,7 +1772,7 @@ void main() {
     expect(controller.value, <MaterialState>{});
     expect(count, 0);
 
-    final Offset center = tester.getCenter(find.byType(OutlinedButton));
+    final Offset center = tester.getCenter(find.byType(Text));
     final TestGesture gesture = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
     );
@@ -1816,24 +1823,37 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: OutlinedButton(
-            statesController: controller,
-            onPressed: null,
-            child: const Text('button'),
-          ),
+        child: icon == null
+          ? OutlinedButton(
+              statesController: controller,
+              onPressed: null,
+              child: const Text('button'),
+            )
+          : OutlinedButton.icon(
+              statesController: controller,
+              onPressed: null,
+              icon: icon,
+              label: const Text('button'),
+            ),
         ),
       ),
     );
     await tester.pumpAndSettle();
     expect(controller.value, <MaterialState>{MaterialState.hovered, MaterialState.disabled});
     expect(count, 10); // removes pressed and adds disabled - two changes
-
     await gesture.moveTo(Offset.zero);
     await tester.pumpAndSettle();
     expect(controller.value, <MaterialState>{MaterialState.disabled});
     expect(count, 11);
-
     await gesture.removePointer();
+  }
+
+  testWidgets('OutlinedButton statesController', (WidgetTester tester) async {
+    testStatesController(null, tester);
+  });
+
+  testWidgets('OutlinedButton.icon statesController', (WidgetTester tester) async {
+    testStatesController(const Icon(Icons.add), tester);
   });
 
   testWidgets('Disabled OutlinedButton statesController', (WidgetTester tester) async {

--- a/packages/flutter/test/material/text_button_test.dart
+++ b/packages/flutter/test/material/text_button_test.dart
@@ -1549,7 +1549,7 @@ void main() {
     expect(material.textStyle!.color, Colors.white);
   });
 
-  testWidgets('TextButton statesController', (WidgetTester tester) async {
+  Future<void> testStatesController(Widget? icon, WidgetTester tester) async {
     int count = 0;
     void valueChanged() {
       count += 1;
@@ -1560,11 +1560,18 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: TextButton(
-            statesController: controller,
-            onPressed: () { },
-            child: const Text('button'),
-          ),
+          child: icon == null
+            ? TextButton(
+                statesController: controller,
+                onPressed: () { },
+                child: const Text('button'),
+              )
+            : TextButton.icon(
+                statesController: controller,
+                onPressed: () { },
+                icon: icon,
+                label: const Text('button'),
+              ),
         ),
       ),
     );
@@ -1572,7 +1579,7 @@ void main() {
     expect(controller.value, <MaterialState>{});
     expect(count, 0);
 
-    final Offset center = tester.getCenter(find.byType(TextButton));
+    final Offset center = tester.getCenter(find.byType(Text));
     final TestGesture gesture = await tester.createGesture(
       kind: PointerDeviceKind.mouse,
     );
@@ -1623,24 +1630,37 @@ void main() {
     await tester.pumpWidget(
       MaterialApp(
         home: Center(
-          child: TextButton(
-            statesController: controller,
-            onPressed: null,
-            child: const Text('button'),
-          ),
+        child: icon == null
+          ? TextButton(
+              statesController: controller,
+              onPressed: null,
+              child: const Text('button'),
+            )
+          : TextButton.icon(
+              statesController: controller,
+              onPressed: null,
+              icon: icon,
+              label: const Text('button'),
+            ),
         ),
       ),
     );
     await tester.pumpAndSettle();
     expect(controller.value, <MaterialState>{MaterialState.hovered, MaterialState.disabled});
     expect(count, 10); // removes pressed and adds disabled - two changes
-
     await gesture.moveTo(Offset.zero);
     await tester.pumpAndSettle();
     expect(controller.value, <MaterialState>{MaterialState.disabled});
     expect(count, 11);
-
     await gesture.removePointer();
+  }
+
+  testWidgets('TextButton statesController', (WidgetTester tester) async {
+    testStatesController(null, tester);
+  });
+
+  testWidgets('TextButton.icon statesController', (WidgetTester tester) async {
+    testStatesController(const Icon(Icons.add), tester);
   });
 
   testWidgets('Disabled TextButton statesController', (WidgetTester tester) async {


### PR DESCRIPTION
#103167 added `statesController` as an argument to the *Button constructors. However, the *Button.icon constructors should also provide this parameter. This PR adds `statesController` to all the button constructors that were missed in the original PR.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
