### PR TITLE
Followup 113705: Allow the `slow` tests to break the tree as all tests in that shard previously could

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -378,7 +378,6 @@ targets:
       - .ci.yaml
 
   - name: Linux framework_tests_slow
-    bringup: true
     recipe: flutter/flutter_drone
     timeout: 60
     properties:


### PR DESCRIPTION
See [LUCI build logs](https://ci.chromium.org/ui/p/flutter/builders/staging/Linux%20framework_tests_slow/1/overview) for proof of the tests working in their new shard.

Followup for #113705.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.