### PR TITLE
[tool] Allow downgrade when install APKs

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -443,6 +443,7 @@ class AndroidDevice extends Device {
         'install',
         '-t',
         '-r',
+        '-d',
         if (userIdentifier != null)
           ...<String>['--user', userIdentifier],
         app.applicationPackage.path,

--- a/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_device_start_test.dart
@@ -88,7 +88,7 @@ void main() {
         command: <String>['adb', '-s', '1234', 'shell', 'pm', 'list', 'packages', 'FlutterApp'],
       ));
       processManager.addCommand(const FakeCommand(
-        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', 'app-debug.apk'],
+        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '-d', 'app-debug.apk'],
       ));
       processManager.addCommand(kShaCommand);
       processManager.addCommand(const FakeCommand(
@@ -198,6 +198,7 @@ void main() {
         'install',
         '-t',
         '-r',
+        '-d',
         '--user',
         '10',
         'app-debug.apk',

--- a/packages/flutter_tools/test/general.shard/android/android_install_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_install_test.dart
@@ -29,6 +29,7 @@ const FakeCommand kInstallCommand = FakeCommand(
     'install',
     '-t',
     '-r',
+    '-d',
     '--user',
     '10',
     'app-debug.apk',
@@ -180,6 +181,7 @@ void main() {
           'install',
           '-t',
           '-r',
+          '-d',
           '--user',
           'jane',
           'app-debug.apk',
@@ -254,7 +256,7 @@ void main() {
         stdout: 'different_example_sha',
       ),
       const FakeCommand(
-        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '--user', '10', 'app-debug.apk'],
+        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '-d', '--user', '10', 'app-debug.apk'],
         exitCode: 1,
         stderr: '[INSTALL_FAILED_INSUFFICIENT_STORAGE]',
       ),
@@ -291,7 +293,7 @@ void main() {
           stdout: '\n'
       ),
       const FakeCommand(
-        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '--user', '10', 'app-debug.apk'],
+        command: <String>['adb', '-s', '1234', 'install', '-t', '-r', '-d', '--user', '10', 'app-debug.apk'],
         exitCode: 1,
         stderr: '[INSTALL_FAILED_INSUFFICIENT_STORAGE]',
       ),


### PR DESCRIPTION
Fix #96588. Adding `-d` with `adb install` to allow version code downgrade for debuggable packages.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
