### PR TITLE
Resolve dwarf paths to enable source-code mapping of stacktraces

### DIFF
--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -205,11 +205,11 @@ class AOTSnapshotter {
         .createSync(recursive: true);
     }
 
-    // Optimization arguments.
+    // Debugging information.
     genSnapshotArgs.addAll(<String>[
-      // Faster async/await
       if (shouldSplitDebugInfo) ...<String>[
         '--dwarf-stack-traces',
+        '--resolve-dwarf-paths',
         '--save-debugging-info=${_fileSystem.path.join(splitDebugInfo!, debugFilename)}',
       ],
       if (dartObfuscation)

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -445,6 +445,7 @@ void main() {
           '--no-use-integer-division',
           '--dwarf-stack-traces',
           '--save-debugging-info=$debugPath',
+          '--resolve-dwarf-paths',
           'main.dill',
         ]
       ));

--- a/packages/flutter_tools/test/general.shard/base/build_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/build_test.dart
@@ -209,6 +209,7 @@ void main() {
           '--snapshot_kind=app-aot-assembly',
           '--assembly=$assembly',
           '--dwarf-stack-traces',
+          '--resolve-dwarf-paths',
           '--save-debugging-info=$debugPath',
           'main.dill',
         ]),
@@ -444,8 +445,8 @@ void main() {
           '--no-sim-use-hardfp',
           '--no-use-integer-division',
           '--dwarf-stack-traces',
-          '--save-debugging-info=$debugPath',
           '--resolve-dwarf-paths',
+          '--save-debugging-info=$debugPath',
           'main.dill',
         ]
       ));


### PR DESCRIPTION
This adds `--resolve-dwarf-paths` to the `gen_snapshot` call - to enable mapping between DWARF stack traces and source app source code.

It is adding the flag as default whenever dwarf symbols are exported. Not sure this is the best way to go about it. See the related issue in the Dart SDK for motivation and discussions: https://github.com/dart-lang/sdk/issues/44325#issuecomment-826771991

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
