### PR TITLE
Update CI to remove plugin tests from release branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -293,6 +293,8 @@ targets:
 
   - name: Linux flutter_plugins
     recipe: flutter/flutter_drone
+    enabled_branches:
+      - master
     timeout: 60
     properties:
       shard: flutter_plugins


### PR DESCRIPTION
Remove flutter_plugins tests from release branches. 