### PR TITLE
Load assets in flutter_test without turning event loop.

### DIFF
--- a/packages/flutter/lib/src/foundation/synchronous_future.dart
+++ b/packages/flutter/lib/src/foundation/synchronous_future.dart
@@ -38,11 +38,11 @@ class SynchronousFuture<T> implements Future<T> {
 
   @override
   Future<R> then<R>(FutureOr<R> Function(T value) onValue, { Function? onError }) {
-    final dynamic result = onValue(_value);
+    final FutureOr<R> result = onValue(_value);
     if (result is Future<R>) {
       return result;
     }
-    return SynchronousFuture<R>(result as R);
+    return SynchronousFuture<R>(result);
   }
 
   @override

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -249,7 +249,7 @@ class PlatformAssetBundle extends CachingAssetBundle {
   @override
   Future<ByteData> load(String key) {
     final Uint8List encoded = utf8.encoder.convert(Uri(path: Uri.encodeFull(key)).path);
-    return ServicesBinding.instance.defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData())!.then((ByteData? asset) {
+    final Future<ByteData>? future = ServicesBinding.instance.defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData())?.then((ByteData? asset) {
       if (asset == null) {
         throw FlutterError.fromParts(<DiagnosticsNode>[
           _errorSummaryWithKey(key),
@@ -258,6 +258,13 @@ class PlatformAssetBundle extends CachingAssetBundle {
       }
       return asset;
     });
+    if (future == null) {
+      throw FlutterError.fromParts(<DiagnosticsNode>[
+          _errorSummaryWithKey(key),
+          ErrorDescription('The asset does not exist or has empty data.'),
+        ]);
+    }
+    return future;
   }
 
   @override

--- a/packages/flutter/lib/src/services/asset_bundle.dart
+++ b/packages/flutter/lib/src/services/asset_bundle.dart
@@ -247,17 +247,17 @@ abstract class CachingAssetBundle extends AssetBundle {
 /// An [AssetBundle] that loads resources using platform messages.
 class PlatformAssetBundle extends CachingAssetBundle {
   @override
-  Future<ByteData> load(String key) async {
+  Future<ByteData> load(String key) {
     final Uint8List encoded = utf8.encoder.convert(Uri(path: Uri.encodeFull(key)).path);
-    final ByteData? asset =
-        await ServicesBinding.instance.defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData());
-    if (asset == null) {
-      throw FlutterError.fromParts(<DiagnosticsNode>[
-        _errorSummaryWithKey(key),
-        ErrorDescription('The asset does not exist or has empty data.'),
-      ]);
-    }
-    return asset;
+    return ServicesBinding.instance.defaultBinaryMessenger.send('flutter/assets', encoded.buffer.asByteData())!.then((ByteData? asset) {
+      if (asset == null) {
+        throw FlutterError.fromParts(<DiagnosticsNode>[
+          _errorSummaryWithKey(key),
+          ErrorDescription('The asset does not exist or has empty data.'),
+        ]);
+      }
+      return asset;
+    });
   }
 
   @override

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as path;
 // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart' as test_package;
@@ -42,7 +42,7 @@ void mockFlutterAssets() {
   /// platform messages.
   SystemChannels.navigation.setMockMethodCallHandler((MethodCall methodCall) async {});
 
-  ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
+  ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) {
     assert(message != null);
     String key = utf8.decode(message!.buffer.asUint8List());
     File asset = File(path.join(assetFolderPath, key));
@@ -62,7 +62,7 @@ void mockFlutterAssets() {
     }
 
     final Uint8List encoded = Uint8List.fromList(asset.readAsBytesSync());
-    return Future<ByteData>.value(encoded.buffer.asByteData());
+    return SynchronousFuture<ByteData>(encoded.buffer.asByteData());
   });
 }
 

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -10,6 +10,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -89,5 +90,14 @@ void main() {
       expect(binding.clock.now(), beforeTime.add(const Duration(seconds: 1)));
       binding.idle();
     });
+  });
+
+  testWidgets('Assets in the tester can be loaded without turning event loop', (WidgetTester tester) async {
+    bool responded = false;
+    // The particular asset does not matter, as long as it exists.
+    rootBundle.load('AssetManifest.json').then((ByteData data) {
+      responded = true;
+    });
+    expect(responded, true);
   });
 }


### PR DESCRIPTION
This makes it possible to load an asset without actually turning the event loop. This is importnat because our FakeAsync zones may cause people to sprinkle in extra pumpAndSettles in when running tests that load assets, which is undesirable.

While I was here I noticed some unnecessary dynamic usage in SynchronousFuture.