### PR TITLE
[flutter roll cherry pick]Fix shrinkwrap on animated list (#115104)

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/animated_scroll_view.dart
@@ -521,6 +521,7 @@ abstract class _AnimatedScrollViewState<T extends _AnimatedScrollView> extends S
       primary: widget.primary,
       physics: widget.physics,
       clipBehavior: widget.clipBehavior,
+      shrinkWrap: widget.shrinkWrap,
       slivers: <Widget>[
         SliverPadding(
           padding: widget.padding ?? EdgeInsets.zero,

--- a/packages/flutter/test/widgets/animated_list_test.dart
+++ b/packages/flutter/test/widgets/animated_list_test.dart
@@ -488,6 +488,31 @@ void main() {
 
     expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).clipBehavior, clipBehavior);
   });
+
+  testWidgets('AnimatedList.shrinkwrap is forwarded to its inner CustomScrollView', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/115040
+    final ScrollController controller = ScrollController();
+    await tester.pumpWidget(
+      Directionality(
+        textDirection: TextDirection.ltr,
+        child: AnimatedList(
+          controller: controller,
+          initialItemCount: 2,
+          shrinkWrap: true,
+          itemBuilder: (BuildContext context, int index, Animation<double> _) {
+            return SizedBox(
+              height: 100.0,
+              child: Center(
+                child: Text('Item $index'),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    expect(tester.widget<CustomScrollView>(find.byType(CustomScrollView)).shrinkWrap, true);
+  });
 }
 
 


### PR DESCRIPTION
Fixes g3 roll failure. Will add more context later.
