### PR TITLE
Fix bug that`timeDilation` is not reset, causing subsequent test errors, and add verifications to ensure such problem does not exist in the future

### DIFF
--- a/dev/tools/examples_smoke_test.dart
+++ b/dev/tools/examples_smoke_test.dart
@@ -165,6 +165,7 @@ void main() {
         expect(find.byType(WidgetsApp), findsOneWidget);
       } finally {
         ErrorWidget.builder = originalBuilder;
+        timeDilation = 1.0;
       }
     },
   );

--- a/dev/tools/examples_smoke_test.dart
+++ b/dev/tools/examples_smoke_test.dart
@@ -119,6 +119,7 @@ Future<File> generateTest(Directory apiDir) async {
   // Collect the examples, and import them all as separate symbols.
   final List<String> imports = <String>[];
   imports.add('''import 'package:flutter/widgets.dart';''');
+  imports.add('''import 'package:flutter/scheduler.dart';''');
   imports.add('''import 'package:flutter_test/flutter_test.dart';''');
   imports.add('''import 'package:integration_test/integration_test.dart';''');
   final List<ExampleInfo> infoList = <ExampleInfo>[];

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -652,6 +652,20 @@ mixin SchedulerBinding on BindingBase {
     return true;
   }
 
+  /// Asserts that there is no artificial time dilation in debug mode.
+  ///
+  /// Throws a [FlutterError] if there are such dilation, as this will make
+  /// subsequent tests see dilation and thus flaky.
+  bool debugAssertNoTimeDilation(String reason) {
+    assert(() {
+      if (timeDilation != 1.0) {
+        throw FlutterError(reason);
+      }
+      return true;
+    }());
+    return true;
+  }
+
   /// Prints the stack for where the current transient callback was registered.
   ///
   /// A transient frame callback is one that was registered with

--- a/packages/flutter/test/scheduler/binding_test.dart
+++ b/packages/flutter/test/scheduler/binding_test.dart
@@ -21,7 +21,7 @@ void main() {
   });
 
   test('debugAssertNoTimeDilation throw if time dilate not reset', () async {
-    timeDilation = 2.0;
+    timeDilation = 3.0;
     expect(
       () => SchedulerBinding.instance.debugAssertNoTimeDilation('reason'),
       throwsA(isA<FlutterError>().having((FlutterError e) => e.message, 'message', 'reason')),

--- a/packages/flutter/test/scheduler/binding_test.dart
+++ b/packages/flutter/test/scheduler/binding_test.dart
@@ -13,4 +13,19 @@ void main() {
     SchedulerBinding.instance.scheduleForcedFrame();
     expect(SchedulerBinding.instance.platformDispatcher.onBeginFrame, isNotNull);
   });
+
+  test('debugAssertNoTimeDilation does not throw if time dilate already reset', () async {
+    timeDilation = 2.0;
+    timeDilation = 1.0;
+    SchedulerBinding.instance.debugAssertNoTimeDilation('reason'); // no error
+  });
+
+  test('debugAssertNoTimeDilation throw if time dilate not reset', () async {
+    timeDilation = 2.0;
+    expect(
+      () => SchedulerBinding.instance.debugAssertNoTimeDilation('reason'),
+      throwsA(isA<FlutterError>().having((FlutterError e) => e.message, 'message', 'reason')),
+    );
+    timeDilation = 1.0;
+  });
 }

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -215,6 +215,8 @@ void main() {
     tick(const Duration(seconds: 8));
     expect(lastTimeStamp, const Duration(seconds: 3)); // 2s + (8 - 6)s / 2
     expect(lastSystemTimeStamp, const Duration(seconds: 8));
+
+    timeDilation = 1.0; // restore time dilation, or it will affect other tests
   });
 
   test('Animation frame scheduled in the middle of the warm-up frame', () {

--- a/packages/flutter/test/scheduler/ticker_test.dart
+++ b/packages/flutter/test/scheduler/ticker_test.dart
@@ -124,6 +124,8 @@ void main() {
     expect(lastDuration, const Duration(milliseconds: 20));
 
     ticker.dispose();
+
+    timeDilation = 1.0; // restore time dilation, or it will affect other tests
   });
 
   testWidgets('Ticker can be slowed down with time dilation', (WidgetTester tester) async {
@@ -140,6 +142,8 @@ void main() {
     expect(lastDuration, const Duration(milliseconds: 5));
 
     ticker.dispose();
+
+    timeDilation = 1.0; // restore time dilation, or it will affect other tests
   });
 
   testWidgets('Ticker stops ticking when application is paused', (WidgetTester tester) async {

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -888,6 +888,9 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     assert(debugAssertNoPendingPerformanceModeRequests(
       'A performance mode was requested and not disposed by a test.'
     ));
+    assert(debugAssertNoTimeDilation(
+      'The timeDilation was changed and not reset by the test.'
+    ));
     assert(debugAssertAllFoundationVarsUnset(
       'The value of a foundation debug variable was changed by the test.',
       debugPrintOverride: debugPrintOverride,


### PR DESCRIPTION
Some tests set the time dilation to be non-one, but is not reset after the test ends. Thus, every test after it will see very weird time. I find this bug because got trapped in https://github.com/flutter/flutter/pull/113828.

The added line, `timeDilation = 1.0; // restore time dilation, or it will affect other tests`, is copied from `image_stream_test.dart`'s `'timeDilation affects animation frame timers'` test.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
