### PR TITLE
[flutter_tools] allow flutter drive to take screenshots when sent a terminating signal

### DIFF
--- a/packages/flutter_tools/lib/executable.dart
+++ b/packages/flutter_tools/lib/executable.dart
@@ -189,6 +189,7 @@ List<FlutterCommand> generateCommands({
     fileSystem: globals.fs,
     logger: globals.logger,
     platform: globals.platform,
+    signals: globals.signals,
   ),
   EmulatorsCommand(),
   FormatCommand(verboseHelp: verboseHelp),

--- a/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/drive_test.dart
@@ -227,6 +227,8 @@ void main() {
 
     expect(screenshotDevice.screenshots, isEmpty);
 
+    // This command will never complete. In reality, a real signal would have
+    // shut down the Dart process.
     unawaited(
       createTestCommandRunner(command).run(
         <String>[
@@ -434,6 +436,7 @@ class FakeDeviceManager extends Fake implements DeviceManager {
   Future<List<Device>> findTargetDevices(FlutterProject? flutterProject, {Duration? timeout, bool promptUserToChooseDevice = true}) async => devices;
 }
 
+/// A [FlutterDriverFactory] that creates a [NeverEndingDriverService].
 class NeverEndingFlutterDriverFactory extends Fake implements FlutterDriverFactory {
   NeverEndingFlutterDriverFactory(this.callback);
 
@@ -443,6 +446,10 @@ class NeverEndingFlutterDriverFactory extends Fake implements FlutterDriverFacto
   DriverService createDriverService(bool web) => NeverEndingDriverService(callback);
 }
 
+/// A [DriverService] that will return a Future from [startTest] that will never complete.
+///
+/// This is to similate when the test will take a long time, but a signal is
+/// expected to interrupt the process.
 class NeverEndingDriverService extends Fake implements DriverService {
   NeverEndingDriverService(this.callback);
 


### PR DESCRIPTION
When LUCI times out a step after 30 minutes, it first sends a signal (SIGTERM on *nix, SIGINT I think on Windows) to the last running process. If the CI build is running `flutter drive --screenshot=/path/to/screenshot ...`, we should try to take a screenshot when this signal is sent.

Should add debugging for https://github.com/flutter/flutter/issues/114025