### PR TITLE
In asset manifest loading and parsing benchmark, move load call into benchmark

### DIFF
--- a/dev/benchmarks/microbenchmarks/lib/foundation/load_and_parse_large_asset_manifest.dart
+++ b/dev/benchmarks/microbenchmarks/lib/foundation/load_and_parse_large_asset_manifest.dart
@@ -20,10 +20,10 @@ void main() async {
   final Stopwatch watch = Stopwatch();
   final PlatformAssetBundle bundle = PlatformAssetBundle();
 
-  final ByteData assetManifestBytes = await bundle.load('money_asset_manifest.json');
   watch.start();
   for (int i = 0; i < _kNumIterations; i++) {
     bundle.clear();
+    final ByteData assetManifestBytes = await bundle.load('money_asset_manifest.json');
     final String json = utf8.decode(assetManifestBytes.buffer.asUint8List());
     // This is a test, so we don't need to worry about this rule.
     // ignore: invalid_use_of_visible_for_testing_member

--- a/dev/devicelab/lib/tasks/microbenchmarks.dart
+++ b/dev/devicelab/lib/tasks/microbenchmarks.dart
@@ -57,7 +57,7 @@ TaskFunction createMicrobenchmarkTask({bool enableImpeller = false}) {
       ...await runMicrobench('lib/foundation/standard_message_codec_bench.dart'),
       ...await runMicrobench('lib/foundation/standard_method_codec_bench.dart'),
       ...await runMicrobench('lib/foundation/timeline_bench.dart'),
-      ...await runMicrobench('lib/foundation/decode_and_parse_asset_manifest.dart'),
+      ...await runMicrobench('lib/foundation/load_and_parse_large_asset_manifest.dart'),
       ...await runMicrobench('lib/geometry/matrix_utils_transform_bench.dart'),
       ...await runMicrobench('lib/geometry/rrect_contains_bench.dart'),
       ...await runMicrobench('lib/gestures/gesture_detector_bench.dart'),


### PR DESCRIPTION
#112836 added a new microbenchmark that measures the time it takes to parse a large asset manifest. The test is named [`load_and_parse_large_asset_manifest`](https://github.com/flutter/flutter/blob/master/dev/benchmarks/microbenchmarks/lib/foundation/decode_and_parse_asset_manifest.dart#L35). However, this name is inaccurate as loading the manifest data itself is not measured. Only the decoding and parsing of the manifest data is measured.

The two options here (besides ignoring this) are
1) Rename the test (is there a way to delete the old benchmarking data or even move it to the renamed test?) or
2) Move the `bundle.load` call into the testing loop.

This change does the latter.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
