### PR TITLE
Fix wasted memory caused by debug fields - 16 bytes per object (when adding that should-be-removed field crosses double-word alignment)

### DIFF
--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -842,7 +842,11 @@ class AnimationController extends Animation<double>
   String toStringDetails() {
     final String paused = isAnimating ? '' : '; paused';
     final String ticker = _ticker == null ? '; DISPOSED' : (_ticker!.muted ? '; silenced' : '');
-    final String label = debugLabel == null ? '' : '; for $debugLabel';
+    String label = '';
+    assert(() {
+      if (debugLabel != null) label = '; for $debugLabel';
+      return true;
+    }());
     final String more = '${super.toStringDetails()} ${value.toStringAsFixed(3)}';
     return '$more$paused$ticker$label';
   }

--- a/packages/flutter/lib/src/animation/animation_controller.dart
+++ b/packages/flutter/lib/src/animation/animation_controller.dart
@@ -844,7 +844,9 @@ class AnimationController extends Animation<double>
     final String ticker = _ticker == null ? '; DISPOSED' : (_ticker!.muted ? '; silenced' : '');
     String label = '';
     assert(() {
-      if (debugLabel != null) label = '; for $debugLabel';
+      if (debugLabel != null) {
+        label = '; for $debugLabel';
+      }
       return true;
     }());
     final String more = '${super.toStringDetails()} ${value.toStringAsFixed(3)}';


### PR DESCRIPTION
Close #113940

## Theoretical analysis

Consider the following example code. Code with "case A" occupies 2.5GB memory, while "case B" is 4.0GB memory.

<details>

```dart
class C {
  int? a;
  int? b;

  // int get computed => a.hashCode; // case A
  int get computed => a.hashCode ^ b.hashCode; // case B
}

Future<void> main() async {
  final arr = <C>[];
  for (var i = 0; i < 100000000; ++i) {
    arr.add(C()
      ..a = 42
      ..b = 100);
  }
  print('hash=${Object.hashAll(arr.map((e) => e.computed))}');

  print('sleep...');
  await Future<void>.delayed(const Duration(seconds: 10000));
}
```

</details>

Therefore, we know that, a field does not occupy memory if there is no read/write to it. For example, the field `b` in case A is never read, so Dart compiler seems so smart that it knows it can be eliminated and no memory is allocated for that. By the way, `b` is *written* even in case A, but seems memory is not allocated as long as it is not read. This agrees with common sense (but since I am not compiler expert, feel free to correct me if I am wrong!).

For fields inside Flutter that is merely used for debug, they are usually accessed inside an `assert(() { ... }());` block. That is great, because if *each and every* field access are inside `assert`, those code will be eliminated in release build, and by discussions above, we will not pay memory for those *debug* fields.

However, `AnimationController.debugLabel` does not seem to follow this. Inside `AnimationController.toStringDetails`, it uses `debugLabel` field *without* being inside a `assert` block. Therefore, IMHO, we will be paying the memory of debugLabel even if we never use that in runtime.

As for why `toStringDetails` is guaranteed to be called, it is simple: `Animation.toString` calls that `toStringDetails`, and we know `toString` will not be tree shaken out.

## Experimental analysis

### Setup

Use these code:

<details>

Need to add two dummy fields to AnimationController, such that it crosses the double-word alignment. (Yes, this PR does not affect memory for *today*'s AnimationController, but who can guarantee it never have two more fields or two less fields, which this PR will reduce 16 bytes).

```dart
class AnimationController {
  int? dummy1;
  int? dummy2;
... old code ...
}
```

Use this code

```dart
import 'package:flutter/material.dart';
import 'package:flutter/scheduler.dart';

void main() => runApp(const MyApp());

class MyApp extends StatefulWidget {
  const MyApp({Key? key}) : super(key: key);

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> {
  final arr = <AnimationController>[];

  @override
  void initState() {
    super.initState();
    for (var i = 0; i < 2000000; ++i) arr.add(AnimationController(vsync: const TestVSync()));
    print('${arr.first.dummy1} ${arr.first.dummy2}'); // ensure the dummy fields are not removed
    arr.first
      ..duration = const Duration(seconds: 1)
      ..forward();
  }

  @override
  Widget build(BuildContext context) => Container();
}

class TestVSync implements TickerProvider {
  const TestVSync();

  @override
  Ticker createTicker(TickerCallback onTick) => Ticker(onTick);
}
```

</details>

### Operations

1. `flutter build apk --extra-gen-snapshot-options='--print-object-layout-to=object_layout.json'` and look at json to know memory layout
2. `flutter run --profile` to know memory consumption at runtime

### Results

#### Without PR

96 bytes per object

<details>

```
  {
    "class": "AnimationController",
    "size": 96,
    "fields": [
      {
        "field": "dummy1",
        "offset": 20
      },
      {
        "field": "dummy2",
        "offset": 24
      },
      {
        "field": "lowerBound",
        "offset": 28
      },
      {
        "field": "upperBound",
        "offset": 36
      },
      {
        "field": "debugLabel",
        "offset": 44
      },
      {
        "field": "animationBehavior",
        "offset": 48
      },
      {
        "field": "duration",
        "offset": 52
      },
      {
        "field": "reverseDuration",
        "offset": 56
      },
      {
        "field": "_ticker",
        "offset": 60
      },
      {
        "field": "_simulation",
        "offset": 64
      },
      {
        "field": "_value",
        "offset": 68
      },
      {
        "field": "_direction",
        "offset": 72
      },
      {
        "field": "_status",
        "offset": 76
      },
      {
        "field": "_lastReportedStatus",
        "offset": 80
      }
    ]
  },
```

</details>

and

![image](https://user-images.githubusercontent.com/5236035/197549017-4166f28a-812c-42b4-b90d-e3b5258ca998.png)

#### With this PR

80 bytes per object

<details>

```
  {
    "class": "AnimationController",
    "size": 80,
    "fields": [
      {
        "field": "dummy1",
        "offset": 20
      },
      {
        "field": "dummy2",
        "offset": 24
      },
      {
        "field": "lowerBound",
        "offset": 28
      },
      {
        "field": "upperBound",
        "offset": 36
      },
      {
        "field": "animationBehavior",
        "offset": 44
      },
      {
        "field": "duration",
        "offset": 48
      },
      {
        "field": "reverseDuration",
        "offset": 52
      },
      {
        "field": "_ticker",
        "offset": 56
      },
      {
        "field": "_simulation",
        "offset": 60
      },
      {
        "field": "_value",
        "offset": 64
      },
      {
        "field": "_direction",
        "offset": 68
      },
      {
        "field": "_status",
        "offset": 72
      },
      {
        "field": "_lastReportedStatus",
        "offset": 76
      }
    ]
  },
```

</details>

and

![image](https://user-images.githubusercontent.com/5236035/197549096-2c9847c9-b17a-41df-9906-2b5ae1c9e798.png)


### Conclusion

16B reduce per object.

#### Without PR



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
