### PR TITLE
Expose `alwaysShowMiddle` in `CupertinoSliverNavigationBar`

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -586,6 +586,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
     this.leading,
     this.automaticallyImplyLeading = true,
     this.automaticallyImplyTitle = true,
+    this.alwaysShowMiddle = true,
     this.previousPageTitle,
     this.middle,
     this.trailing,
@@ -644,6 +645,14 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   ///
   /// This value cannot be null.
   final bool automaticallyImplyTitle;
+
+  /// Controls whether [middle] widget should always be visible (even in
+  /// expanded state).
+  /// 
+  /// If true (default) and [middle] is not null, [middle] widget is always
+  /// visible. If false, [middle] widget is visible only in collapsed state if
+  /// it is provided.
+  final bool alwaysShowMiddle;
 
   /// {@macro flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
   final String? previousPageTitle;
@@ -742,7 +751,7 @@ class _CupertinoSliverNavigationBarState extends State<CupertinoSliverNavigation
           transitionBetweenRoutes: widget.transitionBetweenRoutes,
           heroTag: widget.heroTag,
           persistentHeight: _kNavBarPersistentHeight + MediaQuery.of(context).padding.top,
-          alwaysShowMiddle: widget.middle != null,
+          alwaysShowMiddle: widget.alwaysShowMiddle && widget.middle != null,
           stretchConfiguration: widget.stretch ? OverScrollHeaderStretchConfiguration() : null,
         ),
       ),

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -648,7 +648,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
 
   /// Controls whether [middle] widget should always be visible (even in
   /// expanded state).
-  /// 
+  ///
   /// If true (default) and [middle] is not null, [middle] widget is always
   /// visible. If false, [middle] widget is visible only in collapsed state if
   /// it is provided.

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -666,7 +666,7 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// This widget is visible in both collapsed and expanded states if
   /// [alwaysShowMiddle] is true, otherwise just in collapsed state. The text
   /// supplied in [largeTitle] will no longer appear in collapsed state if a
-  /// [middle] widget is provided. 
+  /// [middle] widget is provided.
   final Widget? middle;
 
   /// {@macro flutter.cupertino.CupertinoNavigationBar.trailing}

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -652,6 +652,9 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// If true (default) and [middle] is not null, [middle] widget is always
   /// visible. If false, [middle] widget is visible only in collapsed state if
   /// it is provided.
+  ///
+  /// This should be set to false if you only want to show [largeTitle] in
+  /// expanded state and [middle] in collapsed state.
   final bool alwaysShowMiddle;
 
   /// {@macro flutter.cupertino.CupertinoNavigationBar.previousPageTitle}
@@ -660,9 +663,10 @@ class CupertinoSliverNavigationBar extends StatefulWidget {
   /// A widget to place in the middle of the static navigation bar instead of
   /// the [largeTitle].
   ///
-  /// This widget is visible in both collapsed and expanded states. The text
+  /// This widget is visible in both collapsed and expanded states if
+  /// [alwaysShowMiddle] is true, otherwise just in collapsed state. The text
   /// supplied in [largeTitle] will no longer appear in collapsed state if a
-  /// [middle] widget is provided.
+  /// [middle] widget is provided. 
   final Widget? middle;
 
   /// {@macro flutter.cupertino.CupertinoNavigationBar.trailing}

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -532,6 +532,52 @@ void main() {
     );
   });
 
+  testWidgets('User specified middle is only visible when sliver is collapsed if alwaysShowMiddle is false', (WidgetTester tester) async {
+    final ScrollController scrollController = ScrollController();
+    await tester.pumpWidget(
+      CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: CustomScrollView(
+            controller: scrollController,
+            slivers: const <Widget>[
+              CupertinoSliverNavigationBar(
+                largeTitle: Text('Large'),
+                middle: Text('Middle'),
+                alwaysShowMiddle: false,
+              ),
+              SliverToBoxAdapter(
+                child: SizedBox(
+                  height: 1200.0,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(scrollController.offset, 0.0);
+    expect(find.text('Middle'), findsOneWidget);
+
+    // Initially (in expanded state) middle widget is not visible.
+    RenderAnimatedOpacity middleOpacity = tester.element(find.text('Middle')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    expect(middleOpacity.opacity.value, 0.0);
+
+    scrollController.jumpTo(600.0);
+    await tester.pumpAndSettle();
+
+    // Middle widget is visible when nav bar is collapsed.
+    middleOpacity = tester.element(find.text('Middle')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    expect(middleOpacity.opacity.value, 1.0);
+
+    scrollController.jumpTo(0.0);
+    await tester.pumpAndSettle();
+
+    // Middle widget is not visible when nav bar is again expanded.
+    middleOpacity = tester.element(find.text('Middle')).findAncestorRenderObjectOfType<RenderAnimatedOpacity>()!;
+    expect(middleOpacity.opacity.value, 0.0);
+  });
+
   testWidgets('Small title can be overridden', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(


### PR DESCRIPTION
Field `alwaysShowMiddle` has been added to `CupertinoSliverNavigationBar` that controls whether `middle` should always be visible (even if `largeTitle` is provided) or not.

Fixes #113542

[flutter/tests](https://github.com/flutter/tests) repo left intact

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.