### PR TITLE
`Layer ... was previously used as oldLayer` assertion error in debug mode, and page being blank in release mode, caused by LeaderLayer addToScene bug

### DIFF
--- a/packages/flutter/lib/src/rendering/layer.dart
+++ b/packages/flutter/lib/src/rendering/layer.dart
@@ -2503,6 +2503,8 @@ class LeaderLayer extends ContainerLayer {
         Matrix4.translationValues(offset.dx, offset.dy, 0.0).storage,
         oldLayer: _engineLayer as ui.TransformEngineLayer?,
       );
+    } else {
+      engineLayer = null;
     }
     addChildrenToScene(builder);
     if (offset != Offset.zero) {

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -56,6 +56,34 @@ void main() {
     expect(box.localToGlobal(Offset.zero), const Offset(118.0, 451.0));
   });
 
+  testWidgets('LeaderLayer should not cause error', (WidgetTester tester) async {
+    final LayerLink link = LayerLink();
+
+    Widget buildWidget({
+      required double paddingLeft,
+      Color siblingColor = const Color(0xff000000),
+    }) =>
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Stack(
+            children: <Widget>[
+              Padding(
+                padding: EdgeInsets.only(left: paddingLeft),
+                child: CompositedTransformTarget(
+                  link: link,
+                  child: RepaintBoundary(child: ClipRect(child: Container(color: const Color(0x00ff0000)))),
+                ),
+              ),
+              Positioned.fill(child: RepaintBoundary(child: ColoredBox(color: siblingColor))),
+            ],
+          ),
+        );
+
+    await tester.pumpWidget(buildWidget(paddingLeft: 10));
+    await tester.pumpWidget(buildWidget(paddingLeft: 0));
+    await tester.pumpWidget(buildWidget(paddingLeft: 0, siblingColor: const Color(0x0000ff00)));
+  });
+
   group('Composited transforms - only offsets', () {
     final GlobalKey key = GlobalKey();
 

--- a/packages/flutter/test/widgets/composited_transform_test.dart
+++ b/packages/flutter/test/widgets/composited_transform_test.dart
@@ -62,22 +62,23 @@ void main() {
     Widget buildWidget({
       required double paddingLeft,
       Color siblingColor = const Color(0xff000000),
-    }) =>
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: Stack(
-            children: <Widget>[
-              Padding(
-                padding: EdgeInsets.only(left: paddingLeft),
-                child: CompositedTransformTarget(
-                  link: link,
-                  child: RepaintBoundary(child: ClipRect(child: Container(color: const Color(0x00ff0000)))),
-                ),
+    }) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: Stack(
+          children: <Widget>[
+            Padding(
+              padding: EdgeInsets.only(left: paddingLeft),
+              child: CompositedTransformTarget(
+                link: link,
+                child: RepaintBoundary(child: ClipRect(child: Container(color: const Color(0x00ff0000)))),
               ),
-              Positioned.fill(child: RepaintBoundary(child: ColoredBox(color: siblingColor))),
-            ],
-          ),
-        );
+            ),
+            Positioned.fill(child: RepaintBoundary(child: ColoredBox(color: siblingColor))),
+          ],
+        ),
+      );
+    }
 
     await tester.pumpWidget(buildWidget(paddingLeft: 10));
     await tester.pumpWidget(buildWidget(paddingLeft: 0));


### PR DESCRIPTION
Close https://github.com/flutter/flutter/issues/113995
Please see the issue for a bug reproduction. Here I will discuss how it is solved and what caused it.

### The real world bug

My app has a part of it not rendered (i.e. page blank) sometimes, which is very weird. After I manage to reproduce it in debug environment, the error is:

<details>

```
======== Exception caught by scheduler library =====================================================
The following assertion was thrown during a scheduler callback:
Layer ClipRectEngineLayer was previously used as oldLayer.
Once a layer is used as oldLayer, it may not be used again. Instead, after calling one of the SceneBuilder.push* methods and passing an oldLayer to it, use the layer returned by the method as oldLayer in subsequent frames.
'dart:ui/compositing.dart':
Failed assertion: line 88 pos 9: '<optimized out>'


Either the assertion indicates an error in the framework itself, or we should provide substantially more information in this error message to help you determine and fix the underlying cause.
In either case, please report this assertion by filing a bug on GitHub:
  https://github.com/flutter/flutter/issues/new?template=2_bug.md

When the exception was thrown, this was the stack: 
#2      _EngineLayerWrapper._debugCheckNotUsedAsOldLayer (dart:ui/compositing.dart:88:9)
#3      SceneBuilder.addRetained.<anonymous closure>.recursivelyCheckChildrenUsedOnce (dart:ui/compositing.dart:656:21)
#4      List.forEach (dart:core-patch/growable_array.dart:416:8)
#5      SceneBuilder.addRetained.<anonymous closure>.recursivelyCheckChildrenUsedOnce (dart:ui/compositing.dart:662:18)
#6      SceneBuilder.addRetained.<anonymous closure> (dart:ui/compositing.dart:665:7)
#7      SceneBuilder.addRetained (dart:ui/compositing.dart:668:6)
#8      Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:643:15)
#9      ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#10     OffsetLayer.addToScene (package:flutter/src/rendering/layer.dart:1378:5)
#11     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#12     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#13     OffsetLayer.addToScene (package:flutter/src/rendering/layer.dart:1378:5)
#14     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#15     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#16     EnhancedLeaderLayer.addToScene (package:flutter_portal/src/enhanced_composited_transform/flutter_src/rendering_layer.dart:159:5)
#17     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#18     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#19     EnhancedLeaderLayer.addToScene (package:flutter_portal/src/enhanced_composited_transform/flutter_src/rendering_layer.dart:159:5)
#20     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#21     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#22     EnhancedLeaderLayer.addToScene (package:flutter_portal/src/enhanced_composited_transform/flutter_src/rendering_layer.dart:159:5)
#23     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#24     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#25     EnhancedLeaderLayer.addToScene (package:flutter_portal/src/enhanced_composited_transform/flutter_src/rendering_layer.dart:159:5)
#26     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#27     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#28     OffsetLayer.addToScene (package:flutter/src/rendering/layer.dart:1378:5)
#29     Layer._addToSceneWithRetainedRendering (package:flutter/src/rendering/layer.dart:646:5)
#30     ContainerLayer.addChildrenToScene (package:flutter/src/rendering/layer.dart:1241:13)
#31     TransformLayer.addToScene (package:flutter/src/rendering/layer.dart:1834:5)
#32     ContainerLayer.buildScene (package:flutter/src/rendering/layer.dart:1054:5)
#33     RenderView.compositeFrame (package:flutter/src/rendering/view.dart:231:37)
#34     RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:517:18)
#35     WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:884:13)
#36     RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:378:5)
#37     SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1175:15)
#38     SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1104:9)
#39     SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1015:5)
#40     _invoke (dart:ui/hooks.dart:148:13)
#41     PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:318:5)
#42     _drawFrame (dart:ui/hooks.dart:115:31)
(elided 2 frames from class _AssertionError)
====================================================================================================
```

</details>

### The minimal reproduction

(I will omit how I find out the root cause. If you are interested I can write down.)

Please see https://github.com/flutter/flutter/issues/113995 with minimal reproduction code

### Why that causes bug

The first pumpWidget creates initial tree, and I deliberately set padding to non-zero, such that LeaderLayer.paint will see non-zero Offset, and thus will pushTransform.

In the second pumpWidget, I deliberately set padding to zero. Then, LeaderLayer.paint will *not* call pushTransform. Correct implementation should set engineLayer to null, but the old code just leave that variable unchanged.

Then comes the third pumpWidget. I change the color inside a RepaintBoundary which is the sibling of LeaderLayer (CompositedTransformTarget). This is carefully constructed (notice the sibling and the RepaintBoundary) to reproduce the following behavior in real-world complicated app: We should (1) ensure `LeaderLayer. _addToSceneWithRetainedRendering` is called, and (2) ensure `LeaderLayer. _needsAddToScene = false`. For example, if we do not add that RepaintBoundary, it will not construct the case, because CompositedTransformTarget's RO will repaint and thus _needsAddToScene becomes true.

Then, interesting thing happens. Look at the code:

```dart
  void _addToSceneWithRetainedRendering(ui.SceneBuilder builder) {
    if (!_needsAddToScene && _engineLayer != null) {
      builder.addRetained(_engineLayer!);
      return;
    }
    ...
```

We have constructed a case, such that the `if` is true. Notice that, if we fix the bug (just as what we do in the PR), the `engineLayer` will be null so if condition will not be true. Thus, buggy code will call `LeaderLayer.addRetained`, while correct code will not.

Then the error happens. Notice that, this `LeaderLayer._engineLayer` indeed is the layer constructed in the second pumpWidget instead of the third (i.e. it is stale from last frame). Therefore, this EngineLayer's children are all from the stale previous frame. For example, the ClipRectLayer from previous frame (second pumpWidget). Since it has already been used as oldLayer in RenderClipRect, that old stale ClipRectLayer should never be used. However we are now using it in addRetained. Therefore, no wonder when `addRetained` is checking all subtree ensuring `_debugCheckNotUsedAsOldLayer`, it fails the assertions.

### Why is the solution valid

With analysis above, we can clearly see this solves the bug. In addition, looking at ClipRectLayer etc, they also have such "engineLayer = null" logic, so even if only mimicking those we should do this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
