### PR TITLE
Allow disable report timing in profile build since it takes not-negligible amount of time

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -231,26 +231,20 @@ class PerformanceModeRequestHandle {
 ///   priority and are executed in priority order according to a
 ///   [schedulingStrategy].
 mixin SchedulerBinding on BindingBase {
-  /// Override [_enableProfileFrame] in debug mode.
+  /// Whether to report timings in non-release mode.
+  ///
+  /// Report timings takes measureable time in low-end devices, which makes
+  /// profile mode slower than release mode measureably. Therefore, if you
+  /// want to have more realistic data, set this to false.
   @visibleForTesting
-  static bool? debugOverrideEnableProfileFrame;
-
-  /// Whether to send frame events to DevTool
-  static bool get _enableProfileFrame {
-    bool? override;
-    assert(() {
-      override = debugOverrideEnableProfileFrame;
-      return true;
-    }());
-    return override ?? const bool.fromEnvironment('FLUTTER_PROFILE_FRAME', defaultValue: true);
-  }
+  static bool enableProfileFrame = true;
 
   @override
   void initInstances() {
     super.initInstances();
     _instance = this;
 
-    if (!kReleaseMode && _enableProfileFrame) {
+    if (!kReleaseMode && enableProfileFrame) {
       addTimingsCallback((List<FrameTiming> timings) {
         timings.forEach(_profileFramePostEvent);
       });

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -231,12 +231,26 @@ class PerformanceModeRequestHandle {
 ///   priority and are executed in priority order according to a
 ///   [schedulingStrategy].
 mixin SchedulerBinding on BindingBase {
+  /// Override [_enableProfileFrame] in debug mode.
+  @visibleForTesting
+  bool? debugOverrideEnableProfileFrame;
+
+  /// Whether to send frame events to DevTool
+  bool get _enableProfileFrame {
+    bool? override;
+    assert(() {
+      override = debugOverrideEnableProfileFrame;
+      return true;
+    }());
+    return override ?? const bool.fromEnvironment('FLUTTER_PROFILE_FRAME', defaultValue: true);
+  }
+
   @override
   void initInstances() {
     super.initInstances();
     _instance = this;
 
-    if (!kReleaseMode) {
+    if (!kReleaseMode && _enableProfileFrame) {
       addTimingsCallback((List<FrameTiming> timings) {
         timings.forEach(_profileFramePostEvent);
       });

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -233,10 +233,10 @@ class PerformanceModeRequestHandle {
 mixin SchedulerBinding on BindingBase {
   /// Override [_enableProfileFrame] in debug mode.
   @visibleForTesting
-  bool? debugOverrideEnableProfileFrame;
+  static bool? debugOverrideEnableProfileFrame;
 
   /// Whether to send frame events to DevTool
-  bool get _enableProfileFrame {
+  static bool get _enableProfileFrame {
     bool? override;
     assert(() {
       override = debugOverrideEnableProfileFrame;

--- a/packages/flutter/test/scheduler/binding_enable_profile_frame_test.dart
+++ b/packages/flutter/test/scheduler/binding_enable_profile_frame_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  SchedulerBinding.debugOverrideEnableProfileFrame = false;
+  SchedulerBinding.enableProfileFrame = false;
   final _TestWidgetsFlutterBinding binding = _TestWidgetsFlutterBinding();
 
   // this test must be in a separate file, because it tests

--- a/packages/flutter/test/scheduler/binding_enable_profile_frame_test.dart
+++ b/packages/flutter/test/scheduler/binding_enable_profile_frame_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  SchedulerBinding.debugOverrideEnableProfileFrame = false;
+  final _TestWidgetsFlutterBinding binding = _TestWidgetsFlutterBinding();
+
+  // this test must be in a separate file, because it tests
+  // binding initialization
+  testWidgets('when enableProfileFrame is false, should not post events', (WidgetTester tester) async {
+    await tester.pumpWidget(const CircularProgressIndicator());
+    for (int i = 0; i < 20; ++i) {
+      await tester.pump();
+    }
+
+    expect(binding.postEventCount, 0, reason: 'when not EnableProfileFrame, should not post event');
+  });
+}
+
+class _TestWidgetsFlutterBinding extends AutomatedTestWidgetsFlutterBinding {
+  int postEventCount = 0;
+
+  @protected
+  @override
+  void postEvent(String eventKind, Map<String, dynamic> eventData) {
+    postEventCount++;
+  }
+}

--- a/packages/flutter/test/scheduler/binding_enable_profile_frame_test.dart
+++ b/packages/flutter/test/scheduler/binding_enable_profile_frame_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Flutter [does say](https://api.flutter.dev/flutter/dart-ui/PlatformDispatcher/onReportTimings.html) the time cost is "less than 0.1ms every 1 second to report the timings measured on iPhone6S". However, not every mobile phone is as high-end as iPhone6S. For example, on my testing device (TRT-AL00, indeed not the lowest-end device!), I measured that it takes about 20-30ms per second. Then we have a problem. When having https://github.com/fzyzcjy/flutter_smooth, we know a big janky frame (say, takes 200ms) will never let user really feel janky, but instead user will see the app being 60FPS smooth. However, this is based on the assumption that misc work such as report timings should not block the UI thread for a continuous period of time - which is not true if report timings happens. After the 200ms janky frame, we see about 6ms of report timing. Among with other things such as dispatch touch events, they easily take up more than ~16ms and we get one jank. Then flutter_smooth is no longer smooth due to the jank.

Except for the case of flutter_smooth, IMHO this PR is also useful for normal Flutter users. It takes 2-3% of CPU time, which is not negligible and may be measured. In addition, this is not a critical feature. Surely, when this is disabled, the DevTool will not show the frame ui/rasterizer time at all. However, not everyone needs to read that timing data, since they may either do not open DevTool, or use the tracing timeline instead (which contains more than enough information to know the frame timing data). Therefore, it looks reasonable to at least give users a *chance* (i.e. a flag) to disable it.

The code is deliberately written by reading a const bool environment variable. Therefore, it has completely zero overhead. I have confirmed that by using compiler explorer before - https://discordapp.com/channels/608014603317936148/608021234516754444/1024141682377236500.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
