### PR TITLE
[flutter_tools] Fix so that the value set by `--dart-define-from-file` can be passed to Gradle

### DIFF
--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -333,18 +333,16 @@ class BuildInfo {
       for (String projectArg in androidProjectArgs)
         '-P$projectArg',
     ];
-    if(dartDefineConfigJsonMap != null) {
-      final List<String> items = <String>[];
-      for (final String gradleConf in result) {
-        final String key = gradleConf.split('=')[0].substring(2);
-        if (dartDefineConfigJsonMap!.containsKey(key)) {
+    if (dartDefineConfigJsonMap != null) {
+      final Iterable<String> gradleConfKeys = result.map((final String gradleConf) => gradleConf.split('=')[0].substring(2));
+      dartDefineConfigJsonMap!.forEach((String key, Object value) {
+        if (gradleConfKeys.contains(key)) {
           globals.printWarning(
               'The key: [$key] already exists, you cannot use gradle variables that have been used by the system!');
         } else {
-          items.add('-P$key=${dartDefineConfigJsonMap?[key]}');
+          result.add('-P$key=$value');
         }
-      }
-      result.addAll(items);
+      });
     }
     return result;
   }

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -319,7 +319,7 @@ void main() {
           dartObfuscation: true,
       );
       buildInfo.toGradleConfig();
-      expect(testLogger.warningText, contains('he key: [dart-defines] already exists, you cannot use gradle variables that have been used by the system'));
+      expect(testLogger.warningText, contains('The key: [dart-defines] already exists, you cannot use gradle variables that have been used by the system'));
     });
 
     testUsingContext('toGradleConfig repeated variable with not set', () async {
@@ -332,7 +332,7 @@ void main() {
           dartObfuscation: true,
       );
       buildInfo.toGradleConfig();
-      expect(testLogger.warningText, contains('he key: [dart-defines] already exists, you cannot use gradle variables that have been used by the system'));
+      expect(testLogger.warningText, contains('The key: [dart-defines] already exists, you cannot use gradle variables that have been used by the system'));
     });
 
     testUsingContext('toGradleConfig with androidProjectArgs override gradle project variant', () async {
@@ -344,7 +344,7 @@ void main() {
           dartObfuscation: true,
       );
       buildInfo.toGradleConfig();
-      expect(testLogger.warningText, contains('The key: [applicationId] already exists, you cannot use gradle variables that have been used'));
+      expect(testLogger.warningText, contains('The key: [applicationId] already exists, you cannot use gradle variables that have been used by the system'));
     });
 
   });

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -289,7 +289,7 @@ void main() {
           treeShakeIcons: true,
           trackWidgetCreation: true,
           dartDefines: <String>['foo=2', 'bar=2'],
-          dartDefineConfigJsonMap: <String,Object>{ 'DART_DEFINES' : 'Define a variable, but it occupies the variable name of the system'},
+          dartDefineConfigJsonMap: <String, Object>{'DART_DEFINES': 'Define a variable, but it occupies the variable name of the system'},
           dartObfuscation: true,
       );
       buildInfo.toEnvironmentConfig();
@@ -315,7 +315,7 @@ void main() {
           treeShakeIcons: true,
           trackWidgetCreation: true,
           dartDefines: <String>['foo=2', 'bar=2'],
-          dartDefineConfigJsonMap: <String,Object>{ 'dart-defines' : 'Define a variable, but it occupies the variable name of the system'},
+          dartDefineConfigJsonMap: <String, Object>{'dart-defines': 'Define a variable, but it occupies the variable name of the system'},
           dartObfuscation: true,
       );
       buildInfo.toGradleConfig();
@@ -328,7 +328,7 @@ void main() {
           treeShakeIcons: true,
           trackWidgetCreation: true,
           dartDefines: <String>['dart-defines=Define a variable, but it occupies the variable name of the system'],
-          dartDefineConfigJsonMap: <String,Object>{ 'dart-defines' : 'Define a variable, but it occupies the variable name of the system'},
+          dartDefineConfigJsonMap: <String, Object>{'dart-defines': 'Define a variable, but it occupies the variable name of the system'},
           dartObfuscation: true,
       );
       buildInfo.toGradleConfig();
@@ -340,7 +340,7 @@ void main() {
           treeShakeIcons: true,
           trackWidgetCreation: true,
           androidProjectArgs: <String>['applicationId=com.google'],
-          dartDefineConfigJsonMap: <String,Object>{ 'applicationId' : 'override applicationId'},
+          dartDefineConfigJsonMap: <String, Object>{'applicationId': 'override applicationId'},
           dartObfuscation: true,
       );
       buildInfo.toGradleConfig();

--- a/packages/flutter_tools/test/general.shard/build_info_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_info_test.dart
@@ -230,6 +230,7 @@ void main() {
       treeShakeIcons: true,
       trackWidgetCreation: true,
       dartDefines: <String>['foo=2', 'bar=2'],
+      dartDefineConfigJsonMap: <String, Object>{'baz': '2'},
       dartObfuscation: true,
       splitDebugInfoPath: 'foo/',
       extraFrontEndOptions: <String>['--enable-experiment=non-nullable', 'bar'],
@@ -252,6 +253,7 @@ void main() {
       '-Pcode-size-directory=foo/code-size',
       '-Pfoo=bar',
       '-Pfizz=bazz',
+      '-Pbaz=2',
     ]);
   });
 


### PR DESCRIPTION
The value set in `--dart-define-from-file` is not being passed to Gradle.

## Issue

close #114296  

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
