### PR TITLE
[tool] Install the corresponding APK in `flutter run`

### DIFF
--- a/dev/devicelab/bin/tasks/run_release_test.dart
+++ b/dev/devicelab/bin/tasks/run_release_test.dart
@@ -114,8 +114,8 @@ void main() {
 
       _findNextMatcherInList(
         stdout,
-        (String line) => line.startsWith('Installing build/app/outputs/flutter-apk/app.apk...'),
-        'Installing build/app/outputs/flutter-apk/app.apk...',
+        (String line) => line.startsWith('Installing build/app/outputs/flutter-apk/app-release.apk...'),
+        'Installing build/app/outputs/flutter-apk/app-release.apk...',
       );
 
       _findNextMatcherInList(

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -103,11 +103,20 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
     required ProcessUtils processUtils,
     required Logger logger,
     required FileSystem fileSystem,
+    BuildInfo? buildInfo,
   }) async {
-    File apkFile;
+    final File apkFile;
+    final String filename;
+    if (buildInfo == null) {
+      filename = 'app.apk';
+    } else if (buildInfo.flavor == null) {
+      filename = 'app-${buildInfo.mode.name}.apk';
+    } else {
+      filename = 'app-${buildInfo.lowerCasedFlavor}-${buildInfo.mode.name}.apk';
+    }
 
     if (androidProject.isUsingGradle && androidProject.isSupportedVersion) {
-      apkFile = getApkDirectory(androidProject.parent).childFile('app.apk');
+      apkFile = getApkDirectory(androidProject.parent).childFile(filename);
       if (apkFile.existsSync()) {
         // Grab information from the .apk. The gradle build script might alter
         // the application Id, so we need to look at what was actually built.
@@ -124,7 +133,7 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
       // command will grab a new AndroidApk after building, to get the updated
       // IDs.
     } else {
-      apkFile = fileSystem.file(fileSystem.path.join(getAndroidBuildDirectory(), 'app.apk'));
+      apkFile = fileSystem.file(fileSystem.path.join(getAndroidBuildDirectory(), filename));
     }
 
     final File manifest = androidProject.appManifestFile;

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -471,19 +471,6 @@ class AndroidGradleBuilder implements AndroidBuilder {
         : listApkPaths(androidBuildInfo);
     final Directory apkDirectory = getApkDirectory(project);
 
-    // Copy the first APK to app.apk.
-    // TODO(AlexV525): Remove the copying once we can identify there are no tools is using the app.apk.
-    final File firstApkFile = apkDirectory.childFile(apkFilesPaths.first);
-    if (!firstApkFile.existsSync()) {
-      _exitWithExpectedFileNotFound(
-        project: project,
-        fileExtension: '.apk',
-        logger: _logger,
-        usage: _usage,
-      );
-    }
-    firstApkFile.copySync(apkDirectory.childFile('app.apk').path);
-
     // Generate sha1 for every generated APKs.
     for (final File apkFile in apkFilesPaths.map(apkDirectory.childFile)) {
       if (!apkFile.existsSync()) {

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -66,6 +66,7 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
             androidSdk: _androidSdk,
             userMessages: _userMessages,
             fileSystem: _fileSystem,
+            buildInfo: buildInfo,
           );
         }
         return AndroidApk.fromApk(

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -65,7 +65,7 @@ void main() {
         platform: FakePlatform(),
         androidSdk: androidSdk,
       );
-      final File apkFile = fileSystem.file('app.apk')..createSync();
+      final File apkFile = fileSystem.file('app-debug.apk')..createSync();
       final AndroidApk apk = AndroidApk(
         id: 'FlutterApp',
         applicationPackage: apkFile,
@@ -88,7 +88,7 @@ void main() {
         command: <String>['adb', '-s', '1234', 'shell', 'pm', 'list', 'packages', 'FlutterApp'],
       ));
       processManager.addCommand(const FakeCommand(
-        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app.apk'],
+        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-debug.apk'],
       ));
       processManager.addCommand(kShaCommand);
       processManager.addCommand(const FakeCommand(
@@ -132,7 +132,7 @@ void main() {
       platform: FakePlatform(),
       androidSdk: androidSdk,
     );
-    final File apkFile = fileSystem.file('app.apk')..createSync();
+    final File apkFile = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk apk = AndroidApk(
       id: 'FlutterApp',
       applicationPackage: apkFile,
@@ -170,7 +170,7 @@ void main() {
       platform: FakePlatform(),
       androidSdk: androidSdk,
     );
-    final File apkFile = fileSystem.file('app.apk')..createSync();
+    final File apkFile = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk apk = AndroidApk(
       id: 'FlutterApp',
       applicationPackage: apkFile,
@@ -200,7 +200,7 @@ void main() {
         '-r',
         '--user',
         '10',
-        'app.apk',
+        'app-debug.apk',
       ],
       stdout: '\n\nThe Dart VM service is listening on http://127.0.0.1:456\n\n',
     ));

--- a/packages/flutter_tools/test/general.shard/android/android_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_install_test.dart
@@ -31,7 +31,7 @@ const FakeCommand kInstallCommand = FakeCommand(
     '-r',
     '--user',
     '10',
-    'app.apk',
+    'app-debug.apk',
   ],
 );
 const FakeCommand kStoreShaCommand = FakeCommand(
@@ -71,7 +71,7 @@ void main() {
         stdout: '[ro.build.version.sdk]: [11]',
       ),
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -87,7 +87,7 @@ void main() {
   });
 
   testWithoutContext('Cannot install app if APK file is missing', () async {
-    final File apk = fileSystem.file('app.apk');
+    final File apk = fileSystem.file('app-debug.apk');
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -115,7 +115,7 @@ void main() {
       kInstallCommand,
       kStoreShaCommand,
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -144,7 +144,7 @@ void main() {
       kInstallCommand,
       kStoreShaCommand,
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -182,13 +182,13 @@ void main() {
           '-r',
           '--user',
           'jane',
-          'app.apk',
+          'app-debug.apk',
         ],
         exitCode: 1,
         stderr: 'Exception occurred while executing: java.lang.IllegalArgumentException: Bad user number: jane',
       ),
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -221,8 +221,8 @@ void main() {
         stdout: 'example_sha',
       ),
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
-    fileSystem.file('app.apk.sha1').writeAsStringSync('example_sha');
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
+    fileSystem.file('app-debug.apk.sha1').writeAsStringSync('example_sha');
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -254,7 +254,7 @@ void main() {
         stdout: 'different_example_sha',
       ),
       const FakeCommand(
-        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '--user', '10', 'app.apk'],
+        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '--user', '10', 'app-debug.apk'],
         exitCode: 1,
         stderr: '[INSTALL_FAILED_INSUFFICIENT_STORAGE]',
       ),
@@ -262,8 +262,8 @@ void main() {
       kInstallCommand,
       const FakeCommand(command: <String>['adb', '-s', '1234', 'shell', 'echo', '-n', 'example_sha', '>', '/data/local/tmp/sky.app.sha1']),
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
-    fileSystem.file('app.apk.sha1').writeAsStringSync('example_sha');
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
+    fileSystem.file('app-debug.apk.sha1').writeAsStringSync('example_sha');
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',
@@ -291,12 +291,12 @@ void main() {
           stdout: '\n'
       ),
       const FakeCommand(
-        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '--user', '10', 'app.apk'],
+        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '--user', '10', 'app-debug.apk'],
         exitCode: 1,
         stderr: '[INSTALL_FAILED_INSUFFICIENT_STORAGE]',
       ),
     ]);
-    final File apk = fileSystem.file('app.apk')..createSync();
+    final File apk = fileSystem.file('app-debug.apk')..createSync();
     final AndroidApk androidApk = AndroidApk(
       applicationPackage: apk,
       id: 'app',

--- a/packages/flutter_tools/test/general.shard/android/gradle_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/gradle_test.dart
@@ -121,6 +121,20 @@ void main() {
   });
 
   group('listApkPaths', () {
+    testWithoutContext('Finds APK without flavor in debug', () {
+      final Iterable<String> apks = listApkPaths(
+        const AndroidBuildInfo(BuildInfo(BuildMode.debug, '', treeShakeIcons: false)),
+      );
+      expect(apks, <String>['app-debug.apk']);
+    });
+
+    testWithoutContext('Finds APK with flavor in debug', () {
+      final Iterable<String> apks = listApkPaths(
+        const AndroidBuildInfo(BuildInfo(BuildMode.debug, 'flavor1', treeShakeIcons: false)),
+      );
+      expect(apks, <String>['app-flavor1-debug.apk']);
+    });
+
     testWithoutContext('Finds APK without flavor in release', () {
       final Iterable<String> apks = listApkPaths(
         const AndroidBuildInfo(BuildInfo(BuildMode.release, '', treeShakeIcons: false)),

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -57,7 +57,7 @@ void main() {
 
     testUsingContext('Licenses not available, platform and buildtools available, apk exists', () async {
       const String aaptPath = 'aaptPath';
-      final File apkFile = globals.fs.file('app.apk');
+      final File apkFile = globals.fs.file('app-debug.apk');
       final FakeAndroidSdkVersion sdkVersion = FakeAndroidSdkVersion();
       sdkVersion.aaptPath = aaptPath;
       sdk.latestVersion = sdkVersion;
@@ -81,7 +81,7 @@ void main() {
         TargetPlatform.android_arm,
         applicationBinary: apkFile,
       ))!;
-      expect(applicationPackage.name, 'app.apk');
+      expect(applicationPackage.name, 'app-debug.apk');
       expect(applicationPackage, isA<PrebuiltApplicationPackage>());
       expect((applicationPackage as PrebuiltApplicationPackage).applicationPackage.path, apkFile.path);
       expect(fakeProcessManager, hasNoRemainingExpectations);
@@ -103,7 +103,7 @@ void main() {
 
       await ApplicationPackageFactory.instance!.getPackageForPlatform(
         TargetPlatform.android_arm,
-        applicationBinary: globals.fs.file('app.apk'),
+        applicationBinary: globals.fs.file('app-debug.apk'),
       );
       expect(fakeProcessManager, hasNoRemainingExpectations);
     }, overrides: overrides);

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -312,7 +312,7 @@ void main() {
       <FlutterDevice>[
         flutterDevice,
       ],
-      applicationBinary: globals.fs.file('app.apk'),
+      applicationBinary: globals.fs.file('app-debug.apk'),
       stayResident: false,
       debuggingOptions: DebuggingOptions.enabled(BuildInfo.debug),
       target: 'main.dart',


### PR DESCRIPTION
Revert #113614. Fix #111585, #113620.

The PR stops copying `app.apk` for `flutter run` and makes the tool installs exactly the generated APK file, which corrects the console's output too. Also, SHA1 will be generated for all generated APKs in the batch.

## Filename comparison (DEBUG Mode)

| Install APK file| Before | After |
|-------|-------------|-----------|
| No flavor | app.apk | app-debug.apk |
| Flavor configured | app.apk | app-flavor-debug.apk |

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
