### PR TITLE
Use correct semantics for toggle buttons

### DIFF
--- a/packages/flutter/lib/src/material/toggle_buttons.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons.dart
@@ -798,7 +798,7 @@ class ToggleButtons extends StatelessWidget {
       return MergeSemantics(
         child: Semantics(
           container: true,
-          toggled: isSelected[index],
+          checked: isSelected[index],
           enabled: onPressed != null,
           child: _InputPadding(
             minSize: minPaddingSize,

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -2006,7 +2006,7 @@ void main() {
                 SemanticsFlag.isButton,
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.hasEnabledState,
-                SemanticsFlag.hasToggledState,
+                SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isFocusable,
               ],
               actions: <SemanticsAction>[
@@ -2019,7 +2019,7 @@ void main() {
                 SemanticsFlag.isButton,
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.hasEnabledState,
-                SemanticsFlag.hasToggledState,
+                SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isFocusable,
               ],
               actions: <SemanticsAction>[
@@ -2032,7 +2032,7 @@ void main() {
                 SemanticsFlag.isButton,
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.hasEnabledState,
-                SemanticsFlag.hasToggledState,
+                SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isFocusable,
               ],
               actions: <SemanticsAction>[
@@ -2079,7 +2079,7 @@ void main() {
                 SemanticsFlag.isButton,
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.hasEnabledState,
-                SemanticsFlag.hasToggledState,
+                SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isFocusable,
               ],
               actions: <SemanticsAction>[
@@ -2092,7 +2092,7 @@ void main() {
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.hasEnabledState,
                 SemanticsFlag.isToggled,
-                SemanticsFlag.hasToggledState,
+                SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isFocusable,
               ],
               actions: <SemanticsAction>[

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -2051,7 +2051,7 @@ void main() {
     semantics.dispose();
   });
 
-    testWidgets('Toggle buttons have correct semantics', (WidgetTester tester) async {
+  testWidgets('Toggle buttons have correct semantics', (WidgetTester tester) async {
     final SemanticsTester semantics = SemanticsTester(tester);
 
     await tester.pumpWidget(
@@ -2091,7 +2091,7 @@ void main() {
                 SemanticsFlag.isButton,
                 SemanticsFlag.isEnabled,
                 SemanticsFlag.hasEnabledState,
-                SemanticsFlag.isToggled,
+                SemanticsFlag.isChecked,
                 SemanticsFlag.hasCheckedState,
                 SemanticsFlag.isFocusable,
               ],


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/106095 (for real)

I mistakenly used the `toggled` semantics in https://github.com/flutter/flutter/pull/106096.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
