### PR TITLE
Upgrade gradle for flutter tool to 7.3.0

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -62,7 +62,7 @@ buildscript {
     }
     dependencies {
         /* When bumping, also update ndkVersion above. */
-        classpath 'com.android.tools.build:gradle:7.2.0'
+        classpath 'com.android.tools.build:gradle:7.3.0'
     }
 }
 

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -43,7 +43,7 @@ class FlutterExtension {
      * Chosen as default version of the AGP version below as found in
      * https://developer.android.com/studio/projects/install-ndk#default-ndk-per-agp
      */
-    static String ndkVersion = "21.4.7075529"
+    static String ndkVersion = "23.1.7779620"
 
     /**
      * Specifies the relative directory to the Flutter project directory.


### PR DESCRIPTION
Build time regression was seen when bumping to AGP 7.2.0 (https://github.com/flutter/flutter/issues/103421), since then a new major release 7.3.0 has been released, so bumping to it to see if it improves build time.