### PR TITLE
Revert "[web] Add `--local-web-sdk` flag and use precompiled platform kernels for dart2js and ddc"

### DIFF
--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -277,22 +277,22 @@ class AndroidGradleBuilder implements AndroidBuilder {
     if (!buildInfo.androidGradleDaemon) {
       command.add('--no-daemon');
     }
-    final LocalEngineInfo? localEngineInfo = _artifacts.localEngineInfo;
-    if (localEngineInfo != null) {
+    if (_artifacts is LocalEngineArtifacts) {
+      final LocalEngineArtifacts localEngineArtifacts = _artifacts as LocalEngineArtifacts;
       final Directory localEngineRepo = _getLocalEngineRepo(
-        engineOutPath: localEngineInfo.engineOutPath,
+        engineOutPath: localEngineArtifacts.engineOutPath,
         androidBuildInfo: androidBuildInfo,
         fileSystem: _fileSystem,
       );
       _logger.printTrace(
-          'Using local engine: ${localEngineInfo.engineOutPath}\n'
+          'Using local engine: ${localEngineArtifacts.engineOutPath}\n'
               'Local Maven repo: ${localEngineRepo.path}'
       );
       command.add('-Plocal-engine-repo=${localEngineRepo.path}');
       command.add('-Plocal-engine-build-mode=${buildInfo.modeName}');
-      command.add('-Plocal-engine-out=${localEngineInfo.engineOutPath}');
+      command.add('-Plocal-engine-out=${localEngineArtifacts.engineOutPath}');
       command.add('-Ptarget-platform=${_getTargetPlatformByLocalEnginePath(
-          localEngineInfo.engineOutPath)}');
+          localEngineArtifacts.engineOutPath)}');
     } else if (androidBuildInfo.targetArchs.isNotEmpty) {
       final String targetPlatforms = androidBuildInfo
           .targetArchs
@@ -611,20 +611,20 @@ class AndroidGradleBuilder implements AndroidBuilder {
       );
     }
 
-    final LocalEngineInfo? localEngineInfo = _artifacts.localEngineInfo;
-    if (localEngineInfo != null) {
+    if (_artifacts is LocalEngineArtifacts) {
+      final LocalEngineArtifacts localEngineArtifacts = _artifacts as LocalEngineArtifacts;
       final Directory localEngineRepo = _getLocalEngineRepo(
-        engineOutPath: localEngineInfo.engineOutPath,
+        engineOutPath: localEngineArtifacts.engineOutPath,
         androidBuildInfo: androidBuildInfo,
         fileSystem: _fileSystem,
       );
       _logger.printTrace(
-        'Using local engine: ${localEngineInfo.engineOutPath}\n'
+        'Using local engine: ${localEngineArtifacts.engineOutPath}\n'
         'Local Maven repo: ${localEngineRepo.path}'
       );
       command.add('-Plocal-engine-repo=${localEngineRepo.path}');
       command.add('-Plocal-engine-build-mode=${buildInfo.modeName}');
-      command.add('-Plocal-engine-out=${localEngineInfo.engineOutPath}');
+      command.add('-Plocal-engine-out=${localEngineArtifacts.engineOutPath}');
 
       // Copy the local engine repo in the output directory.
       try {
@@ -639,7 +639,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
         );
       }
       command.add('-Ptarget-platform=${_getTargetPlatformByLocalEnginePath(
-          localEngineInfo.engineOutPath)}');
+          localEngineArtifacts.engineOutPath)}');
     } else if (androidBuildInfo.targetArchs.isNotEmpty) {
       final String targetPlatforms = androidBuildInfo.targetArchs
           .map(getPlatformNameForAndroidArch).join(',');

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -72,15 +72,6 @@ enum HostArtifact {
   /// The summary dill with null safety enabled for the dartdevc target.
   webPlatformSoundKernelDill,
 
-  /// Folder that contains platform dill files for autodetect web renderer.
-  webPlatformAutoDillDirectory,
-
-  /// Folder that contains platform dill files for html web renderer.
-  webPlatformHtmlDillDirectory,
-
-  /// Folder that contains platform dill files for canvaskit web renderer.
-  webPlatformCanvasKitDillDirectory,
-
   /// The precompiled SDKs and sourcemaps for web debug builds.
   webPrecompiledSdk,
   webPrecompiledSdkSourcemaps,
@@ -248,12 +239,6 @@ String _hostArtifactToFileName(HostArtifact artifact, Platform platform) {
       return 'flutter_ddc_sdk.dill';
     case HostArtifact.webPlatformSoundKernelDill:
       return 'flutter_ddc_sdk_sound.dill';
-    case HostArtifact.webPlatformAutoDillDirectory:
-      return 'auto';
-    case HostArtifact.webPlatformHtmlDillDirectory:
-      return 'html';
-    case HostArtifact.webPlatformCanvasKitDillDirectory:
-      return 'canvaskit';
     case HostArtifact.flutterWebLibrariesJson:
       return 'libraries.json';
     case HostArtifact.webPrecompiledSdk:
@@ -281,23 +266,11 @@ class EngineBuildPaths {
   const EngineBuildPaths({
     required this.targetEngine,
     required this.hostEngine,
-    required this.webSdk,
-  });
+  }) : assert(targetEngine != null),
+       assert(hostEngine != null);
 
-  final String? targetEngine;
-  final String? hostEngine;
-  final String? webSdk;
-}
-
-/// Information about a local engine build
-class LocalEngineInfo {
-  const LocalEngineInfo({
-    required this.engineOutPath,
-    required this.localEngineName,
-  });
-
-  final String engineOutPath;
-  final String localEngineName;
+  final String targetEngine;
+  final String hostEngine;
 }
 
 // Manages the engine artifacts of Flutter.
@@ -316,35 +289,16 @@ abstract class Artifacts {
     return _TestArtifacts(fileSystem);
   }
 
-  static Artifacts getLocalEngine(EngineBuildPaths engineBuildPaths) {
-    Artifacts artifacts = CachedArtifacts(
-      fileSystem: globals.fs,
-      platform: globals.platform,
+  static LocalEngineArtifacts getLocalEngine(EngineBuildPaths engineBuildPaths) {
+    return LocalEngineArtifacts(
+      engineBuildPaths.targetEngine,
+      engineBuildPaths.hostEngine,
       cache: globals.cache,
-      operatingSystemUtils: globals.os
+      fileSystem: globals.fs,
+      processManager: globals.processManager,
+      platform: globals.platform,
+      operatingSystemUtils: globals.os,
     );
-    if (engineBuildPaths.hostEngine != null && engineBuildPaths.targetEngine != null) {
-      artifacts = CachedLocalEngineArtifacts(
-        engineBuildPaths.hostEngine!,
-        engineOutPath: engineBuildPaths.targetEngine!,
-        cache: globals.cache,
-        fileSystem: globals.fs,
-        processManager: globals.processManager,
-        platform: globals.platform,
-        operatingSystemUtils: globals.os,
-        parent: artifacts,
-      );
-    }
-    if (engineBuildPaths.webSdk != null) {
-      artifacts = CachedLocalWebSdkArtifacts(
-        parent: artifacts,
-        webSdkPath: engineBuildPaths.webSdk!,
-        fileSystem: globals.fs,
-        platform: globals.platform,
-        operatingSystemUtils: globals.os
-      );
-    }
-    return artifacts;
   }
 
   /// Returns the requested [artifact] for the [platform], [mode], and [environmentType] combination.
@@ -367,10 +321,6 @@ abstract class Artifacts {
 
   /// Whether these artifacts correspond to a non-versioned local engine.
   bool get isLocalEngine;
-
-  /// If these artifacts are bound to a local engine build, returns info about
-  /// the location and name of the local engine, otherwise returns null.
-  LocalEngineInfo? get localEngineInfo;
 }
 
 /// Manages the engine artifacts downloaded to the local cache.
@@ -389,9 +339,6 @@ class CachedArtifacts implements Artifacts {
   final Platform _platform;
   final Cache _cache;
   final OperatingSystemUtils _operatingSystemUtils;
-
-  @override
-  LocalEngineInfo? get localEngineInfo => null;
 
   @override
   FileSystemEntity getHostArtifact(
@@ -416,13 +363,6 @@ class CachedArtifacts implements Artifacts {
       case HostArtifact.webPlatformSoundKernelDill:
         final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', _hostArtifactToFileName(artifact, _platform));
         return _fileSystem.file(path);
-
-      case HostArtifact.webPlatformAutoDillDirectory:
-      case HostArtifact.webPlatformHtmlDillDirectory:
-      case HostArtifact.webPlatformCanvasKitDillDirectory:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'platforms', _hostArtifactToFileName(artifact, _platform));
-        return _fileSystem.file(path);
-
       case HostArtifact.webPrecompiledSdk:
       case HostArtifact.webPrecompiledSdkSourcemaps:
         final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd', _hostArtifactToFileName(artifact, _platform));
@@ -782,37 +722,43 @@ String _getIosEngineArtifactPath(String engineDirectory,
       .path;
 }
 
-/// Manages the artifacts of a locally built engine.
-class CachedLocalEngineArtifacts implements Artifacts {
-  CachedLocalEngineArtifacts(
-    this._hostEngineOutPath, {
-    required String engineOutPath,
+abstract class LocalEngineArtifacts implements Artifacts {
+  factory LocalEngineArtifacts(String engineOutPath, String hostEngineOutPath, {
     required FileSystem fileSystem,
     required Cache cache,
     required ProcessManager processManager,
     required Platform platform,
     required OperatingSystemUtils operatingSystemUtils,
-    Artifacts? parent,
+  }) = CachedLocalEngineArtifacts;
+
+  String get engineOutPath;
+
+  String get localEngineName;
+}
+
+/// Manages the artifacts of a locally built engine.
+class CachedLocalEngineArtifacts implements LocalEngineArtifacts {
+  CachedLocalEngineArtifacts(
+    this.engineOutPath,
+    this._hostEngineOutPath, {
+    required FileSystem fileSystem,
+    required Cache cache,
+    required ProcessManager processManager,
+    required Platform platform,
+    required OperatingSystemUtils operatingSystemUtils,
   }) : _fileSystem = fileSystem,
-       localEngineInfo =
-         LocalEngineInfo(
-           engineOutPath: engineOutPath,
-           localEngineName: fileSystem.path.basename(engineOutPath)
-         ),
+       localEngineName = fileSystem.path.basename(engineOutPath),
        _cache = cache,
        _processManager = processManager,
        _platform = platform,
        _operatingSystemUtils = operatingSystemUtils,
-       _backupCache = parent ??
-         CachedArtifacts(
-           fileSystem: fileSystem,
-           platform: platform,
-           cache: cache,
-           operatingSystemUtils: operatingSystemUtils
-         );
+       _backupCache = CachedArtifacts(fileSystem: fileSystem, platform: platform, cache: cache, operatingSystemUtils: operatingSystemUtils);
 
   @override
-  final LocalEngineInfo localEngineInfo;
+  final String engineOutPath;
+
+  @override
+  final String localEngineName;
 
   final String _hostEngineOutPath;
   final FileSystem _fileSystem;
@@ -820,7 +766,7 @@ class CachedLocalEngineArtifacts implements Artifacts {
   final ProcessManager _processManager;
   final Platform _platform;
   final OperatingSystemUtils _operatingSystemUtils;
-  final Artifacts _backupCache;
+  final CachedArtifacts _backupCache;
 
   @override
   FileSystemEntity getHostArtifact(HostArtifact artifact) {
@@ -851,11 +797,6 @@ class CachedLocalEngineArtifacts implements Artifacts {
         return _fileSystem.file(path);
       case HostArtifact.webPlatformSoundKernelDill:
         final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', _hostArtifactToFileName(artifact, _platform));
-        return _fileSystem.file(path);
-      case HostArtifact.webPlatformAutoDillDirectory:
-      case HostArtifact.webPlatformHtmlDillDirectory:
-      case HostArtifact.webPlatformCanvasKitDillDirectory:
-        final String path = _fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'platforms', _hostArtifactToFileName(artifact, _platform));
         return _fileSystem.file(path);
       case HostArtifact.webPrecompiledSdk:
       case HostArtifact.webPrecompiledSdkSourcemaps:
@@ -924,28 +865,28 @@ class CachedLocalEngineArtifacts implements Artifacts {
         return _flutterTesterPath(platform!);
       case Artifact.isolateSnapshotData:
       case Artifact.vmSnapshotData:
-        return _fileSystem.path.join(localEngineInfo.engineOutPath, 'gen', 'flutter', 'lib', 'snapshot', artifactFileName);
+        return _fileSystem.path.join(engineOutPath, 'gen', 'flutter', 'lib', 'snapshot', artifactFileName);
       case Artifact.icuData:
       case Artifact.flutterXcframework:
       case Artifact.flutterMacOSFramework:
-        return _fileSystem.path.join(localEngineInfo.engineOutPath, artifactFileName);
+        return _fileSystem.path.join(engineOutPath, artifactFileName);
       case Artifact.platformKernelDill:
         if (platform == TargetPlatform.fuchsia_x64 || platform == TargetPlatform.fuchsia_arm64) {
-          return _fileSystem.path.join(localEngineInfo.engineOutPath, 'flutter_runner_patched_sdk', artifactFileName);
+          return _fileSystem.path.join(engineOutPath, 'flutter_runner_patched_sdk', artifactFileName);
         }
         return _fileSystem.path.join(_getFlutterPatchedSdkPath(mode), artifactFileName);
       case Artifact.platformLibrariesJson:
         return _fileSystem.path.join(_getFlutterPatchedSdkPath(mode), 'lib', artifactFileName);
       case Artifact.flutterFramework:
         return _getIosEngineArtifactPath(
-            localEngineInfo.engineOutPath, environmentType, _fileSystem);
+            engineOutPath, environmentType, _fileSystem);
       case Artifact.flutterPatchedSdkPath:
         // When using local engine always use [BuildMode.debug] regardless of
         // what was specified in [mode] argument because local engine will
         // have only one flutter_patched_sdk in standard location, that
         // is happen to be what debug(non-release) mode is using.
         if (platform == TargetPlatform.fuchsia_x64 || platform == TargetPlatform.fuchsia_arm64) {
-          return _fileSystem.path.join(localEngineInfo.engineOutPath, 'flutter_runner_patched_sdk');
+          return _fileSystem.path.join(engineOutPath, 'flutter_runner_patched_sdk');
         }
         return _getFlutterPatchedSdkPath(BuildMode.debug);
       case Artifact.skyEnginePath:
@@ -954,11 +895,11 @@ class CachedLocalEngineArtifacts implements Artifacts {
         final String hostPlatform = getNameForHostPlatform(getCurrentHostPlatform());
         final String modeName = mode!.isRelease ? 'release' : mode.toString();
         final String dartBinaries = 'dart_binaries-$modeName-$hostPlatform';
-        return _fileSystem.path.join(localEngineInfo.engineOutPath, 'host_bundle', dartBinaries, 'kernel_compiler.dart.snapshot');
+        return _fileSystem.path.join(engineOutPath, 'host_bundle', dartBinaries, 'kernel_compiler.dart.snapshot');
       case Artifact.fuchsiaFlutterRunner:
         final String jitOrAot = mode!.isJit ? '_jit' : '_aot';
         final String productOrNo = mode.isRelease ? '_product' : '';
-        return _fileSystem.path.join(localEngineInfo.engineOutPath, 'flutter$jitOrAot${productOrNo}_runner-0.far');
+        return _fileSystem.path.join(engineOutPath, 'flutter$jitOrAot${productOrNo}_runner-0.far');
       case Artifact.fontSubset:
         return _fileSystem.path.join(_hostEngineOutPath, artifactFileName);
       case Artifact.constFinder:
@@ -977,11 +918,11 @@ class CachedLocalEngineArtifacts implements Artifacts {
 
   @override
   String getEngineType(TargetPlatform platform, [ BuildMode? mode ]) {
-    return _fileSystem.path.basename(localEngineInfo.engineOutPath);
+    return _fileSystem.path.basename(engineOutPath);
   }
 
   String _getFlutterPatchedSdkPath(BuildMode? buildMode) {
-    return _fileSystem.path.join(localEngineInfo.engineOutPath,
+    return _fileSystem.path.join(engineOutPath,
         buildMode == BuildMode.release ? 'flutter_patched_sdk_product' : 'flutter_patched_sdk');
   }
 
@@ -1031,14 +972,14 @@ class CachedLocalEngineArtifacts implements Artifacts {
   }
 
   String _getFlutterWebSdkPath() {
-    return _fileSystem.path.join(localEngineInfo.engineOutPath, 'flutter_web_sdk');
+    return _fileSystem.path.join(engineOutPath, 'flutter_web_sdk');
   }
 
   String _genSnapshotPath() {
     const List<String> clangDirs = <String>['.', 'clang_x64', 'clang_x86', 'clang_i386', 'clang_arm64'];
     final String genSnapshotName = _artifactToFileName(Artifact.genSnapshot)!;
     for (final String clangDir in clangDirs) {
-      final String genSnapshotPath = _fileSystem.path.join(localEngineInfo.engineOutPath, clangDir, genSnapshotName);
+      final String genSnapshotPath = _fileSystem.path.join(engineOutPath, clangDir, genSnapshotName);
       if (_processManager.canRun(genSnapshotPath)) {
         return genSnapshotPath;
       }
@@ -1048,171 +989,17 @@ class CachedLocalEngineArtifacts implements Artifacts {
 
   String _flutterTesterPath(TargetPlatform platform) {
     if (_platform.isLinux) {
-      return _fileSystem.path.join(localEngineInfo.engineOutPath, _artifactToFileName(Artifact.flutterTester));
+      return _fileSystem.path.join(engineOutPath, _artifactToFileName(Artifact.flutterTester));
     } else if (_platform.isMacOS) {
-      return _fileSystem.path.join(localEngineInfo.engineOutPath, 'flutter_tester');
+      return _fileSystem.path.join(engineOutPath, 'flutter_tester');
     } else if (_platform.isWindows) {
-      return _fileSystem.path.join(localEngineInfo.engineOutPath, 'flutter_tester.exe');
+      return _fileSystem.path.join(engineOutPath, 'flutter_tester.exe');
     }
     throw Exception('Unsupported platform $platform.');
   }
 
   @override
   bool get isLocalEngine => true;
-}
-
-class CachedLocalWebSdkArtifacts implements Artifacts {
-  CachedLocalWebSdkArtifacts({
-    required this.parent,
-    required this.webSdkPath,
-    required this.fileSystem,
-    required this.platform,
-    required this.operatingSystemUtils
-  });
-
-  final Artifacts parent;
-  final String webSdkPath;
-  final FileSystem fileSystem;
-  final Platform platform;
-  final OperatingSystemUtils operatingSystemUtils;
-
-  @override
-  String getArtifactPath(Artifact artifact, {TargetPlatform? platform, BuildMode? mode, EnvironmentType? environmentType}) {
-    if (platform == TargetPlatform.web_javascript) {
-      if (artifact == Artifact.frontendServerSnapshotForEngineDartSdk) {
-        return fileSystem.path.join(
-          _getDartSdkPath(), 'bin', 'snapshots',
-          _artifactToFileName(artifact, platform, mode),
-        );
-      } else {
-        throw Exception('Unable to find artifact path for $artifact in local web sdk.');
-      }
-    }
-    return parent.getArtifactPath(artifact, platform: platform, mode: mode, environmentType: environmentType);
-  }
-
-  @override
-  String getEngineType(TargetPlatform platform, [BuildMode? mode]) => parent.getEngineType(platform, mode);
-
-  @override
-  FileSystemEntity getHostArtifact(HostArtifact artifact) {
-    switch (artifact) {
-      case HostArtifact.engineDartSdkPath:
-        final String path = _getDartSdkPath();
-        return fileSystem.directory(path);
-      case HostArtifact.engineDartBinary:
-        final String path = fileSystem.path.join(_getDartSdkPath(), 'bin', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.dart2jsSnapshot:
-        final String path = fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.dartdevcSnapshot:
-        final String path = fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.kernelWorkerSnapshot:
-        final String path = fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.flutterWebSdk:
-        final String path = _getFlutterWebSdkPath();
-        return fileSystem.directory(path);
-      case HostArtifact.flutterWebLibrariesJson:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPlatformKernelDill:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPlatformSoundKernelDill:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPlatformAutoDillDirectory:
-      case HostArtifact.webPlatformHtmlDillDirectory:
-      case HostArtifact.webPlatformCanvasKitDillDirectory:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'platforms', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPrecompiledSdk:
-      case HostArtifact.webPrecompiledSdkSourcemaps:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPrecompiledCanvaskitSdk:
-      case HostArtifact.webPrecompiledCanvaskitSdkSourcemaps:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd-canvaskit', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPrecompiledCanvaskitAndHtmlSdk:
-      case HostArtifact.webPrecompiledCanvaskitAndHtmlSdkSourcemaps:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd-canvaskit-html', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPrecompiledSoundSdk:
-      case HostArtifact.webPrecompiledSoundSdkSourcemaps:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd-sound', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPrecompiledCanvaskitSoundSdk:
-      case HostArtifact.webPrecompiledCanvaskitSoundSdkSourcemaps:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd-canvaskit-sound', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.webPrecompiledCanvaskitAndHtmlSoundSdk:
-      case HostArtifact.webPrecompiledCanvaskitAndHtmlSoundSdkSourcemaps:
-        final String path = fileSystem.path.join(_getFlutterWebSdkPath(), 'kernel', 'amd-canvaskit-html-sound', _hostArtifactToFileName(artifact, platform));
-        return fileSystem.file(path);
-      case HostArtifact.iosDeploy:
-      case HostArtifact.idevicesyslog:
-      case HostArtifact.idevicescreenshot:
-      case HostArtifact.iproxy:
-      case HostArtifact.skyEnginePath:
-      case HostArtifact.impellerc:
-      case HostArtifact.libtessellator:
-        return parent.getHostArtifact(artifact);
-    }
-  }
-
-  String _getDartSdkPath() {
-    // If we couldn't find a built dart sdk, let's look for a prebuilt one.
-    final String prebuiltPath = fileSystem.path.join(_getFlutterPrebuiltsPath(), _getPrebuiltTarget(), 'dart-sdk');
-    if (fileSystem.isDirectorySync(prebuiltPath)) {
-      return prebuiltPath;
-    }
-
-    throw ToolExit('Unable to find a prebuilt dart sdk at: "$prebuiltPath"');
-  }
-
-  String _getFlutterPrebuiltsPath() {
-    final String engineSrcPath = fileSystem.path.dirname(fileSystem.path.dirname(webSdkPath));
-    return fileSystem.path.join(engineSrcPath, 'flutter', 'prebuilts');
-  }
-
-  String _getPrebuiltTarget() {
-    final TargetPlatform hostPlatform = _currentHostPlatform(platform, operatingSystemUtils);
-    switch (hostPlatform) {
-      case TargetPlatform.darwin:
-        return 'macos-x64';
-      case TargetPlatform.linux_arm64:
-        return 'linux-arm64';
-      case TargetPlatform.linux_x64:
-        return 'linux-x64';
-      case TargetPlatform.windows_x64:
-        return 'windows-x64';
-      case TargetPlatform.ios:
-      case TargetPlatform.android:
-      case TargetPlatform.android_arm:
-      case TargetPlatform.android_arm64:
-      case TargetPlatform.android_x64:
-      case TargetPlatform.android_x86:
-      case TargetPlatform.fuchsia_arm64:
-      case TargetPlatform.fuchsia_x64:
-      case TargetPlatform.web_javascript:
-      case TargetPlatform.tester:
-        throwToolExit('Unsupported host platform: $hostPlatform');
-    }
-  }
-
-  String _getFlutterWebSdkPath() {
-    return fileSystem.path.join(webSdkPath, 'flutter_web_sdk');
-  }
-
-  @override
-  bool get isLocalEngine => parent.isLocalEngine;
-
-  @override
-  LocalEngineInfo? get localEngineInfo => parent.localEngineInfo;
 }
 
 /// An implementation of [Artifacts] that provides individual overrides.
@@ -1235,9 +1022,6 @@ class OverrideArtifacts implements Artifacts {
   final File? engineDartBinary;
   final File? platformKernelDill;
   final File? flutterPatchedSdk;
-
-  @override
-  LocalEngineInfo? get localEngineInfo => parent.localEngineInfo;
 
   @override
   String getArtifactPath(
@@ -1291,9 +1075,6 @@ class _TestArtifacts implements Artifacts {
   final FileSystem fileSystem;
 
   @override
-  LocalEngineInfo? get localEngineInfo => null;
-
-  @override
   String getArtifactPath(
     Artifact artifact, {
     TargetPlatform? platform,
@@ -1328,17 +1109,15 @@ class _TestArtifacts implements Artifacts {
   }
 }
 
-class _TestLocalEngine extends _TestArtifacts {
-  _TestLocalEngine(String engineOutPath, super.fileSystem) :
-    localEngineInfo =
-      LocalEngineInfo(
-        engineOutPath: engineOutPath,
-        localEngineName: fileSystem.path.basename(engineOutPath)
-      );
+class _TestLocalEngine extends _TestArtifacts implements LocalEngineArtifacts {
+  _TestLocalEngine(this.engineOutPath, FileSystem fileSystem) : super(fileSystem);
 
   @override
   bool get isLocalEngine => true;
 
   @override
-  final LocalEngineInfo localEngineInfo;
+  final String engineOutPath;
+
+  @override
+  String get localEngineName => fileSystem.path.basename(engineOutPath);
 }

--- a/packages/flutter_tools/lib/src/base/user_messages.dart
+++ b/packages/flutter_tools/lib/src/base/user_messages.dart
@@ -310,12 +310,10 @@ class UserMessages {
       'Unable to detect a Flutter engine build directory in $engineSourcePath.\n'
       "Please ensure that $engineSourcePath is a Flutter engine 'src' directory and that "
       "you have compiled the engine in that directory, which should produce an 'out' directory";
-  String get runnerLocalEngineOrWebSdkRequired =>
-      'You must specify --local-engine or --local-web-sdk if you are using a locally built engine or web sdk.';
+  String get runnerLocalEngineRequired =>
+      'You must specify --local-engine if you are using a locally built engine.';
   String runnerNoEngineBuild(String engineBuildPath) =>
       'No Flutter engine build found at $engineBuildPath.';
-  String runnerNoWebSdk(String webSdkPath) =>
-      'No Flutter web sdk found at $webSdkPath.';
   String runnerWrongFlutterInstance(String flutterRoot, String currentDir) =>
       "Warning: the 'flutter' tool you are currently running is not the one from the current directory:\n"
       '  running Flutter  : $flutterRoot\n'

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -13,7 +13,6 @@ import 'base/os.dart';
 import 'base/utils.dart';
 import 'convert.dart';
 import 'globals.dart' as globals;
-import 'web/compile.dart';
 
 /// Whether icon font subsetting is enabled by default.
 const bool kIconTreeShakerEnabledDefault = true;
@@ -36,7 +35,6 @@ class BuildInfo {
     List<String>? dartDefines,
     this.bundleSkSLPath,
     List<String>? dartExperiments,
-    this.webRenderer = WebRendererMode.autoDetect,
     required this.treeShakeIcons,
     this.performanceMeasurementFile,
     this.dartDefineConfigJsonMap,
@@ -125,9 +123,6 @@ class BuildInfo {
 
   /// A list of Dart experiments.
   final List<String> dartExperiments;
-
-  /// When compiling to web, which web renderer mode we are using (html, canvaskit, auto)
-  final WebRendererMode webRenderer;
 
   /// The name of a file where flutter assemble will output performance
   /// information in a JSON format.
@@ -611,9 +606,8 @@ List<DarwinArch> defaultIOSArchsForEnvironment(
   Artifacts artifacts,
 ) {
   // Handle single-arch local engines.
-  final LocalEngineInfo? localEngineInfo = artifacts.localEngineInfo;
-  if (localEngineInfo != null) {
-    final String localEngineName = localEngineInfo.localEngineName;
+  if (artifacts is LocalEngineArtifacts) {
+    final String localEngineName = artifacts.localEngineName;
     if (localEngineName.contains('_arm64')) {
       return <DarwinArch>[ DarwinArch.arm64 ];
     }
@@ -634,9 +628,8 @@ List<DarwinArch> defaultIOSArchsForEnvironment(
 /// The default set of macOS device architectures to build for.
 List<DarwinArch> defaultMacOSArchsForEnvironment(Artifacts artifacts) {
   // Handle single-arch local engines.
-  final LocalEngineInfo? localEngineInfo = artifacts.localEngineInfo;
-  if (localEngineInfo != null) {
-    if (localEngineInfo.localEngineName.contains('_arm64')) {
+  if (artifacts is LocalEngineArtifacts) {
+    if (artifacts.localEngineName.contains('_arm64')) {
       return <DarwinArch>[ DarwinArch.arm64 ];
     }
     return <DarwinArch>[ DarwinArch.x86_64 ];
@@ -860,17 +853,6 @@ HostPlatform getCurrentHostPlatform() {
   globals.printWarning('Unsupported host platform, defaulting to Linux');
 
   return HostPlatform.linux_x64;
-}
-
-FileSystemEntity getWebPlatformBinariesDirectory(Artifacts artifacts, WebRendererMode webRenderer) {
-  switch (webRenderer) {
-    case WebRendererMode.autoDetect:
-      return artifacts.getHostArtifact(HostArtifact.webPlatformAutoDillDirectory);
-    case WebRendererMode.canvaskit:
-      return artifacts.getHostArtifact(HostArtifact.webPlatformCanvasKitDillDirectory);
-    case WebRendererMode.html:
-      return artifacts.getHostArtifact(HostArtifact.webPlatformHtmlDillDirectory);
-  }
 }
 
 /// Returns the top-level build output directory.

--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -18,7 +18,6 @@ import '../../dart/package_map.dart';
 import '../../flutter_plugins.dart';
 import '../../globals.dart' as globals;
 import '../../project.dart';
-import '../../web/compile.dart';
 import '../../web/file_generators/flutter_js.dart' as flutter_js;
 import '../../web/file_generators/flutter_service_worker_js.dart';
 import '../../web/file_generators/main_dart.dart' as main_dart;
@@ -136,9 +135,7 @@ class WebEntrypointTarget extends Target {
 
 /// Compiles a web entry point with dart2js.
 class Dart2JSTarget extends Target {
-  const Dart2JSTarget(this.webRenderer);
-
-  final WebRendererMode webRenderer;
+  const Dart2JSTarget();
 
   @override
   String get name => 'dart2js';
@@ -186,12 +183,12 @@ class Dart2JSTarget extends Target {
     final bool sourceMapsEnabled = environment.defines[kSourceMapsEnabled] == 'true';
     final bool nativeNullAssertions = environment.defines[kNativeNullAssertions] == 'true';
     final Artifacts artifacts = globals.artifacts!;
-    final String platformBinariesPath = getWebPlatformBinariesDirectory(artifacts, webRenderer).path;
+    final String librariesSpec = (artifacts.getHostArtifact(HostArtifact.flutterWebSdk) as Directory).childFile('libraries.json').path;
     final List<String> sharedCommandOptions = <String>[
       artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,
       '--disable-dart-dev',
       artifacts.getHostArtifact(HostArtifact.dart2jsSnapshot).path,
-      '--platform-binaries=$platformBinariesPath',
+      '--libraries-spec=$librariesSpec',
       ...decodeCommaSeparated(environment.defines, kExtraFrontEndOptions),
       if (nativeNullAssertions)
         '--native-null-assertions',
@@ -259,16 +256,14 @@ class Dart2JSTarget extends Target {
 
 /// Unpacks the dart2js compilation and resources to a given output directory.
 class WebReleaseBundle extends Target {
-  const WebReleaseBundle(this.webRenderer);
-
-  final WebRendererMode webRenderer;
+  const WebReleaseBundle();
 
   @override
   String get name => 'web_release_bundle';
 
   @override
-  List<Target> get dependencies => <Target>[
-    Dart2JSTarget(webRenderer),
+  List<Target> get dependencies => const <Target>[
+    Dart2JSTarget(),
   ];
 
   @override
@@ -446,19 +441,18 @@ class WebBuiltInAssets extends Target {
 
 /// Generate a service worker for a web target.
 class WebServiceWorker extends Target {
-  const WebServiceWorker(this.fileSystem, this.cache, this.webRenderer);
+  const WebServiceWorker(this.fileSystem, this.cache);
 
   final FileSystem fileSystem;
   final Cache cache;
-  final WebRendererMode webRenderer;
 
   @override
   String get name => 'web_service_worker';
 
   @override
   List<Target> get dependencies => <Target>[
-    Dart2JSTarget(webRenderer),
-    WebReleaseBundle(webRenderer),
+    const Dart2JSTarget(),
+    const WebReleaseBundle(),
     WebBuiltInAssets(fileSystem, cache),
   ];
 

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -18,6 +18,7 @@ import '../build_system/targets/deferred_components.dart';
 import '../build_system/targets/ios.dart';
 import '../build_system/targets/linux.dart';
 import '../build_system/targets/macos.dart';
+import '../build_system/targets/web.dart';
 import '../build_system/targets/windows.dart';
 import '../cache.dart';
 import '../convert.dart';
@@ -47,6 +48,8 @@ List<Target> _kDefaultTargets = <Target>[
   const ProfileBundleLinuxAssets(TargetPlatform.linux_arm64),
   const ReleaseBundleLinuxAssets(TargetPlatform.linux_x64),
   const ReleaseBundleLinuxAssets(TargetPlatform.linux_arm64),
+  // Web targets
+  WebServiceWorker(globals.fs, globals.cache),
   const ReleaseAndroidApplication(),
   // This is a one-off rule for bundle and aot compat.
   const CopyFlutterBundle(),

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -741,8 +741,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     {String? additionalSourceUri}
   ) async {
     final String frontendServer = _artifacts.getArtifactPath(
-      Artifact.frontendServerSnapshotForEngineDartSdk,
-      platform: (targetModel == TargetModel.dartdevc) ? TargetPlatform.web_javascript : null,
+      Artifact.frontendServerSnapshotForEngineDartSdk
     );
     final List<String> command = <String>[
       _artifacts.getHostArtifact(HostArtifact.engineDartBinary).path,

--- a/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
+++ b/packages/flutter_tools/lib/src/ios/xcode_build_settings.dart
@@ -170,12 +170,13 @@ Future<List<String>> _xcodeBuildSettingsLines({
   final String buildNumber = parsedBuildNumber(manifest: project.manifest, buildInfo: buildInfo) ?? '1';
   xcodeBuildSettings.add('FLUTTER_BUILD_NUMBER=$buildNumber');
 
-  final LocalEngineInfo? localEngineInfo = globals.artifacts?.localEngineInfo;
-  if (localEngineInfo != null) {
-    final String engineOutPath = localEngineInfo.engineOutPath;
+  final Artifacts? artifacts = globals.artifacts;
+  if (artifacts is LocalEngineArtifacts) {
+    final LocalEngineArtifacts localEngineArtifacts = artifacts;
+    final String engineOutPath = localEngineArtifacts.engineOutPath;
     xcodeBuildSettings.add('FLUTTER_ENGINE=${globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath))}');
 
-    final String localEngineName = localEngineInfo.localEngineName;
+    final String localEngineName = localEngineArtifacts.localEngineName;
     xcodeBuildSettings.add('LOCAL_ENGINE=$localEngineName');
 
     // Tell Xcode not to build universal binaries for local engines, which are

--- a/packages/flutter_tools/lib/src/linux/build_linux.dart
+++ b/packages/flutter_tools/lib/src/linux/build_linux.dart
@@ -53,11 +53,12 @@ Future<void> buildLinux(
   // step.
   final Map<String, String> environmentConfig = buildInfo.toEnvironmentConfig();
   environmentConfig['FLUTTER_TARGET'] = target;
-  final LocalEngineInfo? localEngineInfo = globals.artifacts?.localEngineInfo;
-  if (localEngineInfo != null) {
-    final String engineOutPath = localEngineInfo.engineOutPath;
+  final Artifacts? artifacts = globals.artifacts;
+  if (artifacts is LocalEngineArtifacts) {
+    final LocalEngineArtifacts localEngineArtifacts = artifacts;
+    final String engineOutPath = localEngineArtifacts.engineOutPath;
     environmentConfig['FLUTTER_ENGINE'] = globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath));
-    environmentConfig['LOCAL_ENGINE'] = localEngineInfo.localEngineName;
+    environmentConfig['LOCAL_ENGINE'] = localEngineArtifacts.localEngineName;
   }
   writeGeneratedCmakeConfig(Cache.flutterRoot!, linuxProject, buildInfo, environmentConfig);
 

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -107,26 +107,21 @@ class FlutterDevice {
     // used to file a bug, but the compiler will still start up correctly.
     if (targetPlatform == TargetPlatform.web_javascript) {
       // TODO(zanderso): consistently provide these flags across platforms.
-      late String platformDillName;
+      late HostArtifact platformDillArtifact;
       final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
       if (buildInfo.nullSafetyMode == NullSafetyMode.unsound) {
-        platformDillName = 'ddc_outline.dill';
+        platformDillArtifact = HostArtifact.webPlatformKernelDill;
         if (!extraFrontEndOptions.contains('--no-sound-null-safety')) {
           extraFrontEndOptions.add('--no-sound-null-safety');
         }
       } else if (buildInfo.nullSafetyMode == NullSafetyMode.sound) {
-        platformDillName = 'ddc_outline_sound.dill';
+        platformDillArtifact = HostArtifact.webPlatformSoundKernelDill;
         if (!extraFrontEndOptions.contains('--sound-null-safety')) {
           extraFrontEndOptions.add('--sound-null-safety');
         }
       } else {
         assert(false);
       }
-
-      final String platformDillPath = globals.fs.path.join(
-        getWebPlatformBinariesDirectory(globals.artifacts!, buildInfo.webRenderer).path,
-        platformDillName
-      );
 
       generator = ResidentCompiler(
         globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path,
@@ -144,7 +139,9 @@ class FlutterDevice {
         assumeInitializeFromDillUpToDate: buildInfo.assumeInitializeFromDillUpToDate,
         targetModel: TargetModel.dartdevc,
         extraFrontEndOptions: extraFrontEndOptions,
-        platformDill: globals.fs.file(platformDillPath).absolute.uri.toString(),
+        platformDill: globals.fs.file(globals.artifacts!
+          .getHostArtifact(platformDillArtifact))
+          .absolute.uri.toString(),
         dartDefines: buildInfo.dartDefines,
         librariesSpec: globals.fs.file(globals.artifacts!
           .getHostArtifact(HostArtifact.flutterWebLibrariesJson)).uri.toString(),

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -96,13 +96,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
         hide: !verboseHelp,
         help: 'Name of a build output within the engine out directory, if you are building Flutter locally.\n'
               'Use this to select a specific version of the engine if you have built multiple engine targets.\n'
-              'This path is relative to "--local-engine-src-path" (see above).');
-
-    argParser.addOption('local-web-sdk',
-        hide: !verboseHelp,
-        help: 'Name of a build output within the engine out directory, if you are building Flutter locally.\n'
-              'Use this to select a specific version of the web sdk if you have built multiple engine targets.\n'
-              'This path is relative to "--local-engine-src-path" (see above).');
+              'This path is relative to "--local-engine-src-path" or "--local-engine-src-out" (q.v.).');
 
     if (verboseHelp) {
       argParser.addSeparator('Options for testing the "flutter" tool itself:');
@@ -222,10 +216,9 @@ class FlutterCommandRunner extends CommandRunner<void> {
 
     // Set up the tooling configuration.
     final EngineBuildPaths? engineBuildPaths = await globals.localEngineLocator?.findEnginePath(
-      engineSourcePath: topLevelResults['local-engine-src-path'] as String?,
-      localEngine: topLevelResults['local-engine'] as String?,
-      localWebSdk: topLevelResults['local-web-sdk'] as String?,
-      packagePath: topLevelResults['packages'] as String?,
+      topLevelResults['local-engine-src-path'] as String?,
+      topLevelResults['local-engine'] as String?,
+      topLevelResults['packages'] as String?,
     );
     if (engineBuildPaths != null) {
       contextOverrides.addAll(<Type, Object?>{

--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -46,23 +46,17 @@ class LocalEngineLocator {
   final UserMessages _userMessages;
 
   /// Returns the engine build path of a local engine if one is located, otherwise `null`.
-  Future<EngineBuildPaths?> findEnginePath({String? engineSourcePath, String? localEngine, String? localWebSdk, String? packagePath}) async {
+  Future<EngineBuildPaths?> findEnginePath(String? engineSourcePath, String? localEngine, String? packagePath) async {
     engineSourcePath ??= _platform.environment[kFlutterEngineEnvironmentVariableName];
 
-    if (engineSourcePath == null) {
+    if (engineSourcePath == null && localEngine != null) {
       try {
-        if (localEngine != null) {
-          engineSourcePath = _findEngineSourceByBuildPath(localEngine);
-        }
-        if (localWebSdk != null) {
-          engineSourcePath ??= _findEngineSourceByBuildPath(localWebSdk);
-        }
+        engineSourcePath = _findEngineSourceByLocalEngine(localEngine);
         engineSourcePath ??= await _findEngineSourceByPackageConfig(packagePath);
       } on FileSystemException catch (e) {
         _logger.printTrace('Local engine auto-detection file exception: $e');
         engineSourcePath = null;
       }
-
       // If engineSourcePath is still not set, try to determine it by flutter root.
       engineSourcePath ??= _tryEnginePath(
         _fileSystem.path.join(_fileSystem.directory(_flutterRoot).parent.path, 'engine', 'src'),
@@ -78,9 +72,9 @@ class LocalEngineLocator {
 
     if (engineSourcePath != null) {
       _logger.printTrace('Local engine source at $engineSourcePath');
-      return _findEngineBuildPath(localEngine, localWebSdk, engineSourcePath);
+      return _findEngineBuildPath(localEngine, engineSourcePath);
     }
-    if (localEngine != null || localWebSdk != null) {
+    if (localEngine != null) {
       throwToolExit(
         _userMessages.runnerNoEngineSrcDir(
           kFlutterEnginePackageName,
@@ -92,15 +86,15 @@ class LocalEngineLocator {
     return null;
   }
 
-  String? _findEngineSourceByBuildPath(String buildPath) {
+  String? _findEngineSourceByLocalEngine(String localEngine) {
     // When the local engine is an absolute path to a variant inside the
     // out directory, parse the engine source.
     // --local-engine /path/to/cache/builder/src/out/host_debug_unopt
-    if (_fileSystem.path.isAbsolute(buildPath)) {
-      final Directory buildDirectory = _fileSystem.directory(buildPath);
-      final Directory outDirectory = buildDirectory.parent;
+    if (_fileSystem.path.isAbsolute(localEngine)) {
+      final Directory localEngineDirectory = _fileSystem.directory(localEngine);
+      final Directory outDirectory = localEngineDirectory.parent;
       final Directory srcDirectory = outDirectory.parent;
-      if (buildDirectory.existsSync() && outDirectory.basename == 'out' && srcDirectory.basename == 'src') {
+      if (localEngineDirectory.existsSync() && outDirectory.basename == 'out' && srcDirectory.basename == 'src') {
         _logger.printTrace('Parsed engine source from local engine as ${srcDirectory.path}.');
         return srcDirectory.path;
       }
@@ -171,38 +165,26 @@ class LocalEngineLocator {
     return 'host_$tmpBasename';
   }
 
-  EngineBuildPaths _findEngineBuildPath(String? localEngine, String? localWebSdk, String enginePath) {
-    if (localEngine == null && localWebSdk == null) {
-      throwToolExit(_userMessages.runnerLocalEngineOrWebSdkRequired, exitCode: 2);
+  EngineBuildPaths _findEngineBuildPath(String? localEngine, String enginePath) {
+    if (localEngine == null) {
+      throwToolExit(_userMessages.runnerLocalEngineRequired, exitCode: 2);
     }
 
-    String? engineBuildPath;
-    String? engineHostBuildPath;
-    if (localEngine != null) {
-      engineBuildPath = _fileSystem.path.normalize(_fileSystem.path.join(enginePath, 'out', localEngine));
-      if (!_fileSystem.isDirectorySync(engineBuildPath)) {
-        throwToolExit(_userMessages.runnerNoEngineBuild(engineBuildPath), exitCode: 2);
-      }
-
-      final String basename = _fileSystem.path.basename(engineBuildPath);
-      final String hostBasename = _getHostEngineBasename(basename);
-      engineHostBuildPath = _fileSystem.path.normalize(
-        _fileSystem.path.join(_fileSystem.path.dirname(engineBuildPath), hostBasename),
-      );
-      if (!_fileSystem.isDirectorySync(engineHostBuildPath)) {
-        throwToolExit(_userMessages.runnerNoEngineBuild(engineHostBuildPath), exitCode: 2);
-      }
+    final String engineBuildPath = _fileSystem.path.normalize(_fileSystem.path.join(enginePath, 'out', localEngine));
+    if (!_fileSystem.isDirectorySync(engineBuildPath)) {
+      throwToolExit(_userMessages.runnerNoEngineBuild(engineBuildPath), exitCode: 2);
     }
 
-    String? webSdkPath;
-    if (localWebSdk != null) {
-      webSdkPath = _fileSystem.path.normalize(_fileSystem.path.join(enginePath, 'out', localWebSdk));
-      if (!_fileSystem.isDirectorySync(webSdkPath)) {
-        throwToolExit(_userMessages.runnerNoWebSdk(webSdkPath), exitCode: 2);
-      }
+    final String basename = _fileSystem.path.basename(engineBuildPath);
+    final String hostBasename = _getHostEngineBasename(basename);
+    final String engineHostBuildPath = _fileSystem.path.normalize(
+      _fileSystem.path.join(_fileSystem.path.dirname(engineBuildPath), hostBasename),
+    );
+    if (!_fileSystem.isDirectorySync(engineHostBuildPath)) {
+      throwToolExit(_userMessages.runnerNoEngineBuild(engineHostBuildPath), exitCode: 2);
     }
 
-    return EngineBuildPaths(targetEngine: engineBuildPath, webSdk: webSdkPath, hostEngine: engineHostBuildPath);
+    return EngineBuildPaths(targetEngine: engineBuildPath, hostEngine: engineHostBuildPath);
   }
 
   String? _tryEnginePath(String enginePath) {

--- a/packages/flutter_tools/lib/src/test/web_test_compiler.dart
+++ b/packages/flutter_tools/lib/src/test/web_test_compiler.dart
@@ -50,28 +50,21 @@ class WebTestCompiler {
     required BuildInfo buildInfo,
   }) async {
     LanguageVersion languageVersion = LanguageVersion(2, 8);
-    late final String platformDillName;
-
+    HostArtifact platformDillArtifact = HostArtifact.webPlatformSoundKernelDill;
     // TODO(zanderso): to support autodetect this would need to partition the source code into a
-    // a sound and unsound set and perform separate compilations
+    // a sound and unsound set and perform separate compilations.
     final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
     if (buildInfo.nullSafetyMode == NullSafetyMode.unsound || buildInfo.nullSafetyMode == NullSafetyMode.autodetect) {
-      platformDillName = 'ddc_outline.dill';
+      platformDillArtifact = HostArtifact.webPlatformKernelDill;
       if (!extraFrontEndOptions.contains('--no-sound-null-safety')) {
         extraFrontEndOptions.add('--no-sound-null-safety');
       }
     } else if (buildInfo.nullSafetyMode == NullSafetyMode.sound) {
       languageVersion = currentLanguageVersion(_fileSystem, Cache.flutterRoot!);
-      platformDillName = 'ddc_outline_sound.dill';
       if (!extraFrontEndOptions.contains('--sound-null-safety')) {
         extraFrontEndOptions.add('--sound-null-safety');
       }
     }
-
-    final String platformDillPath = _fileSystem.path.join(
-      getWebPlatformBinariesDirectory(_artifacts, buildInfo.webRenderer).path,
-      platformDillName
-    );
 
     final Directory outputDirectory = _fileSystem.directory(testOutputDir)
       ..createSync(recursive: true);
@@ -123,7 +116,9 @@ class WebTestCompiler {
       initializeFromDill: cachedKernelPath,
       targetModel: TargetModel.dartdevc,
       extraFrontEndOptions: extraFrontEndOptions,
-      platformDill: platformDillPath,
+      platformDill: _artifacts
+        .getHostArtifact(platformDillArtifact)
+        .absolute.uri.toString(),
       dartDefines: buildInfo.dartDefines,
       librariesSpec: _artifacts.getHostArtifact(HostArtifact.flutterWebLibrariesJson).uri.toString(),
       packagesPath: buildInfo.packagesPath,

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -48,42 +48,40 @@ Future<void> buildWeb(
   final Status status = globals.logger.startProgress('Compiling $target for the Web...');
   final Stopwatch sw = Stopwatch()..start();
   try {
-    final BuildResult result = await globals.buildSystem.build(
-      WebServiceWorker(globals.fs, globals.cache, buildInfo.webRenderer),
-      Environment(
-        projectDir: globals.fs.currentDirectory,
-        outputDir: outputDirectory,
-        buildDir: flutterProject.directory
-          .childDirectory('.dart_tool')
-          .childDirectory('flutter_build'),
-        defines: <String, String>{
-          kTargetFile: target,
-          kHasWebPlugins: hasWebPlugins.toString(),
-          kCspMode: csp.toString(),
-          if (baseHref != null)
-            kBaseHref : baseHref,
-          kSourceMapsEnabled: sourceMaps.toString(),
-          kNativeNullAssertions: nativeNullAssertions.toString(),
-          if (serviceWorkerStrategy != null)
-          kServiceWorkerStrategy: serviceWorkerStrategy,
-          if (dart2jsOptimization != null)
-          kDart2jsOptimization: dart2jsOptimization,
-          ...buildInfo.toBuildSystemEnvironment(),
-        },
-        artifacts: globals.artifacts!,
-        fileSystem: globals.fs,
-        logger: globals.logger,
-        processManager: globals.processManager,
-        platform: globals.platform,
-        usage: globals.flutterUsage,
-        cacheDir: globals.cache.getRoot(),
-        engineVersion: globals.artifacts!.isLocalEngine
-          ? null
-          : globals.flutterVersion.engineRevision,
-        flutterRootDir: globals.fs.directory(Cache.flutterRoot),
-        // Web uses a different Dart plugin registry.
-        // https://github.com/flutter/flutter/issues/80406
-        generateDartPluginRegistry: false,
+    final BuildResult result = await globals.buildSystem.build(WebServiceWorker(globals.fs, globals.cache), Environment(
+      projectDir: globals.fs.currentDirectory,
+      outputDir: outputDirectory,
+      buildDir: flutterProject.directory
+        .childDirectory('.dart_tool')
+        .childDirectory('flutter_build'),
+      defines: <String, String>{
+        kTargetFile: target,
+        kHasWebPlugins: hasWebPlugins.toString(),
+        kCspMode: csp.toString(),
+        if (baseHref != null)
+          kBaseHref : baseHref,
+        kSourceMapsEnabled: sourceMaps.toString(),
+        kNativeNullAssertions: nativeNullAssertions.toString(),
+        if (serviceWorkerStrategy != null)
+         kServiceWorkerStrategy: serviceWorkerStrategy,
+        if (dart2jsOptimization != null)
+         kDart2jsOptimization: dart2jsOptimization,
+        ...buildInfo.toBuildSystemEnvironment(),
+      },
+      artifacts: globals.artifacts!,
+      fileSystem: globals.fs,
+      logger: globals.logger,
+      processManager: globals.processManager,
+      platform: globals.platform,
+      usage: globals.flutterUsage,
+      cacheDir: globals.cache.getRoot(),
+      engineVersion: globals.artifacts!.isLocalEngine
+        ? null
+        : globals.flutterVersion.engineRevision,
+      flutterRootDir: globals.fs.directory(Cache.flutterRoot),
+      // Web uses a different Dart plugin registry.
+      // https://github.com/flutter/flutter/issues/80406
+      generateDartPluginRegistry: false,
     ));
     if (!result.success) {
       for (final ExceptionMeasurement measurement in result.exceptions.values) {

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -215,11 +215,11 @@ void _writeGeneratedFlutterConfig(
       'FLUTTER_TARGET': target,
     ...buildInfo.toEnvironmentConfig(),
   };
-  final LocalEngineInfo? localEngineInfo = globals.artifacts?.localEngineInfo;
-  if (localEngineInfo != null) {
-    final String engineOutPath = localEngineInfo.engineOutPath;
+  final Artifacts artifacts = globals.artifacts!;
+  if (artifacts is LocalEngineArtifacts) {
+    final String engineOutPath = artifacts.engineOutPath;
     environment['FLUTTER_ENGINE'] = globals.fs.path.dirname(globals.fs.path.dirname(engineOutPath));
-    environment['LOCAL_ENGINE'] = localEngineInfo.localEngineName;
+    environment['LOCAL_ENGINE'] = artifacts.localEngineName;
   }
   writeGeneratedCmakeConfig(Cache.flutterRoot!, windowsProject, buildInfo, environment);
 }

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -29,7 +29,6 @@ import 'package:flutter_tools/src/reporting/reporting.dart';
 import 'package:flutter_tools/src/resident_runner.dart';
 import 'package:flutter_tools/src/runner/flutter_command.dart';
 import 'package:flutter_tools/src/vmservice.dart';
-import 'package:flutter_tools/src/web/compile.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -674,35 +673,35 @@ void main() {
     });
 
     test('auto web-renderer with no dart-defines', () {
-      dartDefines = FlutterCommand.updateDartDefines(dartDefines, WebRendererMode.autoDetect);
+      dartDefines = FlutterCommand.updateDartDefines(dartDefines, 'auto');
       expect(dartDefines, <String>['FLUTTER_WEB_AUTO_DETECT=true']);
     });
 
     test('canvaskit web-renderer with no dart-defines', () {
-      dartDefines = FlutterCommand.updateDartDefines(dartDefines, WebRendererMode.canvaskit);
+      dartDefines = FlutterCommand.updateDartDefines(dartDefines, 'canvaskit');
       expect(dartDefines, <String>['FLUTTER_WEB_AUTO_DETECT=false','FLUTTER_WEB_USE_SKIA=true']);
     });
 
     test('html web-renderer with no dart-defines', () {
-      dartDefines = FlutterCommand.updateDartDefines(dartDefines, WebRendererMode.html);
+      dartDefines = FlutterCommand.updateDartDefines(dartDefines, 'html');
       expect(dartDefines, <String>['FLUTTER_WEB_AUTO_DETECT=false','FLUTTER_WEB_USE_SKIA=false']);
     });
 
     test('auto web-renderer with existing dart-defines', () {
       dartDefines = <String>['FLUTTER_WEB_USE_SKIA=false'];
-      dartDefines = FlutterCommand.updateDartDefines(dartDefines, WebRendererMode.autoDetect);
+      dartDefines = FlutterCommand.updateDartDefines(dartDefines, 'auto');
       expect(dartDefines, <String>['FLUTTER_WEB_AUTO_DETECT=true']);
     });
 
     test('canvaskit web-renderer with no dart-defines', () {
       dartDefines = <String>['FLUTTER_WEB_USE_SKIA=false'];
-      dartDefines = FlutterCommand.updateDartDefines(dartDefines, WebRendererMode.canvaskit);
+      dartDefines = FlutterCommand.updateDartDefines(dartDefines, 'canvaskit');
       expect(dartDefines, <String>['FLUTTER_WEB_AUTO_DETECT=false','FLUTTER_WEB_USE_SKIA=true']);
     });
 
     test('html web-renderer with no dart-defines', () {
       dartDefines = <String>['FLUTTER_WEB_USE_SKIA=true'];
-      dartDefines = FlutterCommand.updateDartDefines(dartDefines, WebRendererMode.html);
+      dartDefines = FlutterCommand.updateDartDefines(dartDefines, 'html');
       expect(dartDefines, <String>['FLUTTER_WEB_AUTO_DETECT=false','FLUTTER_WEB_USE_SKIA=false']);
     });
   });

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -199,7 +199,7 @@ void main() {
   });
 
   group('LocalEngineArtifacts', () {
-    late Artifacts artifacts;
+    late LocalEngineArtifacts artifacts;
     late Cache cache;
     late FileSystem fileSystem;
     late Platform platform;
@@ -217,9 +217,9 @@ void main() {
         osUtils: FakeOperatingSystemUtils(),
         artifacts: <ArtifactSet>[],
       );
-      artifacts = CachedLocalEngineArtifacts(
+      artifacts = LocalEngineArtifacts(
+        fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'host_debug_unopt'),
-        engineOutPath: fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         cache: cache,
         fileSystem: fileSystem,
         platform: platform,
@@ -435,9 +435,9 @@ void main() {
     });
 
     testWithoutContext('Looks up dart.exe on windows platforms', () async {
-      artifacts = CachedLocalEngineArtifacts(
+      artifacts = LocalEngineArtifacts(
+        fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'host_debug_unopt'),
-        engineOutPath: fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         cache: cache,
         fileSystem: fileSystem,
         platform: FakePlatform(operatingSystem: 'windows'),
@@ -473,9 +473,9 @@ void main() {
     });
 
     testWithoutContext('Finds dart-sdk in windows prebuilts', () async {
-      artifacts = CachedLocalEngineArtifacts(
+      artifacts = LocalEngineArtifacts(
+        fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'host_debug_unopt'),
-        engineOutPath: fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         cache: cache,
         fileSystem: fileSystem,
         platform: FakePlatform(operatingSystem: 'windows'),
@@ -498,9 +498,9 @@ void main() {
     });
 
     testWithoutContext('Finds dart-sdk in macos prebuilts', () async {
-      artifacts = CachedLocalEngineArtifacts(
+      artifacts = LocalEngineArtifacts(
+        fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'host_debug_unopt'),
-        engineOutPath: fileSystem.path.join(fileSystem.currentDirectory.path, 'out', 'android_debug_unopt'),
         cache: cache,
         fileSystem: fileSystem,
         platform: FakePlatform(operatingSystem: 'macos'),

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -13,7 +13,6 @@ import 'package:flutter_tools/src/build_system/depfile.dart';
 import 'package:flutter_tools/src/build_system/targets/web.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 import 'package:flutter_tools/src/isolated/mustache_template.dart';
-import 'package:flutter_tools/src/web/compile.dart';
 import 'package:flutter_tools/src/web/file_generators/flutter_js.dart' as flutter_js;
 import 'package:flutter_tools/src/web/file_generators/flutter_service_worker_js.dart';
 
@@ -25,6 +24,7 @@ const List<String> kDart2jsLinuxArgs = <String>[
   'bin/cache/dart-sdk/bin/dart',
    '--disable-dart-dev',
   'bin/cache/dart-sdk/bin/snapshots/dart2js.dart.snapshot',
+  '--libraries-spec=bin/cache/flutter_web_sdk/libraries.json',
 ];
 
 void main() {
@@ -100,7 +100,7 @@ void main() {
     webResources.childFile('index.html')
         .createSync(recursive: true);
     environment.buildDir.childFile('main.dart.js').createSync();
-    await const WebReleaseBundle(WebRendererMode.autoDetect).build(environment);
+    await const WebReleaseBundle().build(environment);
 
     expect(environment.outputDir.childFile('version.json'), exists);
   }));
@@ -112,7 +112,7 @@ void main() {
       final Directory webResources = environment.projectDir.childDirectory('web');
       webResources.childFile('index.html').createSync(recursive: true);
       environment.buildDir.childFile('main.dart.js').createSync();
-      await const WebReleaseBundle(WebRendererMode.autoDetect).build(environment);
+      await const WebReleaseBundle().build(environment);
 
       final String versionFile = environment.outputDir
           .childFile('version.json')
@@ -130,7 +130,7 @@ void main() {
 <!DOCTYPE html><html><base href="$kBaseHrefPlaceholder"><head></head></html>
     ''');
     environment.buildDir.childFile('main.dart.js').createSync();
-    await const WebReleaseBundle(WebRendererMode.autoDetect).build(environment);
+    await const WebReleaseBundle().build(environment);
 
     expect(environment.outputDir.childFile('index.html').readAsStringSync(), contains('/basehreftest/'));
   }));
@@ -143,7 +143,7 @@ void main() {
 <!DOCTYPE html><html><head><base href='/basehreftest/'></head></html>
     ''');
     environment.buildDir.childFile('main.dart.js').createSync();
-    await const WebReleaseBundle(WebRendererMode.autoDetect).build(environment);
+    await const WebReleaseBundle().build(environment);
 
     expect(environment.outputDir.childFile('index.html').readAsStringSync(), contains('/basehreftest/'));
   }));
@@ -165,7 +165,7 @@ void main() {
       .writeAsStringSync('A');
     environment.buildDir.childFile('main.dart.js').createSync();
 
-    await const WebReleaseBundle(WebRendererMode.autoDetect).build(environment);
+    await const WebReleaseBundle().build(environment);
 
     expect(environment.outputDir.childFile('foo.txt')
       .readAsStringSync(), 'A');
@@ -177,7 +177,7 @@ void main() {
     // Update to arbitrary resource file triggers rebuild.
     webResources.childFile('foo.txt').writeAsStringSync('B');
 
-    await const WebReleaseBundle(WebRendererMode.autoDetect).build(environment);
+    await const WebReleaseBundle().build(environment);
 
     expect(environment.outputDir.childFile('foo.txt')
       .readAsStringSync(), 'B');
@@ -333,7 +333,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -346,7 +345,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',
@@ -358,7 +356,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -370,7 +368,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '--enable-experiment=non-nullable',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
@@ -384,7 +381,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '--enable-experiment=non-nullable',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
@@ -396,7 +392,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -406,7 +402,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-o',
@@ -419,7 +414,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.profile=true',
         '--no-source-maps',
         '-O4',
@@ -430,7 +424,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -440,7 +434,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-o',
@@ -453,7 +446,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-O4',
@@ -463,7 +455,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -474,7 +466,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '--native-null-assertions',
         '-Ddart.vm.product=true',
         '--no-source-maps',
@@ -488,7 +479,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '--native-null-assertions',
         '-Ddart.vm.product=true',
         '--no-source-maps',
@@ -499,7 +489,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -510,7 +500,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-o',
@@ -523,7 +512,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-O3',
@@ -533,7 +521,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -543,7 +531,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '--no-source-maps',
         '-o',
@@ -556,7 +543,7 @@ void main() {
           .writeAsStringSync('file:///a.dart');
       },
     ));
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
 
     expect(environment.buildDir.childFile('dart2js.d'), exists);
     final Depfile depfile = depfileService.parse(environment.buildDir.childFile('dart2js.d'));
@@ -574,7 +561,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -589,7 +575,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -601,7 +586,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -612,7 +597,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '-o',
         environment.buildDir.childFile('app.dill').absolute.path,
@@ -624,7 +608,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.product=true',
         '-O4',
         '-o',
@@ -633,7 +616,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -645,7 +628,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.profile=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -660,7 +642,6 @@ void main() {
     processManager.addCommand(FakeCommand(
       command: <String>[
         ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/auto',
         '-Ddart.vm.profile=true',
         '-DFOO=bar',
         '-DBAZ=qux',
@@ -673,41 +654,7 @@ void main() {
       ]
     ));
 
-    await const Dart2JSTarget(WebRendererMode.autoDetect).build(environment);
-  }, overrides: <Type, Generator>{
-    ProcessManager: () => processManager,
-  }));
-
-    test('Dart2JSTarget uses correct platform binaries with canvaskit web renderer', () => testbed.run(() async {
-    environment.defines[kBuildMode] = 'profile';
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/canvaskit',
-        '-Ddart.vm.profile=true',
-        '--no-source-maps',
-        '-o',
-        environment.buildDir.childFile('app.dill').absolute.path,
-        '--packages=.dart_tool/package_config.json',
-        '--cfe-only',
-        environment.buildDir.childFile('main.dart').absolute.path,
-      ]
-    ));
-    processManager.addCommand(FakeCommand(
-      command: <String>[
-        ...kDart2jsLinuxArgs,
-        '--platform-binaries=bin/cache/flutter_web_sdk/kernel/platforms/canvaskit',
-        '-Ddart.vm.profile=true',
-        '--no-source-maps',
-        '-O4',
-        '--no-minify',
-        '-o',
-        environment.buildDir.childFile('main.dart.js').absolute.path,
-        environment.buildDir.childFile('app.dill').absolute.path,
-      ]
-    ));
-
-    await const Dart2JSTarget(WebRendererMode.canvaskit).build(environment);
+    await const Dart2JSTarget().build(environment);
   }, overrides: <Type, Generator>{
     ProcessManager: () => processManager,
   }));
@@ -734,7 +681,7 @@ void main() {
     environment.outputDir.childDirectory('a').childFile('a.txt')
       ..createSync(recursive: true)
       ..writeAsStringSync('A');
-    await WebServiceWorker(globals.fs, globals.cache, WebRendererMode.autoDetect).build(environment);
+    await WebServiceWorker(globals.fs, globals.cache).build(environment);
 
     expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
     // Contains file hash.
@@ -753,7 +700,7 @@ void main() {
     environment.outputDir
       .childFile('index.html')
       .createSync(recursive: true);
-    await WebServiceWorker(globals.fs, globals.cache, WebRendererMode.autoDetect).build(environment);
+    await WebServiceWorker(globals.fs, globals.cache).build(environment);
 
     expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
     // Contains file hash for both `/` and index.html.
@@ -771,7 +718,7 @@ void main() {
     environment.outputDir
       .childFile('main.dart.js.map')
       .createSync(recursive: true);
-    await WebServiceWorker(globals.fs, globals.cache, WebRendererMode.autoDetect).build(environment);
+    await WebServiceWorker(globals.fs, globals.cache).build(environment);
 
     // No caching of source maps.
     expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -33,7 +33,6 @@ import 'package:flutter_tools/src/run_cold.dart';
 import 'package:flutter_tools/src/run_hot.dart';
 import 'package:flutter_tools/src/version.dart';
 import 'package:flutter_tools/src/vmservice.dart';
-import 'package:flutter_tools/src/web/compile.dart' show WebRendererMode;
 import 'package:package_config/package_config.dart';
 import 'package:test/fake.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
@@ -1921,28 +1920,6 @@ flutter:
     expect(fakeVmServiceHost?.hasRemainingExpectations, false);
   }));
 
-  testUsingContext('FlutterDevice uses canvaskit platform dill when canvaskit mode is selected', () async {
-    fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
-    final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
-    final DefaultResidentCompiler? residentCompiler = (await FlutterDevice.create(
-      device,
-      buildInfo: const BuildInfo(
-        BuildMode.debug,
-        '',
-        treeShakeIcons: false,
-        webRenderer: WebRendererMode.canvaskit,
-      ),
-      target: null,
-      platform: FakePlatform(),
-    )).generator as DefaultResidentCompiler?;
-
-    expect(residentCompiler!.platformDill, 'file:///HostArtifact.webPlatformCanvasKitDillDirectory/ddc_outline_sound.dill');
-  }, overrides: <Type, Generator>{
-    Artifacts: () => Artifacts.test(),
-    FileSystem: () => MemoryFileSystem.test(),
-    ProcessManager: () => FakeProcessManager.any(),
-  });
-
   testUsingContext('FlutterDevice uses dartdevc configuration when targeting web', () async {
     fakeVmServiceHost = FakeVmServiceHost(requests: <VmServiceExpectation>[]);
     final FakeDevice device = FakeDevice(targetPlatform: TargetPlatform.web_javascript);
@@ -1966,7 +1943,7 @@ flutter:
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
       '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformAutoDillDirectory/ddc_outline.dill');
+    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformKernelDill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),
@@ -1997,7 +1974,7 @@ flutter:
     expect(residentCompiler.targetModel, TargetModel.dartdevc);
     expect(residentCompiler.sdkRoot,
       '${globals.artifacts!.getHostArtifact(HostArtifact.flutterWebSdk).path}/');
-    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformAutoDillDirectory/ddc_outline_sound.dill');
+    expect(residentCompiler.platformDill, 'file:///HostArtifact.webPlatformSoundKernelDill');
   }, overrides: <Type, Generator>{
     Artifacts: () => Artifacts.test(),
     FileSystem: () => MemoryFileSystem.test(),

--- a/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/local_engine_test.dart
@@ -43,7 +43,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(localEngine: 'ios_debug'),
+      await localEngineLocator.findEnginePath(null, 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/host_debug',
         targetEngine: '/arbitrary/engine/src/out/ios_debug',
@@ -58,7 +58,7 @@ void main() {
       .writeAsStringSync('sky_engine:file:///symlink/src/out/ios_debug/gen/dart-pkg/sky_engine/lib/');
 
     expect(
-      await localEngineLocator.findEnginePath(localEngine: 'ios_debug'),
+      await localEngineLocator.findEnginePath(null, 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: '/symlink/src/out/host_debug',
         targetEngine: '/symlink/src/out/ios_debug',
@@ -84,7 +84,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(engineSourcePath: '$kArbitraryEngineRoot/src', localEngine: 'ios_debug'),
+      await localEngineLocator.findEnginePath('$kArbitraryEngineRoot/src', 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/host_debug',
         targetEngine: '/arbitrary/engine/src/out/ios_debug',
@@ -111,7 +111,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(localEngine: localEngine.path),
+      await localEngineLocator.findEnginePath(null, localEngine.path, null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/host_debug',
         targetEngine: '/arbitrary/engine/src/out/ios_debug',
@@ -137,7 +137,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(localEngine: localEngine.path),
+      await localEngineLocator.findEnginePath(null, localEngine.path, null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/host_debug',
         targetEngine: '/arbitrary/engine/src/out/host_debug',
@@ -161,7 +161,7 @@ void main() {
     );
 
     await expectToolExitLater(
-      localEngineLocator.findEnginePath(localEngine: localEngine.path),
+      localEngineLocator.findEnginePath(null, localEngine.path, null),
       contains('No Flutter engine build found at /arbitrary/engine/src/out/host_debug'),
     );
   });
@@ -190,7 +190,7 @@ void main() {
     );
 
     expect(
-      await localEngineLocator.findEnginePath(localEngine: 'ios_debug'),
+      await localEngineLocator.findEnginePath(null, 'ios_debug', null),
       matchesEngineBuildPaths(
         hostEngine: 'flutter/engine/src/out/host_debug',
         targetEngine: 'flutter/engine/src/out/ios_debug',
@@ -212,7 +212,7 @@ void main() {
     );
 
     await expectToolExitLater(
-      localEngineLocator.findEnginePath(localEngine: '/path/to/nothing'),
+      localEngineLocator.findEnginePath(null, '/path/to/nothing', null),
       contains('Unable to detect local Flutter engine src directory'),
     );
   });
@@ -236,7 +236,7 @@ void main() {
     );
 
     expect(
-      await localWasmEngineLocator.findEnginePath(localEngine: localWasmEngine.path),
+      await localWasmEngineLocator.findEnginePath(null, localWasmEngine.path, null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/wasm_whatever',
         targetEngine: '/arbitrary/engine/src/out/wasm_whatever',
@@ -254,7 +254,7 @@ void main() {
     );
 
     expect(
-      await localWebEngineLocator.findEnginePath(localEngine: localWebEngine.path),
+      await localWebEngineLocator.findEnginePath(null, localWebEngine.path, null),
       matchesEngineBuildPaths(
         hostEngine: '/arbitrary/engine/src/out/web_whatever',
         targetEngine: '/arbitrary/engine/src/out/web_whatever',


### PR DESCRIPTION
Reverts flutter/flutter#114639

I can no longer rebuild the flutter tool locally. On ToT, no matter where I run the `flutter` command to regenerate a snapshot, I get a message that I must use a local engine argument:

```
jonahwilliams-macbookpro3:flutter jonahwilliams$ flutter
Building flutter tool...
You must specify --local-engine or --local-web-sdk if you are using a locally built engine or web sdk.
```