### PR TITLE
Don't specify libraries-spec argument if we are passing a platform dill.

### DIFF
--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -763,7 +763,9 @@ class DefaultResidentCompiler implements ResidentCompiler {
         '--output-dill',
         outputPath,
       ],
-      if (librariesSpec != null) ...<String>[
+      // If we have a platform dill, we don't need to pass the libraries spec,
+      // since the information is embedded in the .dill file.
+      if (librariesSpec != null && platformDill == null) ...<String>[
         '--libraries-spec',
         librariesSpec!,
       ],

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -445,7 +445,7 @@ void main() {
     expect(fakeProcessManager, hasNoRemainingExpectations);
   });
 
-  testWithoutContext('compile does not pass libraries-spec when using an output dill', () async {
+  testWithoutContext('compile does not pass libraries-spec when using a platform dill', () async {
     fakeProcessManager.addCommand(FakeCommand(
       command: const <String>[
         ...frontendServerCommand,

--- a/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
+++ b/packages/flutter_tools/test/general.shard/compile_incremental_test.dart
@@ -22,6 +22,7 @@ import '../src/fakes.dart';
 void main() {
   late ResidentCompiler generator;
   late ResidentCompiler generatorWithScheme;
+  late ResidentCompiler generatorWithPlatformDillAndLibrariesSpec;
   late MemoryIOSink frontendServerStdIn;
   late BufferLogger testLogger;
   late StdoutHandler generatorStdoutHandler;
@@ -75,6 +76,18 @@ void main() {
       fileSystemScheme: 'scheme',
       fileSystem: MemoryFileSystem.test(),
       stdoutHandler: generatorWithSchemeStdoutHandler,
+    );
+    generatorWithPlatformDillAndLibrariesSpec = DefaultResidentCompiler(
+      'sdkroot',
+      buildMode: BuildMode.debug,
+      logger: testLogger,
+      processManager: fakeProcessManager,
+      artifacts: Artifacts.test(),
+      platform: FakePlatform(),
+      fileSystem: MemoryFileSystem.test(),
+      stdoutHandler: generatorStdoutHandler,
+      platformDill: '/foo/platform.dill',
+      librariesSpec: '/bar/libraries.json',
     );
   });
 
@@ -427,6 +440,32 @@ void main() {
       dartPluginRegistrant: dartPluginRegistrant,
     );
     expect(frontendServerStdIn.getAndClear(), 'compile scheme:///main.dart\n');
+    expect(testLogger.errorText, equals('line1\nline2\n'));
+    expect(output?.outputFilename, equals('/path/to/main.dart.dill'));
+    expect(fakeProcessManager, hasNoRemainingExpectations);
+  });
+
+  testWithoutContext('compile does not pass libraries-spec when using an output dill', () async {
+    fakeProcessManager.addCommand(FakeCommand(
+      command: const <String>[
+        ...frontendServerCommand,
+        '--platform',
+        '/foo/platform.dill',
+        '--verbosity=error'
+      ],
+      stdout: 'result abc\nline1\nline2\nabc\nabc /path/to/main.dart.dill 0',
+      stdin: frontendServerStdIn,
+    ));
+
+    final CompilerOutput? output = await generatorWithPlatformDillAndLibrariesSpec.recompile(
+      Uri.parse('/path/to/main.dart'),
+        null /* invalidatedFiles */,
+      outputPath: '/build/',
+      packageConfig: PackageConfig.empty,
+      fs: MemoryFileSystem(),
+      projectRootPath: '',
+    );
+    expect(frontendServerStdIn.getAndClear(), 'compile /path/to/main.dart\n');
     expect(testLogger.errorText, equals('line1\nline2\n'));
     expect(output?.outputFilename, equals('/path/to/main.dart.dill'));
     expect(fakeProcessManager, hasNoRemainingExpectations);


### PR DESCRIPTION
This fixes part of https://github.com/flutter/flutter/issues/113966. Namely, `flutter run` with local engine pointing to the wasm directory works now.

Note: `flutter build web` with the local engine pointing to a wasm output directory still doesn't work. I'll look at fixing this in a follow-on PR.