### PR TITLE
Delegate TestWindow.updateSemantics to the wrapped SingletonFlutterWindow

### DIFF
--- a/packages/flutter_test/lib/src/window.dart
+++ b/packages/flutter_test/lib/src/window.dart
@@ -464,6 +464,11 @@ class TestWindow implements ui.SingletonFlutterWindow {
   }
 
   @override
+  void updateSemantics(ui.SemanticsUpdate update) {
+    _window.updateSemantics(update);
+  }
+
+  @override
   void setIsolateDebugName(String name) {
     platformDispatcher.setIsolateDebugName(name);
   }


### PR DESCRIPTION
This restores the updateSemantics capability in TestWindow that had been removed in https://github.com/flutter/flutter/pull/113382
