### PR TITLE
Revert "Overlay always applies clip (#113770)"

### DIFF
--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -709,6 +709,8 @@ class _RenderTheatre extends RenderBox with ContainerRenderObjectMixin<RenderBox
     addAll(children);
   }
 
+  bool _hasVisualOverflow = false;
+
   @override
   void setupParentData(RenderBox child) {
     if (child.parentData is! StackParentData) {
@@ -834,6 +836,8 @@ class _RenderTheatre extends RenderBox with ContainerRenderObjectMixin<RenderBox
 
   @override
   void performLayout() {
+    _hasVisualOverflow = false;
+
     if (_onstageChildCount == 0) {
       return;
     }
@@ -852,7 +856,7 @@ class _RenderTheatre extends RenderBox with ContainerRenderObjectMixin<RenderBox
         child.layout(nonPositionedConstraints, parentUsesSize: true);
         childParentData.offset = _resolvedAlignment!.alongOffset(size - child.size as Offset);
       } else {
-        RenderStack.layoutPositionedChild(child, childParentData, size, _resolvedAlignment!);
+        _hasVisualOverflow = RenderStack.layoutPositionedChild(child, childParentData, size, _resolvedAlignment!) || _hasVisualOverflow;
       }
 
       assert(child.parentData == childParentData);
@@ -894,7 +898,7 @@ class _RenderTheatre extends RenderBox with ContainerRenderObjectMixin<RenderBox
 
   @override
   void paint(PaintingContext context, Offset offset) {
-    if (clipBehavior != Clip.none) {
+    if (_hasVisualOverflow && clipBehavior != Clip.none) {
       _clipRectLayer.layer = context.pushClipRect(
         needsCompositing,
         offset,
@@ -935,7 +939,7 @@ class _RenderTheatre extends RenderBox with ContainerRenderObjectMixin<RenderBox
       case Clip.hardEdge:
       case Clip.antiAlias:
       case Clip.antiAliasWithSaveLayer:
-        return Offset.zero & size;
+        return _hasVisualOverflow ? Offset.zero & size : null;
     }
   }
 

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -952,7 +952,7 @@ void main() {
     );
 
     await tester.tap(find.text('Go'));
-    await tester.pumpAndSettle();
+    await tester.pump();
 
     expect(
       semantics,

--- a/packages/flutter/test/widgets/overlay_test.dart
+++ b/packages/flutter/test/widgets/overlay_test.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../rendering/mock_canvas.dart';
 import 'semantics_tester.dart';
 
 void main() {
@@ -1118,28 +1117,6 @@ void main() {
       });
       expect(visited, true);
     }
-  });
-
-  testWidgets('Overlay always applies clip', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: Overlay(
-          initialEntries: <OverlayEntry>[
-            OverlayEntry(
-              builder: (BuildContext context) => Positioned(left: 10, right: 10, child: Container()),
-            ),
-          ],
-        ),
-      ),
-    );
-    final RenderObject renderObject = tester.renderObject(find.byType(Overlay));
-    // ignore: avoid_dynamic_calls
-    expect((renderObject as dynamic).paint, paints
-      ..save()
-      ..clipRect(rect: const Rect.fromLTWH(0.0, 0.0, 800.0, 600.0))
-      ..restore(),
-    );
   });
 
   group('OverlayEntry listenable', () {


### PR DESCRIPTION
This reverts commit 103a5c98b8cac6bdcc8c8af1094d1e6f98453fe6.

internal test failures

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
