### PR TITLE
[Impeller] Build Impeller iOS runtime stage shaders when Impeller is enabled

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/assets.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/assets.dart
@@ -32,6 +32,7 @@ Future<Depfile> copyAssets(
   required TargetPlatform targetPlatform,
   BuildMode? buildMode,
   required ShaderTarget shaderTarget,
+  List<File> additionalInputs = const <File>[],
 }) async {
   // Check for an SkSL bundle.
   final String? shaderBundlePath = environment.defines[kBundleSkSLPath] ?? environment.inputs[kBundleSkSLPath];
@@ -65,6 +66,7 @@ Future<Depfile> copyAssets(
     // An asset manifest with no assets would have zero inputs if not
     // for this pubspec file.
     pubspecFile,
+    ...additionalInputs,
   ];
   final List<File> outputs = <File>[];
 

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -514,7 +514,7 @@ abstract class IosAssetBundle extends Target {
       environment,
       assetDirectory,
       targetPlatform: TargetPlatform.ios,
-      shaderTarget: ShaderTarget.sksl,
+      shaderTarget: ShaderTarget.impelleriOS,
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -513,16 +513,11 @@ abstract class IosAssetBundle extends Target {
     final FlutterProject flutterProject = FlutterProject.fromDirectory(environment.projectDir);
 
     bool isImpellerEnabled() {
-      final PlistParser plistParser = PlistParser(fileSystem: globals.fs, logger: environment.logger, processManager: globals.processManager);
-
       if (!flutterProject.ios.infoPlist.existsSync()) {
         return false;
       }
-      final Map<String, Object> info = plistParser.parseFile(flutterProject.ios.infoPlist.path);
+      final Map<String, Object> info = globals.plistParser.parseFile(flutterProject.ios.infoPlist.path);
 
-      if (!info.containsKey('FLTEnableImpeller')) {
-        return false;
-      }
       return (info['FLTEnableImpeller'] as bool?) ?? false;
     }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -532,6 +532,10 @@ abstract class IosAssetBundle extends Target {
       assetDirectory,
       targetPlatform: TargetPlatform.ios,
       shaderTarget: isImpellerEnabled() ? ShaderTarget.impelleriOS : ShaderTarget.sksl,
+      additionalInputs: <File>[
+        flutterProject.ios.infoPlist,
+        flutterProject.ios.appFrameworkInfoPlist,
+      ],
     );
     final DepfileService depfileService = DepfileService(
       fileSystem: environment.fileSystem,
@@ -543,7 +547,6 @@ abstract class IosAssetBundle extends Target {
     );
 
     // Copy the plist from either the project or module.
-    // TODO(zanderso): add plist to inputs
     flutterProject.ios.appFrameworkInfoPlist
       .copySync(environment.outputDir
       .childDirectory('App.framework')

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -518,7 +518,12 @@ abstract class IosAssetBundle extends Target {
       }
       final Map<String, Object> info = globals.plistParser.parseFile(flutterProject.ios.infoPlist.path);
 
-      return (info['FLTEnableImpeller'] as bool?) ?? false;
+      final Object? enableImpeller = info['FLTEnableImpeller'];
+
+      if (enableImpeller is bool?) {
+        return enableImpeller ?? false;
+      }
+      return false;
     }
 
     // Copy the assets.

--- a/packages/flutter_tools/lib/src/build_system/targets/ios.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/ios.dart
@@ -11,7 +11,6 @@ import '../../base/file_system.dart';
 import '../../base/io.dart';
 import '../../build_info.dart';
 import '../../globals.dart' as globals;
-import '../../ios/plist_parser.dart';
 import '../../macos/xcode.dart';
 import '../../project.dart';
 import '../../reporting/reporting.dart';
@@ -519,11 +518,7 @@ abstract class IosAssetBundle extends Target {
       final Map<String, Object> info = globals.plistParser.parseFile(flutterProject.ios.infoPlist.path);
 
       final Object? enableImpeller = info['FLTEnableImpeller'];
-
-      if (enableImpeller is bool?) {
-        return enableImpeller ?? false;
-      }
-      return false;
+      return enableImpeller is bool && enableImpeller;
     }
 
     // Copy the assets.

--- a/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
@@ -21,8 +21,8 @@ import '../build_system.dart';
 
 /// The output shader format that should be used by the [ShaderCompiler].
 enum ShaderTarget {
-  impellerAndroid('--opengl-es'),
-  impelleriOS('--metal-ios'),
+  impellerAndroid('--runtime-stage-gles'),
+  impelleriOS('--runtime-stage-metal'),
   sksl('--sksl');
 
   const ShaderTarget(this.target);

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -131,6 +131,8 @@ class IosProject extends XcodeBasedProject {
 
   File get appFrameworkInfoPlist => _flutterLibRoot.childDirectory('Flutter').childFile('AppFrameworkInfo.plist');
 
+  File get infoPlist => _editableDirectory.childDirectory('Runner').childFile('Info.plist');
+
   Directory get symlinks => _flutterLibRoot.childDirectory('.symlinks');
 
   /// True, if the app project is using swift.

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -81,7 +81,7 @@ void main() {
       FakeCommand(
         command: <String>[
           impellerc,
-          '--metal-ios',
+          '--runtime-stage-metal',
           '--iplr',
           '--sl=$outputPath',
           '--spirv=$outputPath.spirv',
@@ -117,7 +117,7 @@ void main() {
       FakeCommand(
         command: <String>[
           impellerc,
-          '--opengl-es',
+          '--runtime-stage-gles',
           '--iplr',
           '--sl=$outputPath',
           '--spirv=$outputPath.spirv',

--- a/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/shader_compiler_test.dart
@@ -275,7 +275,7 @@ void main() {
       FakeCommand(
         command: <String>[
           impellerc,
-          '--opengl-es',
+          '--runtime-stage-gles',
           '--iplr',
           '--sl=/.tmp_rand0/0.8255140718871702.temp',
           '--spirv=/.tmp_rand0/0.8255140718871702.temp.spirv',


### PR DESCRIPTION
Fixes the compiler flags for runtime stages.

The `ios.dart` change is a hack that needs to be replaced. Is there a good way to snake the Impeller flag into `build_system/targets/*.dart` so that we can set the `shaderTarget` based on it?