### PR TITLE
Use the new pushImageFilter offset parameter to fix the transform of the children

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -1816,13 +1816,14 @@ class ColorFilterLayer extends ContainerLayer {
 }
 
 /// A composite layer that applies an [ImageFilter] to its children.
-class ImageFilterLayer extends ContainerLayer {
+class ImageFilterLayer extends OffsetLayer {
   /// Creates a layer that applies an [ImageFilter] to its children.
   ///
   /// The [imageFilter] property must be non-null before the compositing phase
   /// of the pipeline.
   ImageFilterLayer({
     ui.ImageFilter? imageFilter,
+    super.offset,
   }) : _imageFilter = imageFilter;
 
   /// The image filter to apply to children.
@@ -1844,6 +1845,7 @@ class ImageFilterLayer extends ContainerLayer {
     assert(imageFilter != null);
     engineLayer = builder.pushImageFilter(
       imageFilter!,
+      offset: offset,
       oldLayer: _engineLayer as ui.ImageFilterEngineLayer?,
     );
     addChildrenToScene(builder);

--- a/packages/flutter/lib/src/widgets/image_filter.dart
+++ b/packages/flutter/lib/src/widgets/image_filter.dart
@@ -105,12 +105,13 @@ class _ImageFilterRenderObject extends RenderProxyBox {
     }
 
     if (layer == null) {
-      layer = ImageFilterLayer(imageFilter: imageFilter);
+      layer = ImageFilterLayer(imageFilter: imageFilter, offset: offset);
     } else {
       final ImageFilterLayer filterLayer = layer! as ImageFilterLayer;
       filterLayer.imageFilter = imageFilter;
+      filterLayer.offset = offset;
     }
-    context.pushLayer(layer!, super.paint, offset);
+    context.pushLayer(layer!, super.paint, Offset.zero);
     assert(() {
       layer!.debugCreator = debugCreator;
       return true;

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -6,6 +6,7 @@
 // machines.
 @Tags(<String>['reduced-test-set'])
 
+import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -26,6 +27,24 @@ void main() {
     await expectLater(
       find.byType(ImageFiltered),
       matchesGoldenFile('image_filter_blur.png'),
+    );
+  });
+
+  testWidgets('Image filter - blur with offset', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      RepaintBoundary(
+        child: Transform.translate(
+          offset: const Offset(50, 50),
+          child: ImageFiltered(
+            imageFilter: ImageFilter.blur(sigmaX: 3.0, sigmaY: 3.0),
+            child: const Placeholder(),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(ImageFiltered),
+      matchesGoldenFile('image_filter_blur_offset.png'),
     );
   });
 
@@ -94,6 +113,42 @@ void main() {
     await expectLater(
       find.byType(ImageFiltered),
       matchesGoldenFile('image_filter_matrix.png'),
+    );
+  });
+
+  testWidgets('Image filter - matrix with offset', (WidgetTester tester) async {
+    final Matrix4 matrix = Matrix4.rotationZ(pi / 18);
+    final ImageFilter matrixFilter = ImageFilter.matrix(matrix.storage);
+    await tester.pumpWidget(
+      RepaintBoundary(
+        child: Transform.translate(
+          offset: const Offset(50, 50),
+          child: ImageFiltered(
+            imageFilter: matrixFilter,
+            child: MaterialApp(
+              title: 'Flutter Demo',
+              theme: ThemeData(primarySwatch: Colors.blue),
+              home: Scaffold(
+                appBar: AppBar(
+                  title: const Text('Matrix ImageFilter Test'),
+                ),
+                body: const Center(
+                  child:Text('Hooray!'),
+                ),
+                floatingActionButton: FloatingActionButton(
+                  onPressed: () { },
+                  tooltip: 'Increment',
+                  child: const Icon(Icons.add),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await expectLater(
+      find.byType(ImageFiltered),
+      matchesGoldenFile('image_filter_matrix_offset.png'),
     );
   });
 


### PR DESCRIPTION
Fixes: https://github.com/flutter/flutter/issues/111855

This PR will fail until https://github.com/flutter/engine/pull/36863 is landed in the engine and rolled into the framework. Once that is done this change can be rebased on top of it to fix the bug.

This PR has already been tested on top of the pending engine fixes to demonstrate that this fixes the bug. I am creating the PR now so that the 2 halves of the fix can be cross-referenced as they sequentially merge into the source base.

There are 2 new goldens created by this test:

<details>
  <summaryNew golden for ImageFilter.blur with offset test.</summary>

![image_filter_blur_offset](https://user-images.githubusercontent.com/50503328/196608486-788110d9-e448-43fb-965c-6087ab05e99d.png)
</details>

<details>
  <summaryNew golden for ImageFilter.matrix with offset test.</summary>

![widgets image_filter_matrix_offset](https://user-images.githubusercontent.com/50503328/196608513-ce092325-0089-4e5c-b672-755378fdbb62.png)
</details>
