### PR TITLE
Revert "Switch the way we retrieve the vm_service_port from /hub to i…

### DIFF
--- a/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
+++ b/packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart
@@ -82,7 +82,7 @@ void main() {
       restoreVmServiceConnectionFunction();
     });
 
-    test('end-to-end with one vm connection and flutter view query', () async {
+    test('end-to-end with three vm connections and flutter view query', () async {
       int port = 0;
       Future<PortForwarder> fakePortForwardingFunction(
         String address,
@@ -102,76 +102,54 @@ void main() {
       fuchsiaPortForwardingFunction = fakePortForwardingFunction;
       final FakeSshCommandRunner fakeRunner = FakeSshCommandRunner();
       // Adds some extra junk to make sure the strings will be cleaned up.
-      fakeRunner.iqueryResponse = <String>[
-        '[',
-        '   {',
-        '     "data_source": "Inspect",',
-        '     "metadata": {',
-        '       "filename": "fuchsia.inspect.Tree",',
-        '       "component_url": "fuchsia-pkg://fuchsia.com/flutter_aot_runner#meta/flutter_runner.cm",',
-        '       "timestamp": 12345678901234',
-        '     },',
-        '     "moniker": "core/session-manager/session\:session/flutter_runner",',
-        '     "payload": {',
-        '       "root": {',
-        '         "vm_service_port": "12345",',
-        '         "16859221": {',
-        '           "empty_tree": "this semantic tree is empty"',
-        '         },',
-        '         "build_info": {',
-        '           "dart_sdk_git_revision": "77e83fcc14fa94049f363d554579f48fbd6bb7a1",',
-        '           "dart_sdk_semantic_version": "2.19.0-317.0.dev",',
-        '           "flutter_engine_git_revision": "563b8e830c697a543bf0a8a9f4ae3edfad86ea86",',
-        '           "fuchsia_sdk_version": "10.20221018.0.1"',
-        '         },',
-        '         "vm": {',
-        '           "dst_status": 1,',
-        '           "get_profile_status": 0,',
-        '           "num_get_profile_calls": 1,',
-        '           "num_intl_provider_errors": 0,',
-        '           "num_on_change_calls": 0,',
-        '           "timezone_content_status": 0,',
-        '           "tz_data_close_status": -1,',
-        '           "tz_data_status": -1',
-        '         }',
-        '       }',
-        '     },',
-        '     "version": 1',
-        '   }',
-        ' ]'
-      ];
+      fakeRunner.findResponse = <String>['/hub/blah/blah/blah/vmservice-port\n'];
+      fakeRunner.lsResponse = <String>['123\n\n\n', '456  ', '789'];
       fakeRunner.address = 'fe80::8eae:4cff:fef4:9247';
       fakeRunner.interface = 'eno1';
 
       final FuchsiaRemoteConnection connection =
           await FuchsiaRemoteConnection.connectWithSshCommandRunner(fakeRunner);
 
-      // [fakePortForwardingFunction] will have returned one
+      // [fakePortForwardingFunction] will have returned three different
       // forwarded ports, incrementing the port each time by one. (Just a sanity
       // check that the forwarding port was called).
-      expect(forwardedPorts.length, 1);
-      expect(forwardedPorts[0].remotePort, 12345);
+      expect(forwardedPorts.length, 3);
+      expect(forwardedPorts[0].remotePort, 123);
+      expect(forwardedPorts[1].remotePort, 456);
+      expect(forwardedPorts[2].remotePort, 789);
       expect(forwardedPorts[0].port, 0);
+      expect(forwardedPorts[1].port, 1);
+      expect(forwardedPorts[2].port, 2);
 
       // VMs should be accessed via localhost ports given by
       // [fakePortForwardingFunction].
       expect(uriConnections[0],
-          Uri(scheme: 'ws', host: '[::1]', port: 0, path: '/ws'));
+        Uri(scheme:'ws', host:'[::1]', port:0, path:'/ws'));
+      expect(uriConnections[1],
+        Uri(scheme:'ws', host:'[::1]', port:1, path:'/ws'));
+      expect(uriConnections[2],
+        Uri(scheme:'ws', host:'[::1]', port:2, path:'/ws'));
 
       final List<FlutterView> views = await connection.getFlutterViews();
       expect(views, isNot(null));
-      expect(views.length, 1);
+      expect(views.length, 3);
       // Since name can be null, check for the ID on all of them.
       expect(views[0].id, 'flutterView0');
+      expect(views[1].id, 'flutterView1');
+      expect(views[2].id, 'flutterView2');
 
       expect(views[0].name, equals(null));
+      expect(views[1].name, 'file://flutterBinary1');
+      expect(views[2].name, 'file://flutterBinary2');
 
       // Ensure the ports are all closed after stop was called.
       await connection.stop();
       expect(forwardedPorts[0].stopped, true);
+      expect(forwardedPorts[1].stopped, true);
+      expect(forwardedPorts[2].stopped, true);
     });
 
-    test('end-to-end with one vm and remote open port', () async {
+    test('end-to-end with three vms and remote open port', () async {
       int port = 0;
       Future<PortForwarder> fakePortForwardingFunction(
         String address,
@@ -192,72 +170,53 @@ void main() {
       fuchsiaPortForwardingFunction = fakePortForwardingFunction;
       final FakeSshCommandRunner fakeRunner = FakeSshCommandRunner();
       // Adds some extra junk to make sure the strings will be cleaned up.
-      fakeRunner.iqueryResponse = <String>[
-        '[',
-        '   {',
-        '     "data_source": "Inspect",',
-        '     "metadata": {',
-        '       "filename": "fuchsia.inspect.Tree",',
-        '       "component_url": "fuchsia-pkg://fuchsia.com/flutter_aot_runner#meta/flutter_runner.cm",',
-        '       "timestamp": 12345678901234',
-        '     },',
-        '     "moniker": "core/session-manager/session\:session/flutter_runner",',
-        '     "payload": {',
-        '       "root": {',
-        '         "vm_service_port": "12345",',
-        '         "16859221": {',
-        '           "empty_tree": "this semantic tree is empty"',
-        '         },',
-        '         "build_info": {',
-        '           "dart_sdk_git_revision": "77e83fcc14fa94049f363d554579f48fbd6bb7a1",',
-        '           "dart_sdk_semantic_version": "2.19.0-317.0.dev",',
-        '           "flutter_engine_git_revision": "563b8e830c697a543bf0a8a9f4ae3edfad86ea86",',
-        '           "fuchsia_sdk_version": "10.20221018.0.1"',
-        '         },',
-        '         "vm": {',
-        '           "dst_status": 1,',
-        '           "get_profile_status": 0,',
-        '           "num_get_profile_calls": 1,',
-        '           "num_intl_provider_errors": 0,',
-        '           "num_on_change_calls": 0,',
-        '           "timezone_content_status": 0,',
-        '           "tz_data_close_status": -1,',
-        '           "tz_data_status": -1',
-        '         }',
-        '       }',
-        '     },',
-        '     "version": 1',
-        '   }',
-        ' ]'
-      ];
+      fakeRunner.findResponse = <String>['/hub/blah/blah/blah/vmservice-port\n'];
+      fakeRunner.lsResponse = <String>['123\n\n\n', '456  ', '789'];
       fakeRunner.address = 'fe80::8eae:4cff:fef4:9247';
       fakeRunner.interface = 'eno1';
       final FuchsiaRemoteConnection connection =
           await FuchsiaRemoteConnection.connectWithSshCommandRunner(fakeRunner);
 
-      expect(forwardedPorts.length, 1);
-      expect(forwardedPorts[0].remotePort, 12345);
+      // [fakePortForwardingFunction] will have returned three different
+      // forwarded ports, incrementing the port each time by one. (Just a sanity
+      // check that the forwarding port was called).
+      expect(forwardedPorts.length, 3);
+      expect(forwardedPorts[0].remotePort, 123);
+      expect(forwardedPorts[1].remotePort, 456);
+      expect(forwardedPorts[2].remotePort, 789);
       expect(forwardedPorts[0].port, 0);
+      expect(forwardedPorts[1].port, 1);
+      expect(forwardedPorts[2].port, 2);
 
       // VMs should be accessed via the alternate address given by
       // [fakePortForwardingFunction].
       expect(uriConnections[0],
-          Uri(scheme: 'ws', host: '[fe80::1:2%25eno2]', port: 0, path: '/ws'));
+        Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:0, path:'/ws'));
+      expect(uriConnections[1],
+        Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:1, path:'/ws'));
+      expect(uriConnections[2],
+        Uri(scheme:'ws', host:'[fe80::1:2%25eno2]', port:2, path:'/ws'));
 
       final List<FlutterView> views = await connection.getFlutterViews();
       expect(views, isNot(null));
-      expect(views.length, 1);
+      expect(views.length, 3);
       // Since name can be null, check for the ID on all of them.
       expect(views[0].id, 'flutterView0');
+      expect(views[1].id, 'flutterView1');
+      expect(views[2].id, 'flutterView2');
 
       expect(views[0].name, equals(null));
+      expect(views[1].name, 'file://flutterBinary1');
+      expect(views[2].name, 'file://flutterBinary2');
 
       // Ensure the ports are all closed after stop was called.
       await connection.stop();
       expect(forwardedPorts[0].stopped, true);
+      expect(forwardedPorts[1].stopped, true);
+      expect(forwardedPorts[2].stopped, true);
     });
 
-    test('end-to-end with one vm and ipv4', () async {
+    test('end-to-end with three vms and ipv4', () async {
       int port = 0;
       Future<PortForwarder> fakePortForwardingFunction(
         String address,
@@ -277,44 +236,8 @@ void main() {
       fuchsiaPortForwardingFunction = fakePortForwardingFunction;
       final FakeSshCommandRunner fakeRunner = FakeSshCommandRunner();
       // Adds some extra junk to make sure the strings will be cleaned up.
-      fakeRunner.iqueryResponse = <String>[
-        '[',
-        '   {',
-        '     "data_source": "Inspect",',
-        '     "metadata": {',
-        '       "filename": "fuchsia.inspect.Tree",',
-        '       "component_url": "fuchsia-pkg://fuchsia.com/flutter_aot_runner#meta/flutter_runner.cm",',
-        '       "timestamp": 12345678901234',
-        '     },',
-        '     "moniker": "core/session-manager/session\:session/flutter_runner",',
-        '     "payload": {',
-        '       "root": {',
-        '         "vm_service_port": "12345",',
-        '         "16859221": {',
-        '           "empty_tree": "this semantic tree is empty"',
-        '         },',
-        '         "build_info": {',
-        '           "dart_sdk_git_revision": "77e83fcc14fa94049f363d554579f48fbd6bb7a1",',
-        '           "dart_sdk_semantic_version": "2.19.0-317.0.dev",',
-        '           "flutter_engine_git_revision": "563b8e830c697a543bf0a8a9f4ae3edfad86ea86",',
-        '           "fuchsia_sdk_version": "10.20221018.0.1"',
-        '         },',
-        '         "vm": {',
-        '           "dst_status": 1,',
-        '           "get_profile_status": 0,',
-        '           "num_get_profile_calls": 1,',
-        '           "num_intl_provider_errors": 0,',
-        '           "num_on_change_calls": 0,',
-        '           "timezone_content_status": 0,',
-        '           "tz_data_close_status": -1,',
-        '           "tz_data_status": -1',
-        '         }',
-        '       }',
-        '     },',
-        '     "version": 1',
-        '   }',
-        ' ]'
-      ];
+      fakeRunner.findResponse = <String>['/hub/blah/blah/blah/vmservice-port\n'];
+      fakeRunner.lsResponse = <String>['123\n\n\n', '456  ', '789'];
       fakeRunner.address = '196.168.1.4';
 
       final FuchsiaRemoteConnection connection =
@@ -323,25 +246,39 @@ void main() {
       // [fakePortForwardingFunction] will have returned three different
       // forwarded ports, incrementing the port each time by one. (Just a sanity
       // check that the forwarding port was called).
-      expect(forwardedPorts.length, 1);
-      expect(forwardedPorts[0].remotePort, 12345);
+      expect(forwardedPorts.length, 3);
+      expect(forwardedPorts[0].remotePort, 123);
+      expect(forwardedPorts[1].remotePort, 456);
+      expect(forwardedPorts[2].remotePort, 789);
       expect(forwardedPorts[0].port, 0);
+      expect(forwardedPorts[1].port, 1);
+      expect(forwardedPorts[2].port, 2);
 
       // VMs should be accessed via the ipv4 loopback.
       expect(uriConnections[0],
-          Uri(scheme: 'ws', host: '127.0.0.1', port: 0, path: '/ws'));
+        Uri(scheme:'ws', host:'127.0.0.1', port:0, path:'/ws'));
+      expect(uriConnections[1],
+        Uri(scheme:'ws', host:'127.0.0.1', port:1, path:'/ws'));
+      expect(uriConnections[2],
+        Uri(scheme:'ws', host:'127.0.0.1', port:2, path:'/ws'));
 
       final List<FlutterView> views = await connection.getFlutterViews();
       expect(views, isNot(null));
-      expect(views.length, 1);
+      expect(views.length, 3);
       // Since name can be null, check for the ID on all of them.
       expect(views[0].id, 'flutterView0');
+      expect(views[1].id, 'flutterView1');
+      expect(views[2].id, 'flutterView2');
 
       expect(views[0].name, equals(null));
+      expect(views[1].name, 'file://flutterBinary1');
+      expect(views[2].name, 'file://flutterBinary2');
 
       // Ensure the ports are all closed after stop was called.
       await connection.stop();
       expect(forwardedPorts[0].stopped, true);
+      expect(forwardedPorts[1].stopped, true);
+      expect(forwardedPorts[2].stopped, true);
     });
 
     test('env variable test without remote addr', () async {
@@ -350,17 +287,22 @@ void main() {
       }
 
       // Should fail as no env variable has been passed.
-      expect(failingFunction, throwsA(isA<FuchsiaRemoteConnectionError>()));
+      expect(failingFunction,
+          throwsA(isA<FuchsiaRemoteConnectionError>()));
     });
   });
 }
 
 class FakeSshCommandRunner extends Fake implements SshCommandRunner {
-  List<String>? iqueryResponse;
+  List<String>? findResponse;
+  List<String>? lsResponse;
   @override
   Future<List<String>> run(String command) async {
-    if (command.startsWith('iquery --format json show')) {
-      return iqueryResponse!;
+    if (command.startsWith('/bin/find')) {
+      return findResponse!;
+    }
+    if (command.startsWith('/bin/ls')) {
+      return lsResponse!;
     }
     throw UnimplementedError(command);
   }


### PR DESCRIPTION
…query, on device. (#114637)"

Causes analysis errors:

```

   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:513:5 • always_specify_types
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:514:10 • always_specify_types
   info • Avoid method calls or property accesses on a "dynamic" target • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:515:11 • avoid_dynamic_calls
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:515:48 • always_specify_types
   info • Separate the control structure expression from its statement • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:515:77 • always_put_control_body_on_new_line
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:516:7 • always_specify_types
   info • Avoid method calls or property accesses on a "dynamic" target • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:518:11 • avoid_dynamic_calls
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:518:51 • always_specify_types
   info • Separate the control structure expression from its statement • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:518:77 • always_put_control_body_on_new_line
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:519:7 • always_specify_types
   info • Avoid method calls or property accesses on a "dynamic" target • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:521:11 • avoid_dynamic_calls
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:522:21 • always_specify_types
   info • Separate the control structure expression from its statement • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:522:58 • always_put_control_body_on_new_line
  error • The argument type 'dynamic' can't be assigned to the parameter type 'String' • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:524:38 • argument_type_not_assignable
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:540:5 • always_specify_types
   info • Avoid escaping inner quotes by converting surrounding quotes • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:541:14 • avoid_escaping_inner_quotes
   info • Specify type annotations • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:542:5 • always_specify_types
  error • The argument type 'dynamic' can't be assigned to the parameter type 'List<dynamic>' • packages/fuchsia_remote_debug_protocol/lib/src/fuchsia_remote_connection.dart:544:45 • argument_type_not_assignable
   info • Remove unnecessary backslashes in strings • packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart:114:55 • unnecessary_string_escapes
   info • Remove unnecessary backslashes in strings • packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart:204:55 • unnecessary_string_escapes
   info • Remove unnecessary backslashes in strings • packages/fuchsia_remote_debug_protocol/test/fuchsia_remote_connection_test.dart:289:55 • unnecessary_string_escapes
```

This reverts commit b187bc474e93aa9b0d58cd194b8d67b2bdf5eeec.

*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
