### PR TITLE
Add inputFormatters in date picker dialog

### DIFF
--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -162,7 +162,7 @@ Future<DateTime?> showDatePicker({
   required DateTime initialDate,
   required DateTime firstDate,
   required DateTime lastDate,
-  DateTime? currentDate,  
+  DateTime? currentDate,
   DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar,
   SelectableDayPredicate? selectableDayPredicate,
   String? helpText,

--- a/packages/flutter/lib/src/material/date_picker.dart
+++ b/packages/flutter/lib/src/material/date_picker.dart
@@ -162,7 +162,7 @@ Future<DateTime?> showDatePicker({
   required DateTime initialDate,
   required DateTime firstDate,
   required DateTime lastDate,
-  DateTime? currentDate,
+  DateTime? currentDate,  
   DatePickerEntryMode initialEntryMode = DatePickerEntryMode.calendar,
   SelectableDayPredicate? selectableDayPredicate,
   String? helpText,
@@ -179,6 +179,7 @@ Future<DateTime?> showDatePicker({
   String? fieldHintText,
   String? fieldLabelText,
   TextInputType? keyboardType,
+  List<TextInputFormatter>? inputFormatters,
   Offset? anchorPoint,
   final ValueChanged<DatePickerEntryMode>? onDatePickerModeChange,
   final Icon? switchToInputEntryModeIcon,
@@ -221,6 +222,7 @@ Future<DateTime?> showDatePicker({
     fieldHintText: fieldHintText,
     fieldLabelText: fieldLabelText,
     keyboardType: keyboardType,
+    inputFormatters: inputFormatters,
     onDatePickerModeChange: onDatePickerModeChange,
     switchToInputEntryModeIcon: switchToInputEntryModeIcon,
     switchToCalendarEntryModeIcon: switchToCalendarEntryModeIcon,
@@ -280,6 +282,7 @@ class DatePickerDialog extends StatefulWidget {
     this.fieldHintText,
     this.fieldLabelText,
     this.keyboardType,
+    this.inputFormatters,
     this.restorationId,
     this.onDatePickerModeChange,
     this.switchToInputEntryModeIcon,
@@ -368,6 +371,9 @@ class DatePickerDialog extends StatefulWidget {
   /// If this is null, it will default to [TextInputType.datetime]
   /// {@endtemplate}
   final TextInputType? keyboardType;
+
+  /// List of TextInputFormatters of the [TextField].
+  final List<TextInputFormatter>? inputFormatters;
 
   /// Restoration ID to save and restore the state of the [DatePickerDialog].
   ///
@@ -588,6 +594,7 @@ class _DatePickerDialogState extends State<DatePickerDialog> with RestorationMix
                   fieldHintText: widget.fieldHintText,
                   fieldLabelText: widget.fieldLabelText,
                   keyboardType: widget.keyboardType,
+                  inputFormatters: widget.inputFormatters,
                   autofocus: true,
                 ),
                 const Spacer(),

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 import 'date.dart';

--- a/packages/flutter/lib/src/material/input_date_picker_form_field.dart
+++ b/packages/flutter/lib/src/material/input_date_picker_form_field.dart
@@ -57,6 +57,7 @@ class InputDatePickerFormField extends StatefulWidget {
     this.fieldHintText,
     this.fieldLabelText,
     this.keyboardType,
+    this.inputFormatters,
     this.autofocus = false,
     this.acceptEmptyDate = false,
   }) : initialDate = initialDate != null ? DateUtils.dateOnly(initialDate) : null,
@@ -127,6 +128,9 @@ class InputDatePickerFormField extends StatefulWidget {
   ///
   /// If this is null, it will default to [TextInputType.datetime]
   final TextInputType? keyboardType;
+
+  /// List of TextInputFormatters of the [TextField].
+  final List<TextInputFormatter>? inputFormatters;
 
   /// {@macro flutter.widgets.editableText.autofocus}
   final bool autofocus;
@@ -261,6 +265,7 @@ class _InputDatePickerFormFieldState extends State<InputDatePickerFormField> {
       ),
       validator: _validateDate,
       keyboardType: widget.keyboardType ?? TextInputType.datetime,
+      inputFormatters: widget.inputFormatters,
       onSaved: _handleSaved,
       onFieldSubmitted: _handleSubmitted,
       autofocus: widget.autofocus,

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -30,6 +30,7 @@ void main() {
   String? fieldLabelText;
   String? helpText;
   TextInputType? keyboardType;
+  List<TextInputFormatter>? inputFormatters;
 
   final Finder nextMonthIcon = find.byWidgetPredicate((Widget w) => w is IconButton && (w.tooltip?.startsWith('Next month') ?? false));
   final Finder previousMonthIcon = find.byWidgetPredicate((Widget w) => w is IconButton && (w.tooltip?.startsWith('Previous month') ?? false));
@@ -57,6 +58,7 @@ void main() {
     fieldLabelText = null;
     helpText = null;
     keyboardType = null;
+    inputFormatters = null;
     currentMode = initialEntryMode;
   });
 
@@ -104,6 +106,7 @@ void main() {
       fieldLabelText: fieldLabelText,
       helpText: helpText,
       keyboardType: keyboardType,
+      inputFormatters: inputFormatters,
       onDatePickerModeChange: (DatePickerEntryMode value) {
         currentMode = value;
       },
@@ -869,6 +872,14 @@ void main() {
       await prepareDatePicker(tester, (Future<DateTime?> date) async {
         final TextField field = textField(tester);
         expect(field.keyboardType, TextInputType.text);
+      });
+    });
+
+    testWidgets('InputFormatters are used', (WidgetTester tester) async {
+      inputFormatters = <TextInputFormatter>[FilteringTextInputFormatter.allow(RegExp('[a-zA-Z]'))];
+      await prepareDatePicker(tester, (Future<DateTime?> date) async {
+        final TextField field = textField(tester);
+        expect(field.inputFormatters?.length, 1);
       });
     });
 


### PR DESCRIPTION
Add inputFormatters in `showDatePicker` function to give users better customizability over the `InputDatePickerFormField`.

Issues: #115151 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above. 
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing. 

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat