### PR TITLE
Avoid creating map literal in `flutter.gradle` multidex check

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -244,7 +244,7 @@ class FlutterPlugin implements Plugin<Project> {
             project.android {
                 defaultConfig {
                     multiDexEnabled true
-                    manifestPlaceholders = [applicationName: "io.flutter.app.FlutterMultiDexApplication"]
+                    manifestPlaceholders.applicationName = "io.flutter.app.FlutterMultiDexApplication"
                 }
                 buildTypes {
                     release {
@@ -263,7 +263,7 @@ class FlutterPlugin implements Plugin<Project> {
             project.android {
                 defaultConfig {
                     // Setting to android.app.Application is the same as omitting the attribute.
-                    manifestPlaceholders = [applicationName: baseApplicationName]
+                    manifestPlaceholders.applicationName = baseApplicationName
                 }
             }
         }


### PR DESCRIPTION
Attempts to mitigate https://github.com/flutter/flutter/issues/103230, directly assign groovy variable rather than through map literal form. This avoids many comparisons, which seems to be causing issues in unclear but rare conditions.

The flake rate of this is low and sporadic, so there is no good way to validate this fixes the flake except to land, wait, and see.