### PR TITLE
mark firebase_release_smoke_test flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -332,6 +332,7 @@ targets:
   - name: Linux firebase_release_smoke_test
     recipe: firebaselab/firebaselab
     timeout: 60
+    bringup: true # https://github.com/flutter/flutter/issues/114183
     properties:
       dependencies: >-
         [


### PR DESCRIPTION
This test is consistently failing due to an infrastructure regression in firebase test lab https://github.com/flutter/flutter/issues/114183

Mark it flaky so I (framework gardener) can monitor and mark un-flaky when the upstream infrastructure issue is resolved.