### PR TITLE
fix a bug when android uses CupertinoPageTransitionsBuilder...

### DIFF
--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -80,6 +80,8 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 ///  * [CupertinoPageTransitionsBuilder], which is the default page transition
 ///    for iOS and macOS.
 mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
+  TargetPlatform? _prevTargetPlatform;
+
   /// Builds the primary contents of the route.
   @protected
   Widget buildContent(BuildContext context);
@@ -116,8 +118,77 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
 
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
-    final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
-    return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child);
+    return ValueListenableBuilder<bool>(
+        valueListenable: navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
+        builder: (BuildContext context, bool useGestureInProgress, Widget? _) {
+          final ThemeData themeData = Theme.of(context);
+          final bool usePrevTargetPlatform;
+          if (useGestureInProgress) {
+            // The platform should be kept unchanged during an user gesture.
+            usePrevTargetPlatform = _prevTargetPlatform != null && _prevTargetPlatform != themeData.platform;
+          } else {
+            _prevTargetPlatform = themeData.platform;
+            usePrevTargetPlatform = false;
+          }
+          return _PlatformOfBuilder(
+            platform: usePrevTargetPlatform ? _prevTargetPlatform : null,
+            builder: (BuildContext context, Widget? child) {
+              assert(child != null);
+              final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
+              return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child!);
+            },
+            child: child,
+          );
+        });
+  }
+}
+
+/// Modify only the [platform] of the [builder], not the [child]
+class _PlatformOfBuilder extends StatefulWidget {
+  const _PlatformOfBuilder({
+    required this.builder,
+    required this.child,
+    required this.platform,
+  });
+
+  final TargetPlatform? platform;
+  final TransitionBuilder builder;
+  final Widget child;
+
+  @override
+  State<_PlatformOfBuilder> createState() => _PlatformOfBuilderState();
+}
+
+class _PlatformOfBuilderState extends State<_PlatformOfBuilder> {
+  final GlobalKey _globalKey = GlobalKey();
+  @override
+  Widget build(BuildContext context) {
+    if (widget.platform == null) {
+      // No need to modify the platform, return early
+      // Use globalKey to prevent losing state after subtree changes.
+      return Builder(
+        key: _globalKey,
+        builder: (BuildContext context) => widget.builder(context, widget.child),
+      );
+    }
+    final ThemeData themeData = Theme.of(context);
+    return Theme(
+      // modify the platform of builder
+      data: themeData.copyWith(platform: widget.platform),
+      child: Builder(
+        key: _globalKey,
+        builder: (BuildContext context) => widget.builder(
+          context,
+          Builder(
+            builder: (BuildContext context) => Theme(
+              // Restore the platform of child
+              data: Theme.of(context).copyWith(platform: themeData.platform),
+              child: widget.child,
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -80,7 +80,7 @@ class MaterialPageRoute<T> extends PageRoute<T> with MaterialRouteTransitionMixi
 ///  * [CupertinoPageTransitionsBuilder], which is the default page transition
 ///    for iOS and macOS.
 mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
-  TargetPlatform? _prevTargetPlatform;
+  TargetPlatform? _effectiveTargetPlatform;
 
   /// Builds the primary contents of the route.
   @protected
@@ -123,16 +123,13 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
       builder: (BuildContext context, bool useGestureInProgress, Widget? _) {
         final ThemeData themeData = Theme.of(context);
 
-        TargetPlatform platform = themeData.platform;
         if (useGestureInProgress) {
           // The platform should be kept unchanged during an user gesture.
-          if (_prevTargetPlatform != null && _prevTargetPlatform != platform) {
-            platform = _prevTargetPlatform!;
-          }
+          _effectiveTargetPlatform ??= themeData.platform;
         } else {
-          _prevTargetPlatform = platform;
+          _effectiveTargetPlatform = themeData.platform;
         }
-        return themeData.pageTransitionsTheme.buildTransitions<T>(this, context, animation, secondaryAnimation, child, platform);
+        return themeData.pageTransitionsTheme.buildTransitions<T>(this, context, animation, secondaryAnimation, child, _effectiveTargetPlatform!);
       },
     );
   }

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -118,10 +118,10 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
 
   @override
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+    final ThemeData themeData = Theme.of(context);
     return ValueListenableBuilder<bool>(
         valueListenable: navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
         builder: (BuildContext context, bool useGestureInProgress, Widget? _) {
-          final ThemeData themeData = Theme.of(context);
           final bool usePrevTargetPlatform;
           if (useGestureInProgress) {
             // The platform should be kept unchanged during an user gesture.
@@ -134,8 +134,7 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
             platform: usePrevTargetPlatform ? _prevTargetPlatform : null,
             builder: (BuildContext context, Widget? child) {
               assert(child != null);
-              final PageTransitionsTheme theme = Theme.of(context).pageTransitionsTheme;
-              return theme.buildTransitions<T>(this, context, animation, secondaryAnimation, child!);
+              return themeData.pageTransitionsTheme.buildTransitions<T>(this, context, animation, secondaryAnimation, child!);
             },
             child: child,
           );

--- a/packages/flutter/lib/src/material/page.dart
+++ b/packages/flutter/lib/src/material/page.dart
@@ -120,7 +120,7 @@ mixin MaterialRouteTransitionMixin<T> on PageRoute<T> {
   Widget buildTransitions(BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
     final ThemeData themeData = Theme.of(context);
     return ValueListenableBuilder<bool>(
-        valueListenable: navigator?.userGestureInProgressNotifier ?? ValueNotifier<bool>(false),
+        valueListenable: navigator!.userGestureInProgressNotifier,
         builder: (BuildContext context, bool useGestureInProgress, Widget? _) {
           final bool usePrevTargetPlatform;
           if (useGestureInProgress) {

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -741,7 +741,7 @@ class PageTransitionsTheme with Diagnosticable {
   Map<TargetPlatform, PageTransitionsBuilder> get builders => _builders;
   final Map<TargetPlatform, PageTransitionsBuilder> _builders;
 
-  /// Delegates to the builder for the current [ThemeData.platform].
+  /// Delegates to the builder for the current [platform].
   /// If a builder for the current platform is not found, then the
   /// [ZoomPageTransitionsBuilder] is used.
   ///
@@ -752,9 +752,8 @@ class PageTransitionsTheme with Diagnosticable {
     Animation<double> animation,
     Animation<double> secondaryAnimation,
     Widget child,
+    TargetPlatform platform,
   ) {
-    final TargetPlatform platform = Theme.of(context).platform;
-
     final PageTransitionsBuilder matchingBuilder =
       builders[platform] ?? const ZoomPageTransitionsBuilder();
     return matchingBuilder.buildTransitions<T>(route, context, animation, secondaryAnimation, child);

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -753,11 +753,7 @@ class PageTransitionsTheme with Diagnosticable {
     Animation<double> secondaryAnimation,
     Widget child,
   ) {
-    TargetPlatform platform = Theme.of(context).platform;
-
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) {
-      platform = TargetPlatform.iOS;
-    }
+    final TargetPlatform platform = Theme.of(context).platform;
 
     final PageTransitionsBuilder matchingBuilder =
       builders[platform] ?? const ZoomPageTransitionsBuilder();

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -392,14 +392,11 @@ void main() {
     await tester.pumpAndSettle();
     expect(builtCount, 1);
 
-    if (Theme.of(tester.element(find.text('pop'))).platform == TargetPlatform.iOS) {
-        await tester.tap(find.text('pop'));
-    } else {
-        final Size size = tester.getSize(find.byType(MaterialApp));
-        await tester.flingFrom(Offset(0, size.height / 2), Offset(size.width * 2 / 3, 0), 500);
-    }
+    final Size size = tester.getSize(find.byType(MaterialApp));
+    await tester.flingFrom(Offset(0, size.height / 2), Offset(size.width * 2 / 3, 0), 500);
+
     await tester.pumpAndSettle();
     expect(find.text('push'), findsOneWidget);
     expect(builtCount, 1);
-  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS}));
+  }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 }

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -399,4 +399,91 @@ void main() {
     expect(find.text('push'), findsOneWidget);
     expect(builtCount, 1);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+  testWidgets('back gesture while TargetPlatform changes', (WidgetTester tester) async {
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => Material(
+        child: TextButton(
+          child: const Text('PUSH'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => const Text('HELLO'),
+    };
+    const PageTransitionsTheme pageTransitionsTheme = PageTransitionsTheme(
+      builders: <TargetPlatform, PageTransitionsBuilder>{
+        TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+        // iOS uses different PageTransitionsBuilder
+        TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
+      },
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          platform: TargetPlatform.android,
+          pageTransitionsTheme: pageTransitionsTheme,
+        ),
+        routes: routes,
+      ),
+    );
+    await tester.tap(find.text('PUSH'));
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(find.text('PUSH'), findsNothing);
+    expect(find.text('HELLO'), findsOneWidget);
+
+    final Offset helloPosition1 = tester.getCenter(find.text('HELLO'));
+    final TestGesture gesture = await tester.startGesture(const Offset(2.5, 300.0));
+    await tester.pump(const Duration(milliseconds: 20));
+    await gesture.moveBy(const Offset(100.0, 0.0));
+    expect(find.text('PUSH'), findsNothing);
+    expect(find.text('HELLO'), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsOneWidget);
+    final Offset helloPosition2 = tester.getCenter(find.text('HELLO'));
+    expect(helloPosition1.dx, lessThan(helloPosition2.dx));
+    expect(helloPosition1.dy, helloPosition2.dy);
+    expect(Theme.of(tester.element(find.text('HELLO'))).platform, TargetPlatform.android);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          platform: TargetPlatform.iOS,
+          pageTransitionsTheme: pageTransitionsTheme,
+        ),
+        routes: routes,
+      ),
+    );
+    // Now we have to let the theme animation run through.
+    // This takes three frames (including the first one above):
+    //  1. Start the Theme animation. It's at t=0 so everything else is identical.
+    //  2. Start any animations that are informed by the Theme, for example, the
+    //     DefaultTextStyle, on the first frame that the theme is not at t=0. In
+    //     this case, it's at t=1.0 of the theme animation, so this is also the
+    //     frame in which the theme animation ends.
+    //  3. End all the other animations.
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(Theme.of(tester.element(find.text('HELLO'))).platform, TargetPlatform.iOS);
+    final Offset helloPosition3 = tester.getCenter(find.text('HELLO'));
+    expect(helloPosition3, helloPosition2);
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsOneWidget);
+    await gesture.moveBy(const Offset(100.0, 0.0));
+    await tester.pump(const Duration(milliseconds: 20));
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsOneWidget);
+    final Offset helloPosition4 = tester.getCenter(find.text('HELLO'));
+    expect(helloPosition3.dx, lessThan(helloPosition4.dx));
+    expect(helloPosition3.dy, helloPosition4.dy);
+    await gesture.moveBy(const Offset(500.0, 0.0));
+    await gesture.up();
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 3);
+    expect(find.text('PUSH'), findsOneWidget);
+    expect(find.text('HELLO'), findsNothing);
+
+    await tester.tap(find.text('PUSH'));
+    expect(await tester.pumpAndSettle(const Duration(minutes: 1)), 2);
+    expect(find.text('PUSH'), findsNothing);
+    expect(find.text('HELLO'), findsOneWidget);
+  });
 }

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -350,4 +350,56 @@ void main() {
     await tester.pumpAndSettle();
     expect(builtCount, 1);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
+
+  testWidgets('android can use CupertinoPageTransitionsBuilder', (WidgetTester tester) async {
+    int builtCount = 0;
+
+    final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
+      '/': (BuildContext context) => Material(
+        child: TextButton(
+          child: const Text('push'),
+          onPressed: () { Navigator.of(context).pushNamed('/b'); },
+        ),
+      ),
+      '/b': (BuildContext context) => StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          builtCount++; // Increase [builtCount] each time the widget build
+          return TextButton(
+            child: const Text('pop'),
+            onPressed: () { Navigator.pop(context); },
+          );
+        },
+      ),
+    };
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(
+          pageTransitionsTheme: const PageTransitionsTheme(
+            builders: <TargetPlatform, PageTransitionsBuilder>{
+              TargetPlatform.android: CupertinoPageTransitionsBuilder(),
+              // iOS uses different PageTransitionsBuilder
+              TargetPlatform.iOS: FadeUpwardsPageTransitionsBuilder(),
+            },
+          ),
+        ),
+        routes: routes,
+      ),
+    );
+
+    // No matter push or pop was called, the child widget should built only once.
+    await tester.tap(find.text('push'));
+    await tester.pumpAndSettle();
+    expect(builtCount, 1);
+
+    if (Theme.of(tester.element(find.text('pop'))).platform == TargetPlatform.iOS) {
+        await tester.tap(find.text('pop'));
+    } else {
+        final Size size = tester.getSize(find.byType(MaterialApp));
+        await tester.flingFrom(Offset(0, size.height / 2), Offset(size.width * 2 / 3, 0), 500);
+    }
+    await tester.pumpAndSettle();
+    expect(find.text('push'), findsOneWidget);
+    expect(builtCount, 1);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android, TargetPlatform.iOS}));
 }

--- a/packages/flutter/test/material/page_transitions_theme_test.dart
+++ b/packages/flutter/test/material/page_transitions_theme_test.dart
@@ -363,7 +363,7 @@ void main() {
       ),
       '/b': (BuildContext context) => StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
-          builtCount++; // Increase [builtCount] each time the widget build
+          builtCount++;
           return TextButton(
             child: const Text('pop'),
             onPressed: () { Navigator.pop(context); },
@@ -454,7 +454,7 @@ void main() {
         routes: routes,
       ),
     );
-    // Now we have to let the theme animation run through.
+    // Now, let the theme animation run through.
     // This takes three frames (including the first one above):
     //  1. Start the Theme animation. It's at t=0 so everything else is identical.
     //  2. Start any animations that are informed by the Theme, for example, the


### PR DESCRIPTION
When android uses iOS style `PageTransitionsBuilder` and iOS uses android style `PageTransitionsBuilder`, on android, swipe from the left edge of the screen doesn't work. This PR solves that problem.

#99919 introduced a breaking change, the pr re-implemented it <del>without introducing a breaking change.**</del>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
