### PR TITLE
[flutter_tools] Fix service_worker not caching assets when base-href is different than "/"

### DIFF
--- a/packages/flutter_tools/lib/src/build_system/targets/web.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/web.dart
@@ -483,7 +483,13 @@ class WebServiceWorker extends Target {
         file.path.endsWith('.part.js.map')) {
         continue;
       }
-      final String url = globals.fs.path.toUri(
+
+      // because caching logic expects RESOURCES without leading slash
+      final String baseHrefWithoutLeadingSlash = environment.defines[kBaseHref] != null
+        ? environment.defines[kBaseHref]!.substring(1)
+        : '';
+
+      final String url = baseHrefWithoutLeadingSlash + globals.fs.path.toUri(
         globals.fs.path.relative(
           file.path,
           from: environment.outputDir.path),
@@ -492,7 +498,11 @@ class WebServiceWorker extends Target {
       urlToHash[url] = hash;
       // Add an additional entry for the base URL.
       if (globals.fs.path.basename(url) == 'index.html') {
-        urlToHash['/'] = hash;
+        if(baseHrefWithoutLeadingSlash.isEmpty) {
+          urlToHash['/'] = hash;
+        } else {
+          urlToHash[baseHrefWithoutLeadingSlash] = hash;
+        }
       }
     }
 

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -711,6 +711,25 @@ void main() {
     expect(environment.buildDir.childFile('service_worker.d'), exists);
   }));
 
+  test('RESOURCES are prefixed with base href when defined', () => testbed.run(() async {
+    environment.outputDir
+      .childFile('index.html')
+      .createSync(recursive: true);
+    
+    environment.defines[kBaseHref] = '/basehreftest/';
+    await WebServiceWorker(globals.fs, globals.cache).build(environment);
+
+    expect(environment.outputDir.childFile('flutter_service_worker.js'), exists);
+
+    expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
+      // Leading slash in base-href must be removed because that's how the caching logic expects it
+      contains('"basehreftest/index.html": "d41d8cd98f00b204e9800998ecf8427e"'));
+
+    expect(environment.outputDir.childFile('flutter_service_worker.js').readAsStringSync(),
+      // This is equivalent to "/" when base-href is null
+      contains('"basehreftest/": "d41d8cd98f00b204e9800998ecf8427e"'));
+  }));
+
   test('WebServiceWorker does not cache source maps', () => testbed.run(() async {
     environment.outputDir
       .childFile('main.dart.js')


### PR DESCRIPTION
**What does this PR changes?**
Fixes **service_worker** not caching assets when **base-href** is different than `/` (example: `/basehreftest/`)
Issue: https://github.com/flutter/flutter/issues/111866

**Repro steps:**
- create new project: `flutter create demo` (using HEAD rev on this repo or any stable version)
- build it for web using a custom base-href: `flutter build web --base-href /basehreftest/`
- put the build inside /basehreftest/ and run a server one folder up `python -m http.server`
- note how all assets are always redownloaded 💣(sadly this has a big impact in my use case)

**Evidence of the fix working:**

https://user-images.githubusercontent.com/79719460/201554439-6ddaf720-95b6-4cd9-b07a-d3d43556f4b4.mp4

✅ Unit test added 
✅Existing unit test of that module are all passing (tested inside packages/flutter_tools)

```
flutter test test/general.shard/build_system/targets/web_test.dart
```
![image](https://user-images.githubusercontent.com/79719460/201554636-5d4b170a-acd6-4e43-9344-f56bab6620ef.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
