### PR TITLE
Revert part of "Terminate simulator app on "q" (#113581)"

### DIFF
--- a/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_simulator.dart
+++ b/dev/devicelab/bin/tasks/hot_mode_dev_cycle_ios_simulator.dart
@@ -16,7 +16,7 @@ Future<void> main() async {
       await testWithNewIOSSimulator('TestHotReloadSim', (String deviceId) async {
         simulatorDeviceId = deviceId;
         // This isn't actually a benchmark test, so do not use the returned `benchmarkScoreKeys` result.
-        await createHotModeTest(deviceIdOverride: deviceId, checkAppRunningOnLocalDevice: true)();
+        await createHotModeTest(deviceIdOverride: deviceId)();
       });
     } finally {
       await removeIOSimulator(simulatorDeviceId);

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -257,25 +257,6 @@ class SimControl {
     return result;
   }
 
-  Future<RunResult> stopApp(String deviceId, String appIdentifier) async {
-    RunResult result;
-    try {
-      result = await _processUtils.run(
-        <String>[
-          ..._xcode.xcrunCommand(),
-          'simctl',
-          'terminate',
-          deviceId,
-          appIdentifier,
-        ],
-        throwOnError: true,
-      );
-    } on ProcessException catch (exception) {
-      throwToolExit('Unable to terminate $appIdentifier on $deviceId:\n$exception');
-    }
-    return result;
-  }
-
   Future<void> takeScreenshot(String deviceId, String outputPath) async {
     try {
       await _processUtils.run(
@@ -555,7 +536,8 @@ class IOSSimulator extends Device {
     ApplicationPackage app, {
     String? userIdentifier,
   }) async {
-    return (await _simControl.stopApp(id, app.id)).exitCode == 0;
+    // Currently we don't have a way to stop an app running on iOS.
+    return false;
   }
 
   String get logFilePath {

--- a/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
+++ b/packages/flutter_tools/test/general.shard/ios/simulators_test.dart
@@ -901,24 +901,6 @@ Dec 20 17:04:32 md32-11-vm1 Another App[88374]: Ignore this text'''
         throwsToolExit(message: r'Unable to launch'),
       );
     });
-
-    testWithoutContext('.stopApp() handles exceptions', () async {
-      fakeProcessManager.addCommand(const FakeCommand(
-        command: <String>[
-          'xcrun',
-          'simctl',
-          'terminate',
-          deviceId,
-          appId,
-        ],
-        exception: ProcessException('xcrun', <String>[]),
-      ));
-
-      expect(
-        () async => simControl.stopApp(deviceId, appId),
-        throwsToolExit(message: r'Unable to terminate'),
-      );
-    });
   });
 
   group('startApp', () {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/113581 caused a [TAP failure](https://fusion2.corp.google.com/invocations/68e930bd-fdd0-486f-9b8d-dec7798677c9/targets/%2F%2Fmobile%2Fflutter%2Ftests%2Fapp:app_basic_runner_attach_ios_test_IPHONE_11_13_0/tests) and is blocking the roll.  Keep the new `hot_mode_dev_cycle_ios_simulator` test as that is still valuable (and I don't feel like dealing with `bringup` again), but just revert the part that validated the app actually quit.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
