### PR TITLE
Expose `Ticker.startTime` so users know the start time and the absolute time

### DIFF
--- a/packages/flutter/lib/src/scheduler/ticker.dart
+++ b/packages/flutter/lib/src/scheduler/ticker.dart
@@ -137,6 +137,13 @@ class Ticker {
   /// [isTicking].
   bool get isActive => _future != null;
 
+  /// The start time of the ticker.
+  ///
+  /// When [_onTick], the callback is provided with a relative time (the
+  /// "elapsed"). By adding the `elapsed` to this [startTime], you can get the
+  /// absolute time.
+  Duration? get startTime => _startTime;
+
   Duration? _startTime;
 
   /// Starts the clock for this [Ticker]. If the ticker is not [muted], then this

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -312,6 +312,9 @@ class FakeTicker implements Ticker {
   bool get isActive => throw UnimplementedError();
 
   @override
+  Duration? get startTime => throw UnimplementedError();
+
+  @override
   bool get isTicking => throw UnimplementedError();
 
   @override

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -193,4 +193,22 @@ void main() {
 
     ticker.stop();
   });
+
+  testWidgets('Ticker can get start time', (WidgetTester tester) async {
+    void handleTick(Duration duration) {
+      // nothing
+    }
+
+    final Ticker ticker = Ticker(handleTick);
+    ticker.start();
+
+    await tester.pump(const Duration(milliseconds: 10));
+    final DateTime expectStartTime = tester.binding.clock.now();
+    expect(ticker.startTime, expectStartTime);
+
+    await tester.pump(const Duration(milliseconds: 10));
+    expect(ticker.startTime, expectStartTime);
+
+    ticker.dispose();
+  });
 }

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -199,15 +200,17 @@ void main() {
       // nothing
     }
 
+    await tester.pumpWidget(const CircularProgressIndicator());
+    await tester.pump(const Duration(milliseconds: 42));
+
     final Ticker ticker = Ticker(handleTick);
     ticker.start();
 
     await tester.pump(const Duration(milliseconds: 10));
-    final DateTime expectStartTime = tester.binding.clock.now();
-    expect(ticker.startTime, expectStartTime);
+    expect(ticker.startTime, const Duration(seconds: 52));
 
     await tester.pump(const Duration(milliseconds: 10));
-    expect(ticker.startTime, expectStartTime);
+    expect(ticker.startTime, const Duration(seconds: 52));
 
     ticker.dispose();
   });

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -207,10 +207,10 @@ void main() {
     ticker.start();
 
     await tester.pump(const Duration(milliseconds: 10));
-    expect(ticker.startTime, const Duration(seconds: 52));
+    expect(ticker.startTime, const Duration(milliseconds: 52));
 
     await tester.pump(const Duration(milliseconds: 10));
-    expect(ticker.startTime, const Duration(seconds: 52));
+    expect(ticker.startTime, const Duration(milliseconds: 52));
 
     ticker.dispose();
   });


### PR DESCRIPTION
1. I will finish code details, refine code, add tests, make tests pass, etc, after a code review that thinks the *rough idea* is acceptable. It is because, from my past experience, reviews may request changing a lot. If the general idea is to be changed, all detailed implementation efforts are wasted :)
2. The PR has an already-working counterpart, and it produces ~60FPS smooth experimental results. The benchmark results and detailed analysis is in chapter https://cjycode.com/flutter_smooth/benchmark/. All the source code is in  https://github.com/fzyzcjy/engine/tree/flutter-smooth and https://github.com/fzyzcjy/flutter/tree/flutter-smooth.
3. Possibly useful as a context to this PR, there is a whole chapter discussing the internals - how flutter_smooth is implemented. (Link: https://cjycode.com/flutter_smooth/design/)

---

Currently, the user of `Ticker` only knows the `elapsed` time. However, it looks reasonable to allow the user to know when the ticker thinks it *starts* ticking.

If this does not wanted to be widely used, maybe we can mark it as `@protected` or `@visibleForTesting` or [`@experimental`](https://pub.dev/documentation/meta/latest/meta/experimental-constant.html).

As for where it is needed inside flutter_smooth, it is utilized to know the relative time between a few Tickers as well as the system. In other words, when Ticker A says it elapsed 1 second, flutter_smooth needs to know the startTime such that it knows what "1second" means in absolute time. Detailed code can be seen in https://github.com/fzyzcjy/flutter_smooth/blob/0c5db0ff270aa0c8cff28ea19055999627a8df6d/packages/smooth/lib/src/drop_in/list_view/shift.dart#L352-L356
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
