### PR TITLE
Fix text color not resolving when `CupertinoThemeData.brightness` is null

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -526,8 +526,8 @@ class _CupertinoAppState extends State<CupertinoApp> {
   }
 
   Widget _cupertinoBuilder(BuildContext context, Widget? child) {
-    final CupertinoThemeData effectiveThemeData = CupertinoTheme.of(context);
-
+    final CupertinoThemeData effectiveThemeData = (widget.theme ?? const CupertinoThemeData()).resolveFrom(context);
+    
     return CupertinoTheme(
       data: effectiveThemeData,
       // DefaultTextStyle has to be declared here because

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -494,6 +494,8 @@ class _CupertinoAppState extends State<CupertinoApp> {
   late HeroController _heroController;
   bool get _usesRouter => widget.routerDelegate != null || widget.routerConfig != null;
 
+  late Color color;
+
   @override
   void initState() {
     super.initState();
@@ -528,6 +530,10 @@ class _CupertinoAppState extends State<CupertinoApp> {
   Widget _cupertinoBuilder(BuildContext context, Widget? child) {
     final CupertinoThemeData effectiveThemeData = (widget.theme ?? const CupertinoThemeData()).resolveFrom(context);
 
+    if (color is CupertinoDynamicColor) {
+      color = (color as CupertinoDynamicColor).resolveFrom(context);
+    }
+
     return CupertinoTheme(
       data: effectiveThemeData,
       // DefaultTextStyle has to be declared here because
@@ -551,10 +557,9 @@ class _CupertinoAppState extends State<CupertinoApp> {
   }
 
   WidgetsApp _buildWidgetApp(BuildContext context) {
-    // CupertinoTheme won't resolve colors in this context if brightness
-    // is null, so this doesn't really work.
-    final CupertinoThemeData effectiveThemeData = CupertinoTheme.of(context);
-    final Color color = CupertinoDynamicColor.resolve(widget.color ?? effectiveThemeData.primaryColor, context);
+    // If this color is a CupertinoDynamicColor, it
+    // is going to be resolved in the _cupertinoBuilder.
+    color = widget.color ?? widget.theme?.primaryColor ?? CupertinoColors.systemBlue;
 
     if (_usesRouter) {
       return WidgetsApp.router(
@@ -624,13 +629,10 @@ class _CupertinoAppState extends State<CupertinoApp> {
       behavior: widget.scrollBehavior ?? const CupertinoScrollBehavior(),
       child: CupertinoUserInterfaceLevel(
         data: CupertinoUserInterfaceLevelData.base,
-        child: CupertinoTheme(
-          data: widget.theme ?? const CupertinoThemeData(),
-          child: HeroControllerScope(
-            controller: _heroController,
-            child: Builder(
-              builder: _buildWidgetApp,
-            ),
+        child: HeroControllerScope(
+          controller: _heroController,
+          child: Builder(
+            builder: _buildWidgetApp,
           ),
         ),
       ),

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -531,7 +531,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
     return CupertinoTheme(
       data: effectiveThemeData,
       // DefaultTextStyle has to be declared here because
-      // passing a textStyle directly to the WidgetsApp 
+      // passing a textStyle directly to the WidgetsApp
       // will make it non-resolvable.
       child: DefaultTextStyle(
         style: effectiveThemeData.textTheme.textStyle,
@@ -557,7 +557,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
     //
     // This is similiar to the logic in [MaterialApp].
     final Color color = widget.color ?? widget.theme?.primaryColor ?? CupertinoColors.activeBlue;
-    
+
     if (_usesRouter) {
       return WidgetsApp.router(
         key: GlobalObjectKey(this),

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -494,8 +494,6 @@ class _CupertinoAppState extends State<CupertinoApp> {
   late HeroController _heroController;
   bool get _usesRouter => widget.routerDelegate != null || widget.routerConfig != null;
 
-  late Color color;
-
   @override
   void initState() {
     super.initState();
@@ -530,10 +528,6 @@ class _CupertinoAppState extends State<CupertinoApp> {
   Widget _cupertinoBuilder(BuildContext context, Widget? child) {
     final CupertinoThemeData effectiveThemeData = (widget.theme ?? const CupertinoThemeData()).resolveFrom(context);
 
-    if (color is CupertinoDynamicColor) {
-      color = (color as CupertinoDynamicColor).resolveFrom(context);
-    }
-
     return CupertinoTheme(
       data: effectiveThemeData,
       // DefaultTextStyle has to be declared here because
@@ -557,9 +551,10 @@ class _CupertinoAppState extends State<CupertinoApp> {
   }
 
   WidgetsApp _buildWidgetApp(BuildContext context) {
-    // If this color is a CupertinoDynamicColor, it
-    // is going to be resolved in the _cupertinoBuilder.
-    color = widget.color ?? widget.theme?.primaryColor ?? CupertinoColors.systemBlue;
+    // CupertinoTheme won't resolve colors in this context if brightness
+    // is null, so this doesn't really work.
+    final CupertinoThemeData effectiveThemeData = CupertinoTheme.of(context);
+    final Color color = CupertinoDynamicColor.resolve(widget.color ?? effectiveThemeData.primaryColor, context);
 
     if (_usesRouter) {
       return WidgetsApp.router(
@@ -629,10 +624,13 @@ class _CupertinoAppState extends State<CupertinoApp> {
       behavior: widget.scrollBehavior ?? const CupertinoScrollBehavior(),
       child: CupertinoUserInterfaceLevel(
         data: CupertinoUserInterfaceLevelData.base,
-        child: HeroControllerScope(
-          controller: _heroController,
-          child: Builder(
-            builder: _buildWidgetApp,
+        child: CupertinoTheme(
+          data: widget.theme ?? const CupertinoThemeData(),
+          child: HeroControllerScope(
+            controller: _heroController,
+            child: Builder(
+              builder: _buildWidgetApp,
+            ),
           ),
         ),
       ),

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -619,7 +619,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
                     ),
             ),
           ),
-        ), 
+        ),
       ),
     );
   }

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -608,12 +608,18 @@ class _CupertinoAppState extends State<CupertinoApp> {
             cursorColor: effectiveThemeData.primaryColor,
             child: HeroControllerScope(
               controller: _heroController,
-              child: Builder(
-                builder: _buildWidgetApp,
-              ),
+              child: !widget.useInheritedMediaQuery
+                  ? MediaQuery.fromWindow(
+                      child: Builder(
+                        builder: _buildWidgetApp,
+                      ),
+                    )
+                  : Builder(
+                      builder: _buildWidgetApp,
+                    ),
             ),
           ),
-        ),
+        ), 
       ),
     );
   }

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -527,7 +527,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
 
   Widget _cupertinoBuilder(BuildContext context, Widget? child) {
     final CupertinoThemeData effectiveThemeData = (widget.theme ?? const CupertinoThemeData()).resolveFrom(context);
-    
+
     return CupertinoTheme(
       data: effectiveThemeData,
       // DefaultTextStyle has to be declared here because

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -525,34 +525,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
     );
   }
 
-  Widget _cupertinoBuilder(BuildContext context, Widget? child) {
-    final CupertinoThemeData effectiveThemeData = (widget.theme ?? const CupertinoThemeData()).resolveFrom(context);
-
-    return CupertinoTheme(
-      data: effectiveThemeData,
-      // DefaultTextStyle has to be declared here because
-      // passing a textStyle directly to the WidgetsApp
-      // will make it non-resolvable.
-      child: DefaultTextStyle(
-        style: effectiveThemeData.textTheme.textStyle,
-        child: DefaultSelectionStyle(
-          selectionColor: effectiveThemeData.primaryColor.withOpacity(0.2),
-          cursorColor: effectiveThemeData.primaryColor,
-          child: widget.builder != null
-              ? Builder(
-                  builder: (BuildContext context) {
-                    return widget.builder!(context, child);
-                  },
-                )
-              : child ?? const SizedBox.shrink(),
-        ),
-      ),
-    );
-  }
-
   WidgetsApp _buildWidgetApp(BuildContext context) {
-    // CupertinoTheme won't resolve colors in this context if brightness
-    // is null, so this doesn't really work.
     final CupertinoThemeData effectiveThemeData = CupertinoTheme.of(context);
     final Color color = CupertinoDynamicColor.resolve(widget.color ?? effectiveThemeData.primaryColor, context);
 
@@ -564,9 +537,10 @@ class _CupertinoAppState extends State<CupertinoApp> {
         routerDelegate: widget.routerDelegate,
         routerConfig: widget.routerConfig,
         backButtonDispatcher: widget.backButtonDispatcher,
-        builder: _cupertinoBuilder,
+        builder: widget.builder,
         title: widget.title,
         onGenerateTitle: widget.onGenerateTitle,
+        textStyle: effectiveThemeData.textTheme.textStyle,
         color: color,
         locale: widget.locale,
         localizationsDelegates: _localizationsDelegates,
@@ -584,6 +558,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
         restorationScopeId: widget.restorationScopeId,
       );
     }
+
     return WidgetsApp(
       key: GlobalObjectKey(this),
       navigatorKey: widget.navigatorKey,
@@ -597,9 +572,10 @@ class _CupertinoAppState extends State<CupertinoApp> {
       onGenerateRoute: widget.onGenerateRoute,
       onGenerateInitialRoutes: widget.onGenerateInitialRoutes,
       onUnknownRoute: widget.onUnknownRoute,
-      builder: _cupertinoBuilder,
+      builder: widget.builder,
       title: widget.title,
       onGenerateTitle: widget.onGenerateTitle,
+      textStyle: effectiveThemeData.textTheme.textStyle,
       color: color,
       locale: widget.locale,
       localizationsDelegates: _localizationsDelegates,
@@ -620,16 +596,22 @@ class _CupertinoAppState extends State<CupertinoApp> {
 
   @override
   Widget build(BuildContext context) {
+    final CupertinoThemeData effectiveThemeData = (widget.theme ?? const CupertinoThemeData()).resolveFrom(context);
+
     return ScrollConfiguration(
       behavior: widget.scrollBehavior ?? const CupertinoScrollBehavior(),
       child: CupertinoUserInterfaceLevel(
         data: CupertinoUserInterfaceLevelData.base,
         child: CupertinoTheme(
-          data: widget.theme ?? const CupertinoThemeData(),
-          child: HeroControllerScope(
-            controller: _heroController,
-            child: Builder(
-              builder: _buildWidgetApp,
+          data: effectiveThemeData,
+          child: DefaultSelectionStyle(
+            selectionColor: effectiveThemeData.primaryColor.withOpacity(0.2),
+            cursorColor: effectiveThemeData.primaryColor,
+            child: HeroControllerScope(
+              controller: _heroController,
+              child: Builder(
+                builder: _buildWidgetApp,
+              ),
             ),
           ),
         ),

--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -551,12 +551,10 @@ class _CupertinoAppState extends State<CupertinoApp> {
   }
 
   WidgetsApp _buildWidgetApp(BuildContext context) {
-    // Since colors can't be resolved in this context, we use the theme's
-    // primary color if it's available. Otherwise, we use the default
-    // Cupertino activeBlue.
-    //
-    // This is similiar to the logic in [MaterialApp].
-    final Color color = widget.color ?? widget.theme?.primaryColor ?? CupertinoColors.activeBlue;
+    // CupertinoTheme won't resolve colors in this context if brightness
+    // is null, so this doesn't really work.
+    final CupertinoThemeData effectiveThemeData = CupertinoTheme.of(context);
+    final Color color = CupertinoDynamicColor.resolve(widget.color ?? effectiveThemeData.primaryColor, context);
 
     if (_usesRouter) {
       return WidgetsApp.router(
@@ -626,10 +624,13 @@ class _CupertinoAppState extends State<CupertinoApp> {
       behavior: widget.scrollBehavior ?? const CupertinoScrollBehavior(),
       child: CupertinoUserInterfaceLevel(
         data: CupertinoUserInterfaceLevelData.base,
-        child: HeroControllerScope(
-          controller: _heroController,
-          child: Builder(
-            builder: _buildWidgetApp,
+        child: CupertinoTheme(
+          data: widget.theme ?? const CupertinoThemeData(),
+          child: HeroControllerScope(
+            controller: _heroController,
+            child: Builder(
+              builder: _buildWidgetApp,
+            ),
           ),
         ),
       ),

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -424,33 +424,6 @@ void main() {
 
     debugBrightnessOverride = null;
   });
-
-  testWidgets('Properties of CupertinoThemeData are effective', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      CupertinoApp(
-        theme: const CupertinoThemeData(
-          primaryColor: CupertinoColors.activeOrange,
-        ),
-        home: CupertinoPageScaffold(
-          child: Builder(
-            builder: (BuildContext context) {
-              return Text(
-                'Primary color',
-                style: TextStyle(
-                  color: CupertinoTheme.of(context).primaryColor,
-                ),
-              );
-            },
-          ),
-        ),
-      ),
-    );
-
-    final RenderParagraph paragraph = tester.renderObject(find.text('Primary color'));
-    final CupertinoDynamicColor textColor = paragraph.text.style!.color! as CupertinoDynamicColor;
-
-    expect(textColor, CupertinoColors.activeOrange);
-  });
 }
 
 class MockScrollBehavior extends ScrollBehavior {

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -373,6 +373,58 @@ void main() {
     debugBrightnessOverride = null;
   });
 
+  testWidgets('Cursor color is resolved when CupertinoThemeData.brightness is null', (WidgetTester tester) async {
+    debugBrightnessOverride = Brightness.dark;
+
+    RenderEditable findRenderEditable(WidgetTester tester) {
+      final RenderObject root = tester.renderObject(find.byType(EditableText));
+      expect(root, isNotNull);
+
+      RenderEditable? renderEditable;
+      void recursiveFinder(RenderObject child) {
+        if (child is RenderEditable) {
+          renderEditable = child;
+          return;
+        }
+        child.visitChildren(recursiveFinder);
+      }
+
+      root.visitChildren(recursiveFinder);
+      expect(renderEditable, isNotNull);
+      return renderEditable!;
+    }
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(
+          primaryColor: CupertinoColors.activeOrange,
+        ),
+        home: CupertinoPageScaffold(
+          child: Builder(
+            builder: (BuildContext context) {
+              return EditableText(
+                backgroundCursorColor: DefaultSelectionStyle.of(context).selectionColor!,
+                cursorColor: DefaultSelectionStyle.of(context).cursorColor!,
+                controller: TextEditingController(),
+                focusNode: FocusNode(),
+                style: const TextStyle(),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final RenderEditable editableText = findRenderEditable(tester);
+    final Color cursorColor = editableText.cursorColor!;
+
+    // Cursor color should be equal to the dark variant of the primary color.
+    // Alpha value needs to be 0, because cursor is not visible by default.
+    expect(cursorColor, CupertinoColors.activeOrange.darkColor.withAlpha(0));
+
+    debugBrightnessOverride = null;
+  });
+
   testWidgets('Properties of CupertinoThemeData are effective', (WidgetTester tester) async {
     await tester.pumpWidget(
       CupertinoApp(

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -347,7 +347,7 @@ void main() {
 
     final RenderParagraph paragraph = tester.renderObject(find.text('Hello'));
     final CupertinoDynamicColor textColor = paragraph.text.style!.color! as CupertinoDynamicColor;
-    
+
     // App with non-null brightness, so resolving color
     // doesn't depend on the MediaQuery.platformBrightness.
     late BuildContext capturedContext;
@@ -365,7 +365,7 @@ void main() {
         ),
       ),
     );
-    
+
     // We expect the string representations of the colors to have darkColor indicated (*) as effective color.
     // (color = Color(0xff000000), *darkColor = Color(0xffffffff)*, resolved by: Builder)
     expect(textColor.toString(), CupertinoColors.label.resolveFrom(capturedContext).toString());

--- a/packages/flutter/test/cupertino/app_test.dart
+++ b/packages/flutter/test/cupertino/app_test.dart
@@ -372,6 +372,33 @@ void main() {
 
     debugBrightnessOverride = null;
   });
+
+  testWidgets('Properties of CupertinoThemeData are effective', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      CupertinoApp(
+        theme: const CupertinoThemeData(
+          primaryColor: CupertinoColors.activeOrange,
+        ),
+        home: CupertinoPageScaffold(
+          child: Builder(
+            builder: (BuildContext context) {
+              return Text(
+                'Primary color',
+                style: TextStyle(
+                  color: CupertinoTheme.of(context).primaryColor,
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    final RenderParagraph paragraph = tester.renderObject(find.text('Primary color'));
+    final CupertinoDynamicColor textColor = paragraph.text.style!.color! as CupertinoDynamicColor;
+
+    expect(textColor, CupertinoColors.activeOrange);
+  });
 }
 
 class MockScrollBehavior extends ScrollBehavior {


### PR DESCRIPTION
In the build method of the `CupertinoApp`, `CupertinoTheme.of(context)` gets called before MediaQuery exists in the tree.

By default, every value of the `CupertinoTheme.data` gets resolved according to the `CupertinoThemeData.brightness`, but if `CupertinoThemeData.brightness` is null, `MediaQuery.maybeOf(context)?.platformBrightness` is used.
Due to the lack of `MediaQuery` in the tree, `CupertinoTheme.data` gets its values resolved against `Brightness.light`.
This causes text color to be constantly equal to black - `0xff000000`.

https://github.com/flutter/flutter/blob/8b32ac7a512b35b2b01da949ff41be814d025207/packages/flutter/lib/src/cupertino/colors.dart#L990-L994
Fixes #48438

Before / After
<img src="https://user-images.githubusercontent.com/57679865/200957641-ebd8ad75-a06e-49be-8e87-10f5baf281a1.png" width="40%"/>  <img src="https://user-images.githubusercontent.com/57679865/200957649-6175c8e1-0e10-4eff-b90c-a12d1b91a2e6.png" width="40%"/>

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
