### PR TITLE
Add the `channel` parameter to the Dartpad samples

### DIFF
--- a/dev/snippets/config/skeletons/dartpad-sample.html
+++ b/dev/snippets/config/skeletons/dartpad-sample.html
@@ -13,7 +13,7 @@
         </p>
     </div>
     <iframe class="snippet-dartpad"
-        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;null_safety=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}">
+        src="https://dartpad.dev/embed-flutter.html?split=60&amp;run=true&amp;null_safety=true&amp;sample_id={{id}}&amp;sample_channel={{channel}}&amp;channel={{channel}}">
     </iframe>
 </div>
 {@end-inject-html}

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -444,7 +444,7 @@ void sanityCheckDocs([Platform platform = const LocalPlatform()]) {
     r'split=\d+',
     r'run=true',
     r'null_safety=true',
-    r'sample_id=widgets\.Listener\.1',
+    r'sample_id=widgets\.Listener\.\d+',
     'sample_channel=$expectedBranch',
     'channel=$expectedBranch',
   ];
@@ -452,9 +452,9 @@ void sanityCheckDocs([Platform platform = const LocalPlatform()]) {
     _sanityCheckExample(
       '$kPublishRoot/api/widgets/Listener-class.html',
       r'\s*<iframe\s+class="snippet-dartpad"\s+src="'
-      r'https://dartpad\.dev.*sample_id=widgets\.Listener\.\d+\?.*?'
+      r'https:\/\/dartpad.dev\/embed-flutter.html\?.*?\b'
       '$argumentRegExp'
-      r'">\s*</iframe>',
+      r'\b.*">\s*<\/iframe>',
     );
   }
 }

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -394,7 +394,7 @@ void _sanityCheckExample(String fileString, String regExpString) {
     final RegExp regExp = RegExp(regExpString, dotAll: true);
     final String contents = file.readAsStringSync();
     if (!regExp.hasMatch(contents)) {
-      throw Exception("Missing example code in ${file.path}. Either it didn't get published, publishing has changed, or the example no longer exists.");
+      throw Exception("Missing example code matching '$regExpString' in ${file.path}.");
     }
   } else {
     throw Exception(
@@ -403,7 +403,7 @@ void _sanityCheckExample(String fileString, String regExpString) {
 }
 
 /// Runs a sanity check by running a test.
-void sanityCheckDocs() {
+void sanityCheckDocs([Platform platform = const LocalPlatform()]) {
   final List<String> canaries = <String>[
     '$kPublishRoot/assets/overrides.css',
     '$kPublishRoot/api/dart-io/File-class.html',
@@ -414,6 +414,7 @@ void sanityCheckDocs() {
     '$kPublishRoot/api/material/Material-class.html',
     '$kPublishRoot/api/material/Tooltip-class.html',
     '$kPublishRoot/api/widgets/Widget-class.html',
+    '$kPublishRoot/api/widgets/Listener-class.html',
   ];
   for (final String canary in canaries) {
     if (!File(canary).existsSync()) {
@@ -434,11 +435,28 @@ void sanityCheckDocs() {
     r'\s*<pre.*id="sample-code">.*Color\s+get\s+barrierColor.*</pre>',
   );
 
-  // Check a "dartpad" example, any one will do.
-  _sanityCheckExample(
-    '$kPublishRoot/api/widgets/PhysicalShape-class.html',
-    r'\s*<iframe\s+class="snippet-dartpad"\s+src="https://dartpad\.dev.*sample_id=widgets\.PhysicalShape\.\d+.*">\s*</iframe>',
-  );
+  // Check a "dartpad" example, any one will do, and check for the correct URL
+  // arguments.
+  // Just use "master" for any branch other than the LUCH_BRANCH.
+  final String? luciBranch = platform.environment['LUCI_BRANCH']?.trim();
+  final String expectedBranch = luciBranch != null && luciBranch.isNotEmpty ? luciBranch : 'master';
+  final List<String> argumentRegExps = <String>[
+    r'split=\d+',
+    r'run=true',
+    r'null_safety=true',
+    r'sample_id=widgets\.Listener\.1',
+    'sample_channel=$expectedBranch',
+    'channel=$expectedBranch',
+  ];
+  for (final String argumentRegExp in argumentRegExps) {
+    _sanityCheckExample(
+      '$kPublishRoot/api/widgets/Listener-class.html',
+      r'\s*<iframe\s+class="snippet-dartpad"\s+src="'
+      r'https://dartpad\.dev.*sample_id=widgets\.Listener\.\d+\?.*?'
+      '$argumentRegExp'
+      r'">\s*</iframe>',
+    );
+  }
 }
 
 /// Creates a custom index.html because we try to maintain old


### PR DESCRIPTION
## Description

This adds a missing `&channel=master` or `&channel=stable` to the URL parameter for Dartpad samples in the API docs.

## Related Issues
 - https://github.com/flutter/flutter/issues/114795

## Tests
 - Added a sanity check for dartpad URL parameters in dartdoc_test.dart