### PR TITLE
Ensure methods like dispose are not async by accident

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5098,13 +5098,14 @@ class StatefulElement extends ComponentElement {
   @override
   void _firstBuild() {
     assert(state._debugLifecycleState == _StateLifecycle.created);
-    final Object? debugCheckForReturnedFuture = state.initState() as dynamic;
+    Object? debugCheckForReturnedFuture = state.initState() as dynamic;
     assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'initState'));
     assert(() {
       state._debugLifecycleState = _StateLifecycle.initialized;
       return true;
     }());
-    state.didChangeDependencies();
+    debugCheckForReturnedFuture = state.didChangeDependencies() as dynamic;
+    assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'didChangeDependencies'));
     assert(() {
       state._debugLifecycleState = _StateLifecycle.ready;
       return true;
@@ -5115,7 +5116,8 @@ class StatefulElement extends ComponentElement {
   @override
   void performRebuild() {
     if (_didChangeDependencies) {
-      state.didChangeDependencies();
+      final Object? debugCheckForReturnedFuture = state.didChangeDependencies() as dynamic;
+      assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'didChangeDependencies'));
       _didChangeDependencies = false;
     }
     super.performRebuild();
@@ -5149,7 +5151,8 @@ class StatefulElement extends ComponentElement {
   @override
   void activate() {
     super.activate();
-    state.activate();
+    final Object? debugCheckForReturnedFuture = state.activate() as dynamic;
+    assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'activate'));
     // Since the State could have observed the deactivate() and thus disposed of
     // resources allocated in the build method, we have to rebuild the widget
     // so that its State can reallocate its resources.
@@ -5159,14 +5162,16 @@ class StatefulElement extends ComponentElement {
 
   @override
   void deactivate() {
-    state.deactivate();
+    final Object? debugCheckForReturnedFuture = state.deactivate() as dynamic;
+    assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'deactivate'));
     super.deactivate();
   }
 
   @override
   void unmount() {
     super.unmount();
-    state.dispose();
+    final Object? debugCheckForReturnedFuture = state.dispose() as dynamic;
+    assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'dispose'));
     assert(() {
       if (state._debugLifecycleState == _StateLifecycle.defunct) {
         return true;

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -5099,19 +5099,7 @@ class StatefulElement extends ComponentElement {
   void _firstBuild() {
     assert(state._debugLifecycleState == _StateLifecycle.created);
     final Object? debugCheckForReturnedFuture = state.initState() as dynamic;
-    assert(() {
-      if (debugCheckForReturnedFuture is Future) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('${state.runtimeType}.initState() returned a Future.'),
-          ErrorDescription('State.initState() must be a void method without an `async` keyword.'),
-          ErrorHint(
-            'Rather than awaiting on asynchronous work directly inside of initState, '
-            'call a separate method to do this work without awaiting it.',
-          ),
-        ]);
-      }
-      return true;
-    }());
+    assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'initState'));
     assert(() {
       state._debugLifecycleState = _StateLifecycle.initialized;
       return true;
@@ -5140,20 +5128,22 @@ class StatefulElement extends ComponentElement {
     final StatefulWidget oldWidget = state._widget!;
     state._widget = widget as StatefulWidget;
     final Object? debugCheckForReturnedFuture = state.didUpdateWidget(oldWidget) as dynamic;
-    assert(() {
-      if (debugCheckForReturnedFuture is Future) {
-        throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('${state.runtimeType}.didUpdateWidget() returned a Future.'),
-          ErrorDescription( 'State.didUpdateWidget() must be a void method without an `async` keyword.'),
-          ErrorHint(
-            'Rather than awaiting on asynchronous work directly inside of didUpdateWidget, '
-            'call a separate method to do this work without awaiting it.',
-          ),
-        ]);
-      }
-      return true;
-    }());
+    assert(_debugCheckReturnValueNotFuture(debugCheckForReturnedFuture, 'didUpdateWidget'));
     rebuild(force: true);
+  }
+
+  bool _debugCheckReturnValueNotFuture(Object? value, String name) {
+    if (value is Future) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+        ErrorSummary('${state.runtimeType}.$name() returned a Future.'),
+        ErrorDescription('State.$name() must be a void method without an `async` keyword.'),
+        ErrorHint(
+          'Rather than awaiting on asynchronous work directly inside of $name, '
+              'call a separate method to do this work without awaiting it.',
+        ),
+      ]);
+    }
+    return true;
   }
 
   @override

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -48,6 +48,32 @@ void main() {
     expect(exception.toString(), contains('returned a Future'));
   });
 
+  testWidgets('Async activate should throw', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncActivate());
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('returned a Future'));
+  });
+
+  testWidgets('Async deactivate should throw', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncDeactivate());
+    await tester.pumpWidget(Container());
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('returned a Future'));
+  });
+
+  testWidgets('Async didChangeDependencies should throw', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncDidChangeDependencies(arg: 1));
+    await tester.pumpWidget(const _AsyncDidChangeDependencies(arg: 2));
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('returned a Future'));
+  });
+
   testWidgets('UniqueKey control test', (WidgetTester tester) async {
     final Key key = UniqueKey();
     expect(key, hasOneLineDescription);
@@ -1829,6 +1855,59 @@ class _AsyncDisposeState extends State<_AsyncDispose> {
   @override
   Future<void> dispose() async {
     super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
+class _AsyncActivate extends StatefulWidget {
+  const _AsyncActivate();
+
+  @override
+  State<_AsyncActivate> createState() => _AsyncActivateState();
+}
+
+class _AsyncActivateState extends State<_AsyncActivate> {
+  @override
+  Future<void> activate() async {
+    super.activate();
+  }
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
+class _AsyncDeactivate extends StatefulWidget {
+  const _AsyncDeactivate();
+
+  @override
+  State<_AsyncDeactivate> createState() => _AsyncDeactivateState();
+}
+
+class _AsyncDeactivateState extends State<_AsyncDeactivate> {
+  @override
+  Future<void> deactivate() async {
+    super.deactivate();
+  }
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
+class _AsyncDidChangeDependencies extends StatefulWidget {
+  const _AsyncDidChangeDependencies({required this.arg});
+
+  final int arg;
+
+  @override
+  State<_AsyncDidChangeDependencies> createState() => _AsyncDidChangeDependenciesState();
+}
+
+class _AsyncDidChangeDependenciesState extends State<_AsyncDidChangeDependencies> {
+  @override
+  Future<void> didChangeDependencies() async {
+    super.didChangeDependencies();
   }
 
   @override

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -48,30 +48,6 @@ void main() {
     expect(exception.toString(), contains('returned a Future'));
   });
 
-  testWidgets('Async activate should throw', (WidgetTester tester) async {
-    final GlobalKey<State<StatefulWidget>> key = GlobalKey();
-    await tester.pumpWidget(MaterialApp(
-      home: Stack(
-        children: <Widget>[
-          Container(key: key, child: const _AsyncActivate()),
-          const SizedBox(),
-        ],
-      ),
-    ));
-    await tester.pumpWidget(MaterialApp(
-      home: Stack(
-        children: <Widget>[
-          const SizedBox(),
-          Container(key: key, child: const _AsyncActivate()),
-        ],
-      ),
-    ));
-
-    final dynamic exception = tester.takeException();
-    expect(exception, isFlutterError);
-    expect(exception.toString(), contains('returned a Future'));
-  });
-
   testWidgets('Async deactivate should throw', (WidgetTester tester) async {
     await tester.pumpWidget(const _AsyncDeactivate());
     await tester.pumpWidget(Container());
@@ -1870,23 +1846,6 @@ class _AsyncDisposeState extends State<_AsyncDispose> {
   @override
   Future<void> dispose() async {
     super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) => Container();
-}
-
-class _AsyncActivate extends StatefulWidget {
-  const _AsyncActivate({super.key});
-
-  @override
-  State<_AsyncActivate> createState() => _AsyncActivateState();
-}
-
-class _AsyncActivateState extends State<_AsyncActivate> {
-  @override
-  Future<void> activate() async {
-    super.activate();
   }
 
   @override

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -49,7 +49,23 @@ void main() {
   });
 
   testWidgets('Async activate should throw', (WidgetTester tester) async {
-    await tester.pumpWidget(const _AsyncActivate());
+    final GlobalKey<State<StatefulWidget>> key = GlobalKey();
+    await tester.pumpWidget(MaterialApp(
+      home: Stack(
+        children: <Widget>[
+          Container(key: key, child: const _AsyncActivate()),
+          const SizedBox(),
+        ],
+      ),
+    ));
+    await tester.pumpWidget(MaterialApp(
+      home: Stack(
+        children: <Widget>[
+          const SizedBox(),
+          Container(key: key, child: const _AsyncActivate()),
+        ],
+      ),
+    ));
 
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
@@ -67,7 +83,6 @@ void main() {
 
   testWidgets('Async didChangeDependencies should throw', (WidgetTester tester) async {
     await tester.pumpWidget(const _AsyncDidChangeDependencies(arg: 1));
-    await tester.pumpWidget(const _AsyncDidChangeDependencies(arg: 2));
 
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
@@ -1862,7 +1877,7 @@ class _AsyncDisposeState extends State<_AsyncDispose> {
 }
 
 class _AsyncActivate extends StatefulWidget {
-  const _AsyncActivate();
+  const _AsyncActivate({super.key});
 
   @override
   State<_AsyncActivate> createState() => _AsyncActivateState();

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -24,7 +24,25 @@ class _MyGlobalObjectKey<T extends State<StatefulWidget>> extends GlobalObjectKe
 void main() {
   testWidgets('Async initState should throw', (WidgetTester tester) async {
     await tester.pumpWidget(const _AsyncInitState());
-    expect(tester.takeException());
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('returned a Future'));
+  });
+
+  testWidgets('Async didUpdateWidget should throw', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncDidUpdateWidget(arg: 1));
+    await tester.pumpWidget(const _AsyncDidUpdateWidget(arg: 2));
+
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('returned a Future'));
+  });
+
+  testWidgets('Async dispose should throw', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncDispose());
+    await tester.pumpWidget(Container());
+
     final dynamic exception = tester.takeException();
     expect(exception, isFlutterError);
     expect(exception.toString(), contains('returned a Future'));
@@ -1775,6 +1793,42 @@ class _AsyncInitStateState extends State<_AsyncInitState> {
   @override
   Future<void> initState() async {
     super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
+class _AsyncDidUpdateWidget extends StatefulWidget {
+  const _AsyncDidUpdateWidget({required this.arg});
+
+  final int arg;
+
+  @override
+  State<_AsyncDidUpdateWidget> createState() => _AsyncDidUpdateWidgetState();
+}
+
+class _AsyncDidUpdateWidgetState extends State<_AsyncDidUpdateWidget> {
+  @override
+  Future<void> didUpdateWidget(covariant _AsyncDidUpdateWidget oldWidget) async {
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) => Container();
+}
+
+class _AsyncDispose extends StatefulWidget {
+  const _AsyncDispose();
+
+  @override
+  State<_AsyncDispose> createState() => _AsyncDisposeState();
+}
+
+class _AsyncDisposeState extends State<_AsyncDispose> {
+  @override
+  Future<void> dispose() async {
+    super.dispose();
   }
 
   @override

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -22,6 +22,14 @@ class _MyGlobalObjectKey<T extends State<StatefulWidget>> extends GlobalObjectKe
 }
 
 void main() {
+  testWidgets('Async initState should throw', (WidgetTester tester) async {
+    await tester.pumpWidget(const _AsyncInitState());
+    expect(tester.takeException());
+    final dynamic exception = tester.takeException();
+    expect(exception, isFlutterError);
+    expect(exception.toString(), contains('returned a Future'));
+  });
+
   testWidgets('UniqueKey control test', (WidgetTester tester) async {
     final Key key = UniqueKey();
     expect(key, hasOneLineDescription);
@@ -1754,6 +1762,23 @@ The findRenderObject() method was called for the following element:
     child.dependOnInheritedElement(ancestor);
     expect(child.doesDependOnInheritedElement(ancestor), isTrue);
   });
+}
+
+class _AsyncInitState extends StatefulWidget {
+  const _AsyncInitState();
+
+  @override
+  State<_AsyncInitState> createState() => _AsyncInitStateState();
+}
+
+class _AsyncInitStateState extends State<_AsyncInitState> {
+  @override
+  Future<void> initState() async {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) => Container();
 }
 
 class _TestInheritedElement extends InheritedElement {


### PR DESCRIPTION
Tiny PR, just ensure nobody will accidentially write sth like `Future<void> didChangeDependencies()` or `Future<void> dispose`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
