### PR TITLE
Update `CircleAvatar` to support Material 3

### DIFF
--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -197,7 +197,10 @@ class CircleAvatar extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     final Color? effectiveForegroundColor = foregroundColor
       ?? (theme.useMaterial3 ? theme.colorScheme.onPrimaryContainer : null);
-    TextStyle textStyle = theme.primaryTextTheme.titleMedium!.copyWith(color: effectiveForegroundColor);
+    final TextStyle effectiveTextStyle = theme.useMaterial3
+      ? theme.textTheme.titleMedium!
+      : theme.primaryTextTheme.titleMedium!;
+    TextStyle textStyle = effectiveTextStyle.copyWith(color: effectiveForegroundColor);
     Color? effectiveBackgroundColor = backgroundColor
       ?? (theme.useMaterial3 ? theme.colorScheme.primaryContainer : null);
     if (effectiveBackgroundColor == null) {

--- a/packages/flutter/lib/src/material/circle_avatar.dart
+++ b/packages/flutter/lib/src/material/circle_avatar.dart
@@ -84,7 +84,8 @@ class CircleAvatar extends StatelessWidget {
   /// The color with which to fill the circle. Changing the background
   /// color will cause the avatar to animate to the new color.
   ///
-  /// If a [backgroundColor] is not specified, the theme's
+  /// If a [backgroundColor] is not specified and [ThemeData.useMaterial3] is true,
+  /// [ColorScheme.primaryContainer] will be used, otherwise the theme's
   /// [ThemeData.primaryColorLight] is used with dark foreground colors, and
   /// [ThemeData.primaryColorDark] with light foreground colors.
   final Color? backgroundColor;
@@ -94,7 +95,9 @@ class CircleAvatar extends StatelessWidget {
   /// Defaults to the primary text theme color if no [backgroundColor] is
   /// specified.
   ///
-  /// Defaults to [ThemeData.primaryColorLight] for dark background colors, and
+  /// If a [foregroundColor] is not specified and [ThemeData.useMaterial3] is true,
+  /// [ColorScheme.onPrimaryContainer] will be used, otherwise the theme's
+  /// [ThemeData.primaryColorLight] for dark background colors, and
   /// [ThemeData.primaryColorDark] for light background colors.
   final Color? foregroundColor;
 
@@ -192,8 +195,11 @@ class CircleAvatar extends StatelessWidget {
   Widget build(BuildContext context) {
     assert(debugCheckHasMediaQuery(context));
     final ThemeData theme = Theme.of(context);
-    TextStyle textStyle = theme.primaryTextTheme.titleMedium!.copyWith(color: foregroundColor);
-    Color? effectiveBackgroundColor = backgroundColor;
+    final Color? effectiveForegroundColor = foregroundColor
+      ?? (theme.useMaterial3 ? theme.colorScheme.onPrimaryContainer : null);
+    TextStyle textStyle = theme.primaryTextTheme.titleMedium!.copyWith(color: effectiveForegroundColor);
+    Color? effectiveBackgroundColor = backgroundColor
+      ?? (theme.useMaterial3 ? theme.colorScheme.primaryContainer : null);
     if (effectiveBackgroundColor == null) {
       switch (ThemeData.estimateBrightnessForColor(textStyle.color!)) {
         case Brightness.dark:
@@ -203,7 +209,7 @@ class CircleAvatar extends StatelessWidget {
           effectiveBackgroundColor = theme.primaryColorDark;
           break;
       }
-    } else if (foregroundColor == null) {
+    } else if (effectiveForegroundColor == null) {
       switch (ThemeData.estimateBrightnessForColor(backgroundColor!)) {
         case Brightness.dark:
           textStyle = textStyle.copyWith(color: theme.primaryColorLight);

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -144,11 +144,8 @@ void main() {
     expect(paragraph.text.style!.color, equals(foregroundColor));
   });
 
-  testWidgets('CircleAvatar with light theme', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData(
-      primaryColor: Colors.grey.shade100,
-      primaryColorBrightness: Brightness.light,
-    );
+  testWidgets('CircleAvatar default colors', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(
       wrap(
         child: Theme(
@@ -163,35 +160,10 @@ void main() {
     final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
     final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
     final BoxDecoration decoration = child.decoration as BoxDecoration;
-    expect(decoration.color, equals(theme.primaryColorLight));
+    expect(decoration.color, equals(theme.colorScheme.primaryContainer));
 
     final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
-    expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.titleLarge!.color));
-  });
-
-  testWidgets('CircleAvatar with dark theme', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData(
-      primaryColor: Colors.grey.shade800,
-      primaryColorBrightness: Brightness.dark,
-    );
-    await tester.pumpWidget(
-      wrap(
-        child: Theme(
-          data: theme,
-          child: const CircleAvatar(
-            child: Text('Z'),
-          ),
-        ),
-      ),
-    );
-
-    final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
-    final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
-    final BoxDecoration decoration = child.decoration as BoxDecoration;
-    expect(decoration.color, equals(theme.primaryColorDark));
-
-    final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
-    expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.titleLarge!.color));
+    expect(paragraph.text.style!.color, equals(theme.colorScheme.onPrimaryContainer));
   });
 
   testWidgets('CircleAvatar text does not expand with textScaleFactor', (WidgetTester tester) async {
@@ -305,6 +277,61 @@ void main() {
 
     final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
     expect(paragraph.text.style!.color, equals(ThemeData.fallback().primaryColorLight));
+  });
+
+  group('Material 2', () {
+    // Tests that are only relevant for Material 2. Once ThemeData.useMaterial3
+    // is turned on by default, these tests can be removed.
+
+    testWidgets('CircleAvatar default colors with light theme', (WidgetTester tester) async {
+      final ThemeData theme = ThemeData(
+        primaryColor: Colors.grey.shade100,
+        primaryColorBrightness: Brightness.light,
+      );
+      await tester.pumpWidget(
+        wrap(
+          child: Theme(
+            data: theme,
+            child: const CircleAvatar(
+              child: Text('Z'),
+            ),
+          ),
+        ),
+      );
+
+      final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+      final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
+      final BoxDecoration decoration = child.decoration as BoxDecoration;
+      expect(decoration.color, equals(theme.primaryColorLight));
+
+      final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
+      expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.titleLarge!.color));
+    });
+
+    testWidgets('CircleAvatar default colors with dark theme', (WidgetTester tester) async {
+      final ThemeData theme = ThemeData(
+        primaryColor: Colors.grey.shade800,
+        primaryColorBrightness: Brightness.dark,
+      );
+      await tester.pumpWidget(
+        wrap(
+          child: Theme(
+            data: theme,
+            child: const CircleAvatar(
+              child: Text('Z'),
+            ),
+          ),
+        ),
+      );
+
+      final RenderConstrainedBox box = tester.renderObject(find.byType(CircleAvatar));
+      final RenderDecoratedBox child = box.child! as RenderDecoratedBox;
+      final BoxDecoration decoration = child.decoration as BoxDecoration;
+      expect(decoration.color, equals(theme.primaryColorDark));
+
+      final RenderParagraph paragraph = tester.renderObject(find.text('Z'));
+      expect(paragraph.text.style!.color, equals(theme.primaryTextTheme.titleLarge!.color));
+    });
   });
 }
 


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/114811

This PR updates `CircleAvatar` to support Material 3.

![Screenshot 2022-11-07 at 15 31 08](https://user-images.githubusercontent.com/48603081/200328095-00e49ae2-969a-470b-8313-d4660091ffc6.png)

Since there is no theme for the `CircleAvatar`, I just updated the default colors. 
M3 Avatar size and font are the same as the current one. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
