### PR TITLE
Adding the serviceWorkerVersion to main.dart.js

### DIFF
--- a/dev/integration_tests/flutter_gallery/web/index.html
+++ b/dev/integration_tests/flutter_gallery/web/index.html
@@ -3,21 +3,24 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A demo app for Flutter's material and cupertino widgets, as well as many other features of the Flutter SDK.">
+  <meta name="description"
+    content="A demo app for Flutter's material and cupertino widgets, as well as many other features of the Flutter SDK.">
 
   <!-- iOS meta tags & icons -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
   <meta name="apple-mobile-web-app-title" content="Flutter Gallery">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
-  <link rel="shortcut icon" type="image/png" href="favicon.png"/>
+  <link rel="shortcut icon" type="image/png" href="favicon.png" />
 
   <title>Flutter Gallery</title>
   <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
   application. For more information, see:
@@ -31,7 +34,7 @@ found in the LICENSE file. -->
       }
       scriptLoaded = true;
       var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
+      scriptTag.src = 'main.dart.js?v=' + serviceWorkerVersion;
       scriptTag.type = 'application/javascript';
       document.body.append(scriptTag);
     }
@@ -87,4 +90,5 @@ found in the LICENSE file. -->
     }
   </script>
 </body>
+
 </html>

--- a/dev/integration_tests/web/web/index.html
+++ b/dev/integration_tests/web/web/index.html
@@ -3,6 +3,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
@@ -14,6 +15,7 @@ found in the LICENSE file. -->
   <meta name="apple-mobile-web-app-title" content="Web Test">
   <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
   application. For more information, see:
@@ -27,7 +29,7 @@ found in the LICENSE file. -->
       }
       scriptLoaded = true;
       var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
+      scriptTag.src = 'main.dart.js?v=' + serviceWorkerVersion;
       scriptTag.type = 'application/javascript';
       document.body.append(scriptTag);
     }
@@ -83,4 +85,5 @@ found in the LICENSE file. -->
     }
   </script>
 </body>
+
 </html>

--- a/dev/integration_tests/web/web/index_without_flutterjs.html
+++ b/dev/integration_tests/web/web/index_without_flutterjs.html
@@ -3,6 +3,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
+
 <head>
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
@@ -14,6 +15,7 @@ found in the LICENSE file. -->
   <meta name="apple-mobile-web-app-title" content="Web Test">
   <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
   application. For more information, see:
@@ -27,7 +29,7 @@ found in the LICENSE file. -->
       }
       scriptLoaded = true;
       var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
+      scriptTag.src = 'main.dart.js?v=' + serviceWorkerVersion;
       scriptTag.type = 'application/javascript';
       document.body.append(scriptTag);
     }
@@ -83,4 +85,5 @@ found in the LICENSE file. -->
     }
   </script>
 </body>
+
 </html>

--- a/dev/manual_tests/web/index.html
+++ b/dev/manual_tests/web/index.html
@@ -4,6 +4,7 @@ Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 
 <html>
+
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -31,11 +32,12 @@ found in the LICENSE file. -->
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
-  <link rel="icon" type="image/png" href="favicon.png"/>
+  <link rel="icon" type="image/png" href="favicon.png" />
 
   <title>manual_tests</title>
   <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
@@ -49,7 +51,7 @@ found in the LICENSE file. -->
       }
       scriptLoaded = true;
       var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
+      scriptTag.src = 'main.dart.js?v=' + serviceWorkerVersion;
       scriptTag.type = 'application/javascript';
       document.body.append(scriptTag);
     }
@@ -105,4 +107,5 @@ found in the LICENSE file. -->
     }
   </script>
 </body>
+
 </html>

--- a/examples/api/web/index.html
+++ b/examples/api/web/index.html
@@ -3,6 +3,7 @@
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file. -->
 <html>
+
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the
@@ -32,6 +33,7 @@ found in the LICENSE file. -->
   <title>Flutter API Sample</title>
   <link rel="manifest" href="manifest.json">
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
@@ -45,7 +47,7 @@ found in the LICENSE file. -->
       }
       scriptLoaded = true;
       var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
+      scriptTag.src = 'main.dart.js?v=' + serviceWorkerVersion;
       scriptTag.type = 'application/javascript';
       document.body.append(scriptTag);
     }
@@ -101,4 +103,5 @@ found in the LICENSE file. -->
     }
   </script>
 </body>
+
 </html>

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 /// Generates the flutter.js file.
 ///
 /// flutter.js should be completely static, so **do not use any parameter or
@@ -238,9 +237,12 @@ _flutter.loader = null;
      * EngineInitializer, or will be rejected with the error caused by the loader.
      * Returns undefined when an `onEntrypointLoaded` callback is supplied in `options`.
      */
-    async loadEntrypoint(options) {
-      const { entrypointUrl = "main.dart.js", onEntrypointLoaded } =
-        options || {};
+    async loadEntrypoint(options) {        
+      const {
+        entrypointUrl = "main.dart.js?v=" + serviceWorkerVersion,
+        onEntrypointLoaded
+      } = options || {};
+
 
       return this._loadEntrypoint(entrypointUrl, onEntrypointLoaded);
     }

--- a/packages/flutter_tools/test/web.shard/test_data/hot_reload_index_html_samples.dart
+++ b/packages/flutter_tools/test/web.shard/test_data/hot_reload_index_html_samples.dart
@@ -87,7 +87,7 @@ found in the LICENSE file. -->
       }
       scriptLoaded = true;
       var scriptTag = document.createElement('script');
-      scriptTag.src = 'main.dart.js';
+      scriptTag.src = 'main.dart.js?v=' + serviceWorkerVersion;
       scriptTag.type = 'application/javascript';
       document.body.append(scriptTag);
     }


### PR DESCRIPTION
WIP

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
The `serviceWorkerVersion` seems to control that the browser fetches the latest `main.dart.js` file, rather than relying on cache, if a new version is available. This works fine in most cases, but Safari on MacOS seems not the refresh the `main.dart.js` even though you can read in the console that the new serviceworker was detected.

By adding the `?v=$serviceWorkerVersion` to `main.dart.js`, Safari is forced to refresh the file if a new one was deployed.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/63500

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
