### PR TITLE
Add HitTestBehavior to TapRegion

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -173,7 +173,12 @@ abstract class RenderProxyBoxWithHitTestBehavior extends RenderProxyBox {
     RenderBox? child,
   }) : super(child);
 
-  /// How to behave during hit testing.
+  /// How to behave during hit testing when deciding how the hit test propagates
+  /// to children and whether to consider targets behind this one.
+  ///
+  /// Defaults to [HitTestBehavior.deferToChild].
+  ///
+  /// See [HitTestBehavior] for the allowed values and their meanings.
   HitTestBehavior behavior;
 
   @override

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -970,10 +970,14 @@ class GestureDetector extends StatelessWidget {
   /// detecting screens.
   final GestureForcePressEndCallback? onForcePressEnd;
 
-  /// How this gesture detector should behave during hit testing.
+  /// How this gesture detector should behave during hit testing when deciding
+  /// how the hit test propagates to children and whether to consider targets
+  /// behind this one.
   ///
   /// This defaults to [HitTestBehavior.deferToChild] if [child] is not null and
   /// [HitTestBehavior.translucent] if child is null.
+  ///
+  /// See [HitTestBehavior] for the allowed values and their meanings.
   final HitTestBehavior? behavior;
 
   /// Whether to exclude these gestures from the semantics tree. For

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -6,7 +6,6 @@ import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -376,50 +375,4 @@ void main() {
         ]));
     tappedOutside.clear();
   });
-}
-
-DoesNotHitRenderBox doesNotHit(RenderBox renderBox) => DoesNotHitRenderBox(renderBox);
-
-class DoesNotHitRenderBox extends Matcher {
-  const DoesNotHitRenderBox(this.renderBox);
-
-  final RenderBox renderBox;
-
-  @override
-  Description describe(Description description) =>
-    description.add("hit test result doesn't contain ").addDescriptionOf(renderBox);
-
-  @override
-  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
-    final HitTestResult hitTestResult = item as HitTestResult;
-    return hitTestResult.path.where(
-      (HitTestEntry entry) => entry.target == renderBox,
-    ).isEmpty;
-  }
-}
-
-class _MockPaintingContext extends Fake implements PaintingContext {
-  final List<RenderObject> children = <RenderObject>[];
-  final List<Offset> offsets = <Offset>[];
-
-  @override
-  final _MockCanvas canvas = _MockCanvas();
-
-  @override
-  void paintChild(RenderObject child, Offset offset) {
-    children.add(child);
-    offsets.add(offset);
-  }
-}
-
-class _MockCanvas extends Fake implements Canvas {
-  final List<Rect> rects = <Rect>[];
-  final List<Paint> paints = <Paint>[];
-  bool didPaint = false;
-
-  @override
-  void drawRect(Rect rect, Paint paint) {
-    rects.add(rect);
-    paints.add(paint);
-  }
 }

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -4,7 +4,9 @@
 
 import 'dart:ui';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -99,6 +101,7 @@ void main() {
     await click(find.text('Outside Surface'));
     expect(tappedOutside, isEmpty);
   });
+
   testWidgets('TapRegionSurface detects inside taps', (WidgetTester tester) async {
     final Set<String> tappedInside = <String>{};
     await tester.pumpWidget(
@@ -185,6 +188,94 @@ void main() {
     await click(find.text('Outside Surface'));
     expect(tappedInside, isEmpty);
   });
+
+  testWidgets('TapRegionSurface detects inside taps correctly with behavior', (WidgetTester tester) async {
+    final Set<String> tappedInside = <String>{};
+    const ValueKey<String> noGroupKey = ValueKey<String>('No Group');
+    const ValueKey<String> group1AKey = ValueKey<String>('Group 1 A');
+    const ValueKey<String> group1BKey = ValueKey<String>('Group 1 B');
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: Column(
+          children: <Widget>[
+            const Text('Outside Surface'),
+            TapRegionSurface(
+              child: Row(
+                children: <Widget>[
+                  ConstrainedBox(
+                    constraints: const BoxConstraints.tightFor(width: 100, height: 100),
+                    child: TapRegion(
+                      // ignore: avoid_redundant_argument_values
+                      behavior: HitTestBehavior.deferToChild,
+                      onTapInside: (PointerEvent event) {
+                        tappedInside.add(noGroupKey.value);
+                      },
+                      child: Stack(key: noGroupKey),
+                    ),
+                  ),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints.tightFor(width: 100, height: 100),
+                    child: TapRegion(
+                      groupId: 1,
+                      behavior: HitTestBehavior.opaque,
+                      onTapInside: (PointerEvent event) {
+                        tappedInside.add(group1AKey.value);
+                      },
+                      child: Stack(key: group1AKey),
+                    ),
+                  ),
+                  ConstrainedBox(
+                    constraints: const BoxConstraints.tightFor(width: 100, height: 100),
+                    child: TapRegion(
+                      groupId: 1,
+                      behavior: HitTestBehavior.translucent,
+                      onTapInside: (PointerEvent event) {
+                        tappedInside.add(group1BKey.value);
+                      },
+                      child: Stack(key: group1BKey),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    Future<void> click(Finder finder) async {
+      final TestGesture gesture = await tester.startGesture(
+        tester.getCenter(finder),
+        kind: PointerDeviceKind.mouse,
+      );
+      await gesture.up();
+      await gesture.removePointer();
+    }
+
+    expect(tappedInside, isEmpty);
+
+    await click(find.byKey(noGroupKey));
+    expect(tappedInside, isEmpty); // No hittable children, so no hit.
+
+    await click(find.byKey(group1AKey));
+    // No hittable children, but set to opaque, so it hits, triggering the
+    // group.
+    expect(tappedInside,
+      equals(<String>{
+        'Group 1 A',
+        'Group 1 B',
+      }),
+    );
+    tappedInside.clear();
+
+    await click(find.byKey(group1BKey));
+    expect(tappedInside, isEmpty); // No hittable children while translucent, so no hit.
+    tappedInside.clear();
+  });
+
   testWidgets('Setting the group updates the registration', (WidgetTester tester) async {
     final Set<String> tappedOutside = <String>{};
     await tester.pumpWidget(
@@ -285,4 +376,50 @@ void main() {
         ]));
     tappedOutside.clear();
   });
+}
+
+DoesNotHitRenderBox doesNotHit(RenderBox renderBox) => DoesNotHitRenderBox(renderBox);
+
+class DoesNotHitRenderBox extends Matcher {
+  const DoesNotHitRenderBox(this.renderBox);
+
+  final RenderBox renderBox;
+
+  @override
+  Description describe(Description description) =>
+    description.add("hit test result doesn't contain ").addDescriptionOf(renderBox);
+
+  @override
+  bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
+    final HitTestResult hitTestResult = item as HitTestResult;
+    return hitTestResult.path.where(
+      (HitTestEntry entry) => entry.target == renderBox,
+    ).isEmpty;
+  }
+}
+
+class _MockPaintingContext extends Fake implements PaintingContext {
+  final List<RenderObject> children = <RenderObject>[];
+  final List<Offset> offsets = <Offset>[];
+
+  @override
+  final _MockCanvas canvas = _MockCanvas();
+
+  @override
+  void paintChild(RenderObject child, Offset offset) {
+    children.add(child);
+    offsets.add(offset);
+  }
+}
+
+class _MockCanvas extends Fake implements Canvas {
+  final List<Rect> rects = <Rect>[];
+  final List<Paint> paints = <Paint>[];
+  bool didPaint = false;
+
+  @override
+  void drawRect(Rect rect, Paint paint) {
+    rects.add(rect);
+    paints.add(paint);
+  }
 }


### PR DESCRIPTION
## Description

This adds a `behavior` attribute to `TapRegion` to allow it to control how each region reacts to hit tests. It defaults to `HitTestBehavior.deferToChild`, which is the existing behavior.

## Related Issues
 - https://github.com/flutter/flutter/issues/112924

## Tests
 - Added tests to make sure behavior is handled correctly.