### PR TITLE
Add a mechanism to force override semantics debugger outline colors

### DIFF
--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -42,6 +42,13 @@ class SemanticsDebugger extends StatefulWidget {
   /// The [TextStyle] to use when rendering semantics labels.
   final TextStyle labelStyle;
 
+  /// If true, all semantics outlines use a fixed deterministic color of
+  /// `0xFFC00000`.
+  ///
+  /// Defaults to false, meaning the outline color is random value based
+  /// on the identifier of the semantics node.
+  static bool debugDeterministicOutlineColor = false;
+
   @override
   State<SemanticsDebugger> createState() => _SemanticsDebuggerState();
 }
@@ -355,6 +362,8 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     return childrenDepth + 1;
   }
 
+  static const Color _kChuckNorris = Color(0xFFC00000);
+
   void _paint(Canvas canvas, SemanticsNode node, int rank) {
     canvas.save();
     if (node.transform != null) {
@@ -362,7 +371,9 @@ class _SemanticsDebuggerPainter extends CustomPainter {
     }
     final Rect rect = node.rect;
     if (!rect.isEmpty) {
-      final Color lineColor = Color(0xFF000000 + math.Random(node.id).nextInt(0xFFFFFF));
+      final Color lineColor = SemanticsDebugger.debugDeterministicOutlineColor
+        ? _kChuckNorris
+        : Color(0xFF000000 + math.Random(node.id).nextInt(0xFFFFFF));
       final Rect innerRect = rect.deflate(rank * 1.0);
       if (innerRect.isEmpty) {
         final Paint fill = Paint()

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 void main() {
   testWidgets('SemanticsDebugger will schedule a frame', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -484,6 +486,35 @@ void main() {
 
     // ignore: avoid_dynamic_calls
     expect(_getSemanticsDebuggerPainter(debuggerKey: debugger, tester: tester).labelStyle, labelStyle);
+  });
+
+  testWidgets('SemanticsDebugger can override outline color to be deterministic', (WidgetTester tester) async {
+    try {
+      SemanticsDebugger.debugDeterministicOutlineColor = true;
+      final UniqueKey debugger = UniqueKey();
+      const TextStyle labelStyle = TextStyle(color: Colors.amber);
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: SemanticsDebugger(
+            key: debugger,
+            labelStyle: labelStyle,
+            child: Semantics(
+              label: 'label',
+              textDirection: TextDirection.ltr,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(SemanticsDebugger), paints
+        ..rect(color: const Color(0xFFFFFFFF), style: PaintingStyle.fill)
+        // This color is fixed by debugDeterministicOutlineColor.
+        ..rect(color: const Color(0xFFC00000), style: PaintingStyle.stroke)
+      );
+    } finally {
+      SemanticsDebugger.debugDeterministicOutlineColor = false;
+    }
   });
 }
 

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -53,6 +53,7 @@ abstract class FlutterTestRunner {
     Device? integrationTestDevice,
     String? integrationTestUserIdentifier,
     TestTimeRecorder? testTimeRecorder,
+    bool debugDeterministicSemanticsDebugger = false,
   });
 }
 
@@ -90,6 +91,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     Device? integrationTestDevice,
     String? integrationTestUserIdentifier,
     TestTimeRecorder? testTimeRecorder,
+    bool debugDeterministicSemanticsDebugger = false,
   }) async {
     // Configure package:test to use the Flutter engine for child processes.
     final String shellPath = globals.artifacts!.getArtifactPath(Artifact.flutterTester);
@@ -209,6 +211,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
       integrationTestDevice: integrationTestDevice,
       integrationTestUserIdentifier: integrationTestUserIdentifier,
       testTimeRecorder: testTimeRecorder,
+      debugDeterministicSemanticsDebugger: debugDeterministicSemanticsDebugger,
     );
 
     try {

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -821,6 +821,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     Device? integrationTestDevice,
     String? integrationTestUserIdentifier,
     TestTimeRecorder? testTimeRecorder,
+    bool debugDeterministicSemanticsDebugger = false,
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     lastDebuggingOptionsValue = debuggingOptions;


### PR DESCRIPTION
In order to avoid the problem of massive scuba diffs when semantics node change, allow forcing the semantics debugger to use a fixed color. This can be forced in the bootstrap method of flutter tests (which is also used by google3) if the flag is set. If we can wire that up to the build rules, then we can gradually migrate customer money and avoid extra scuba churn