### PR TITLE
[tools]build ipa validate template icon files

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_ios.dart
+++ b/packages/flutter_tools/lib/src/commands/build_ios.dart
@@ -183,7 +183,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     .isNotEmpty;
 
     if (hasConflict) {
-      messageBuffer.writeln('\nWarning: You may want to replace template app icons.');
+      messageBuffer.writeln('\nWarning: App icon is set to the default placeholder icon. Replace with unique icons.');
     }
   }
 
@@ -210,7 +210,7 @@ class BuildIOSArchiveCommand extends _BuildIOSSubCommand {
     });
 
     if (xcodeProjectSettingsMap.values.any((String? element) => element == null)) {
-      messageBuffer.writeln('\nYou must set up the missing settings');
+      messageBuffer.writeln('\nYou must set up the missing settings.');
     }
   }
 

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -5,7 +5,9 @@
 import '../application_package.dart';
 import '../base/file_system.dart';
 import '../build_info.dart';
+import '../cache.dart';
 import '../globals.dart' as globals;
+import '../template.dart';
 import '../xcode_project.dart';
 import 'plist_parser.dart';
 
@@ -151,12 +153,34 @@ class BuildableIOSApp extends IOSApp {
       _hostAppBundleName == null ? 'Runner.app' : _hostAppBundleName!,
       'Info.plist');
 
+  // Both project icon's image assets and Contents.json are in the same directory.
+  String get projectAppIconDirName => globals.fs.path.join('ios', _appIconDirNameSuffix);
+
+  // template icon's Contents.json is in flutter_tools.
+  String get templateAppIconDirNameForContentsJson => globals.fs.path.join(
+    Cache.flutterRoot!,
+    'packages/flutter_tools/templates/app_shared/ios.tmpl',
+    _appIconDirNameSuffix,
+  );
+
+  // template icon's image assets are in flutter_template_images package.
+  Future<String> get templateAppIconDirNameForImages async {
+    final Directory imageTemplate = await templateImageDirectory('.', globals.fs, globals.logger);
+    return globals.fs.path.join(
+      imageTemplate.path,
+      'app_shared/ios.tmpl',
+      _appIconDirNameSuffix,
+    );
+  }
+
   String get ipaOutputPath =>
       globals.fs.path.join(getIosBuildDirectory(), 'ipa');
 
   String _buildAppPath(String type) {
     return globals.fs.path.join(getIosBuildDirectory(), type, _hostAppBundleName);
   }
+
+  String get _appIconDirNameSuffix => 'Runner/Assets.xcassets/AppIcon.appiconset';
 }
 
 class PrebuiltIOSApp extends IOSApp implements PrebuiltApplicationPackage {

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -159,16 +159,21 @@ class BuildableIOSApp extends IOSApp {
   // template icon's Contents.json is in flutter_tools.
   String get templateAppIconDirNameForContentsJson => globals.fs.path.join(
     Cache.flutterRoot!,
-    'packages/flutter_tools/templates/app_shared/ios.tmpl',
+    'packages',
+    'flutter_tools',
+    'templates',
+    'app_shared',
+    'ios.tmpl',
     _appIconDirNameSuffix,
   );
 
   // template icon's image assets are in flutter_template_images package.
   Future<String> get templateAppIconDirNameForImages async {
-    final Directory imageTemplate = await templateImageDirectory('.', globals.fs, globals.logger);
+    final Directory imageTemplate = await templateImageDirectory(null, globals.fs, globals.logger);
     return globals.fs.path.join(
       imageTemplate.path,
-      'app_shared/ios.tmpl',
+      'app_shared',
+      'ios.tmpl',
       _appIconDirNameSuffix,
     );
   }
@@ -180,7 +185,10 @@ class BuildableIOSApp extends IOSApp {
     return globals.fs.path.join(getIosBuildDirectory(), type, _hostAppBundleName);
   }
 
-  String get _appIconDirNameSuffix => 'Runner/Assets.xcassets/AppIcon.appiconset';
+  String get _appIconDirNameSuffix => globals.fs.path.join(
+      'Runner',
+      'Assets.xcassets',
+      'AppIcon.appiconset');
 }
 
 class PrebuiltIOSApp extends IOSApp implements PrebuiltApplicationPackage {

--- a/packages/flutter_tools/lib/src/ios/application_package.dart
+++ b/packages/flutter_tools/lib/src/ios/application_package.dart
@@ -186,9 +186,9 @@ class BuildableIOSApp extends IOSApp {
   }
 
   String get _appIconDirNameSuffix => globals.fs.path.join(
-      'Runner',
-      'Assets.xcassets',
-      'AppIcon.appiconset');
+    'Runner',
+    'Assets.xcassets',
+    'AppIcon.appiconset');
 }
 
 class PrebuiltIOSApp extends IOSApp implements PrebuiltApplicationPackage {

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -352,7 +352,8 @@ Directory _templateDirectoryInPackage(String name, FileSystem fileSystem) {
 
 /// Returns the directory containing the 'name' template directory in
 /// flutter_template_images, to resolve image placeholder against.
-Future<Directory> templateImageDirectory(String name, FileSystem fileSystem, Logger logger) async {
+/// if 'name' is null, return the parent template directory.
+Future<Directory> templateImageDirectory(String? name, FileSystem fileSystem, Logger logger) async {
   final String toolPackagePath = fileSystem.path.join(
       Cache.flutterRoot!, 'packages', 'flutter_tools');
   final String packageFilePath = fileSystem.path.join(toolPackagePath, '.dart_tool', 'package_config.json');
@@ -361,10 +362,10 @@ Future<Directory> templateImageDirectory(String name, FileSystem fileSystem, Log
     logger: logger,
   );
   final Uri? imagePackageLibDir = packageConfig['flutter_template_images']?.packageUriRoot;
-  return fileSystem.directory(imagePackageLibDir)
+  final Directory templateDirectory = fileSystem.directory(imagePackageLibDir)
       .parent
-      .childDirectory('templates')
-      .childDirectory(name);
+      .childDirectory('templates');
+  return name == null ? templateDirectory : templateDirectory.childDirectory(name);
 }
 
 String _escapeKotlinKeywords(String androidIdentifier) {

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -101,7 +101,7 @@ class Template {
   }) async {
     // All named templates are placed in the 'templates' directory
     final Directory templateDir = _templateDirectoryInPackage(name, fileSystem);
-    final Directory imageDir = await _templateImageDirectory(name, fileSystem, logger);
+    final Directory imageDir = await templateImageDirectory(name, fileSystem, logger);
     return Template._(
       <Directory>[templateDir],
       <Directory>[imageDir],
@@ -126,8 +126,8 @@ class Template {
       ],
       <Directory>[
         for (final String name in names)
-          if ((await _templateImageDirectory(name, fileSystem, logger)).existsSync())
-            await _templateImageDirectory(name, fileSystem, logger),
+          if ((await templateImageDirectory(name, fileSystem, logger)).existsSync())
+            await templateImageDirectory(name, fileSystem, logger),
       ],
       fileSystem: fileSystem,
       logger: logger,
@@ -350,9 +350,9 @@ Directory _templateDirectoryInPackage(String name, FileSystem fileSystem) {
   return fileSystem.directory(fileSystem.path.join(templatesDir, name));
 }
 
-// Returns the directory containing the 'name' template directory in
-// flutter_template_images, to resolve image placeholder against.
-Future<Directory> _templateImageDirectory(String name, FileSystem fileSystem, Logger logger) async {
+/// Returns the directory containing the 'name' template directory in
+/// flutter_template_images, to resolve image placeholder against.
+Future<Directory> templateImageDirectory(String name, FileSystem fileSystem, Logger logger) async {
   final String toolPackagePath = fileSystem.path.join(
       Cache.flutterRoot!, 'packages', 'flutter_tools');
   final String packageFilePath = fileSystem.path.join(toolPackagePath, '.dart_tool', 'package_config.json');

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -916,17 +916,17 @@ void main() {
     expect(
         testLogger.statusText,
         contains(
-          '┌─ App Settings ────────────────────────────────────────┐\n'
-                '│ Version Number: Missing                               │\n'
-                '│ Build Number: Missing                                 │\n'
-                '│ Display Name: Missing                                 │\n'
-                '│ Deployment Target: Missing                            │\n'
-                '│ Bundle Identifier: io.flutter.someProject             │\n'
-                '│                                                       │\n'
-                '│ You must set up the missing settings                  │\n'
-                '│ Instructions: https://docs.flutter.dev/deployment/ios │\n'
-                '└───────────────────────────────────────────────────────┘'
-        )
+            '┌─ App Settings ──────────────────────────────────────────────────────────────────┐\n'
+                '│ Version Number: Missing                                                         │\n'
+                '│ Build Number: Missing                                                           │\n'
+                '│ Display Name: Missing                                                           │\n'
+                '│ Deployment Target: Missing                                                      │\n'
+                '│ Bundle Identifier: io.flutter.someProject                                       │\n'
+                '│                                                                                 │\n'
+                '│ You must set up the missing settings                                            │\n'
+                '│                                                                                 │\n'
+                '│ To update the settings, please refer to https://docs.flutter.dev/deployment/ios │\n'
+                '└─────────────────────────────────────────────────────────────────────────────────┘\n'        )
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -970,13 +970,15 @@ void main() {
     expect(
         testLogger.statusText,
         contains(
-            '┌─ App Settings ────────────────────────────┐\n'
-                '│ Version Number: 12.34.56                  │\n'
-                '│ Build Number: 666                         │\n'
-                '│ Display Name: Awesome Gallery             │\n'
-                '│ Deployment Target: 11.0                   │\n'
-                '│ Bundle Identifier: io.flutter.someProject │\n'
-                '└───────────────────────────────────────────┘\n'
+            '┌─ App Settings ──────────────────────────────────────────────────────────────────┐\n'
+                '│ Version Number: 12.34.56                                                        │\n'
+                '│ Build Number: 666                                                               │\n'
+                '│ Display Name: Awesome Gallery                                                   │\n'
+                '│ Deployment Target: 11.0                                                         │\n'
+                '│ Bundle Identifier: io.flutter.someProject                                       │\n'
+                '│                                                                                 │\n'
+                '│ To update the settings, please refer to https://docs.flutter.dev/deployment/ios │\n'
+                '└─────────────────────────────────────────────────────────────────────────────────┘\n'
         )
     );
   }, overrides: <Type, Generator>{
@@ -1044,12 +1046,7 @@ void main() {
 
     expect(
         testLogger.statusText,
-        contains(
-            '┌─ App Icons ───────────────────────────────────────────────────────────────────────────┐\n'
-                '│ You may want to replace the following template app icons:                             │\n'
-                '│ [iphone 20x20 2x] ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png │\n'
-                '└───────────────────────────────────────────────────────────────────────────────────────┘\n'
-        )
+        contains('Warning: You may want to replace template app icons.'),
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1112,15 +1109,13 @@ void main() {
     await createTestCommandRunner(command).run(
         <String>['build', 'ipa', '--no-pub']);
 
-    expect(testLogger.statusText, contains('Your app is not using any of the Flutter template icons.'));
+    expect(testLogger.statusText, isNot(contains('Warning: You may want to replace template app icons.')));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,
     Platform: () => macosPlatform,
     XcodeProjectInterpreter: () => FakeXcodeProjectInterpreterWithBuildSettings(),
   });
-
-
 }
 
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -1040,7 +1040,13 @@ void main() {
 
     createMinimalMockProjectFiles();
 
-    final BuildCommand command = BuildCommand();
+    final BuildCommand command = BuildCommand(
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      osUtils: FakeOperatingSystemUtils(),
+    );
     await createTestCommandRunner(command).run(
         <String>['build', 'ipa', '--no-pub']);
 
@@ -1105,7 +1111,13 @@ void main() {
 
     createMinimalMockProjectFiles();
 
-    final BuildCommand command = BuildCommand();
+    final BuildCommand command = BuildCommand(
+      androidSdk: FakeAndroidSdk(),
+      buildSystem: TestBuildSystem.all(BuildResult(success: true)),
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      osUtils: FakeOperatingSystemUtils(),
+    );
     await createTestCommandRunner(command).run(
         <String>['build', 'ipa', '--no-pub']);
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -914,20 +914,20 @@ void main() {
         <String>['build', 'ipa', '--no-pub']);
 
     expect(
-        testLogger.statusText,
-        contains(
-            '┌─ App Settings ──────────────────────────────────────────────────────────────────┐\n'
-                '│ Version Number: Missing                                                         │\n'
-                '│ Build Number: Missing                                                           │\n'
-                '│ Display Name: Missing                                                           │\n'
-                '│ Deployment Target: Missing                                                      │\n'
-                '│ Bundle Identifier: io.flutter.someProject                                       │\n'
-                '│                                                                                 │\n'
-                '│ You must set up the missing settings                                            │\n'
-                '│                                                                                 │\n'
-                '│ To update the settings, please refer to https://docs.flutter.dev/deployment/ios │\n'
-                '└─────────────────────────────────────────────────────────────────────────────────┘\n'        )
-    );
+      testLogger.statusText,
+      contains(
+        '┌─ App Settings ──────────────────────────────────────────────────────────────────┐\n'
+        '│ Version Number: Missing                                                         │\n'
+        '│ Build Number: Missing                                                           │\n'
+        '│ Display Name: Missing                                                           │\n'
+        '│ Deployment Target: Missing                                                      │\n'
+        '│ Bundle Identifier: io.flutter.someProject                                       │\n'
+        '│                                                                                 │\n'
+        '│ You must set up the missing settings.                                           │\n'
+        '│                                                                                 │\n'
+        '│ To update the settings, please refer to https://docs.flutter.dev/deployment/ios │\n'
+        '└─────────────────────────────────────────────────────────────────────────────────┘\n'
+    ));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,
@@ -968,18 +968,18 @@ void main() {
         <String>['build', 'ipa', '--no-pub']);
 
     expect(
-        testLogger.statusText,
-        contains(
-            '┌─ App Settings ──────────────────────────────────────────────────────────────────┐\n'
-                '│ Version Number: 12.34.56                                                        │\n'
-                '│ Build Number: 666                                                               │\n'
-                '│ Display Name: Awesome Gallery                                                   │\n'
-                '│ Deployment Target: 11.0                                                         │\n'
-                '│ Bundle Identifier: io.flutter.someProject                                       │\n'
-                '│                                                                                 │\n'
-                '│ To update the settings, please refer to https://docs.flutter.dev/deployment/ios │\n'
-                '└─────────────────────────────────────────────────────────────────────────────────┘\n'
-        )
+      testLogger.statusText,
+      contains(
+        '┌─ App Settings ──────────────────────────────────────────────────────────────────┐\n'
+        '│ Version Number: 12.34.56                                                        │\n'
+        '│ Build Number: 666                                                               │\n'
+        '│ Display Name: Awesome Gallery                                                   │\n'
+        '│ Deployment Target: 11.0                                                         │\n'
+        '│ Bundle Identifier: io.flutter.someProject                                       │\n'
+        '│                                                                                 │\n'
+        '│ To update the settings, please refer to https://docs.flutter.dev/deployment/ios │\n'
+        '└─────────────────────────────────────────────────────────────────────────────────┘\n'
+      )
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1051,8 +1051,8 @@ void main() {
         <String>['build', 'ipa', '--no-pub']);
 
     expect(
-        testLogger.statusText,
-        contains('Warning: You may want to replace template app icons.'),
+      testLogger.statusText,
+      contains('Warning: App icon is set to the default placeholder icon. Replace with unique icons.'),
     );
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
@@ -1121,7 +1121,7 @@ void main() {
     await createTestCommandRunner(command).run(
         <String>['build', 'ipa', '--no-pub']);
 
-    expect(testLogger.statusText, isNot(contains('Warning: You may want to replace template app icons.')));
+    expect(testLogger.statusText, isNot(contains('Warning: App icon is set to the default placeholder icon. Replace with unique icons.')));
   }, overrides: <Type, Generator>{
     FileSystem: () => fileSystem,
     ProcessManager: () => fakeProcessManager,

--- a/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/build_ipa_test.dart
@@ -103,7 +103,7 @@ void main() {
   "packages": [
     {
       "name": "flutter_template_images",
-      "rootUri": "flutter_template_images",
+      "rootUri": "/flutter_template_images",
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }
@@ -994,7 +994,7 @@ void main() {
     const String projectIconContentsJsonPath = 'ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json';
     const String projectIconImagePath = 'ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
     final String templateIconContentsJsonPath = '${Cache.flutterRoot!}/packages/flutter_tools/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json';
-    final String templateIconImagePath = '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/flutter_template_images/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
+    const String templateIconImagePath = '/flutter_template_images/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
     fakeProcessManager.addCommands(<FakeCommand>[
       xattrCommand,
@@ -1059,7 +1059,7 @@ void main() {
     const String projectIconContentsJsonPath = 'ios/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json';
     const String projectIconImagePath = 'ios/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
     final String templateIconContentsJsonPath = '${Cache.flutterRoot!}/packages/flutter_tools/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Contents.json';
-    final String templateIconImagePath = '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/flutter_template_images/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
+    const String templateIconImagePath = '/flutter_template_images/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset/Icon-App-20x20@2x.png';
 
     fakeProcessManager.addCommands(<FakeCommand>[
       xattrCommand,

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -390,6 +390,57 @@ void main() {
 
       expect(iosApp, null);
     }, overrides: overrides);
+
+    testUsingContext('returns project app icon dirname', () async {
+      final BuildableIOSApp iosApp = BuildableIOSApp(
+          IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
+          'com.foo.bar',
+          'Runner');
+
+      expect(
+          iosApp.projectAppIconDirName,
+          'ios/Runner/Assets.xcassets/AppIcon.appiconset');
+    }, overrides: overrides);
+
+    testUsingContext('returns template app icon dirname for Contents.json', () async {
+      final BuildableIOSApp iosApp = BuildableIOSApp(
+          IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
+          'com.foo.bar',
+          'Runner');
+
+      expect(
+        iosApp.templateAppIconDirNameForContentsJson,
+        '${Cache.flutterRoot!}/packages/flutter_tools/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset');
+    }, overrides: overrides);
+
+    testUsingContext('returns template app icon dirname for images', () async {
+      final String packageConfigPath = '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/package_config.json';
+      globals.fs.file(packageConfigPath)
+        ..createSync(recursive: true)
+        ..writeAsStringSync('''
+{
+  "configVersion": 2,
+  "packages": [
+    {
+      "name": "flutter_template_images",
+      "rootUri": "flutter_template_images",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    }
+  ]
+}
+''');
+
+      final BuildableIOSApp iosApp = BuildableIOSApp(
+          IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
+          'com.foo.bar',
+          'Runner');
+
+      expect(
+        await iosApp.templateAppIconDirNameForImages,
+        '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/flutter_template_images/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset',
+      );
+    }, overrides: overrides);
   });
 
   group('FuchsiaApp', () {

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -21,7 +21,6 @@ import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
-import '../integration.shard/test_utils.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fake_process_manager.dart';

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -447,7 +447,7 @@ void main() {
   "packages": [
     {
       "name": "flutter_template_images",
-      "rootUri": "flutter_template_images",
+      "rootUri": "/flutter_template_images",
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }
@@ -465,9 +465,7 @@ void main() {
       );
       expect(
         await iosApp.templateAppIconDirNameForImages,
-        globals.fs.path.join(
-            toolsDir,
-            '.dart_tool',
+        globals.fs.path.absolute(
             'flutter_template_images',
             'templates',
             'app_shared',

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -386,58 +386,60 @@ void main() {
       final Directory project = globals.fs.directory('ios/Runner.xcodeproj')..createSync(recursive: true);
       project.childFile('project.pbxproj').createSync();
       final BuildableIOSApp? iosApp = await IOSApp.fromIosProject(
-          FlutterProject.fromDirectory(globals.fs.currentDirectory).ios, null) as BuildableIOSApp?;
+        FlutterProject.fromDirectory(globals.fs.currentDirectory).ios, null) as BuildableIOSApp?;
 
       expect(iosApp, null);
     }, overrides: overrides);
 
     testUsingContext('returns project app icon dirname', () async {
       final BuildableIOSApp iosApp = BuildableIOSApp(
-          IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
-          'com.foo.bar',
-          'Runner');
+        IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
+        'com.foo.bar',
+        'Runner',
+      );
       final String iconDirSuffix = globals.fs.path.join(
-          'Runner',
-          'Assets.xcassets',
-          'AppIcon.appiconset',
+        'Runner',
+        'Assets.xcassets',
+        'AppIcon.appiconset',
       );
       expect(iosApp.projectAppIconDirName, globals.fs.path.join('ios', iconDirSuffix));
     }, overrides: overrides);
 
     testUsingContext('returns template app icon dirname for Contents.json', () async {
       final BuildableIOSApp iosApp = BuildableIOSApp(
-          IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
-          'com.foo.bar',
-          'Runner');
+        IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
+        'com.foo.bar',
+        'Runner',
+      );
       final String iconDirSuffix = globals.fs.path.join(
-          'Runner',
-          'Assets.xcassets',
-          'AppIcon.appiconset',
+        'Runner',
+        'Assets.xcassets',
+        'AppIcon.appiconset',
       );
       expect(
         iosApp.templateAppIconDirNameForContentsJson,
         globals.fs.path.join(
-            Cache.flutterRoot!,
-            'packages',
-            'flutter_tools',
-            'templates',
-            'app_shared',
-            'ios.tmpl',
-            iconDirSuffix,
+          Cache.flutterRoot!,
+          'packages',
+          'flutter_tools',
+          'templates',
+          'app_shared',
+          'ios.tmpl',
+          iconDirSuffix,
         ),
       );
     }, overrides: overrides);
 
     testUsingContext('returns template app icon dirname for images', () async {
       final String toolsDir = globals.fs.path.join(
-          Cache.flutterRoot!,
-          'packages',
-          'flutter_tools',
+        Cache.flutterRoot!,
+        'packages',
+        'flutter_tools',
       );
       final String packageConfigPath = globals.fs.path.join(
-          toolsDir,
-          '.dart_tool',
-          'package_config.json'
+        toolsDir,
+        '.dart_tool',
+        'package_config.json'
       );
       globals.fs.file(packageConfigPath)
         ..createSync(recursive: true)
@@ -455,22 +457,22 @@ void main() {
 }
 ''');
       final BuildableIOSApp iosApp = BuildableIOSApp(
-          IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
-          'com.foo.bar',
-          'Runner');
+        IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
+        'com.foo.bar',
+        'Runner');
       final String iconDirSuffix = globals.fs.path.join(
-          'Runner',
-          'Assets.xcassets',
-          'AppIcon.appiconset',
+        'Runner',
+        'Assets.xcassets',
+        'AppIcon.appiconset',
       );
       expect(
         await iosApp.templateAppIconDirNameForImages,
         globals.fs.path.absolute(
-            'flutter_template_images',
-            'templates',
-            'app_shared',
-            'ios.tmpl',
-            iconDirSuffix,
+          'flutter_template_images',
+          'templates',
+          'app_shared',
+          'ios.tmpl',
+          iconDirSuffix,
         ),
       );
     }, overrides: overrides);

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
+import '../integration.shard/test_utils.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fake_process_manager.dart';
@@ -396,10 +397,12 @@ void main() {
           IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
           'com.foo.bar',
           'Runner');
-
-      expect(
-          iosApp.projectAppIconDirName,
-          'ios/Runner/Assets.xcassets/AppIcon.appiconset');
+      final String iconDirSuffix = fileSystem.path.join(
+          'Runner',
+          'Assets.xcassets',
+          'AppIcon.appiconset',
+      );
+      expect(iosApp.projectAppIconDirName, fileSystem.path.join('ios', iconDirSuffix));
     }, overrides: overrides);
 
     testUsingContext('returns template app icon dirname for Contents.json', () async {
@@ -407,14 +410,36 @@ void main() {
           IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
           'com.foo.bar',
           'Runner');
-
+      final String iconDirSuffix = fileSystem.path.join(
+          'Runner',
+          'Assets.xcassets',
+          'AppIcon.appiconset',
+      );
       expect(
         iosApp.templateAppIconDirNameForContentsJson,
-        '${Cache.flutterRoot!}/packages/flutter_tools/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset');
+        fileSystem.path.join(
+            Cache.flutterRoot!,
+            'packages',
+            'flutter_tools',
+            'templates',
+            'app_shared',
+            'ios.tmpl',
+            iconDirSuffix,
+        ),
+      );
     }, overrides: overrides);
 
     testUsingContext('returns template app icon dirname for images', () async {
-      final String packageConfigPath = '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/package_config.json';
+      final String toolsDir = fileSystem.path.join(
+          Cache.flutterRoot!,
+          'packages',
+          'flutter_tools',
+      );
+      final String packageConfigPath = fileSystem.path.join(
+          toolsDir,
+          '.dart_tool',
+          'package_config.json'
+      );
       globals.fs.file(packageConfigPath)
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -430,15 +455,26 @@ void main() {
   ]
 }
 ''');
-
       final BuildableIOSApp iosApp = BuildableIOSApp(
           IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
           'com.foo.bar',
           'Runner');
-
+      final String iconDirSuffix = fileSystem.path.join(
+          'Runner',
+          'Assets.xcassets',
+          'AppIcon.appiconset',
+      );
       expect(
         await iosApp.templateAppIconDirNameForImages,
-        '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/flutter_template_images/templates/app_shared/ios.tmpl/Runner/Assets.xcassets/AppIcon.appiconset',
+        fileSystem.path.join(
+            toolsDir,
+            '.dart_tool',
+            'flutter_template_images',
+            'templates',
+            'app_shared',
+            'ios.tmpl',
+            iconDirSuffix,
+        ),
       );
     }, overrides: overrides);
   });

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -397,12 +397,12 @@ void main() {
           IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
           'com.foo.bar',
           'Runner');
-      final String iconDirSuffix = fileSystem.path.join(
+      final String iconDirSuffix = globals.fs.path.join(
           'Runner',
           'Assets.xcassets',
           'AppIcon.appiconset',
       );
-      expect(iosApp.projectAppIconDirName, fileSystem.path.join('ios', iconDirSuffix));
+      expect(iosApp.projectAppIconDirName, globals.fs.path.join('ios', iconDirSuffix));
     }, overrides: overrides);
 
     testUsingContext('returns template app icon dirname for Contents.json', () async {
@@ -410,14 +410,14 @@ void main() {
           IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
           'com.foo.bar',
           'Runner');
-      final String iconDirSuffix = fileSystem.path.join(
+      final String iconDirSuffix = globals.fs.path.join(
           'Runner',
           'Assets.xcassets',
           'AppIcon.appiconset',
       );
       expect(
         iosApp.templateAppIconDirNameForContentsJson,
-        fileSystem.path.join(
+        globals.fs.path.join(
             Cache.flutterRoot!,
             'packages',
             'flutter_tools',
@@ -430,12 +430,12 @@ void main() {
     }, overrides: overrides);
 
     testUsingContext('returns template app icon dirname for images', () async {
-      final String toolsDir = fileSystem.path.join(
+      final String toolsDir = globals.fs.path.join(
           Cache.flutterRoot!,
           'packages',
           'flutter_tools',
       );
-      final String packageConfigPath = fileSystem.path.join(
+      final String packageConfigPath = globals.fs.path.join(
           toolsDir,
           '.dart_tool',
           'package_config.json'
@@ -459,14 +459,14 @@ void main() {
           IosProject.fromFlutter(FlutterProject.fromDirectory(globals.fs.currentDirectory)),
           'com.foo.bar',
           'Runner');
-      final String iconDirSuffix = fileSystem.path.join(
+      final String iconDirSuffix = globals.fs.path.join(
           'Runner',
           'Assets.xcassets',
           'AppIcon.appiconset',
       );
       expect(
         await iosApp.templateAppIconDirNameForImages,
-        fileSystem.path.join(
+        globals.fs.path.join(
             toolsDir,
             '.dart_tool',
             'flutter_template_images',

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -54,11 +54,11 @@ void main() {
 
     testUsingContext('templateImageDirectory returns parent template directory if passed null name', () async {
       final String packageConfigPath = globals.fs.path.join(
-          Cache.flutterRoot!,
-          'packages',
-          'flutter_tools',
-          '.dart_tool',
-          'package_config.json',
+        Cache.flutterRoot!,
+        'packages',
+        'flutter_tools',
+        '.dart_tool',
+        'package_config.json',
       );
 
       globals.fs.file(packageConfigPath)
@@ -79,19 +79,19 @@ void main() {
       expect(
           (await templateImageDirectory(null, globals.fs, globals.logger)).path,
           globals.fs.path.absolute(
-              'flutter_template_images',
-              'templates',
+            'flutter_template_images',
+            'templates',
           ),
       );
     }, overrides: overrides);
 
     testUsingContext('templateImageDirectory returns the directory containing the `name` template directory', () async {
       final String packageConfigPath = globals.fs.path.join(
-          Cache.flutterRoot!,
-          'packages',
-          'flutter_tools',
-          '.dart_tool',
-          'package_config.json',
+        Cache.flutterRoot!,
+        'packages',
+        'flutter_tools',
+        '.dart_tool',
+        'package_config.json',
       );
       globals.fs.file(packageConfigPath)
         ..createSync(recursive: true)
@@ -111,9 +111,9 @@ void main() {
       expect(
         (await templateImageDirectory('app_shared', globals.fs, globals.logger)).path,
         globals.fs.path.absolute(
-            'flutter_template_images',
-            'templates',
-            'app_shared',
+          'flutter_template_images',
+          'templates',
+          'app_shared',
         ),
       );
     }, overrides: overrides);

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -69,7 +69,7 @@ void main() {
   "packages": [
     {
       "name": "flutter_template_images",
-      "rootUri": "flutter_template_images",
+      "rootUri": "/flutter_template_images",
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }
@@ -78,11 +78,7 @@ void main() {
 ''');
       expect(
           (await templateImageDirectory(null, globals.fs, globals.logger)).path,
-          globals.fs.path.join(
-              Cache.flutterRoot!,
-              'packages',
-              'flutter_tools',
-              '.dart_tool',
+          globals.fs.path.absolute(
               'flutter_template_images',
               'templates',
           ),
@@ -105,7 +101,7 @@ void main() {
   "packages": [
     {
       "name": "flutter_template_images",
-      "rootUri": "flutter_template_images",
+      "rootUri": "/flutter_template_images",
       "packageUri": "lib/",
       "languageVersion": "2.12"
     }
@@ -114,11 +110,7 @@ void main() {
 ''');
       expect(
         (await templateImageDirectory('app_shared', globals.fs, globals.logger)).path,
-        globals.fs.path.join(
-            Cache.flutterRoot!,
-            'packages',
-            'flutter_tools',
-            '.dart_tool',
+        globals.fs.path.absolute(
             'flutter_template_images',
             'templates',
             'app_shared',

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/template.dart';
 import 'package:flutter_tools/src/cache.dart';
+import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/template.dart';
 import '../src/common.dart';
 import '../src/context.dart';
@@ -46,16 +47,13 @@ void main() {
   });
 
   group('template image directory', () {
-    late BufferLogger logger;
-    late MemoryFileSystem fileSystem;
-
-    setUp(() {
-      fileSystem = MemoryFileSystem.test();
-      logger = BufferLogger.test();
-    });
+    final Map<Type, Generator> overrides = <Type, Generator>{
+      FileSystem: () => MemoryFileSystem.test(),
+      ProcessManager: () => FakeProcessManager.any(),
+    };
 
     testUsingContext('templateImageDirectory returns parent template directory if passed null name', () async {
-      final String packageConfigPath = fileSystem.path.join(
+      final String packageConfigPath = globals.fs.path.join(
           Cache.flutterRoot!,
           'packages',
           'flutter_tools',
@@ -63,7 +61,7 @@ void main() {
           'package_config.json',
       );
 
-      fileSystem.file(packageConfigPath)
+      globals.fs.file(packageConfigPath)
         ..createSync(recursive: true)
         ..writeAsStringSync('''
 {
@@ -79,8 +77,8 @@ void main() {
 }
 ''');
       expect(
-          (await templateImageDirectory(null, fileSystem, logger)).path,
-          fileSystem.path.join(
+          (await templateImageDirectory(null, globals.fs, globals.logger)).path,
+          globals.fs.path.join(
               Cache.flutterRoot!,
               'packages',
               'flutter_tools',
@@ -89,17 +87,17 @@ void main() {
               'templates',
           ),
       );
-    });
+    }, overrides: overrides);
 
     testUsingContext('templateImageDirectory returns the directory containing the `name` template directory', () async {
-      final String packageConfigPath = fileSystem.path.join(
+      final String packageConfigPath = globals.fs.path.join(
           Cache.flutterRoot!,
           'packages',
           'flutter_tools',
           '.dart_tool',
           'package_config.json',
       );
-      fileSystem.file(packageConfigPath)
+      globals.fs.file(packageConfigPath)
         ..createSync(recursive: true)
         ..writeAsStringSync('''
 {
@@ -115,8 +113,8 @@ void main() {
 }
 ''');
       expect(
-        (await templateImageDirectory('app_shared', fileSystem, logger)).path,
-        fileSystem.path.join(
+        (await templateImageDirectory('app_shared', globals.fs, globals.logger)).path,
+        globals.fs.path.join(
             Cache.flutterRoot!,
             'packages',
             'flutter_tools',
@@ -126,7 +124,7 @@ void main() {
             'app_shared',
         ),
       );
-    });
+    }, overrides: overrides);
   });
 
   group('renders template', () {

--- a/packages/flutter_tools/test/general.shard/template_test.dart
+++ b/packages/flutter_tools/test/general.shard/template_test.dart
@@ -55,7 +55,14 @@ void main() {
     });
 
     testUsingContext('templateImageDirectory returns parent template directory if passed null name', () async {
-      final String packageConfigPath = '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/package_config.json';
+      final String packageConfigPath = fileSystem.path.join(
+          Cache.flutterRoot!,
+          'packages',
+          'flutter_tools',
+          '.dart_tool',
+          'package_config.json',
+      );
+
       fileSystem.file(packageConfigPath)
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -73,12 +80,25 @@ void main() {
 ''');
       expect(
           (await templateImageDirectory(null, fileSystem, logger)).path,
-          '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/flutter_template_images/templates',
+          fileSystem.path.join(
+              Cache.flutterRoot!,
+              'packages',
+              'flutter_tools',
+              '.dart_tool',
+              'flutter_template_images',
+              'templates',
+          ),
       );
     });
 
     testUsingContext('templateImageDirectory returns the directory containing the `name` template directory', () async {
-      final String packageConfigPath = '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/package_config.json';
+      final String packageConfigPath = fileSystem.path.join(
+          Cache.flutterRoot!,
+          'packages',
+          'flutter_tools',
+          '.dart_tool',
+          'package_config.json',
+      );
       fileSystem.file(packageConfigPath)
         ..createSync(recursive: true)
         ..writeAsStringSync('''
@@ -96,7 +116,15 @@ void main() {
 ''');
       expect(
         (await templateImageDirectory('app_shared', fileSystem, logger)).path,
-        '${Cache.flutterRoot!}/packages/flutter_tools/.dart_tool/flutter_template_images/templates/app_shared',
+        fileSystem.path.join(
+            Cache.flutterRoot!,
+            'packages',
+            'flutter_tools',
+            '.dart_tool',
+            'flutter_template_images',
+            'templates',
+            'app_shared',
+        ),
       );
     });
   });


### PR DESCRIPTION
Validate if any of the icons are still using flutter template icon when building IPA. 

The basic idea is to parse the `Contents.json` file to get a map of `(idiom, size, scale) => image_file_name`, and then read the bytes of matching pairs of icon images, to check if any conflicts. 

Note that `flutter_gallery`'s icons are different from what's used in the template assets (so i had to `flutter create` a new project). This PR only checks the exact match. It is probably not worth the effort to check for similarity (e.g. machine learning stuff). 

<s>When fails the validation, We want to print out both `(idiom, size, scale)` and the `file path`. `(idiom, size, scale)` is helpful if developers want to edit icons in xcode; `file path` is helpful if they directly replace files in `AppIcon.appiconset` folder (personally i tend to do the latter, but editing in xcode has the benefit that xcode checks for icon size for you).

We want to print out each conflicting file, because it's possible that developer only updates the home screen icon file when they start developing the app, and forget about other icons later (I made that mistake sometimes).  </s>

In the future, we may also want to validate the image size of app icons.  Xcode gives warning about the wrong size, but developers may directly replace images without using Xcode (me, for example). 


*List which issues are fixed by this PR. You must list at least one issue.*

https://github.com/flutter/flutter/issues/97730

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
