### PR TITLE
Fix NPE in coverage collector

### DIFF
--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -36,7 +36,7 @@ class CoverageCollector extends TestWatcher {
   Set<String>? libraryNames;
 
   final coverage.Resolver? resolver;
-  final Map<String, List<List<int>>> _ignoredLinesInFilesCache = <String, List<List<int>>>{};
+  final Map<String, List<List<int>>?> _ignoredLinesInFilesCache = <String, List<List<int>>?>{};
 
   final TestTimeRecorder? testTimeRecorder;
 


### PR DESCRIPTION
Fixes #114123

The NPE was happening when parsing ignore-file comments, so I added a test for that.