### PR TITLE
update google material icon search site

### DIFF
--- a/packages/flutter/lib/src/material/icons.dart
+++ b/packages/flutter/lib/src/material/icons.dart
@@ -93,12 +93,12 @@ class PlatformAdaptiveIcons implements Icons {
   // END GENERATED PLATFORM ADAPTIVE ICONS
 }
 
-/// Identifiers for the supported [Material Icons](https://material.io/resources/icons).
+/// Identifiers for the supported [Material Icons](https://fonts.google.com/icons).
 ///
 /// Use with the [Icon] class to show specific icons. Icons are identified by
 /// their name as listed below, e.g. [Icons.airplanemode_on].
 ///
-/// Search and find the perfect icon on the [Google Fonts](https://material.io/resources/icons) website.
+/// Search and find the perfect icon on the [Google Fonts](https://fonts.google.com/icons) website.
 ///
 /// To use this class, make sure you set `uses-material-design: true` in your
 /// project's `pubspec.yaml` file in the `flutter` section. This ensures that
@@ -147,7 +147,7 @@ class PlatformAdaptiveIcons implements Icons {
 ///
 ///  * [Icon]
 ///  * [IconButton]
-///  * <https://material.io/resources/icons>
+///  * <https://fonts.google.com/icons>
 ///  * [AnimatedIcons], for the list of available animated Material Icons.
 class Icons {
   // This class is not meant to be instantiated or extended; this constructor


### PR DESCRIPTION
The links on the Icon docs no longer points to a usable location for searching material fonts. This is a simple update to fix those links.

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
