### PR TITLE
Make FutureBuilder handle SynchronousFuture correctly, reland SynchronousFuture usage in test assets

### DIFF
--- a/packages/flutter/lib/src/foundation/synchronous_future.dart
+++ b/packages/flutter/lib/src/foundation/synchronous_future.dart
@@ -38,11 +38,11 @@ class SynchronousFuture<T> implements Future<T> {
 
   @override
   Future<R> then<R>(FutureOr<R> Function(T value) onValue, { Function? onError }) {
-    final dynamic result = onValue(_value);
+    final FutureOr<R> result = onValue(_value);
     if (result is Future<R>) {
       return result;
     }
-    return SynchronousFuture<R>(result as R);
+    return SynchronousFuture<R>(result);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -645,7 +645,11 @@ class _FutureBuilderState<T> extends State<FutureBuilder<T>> {
         }());
 
       });
-      _snapshot = _snapshot.inState(ConnectionState.waiting);
+      // An implementation like `SynchronousFuture` may have already called the
+      // .then closure. Do not overwrite it in that case.
+      if (_snapshot.connectionState != ConnectionState.done) {
+        _snapshot = _snapshot.inState(ConnectionState.waiting);
+      }
     }
   }
 

--- a/packages/flutter/test/widgets/async_test.dart
+++ b/packages/flutter/test/widgets/async_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -87,6 +88,20 @@ void main() {
     });
   });
   group('FutureBuilder', () {
+    testWidgets('gives expected snapshot with SynchronousFuture', (WidgetTester tester) async {
+      final SynchronousFuture<String> future = SynchronousFuture<String>('flutter');
+      await tester.pumpWidget(FutureBuilder<String>(
+        future: future,
+        builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+          expect(snapshot.connectionState, ConnectionState.done);
+          expect(snapshot.data, 'flutter');
+          expect(snapshot.error, null);
+          expect(snapshot.stackTrace, null);
+          return const Placeholder();
+        },
+      ));
+    });
+
     testWidgets('gracefully handles transition from null future', (WidgetTester tester) async {
       final GlobalKey key = GlobalKey();
       await tester.pumpWidget(FutureBuilder<String>(

--- a/packages/flutter_test/lib/src/_binding_io.dart
+++ b/packages/flutter_test/lib/src/_binding_io.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:path/path.dart' as path;
 // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart' as test_package;
@@ -42,7 +42,7 @@ void mockFlutterAssets() {
   /// platform messages.
   SystemChannels.navigation.setMockMethodCallHandler((MethodCall methodCall) async {});
 
-  ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) async {
+  ServicesBinding.instance.defaultBinaryMessenger.setMockMessageHandler('flutter/assets', (ByteData? message) {
     assert(message != null);
     String key = utf8.decode(message!.buffer.asUint8List());
     File asset = File(path.join(assetFolderPath, key));
@@ -62,7 +62,7 @@ void mockFlutterAssets() {
     }
 
     final Uint8List encoded = Uint8List.fromList(asset.readAsBytesSync());
-    return Future<ByteData>.value(encoded.buffer.asByteData());
+    return SynchronousFuture<ByteData>(encoded.buffer.asByteData());
   });
 }
 

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -10,6 +10,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -89,5 +90,14 @@ void main() {
       expect(binding.clock.now(), beforeTime.add(const Duration(seconds: 1)));
       binding.idle();
     });
+  });
+
+  testWidgets('Assets in the tester can be loaded without turning event loop', (WidgetTester tester) async {
+    bool responded = false;
+    // The particular asset does not matter, as long as it exists.
+    rootBundle.load('AssetManifest.json').then((ByteData data) {
+      responded = true;
+    });
+    expect(responded, true);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/115171

Allows reland of https://github.com/flutter/flutter/pull/115156