### PR TITLE
[flutter_tools] Decouple fatal-warnings check from fatal-infos

### DIFF
--- a/packages/flutter_tools/lib/src/commands/analyze_once.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_once.dart
@@ -167,8 +167,7 @@ class AnalyzeOnce extends AnalyzeBase {
       if (severityLevel == AnalysisSeverity.error) {
         return true;
       }
-      if (severityLevel == AnalysisSeverity.warning &&
-        (argResults['fatal-warnings'] as bool || argResults['fatal-infos'] as bool)) {
+      if (severityLevel == AnalysisSeverity.warning && argResults['fatal-warnings'] as bool) {
         return true;
       }
       if (severityLevel == AnalysisSeverity.info && argResults['fatal-infos'] as bool) {

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -363,6 +363,31 @@ analyzer:
   });
 }
 
+testWithoutContext('analyze once only fatal-warnings has warning issue finally exit code 1.', () async {
+    const String warningSourceCode = '''
+int analyze() {}
+''';
+
+    final File optionsFile = fileSystem.file(fileSystem.path.join(projectPath, 'analysis_options.yaml'));
+    optionsFile.writeAsStringSync('''
+analyzer:
+  errors:
+    missing_return: warning
+  ''');
+
+    fileSystem.directory(projectPath).childFile('main.dart').writeAsStringSync(warningSourceCode);
+    await runCommand(
+      arguments: <String>['analyze','--no-pub', '--no-fatal-infos', 'fatal-warnings'],
+      statusTextContains: <String>[
+        'warning',
+        'missing_return',
+      ],
+      exitMessageContains: '1 issue found.',
+      exitCode: 1,
+    );
+  });
+}
+
 void assertContains(String text, List<String> patterns) {
   if (patterns != null) {
     for (final String pattern in patterns) {

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -339,7 +339,7 @@ int analyze() {}
     );
   });
 
-  testWithoutContext('analyze once only fatal-infos has warning issue finally exit code 1.', () async {
+  testWithoutContext('analyze once only fatal-infos has warning issue finally exit code 0.', () async {
     const String warningSourceCode = '''
 int analyze() {}
 ''';

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -359,7 +359,6 @@ analyzer:
         'missing_return',
       ],
       exitMessageContains: '1 issue found.',
-      exitCode: 0,
     );
   });
 }

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -377,7 +377,7 @@ analyzer:
 
     fileSystem.directory(projectPath).childFile('main.dart').writeAsStringSync(warningSourceCode);
     await runCommand(
-      arguments: <String>['analyze','--no-pub', '--no-fatal-infos', 'fatal-warnings'],
+      arguments: <String>['analyze','--no-pub', '--no-fatal-infos', '--fatal-warnings'],
       statusTextContains: <String>[
         'warning',
         'missing_return',

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -361,9 +361,9 @@ analyzer:
       exitMessageContains: '1 issue found.',
     );
   });
-}
 
-testWithoutContext('analyze once only fatal-warnings has warning issue finally exit code 1.', () async {
+
+  testWithoutContext('analyze once only fatal-warnings has warning issue finally exit code 1.', () async {
     const String warningSourceCode = '''
 int analyze() {}
 ''';

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -359,7 +359,7 @@ analyzer:
         'missing_return',
       ],
       exitMessageContains: '1 issue found.',
-      exitCode: 1,
+      exitCode: 0,
     );
   });
 }


### PR DESCRIPTION
Currently, the command `flutter analyze --no-fatal-warnings` fails when the code has **warnings** or **info** level of suggestions. Since there are 2 commands `--no-fatal-warnings` and `--no-fatal-infos`, this PR is updating it to check only **warnings** making it scoped to its own severity. 

E.g: `flutter analyze --no-fatal-warnings` fails only when finding **warnings** (ignoring other severities)
       `flutter analyze --no-fatal-infos` fails only when finding **infos** (ignoring other severities, same behavior as today)

*List which issues are fixed by this PR. You must list at least one issue.*
- `flutter analyze --no-fatal-warnings` working only when adding `--no-fatal-infos`

**Before fix**
![with-bug](https://user-images.githubusercontent.com/14953997/196911099-2448ba8a-3b7d-4761-8b16-9d2c53fb3523.png)

**After fix**
![without-bug](https://user-images.githubusercontent.com/14953997/196911156-9bc19e1f-4bac-4d58-83dd-9e2237eaefc0.png)


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
