### PR TITLE
[ci.yaml] Increase docs targets to use 32 cores

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -257,6 +257,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cores: "32"
       dependencies: >-
         [
           {"dependency": "dashing", "version": "0.4.0"},
@@ -273,6 +274,7 @@ targets:
     recipe: flutter/flutter
     timeout: 60
     properties:
+      cores: "32"
       dependencies: >-
         [
           {"dependency": "dashing", "version": "0.4.0"}


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/113451

Per the issue, this work would benefit from having more cores. We can reuse the existing 32 core machines that are used in the engine.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
