### PR TITLE
Disallow dispose during listener callback

### DIFF
--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -330,6 +330,8 @@ class ChangeNotifier implements Listenable {
       MemoryAllocations.instance.dispatchObjectDisposed(object: this);
     }
     _listeners = _emptyListeners;
+    // Set to zero to avoid crashing in release build if dispose is called
+    // in listener callbacks.
     _reentrantlyRemovedListeners = 0;
     _count = 0;
   }

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -321,6 +321,7 @@ class ChangeNotifier implements Listenable {
   @mustCallSuper
   void dispose() {
     assert(ChangeNotifier.debugAssertNotDisposed(this));
+    assert(_notificationCallStackDepth == 0 && _reentrantlyRemovedListeners == 0, 'dispose can not be called during listener callbacks');
     assert(() {
       _debugDisposed = true;
       return true;
@@ -328,7 +329,9 @@ class ChangeNotifier implements Listenable {
     if (kFlutterMemoryAllocationsEnabled && _creationDispatched) {
       MemoryAllocations.instance.dispatchObjectDisposed(object: this);
     }
+    print('dispose is called $_notificationCallStackDepth $_reentrantlyRemovedListeners, _debugDisposed $_debugDisposed');
     _listeners = _emptyListeners;
+    _reentrantlyRemovedListeners = 0;
     _count = 0;
   }
 

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -321,7 +321,7 @@ class ChangeNotifier implements Listenable {
   @mustCallSuper
   void dispose() {
     assert(ChangeNotifier.debugAssertNotDisposed(this));
-    assert(_notificationCallStackDepth == 0 && _reentrantlyRemovedListeners == 0, 'dispose can not be called during listener callbacks');
+    assert(_notificationCallStackDepth == 0, 'dispose can not be called during listener callbacks');
     assert(() {
       _debugDisposed = true;
       return true;
@@ -329,7 +329,6 @@ class ChangeNotifier implements Listenable {
     if (kFlutterMemoryAllocationsEnabled && _creationDispatched) {
       MemoryAllocations.instance.dispatchObjectDisposed(object: this);
     }
-    print('dispose is called $_notificationCallStackDepth $_reentrantlyRemovedListeners, _debugDisposed $_debugDisposed');
     _listeners = _emptyListeners;
     _reentrantlyRemovedListeners = 0;
     _count = 0;

--- a/packages/flutter/lib/src/foundation/change_notifier.dart
+++ b/packages/flutter/lib/src/foundation/change_notifier.dart
@@ -321,7 +321,12 @@ class ChangeNotifier implements Listenable {
   @mustCallSuper
   void dispose() {
     assert(ChangeNotifier.debugAssertNotDisposed(this));
-    assert(_notificationCallStackDepth == 0, 'dispose can not be called during listener callbacks');
+    assert(
+      _notificationCallStackDepth == 0,
+      'The "dispose()" method on $this was called during the call to '
+      '"notifyListeners()". This is likely to cause errors since it modifies '
+      'the list of listeners while the list is being used.',
+    );
     assert(() {
       _debugDisposed = true;
       return true;
@@ -330,9 +335,6 @@ class ChangeNotifier implements Listenable {
       MemoryAllocations.instance.dispatchObjectDisposed(object: this);
     }
     _listeners = _emptyListeners;
-    // Set to zero to avoid crashing in release build if dispose is called
-    // in listener callbacks.
-    _reentrantlyRemovedListeners = 0;
     _count = 0;
   }
 

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -60,7 +60,7 @@ void main() {
     test.addListener(foo);
     test.notify();
     final AssertionError error = tester.takeException() as AssertionError;
-    expect(error.toString().contains('The "dispose()" method on'), isTrue);
+    expect(error.toString().contains('dispose()'), isTrue);
     // Make sure it crashes during dispose call.
     expect(callbackDidFinish, isFalse);
   });

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -49,6 +49,23 @@ class Counter with ChangeNotifier {
 }
 
 void main() {
+  testWidgets('ValueNotifier can not dispose in callback', (WidgetTester tester) async {
+    final ValueNotifier<int> vn = ValueNotifier<int>(0);
+    bool callbackDidFinish = false;
+    void foo() {
+      vn.removeListener(foo);
+      vn.dispose();
+      callbackDidFinish = true;
+    }
+
+    vn.addListener(foo);
+    vn.value = 3;
+    final AssertionError error = tester.takeException() as AssertionError;
+    expect(error.toString().contains('dispose can not be called during listener callbacks'), isTrue);
+    // Make sure it crashes during dispose call.
+    expect(callbackDidFinish, isFalse);
+  });
+
   testWidgets('ChangeNotifier', (WidgetTester tester) async {
     final List<String> log = <String>[];
     void listener() {

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -60,7 +60,7 @@ void main() {
     test.addListener(foo);
     test.notify();
     final AssertionError error = tester.takeException() as AssertionError;
-    expect(error.toString().contains('dispose can not be called during listener callbacks'), isTrue);
+    expect(error.toString().contains('The "dispose()" method on'), isTrue);
     // Make sure it crashes during dispose call.
     expect(callbackDidFinish, isFalse);
   });

--- a/packages/flutter/test/foundation/change_notifier_test.dart
+++ b/packages/flutter/test/foundation/change_notifier_test.dart
@@ -49,17 +49,16 @@ class Counter with ChangeNotifier {
 }
 
 void main() {
-  testWidgets('ValueNotifier can not dispose in callback', (WidgetTester tester) async {
-    final ValueNotifier<int> vn = ValueNotifier<int>(0);
+  testWidgets('ChangeNotifier can not dispose in callback', (WidgetTester tester) async {
+    final TestNotifier test = TestNotifier();
     bool callbackDidFinish = false;
     void foo() {
-      vn.removeListener(foo);
-      vn.dispose();
+      test.dispose();
       callbackDidFinish = true;
     }
 
-    vn.addListener(foo);
-    vn.value = 3;
+    test.addListener(foo);
+    test.notify();
     final AssertionError error = tester.takeException() as AssertionError;
     expect(error.toString().contains('dispose can not be called during listener callbacks'), isTrue);
     // Make sure it crashes during dispose call.


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/114224

I think this is the correct way to handle the lifecycle of change listenable, but this may be a hard breaking change that requires non trivial migration.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
