### PR TITLE
Resolve 113705: Separated longer running tests from `runMisc` to prevent flakiness from timeouts

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -399,6 +399,15 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      dependencies: >-
+      [
+          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
+          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
+          {"dependency": "cmake", "version": "version:3.16.1"},
+          {"dependency": "ninja", "version": "version:1.9.0"},
+          {"dependency": "open_jdk", "version": "version:11"},
+          {"dependency": "android_sdk", "version": "version:33v6"}
+      ]
       shard: framework_tests
       subshard: misc
       tags: >
@@ -2579,6 +2588,14 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"},
+          {"dependency": "open_jdk", "version": "version:11"},
+          {"dependency": "android_sdk", "version": "version:33v6"}
+        ]
       shard: framework_tests
       subshard: misc
       tags: >
@@ -3936,6 +3953,13 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
+          {"dependency": "vs_build", "version": "version:vs2019"},
+          {"dependency": "open_jdk", "version": "version:11"},
+          {"dependency": "android_sdk", "version": "version:33v6"}
+        ]
       shard: framework_tests
       subshard: misc
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -398,7 +398,9 @@ targets:
     timeout: 60
     properties:
       dependencies: >-
-        [ ]
+        [
+          {"dependency": "android_sdk", "version": "version:33v6"}
+        ]
       shard: framework_tests
       subshard: slow
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -400,14 +400,14 @@ targets:
     timeout: 60
     properties:
       dependencies: >-
-      [
+        [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "version:3.16.1"},
           {"dependency": "ninja", "version": "version:1.9.0"},
           {"dependency": "open_jdk", "version": "version:11"},
           {"dependency": "android_sdk", "version": "version:33v6"}
-      ]
+        ]
       shard: framework_tests
       subshard: misc
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -375,7 +375,9 @@ targets:
     timeout: 60
     properties:
       dependencies: >-
-        [ ]
+        [
+          {"dependency": "android_sdk", "version": "version:33v6"}
+        ]
       shard: framework_tests
       subshard: slow
       tags: >
@@ -397,12 +399,8 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "android_sdk", "version": "version:33v6"}
-        ]
       shard: framework_tests
-      subshard: slow
+      subshard: misc
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -369,19 +369,35 @@ targets:
       - bin/
       - .ci.yaml
 
+  - name: Linux framework_tests_slow
+    recipe: flutter/flutter_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [ ]
+      shard: framework_tests
+      subshard: slow
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+    runIf:
+      - dev/
+      - packages/flutter/
+      - packages/flutter_driver/
+      - packages/integration_test/
+      - packages/flutter_localizations/
+      - packages/fuchsia_remote_debug_protocol/
+      - packages/flutter_test/
+      - packages/flutter_goldens/
+      - packages/flutter_tools/
+      - bin/
+      - .ci.yaml
+
   - name: Linux framework_tests_misc
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
       dependencies: >-
-        [
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
-          {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
-          {"dependency": "cmake", "version": "version:3.16.1"},
-          {"dependency": "ninja", "version": "version:1.9.0"},
-          {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "android_sdk", "version": "version:33v6"}
-        ]
+        [ ]
       shard: framework_tests
       subshard: misc
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -370,6 +370,7 @@ targets:
       - .ci.yaml
 
   - name: Linux framework_tests_slow
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -370,7 +370,6 @@ targets:
       - .ci.yaml
 
   - name: Linux framework_tests_slow
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2579,14 +2579,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "android_sdk", "version": "version:33v6"}
-        ]
       shard: framework_tests
       subshard: misc
       tags: >
@@ -3944,13 +3936,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
-          {"dependency": "vs_build", "version": "version:vs2019"},
-          {"dependency": "open_jdk", "version": "version:11"},
-          {"dependency": "android_sdk", "version": "version:33v6"}
-        ]
       shard: framework_tests
       subshard: misc
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -370,6 +370,7 @@ targets:
       - .ci.yaml
 
   - name: Linux framework_tests_slow
+    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
@@ -399,7 +400,7 @@ targets:
       dependencies: >-
         [ ]
       shard: framework_tests
-      subshard: misc
+      subshard: slow
       tags: >
         ["framework", "hostonly", "shard", "linux"]
     runIf:

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -967,6 +967,8 @@ Future<void> _runFrameworkTests() async {
 
   // Tests that take longer than average to run. This is usually because they
   // need to compile something large or make use of the analyzer for the test.
+  // These tests need to be platform agnostic as they are only run on a linux
+  // machine to save on execution time and cost.
   Future<void> runSlow() async {
     printProgress('${green}Running slow package tests$reset for directories other than packages/flutter');
     await runTracingTests();

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -967,8 +967,8 @@ Future<void> _runFrameworkTests() async {
 
   // Tests that take longer than average to run. This is usually because they
   // need to compile something large or make use of the analyzer for the test.
-  Future<void> runLong() async {
-    printProgress('${green}Running longer package tests$reset for directories other than packages/flutter');
+  Future<void> runSlow() async {
+    printProgress('${green}Running slow package tests$reset for directories other than packages/flutter');
     await runExampleTests();
     await runTracingTests();
     await runFixTests();
@@ -1029,7 +1029,7 @@ Future<void> _runFrameworkTests() async {
   await selectSubshard(<String, ShardRunner>{
     'widgets': runWidgets,
     'libraries': runLibraries,
-    'long_running': runLong,
+    'slow': runSlow,
     'misc': runMisc,
   });
 }

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -969,7 +969,6 @@ Future<void> _runFrameworkTests() async {
   // need to compile something large or make use of the analyzer for the test.
   Future<void> runSlow() async {
     printProgress('${green}Running slow package tests$reset for directories other than packages/flutter');
-    await runExampleTests();
     await runTracingTests();
     await runFixTests();
     await runPrivateTests();
@@ -978,6 +977,7 @@ Future<void> _runFrameworkTests() async {
   Future<void> runMisc() async {
     printProgress('${green}Running package tests$reset for directories other than packages/flutter');
     await _runTestHarnessTests();
+    await runExampleTests();
     await _runDartTest(path.join(flutterRoot, 'dev', 'bots'));
     await _runDartTest(path.join(flutterRoot, 'dev', 'devicelab'), ensurePrecompiledTool: false); // See https://github.com/flutter/flutter/issues/86209
     await _runDartTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -965,14 +965,23 @@ Future<void> _runFrameworkTests() async {
     );
   }
 
+  // Tests that take longer than average to run. This is usually because they
+  // need to compile something large or make use of the analyzer for the test.
+  Future<void> runLong() async {
+    printProgress('${green}Running longer package tests$reset for directories other than packages/flutter');
+    await runExampleTests();
+    await runTracingTests();
+    await runFixTests();
+    await runPrivateTests();
+  }
+
   Future<void> runMisc() async {
     printProgress('${green}Running package tests$reset for directories other than packages/flutter');
     await _runTestHarnessTests();
-    await runExampleTests();
     await _runDartTest(path.join(flutterRoot, 'dev', 'bots'));
     await _runDartTest(path.join(flutterRoot, 'dev', 'devicelab'), ensurePrecompiledTool: false); // See https://github.com/flutter/flutter/issues/86209
     await _runDartTest(path.join(flutterRoot, 'dev', 'conductor', 'core'), forceSingleCore: true);
-    // TODO(gspencergoog): Remove the exception for fatalWarnings once https://github.com/flutter/flutter/pull/91127 has landed.
+    // TODO(gspencergoog): Remove the exception for fatalWarnings once https://github.com/flutter/flutter/issues/113782 has landed.
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'android_semantics_testing'), fatalWarnings: false);
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'ui'));
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'manual_tests'));
@@ -991,9 +1000,6 @@ Future<void> _runFrameworkTests() async {
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'flutter_test'), options: soundNullSafetyOptions);
     await _runFlutterTest(path.join(flutterRoot, 'packages', 'fuchsia_remote_debug_protocol'), options: soundNullSafetyOptions);
     await _runFlutterTest(path.join(flutterRoot, 'dev', 'integration_tests', 'non_nullable'), options: mixedModeNullSafetyOptions);
-    await runTracingTests();
-    await runFixTests();
-    await runPrivateTests();
     const String httpClientWarning =
       'Warning: At least one test in this suite creates an HttpClient. When\n'
       'running a test suite that uses TestWidgetsFlutterBinding, all HTTP\n'
@@ -1023,6 +1029,7 @@ Future<void> _runFrameworkTests() async {
   await selectSubshard(<String, ShardRunner>{
     'widgets': runWidgets,
     'libraries': runLibraries,
+    'long_running': runLong,
     'misc': runMisc,
   });
 }


### PR DESCRIPTION
Separated out some longer running tests from `runMisc` to prevent flakiness from timeouts.

Closes #113705.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.