### PR TITLE
Check whether slider is mounted before interaction, no-op if unmounted

### DIFF
--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1445,9 +1445,6 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   void _startInteraction(Offset globalPosition) {
-    if (!_state.mounted) {
-      return;
-    }
     _state.showValueIndicator();
     if (!_active && isInteractive) {
       _active = true;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1531,6 +1531,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
 
   @override
   void handleEvent(PointerEvent event, BoxHitTestEntry entry) {
+    if (!_state.mounted) {
+      return;
+    }
     assert(debugHandleEvent(event, entry));
     if (event is PointerDownEvent && isInteractive) {
       // We need to add the drag first so that it has priority.

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1445,6 +1445,7 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   void _startInteraction(Offset globalPosition) {
+    if (!mounted) return;
     _state.showValueIndicator();
     if (!_active && isInteractive) {
       _active = true;

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -1445,7 +1445,9 @@ class _RenderSlider extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   }
 
   void _startInteraction(Offset globalPosition) {
-    if (!mounted) return;
+    if (!_state.mounted) {
+      return;
+    }
     _state.showValueIndicator();
     if (!_active && isInteractive) {
       _active = true;

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -3437,6 +3437,57 @@ void main() {
     );
   }, variant: TargetPlatformVariant.desktop());
 
+  testWidgets('Event on Slider should perform no-op if already unmounted', (WidgetTester tester) async {
+    double value = 0.0;
+    final ValueNotifier<bool> shouldShowSliderListenable = ValueNotifier<bool>(true);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Directionality(
+          textDirection: TextDirection.ltr,
+          child: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Material(
+                child: Center(
+                  child: ValueListenableBuilder<bool>(
+                    valueListenable: shouldShowSliderListenable,
+                    builder: (BuildContext context, bool shouldShowSlider, _) {
+                      return shouldShowSlider ? Slider(
+                      value: value,
+                      onChanged: (double newValue) {
+                        setState(() {
+                          value = newValue;
+                        });
+                      },
+                    ) : const SizedBox.shrink();
+                    },
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final TestGesture gesture = await tester
+          .startGesture(tester.getRect(find.byType(Slider)).centerLeft);
+
+    // Intentioanlly not calling `await tester.pumpAndSettle()` to allow drag
+    // event performed on `Slider` before it is about to get unmounted.
+    shouldShowSliderListenable.value = false;
+
+    await tester.drag(find.byType(Slider), const Offset(1.0, 0.0));
+    await tester.pumpAndSettle();
+
+    expect(value, equals(0.0));
+
+    // This is supposed to trigger animation on `Slider` if it is mounted.
+    await gesture.up();
+
+    await tester.pumpAndSettle();
+  });
+
   group('Material 2', () {
     // Tests that are only relevant for Material 2. Once ThemeData.useMaterial3
     // is turned on by default, these tests can be removed.

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -3437,9 +3437,12 @@ void main() {
     );
   }, variant: TargetPlatformVariant.desktop());
 
-  testWidgets('Event on Slider should perform no-op if already unmounted', (WidgetTester tester) async {
+  testWidgets('Event on Slider should perform no-op if already unmounted',
+      (WidgetTester tester) async {
+    // Test covering crashing found in Google internal issue b/192329942.
     double value = 0.0;
-    final ValueNotifier<bool> shouldShowSliderListenable = ValueNotifier<bool>(true);
+    final ValueNotifier<bool> shouldShowSliderListenable =
+        ValueNotifier<bool>(true);
 
     await tester.pumpWidget(
       MaterialApp(
@@ -3452,14 +3455,16 @@ void main() {
                   child: ValueListenableBuilder<bool>(
                     valueListenable: shouldShowSliderListenable,
                     builder: (BuildContext context, bool shouldShowSlider, _) {
-                      return shouldShowSlider ? Slider(
-                      value: value,
-                      onChanged: (double newValue) {
-                        setState(() {
-                          value = newValue;
-                        });
-                      },
-                    ) : const SizedBox.shrink();
+                      return shouldShowSlider
+                          ? Slider(
+                              value: value,
+                              onChanged: (double newValue) {
+                                setState(() {
+                                  value = newValue;
+                                });
+                              },
+                            )
+                          : const SizedBox.shrink();
                     },
                   ),
                 ),
@@ -3471,7 +3476,7 @@ void main() {
     );
 
     final TestGesture gesture = await tester
-          .startGesture(tester.getRect(find.byType(Slider)).centerLeft);
+        .startGesture(tester.getRect(find.byType(Slider)).centerLeft);
 
     // Intentioanlly not calling `await tester.pumpAndSettle()` to allow drag
     // event performed on `Slider` before it is about to get unmounted.
@@ -3485,7 +3490,7 @@ void main() {
     // This is supposed to trigger animation on `Slider` if it is mounted.
     await gesture.up();
 
-    await tester.pumpAndSettle();
+    expect(tester.takeException(), null);
   });
 
   group('Material 2', () {

--- a/packages/flutter/test/material/slider_test.dart
+++ b/packages/flutter/test/material/slider_test.dart
@@ -3437,8 +3437,7 @@ void main() {
     );
   }, variant: TargetPlatformVariant.desktop());
 
-  testWidgets('Event on Slider should perform no-op if already unmounted',
-      (WidgetTester tester) async {
+  testWidgets('Event on Slider should perform no-op if already unmounted', (WidgetTester tester) async {
     // Test covering crashing found in Google internal issue b/192329942.
     double value = 0.0;
     final ValueNotifier<bool> shouldShowSliderListenable =


### PR DESCRIPTION
If user interacts with a slider and, during that time, the slider disposed / unmounted (say, a timer that hides the timer), an exception will be thrown.

This pull request fixes it by adding a `mounted` check before any interaction with the slider.

*List which issues are fixed by this PR. You must list at least one issue.*

- See internal bug: b/192329942

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
