### PR TITLE
[macOS] Refactor the `flutter run` macOS console output test

### DIFF
--- a/dev/devicelab/bin/tasks/run_release_test_macos.dart
+++ b/dev/devicelab/bin/tasks/run_release_test_macos.dart
@@ -2,122 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
-import 'package:flutter_devicelab/framework/task_result.dart';
-import 'package:flutter_devicelab/framework/utils.dart';
-import 'package:path/path.dart' as path;
+import 'package:flutter_devicelab/tasks/run_tests.dart';
 
 /// Basic launch test for desktop operating systems.
 void main() {
-  task(() async {
-    deviceOperatingSystem = DeviceOperatingSystem.macos;
-    final Device device = await devices.workingDevice;
-    // TODO(cbracken): https://github.com/flutter/flutter/issues/87508#issuecomment-1043753201
-    // Switch to dev/integration_tests/ui once we have CocoaPods working on M1 Macs.
-    final Directory appDir = dir(path.join(flutterDirectory.path, 'examples/hello_world'));
-    await inDirectory(appDir, () async {
-      final Completer<void> ready = Completer<void>();
-      final List<String> stdout = <String>[];
-      final List<String> stderr = <String>[];
-
-      print('run: starting...');
-      final List<String> options = <String>[
-        '--release',
-        '-d',
-        device.deviceId,
-      ];
-      final Process run = await startFlutter(
-        'run',
-        options: options,
-        isBot: false,
-      );
-      int? runExitCode;
-      run.stdout
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
-        .listen((String line) {
-          print('run:stdout: $line');
-          if (
-            !line.startsWith('Building flutter tool...') &&
-            !line.startsWith('Running "flutter pub get" in ui...') &&
-            !line.startsWith('Resolving dependencies...') &&
-            // Catch engine piped output from unrelated concurrent Flutter apps
-            !line.contains(RegExp(r'[A-Z]\/flutter \([0-9]+\):')) &&
-            // Empty lines could be due to the progress spinner breaking up.
-            line.length > 1
-          ) {
-            stdout.add(line);
-          }
-          if (line.contains('Quit (terminate the application on the device).')) {
-            ready.complete();
-          }
-        });
-      run.stderr
-        .transform<String>(utf8.decoder)
-        .transform<String>(const LineSplitter())
-        .listen((String line) {
-          print('run:stderr: $line');
-          stderr.add(line);
-        });
-      unawaited(run.exitCode.then<void>((int exitCode) { runExitCode = exitCode; }));
-      await Future.any<dynamic>(<Future<dynamic>>[ ready.future, run.exitCode ]);
-      if (runExitCode != null) {
-        throw 'Failed to run test app; runner unexpected exited, with exit code $runExitCode.';
-      }
-      run.stdin.write('q');
-
-      await run.exitCode;
-
-      _findNextMatcherInList(
-        stdout,
-        (String line) => line.startsWith('Launching lib/main.dart on ') && line.endsWith(' in release mode...'),
-        'Launching lib/main.dart on',
-      );
-
-      _findNextMatcherInList(
-        stdout,
-        (String line) => line.contains('Quit (terminate the application on the device).'),
-        'q Quit (terminate the application on the device)',
-      );
-
-      _findNextMatcherInList(
-        stdout,
-        (String line) => line == 'Application finished.',
-        'Application finished.',
-      );
-    });
-    return TaskResult.success(null);
-  });
-}
-
-void _findNextMatcherInList(
-  List<String> list,
-  bool Function(String testLine) matcher,
-  String errorMessageExpectedLine
-) {
-  final List<String> copyOfListForErrorMessage = List<String>.from(list);
-
-  while (list.isNotEmpty) {
-    final String nextLine = list.first;
-    list.removeAt(0);
-
-    if (matcher(nextLine)) {
-      return;
-    }
-  }
-
-  throw '''
-Did not find expected line
-
-$errorMessageExpectedLine
-
-in flutter run --release stdout
-
-$copyOfListForErrorMessage
-  ''';
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  task(createMacOSRunReleaseTest());
 }

--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -1,0 +1,158 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import '../framework/devices.dart';
+import '../framework/framework.dart';
+import '../framework/task_result.dart';
+import '../framework/utils.dart';
+
+TaskFunction createMacOSRunReleaseTest() {
+  return DesktopRunOutputTest(
+    // TODO(cbracken): https://github.com/flutter/flutter/issues/87508#issuecomment-1043753201
+    // Switch to dev/integration_tests/ui once we have CocoaPods working on M1 Macs.
+    '${flutterDirectory.path}/examples/hello_world',
+    'lib/main.dart',
+    release: true,
+  );
+}
+
+class DesktopRunOutputTest extends RunOutputTask {
+  DesktopRunOutputTest(
+    super.testDirectory,
+    super.testTarget, {
+      required super.release,
+    }
+  );
+
+  @override
+  TaskResult verify(List<String> stdout, List<String> stderr) {
+    _findNextMatcherInList(
+      stdout,
+      (String line) => line.startsWith('Launching lib/main.dart on ') &&
+        line.endsWith(' in ${release ? 'release' : 'debug'} mode...'),
+      'Launching lib/main.dart on',
+    );
+
+    _findNextMatcherInList(
+      stdout,
+      (String line) => line.contains('Quit (terminate the application on the device).'),
+      'q Quit (terminate the application on the device)',
+    );
+
+    _findNextMatcherInList(
+      stdout,
+      (String line) => line == 'Application finished.',
+      'Application finished.',
+    );
+
+    return TaskResult.success(null);
+  }
+}
+
+/// Test that the output of `flutter run` is expected.
+abstract class RunOutputTask {
+  RunOutputTask(
+    this.testDirectory,
+    this.testTarget, {
+      required this.release,
+    }
+  );
+
+  /// The directory where the app under test is defined.
+  final String testDirectory;
+  /// The main entry-point file of the application, as run on the device.
+  final String testTarget;
+  /// Whether to run the app in release mode.
+  final bool release;
+
+  Future<TaskResult> call() {
+    return inDirectory<TaskResult>(testDirectory, () async {
+      final Device device = await devices.workingDevice;
+      await device.unlock();
+      final String deviceId = device.deviceId;
+
+      final Completer<void> ready = Completer<void>();
+      final List<String> stdout = <String>[];
+      final List<String> stderr = <String>[];
+
+      final List<String> options = <String>[
+        testTarget,
+        '-d',
+        deviceId,
+        if (release) '--release',
+      ];
+
+      final Process run = await startFlutter(
+        'run',
+        options: options,
+        isBot: false,
+      );
+
+      int? runExitCode;
+      run.stdout
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+          print('run:stdout: $line');
+          stdout.add(line);
+          if (line.contains('Quit (terminate the application on the device).')) {
+            ready.complete();
+          }
+        });
+      run.stderr
+        .transform<String>(utf8.decoder)
+        .transform<String>(const LineSplitter())
+        .listen((String line) {
+          print('run:stderr: $line');
+          stderr.add(line);
+        });
+      unawaited(run.exitCode.then<void>((int exitCode) { runExitCode = exitCode; }));
+      await Future.any<dynamic>(<Future<dynamic>>[ ready.future, run.exitCode ]);
+      if (runExitCode != null) {
+        throw 'Failed to run test app; runner unexpected exited, with exit code $runExitCode.';
+      }
+      run.stdin.write('q');
+
+      await run.exitCode;
+
+      return verify(stdout, stderr);
+    });
+  }
+
+  /// Verify the output of `flutter run`.
+  TaskResult verify(List<String> stdout, List<String> stderr) => throw UnimplementedError('verify is not implemented');
+
+  /// Helper that verifies a line in [list] matches [matcher].
+  /// The [list] is updated to contain the lines remaining after the match.
+  void _findNextMatcherInList(
+    List<String> list,
+    bool Function(String testLine) matcher,
+    String errorMessageExpectedLine
+  ) {
+    final List<String> copyOfListForErrorMessage = List<String>.from(list);
+
+    while (list.isNotEmpty) {
+      final String nextLine = list.first;
+      list.removeAt(0);
+
+      if (matcher(nextLine)) {
+        return;
+      }
+    }
+
+    throw '''
+Did not find expected line
+
+$errorMessageExpectedLine
+
+in flutter run ${release ? '--release' : ''} stdout
+
+$copyOfListForErrorMessage
+''';
+  }
+}


### PR DESCRIPTION
The [`run_release_test_macos`](https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/run_release_test_macos.dart) integration test verifies that that the console output of `flutter run -d macos --release` is expected. This change introduces a `RunOutputTask` abstraction so that the test's logic can be reused by other platforms like Android and Windows. This new `RunOutputTask` mirrors other existing device lab tasks like [`BuildTestTask`](https://github.com/flutter/flutter/blob/44ecbbcc54c1029eed51662dc7f123607384b564/dev/devicelab/lib/tasks/build_test_task.dart#L16) and [`PerfTest`](https://github.com/flutter/flutter/blob/44ecbbcc54c1029eed51662dc7f123607384b564/dev/devicelab/lib/tasks/perf_tests.dart#L901).

In the future, we will:
1. Move the existing [`run_release_test`](https://github.com/flutter/flutter/blob/master/dev/devicelab/bin/tasks/run_release_test.dart) Android integration test to `RunOutputTask`
2. Add a new `flutter run` console output integration test for Windows (see https://github.com/flutter/flutter/issues/111577)
3. Consider adding `flutter run` console output tests for other platforms like iOS, Linux, web

Part of https://github.com/flutter/flutter/issues/111577

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
