### PR TITLE
Fix `RangeSlider` semantics node size

### DIFF
--- a/packages/flutter/lib/src/material/range_slider.dart
+++ b/packages/flutter/lib/src/material/range_slider.dart
@@ -840,6 +840,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
   late TapGestureRecognizer _tap;
   bool _active = false;
   late RangeValues _newValues;
+  late Offset _startThumbCenter;
+  late Offset _endThumbCenter;
 
   bool get isEnabled => onChanged != null;
 
@@ -1303,8 +1305,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
         sliderTheme: _sliderTheme,
         isDiscrete: isDiscrete,
     );
-    final Offset startThumbCenter = Offset(trackRect.left + startVisualPosition * trackRect.width, trackRect.center.dy);
-    final Offset endThumbCenter = Offset(trackRect.left + endVisualPosition * trackRect.width, trackRect.center.dy);
+    _startThumbCenter = Offset(trackRect.left + startVisualPosition * trackRect.width, trackRect.center.dy);
+    _endThumbCenter = Offset(trackRect.left + endVisualPosition * trackRect.width, trackRect.center.dy);
 
     _sliderTheme.rangeTrackShape!.paint(
         context,
@@ -1313,8 +1315,8 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
         sliderTheme: _sliderTheme,
         enableAnimation: _enableAnimation,
         textDirection: _textDirection,
-        startThumbCenter: startThumbCenter,
-        endThumbCenter: endThumbCenter,
+        startThumbCenter: _startThumbCenter,
+        endThumbCenter: _endThumbCenter,
         isDiscrete: isDiscrete,
         isEnabled: isEnabled,
     );
@@ -1327,7 +1329,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       if (startThumbSelected) {
         _sliderTheme.overlayShape!.paint(
           context,
-          startThumbCenter,
+          _startThumbCenter,
           activationAnimation: _overlayAnimation,
           enableAnimation: _enableAnimation,
           isDiscrete: isDiscrete,
@@ -1343,7 +1345,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       if (endThumbSelected) {
         _sliderTheme.overlayShape!.paint(
           context,
-          endThumbCenter,
+          _endThumbCenter,
           activationAnimation: _overlayAnimation,
           enableAnimation: _enableAnimation,
           isDiscrete: isDiscrete,
@@ -1381,21 +1383,21 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
             sliderTheme: _sliderTheme,
             enableAnimation: _enableAnimation,
             textDirection: _textDirection,
-            startThumbCenter: startThumbCenter,
-            endThumbCenter: endThumbCenter,
+            startThumbCenter: _startThumbCenter,
+            endThumbCenter: _endThumbCenter,
             isEnabled: isEnabled,
           );
         }
       }
     }
 
-    final double thumbDelta = (endThumbCenter.dx - startThumbCenter.dx).abs();
+    final double thumbDelta = (_endThumbCenter.dx - _startThumbCenter.dx).abs();
 
     final bool isLastThumbStart = _lastThumbSelection == Thumb.start;
     final Thumb bottomThumb = isLastThumbStart ? Thumb.end : Thumb.start;
     final Thumb topThumb = isLastThumbStart ? Thumb.start : Thumb.end;
-    final Offset bottomThumbCenter = isLastThumbStart ? endThumbCenter : startThumbCenter;
-    final Offset topThumbCenter = isLastThumbStart ? startThumbCenter : endThumbCenter;
+    final Offset bottomThumbCenter = isLastThumbStart ? _endThumbCenter : _startThumbCenter;
+    final Offset topThumbCenter = isLastThumbStart ? _startThumbCenter : _endThumbCenter;
     final TextPainter bottomLabelPainter = isLastThumbStart ? _endLabelPainter : _startLabelPainter;
     final TextPainter topLabelPainter = isLastThumbStart ? _startLabelPainter : _endLabelPainter;
     final double bottomValue = isLastThumbStart ? endValue : startValue;
@@ -1441,7 +1443,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     if (shouldPaintValueIndicators) {
       final double startOffset = sliderTheme.rangeValueIndicatorShape!.getHorizontalShift(
         parentBox: this,
-        center: startThumbCenter,
+        center: _startThumbCenter,
         labelPainter: _startLabelPainter,
         activationAnimation: _valueIndicatorAnimation,
         textScaleFactor: textScaleFactor,
@@ -1449,7 +1451,7 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
       );
       final double endOffset = sliderTheme.rangeValueIndicatorShape!.getHorizontalShift(
         parentBox: this,
-        center: endThumbCenter,
+        center: _endThumbCenter,
         labelPainter: _endLabelPainter,
         activationAnimation: _valueIndicatorAnimation,
         textScaleFactor: textScaleFactor,
@@ -1575,8 +1577,16 @@ class _RenderRangeSlider extends RenderBox with RelayoutWhenSystemFontsChangeMix
     );
 
     // Split the semantics node area between the start and end nodes.
-    final Rect leftRect = Rect.fromPoints(node.rect.topLeft, node.rect.bottomCenter);
-    final Rect rightRect = Rect.fromPoints(node.rect.topCenter, node.rect.bottomRight);
+    final Rect leftRect = Rect.fromCenter(
+      center: _startThumbCenter,
+      width: kMinInteractiveDimension,
+      height: kMinInteractiveDimension,
+    );
+    final Rect rightRect = Rect.fromCenter(
+      center: _endThumbCenter,
+      width: kMinInteractiveDimension,
+      height: kMinInteractiveDimension,
+    );
     switch (textDirection) {
       case TextDirection.ltr:
         _startSemanticsNode!.rect = leftRect;

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1853,7 +1853,7 @@ void main() {
     );
   });
 
-  testWidgets('Range Slider Semantics', (WidgetTester tester) async {
+  testWidgets('Range Slider Semantics - ltr', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Theme(
@@ -1862,7 +1862,7 @@ void main() {
             textDirection: TextDirection.ltr,
             child: Material(
               child: RangeSlider(
-                values: const RangeValues(10.0, 12.0),
+                values: const RangeValues(10.0, 30.0),
                 max: 100.0,
                 onChanged: (RangeValues v) { },
               ),
@@ -1874,8 +1874,9 @@ void main() {
 
     await tester.pumpAndSettle();
 
+    final SemanticsNode semanticsNode = tester.getSemantics(find.byType(RangeSlider));
     expect(
-      tester.getSemantics(find.byType(RangeSlider)),
+      semanticsNode,
       matchesSemantics(
         scopesRoute: true,
         children:<Matcher>[
@@ -1888,7 +1889,88 @@ void main() {
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
                 value: '10%',
-                increasedValue: '10%',
+                increasedValue: '15%',
+                decreasedValue: '5%',
+                rect: const Rect.fromLTRB(75.2, 276.0, 123.2, 324.0),
+              ),
+              matchesSemantics(
+                isEnabled: true,
+                isSlider: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '30%',
+                increasedValue: '35%',
+                decreasedValue: '25%',
+                rect: const Rect.fromLTRB(225.6, 276.0, 273.6, 324.0),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+
+    // Get semantics node rects.
+    final List<Rect> rects = <Rect>[];
+    semanticsNode.visitChildren((SemanticsNode node) {
+      node.visitChildren((SemanticsNode node) {
+       // Round rect values to avoid floating point errors.
+        rects.add(
+          Rect.fromLTRB(
+            node.rect.left.roundToDouble(),
+            node.rect.top.roundToDouble(),
+            node.rect.right.roundToDouble(),
+            node.rect.bottom.roundToDouble(),
+          ),
+        );
+        return true;
+      });
+      return true;
+    });
+    // Test that the semantics node rect sizes are correct.
+    expect(rects, <Rect>[
+      const Rect.fromLTRB(75.0, 276.0, 123.0, 324.0),
+      const Rect.fromLTRB(226.0, 276.0, 274.0, 324.0)
+    ]);
+  });
+
+  testWidgets('Range Slider Semantics - rtl', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Theme(
+          data: ThemeData.light(),
+          child: Directionality(
+            textDirection: TextDirection.rtl,
+            child: Material(
+              child: RangeSlider(
+                values: const RangeValues(10.0, 30.0),
+                max: 100.0,
+                onChanged: (RangeValues v) { },
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final SemanticsNode semanticsNode = tester.getSemantics(find.byType(RangeSlider));
+    expect(
+      semanticsNode,
+      matchesSemantics(
+        scopesRoute: true,
+        children:<Matcher>[
+          matchesSemantics(
+            children:  <Matcher>[
+              matchesSemantics(
+                isEnabled: true,
+                isSlider: true,
+                hasEnabledState: true,
+                hasIncreaseAction: true,
+                hasDecreaseAction: true,
+                value: '10%',
+                increasedValue: '15%',
                 decreasedValue: '5%',
               ),
               matchesSemantics(
@@ -1897,15 +1979,38 @@ void main() {
                 hasEnabledState: true,
                 hasIncreaseAction: true,
                 hasDecreaseAction: true,
-                value: '12%',
-                increasedValue: '17%',
-                decreasedValue: '12%',
+                value: '30%',
+                increasedValue: '35%',
+                decreasedValue: '25%',
               ),
             ],
           ),
         ],
       ),
     );
+
+    // Get semantics node rects.
+    final List<Rect> rects = <Rect>[];
+    semanticsNode.visitChildren((SemanticsNode node) {
+      node.visitChildren((SemanticsNode node) {
+        // Round rect values to avoid floating point errors.
+        rects.add(
+          Rect.fromLTRB(
+            node.rect.left.roundToDouble(),
+            node.rect.top.roundToDouble(),
+            node.rect.right.roundToDouble(),
+            node.rect.bottom.roundToDouble(),
+          ),
+        );
+        return true;
+      });
+      return true;
+    });
+    // Test that the semantics node rect sizes are correct.
+    expect(rects, <Rect>[
+      const Rect.fromLTRB(526.0, 276.0, 574.0, 324.0),
+      const Rect.fromLTRB(677.0, 276.0, 725.0, 324.0)
+    ]);
   });
 
   testWidgets('Range Slider implements debugFillProperties', (WidgetTester tester) async {

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1910,6 +1910,9 @@ void main() {
       ),
     );
 
+    // TODO(tahatesser): This is a workaround for matching
+    // the semantics node rects by avoiding floating point errors.
+    // https://github.com/flutter/flutter/issues/115079
     // Get semantics node rects.
     final List<Rect> rects = <Rect>[];
     semanticsNode.visitChildren((SemanticsNode node) {
@@ -1989,6 +1992,9 @@ void main() {
       ),
     );
 
+    // TODO(tahatesser): This is a workaround for matching
+    // the semantics node rects by avoiding floating point errors.
+    // https://github.com/flutter/flutter/issues/115079
     // Get semantics node rects.
     final List<Rect> rects = <Rect>[];
     semanticsNode.visitChildren((SemanticsNode node) {


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/114225 

### Description

This PR fixes semantics node size for `RangeSlider` 

Current behavior simply divides the node size in half.  This doesn't match when testing on Android.

### Android

| Left | Right |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/198580902-fa0442c7-8b00-495e-b4d5-35c1679b6948.jpg" /> | <img src="https://user-images.githubusercontent.com/48603081/200887798-c9e9e8ef-bb78-48eb-9cea-0b47abf69cf2.png"  /> |


### Flutter

| Before | After |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/200887674-87740633-fe1f-447a-9001-7a3c1ab37572.gif" /> | <img src="https://user-images.githubusercontent.com/48603081/200887708-99cc87b0-c326-476f-91d4-f44b7a461f0e.gif"  /> |



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
