### PR TITLE
Add option to build app for Windows on Arm

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -226,6 +226,7 @@ class AndroidDevice extends Device {
       case TargetPlatform.tester:
       case TargetPlatform.web_javascript:
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
         throw UnsupportedError('Invalid target platform for Android');
     }
   }
@@ -563,6 +564,7 @@ class AndroidDevice extends Device {
       case TargetPlatform.linux_x64:
       case TargetPlatform.tester:
       case TargetPlatform.web_javascript:
+      case TargetPlatform.windows_arm64:
       case TargetPlatform.windows_x64:
         _logger.printError('Android platforms are only supported.');
         return LaunchResult.failed();

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -118,6 +118,7 @@ TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
     case TargetPlatform.linux_x64:
     case TargetPlatform.linux_arm64:
     case TargetPlatform.windows_x64:
+    case TargetPlatform.windows_arm64:
     case TargetPlatform.fuchsia_arm64:
     case TargetPlatform.fuchsia_x64:
     case TargetPlatform.tester:
@@ -134,6 +135,7 @@ TargetPlatform? _mapTargetPlatform(TargetPlatform? targetPlatform) {
 bool _isWindows(TargetPlatform? platform) {
   switch (platform) {
     case TargetPlatform.windows_x64:
+    case TargetPlatform.windows_arm64:
       return true;
     case TargetPlatform.android:
     case TargetPlatform.android_arm:
@@ -437,6 +439,10 @@ class CachedArtifacts implements Artifacts {
       case TargetPlatform.linux_arm64:
       case TargetPlatform.windows_x64:
         return _getDesktopArtifactPath(artifact, platform, mode);
+      // Artifacts for windows-arm64 are not yet available.
+      // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/62597
+      case TargetPlatform.windows_arm64:
+        return _getDesktopArtifactPath(artifact, TargetPlatform.windows_x64, mode);
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
         return _getFuchsiaArtifactPath(artifact, platform!, mode!);
@@ -645,6 +651,7 @@ class CachedArtifacts implements Artifacts {
       case TargetPlatform.linux_arm64:
       case TargetPlatform.darwin:
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
         // TODO(zanderso): remove once debug desktop artifacts are uploaded
         // under a separate directory from the host artifacts.
         // https://github.com/flutter/flutter/issues/38935
@@ -956,6 +963,10 @@ class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
       case TargetPlatform.linux_x64:
         return 'linux-x64';
       case TargetPlatform.windows_x64:
+        return 'windows-x64';
+      case TargetPlatform.windows_arm64:
+        // Artifacts for windows-arm64 are not yet available, use x64 instead
+        // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/62597
         return 'windows-x64';
       case TargetPlatform.ios:
       case TargetPlatform.android:

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -472,8 +472,17 @@ class _WindowsUtils extends OperatingSystemUtils {
     required super.processManager,
   }) : super._private();
 
+  HostPlatform? _hostPlatform;
+
   @override
-  HostPlatform hostPlatform = HostPlatform.windows_x64;
+  HostPlatform get hostPlatform {
+    if (_hostPlatform == null) {
+      final String arch = _platform.environment['PROCESSOR_ARCHITECTURE'] ?? '';
+      _hostPlatform = (arch == 'ARM64') ? HostPlatform.windows_arm64 :
+                                          HostPlatform.windows_x64;
+    }
+    return _hostPlatform!;
+  }
 
   @override
   void makeExecutable(File file) {}
@@ -608,6 +617,7 @@ enum HostPlatform {
   linux_x64,
   linux_arm64,
   windows_x64,
+  windows_arm64,
 }
 
 String getNameForHostPlatform(HostPlatform platform) {
@@ -622,5 +632,7 @@ String getNameForHostPlatform(HostPlatform platform) {
       return 'linux-arm64';
     case HostPlatform.windows_x64:
       return 'windows-x64';
+    case HostPlatform.windows_arm64:
+      return 'windows-arm64';
   }
 }

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -569,6 +569,7 @@ enum TargetPlatform {
   linux_x64,
   linux_arm64,
   windows_x64,
+  windows_arm64,
   fuchsia_arm64,
   fuchsia_x64,
   tester,
@@ -727,6 +728,8 @@ String getNameForTargetPlatform(TargetPlatform platform, {DarwinArch? darwinArch
       return 'linux-arm64';
     case TargetPlatform.windows_x64:
       return 'windows-x64';
+    case TargetPlatform.windows_arm64:
+      return 'windows-arm64';
     case TargetPlatform.fuchsia_arm64:
       return 'fuchsia-arm64';
     case TargetPlatform.fuchsia_x64:
@@ -770,6 +773,8 @@ TargetPlatform getTargetPlatformForName(String platform) {
       return TargetPlatform.linux_arm64;
     case 'windows-x64':
       return TargetPlatform.windows_x64;
+    case 'windows-arm64':
+      return TargetPlatform.windows_arm64;
     case 'web-javascript':
       return TargetPlatform.web_javascript;
   }
@@ -834,6 +839,7 @@ String fuchsiaArchForTargetPlatform(TargetPlatform targetPlatform) {
     case TargetPlatform.tester:
     case TargetPlatform.web_javascript:
     case TargetPlatform.windows_x64:
+    case TargetPlatform.windows_arm64:
       throw UnsupportedError('Unexpected Fuchsia platform $targetPlatform');
   }
 }
@@ -1078,6 +1084,7 @@ String getNameForTargetPlatformArch(TargetPlatform platform) {
     case TargetPlatform.windows_x64:
       return 'x64';
     case TargetPlatform.linux_arm64:
+    case TargetPlatform.windows_arm64:
       return 'arm64';
     case TargetPlatform.android:
     case TargetPlatform.android_arm:
@@ -1105,6 +1112,8 @@ String getNameForHostPlatformArch(HostPlatform platform) {
       return 'arm64';
     case HostPlatform.windows_x64:
       return 'x64';
+    case HostPlatform.windows_arm64:
+      return 'arm64';
   }
 }
 

--- a/packages/flutter_tools/lib/src/build_system/targets/common.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/common.dart
@@ -194,6 +194,7 @@ class KernelSnapshot extends Target {
     switch (targetPlatform) {
       case TargetPlatform.darwin:
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
       case TargetPlatform.linux_x64:
         forceLinkPlatform = true;
         break;

--- a/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/shader_compiler.dart
@@ -67,6 +67,7 @@ class DevelopmentShaderCompiler {
       case TargetPlatform.linux_x64:
       case TargetPlatform.linux_arm64:
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
       case TargetPlatform.fuchsia_arm64:
       case TargetPlatform.fuchsia_x64:
       case TargetPlatform.tester:

--- a/packages/flutter_tools/lib/src/commands/build.dart
+++ b/packages/flutter_tools/lib/src/commands/build.dart
@@ -66,7 +66,10 @@ class BuildCommand extends FlutterCommand {
       operatingSystemUtils: osUtils,
       verboseHelp: verboseHelp
     ));
-    _addSubcommand(BuildWindowsCommand(logger: logger, verboseHelp: verboseHelp));
+    _addSubcommand(BuildWindowsCommand(
+      logger: logger,
+      verboseHelp: verboseHelp,
+    ));
   }
 
   void _addSubcommand(BuildSubCommand command) {

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -43,6 +43,7 @@ class BuildBundleCommand extends BuildSubCommand {
           'linux-x64',
           'linux-arm64',
           'windows-x64',
+          'windows-arm64',
         ],
         help: 'The architecture for which to build the application.',
       )
@@ -109,6 +110,7 @@ class BuildBundleCommand extends BuildSubCommand {
         }
         break;
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
         if (!featureFlags.isWindowsEnabled) {
           throwToolExit('Windows is not a supported target platform.');
         }

--- a/packages/flutter_tools/lib/src/commands/build_windows.dart
+++ b/packages/flutter_tools/lib/src/commands/build_windows.dart
@@ -23,6 +23,15 @@ class BuildWindowsCommand extends BuildSubCommand {
     bool verboseHelp = false,
   }) : super(verboseHelp: verboseHelp) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
+    // As long as arm64 does not have artifacts available, stick to x64.
+    // OperatingSystemUtils can be used to identify host architecture.
+    // TODO(stuartmorgan): https://github.com/flutter/flutter/issues/62597
+    const String defaultTargetPlatform = 'windows-x64';
+    argParser.addOption('target-platform',
+      defaultsTo: defaultTargetPlatform,
+      allowed: <String>['windows-arm64', 'windows-x64'],
+      help: 'The target platform for which the app is compiled.',
+    );
   }
 
   @override
@@ -46,6 +55,8 @@ class BuildWindowsCommand extends BuildSubCommand {
   Future<FlutterCommandResult> runCommand() async {
     final FlutterProject flutterProject = FlutterProject.current();
     final BuildInfo buildInfo = await getBuildInfo();
+    final TargetPlatform targetPlatform =
+        getTargetPlatformForName(stringArg('target-platform')!);
     if (!featureFlags.isWindowsEnabled) {
       throwToolExit('"build windows" is not currently supported. To enable, run "flutter config --enable-windows-desktop".');
     }
@@ -57,6 +68,7 @@ class BuildWindowsCommand extends BuildSubCommand {
       flutterProject.windows,
       buildInfo,
       target: targetFile,
+      targetPlatform: targetPlatform,
       visualStudioOverride: visualStudioOverride,
       sizeAnalyzer: SizeAnalyzer(
         fileSystem: globals.fs,

--- a/packages/flutter_tools/lib/src/flutter_application_package.dart
+++ b/packages/flutter_tools/lib/src/flutter_application_package.dart
@@ -98,6 +98,7 @@ class FlutterApplicationPackageFactory extends ApplicationPackageFactory {
             ? LinuxApp.fromLinuxProject(FlutterProject.current().linux)
             : LinuxApp.fromPrebuiltApp(applicationBinary);
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
         return applicationBinary == null
             ? WindowsApp.fromWindowsProject(FlutterProject.current().windows)
             : WindowsApp.fromPrebuiltApp(applicationBinary);

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -218,6 +218,7 @@ class MDnsObservatoryDiscovery {
       case TargetPlatform.tester:
       case TargetPlatform.web_javascript:
       case TargetPlatform.windows_x64:
+      case TargetPlatform.windows_arm64:
         _logger.printTrace('No interface with an ipv4 link local address was found.');
         break;
     }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -1562,6 +1562,7 @@ Future<String?> getMissingPackageHintForPlatform(TargetPlatform platform) async 
     case TargetPlatform.tester:
     case TargetPlatform.web_javascript:
     case TargetPlatform.windows_x64:
+    case TargetPlatform.windows_arm64:
       return null;
   }
 }

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1709,6 +1709,7 @@ DevelopmentArtifact? artifactFromTargetPlatform(TargetPlatform targetPlatform) {
       }
       return null;
     case TargetPlatform.windows_x64:
+    case TargetPlatform.windows_arm64:
       if (featureFlags.isWindowsEnabled) {
         return DevelopmentArtifact.windows;
       }

--- a/packages/flutter_tools/lib/src/sksl_writer.dart
+++ b/packages/flutter_tools/lib/src/sksl_writer.dart
@@ -55,6 +55,7 @@ Future<String?> sharedSkSlWriter(Device device, Map<String, Object?>? data, {
     case TargetPlatform.tester:
     case TargetPlatform.web_javascript:
     case TargetPlatform.windows_x64:
+    case TargetPlatform.windows_arm64:
       break;
   }
   final Map<String, Object> manifest = <String, Object>{

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_windows_test.dart
@@ -7,10 +7,12 @@ import 'package:file_testing/file_testing.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/platform.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/build_windows.dart';
 import 'package:flutter_tools/src/features.dart';
 import 'package:flutter_tools/src/reporting/reporting.dart';
+import 'package:flutter_tools/src/windows/build_windows.dart';
 import 'package:flutter_tools/src/windows/visual_studio.dart';
 import 'package:test/fake.dart';
 
@@ -75,6 +77,7 @@ void main() {
   FakeCommand cmakeGenerationCommand({
     void Function()? onRun,
     String generator = _defaultGenerator,
+    TargetPlatform targetPlatform = TargetPlatform.windows_x64,
   }) {
     return FakeCommand(
       command: <String>[
@@ -85,6 +88,8 @@ void main() {
         r'build\windows',
         '-G',
         generator,
+        '-A',
+        getCmakeWindowsArch(targetPlatform),
       ],
       onRun: onRun,
     );

--- a/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/build_bundle_test.dart
@@ -88,7 +88,7 @@ void main() {
     expect((await command.usageValues).commandBuildBundleTargetPlatform, 'android-arm');
   });
 
-  testUsingContext('bundle fails to build for Windows if feature is disabled', () async {
+  testUsingContext('bundle fails to build for Windows x64 if feature is disabled', () async {
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     globals.fs.file('pubspec.yaml').createSync(recursive: true);
     globals.fs.file('.packages').createSync(recursive: true);
@@ -101,6 +101,26 @@ void main() {
       'bundle',
       '--no-pub',
       '--target-platform=windows-x64',
+    ]), throwsToolExit());
+  }, overrides: <Type, Generator>{
+    FileSystem: fsFactory,
+    ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: () => TestFeatureFlags(),
+  });
+
+  testUsingContext('bundle fails to build for Windows arm64 if feature is disabled', () async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    globals.fs.file('pubspec.yaml').createSync(recursive: true);
+    globals.fs.file('.packages').createSync(recursive: true);
+    final CommandRunner<void> runner = createTestCommandRunner(BuildBundleCommand(
+      logger: BufferLogger.test(),
+      bundleBuilder: FakeBundleBuilder(),
+    ));
+
+    expect(() => runner.run(<String>[
+      'bundle',
+      '--no-pub',
+      '--target-platform=windows-arm64',
     ]), throwsToolExit());
   }, overrides: <Type, Generator>{
     FileSystem: fsFactory,
@@ -168,7 +188,7 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
   });
 
-  testUsingContext('bundle can build for Windows if feature is enabled', () async {
+  testUsingContext('bundle can build for Windows x64 if feature is enabled', () async {
     globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
     globals.fs.file('pubspec.yaml').createSync();
     globals.fs.file('.packages').createSync();
@@ -181,6 +201,26 @@ void main() {
       'bundle',
       '--no-pub',
       '--target-platform=windows-x64',
+    ]);
+  }, overrides: <Type, Generator>{
+    FileSystem: fsFactory,
+    ProcessManager: () => FakeProcessManager.any(),
+    FeatureFlags: () => TestFeatureFlags(isWindowsEnabled: true),
+  });
+
+  testUsingContext('bundle can build for Windows arm64 if feature is enabled', () async {
+    globals.fs.file(globals.fs.path.join('lib', 'main.dart')).createSync(recursive: true);
+    globals.fs.file('pubspec.yaml').createSync();
+    globals.fs.file('.packages').createSync();
+    final CommandRunner<void> runner = createTestCommandRunner(BuildBundleCommand(
+      logger: BufferLogger.test(),
+      bundleBuilder: FakeBundleBuilder()
+    ));
+
+    await runner.run(<String>[
+      'bundle',
+      '--no-pub',
+      '--target-platform=windows-arm64',
     ]);
   }, overrides: <Type, Generator>{
     FileSystem: fsFactory,

--- a/packages/flutter_tools/test/general.shard/base/os_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/os_test.dart
@@ -160,10 +160,28 @@ void main() {
       expect(utils.hostPlatform, HostPlatform.linux_x64);
     });
 
-    testWithoutContext('Windows', () async {
+    testWithoutContext('Windows default', () async {
       final OperatingSystemUtils utils =
       createOSUtils(FakePlatform(operatingSystem: 'windows'));
       expect(utils.hostPlatform, HostPlatform.windows_x64);
+    });
+
+    testWithoutContext('Windows x64', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(
+        operatingSystem: 'windows',
+        environment: <String, String>{'PROCESSOR_ARCHITECTURE': 'AMD64'},
+      ));
+      expect(utils.hostPlatform, HostPlatform.windows_x64);
+    });
+
+    testWithoutContext('Windows arm64', () async {
+      final OperatingSystemUtils utils =
+      createOSUtils(FakePlatform(
+        operatingSystem: 'windows',
+        environment: <String, String>{'PROCESSOR_ARCHITECTURE': 'ARM64'},
+      ));
+      expect(utils.hostPlatform, HostPlatform.windows_arm64);
     });
 
     testWithoutContext('Linux x64', () async {


### PR DESCRIPTION
This PR adds Windows on Arm as a known platform,
and an option --target-plaftorm to "build windows" command, similar to what exists for build-linux.

Default behavior was not changed. See commits for details.

Tested by building https://github.com/flutter/gallery with this.

Issue: https://github.com/flutter/flutter/issues/62597

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
