### PR TITLE
[flutter_tools/dap] Map org-dartlang-sdk URIs to the location of the source files found by the analyzer

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -19,7 +19,7 @@ import 'mixins.dart';
 
 /// A DAP Debug Adapter for running and debugging Flutter applications.
 class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments, FlutterAttachRequestArguments>
-    with PidTracker {
+    with PidTracker, FlutterAdapter {
   FlutterDebugAdapter(
     super.channel, {
     required this.fileSystem,
@@ -30,13 +30,20 @@ class FlutterDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments
     super.logger,
     super.onError,
   })  : _enableDds = enableDds,
+        flutterSdkRoot = Cache.flutterRoot!,
         // Always disable in the DAP layer as it's handled in the spawned
         // 'flutter' process.
-        super(enableDds: false);
+        super(enableDds: false) {
+          configureOrgDartlangSdkMappings();
+        }
 
+  @override
   FileSystem fileSystem;
   Platform platform;
   Process? _process;
+
+  @override
+  final String flutterSdkRoot;
 
   /// Whether DDS should be enabled in the Flutter process.
   ///

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_test_adapter.dart
@@ -19,7 +19,7 @@ import 'mixins.dart';
 
 /// A DAP Debug Adapter for running and debugging Flutter tests.
 class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArguments, FlutterAttachRequestArguments>
-    with PidTracker, TestAdapter {
+    with PidTracker, FlutterAdapter, TestAdapter {
   FlutterTestDebugAdapter(
     super.channel, {
     required this.fileSystem,
@@ -30,13 +30,20 @@ class FlutterTestDebugAdapter extends DartDebugAdapter<FlutterLaunchRequestArgum
     super.logger,
     super.onError,
   })  : _enableDds = enableDds,
+        flutterSdkRoot = Cache.flutterRoot!,
         // Always disable in the DAP layer as it's handled in the spawned
         // 'flutter' process.
-        super(enableDds: false);
+        super(enableDds: false) {
+          configureOrgDartlangSdkMappings();
+        }
 
+  @override
   FileSystem fileSystem;
   Platform platform;
   Process? _process;
+
+  @override
+  final String flutterSdkRoot;
 
   /// Whether DDS should be enabled in the Flutter process.
   ///

--- a/packages/flutter_tools/lib/src/debug_adapters/mixins.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/mixins.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import '../base/file_system.dart';
 import '../base/io.dart';
 
 /// A mixin for tracking additional PIDs that can be shut down at the end of a debug session.
@@ -20,5 +21,40 @@ mixin PidTracker {
   /// Terminates all processes with the PIDs registered in [pidsToTerminate].
   void terminatePids(ProcessSignal signal) {
     pidsToTerminate.forEach(signal.send);
+  }
+}
+
+mixin FlutterAdapter  {
+  Map<String, Uri> get orgDartlangSdkMappings;
+  String get flutterSdkRoot;
+  FileSystem get fileSystem;
+
+  void configureOrgDartlangSdkMappings() {
+    /// When a user navigates into 'dart:xxx' sources in their editor (via the
+    /// analysis server) they will land in flutter_sdk/bin/cache/pkg/sky_engine.
+    ///
+    /// The running VM knows nothing about these paths and will resolve these
+    /// libraries to 'org-dartlang-sdk://' URIs. We need to map between these
+    /// to ensure that if a user puts a breakpoint inside sky_engine the VM can
+    /// apply it to the correct place and once hit, we can navigate the user
+    /// back to the correct file on their disk.
+    ///
+    /// The mapping is handled by the base adapter but we need to override the
+    /// paths to match the layout used by Flutter.
+    ///
+    /// In future this might become unnecessary if
+    /// https://github.com/dart-lang/sdk/issues/48435 is implemented. Until
+    /// then, providing these mappings improves the debugging experience.
+
+    // Clear original Dart SDK mappings because they're not valid here.
+    orgDartlangSdkMappings.clear();
+
+    // 'dart:ui' maps to /flutter/lib/ui
+    final String flutterRoot = fileSystem.path.join(flutterSdkRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'ui');
+    orgDartlangSdkMappings[flutterRoot] = Uri.parse('org-dartlang-sdk:///flutter/lib/ui');
+
+    // The rest of the Dart SDK maps to /third_party/dart/sdk
+    final String dartRoot = fileSystem.path.join(flutterSdkRoot, 'bin', 'cache', 'pkg', 'sky_engine');
+    orgDartlangSdkMappings[dartRoot] = Uri.parse('org-dartlang-sdk:///third_party/dart/sdk');
   }
 }

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -6,8 +6,10 @@ import 'dart:async';
 
 import 'package:dds/dap.dart';
 import 'package:file/memory.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/debug_adapters/flutter_adapter.dart';
 import 'package:flutter_tools/src/debug_adapters/flutter_adapter_args.dart';
 import 'package:flutter_tools/src/globals.dart' as globals show platform;
 import 'package:test/fake.dart';
@@ -20,6 +22,9 @@ void main() {
   // Use the real platform as a base so that Windows bots test paths.
   final FakePlatform platform = FakePlatform.fromPlatform(globals.platform);
   final FileSystemStyle fsStyle = platform.isWindows ? FileSystemStyle.windows : FileSystemStyle.posix;
+  final String flutterRoot = platform.isWindows
+                                ? r'C:\fake\flutter'
+                                : '/fake/flutter';
 
   group('flutter adapter', () {
     final String expectedFlutterExecutable = platform.isWindows
@@ -27,9 +32,7 @@ void main() {
         : '/fake/flutter/bin/flutter';
 
     setUpAll(() {
-      Cache.flutterRoot = platform.isWindows
-          ? r'C:\fake\flutter'
-          : '/fake/flutter';
+      Cache.flutterRoot = flutterRoot;
     });
 
     group('launchRequest', () {
@@ -312,6 +315,46 @@ void main() {
 
       expect(adapter.executable, equals(expectedFlutterExecutable));
       expect(adapter.processArgs, contains('tool_arg'));
+    });
+
+    group('maps org-dartlang-sdk paths', () {
+      late FileSystem fs;
+      late FlutterDebugAdapter adapter;
+      setUp(() {
+        fs = MemoryFileSystem.test(style: fsStyle);
+        adapter = MockFlutterDebugAdapter(
+          fileSystem: fs,
+          platform: platform,
+        );
+      });
+
+      test('dart:ui URI to file path', () async {
+        expect(
+          adapter.convertOrgDartlangSdkToPath(Uri.parse('org-dartlang-sdk:///flutter/lib/ui/ui.dart')),
+          fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'ui', 'ui.dart'),
+        );
+      });
+
+      test('dart:ui file path to URI', () async {
+        expect(
+          adapter.convertPathToOrgDartlangSdk(fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'ui', 'ui.dart')),
+          Uri.parse('org-dartlang-sdk:///flutter/lib/ui/ui.dart'),
+        );
+      });
+
+      test('dart:core URI to file path', () async {
+        expect(
+          adapter.convertOrgDartlangSdkToPath(Uri.parse('org-dartlang-sdk:///third_party/dart/sdk/lib/core/core.dart')),
+          fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'core', 'core.dart'),
+        );
+      });
+
+      test('dart:core file path to URI', () async {
+        expect(
+          adapter.convertPathToOrgDartlangSdk(fs.path.join(flutterRoot, 'bin', 'cache', 'pkg', 'sky_engine', 'lib', 'core', 'core.dart')),
+          Uri.parse('org-dartlang-sdk:///third_party/dart/sdk/lib/core/core.dart'),
+        );
+      });
     });
 
     group('includes customTool', () {


### PR DESCRIPTION
@christopherfujino this is a fix for https://github.com/Dart-Code/Dart-Code/issues/4128.

The issue is that when the user navigates to an SDK sources using Go-to-Definition in their editor, they go into a local file in the SDK folder. The running VMs know nothing about this path so any breakpoints set inside it will not resolve (and similarly, if the debugger breaks inside SDK sources, it does not map back to these files and gives the user a temporary downloaded-from-the-vm version of the file instead).

To fix this, we need to map between the `org-dartlang-sdk://` URIs that the VM Service can give us and the local file paths we know on the users machine. This (currently) needs to be done in DAP because it's the only place that has access to both.

I previously fixed this for Dart in https://github.com/dart-lang/sdk/commit/08db7182908322d714cf2be4d190fd876f929810 however I subsequently found that Flutter apps have different URIs for the Dart SDK (`org-dartlang-sdk:///third_party/dart` instead of `org-dartlang-sdk://dart`) as well as having a `dart:ui` that maps to `org-dartlang-sdk:///flutter`.

So, I've updated DDS/DAP to allow debug adapters to contribute their own mappings, and this change adds the mappings for the Dart SDK and `dart:ui` based on their current locations. With this change, you can Go-to-Definition into both Dart SDK sources and `dart:ui` sources (both of which live in `pkg/sky_engine` on disk) and add breakpoints, and they will be hit while debugging.

Related:

- https://github.com/dart-lang/sdk/issues/49863
- https://github.com/dart-lang/sdk/issues/48435

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
