### PR TITLE
Remove cross_arch_tests from recipes cq.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2848,7 +2848,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      add_recipes_cq: "true"
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2870,7 +2869,6 @@ targets:
     timeout: 60
     properties:
       ignore_flakiness: "true"
-      add_recipes_cq: "true"
       cpu: arm64
       dependencies: >-
         [


### PR DESCRIPTION
These tests are blocking rolls of the recipe dependencies.

https://ci.chromium.org/p/flutter/builders/try/recipes-with-led/b8800032390708370785?

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
