### PR TITLE
[framework] conditional removal of animated opacity

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_sliver.dart
+++ b/packages/flutter/lib/src/rendering/proxy_sliver.dart
@@ -401,10 +401,12 @@ class RenderSliverAnimatedOpacity extends RenderProxySliver with RenderAnimatedO
     required Animation<double> opacity,
     bool alwaysIncludeSemantics = false,
     RenderSliver? sliver,
+    required double advisoryDevicePixelRatio,
   }) : assert(opacity != null),
        assert(alwaysIncludeSemantics != null) {
     this.opacity = opacity;
     this.alwaysIncludeSemantics = alwaysIncludeSemantics;
+    this.advisoryDevicePixelRatio = advisoryDevicePixelRatio;
     child = sliver;
   }
 }

--- a/packages/flutter/lib/src/widgets/transitions.dart
+++ b/packages/flutter/lib/src/widgets/transitions.dart
@@ -9,6 +9,7 @@ import 'package:flutter/rendering.dart';
 import 'basic.dart';
 import 'container.dart';
 import 'framework.dart';
+import 'media_query.dart';
 import 'text.dart';
 
 export 'package:flutter/rendering.dart' show RelativeRect;
@@ -554,6 +555,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
     return RenderAnimatedOpacity(
       opacity: opacity,
       alwaysIncludeSemantics: alwaysIncludeSemantics,
+      advisoryDevicePixelRatio: MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0,
     );
   }
 
@@ -561,6 +563,7 @@ class FadeTransition extends SingleChildRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderAnimatedOpacity renderObject) {
     renderObject
       ..opacity = opacity
+      ..advisoryDevicePixelRatio = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0
       ..alwaysIncludeSemantics = alwaysIncludeSemantics;
   }
 
@@ -625,6 +628,7 @@ class SliverFadeTransition extends SingleChildRenderObjectWidget {
     return RenderSliverAnimatedOpacity(
       opacity: opacity,
       alwaysIncludeSemantics: alwaysIncludeSemantics,
+      advisoryDevicePixelRatio: MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0,
     );
   }
 
@@ -632,6 +636,7 @@ class SliverFadeTransition extends SingleChildRenderObjectWidget {
   void updateRenderObject(BuildContext context, RenderSliverAnimatedOpacity renderObject) {
     renderObject
       ..opacity = opacity
+      ..advisoryDevicePixelRatio = MediaQuery.maybeOf(context)?.devicePixelRatio ?? 1.0
       ..alwaysIncludeSemantics = alwaysIncludeSemantics;
   }
 

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -364,13 +364,14 @@ void main() {
     final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
       opacity: opacityAnimation,
       child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      advisoryDevicePixelRatio: 1.0, // device pixel ratio doesn't matter
     );
 
     layout(renderAnimatedOpacity, phase: EnginePhase.composite);
     expect(renderAnimatedOpacity.needsCompositing, false);
   });
 
-  test('RenderAnimatedOpacity does composite if it is opaque', () {
+  test('RenderAnimatedOpacity does composite if it is opaque and advisoryDevicePixelRatio < 2.0', () {
     final Animation<double> opacityAnimation = AnimationController(
       vsync: FakeTickerProvider(),
     )..value = 1.0;
@@ -378,10 +379,26 @@ void main() {
     final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
       opacity: opacityAnimation,
       child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      advisoryDevicePixelRatio: 1.999, // device pixel ratio must be < 2.0 to force compositing
     );
 
     layout(renderAnimatedOpacity, phase: EnginePhase.composite);
     expect(renderAnimatedOpacity.needsCompositing, true);
+  });
+
+  test('RenderAnimatedOpacity does not composite if it is opaque and advisoryDevicePixelRatio >= 2.0', () {
+    final Animation<double> opacityAnimation = AnimationController(
+      vsync: FakeTickerProvider(),
+    )..value = 1.0;
+
+    final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
+      opacity: opacityAnimation,
+      child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      advisoryDevicePixelRatio: 2.0, // device pixel ratio must be < 2.0 to force compositing
+    );
+
+    layout(renderAnimatedOpacity, phase: EnginePhase.composite);
+    expect(renderAnimatedOpacity.needsCompositing, false);
   });
 
   test('RenderAnimatedOpacity does composite if it is partially opaque', () {
@@ -392,6 +409,7 @@ void main() {
     final RenderAnimatedOpacity renderAnimatedOpacity = RenderAnimatedOpacity(
       opacity: opacityAnimation,
       child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      advisoryDevicePixelRatio: 1.0, // device pixel ratio doesn't matter
     );
 
     layout(renderAnimatedOpacity, phase: EnginePhase.composite);
@@ -406,6 +424,7 @@ void main() {
     _testLayerReuse<OpacityLayer>(RenderAnimatedOpacity(
       opacity: opacityAnimation,
       child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      advisoryDevicePixelRatio: 1.0, // device pixel ratio doesn't matter
     ));
   });
 
@@ -834,7 +853,7 @@ void main() {
     final RenderBox box = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 20));
     final RenderBox parent = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 20));
     final AnimationController opacityAnimation = AnimationController(value: 1, vsync: FakeTickerProvider());
-    final RenderAnimatedOpacity opacity = RenderAnimatedOpacity(opacity: opacityAnimation, child: box);
+    final RenderAnimatedOpacity opacity = RenderAnimatedOpacity(opacity: opacityAnimation, child: box, advisoryDevicePixelRatio: 1.0);
     parent.adoptChild(opacity);
 
     // Make it listen to the animation.
@@ -851,7 +870,7 @@ void main() {
     final RenderSliver sliver = RenderSliverToBoxAdapter(child: RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 20)));
     final RenderBox parent = RenderConstrainedBox(additionalConstraints: const BoxConstraints.tightFor(width: 20));
     final AnimationController opacityAnimation = AnimationController(value: 1, vsync: FakeTickerProvider());
-    final RenderSliverAnimatedOpacity opacity = RenderSliverAnimatedOpacity(opacity: opacityAnimation, sliver: sliver);
+    final RenderSliverAnimatedOpacity opacity = RenderSliverAnimatedOpacity(opacity: opacityAnimation, sliver: sliver, advisoryDevicePixelRatio: 1.0);
     parent.adoptChild(opacity);
 
     // Make it listen to the animation.

--- a/packages/flutter/test/rendering/proxy_sliver_test.dart
+++ b/packages/flutter/test/rendering/proxy_sliver_test.dart
@@ -83,6 +83,7 @@ void main() {
 
     final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
       opacity: opacityAnimation,
+      advisoryDevicePixelRatio: 1.0, // device pixel ratio doesn't matter
       sliver: RenderSliverToBoxAdapter(
         child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
       ),
@@ -106,6 +107,7 @@ void main() {
 
     final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
       opacity: opacityAnimation,
+      advisoryDevicePixelRatio: 1.0, // device pixel ratio doesn't matter
       sliver: RenderSliverToBoxAdapter(
         child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
       ),
@@ -122,13 +124,14 @@ void main() {
     expect(renderSliverAnimatedOpacity.needsCompositing, true);
   });
 
-  test('RenderSliverAnimatedOpacity does composite if it is opaque', () {
+  test('RenderSliverAnimatedOpacity does composite if it is opaque and devicePixelRatio < 2.0', () {
     final Animation<double> opacityAnimation = AnimationController(
       vsync: FakeTickerProvider(),
     )..value = 1.0;
 
     final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
       opacity: opacityAnimation,
+      advisoryDevicePixelRatio: 1.999, // device pixel ratio must be < 2.0 to composite
       sliver: RenderSliverToBoxAdapter(
         child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
       ),
@@ -143,6 +146,30 @@ void main() {
 
     layout(root, phase: EnginePhase.composite);
     expect(renderSliverAnimatedOpacity.needsCompositing, true);
+  });
+
+  test('RenderSliverAnimatedOpacity does not composite if it is opaque and devicePixelRatio >- 2.0', () {
+    final Animation<double> opacityAnimation = AnimationController(
+      vsync: FakeTickerProvider(),
+    )..value = 1.0;
+
+    final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
+      opacity: opacityAnimation,
+      advisoryDevicePixelRatio: 2.0, // device pixel ratio must be < 2.0 to composite
+      sliver: RenderSliverToBoxAdapter(
+        child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter
+      ),
+    );
+
+    final RenderViewport root = RenderViewport(
+      crossAxisDirection: AxisDirection.right,
+      offset: ViewportOffset.zero(),
+      cacheExtent: 250.0,
+      children: <RenderSliver>[renderSliverAnimatedOpacity],
+    );
+
+    layout(root, phase: EnginePhase.composite);
+    expect(renderSliverAnimatedOpacity.needsCompositing, false);
   });
 
   test('RenderSliverAnimatedOpacity reuses its layer', () {
@@ -151,6 +178,7 @@ void main() {
     )..value = 0.5;  // must not be 0 or 1.0. Otherwise, it won't create a layer
 
     final RenderSliverAnimatedOpacity renderSliverAnimatedOpacity = RenderSliverAnimatedOpacity(
+      advisoryDevicePixelRatio: 1.0,
       opacity: opacityAnimation,
       sliver: RenderSliverToBoxAdapter(
         child: RenderSizedBox(const Size(1.0, 1.0)), // size doesn't matter

--- a/packages/flutter/test/rendering/semantics_and_children_test.dart
+++ b/packages/flutter/test/rendering/semantics_and_children_test.dart
@@ -45,6 +45,7 @@ void main() {
     final AnimationController controller = AnimationController(vsync: const TestVSync());
     final RenderAnimatedOpacity box = RenderAnimatedOpacity(
       opacity: controller,
+      advisoryDevicePixelRatio: 1.0,
       child: RenderParagraph(
         const TextSpan(),
         textDirection: TextDirection.ltr,


### PR DESCRIPTION
Sort of fixes https://github.com/flutter/flutter/issues/113879

Reduces raster time from ~14ms to 4ms on a Pixel 6 for the test app linked in the issue.
