### PR TITLE
chore: enable Flutter Android workflow on aarch64

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -44,19 +44,14 @@ class AndroidWorkflow implements Workflow {
   AndroidWorkflow({
     required AndroidSdk? androidSdk,
     required FeatureFlags featureFlags,
-    required OperatingSystemUtils operatingSystemUtils,
   }) : _androidSdk = androidSdk,
-       _featureFlags = featureFlags,
-       _operatingSystemUtils = operatingSystemUtils;
+       _featureFlags = featureFlags;
 
   final AndroidSdk? _androidSdk;
   final FeatureFlags _featureFlags;
-  final OperatingSystemUtils _operatingSystemUtils;
 
   @override
-  bool get appliesToHostPlatform => _featureFlags.isAndroidEnabled
-    // Android Studio is not currently supported on Linux Arm64 Hosts.
-    && _operatingSystemUtils.hostPlatform != HostPlatform.linux_arm64;
+  bool get appliesToHostPlatform => _featureFlags.isAndroidEnabled;
 
   @override
   bool get canListDevices => appliesToHostPlatform && _androidSdk != null

--- a/packages/flutter_tools/lib/src/context_runner.dart
+++ b/packages/flutter_tools/lib/src/context_runner.dart
@@ -120,7 +120,6 @@ Future<T> runInContext<T>(
       AndroidWorkflow: () => AndroidWorkflow(
         androidSdk: globals.androidSdk,
         featureFlags: featureFlags,
-        operatingSystemUtils: globals.os,
       ),
       ApplicationPackageFactory: () => FlutterApplicationPackageFactory(
         userMessages: globals.userMessages,

--- a/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_discovery_test.dart
@@ -23,7 +23,6 @@ void main() {
     androidWorkflow = AndroidWorkflow(
       androidSdk: FakeAndroidSdk(),
       featureFlags: TestFeatureFlags(),
-      operatingSystemUtils: FakeOperatingSystemUtils(),
     );
   });
 
@@ -34,7 +33,6 @@ void main() {
       androidWorkflow: AndroidWorkflow(
         androidSdk: FakeAndroidSdk(null),
         featureFlags: TestFeatureFlags(),
-        operatingSystemUtils: FakeOperatingSystemUtils(),
       ),
       processManager: FakeProcessManager.empty(),
       fileSystem: MemoryFileSystem.test(),
@@ -55,7 +53,6 @@ void main() {
       androidWorkflow: AndroidWorkflow(
         androidSdk: FakeAndroidSdk(),
         featureFlags: TestFeatureFlags(),
-        operatingSystemUtils: FakeOperatingSystemUtils(),
       ),
       processManager: fakeProcessManager,
       fileSystem: MemoryFileSystem.test(),
@@ -74,7 +71,6 @@ void main() {
       androidWorkflow: AndroidWorkflow(
         androidSdk: FakeAndroidSdk(null),
         featureFlags: TestFeatureFlags(),
-        operatingSystemUtils: FakeOperatingSystemUtils(),
       ),
       processManager: FakeProcessManager.empty(),
       fileSystem: MemoryFileSystem.test(),
@@ -116,7 +112,6 @@ void main() {
         featureFlags: TestFeatureFlags(
           isAndroidEnabled: false,
         ),
-        operatingSystemUtils: FakeOperatingSystemUtils(),
       ),
       processManager: FakeProcessManager.any(),
       fileSystem: MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -39,7 +39,6 @@ void main() {
     final AndroidWorkflow androidWorkflow = AndroidWorkflow(
       featureFlags: TestFeatureFlags(),
       androidSdk: null,
-      operatingSystemUtils: FakeOperatingSystemUtils(),
     );
 
     expect(androidWorkflow.canLaunchDevices, false);
@@ -53,7 +52,6 @@ void main() {
     final AndroidWorkflow androidWorkflow = AndroidWorkflow(
       featureFlags: TestFeatureFlags(),
       androidSdk: androidSdk,
-      operatingSystemUtils: FakeOperatingSystemUtils(),
     );
 
     expect(androidWorkflow.canLaunchDevices, false);
@@ -61,20 +59,19 @@ void main() {
     expect(androidWorkflow.canListEmulators, false);
   });
 
-  // Android Studio is not currently supported on Linux Arm64 hosts.
-  testWithoutContext('Not supported AndroidStudio on Linux Arm Hosts', () {
+  // Android SDK is actually supported on Linux Arm64 hosts.
+  testWithoutContext('Support for Android SDK on Linux Arm Hosts', () {
     final FakeAndroidSdk androidSdk = FakeAndroidSdk();
     androidSdk.adbPath = null;
     final AndroidWorkflow androidWorkflow = AndroidWorkflow(
       featureFlags: TestFeatureFlags(),
       androidSdk: androidSdk,
-      operatingSystemUtils: CustomFakeOperatingSystemUtils(hostPlatform: HostPlatform.linux_arm64),
     );
 
-    expect(androidWorkflow.appliesToHostPlatform, false);
-    expect(androidWorkflow.canLaunchDevices, false);
-    expect(androidWorkflow.canListDevices, false);
-    expect(androidWorkflow.canListEmulators, false);
+    expect(androidWorkflow.appliesToHostPlatform, isTrue);
+    expect(androidWorkflow.canLaunchDevices, isFalse);
+    expect(androidWorkflow.canListDevices, isFalse);
+    expect(androidWorkflow.canListEmulators, isFalse);
   });
 
   testWithoutContext('AndroidWorkflow is disabled if feature is disabled', () {
@@ -83,7 +80,6 @@ void main() {
     final AndroidWorkflow androidWorkflow = AndroidWorkflow(
       featureFlags: TestFeatureFlags(isAndroidEnabled: false),
       androidSdk: androidSdk,
-      operatingSystemUtils: FakeOperatingSystemUtils(),
     );
 
     expect(androidWorkflow.appliesToHostPlatform, false);
@@ -98,7 +94,6 @@ void main() {
     final AndroidWorkflow androidWorkflow = AndroidWorkflow(
       featureFlags: TestFeatureFlags(),
       androidSdk: androidSdk,
-      operatingSystemUtils: FakeOperatingSystemUtils(),
     );
 
     expect(androidWorkflow.appliesToHostPlatform, true);
@@ -114,7 +109,6 @@ void main() {
     final AndroidWorkflow androidWorkflow = AndroidWorkflow(
       featureFlags: TestFeatureFlags(),
       androidSdk: androidSdk,
-      operatingSystemUtils: FakeOperatingSystemUtils(),
     );
 
     expect(androidWorkflow.appliesToHostPlatform, true);

--- a/packages/flutter_tools/test/general.shard/emulator_test.dart
+++ b/packages/flutter_tools/test/general.shard/emulator_test.dart
@@ -79,7 +79,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
 
@@ -101,7 +100,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
 
@@ -116,7 +114,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
         fileSystem: fileSystem,
       );
@@ -144,7 +141,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
       final CreateEmulatorResult result = await emulatorManager.createEmulator();
@@ -186,7 +182,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
       final CreateEmulatorResult result = await emulatorManager.createEmulator();
@@ -223,7 +218,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
       final CreateEmulatorResult result = await emulatorManager.createEmulator(name: 'test');
@@ -262,7 +256,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
       final CreateEmulatorResult result = await emulatorManager.createEmulator(name: 'existing-avd-1');
@@ -304,7 +297,6 @@ void main() {
         androidWorkflow: AndroidWorkflow(
           androidSdk: sdk,
           featureFlags: TestFeatureFlags(),
-          operatingSystemUtils: FakeOperatingSystemUtils(),
         ),
       );
       final CreateEmulatorResult result = await emulatorManager.createEmulator();


### PR DESCRIPTION
- removes invalid arch check on Android workflow in order to enable Android development on any device supported

Fixes: #99333

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
