### PR TITLE
[flutter_tools/dap] Add support for forwarding `flutter run --machine` exposeUrl requests to the DAP client

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -169,8 +169,8 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
         sendResponse(null);
         break;
 
-      // Handle requests that are the client providing us a response to
-      // a reverse-requests that we forwarded from Flutter to them.
+      // Handle requests (from the client) that provide responses to reverse-requests
+      // that we forwarded from `flutter run --machine`.
       case 'flutter.sendForwardedRequestResponse':
         _handleForwardedResponse(args);
         sendResponse(null);

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -326,14 +326,15 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
   ///
   /// Throws `DebugAdapterException` if a Flutter process is not yet running.
   void sendFlutterMessage(Map<String, Object?> message) {
-    if (process != null) {
+    final Process? process = this.process;
+    if (process == null) {
       throw DebugAdapterException('Flutter process has not yet started');
     }
 
     final String messageString = jsonEncode(message);
     // Flutter requests are always wrapped in brackets as an array.
     final String payload = '[$messageString]\n';
-    process!.stdin.writeln(payload);
+    process.stdin.writeln(payload);
   }
 
   /// Called by [terminateRequest] to request that we gracefully shut down the app being run (or in the case of an attach, disconnect).

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -324,10 +324,12 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
 
   /// Sends a message to the Flutter run daemon.
   ///
-  /// Assumes a `flutter` process has already been started (via` launchRequest`
-  /// or `attachRequest`) and will throw if not.
+  /// Throws `DebugAdapterException` if a Flutter process is not yet running.
   void sendFlutterMessage(Map<String, Object?> message) {
-    assert(process != null, 'Cannot send messages to Flutter process before it is started');
+    if (process != null) {
+      throw DebugAdapterException('Flutter process has not yet started');
+    }
+
     final String messageString = jsonEncode(message);
     // Flutter requests are always wrapped in brackets as an array.
     final String payload = '[$messageString]\n';

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -501,7 +501,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     final Object? error = args?.args['error'];
     final Completer<Object?>? completer = _reverseRequestCompleters[id];
     if (error != null) {
-      completer?.completeError(StateError('Client reported an error handling reverse-request $error'));
+      completer?.completeError(DebugAdapterException('Client reported an error handling reverse-request $error'));
     } else {
       completer?.complete(result);
     }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -50,6 +50,24 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
   @override
   bool get supportsRestartRequest => true;
 
+  /// A list of reverse-requests from `flutter run --machine` that should be forwarded to the client.
+  final Set<String> _requestsToForwardToClient = <String>{
+    // The 'app.exposeUrl' request is sent by Flutter to request the client
+    // exposes a URL to the user and return the public version of that URL.
+    //
+    // This supports some web scenarios where the `flutter` tool may be running
+    // on a different machine to the user (for example a cloud IDE or in VS Code
+    // remote workspace) so we cannot just use the raw URL because the hostname
+    // and/or port might not be available to the machine the user is using.
+    // Instead, the IDE/infrastructure can set up port forwarding/proxying and
+    // return a user-facing URL that will map to the original (localhost) URL
+    // Flutter provided.
+    'app.exposeUrl',
+  };
+
+  /// Completers for reverse requests from Flutter that may need to be handled by the client.
+  final Map<Object, Completer<Object?>> _reverseRequestCompleters = <Object, Completer<Object?>>{};
+
   /// Whether or not the user requested debugging be enabled.
   ///
   /// For debugging to be enabled, the user must have chosen "Debug" (and not
@@ -148,6 +166,13 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
       case 'hotReload':
         final bool isFullRestart = request.command == 'hotRestart';
         await _performRestart(isFullRestart, args?.args['reason'] as String?);
+        sendResponse(null);
+        break;
+
+      // Handle requests that are the client providing us a response to
+      // a reverse-requests that we forwarded from Flutter to them.
+      case 'flutter.sendForwardedRequestResponse':
+        _handleForwardedResponse(args);
         sendResponse(null);
         break;
 
@@ -275,42 +300,36 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     sendResponse();
   }
 
-  /// Sends a request to the Flutter daemon that is running/attaching to the app and waits for a response.
+  /// Sends a request to the Flutter run daemon that is running/attaching to the app and waits for a response.
   ///
-  /// If [failSilently] is `true` (the default) and there is no process, the
-  /// message will be silently ignored (this is common during the application
-  /// being stopped, where async messages may be processed). Setting it to
-  /// `false` will cause a [DebugAdapterException] to be thrown in that case.
+  /// If there is no process, the message will be silently ignored (this is
+  /// common during the application being stopped, where async messages may be
+  /// processed).
   Future<Object?> sendFlutterRequest(
     String method,
-    Map<String, Object?>? params, {
-    bool failSilently = true,
-  }) async {
-    final Process? process = this.process;
-
-    if (process == null) {
-      if (failSilently) {
-        return null;
-      } else {
-        throw DebugAdapterException(
-          'Unable to Restart because Flutter process is not available',
-        );
-      }
-    }
-
+    Map<String, Object?>? params,
+  ) async {
     final Completer<Object?> completer = Completer<Object?>();
     final int id = _flutterRequestId++;
     _flutterRequestCompleters[id] = completer;
 
-    // Flutter requests are always wrapped in brackets as an array.
-    final String messageString = jsonEncode(
-      <String, Object?>{'id': id, 'method': method, 'params': params},
-    );
-    final String payload = '[$messageString]\n';
-
-    process.stdin.writeln(payload);
+    sendFlutterMessage(<String, Object?>{
+      'id': id,
+      'method': method,
+      'params': params,
+    });
 
     return completer.future;
+  }
+
+  /// Sends a message to the Flutter run daemon.
+  ///
+  /// If no `flutter` process is running, does nothing.
+  void sendFlutterMessage(Map<String, Object?> message) {
+    final String messageString = jsonEncode(message);
+    // Flutter requests are always wrapped in brackets as an array.
+    final String payload = '[$messageString]\n';
+    process?.stdin.writeln(payload);
   }
 
   /// Called by [terminateRequest] to request that we gracefully shut down the app being run (or in the case of an attach, disconnect).
@@ -432,6 +451,62 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     }
   }
 
+  /// Handles incoming reverse requests from `flutter run --machine`.
+  ///
+  /// These requests are usually just forwarded to the client via an event
+  /// (`flutter.forwardedRequest`) and responses are provided by the client in a
+  /// custom event (`flutter.forwardedRequestResponse`).
+  void _handleJsonRequest(
+    Object id,
+    String method,
+    Map<String, Object?>? params,
+  ) {
+    /// A helper to send a client response to Flutter.
+    void sendResponseToFlutter(Object? id, Object? value, { bool error = false }) {
+      sendFlutterMessage(<String, Object?>{
+        'id': id,
+        if (error)
+          'error': value
+        else
+          'result': value
+      });
+    }
+
+    // Set up a completer to forward the response back to `flutter` when it arrives.
+    final Completer<Object?> completer = Completer<Object?>();
+    _reverseRequestCompleters[id] = completer;
+    completer.future
+        .then((Object? value) => sendResponseToFlutter(id, value))
+        .catchError((Object? e) => sendResponseToFlutter(id, e.toString(), error: true));
+
+    if (_requestsToForwardToClient.contains(method)) {
+      // Forward the request to the client in an event.
+      sendEvent(
+        RawEventBody(<String, Object?>{
+          'id': id,
+          'method': method,
+          'params': params,
+        }),
+        eventType: 'flutter.forwardedRequest',
+      );
+    } else {
+      completer.completeError('Unknown request method "$method".');
+    }
+  }
+
+  /// Handles client responses to reverse-requests that were forwarded from Flutter.
+  void _handleForwardedResponse(RawRequestArguments? args) {
+    final Object? id = args?.args['id'];
+    final Object? result = args?.args['result'];
+    final Object? error = args?.args['error'];
+    final Completer<Object?>? completer = _reverseRequestCompleters[id];
+    if (error != null) {
+      completer?.completeError(error);
+    } else {
+      completer?.complete(result);
+    }
+  }
+
   /// Handles incoming JSON messages from `flutter run --machine` that are responses to requests that we sent.
   void _handleJsonResponse(int id, Map<String, Object?> response) {
     final Completer<Object?>? handler = _flutterRequestCompleters.remove(id);
@@ -509,10 +584,13 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     }
 
     final Object? event = payload['event'];
+    final Object? method = payload['method'];
     final Object? params = payload['params'];
     final Object? id = payload['id'];
     if (event is String && params is Map<String, Object?>?) {
       _handleJsonEvent(event, params);
+    } else if (id != null && method is String && params is Map<String, Object?>?) {
+      _handleJsonRequest(id, method, params);
     } else if (id is int && _flutterRequestCompleters.containsKey(id)) {
       _handleJsonResponse(id, payload);
     } else {

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -490,7 +490,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
         eventType: 'flutter.forwardedRequest',
       );
     } else {
-      completer.completeError('Unknown request method "$method".');
+      completer.completeError(ArgumentError.value(method, 'Unknown request method.'));
     }
   }
 
@@ -501,7 +501,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     final Object? error = args?.args['error'];
     final Completer<Object?>? completer = _reverseRequestCompleters[id];
     if (error != null) {
-      completer?.completeError(error);
+      completer?.completeError(StateError('Client reported an error handling reverse-request $error'));
     } else {
       completer?.complete(result);
     }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -324,12 +324,14 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
 
   /// Sends a message to the Flutter run daemon.
   ///
-  /// If no `flutter` process is running, does nothing.
+  /// Assumes a `flutter` process has already been started (via` launchRequest`
+  /// or `attachRequest`) and will throw if not.
   void sendFlutterMessage(Map<String, Object?> message) {
+    assert(process != null, 'Cannot send messages to Flutter process before it is started');
     final String messageString = jsonEncode(message);
     // Flutter requests are always wrapped in brackets as an array.
     final String payload = '[$messageString]\n';
-    process?.stdin.writeln(payload);
+    process!.stdin.writeln(payload);
   }
 
   /// Called by [terminateRequest] to request that we gracefully shut down the app being run (or in the case of an attach, disconnect).

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:dds/dap.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/platform.dart';
@@ -21,11 +22,11 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     final StreamController<List<int>> stdinController = StreamController<List<int>>();
     final StreamController<List<int>> stdoutController = StreamController<List<int>>();
     final ByteStreamServerChannel channel = ByteStreamServerChannel(stdinController.stream, stdoutController.sink, null);
+    final ByteStreamServerChannel clientChannel = ByteStreamServerChannel(stdoutController.stream, stdinController.sink, null);
 
     return MockFlutterDebugAdapter._(
-      stdinController.sink,
-      stdoutController.stream,
       channel,
+      clientChannel: clientChannel,
       fileSystem: fileSystem,
       platform: platform,
       simulateAppStarted: simulateAppStarted,
@@ -33,22 +34,36 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   }
 
   MockFlutterDebugAdapter._(
-    this.stdin,
-    this.stdout,
-    ByteStreamServerChannel channel, {
-    required FileSystem fileSystem,
-    required Platform platform,
+    super.channel, {
+    required this.clientChannel,
+    required super.fileSystem,
+    required super.platform,
     this.simulateAppStarted = true,
-  }) : super(channel, fileSystem: fileSystem, platform: platform);
+  }) {
+    clientChannel.listen((ProtocolMessage message) {
+      _handleDapToClientMessage(message);
+    });
+  }
 
-  final StreamSink<List<int>> stdin;
-  final Stream<List<int>> stdout;
+  int _seq = 1;
+  final ByteStreamServerChannel clientChannel;
   final bool simulateAppStarted;
 
   late String executable;
   late List<String> processArgs;
   late Map<String, String>? env;
-  final List<String> flutterRequests = <String>[];
+
+  /// A list of all messages sent to the `flutter run` processes `stdin`.
+  final List<Map<String, Object?>> flutterMessages = <Map<String, Object?>>[];
+
+  /// The `method`s of all requests send to the `flutter run` processes `stdin`.
+  List<String> get flutterRequests => flutterMessages
+      .map((Map<String, Object?> message) => message['method'] as String?)
+      .whereNotNull()
+      .toList();
+
+  /// A handler for the 'app.exposeUrl' reverse-request.
+  String Function(String)? exposeUrlHandler;
 
   @override
   Future<void> launchAsProcess({
@@ -75,6 +90,39 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     }
   }
 
+  /// Handles messages sent from the debug adapter back to the client.
+  void _handleDapToClientMessage(ProtocolMessage message) {
+    // Pretend to be the client, delegating any reverse-requests to the relevant
+    // handler that is provided by the test.
+    if (message is Event && message.event == 'flutter.forwardedRequest') {
+      final Map<String, Object?> body = (message.body as Map<String, Object?>?)!;
+      final String method = (body['method'] as String?)!;
+      final Map<String, Object?>? params = body['params'] as Map<String, Object?>?;
+
+      final Object? result = _handleReverseRequest(method, params);
+
+      // Send the result back in the same way the client would.
+      clientChannel.sendRequest(Request(
+        seq: _seq++,
+        command: 'flutter.sendForwardedRequestResponse',
+        arguments: <String, Object?>{
+          'id': body['id'],
+          'result': result,
+        },
+      ));
+    }
+  }
+
+  Object? _handleReverseRequest(String method, Map<String, Object?>? params) {
+    switch (method) {
+      case 'app.exposeUrl':
+        final String url = (params!['url'] as String?)!;
+        return exposeUrlHandler!(url);
+      default:
+        throw ArgumentError('Reverse-request $method is unknown');
+    }
+  }
+
   /// Simulates a message emitted by the `flutter run` process by directly
   /// calling the debug adapters [handleStdout] method.
   void simulateStdoutMessage(Map<String, Object?> message) {
@@ -84,13 +132,9 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   }
 
   @override
-  Future<Object?> sendFlutterRequest(
-    String method,
-    Map<String, Object?>? params, {
-    bool failSilently = true,
-  }) {
-    flutterRequests.add(method);
-    return super.sendFlutterRequest(method, params, failSilently: failSilently);
+  void sendFlutterMessage(Map<String, Object?> message) {
+    flutterMessages.add(message);
+    return super.sendFlutterMessage(message);
   }
 
   @override

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -134,7 +134,8 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   @override
   void sendFlutterMessage(Map<String, Object?> message) {
     flutterMessages.add(message);
-    return super.sendFlutterMessage(message);
+    // Don't call super because it will try to write to the process that we
+    // didn't actually spawn.
   }
 
   @override


### PR DESCRIPTION
This adds support for the `app.exposeUrl` functionality of the `flutter run --machine` daemon to the DAPs to support some types of remote workspaces.

The functionality already exists in the Flutter daemon and the original Dart-Code DAP, but was not reproduced here.

The way this works is:

- IDE runs `flutter run --machine` with the `--allow-expose-url` flag
- When Flutter runs a web server (for the app, or the DWDS proxy), it sends an `app.exposeUrl` request back to the client asking it to make the URL (usually `localhost` with some port) available to the users machine, and return the URL that should be used (for example when running in Docker, it would expose the port in docker and return the URL with the port number swapped... when running in a cloud IDE, it would set up forwarding through a proxy and map `localhost` to something like `my-app-port-8080.some_long_guid.cloud-ide.foo`)
- Flutter would then use that URL when it needs to provide the URL in a context that will be used by the end user (for example when opening a browser tab or injecting DWDS metadata into the app)

So this change adds support for forwarding requests from `stdout` of `flutter run --machine` over to the client (via a custom event) and accepts their response (via a custom request) and sends it back to Flutter. Right now, `app.exposeUrl` is the only daemon-to-editor request (see https://github.com/flutter/flutter/blob/master/packages/flutter_tools/doc/daemon.md#daemon-to-editor-requests) but this code is mostly generic so if others are added in future they will only need adding to `_requestsToForwardToClient`.

In the test for this, we play the part of the client, by accepting the forwarded request and just changing the host to `mapped-host` and then verify that a message is sent back to Flutter with that new URL.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
