### PR TITLE
`updateSemantics` in TestWindow should always be implemented.

### DIFF
--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui show window;
-import 'dart:ui' show AccessibilityFeatures, Brightness, Locale, SemanticsUpdate, SingletonFlutterWindow, Size, WindowPadding, PlatformDispatcher;
+import 'dart:ui' show AccessibilityFeatures, Brightness, Locale, PlatformDispatcher, SemanticsUpdate, SingletonFlutterWindow, Size, WindowPadding;
 
 import 'package:flutter/semantics.dart' show SemanticsUpdateBuilder;
 import 'package:flutter/widgets.dart' show WidgetsBinding, WidgetsBindingObserver;

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui show window;
-import 'dart:ui' show AccessibilityFeatures, Brightness, Locale, SemanticsUpdate, Size, WindowPadding;
+import 'dart:ui' show AccessibilityFeatures, Brightness, Locale, SemanticsUpdate, SingletonFlutterWindow, Size, WindowPadding, PlatformDispatcher;
 
 import 'package:flutter/semantics.dart' show SemanticsUpdateBuilder;
 import 'package:flutter/widgets.dart' show WidgetsBinding, WidgetsBindingObserver;
@@ -209,12 +209,12 @@ void main() {
     retrieveTestBinding(tester).window.localesTestValue = defaultLocales;
   });
 
-  testWidgets('TestWindow can updateSemantics', (WidgetTester tester) async {
-    final TestWindow testWindow = retrieveTestBinding(tester).window;
-    final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder();
-    final SemanticsUpdate update = builder.build();
-
+test('Window test', () {
+    final FakeSingletonWindow fakeWindow = FakeSingletonWindow();
+    final TestWindow testWindow = TestWindow(window: fakeWindow);
+    final SemanticsUpdate update = SemanticsUpdateBuilder().build();
     testWindow.updateSemantics(update);
+    expect(fakeWindow.lastUpdate, update);
   });
 }
 
@@ -273,5 +273,17 @@ class TestObserver with WidgetsBindingObserver {
   @override
   void didChangeLocales(List<Locale>? locales) {
     this.locales = locales;
+  }
+}
+
+class FakeSingletonWindow extends Fake implements SingletonFlutterWindow {
+  SemanticsUpdate? lastUpdate;
+
+  @override
+  PlatformDispatcher get platformDispatcher => PlatformDispatcher.instance;
+
+  @override
+  void updateSemantics(SemanticsUpdate update) {
+    lastUpdate = update;
   }
 }

--- a/packages/flutter_test/test/window_test.dart
+++ b/packages/flutter_test/test/window_test.dart
@@ -3,8 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:ui' as ui show window;
-import 'dart:ui' show AccessibilityFeatures, Brightness, Locale, Size, WindowPadding;
+import 'dart:ui' show AccessibilityFeatures, Brightness, Locale, SemanticsUpdate, Size, WindowPadding;
 
+import 'package:flutter/semantics.dart' show SemanticsUpdateBuilder;
 import 'package:flutter/widgets.dart' show WidgetsBinding, WidgetsBindingObserver;
 import 'package:flutter_test/flutter_test.dart';
 
@@ -206,6 +207,14 @@ void main() {
     retrieveTestBinding(tester).window.localesTestValue = expectedValue;
     expect(observer.locales, equals(expectedValue));
     retrieveTestBinding(tester).window.localesTestValue = defaultLocales;
+  });
+
+  testWidgets('TestWindow can updateSemantics', (WidgetTester tester) async {
+    final TestWindow testWindow = retrieveTestBinding(tester).window;
+    final SemanticsUpdateBuilder builder = SemanticsUpdateBuilder();
+    final SemanticsUpdate update = builder.build();
+
+    testWindow.updateSemantics(update);
   });
 }
 


### PR DESCRIPTION
Adds a test that calls `updateSemantics`. Since `TestWindow` implements `FlutterWindow` and does not extend it, it will not inherit this method. I'm glad that we caught this 👍 .

## Fixes https://github.com/flutter/flutter/issues/114829

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
