### PR TITLE
Make `Linux_android  android_semantics_integration_test` flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1344,6 +1344,7 @@ targets:
 
   - name: Linux_android android_semantics_integration_test
     recipe: devicelab/devicelab_drone
+    bringup: true # Flaky: https://github.com/flutter/flutter/issues/114360
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/114360

/cc Gardener @cbracken 