### PR TITLE
WidgetController.startGesture trackpad support

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -1086,12 +1086,14 @@ abstract class WidgetController {
     );
   }
 
-  /// Creates a gesture with an initial down gesture at a particular point, and
-  /// returns the [TestGesture] object which you can use to continue the
-  /// gesture.
+  /// Creates a gesture with an initial appropriate starting gesture at a
+  /// particular point, and returns the [TestGesture] object which you can use
+  /// to continue the gesture. Usually, the starting gesture will be a down event,
+  /// but if [kind] is set to [PointerDeviceKind.trackpad], the gesture will start
+  /// with a panZoomStart gesture.
   ///
   /// You can use [createGesture] if your gesture doesn't begin with an initial
-  /// down gesture.
+  /// down or panZoomStart gesture.
   ///
   /// See also:
   ///  * [WidgetController.drag], a method to simulate a drag.
@@ -1110,7 +1112,11 @@ abstract class WidgetController {
       kind: kind,
       buttons: buttons,
     );
-    await result.down(downLocation);
+    if (kind == PointerDeviceKind.trackpad) {
+      await result.panZoomStart(downLocation);
+    } else {
+      await result.down(downLocation);
+    }
     return result;
   }
 

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -386,6 +386,40 @@ void main() {
   );
 
   testWidgets(
+    'WidgetTester.drag works with trackpad kind',
+    (WidgetTester tester) async {
+      final List<String> logs = <String>[];
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: Listener(
+            onPointerDown: (PointerDownEvent event) => logs.add('down ${event.buttons}'),
+            onPointerMove: (PointerMoveEvent event) => logs.add('move ${event.buttons}'),
+            onPointerUp: (PointerUpEvent event) => logs.add('up ${event.buttons}'),
+            onPointerPanZoomStart: (PointerPanZoomStartEvent event) => logs.add('panZoomStart'),
+            onPointerPanZoomUpdate: (PointerPanZoomUpdateEvent event) => logs.add('panZoomUpdate ${event.pan}'),
+            onPointerPanZoomEnd: (PointerPanZoomEndEvent event) => logs.add('panZoomEnd'),
+            child: const Text('test'),
+          ),
+        ),
+      );
+
+      await tester.drag(find.text('test'), const Offset(-150.0, 200.0), kind: PointerDeviceKind.trackpad);
+
+      for(int i = 0; i < logs.length; i++) {
+        if (i == 0) {
+          expect(logs[i], 'panZoomStart');
+        } else if (i != logs.length - 1) {
+          expect(logs[i], startsWith('panZoomUpdate'));
+        } else {
+          expect(logs[i], 'panZoomEnd');
+        }
+      }
+    },
+  );
+
+  testWidgets(
     'WidgetTester.fling must respect buttons',
     (WidgetTester tester) async {
       final List<String> logs = <String>[];


### PR DESCRIPTION
Recreation of #114312

---

WidgetController.startGesture starts with a down event. It's updated here to start with a panZoomStart event if kind is set to `PointerDeviceKind.trackpad`. The `moveBy` and `up` method have also been updated so that the `TestGesture` can be used in the same way for trackpad as other device kinds, but sending appropriate gesture events for a trackpad. Added some more descriptive assertions when trying to send inappropriate events on a trackpad pointer.

Fixes #113773

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].
