### PR TITLE
Mark new_gallery__transition_perf as non-flaky

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1998,7 +1998,6 @@ targets:
 
   - name: Linux_android new_gallery__transition_perf
     recipe: devicelab/devicelab_drone
-    bringup: true # Flaky: https://github.com/flutter/flutter/issues/114025
     presubmit: false
     timeout: 60
     properties:


### PR DESCRIPTION
These were marked flaky due to a timeout switching between items in the Studies list at the top of the screen, which had snap-to-item scroll physics.

The same flake also affected new_gallery_impeller__transition_perf which was failing with the same flake, though was separately marked flaky due to a separate (engine crash) flake documented in:
* https://github.com/flutter/flutter/issues/112577
* https://github.com/flutter/flutter/issues/112438

Leaving the latter marked flaky for the time being while that separate issue is investigated.

Issue: https://github.com/flutter/flutter/issues/114025

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
