### PR TITLE
[Android] Fix spell check integration test guarded function conflict

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2104,6 +2104,7 @@ targets:
       task_name: routing_test
 
   - name: Linux_android spell_check_test
+    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2104,7 +2104,6 @@ targets:
       task_name: routing_test
 
   - name: Linux_android spell_check_test
-    bringup: true # TESTING PURPOSES ONLY
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/dev/integration_tests/spell_check/integration_test/integration_test.dart
+++ b/dev/integration_tests/spell_check/integration_test/integration_test.dart
@@ -12,37 +12,6 @@ import 'package:spell_check/main.dart';
 late DefaultSpellCheckService defaultSpellCheckService;
 late Locale locale;
 
-/// Waits to find [EditableText] that displays text with misspelled
-/// words marked the same as the [TextSpan] provided and returns
-/// true if it is found before timing out at 20 seconds.
-Future<bool> findTextSpanTree(
-  WidgetTester tester,
-  TextSpan inlineSpan,
-) async {
-  final RenderObject root = tester.renderObject(find.byType(EditableText));
-  expect(root, isNotNull);
-
-  RenderEditable? renderEditable;
-  void recursiveFinder(RenderObject child) {
-    if (child is RenderEditable && child.text == inlineSpan) {
-      renderEditable = child;
-      return;
-    }
-    child.visitChildren(recursiveFinder);
-  }
-
-  final DateTime endTime = tester.binding.clock.now().add(const Duration(seconds: 20));
-  do {
-    if (tester.binding.clock.now().isAfter(endTime)) {
-      return false;
-    }
-    await tester.pump(const Duration(seconds: 1));
-    root.visitChildren(recursiveFinder);
-  } while (renderEditable == null);
-
-  return true;
-}
-
 Future<void> main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -171,6 +140,34 @@ Future<void> main() async {
         TextSpan(style: misspelledTextStyle, text: 'qocnakoef'),
         TextSpan(style: style, text: '! Hey!'),
     ]);
+
+    Future<bool> findTextSpanTree(
+      WidgetTester tester,
+      TextSpan inlineSpan,
+    ) async {
+      final RenderObject root = tester.renderObject(find.byType(EditableText));
+      expect(root, isNotNull);
+
+      RenderEditable? renderEditable;
+      void recursiveFinder(RenderObject child) {
+        if (child is RenderEditable && child.text == inlineSpan) {
+          renderEditable = child;
+          return;
+        }
+        child.visitChildren(recursiveFinder);
+      }
+
+      final DateTime endTime = tester.binding.clock.now().add(const Duration(seconds: 20));
+      do {
+        if (tester.binding.clock.now().isAfter(endTime)) {
+          return false;
+        }
+        await tester.pump(const Duration(seconds: 1));
+        root.visitChildren(recursiveFinder);
+      } while (renderEditable == null);
+
+      return true;
+    }
 
     final bool expectedTextSpanTreeFound = await findTextSpanTree(tester, expectedTextSpanTree);
 

--- a/dev/integration_tests/spell_check/integration_test/integration_test.dart
+++ b/dev/integration_tests/spell_check/integration_test/integration_test.dart
@@ -12,7 +12,39 @@ import 'package:spell_check/main.dart';
 late DefaultSpellCheckService defaultSpellCheckService;
 late Locale locale;
 
-Future<void> main() async {
+/// Waits to find [EditableText] that displays text with misspelled
+/// words marked the same as the [TextSpan] provided and returns
+/// true if it is found before timing out at 20 seconds.
+Future<bool> findTextSpanTree(
+  WidgetTester tester,
+  TextSpan inlineSpan,
+) async {
+  final RenderObject root = tester.renderObject(find.byType(EditableText));
+  expect(root, isNotNull);
+
+  RenderEditable? renderEditable;
+  void recursiveFinder(RenderObject child) {
+    if (child is RenderEditable && child.text == inlineSpan) {
+      renderEditable = child;
+      return;
+    }
+    child.visitChildren(recursiveFinder);
+  }
+
+  final DateTime endTime = tester.binding.clock.now().add(const Duration(seconds: 20));
+  do {
+    if (tester.binding.clock.now().isAfter(endTime)) {
+      return false;
+    }
+    await tester.pump(const Duration(seconds: 1));
+    root.visitChildren(recursiveFinder);
+  } while (renderEditable == null);
+
+  return true;
+}
+
+// Future<void> main() async {
+  void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
@@ -129,45 +161,17 @@ Future<void> main() async {
 
     await tester.pumpWidget(const MyApp());
 
-    await tester.enterText(find.byType(EditableText), 'Hey cfabiueq qocnakoef! Hey!');
+    await tester.enterText(find.byType(EditableText), 'Hey cfabdiuetq qocsnakoef! Hey!');
 
     const TextSpan expectedTextSpanTree = TextSpan(
       style: style,
       children: <TextSpan>[
         TextSpan(style: style, text: 'Hey '),
-        TextSpan(style: misspelledTextStyle, text: 'cfabiueq'),
+        TextSpan(style: misspelledTextStyle, text: 'cfabdiuetq'),
         TextSpan(style: style, text: ' '),
-        TextSpan(style: misspelledTextStyle, text: 'qocnakoef'),
+        TextSpan(style: misspelledTextStyle, text: 'qocsnakoef'),
         TextSpan(style: style, text: '! Hey!'),
     ]);
-
-    Future<bool> findTextSpanTree(
-      WidgetTester tester,
-      TextSpan inlineSpan,
-    ) async {
-      final RenderObject root = tester.renderObject(find.byType(EditableText));
-      expect(root, isNotNull);
-
-      RenderEditable? renderEditable;
-      void recursiveFinder(RenderObject child) {
-        if (child is RenderEditable && child.text == inlineSpan) {
-          renderEditable = child;
-          return;
-        }
-        child.visitChildren(recursiveFinder);
-      }
-
-      final DateTime endTime = tester.binding.clock.now().add(const Duration(seconds: 20));
-      do {
-        if (tester.binding.clock.now().isAfter(endTime)) {
-          return false;
-        }
-        await tester.pump(const Duration(seconds: 1));
-        root.visitChildren(recursiveFinder);
-      } while (renderEditable == null);
-
-      return true;
-    }
 
     final bool expectedTextSpanTreeFound = await findTextSpanTree(tester, expectedTextSpanTree);
 

--- a/dev/integration_tests/spell_check/integration_test/integration_test.dart
+++ b/dev/integration_tests/spell_check/integration_test/integration_test.dart
@@ -43,8 +43,7 @@ Future<bool> findTextSpanTree(
   return true;
 }
 
-// Future<void> main() async {
-  void main() {
+void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() {
@@ -161,15 +160,15 @@ Future<bool> findTextSpanTree(
 
     await tester.pumpWidget(const MyApp());
 
-    await tester.enterText(find.byType(EditableText), 'Hey cfabdiuetq qocsnakoef! Hey!');
+    await tester.enterText(find.byType(EditableText), 'Hey cfabiueq qocnakoef! Hey!');
 
     const TextSpan expectedTextSpanTree = TextSpan(
       style: style,
       children: <TextSpan>[
         TextSpan(style: style, text: 'Hey '),
-        TextSpan(style: misspelledTextStyle, text: 'cfabdiuetq'),
+        TextSpan(style: misspelledTextStyle, text: 'cfabiueq'),
         TextSpan(style: style, text: ' '),
-        TextSpan(style: misspelledTextStyle, text: 'qocsnakoef'),
+        TextSpan(style: misspelledTextStyle, text: 'qocnakoef'),
         TextSpan(style: style, text: '! Hey!'),
     ]);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/112949 by fixing the guarded function conflict causing the flake.

Also sets `bringup` to false, since it was only set to `true` for testing purposes in https://github.com/flutter/flutter/pull/112109.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
