### PR TITLE
Prevent tests from producing dill files alongside the test file

### DIFF
--- a/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
+++ b/packages/flutter_tools/test/integration.shard/expression_evaluation_test.dart
@@ -116,6 +116,12 @@ void batch2() {
     );
     await flutter.waitForPause();
     await evaluateTrivialExpressions(flutter);
+
+    // Ensure we did not leave a dill file alongside the test.
+    // https://github.com/Dart-Code/Dart-Code/issues/4243.
+    final String dillFilename = '${project.testFilePath}.dill';
+    expect(fileSystem.file(dillFilename).existsSync(), isFalse);
+
     await cleanProject();
   });
 
@@ -168,6 +174,12 @@ void batch3() {
     );
     await flutter.waitForPause();
     await evaluateTrivialExpressions(flutter);
+
+    // Ensure we did not leave a dill file alongside the test.
+    // https://github.com/Dart-Code/Dart-Code/issues/4243.
+    final String dillFilename = '${project.testFilePath}.dill';
+    expect(fileSystem.file(dillFilename).existsSync(), isFalse);
+
     await cleanProject();
   });
 


### PR DESCRIPTION
My changes in #113481 to set up a compiler for expression evaluation resulted in compiling test files as part of initialisation and created unwanted `.dill` files alongside tests in the user project.

This change prevents the new code running for unit tests (where it wasn't necessary) and compiles the `mainDart` file (which is in a temporary file) instead of `testFile` in the integration test case.

@christopherfujino I don't know if there are any unwanted side-effects of compiling `mainDart` here, but in my last test this seemed to solve the bug and pass all other existing tests (and works in my local testing).

Fixes https://github.com/Dart-Code/Dart-Code/issues/4243.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
