### PR TITLE
Add an onStatusBarTap callback to Scaffolds

### DIFF
--- a/packages/flutter/lib/src/cupertino/page_scaffold.dart
+++ b/packages/flutter/lib/src/cupertino/page_scaffold.dart
@@ -38,6 +38,7 @@ class CupertinoPageScaffold extends StatefulWidget {
     this.navigationBar,
     this.backgroundColor,
     this.resizeToAvoidBottomInset = true,
+    this.onStatusBarTap,
     required this.child,
   }) : assert(child != null),
        assert(resizeToAvoidBottomInset != null);
@@ -83,6 +84,11 @@ class CupertinoPageScaffold extends StatefulWidget {
   /// Defaults to true and cannot be null.
   final bool resizeToAvoidBottomInset;
 
+  /// Optional callback that is called when the Scaffold's status bar is tapped.
+  ///
+  /// This callback is only called in iOS and macOS applications.
+  final void Function()? onStatusBarTap;
+
   @override
   State<CupertinoPageScaffold> createState() => _CupertinoPageScaffoldState();
 }
@@ -100,6 +106,8 @@ class _CupertinoPageScaffoldState extends State<CupertinoPageScaffold> {
         curve: Curves.linearToEaseOut,
       );
     }
+
+    widget.onStatusBarTap?.call();
   }
 
   @override

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -1577,6 +1577,7 @@ class Scaffold extends StatefulWidget {
     this.onDrawerChanged,
     this.endDrawer,
     this.onEndDrawerChanged,
+    this.onStatusBarTap,
     this.bottomNavigationBar,
     this.bottomSheet,
     this.backgroundColor,
@@ -1731,6 +1732,11 @@ class Scaffold extends StatefulWidget {
 
   /// Optional callback that is called when the [Scaffold.endDrawer] is opened or closed.
   final DrawerCallback? onEndDrawerChanged;
+
+  /// Optional callback that is called when the Scaffold's status bar is tapped.
+  ///
+  /// This callback is only called in iOS and macOS applications.
+  final void Function()? onStatusBarTap;
 
   /// The color to use for the scrim that obscures primary content while a drawer is open.
   ///
@@ -2544,6 +2550,8 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         curve: Curves.easeOutCirc,
       );
     }
+
+    widget.onStatusBarTap?.call();
   }
 
   // INTERNALS

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -484,6 +484,39 @@ void main() {
     expect(find.text('12'), findsNothing);
   });
 
+  testWidgets('Tapping the status bar callback test', (WidgetTester tester) async {
+    bool isStatusBarTapped = false;
+
+    await tester.pumpWidget(
+      CupertinoApp(
+        builder: (BuildContext context, Widget? child) {
+          // Acts as a 20px status bar at the root of the app.
+          return MediaQuery(
+            data: MediaQuery.of(context).copyWith(padding: const EdgeInsets.only(top: 20)),
+            child: child!,
+          );
+        },
+        home: CupertinoPageScaffold(
+          // Default nav bar is translucent.
+          navigationBar: const CupertinoNavigationBar(
+            middle: Text('Title'),
+          ),
+          onStatusBarTap: () {
+            isStatusBarTapped = true;
+          },
+          child: ListView.builder(
+            itemExtent: 50,
+            itemBuilder: (BuildContext context, int index) => Text(index.toString()),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(const Offset(100.0, 10.0));
+    await tester.pump();
+    expect(isStatusBarTapped, true);
+  });
+
   testWidgets('resizeToAvoidBottomInset is supported even when no navigationBar', (WidgetTester tester) async {
     Widget buildFrame(bool showNavigationBar, bool showKeyboard) {
       return CupertinoApp(

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -499,6 +499,78 @@ void main() {
     expect(scrollable.position.pixels, equals(500.0));
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.android }));
 
+  testWidgets('Tapping the status bar callback test', (WidgetTester tester) async {
+    bool isStatusBarTapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: debugDefaultTargetPlatformOverride),
+        home: MediaQuery(
+          data: const MediaQueryData(padding: EdgeInsets.only(top: 25.0)), // status bar
+          child: Scaffold(
+            onStatusBarTap: () {
+              isStatusBarTapped = true;
+            },
+            body: CustomScrollView(
+              primary: true,
+              slivers: <Widget>[
+                const SliverAppBar(
+                  title: Text('Title'),
+                ),
+                SliverList(
+                  delegate: SliverChildListDelegate(List<Widget>.generate(
+                    20,
+                    (int index) => SizedBox(height: 100.0, child: Text('$index')),
+                  )),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(const Offset(100.0, 10.0));
+    await tester.pump();
+    expect(isStatusBarTapped, true);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.iOS, TargetPlatform.macOS}));
+
+  testWidgets('Tapping the status bar does not callback', (WidgetTester tester) async {
+    bool isStatusBarTapped = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(platform: debugDefaultTargetPlatformOverride),
+        home: MediaQuery(
+          data: const MediaQueryData(padding: EdgeInsets.only(top: 25.0)), // status bar
+          child: Scaffold(
+            onStatusBarTap: () {
+              isStatusBarTapped = true;
+            },
+            body: CustomScrollView(
+              primary: true,
+              slivers: <Widget>[
+                const SliverAppBar(
+                  title: Text('Title'),
+                ),
+                SliverList(
+                  delegate: SliverChildListDelegate(List<Widget>.generate(
+                    20,
+                    (int index) => SizedBox(height: 100.0, child: Text('$index')),
+                  )),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tapAt(const Offset(100.0, 10.0));
+    await tester.pump();
+    expect(isStatusBarTapped, false);
+  }, variant: const TargetPlatformVariant(<TargetPlatform>{TargetPlatform.android}));
+
   testWidgets('Bottom sheet cannot overlap app bar', (WidgetTester tester) async {
     final Key sheetKey = UniqueKey();
 


### PR DESCRIPTION
Adds an onStatusBarTap callback to Material and Cupertino Scaffolds. This callback exposes the private _handleStatusBarTap() method call (which is only called in iOS and macOS applications). This serves as a workaround until the scroll to top functionality is refactored (see proposal https://github.com/flutter/flutter/issues/74727).

*List which issues are fixed by this PR. You must list at least one issue.*

- https://github.com/flutter/flutter/issues/85603
- https://github.com/flutter/flutter/issues/35050
- https://github.com/flutter/flutter/issues/96696

This callback also suffers from the hot restart bug https://github.com/flutter/flutter/issues/105975

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
