### PR TITLE
InteractiveViewer parameter to return to pre-3.3 trackpad/Magic Mouse behaviour

### DIFF
--- a/packages/flutter/lib/src/gestures/scale.dart
+++ b/packages/flutter/lib/src/gestures/scale.dart
@@ -15,11 +15,18 @@ export 'events.dart' show PointerDownEvent, PointerEvent, PointerPanZoomStartEve
 export 'recognizer.dart' show DragStartBehavior;
 export 'velocity_tracker.dart' show Velocity;
 
+/// The default conversion factor when treating mouse scrolling as scaling.
+///
+/// The value was arbitrarily chosen to feel natural for most mousewheels on
+/// all supported platforms.
+const double kDefaultMouseScrollToScaleFactor = 200;
+
 /// The default conversion factor when treating trackpad scrolling as scaling.
 ///
-/// This factor matches the default [InteractiveViewer.scaleFactor] of 200 and
-/// the convention that scrolling up means zooming in.
-const Offset kDefaultTrackpadScrollToScaleFactor = Offset(0, -1/200);
+/// This factor matches the default [kDefaultMouseScrollToScaleFactor] of 200 to
+/// feel natural for most trackpads, and the convention that scrolling up means
+/// zooming in.
+const Offset kDefaultTrackpadScrollToScaleFactor = Offset(0, -1/kDefaultMouseScrollToScaleFactor);
 
 /// The possible states of a [ScaleGestureRecognizer].
 enum _ScaleState {
@@ -384,6 +391,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Defaults to false.
   /// {@endtemplate}
   bool trackpadScrollCausesScale;
+
   /// {@template flutter.gestures.scale.trackpadScrollToScaleFactor}
   /// A factor to control the direction and magnitude of scale when converting
   /// trackpad scrolling.
@@ -395,6 +403,7 @@ class ScaleGestureRecognizer extends OneSequenceGestureRecognizer {
   /// Defaults to [kDefaultTrackpadScrollToScaleFactor].
   /// {@endtemplate}
   Offset trackpadScrollToScaleFactor;
+
   late Offset _initialFocalPoint;
   Offset? _currentFocalPoint;
   late double _initialSpan;

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -288,6 +288,7 @@ class GestureDetector extends StatelessWidget {
     this.behavior,
     this.excludeFromSemantics = false,
     this.dragStartBehavior = DragStartBehavior.start,
+    this.trackpadPanShouldActAsZoom = false,
     this.supportedDevices,
   }) : assert(excludeFromSemantics != null),
        assert(dragStartBehavior != null),
@@ -1014,6 +1015,13 @@ class GestureDetector extends StatelessWidget {
   /// If set to null, events from all device types will be recognized. Defaults to null.
   final Set<PointerDeviceKind>? supportedDevices;
 
+  /// Whether scrolling up/down on a trackpad or Magic Mouse should map to
+  /// zooming in/out. Settings this to true will help in reproducing behaviours
+  /// pre-Flutter 3.3 trackpad gestures rewrite.
+  ///
+  /// Defaults to false.
+  final bool trackpadPanShouldActAsZoom;
+
   @override
   Widget build(BuildContext context) {
     final Map<Type, GestureRecognizerFactory> gestures = <Type, GestureRecognizerFactory>{};
@@ -1186,7 +1194,8 @@ class GestureDetector extends StatelessWidget {
             ..onUpdate = onScaleUpdate
             ..onEnd = onScaleEnd
             ..dragStartBehavior = dragStartBehavior
-            ..gestureSettings = gestureSettings;
+            ..gestureSettings = gestureSettings
+            ..trackpadPanShouldActAsZoom = trackpadPanShouldActAsZoom;
         },
       );
     }

--- a/packages/flutter/lib/src/widgets/gesture_detector.dart
+++ b/packages/flutter/lib/src/widgets/gesture_detector.dart
@@ -288,7 +288,8 @@ class GestureDetector extends StatelessWidget {
     this.behavior,
     this.excludeFromSemantics = false,
     this.dragStartBehavior = DragStartBehavior.start,
-    this.trackpadPanShouldActAsZoom = false,
+    this.trackpadScrollCausesScale = false,
+    this.trackpadScrollToScaleFactor = kDefaultTrackpadScrollToScaleFactor,
     this.supportedDevices,
   }) : assert(excludeFromSemantics != null),
        assert(dragStartBehavior != null),
@@ -1015,12 +1016,11 @@ class GestureDetector extends StatelessWidget {
   /// If set to null, events from all device types will be recognized. Defaults to null.
   final Set<PointerDeviceKind>? supportedDevices;
 
-  /// Whether scrolling up/down on a trackpad or Magic Mouse should map to
-  /// zooming in/out. Settings this to true will help in reproducing behaviours
-  /// pre-Flutter 3.3 trackpad gestures rewrite.
-  ///
-  /// Defaults to false.
-  final bool trackpadPanShouldActAsZoom;
+  /// {@macro flutter.gestures.scale.trackpadScrollCausesScale}
+  final bool trackpadScrollCausesScale;
+
+  /// {@macro flutter.gestures.scale.trackpadScrollToScaleFactor}
+  final Offset trackpadScrollToScaleFactor;
 
   @override
   Widget build(BuildContext context) {
@@ -1195,7 +1195,8 @@ class GestureDetector extends StatelessWidget {
             ..onEnd = onScaleEnd
             ..dragStartBehavior = dragStartBehavior
             ..gestureSettings = gestureSettings
-            ..trackpadPanShouldActAsZoom = trackpadPanShouldActAsZoom;
+            ..trackpadScrollCausesScale = trackpadScrollCausesScale
+            ..trackpadScrollToScaleFactor = trackpadScrollToScaleFactor;
         },
       );
     }

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -88,7 +88,7 @@ class InteractiveViewer extends StatefulWidget {
     this.scaleFactor = 200.0,
     this.transformationController,
     this.alignment,
-    this.trackpadPanShouldActAsZoom = false,
+    this.trackpadScrollCausesScale = false,
     required Widget this.child,
   }) : assert(alignPanAxis != null),
        assert(panAxis != null),
@@ -104,7 +104,7 @@ class InteractiveViewer extends StatefulWidget {
        assert(maxScale >= minScale),
        assert(panEnabled != null),
        assert(scaleEnabled != null),
-       assert(trackpadPanShouldActAsZoom != null),
+       assert(trackpadScrollCausesScale != null),
        // boundaryMargin must be either fully infinite or fully finite, but not
        // a mix of both.
        assert(
@@ -145,7 +145,7 @@ class InteractiveViewer extends StatefulWidget {
     this.scaleFactor = 200.0,
     this.transformationController,
     this.alignment,
-    this.trackpadPanShouldActAsZoom = false,
+    this.trackpadScrollCausesScale = false,
     required InteractiveViewerWidgetBuilder this.builder,
   }) : assert(panAxis != null),
        assert(builder != null),
@@ -159,7 +159,7 @@ class InteractiveViewer extends StatefulWidget {
        assert(maxScale >= minScale),
        assert(panEnabled != null),
        assert(scaleEnabled != null),
-       assert(trackpadPanShouldActAsZoom != null),
+       assert(trackpadScrollCausesScale != null),
        // boundaryMargin must be either fully infinite or fully finite, but not
        // a mix of both.
        assert(
@@ -299,12 +299,8 @@ class InteractiveViewer extends StatefulWidget {
   ///   * [panEnabled], which is similar but for panning.
   final bool scaleEnabled;
 
-  /// Whether scrolling up/down on a trackpad or Magic Mouse should map to
-  /// zooming in/out. Settings this to true will make InteractiveViewer behave
-  /// as it did pre-Flutter 3.3 trackpad gestures rewrite.
-  ///
-  /// Defaults to false.
-  final bool trackpadPanShouldActAsZoom;
+  /// {@macro flutter.gestures.scale.trackpadScrollCausesScale}
+  final bool trackpadScrollCausesScale;
 
   /// Determines the amount of scale to be performed per pointer scroll.
   ///
@@ -974,8 +970,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       _controller.duration = Duration(milliseconds: (tFinal * 1000).round());
       _animation!.addListener(_onAnimate);
       _controller.forward();
-    }
-    else if (_gestureType == _GestureType.scale) {
+    } else if (_gestureType == _GestureType.scale) {
       if (details.scaleVelocity.abs() < 0.1) {
         _currentAxis = null;
         return;
@@ -1130,7 +1125,7 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
       translationChangeScene,
     );
   }
-  
+
   // Handle inertia scale animation.
   void _onScaleAnimate() {
     if (!_scaleController.isAnimating) {
@@ -1263,7 +1258,8 @@ class _InteractiveViewerState extends State<InteractiveViewer> with TickerProvid
         onScaleEnd: _onScaleEnd,
         onScaleStart: _onScaleStart,
         onScaleUpdate: _onScaleUpdate,
-        trackpadPanShouldActAsZoom: widget.trackpadPanShouldActAsZoom,
+        trackpadScrollCausesScale: widget.trackpadScrollCausesScale,
+        trackpadScrollToScaleFactor: Offset(0, -1/widget.scaleFactor),
         child: child,
       ),
     );

--- a/packages/flutter/lib/src/widgets/interactive_viewer.dart
+++ b/packages/flutter/lib/src/widgets/interactive_viewer.dart
@@ -85,7 +85,7 @@ class InteractiveViewer extends StatefulWidget {
     this.onInteractionUpdate,
     this.panEnabled = true,
     this.scaleEnabled = true,
-    this.scaleFactor = 200.0,
+    this.scaleFactor = kDefaultMouseScrollToScaleFactor,
     this.transformationController,
     this.alignment,
     this.trackpadScrollCausesScale = false,
@@ -304,8 +304,7 @@ class InteractiveViewer extends StatefulWidget {
 
   /// Determines the amount of scale to be performed per pointer scroll.
   ///
-  /// Defaults to 200.0, which was arbitrarily chosen to feel natural for most
-  /// trackpads and mousewheels on all supported platforms.
+  /// Defaults to [kDefaultMouseScrollToScaleFactor].
   ///
   /// Increasing this value above the default causes scaling to feel slower,
   /// while decreasing it causes scaling to feel faster.

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -1173,4 +1173,12 @@ void main() {
       ),
     );
   });
+
+  testGesture('scale trackpadPanShouldActAsZoom', (GestureTester tester) {
+    // TODO(@moffatman)
+  });
+
+  testGesture('scale ending velocity', (GestureTester tester) {
+    // TODO(@moffatman)
+  });
 }

--- a/packages/flutter/test/gestures/scale_test.dart
+++ b/packages/flutter/test/gestures/scale_test.dart
@@ -1174,11 +1174,195 @@ void main() {
     );
   });
 
-  testGesture('scale trackpadPanShouldActAsZoom', (GestureTester tester) {
-    // TODO(@moffatman)
+  testGesture('scale trackpadScrollCausesScale', (GestureTester tester) {
+    final ScaleGestureRecognizer scale = ScaleGestureRecognizer(
+      dragStartBehavior: DragStartBehavior.start,
+      trackpadScrollCausesScale: true
+    );
+
+    bool didStartScale = false;
+    Offset? updatedFocalPoint;
+    scale.onStart = (ScaleStartDetails details) {
+      didStartScale = true;
+      updatedFocalPoint = details.focalPoint;
+    };
+
+    double? updatedScale;
+    Offset? updatedDelta;
+    scale.onUpdate = (ScaleUpdateDetails details) {
+      updatedScale = details.scale;
+      updatedFocalPoint = details.focalPoint;
+      updatedDelta = details.focalPointDelta;
+    };
+
+    bool didEndScale = false;
+    scale.onEnd = (ScaleEndDetails details) {
+      didEndScale = true;
+    };
+
+    final TestPointer pointer1 = TestPointer(2, PointerDeviceKind.trackpad);
+
+    final PointerPanZoomStartEvent start = pointer1.panZoomStart(Offset.zero);
+    scale.addPointerPanZoom(start);
+
+    tester.closeArena(2);
+    expect(didStartScale, isFalse);
+    expect(updatedScale, isNull);
+    expect(updatedFocalPoint, isNull);
+    expect(updatedDelta, isNull);
+    expect(didEndScale, isFalse);
+
+    tester.route(start);
+    expect(didStartScale, isTrue);
+    didStartScale = false;
+    expect(updatedScale, isNull);
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(updatedDelta, isNull);
+    expect(didEndScale, isFalse);
+
+    // Zoom in by scrolling up.
+    tester.route(pointer1.panZoomUpdate(Offset.zero, pan: const Offset(0, -200)));
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(updatedScale, math.e);
+    updatedScale = null;
+    expect(updatedDelta, Offset.zero);
+    updatedDelta = null;
+    expect(didEndScale, isFalse);
+
+    // A horizontal scroll should do nothing.
+    tester.route(pointer1.panZoomUpdate(Offset.zero, pan: const Offset(200, -200)));
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(updatedScale, math.e);
+    updatedScale = null;
+    expect(updatedDelta, Offset.zero);
+    updatedDelta = null;
+    expect(didEndScale, isFalse);
+
+    // End.
+    tester.route(pointer1.panZoomEnd());
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, isNull);
+    expect(updatedScale, isNull);
+    expect(updatedDelta, isNull);
+    expect(didEndScale, isTrue);
+    didEndScale = false;
+
+    // Try with a different trackpadScrollToScaleFactor
+    scale.trackpadScrollToScaleFactor = const Offset(1/125, 0);
+
+    final PointerPanZoomStartEvent start2 = pointer1.panZoomStart(Offset.zero);
+    scale.addPointerPanZoom(start2);
+
+    tester.closeArena(2);
+    expect(didStartScale, isFalse);
+    expect(updatedScale, isNull);
+    expect(updatedFocalPoint, isNull);
+    expect(updatedDelta, isNull);
+    expect(didEndScale, isFalse);
+
+    tester.route(start2);
+    expect(didStartScale, isTrue);
+    didStartScale = false;
+    expect(updatedScale, isNull);
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(updatedDelta, isNull);
+    expect(didEndScale, isFalse);
+
+    // Zoom in by scrolling left.
+    tester.route(pointer1.panZoomUpdate(Offset.zero, pan: const Offset(125, 0)));
+    expect(didStartScale, isFalse);
+    didStartScale = false;
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(updatedScale, math.e);
+    updatedScale = null;
+    expect(updatedDelta, Offset.zero);
+    updatedDelta = null;
+    expect(didEndScale, isFalse);
+
+    // A vertical scroll should do nothing.
+    tester.route(pointer1.panZoomUpdate(Offset.zero, pan: const Offset(125, 125)));
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(updatedScale, math.e);
+    updatedScale = null;
+    expect(updatedDelta, Offset.zero);
+    updatedDelta = null;
+    expect(didEndScale, isFalse);
+
+    // End.
+    tester.route(pointer1.panZoomEnd());
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, isNull);
+    expect(updatedScale, isNull);
+    expect(updatedDelta, isNull);
+    expect(didEndScale, isTrue);
+    didEndScale = false;
+
+    scale.dispose();
   });
 
   testGesture('scale ending velocity', (GestureTester tester) {
-    // TODO(@moffatman)
+    final ScaleGestureRecognizer scale = ScaleGestureRecognizer(
+      dragStartBehavior: DragStartBehavior.start,
+      trackpadScrollCausesScale: true
+    );
+
+    bool didStartScale = false;
+    Offset? updatedFocalPoint;
+    scale.onStart = (ScaleStartDetails details) {
+      didStartScale = true;
+      updatedFocalPoint = details.focalPoint;
+    };
+
+    bool didEndScale = false;
+    double? scaleEndVelocity;
+    scale.onEnd = (ScaleEndDetails details) {
+      didEndScale = true;
+      scaleEndVelocity = details.scaleVelocity;
+    };
+
+    final TestPointer pointer1 = TestPointer(2, PointerDeviceKind.trackpad);
+
+    final PointerPanZoomStartEvent start = pointer1.panZoomStart(Offset.zero);
+    scale.addPointerPanZoom(start);
+
+    tester.closeArena(2);
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, isNull);
+    expect(didEndScale, isFalse);
+
+    tester.route(start);
+    expect(didStartScale, isTrue);
+    didStartScale = false;
+    expect(updatedFocalPoint, Offset.zero);
+    updatedFocalPoint = null;
+    expect(didEndScale, isFalse);
+
+    // Zoom in by scrolling up.
+    for (int i = 0; i < 100; i++) {
+      tester.route(pointer1.panZoomUpdate(
+        Offset.zero,
+        pan: Offset(0, i * -10),
+        timeStamp: Duration(milliseconds: i * 25)
+      ));
+    }
+
+    // End.
+    tester.route(pointer1.panZoomEnd(timeStamp: const Duration(milliseconds: 2500)));
+    expect(didStartScale, isFalse);
+    expect(updatedFocalPoint, isNull);
+    expect(didEndScale, isTrue);
+    didEndScale = false;
+    expect(scaleEndVelocity, moreOrLessEquals(281.41454098027765));
+
+    scale.dispose();
   });
 }

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -1802,6 +1802,46 @@ void main() {
       await tester.pump();
       expect(transformationController.value.getMaxScaleOnAxis(), 2.5); // capped at maxScale (2.5)
     });
+
+    testWidgets('trackpadPanShouldActAsZoom', (WidgetTester tester) async {
+      final TransformationController transformationController = TransformationController();
+      const double boundaryMargin = 50.0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                boundaryMargin: const EdgeInsets.all(boundaryMargin),
+                transformationController: transformationController,
+                trackpadPanShouldActAsZoom: true,
+                child: const SizedBox(width: 200.0, height: 200.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(transformationController.value.getMaxScaleOnAxis(), 1.0);
+
+      // Send a vertical scroll.
+      final TestPointer pointer = TestPointer(1, PointerDeviceKind.trackpad);
+      final Offset center = tester.getCenter(find.byType(SizedBox));
+      await tester.sendEventToBinding(pointer.panZoomStart(center));
+      await tester.pump();
+      expect(transformationController.value.getMaxScaleOnAxis(), 1.0);
+      await tester.sendEventToBinding(pointer.panZoomUpdate(center, pan: const Offset(0, 81)));
+      await tester.pump();
+      expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.499302500056767));
+
+      // Send a horizontal scroll (should have no effect).
+      await tester.sendEventToBinding(pointer.panZoomUpdate(center, pan: const Offset(81, 81)));
+      await tester.pump();
+      expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.499302500056767));
+    });
+
+    testWidgets('Scaling inertia', (WidgetTester tester) async {
+      // TODO(@moffatman)
+    });
   });
 
   group('getNearestPointOnLine', () {

--- a/packages/flutter/test/widgets/interactive_viewer_test.dart
+++ b/packages/flutter/test/widgets/interactive_viewer_test.dart
@@ -1803,7 +1803,7 @@ void main() {
       expect(transformationController.value.getMaxScaleOnAxis(), 2.5); // capped at maxScale (2.5)
     });
 
-    testWidgets('trackpadPanShouldActAsZoom', (WidgetTester tester) async {
+    testWidgets('trackpadScrollCausesScale', (WidgetTester tester) async {
       final TransformationController transformationController = TransformationController();
       const double boundaryMargin = 50.0;
       await tester.pumpWidget(
@@ -1813,7 +1813,7 @@ void main() {
               child: InteractiveViewer(
                 boundaryMargin: const EdgeInsets.all(boundaryMargin),
                 transformationController: transformationController,
-                trackpadPanShouldActAsZoom: true,
+                trackpadScrollCausesScale: true,
                 child: const SizedBox(width: 200.0, height: 200.0),
               ),
             ),
@@ -1829,18 +1829,50 @@ void main() {
       await tester.sendEventToBinding(pointer.panZoomStart(center));
       await tester.pump();
       expect(transformationController.value.getMaxScaleOnAxis(), 1.0);
-      await tester.sendEventToBinding(pointer.panZoomUpdate(center, pan: const Offset(0, 81)));
+      await tester.sendEventToBinding(pointer.panZoomUpdate(center, pan: const Offset(0, -81)));
       await tester.pump();
       expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.499302500056767));
 
       // Send a horizontal scroll (should have no effect).
-      await tester.sendEventToBinding(pointer.panZoomUpdate(center, pan: const Offset(81, 81)));
+      await tester.sendEventToBinding(pointer.panZoomUpdate(center, pan: const Offset(81, -81)));
       await tester.pump();
       expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.499302500056767));
     });
 
     testWidgets('Scaling inertia', (WidgetTester tester) async {
-      // TODO(@moffatman)
+      final TransformationController transformationController = TransformationController();
+      const double boundaryMargin = 50.0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: InteractiveViewer(
+                boundaryMargin: const EdgeInsets.all(boundaryMargin),
+                transformationController: transformationController,
+                trackpadScrollCausesScale: true,
+                child: const SizedBox(width: 200.0, height: 200.0),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(transformationController.value.getMaxScaleOnAxis(), 1.0);
+
+      // Send a vertical scroll fling, which will cause inertia.
+      await tester.trackpadFling(
+        find.byType(InteractiveViewer),
+        const Offset(0, -100),
+        3000
+      );
+      await tester.pump();
+      expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.6487212707001282));
+      await tester.pump(const Duration(milliseconds: 80));
+      expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.7966838346780103));
+      await tester.pumpAndSettle();
+      expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.9984509673751225));
+      await tester.pump(const Duration(seconds: 10));
+      expect(transformationController.value.getMaxScaleOnAxis(), moreOrLessEquals(1.9984509673751225));
     });
   });
 


### PR DESCRIPTION
After trackpad gestures rewrite, `InteractiveViewer` behaves differently, panning around instead of zooming when scrolling up/down on trackpad and magic mouse. If the old behaviour is desired, this new parameter `trackpadPanShouldActAsZoom` can allow that.

To reproduce exactly, zooming inertia is added to `InteractiveViewer`, this should also benefit touch usage.

Also fixed a bug where the `ScaleGestureRecognizer` had the wrong `focalPointDelta` on the first update due to not updating the transform, this is now covered by the `InteractiveViewer` test case. 

Fixes #114257

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
