### PR TITLE
Fix references to parent focus nodes

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3371,7 +3371,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     final Intent? intent = intentForMacOSSelector(selectorName);
 
     if (intent != null) {
-      final BuildContext? primaryContext = primaryFocus?.context;
+      final BuildContext? primaryContext = widget.focusNode.context;
       if (primaryContext != null) {
         Actions.invoke(primaryContext, intent);
       }

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -13573,6 +13573,62 @@ void main() {
         const TextSelection.collapsed(offset: 0),
       );
     });
+
+    testWidgets('macOS selectors work when focus is on a child focus node', (WidgetTester tester) async {
+      controller.text = 'test\nline2';
+      controller.selection = TextSelection.collapsed(offset: controller.text.length);
+
+      final GlobalKey<EditableTextState> key = GlobalKey<EditableTextState>();
+      final FocusNode textFieldFocus = FocusNode(debugLabel: 'EditableText');
+
+      await tester.pumpWidget(MaterialApp(
+        home: Align(
+          alignment: Alignment.topLeft,
+          child: Column(
+            children: <Widget>[
+              SizedBox(
+                width: 400,
+                child: EditableText(
+                  key: key,
+                  maxLines: 10,
+                  controller: controller,
+                  showSelectionHandles: true,
+                  autofocus: true,
+                  focusNode: textFieldFocus,
+                  style: Typography.material2018().black.titleMedium!,
+                  cursorColor: Colors.blue,
+                  backgroundCursorColor: Colors.grey,
+                  selectionControls: materialTextSelectionControls,
+                  keyboardType: TextInputType.text,
+                  textAlign: TextAlign.right,
+                ),
+              ),
+              Focus(
+                parentNode: textFieldFocus,
+                autofocus: true,
+                child: const SizedBox(width: 10, height: 10),
+              ),
+            ],
+          ),
+        ),
+      ));
+      await tester.pump(); // Let autofocus take effect.
+
+      expect(textFieldFocus.hasFocus, isTrue);
+      expect(textFieldFocus.hasPrimaryFocus, isFalse);
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 10),
+      );
+
+      key.currentState!.performSelector('moveLeft:');
+      await tester.pump();
+
+      expect(
+        controller.selection,
+        const TextSelection.collapsed(offset: 9),
+      );
+    });
   });
 
   group('Spell check', () {


### PR DESCRIPTION
## Description

This fixes the execution of macOS selectors in `EditableText` to use the focus node of the `EditableText` that they are connected to in order to find the associated actions, instead of using the `primaryFocus`, since now `FocusScope` widgets can have `FocusNode` parents that don't follow the widget hierarchy.

## Tests
 - Added an `EditableText` test that fails before the change, and succeeds after.