### PR TITLE
Make Flutter Driver actively wait for runnable isolate

### DIFF
--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -216,7 +216,8 @@ class VMServiceFlutterDriver extends FlutterDriver {
     } else if (isolate.pauseEvent!.kind == vms.EventKind.kPauseExit ||
         isolate.pauseEvent!.kind == vms.EventKind.kPauseBreakpoint ||
         isolate.pauseEvent!.kind == vms.EventKind.kPauseException ||
-        isolate.pauseEvent!.kind == vms.EventKind.kPauseInterrupted) {
+        isolate.pauseEvent!.kind == vms.EventKind.kPauseInterrupted ||
+        isolate.pauseEvent!.kind == vms.EventKind.kPausePostRequest) {
       // If the isolate is paused for any other reason, assume the extension is
       // already there.
       _log('Isolate is paused mid-flight.');

--- a/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
+++ b/packages/flutter_driver/lib/src/driver/vmservice_driver.dart
@@ -100,6 +100,19 @@ class VMServiceFlutterDriver extends FlutterDriver {
       }
     }
 
+    // Refreshes the isolate state periodically until the isolate reports as
+    // being runnable.
+    Future<vms.Isolate> waitForIsolateToBeRunnable(vms.IsolateRef ref) async {
+      while (true) {
+        final vms.Isolate isolate = await client.getIsolate(ref.id!);
+        if (isolate.pauseEvent!.kind == vms.EventKind.kNone) {
+          await Future<void>.delayed(_kPauseBetweenIsolateRefresh);
+        } else {
+          return isolate;
+        }
+      }
+    }
+
     final vms.IsolateRef isolateRef = (await _warnIfSlow<vms.IsolateRef?>(
       future: waitForRootIsolate(),
       timeout: kUnusuallyLongTimeout,
@@ -108,11 +121,13 @@ class VMServiceFlutterDriver extends FlutterDriver {
         : 'Isolate $isolateNumber is taking an unusually long time to start.',
     ))!;
     _log('Isolate found with number: ${isolateRef.number}');
-    vms.Isolate isolate = await client.getIsolate(isolateRef.id!);
-
-    if (isolate.pauseEvent!.kind == vms.EventKind.kNone) {
-      isolate = await client.getIsolate(isolateRef.id!);
-    }
+    final vms.Isolate isolate = await _warnIfSlow<vms.Isolate>(
+      future: waitForIsolateToBeRunnable(isolateRef),
+      timeout: kUnusuallyLongTimeout,
+      message: 'The isolate ${isolateRef.number} is taking unusually long time '
+          'to initialize. It still reports ${vms.EventKind.kNone} as pause '
+          'event which is incorrect.',
+    );
 
     final VMServiceFlutterDriver driver = VMServiceFlutterDriver.connectedTo(
       client,
@@ -582,6 +597,9 @@ Future<vms.VmService> _waitAndConnect(String url, Map<String, dynamic>? headers)
 /// The amount of time we wait prior to making the next attempt to connect to
 /// the VM service.
 const Duration _kPauseBetweenReconnectAttempts = Duration(seconds: 1);
+
+/// The amount of time we wait prior to refreshing the isolate state.
+const Duration _kPauseBetweenIsolateRefresh = Duration(milliseconds: 100);
 
 // See `timeline_streams` in
 // https://github.com/dart-lang/sdk/blob/main/runtime/vm/timeline.cc

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -273,6 +273,14 @@ void main() {
       expectLogContains('Isolate is paused mid-flight');
     });
 
+    test('connects to isolate paused mid-flight after request', () async {
+      fakeIsolate.pauseEvent = vms.Event(kind: vms.EventKind.kPausePostRequest, timestamp: 0);
+
+      final FlutterDriver driver = await FlutterDriver.connect(dartVmServiceUrl: '');
+      expect(driver, isNotNull);
+      expectLogContains('Isolate is paused mid-flight');
+    });
+
     // This test simulates a situation when we believe that the isolate is
     // currently paused, but something else (e.g. a debugger) resumes it before
     // we do. There's no need to fail as we should be able to drive the app

--- a/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/flutter_driver_test.dart
@@ -1092,7 +1092,7 @@ vms.Response? makeFakeResponse(
 
 void Function(vms.Isolate) changeIsolateEventAfter(int gets, vms.Event nextEvent) {
   return (vms.Isolate i) {
-    gets--;
+    gets -= 1;
     if (gets == 0) {
       i.pauseEvent = nextEvent;
     }


### PR DESCRIPTION
This PR changes the way Flutter Driver waits for runnable `main` isolate. Previously, it tried to get the info about isolate again if the isolate was in `None` state when first getting it. Unfortunately, this seems to be overly optimistic in CI environments like GitHub Actions. [From our experience](https://github.com/leancodepl/patrol/issues/272) it seems that the main isolate running on an emulator on a macOS VM might take a little bit longer to become runnable. If it stays in `None`, it will miss being resumed.

Now, the client is polled periodically until the isolate is in other than `None` state. Then it proceeds to resume the isolate if it is paused.

Why polling instead of waiting for an event? Because it is hard to detect when isolate changes `pauseEvent` based on the events in the `onIsolateEvent` stream. We don't have a list of run-related events (that I know of) and it would require hardcoding them, which would result in this problem resurfacing after another pause-related event is added. The other option would be to `getIsolate` on every event, which seems to be quite a heavy solution (as there is a spike of events at the beginning). Polling every 100ms seems like the least heavy option.

There is another change that adds `PausePostRequest` to a `pauseEvent` that results in `resume`s - this looks like an omission.

This issue fixes problem that occurs in [Patrol](https://github.com/leancodepl/patrol/issues/272).
It should also somewhat help with this issue: https://github.com/flutter/flutter/issues/50898 .

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
