### PR TITLE
[framework] re-rasterize page transition when layout size changes

### DIFF
--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -356,15 +356,6 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
   }
 
   @override
-  void didChangeDependencies() {
-    // If the screen size changes during the transition, perhaps due to
-    // a keyboard dismissal, then ensure that contents are re-rasterized once.
-    // We cannot check view insets as nested scaffolds may remove them.
-    controller.clear();
-    super.didChangeDependencies();
-  }
-
-  @override
   void dispose() {
     widget.animation.removeListener(onAnimationValueChange);
     widget.animation.removeStatusListener(onAnimationStatusChange);
@@ -374,11 +365,11 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
 
   @override
   Widget build(BuildContext context) {
-    MediaQuery.maybeOf(context);
     return SnapshotWidget(
       painter: delegate,
       controller: controller,
       mode: SnapshotMode.permissive,
+      autoresize: true,
       child: widget.child,
     );
   }
@@ -469,15 +460,6 @@ class _ZoomExitTransitionState extends State<_ZoomExitTransition> with _ZoomTran
   }
 
   @override
-  void didChangeDependencies() {
-    // If the screen size changes during the transition, perhaps due to
-    // a keyboard dismissal, then ensure that contents are re-rasterized once.
-    // We cannot check view insets as nested scaffolds may remove them.
-    controller.clear();
-    super.didChangeDependencies();
-  }
-
-  @override
   void dispose() {
     widget.animation.removeListener(onAnimationValueChange);
     widget.animation.removeStatusListener(onAnimationStatusChange);
@@ -487,11 +469,11 @@ class _ZoomExitTransitionState extends State<_ZoomExitTransition> with _ZoomTran
 
   @override
   Widget build(BuildContext context) {
-    MediaQuery.maybeOf(context);
     return SnapshotWidget(
       painter: delegate,
       controller: controller,
       mode: SnapshotMode.permissive,
+      autoresize: true,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -291,7 +291,6 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
   bool get useSnapshot => !kIsWeb && widget.allowSnapshotting;
 
   late _ZoomEnterTransitionPainter delegate;
-  MediaQueryData? mediaQueryData;
 
   static final Animatable<double> _fadeInTransition = Tween<double>(
     begin: 0.0,
@@ -357,18 +356,6 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
   }
 
   @override
-  void didChangeDependencies() {
-    // If the screen size changes during the transition, perhaps due to
-    // a keyboard dismissal, then ensure that contents are re-rasterized once.
-    final MediaQueryData? data = MediaQuery.maybeOf(context);
-    if (mediaQueryDataChanged(mediaQueryData, data)) {
-      controller.clear();
-    }
-    mediaQueryData = data;
-    super.didChangeDependencies();
-  }
-
-  @override
   void dispose() {
     widget.animation.removeListener(onAnimationValueChange);
     widget.animation.removeStatusListener(onAnimationStatusChange);
@@ -382,6 +369,7 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
       painter: delegate,
       controller: controller,
       mode: SnapshotMode.permissive,
+      autoresize: true,
       child: widget.child,
     );
   }
@@ -498,6 +486,7 @@ class _ZoomExitTransitionState extends State<_ZoomExitTransition> with _ZoomTran
       painter: delegate,
       controller: controller,
       mode: SnapshotMode.permissive,
+      autoresize: true,
       child: widget.child,
     );
   }

--- a/packages/flutter/lib/src/material/page_transitions_theme.dart
+++ b/packages/flutter/lib/src/material/page_transitions_theme.dart
@@ -356,6 +356,15 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
   }
 
   @override
+  void didChangeDependencies() {
+    // If the screen size changes during the transition, perhaps due to
+    // a keyboard dismissal, then ensure that contents are re-rasterized once.
+    // We cannot check view insets as nested scaffolds may remove them.
+    controller.clear();
+    super.didChangeDependencies();
+  }
+
+  @override
   void dispose() {
     widget.animation.removeListener(onAnimationValueChange);
     widget.animation.removeStatusListener(onAnimationStatusChange);
@@ -365,11 +374,11 @@ class _ZoomEnterTransitionState extends State<_ZoomEnterTransition> with _ZoomTr
 
   @override
   Widget build(BuildContext context) {
+    MediaQuery.maybeOf(context);
     return SnapshotWidget(
       painter: delegate,
       controller: controller,
       mode: SnapshotMode.permissive,
-      autoresize: true,
       child: widget.child,
     );
   }
@@ -395,7 +404,6 @@ class _ZoomExitTransition extends StatefulWidget {
 
 class _ZoomExitTransitionState extends State<_ZoomExitTransition> with _ZoomTransitionBase {
   late _ZoomExitTransitionPainter delegate;
-  MediaQueryData? mediaQueryData;
 
   // See SnapshotWidget doc comment, this is disabled on web because the HTML backend doesn't
   // support this functionality and the canvaskit backend uses a single thread for UI and raster
@@ -464,11 +472,8 @@ class _ZoomExitTransitionState extends State<_ZoomExitTransition> with _ZoomTran
   void didChangeDependencies() {
     // If the screen size changes during the transition, perhaps due to
     // a keyboard dismissal, then ensure that contents are re-rasterized once.
-    final MediaQueryData? data = MediaQuery.maybeOf(context);
-    if (mediaQueryDataChanged(mediaQueryData, data)) {
-      controller.clear();
-    }
-    mediaQueryData = data;
+    // We cannot check view insets as nested scaffolds may remove them.
+    controller.clear();
     super.didChangeDependencies();
   }
 
@@ -482,11 +487,11 @@ class _ZoomExitTransitionState extends State<_ZoomExitTransition> with _ZoomTran
 
   @override
   Widget build(BuildContext context) {
+    MediaQuery.maybeOf(context);
     return SnapshotWidget(
       painter: delegate,
       controller: controller,
       mode: SnapshotMode.permissive,
-      autoresize: true,
       child: widget.child,
     );
   }
@@ -818,13 +823,6 @@ mixin _ZoomTransitionBase {
         controller.allowSnapshotting = useSnapshot;
         break;
     }
-  }
-
-  // Whether any of the properties that would impact the page transition
-  // changed.
-  bool mediaQueryDataChanged(MediaQueryData? oldData, MediaQueryData? newData) {
-    return oldData?.size != newData?.size ||
-      oldData?.viewInsets != newData?.viewInsets;
   }
 }
 

--- a/packages/flutter/lib/src/widgets/snapshot_widget.dart
+++ b/packages/flutter/lib/src/widgets/snapshot_widget.dart
@@ -110,6 +110,7 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
     super.key,
     this.mode = SnapshotMode.normal,
     this.painter = const _DefaultSnapshotPainter(),
+    this.autoresize = false,
     required this.controller,
     required super.child
   });
@@ -125,6 +126,12 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
   /// See [SnapshotMode] for more information.
   final SnapshotMode mode;
 
+  /// Whether or not changes in render object size should automatically re-create
+  /// the snapshot.
+  ///
+  /// Defaults to false.
+  final bool autoresize;
+
   /// The painter used to paint the child snapshot or child widgets.
   final SnapshotPainter painter;
 
@@ -136,6 +143,7 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
       mode: mode,
       devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
       painter: painter,
+      autoresize: autoresize,
     );
   }
 
@@ -146,7 +154,8 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
       ..controller = controller
       ..mode = mode
       ..devicePixelRatio = MediaQuery.of(context).devicePixelRatio
-      ..painter = painter;
+      ..painter = painter
+      ..autoresize = autoresize;
   }
 }
 
@@ -159,10 +168,12 @@ class _RenderSnapshotWidget extends RenderProxyBox {
     required SnapshotController controller,
     required SnapshotMode mode,
     required SnapshotPainter painter,
+    required bool autoresize,
   }) : _devicePixelRatio = devicePixelRatio,
        _controller = controller,
        _mode = mode,
-       _painter = painter;
+       _painter = painter,
+       _autoresize = autoresize;
 
   /// The device pixel ratio used to create the child image.
   double get devicePixelRatio => _devicePixelRatio;
@@ -230,6 +241,17 @@ class _RenderSnapshotWidget extends RenderProxyBox {
     markNeedsPaint();
   }
 
+  /// Whether or not changes in render object size should automatically re-rasterize.
+  bool get autoresize => _autoresize;
+  bool _autoresize;
+  set autoresize(bool value) {
+    if (value == autoresize) {
+      return;
+    }
+    _autoresize = value;
+    markNeedsPaint();
+  }
+
   ui.Image? _childRaster;
   Size? _childRasterSize;
   // Set to true if the snapshot mode was not forced and a platform view
@@ -292,8 +314,11 @@ class _RenderSnapshotWidget extends RenderProxyBox {
     }
     final ui.Image image = offsetLayer.toImageSync(Offset.zero & size, pixelRatio: devicePixelRatio);
     offsetLayer.dispose();
+    _lastCachedSize = size;
     return image;
   }
+
+  Size? _lastCachedSize;
 
   @override
   void paint(PaintingContext context, Offset offset) {
@@ -310,6 +335,12 @@ class _RenderSnapshotWidget extends RenderProxyBox {
       painter.paint(context, offset, size, super.paint);
       return;
     }
+
+    if (autoresize && size != _lastCachedSize && _lastCachedSize != null) {
+      _childRaster?.dispose();
+      _childRaster = null;
+    }
+
     if (_childRaster == null) {
       _childRaster = _paintAndDetachToImage();
       _childRasterSize = size * devicePixelRatio;

--- a/packages/flutter/lib/src/widgets/snapshot_widget.dart
+++ b/packages/flutter/lib/src/widgets/snapshot_widget.dart
@@ -110,7 +110,6 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
     super.key,
     this.mode = SnapshotMode.normal,
     this.painter = const _DefaultSnapshotPainter(),
-    this.autoresize = false,
     required this.controller,
     required super.child
   });
@@ -129,12 +128,6 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
   /// The painter used to paint the child snapshot or child widgets.
   final SnapshotPainter painter;
 
-  /// If true, the snapshot widget will regenerate the snapshot if the render
-  /// objects size changes.
-  ///
-  /// Defaults to `false`.
-  final bool autoresize;
-
   @override
   RenderObject createRenderObject(BuildContext context) {
     debugCheckHasMediaQuery(context);
@@ -143,7 +136,6 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
       mode: mode,
       devicePixelRatio: MediaQuery.of(context).devicePixelRatio,
       painter: painter,
-      autoresize: autoresize,
     );
   }
 
@@ -154,8 +146,7 @@ class SnapshotWidget extends SingleChildRenderObjectWidget {
       ..controller = controller
       ..mode = mode
       ..devicePixelRatio = MediaQuery.of(context).devicePixelRatio
-      ..painter = painter
-      ..autoresize = autoresize;
+      ..painter = painter;
   }
 }
 
@@ -168,12 +159,10 @@ class _RenderSnapshotWidget extends RenderProxyBox {
     required SnapshotController controller,
     required SnapshotMode mode,
     required SnapshotPainter painter,
-    required bool autoresize,
   }) : _devicePixelRatio = devicePixelRatio,
        _controller = controller,
        _mode = mode,
-       _painter = painter,
-       _autoresize = autoresize;
+       _painter = painter;
 
   /// The device pixel ratio used to create the child image.
   double get devicePixelRatio => _devicePixelRatio;
@@ -241,19 +230,8 @@ class _RenderSnapshotWidget extends RenderProxyBox {
     markNeedsPaint();
   }
 
-  bool get autoresize => _autoresize;
-  bool _autoresize;
-  set autoresize(bool value) {
-    if (value == autoresize) {
-      return;
-    }
-    _autoresize = value;
-    markNeedsPaint();
-  }
-
   ui.Image? _childRaster;
   Size? _childRasterSize;
-  Size? _lastPaintSize;
   // Set to true if the snapshot mode was not forced and a platform view
   // was encountered while attempting to snapshot the child.
   bool _disableSnapshotAttempt = false;
@@ -314,7 +292,6 @@ class _RenderSnapshotWidget extends RenderProxyBox {
     }
     final ui.Image image = offsetLayer.toImageSync(Offset.zero & size, pixelRatio: devicePixelRatio);
     offsetLayer.dispose();
-    _lastPaintSize = size;
     return image;
   }
 
@@ -332,10 +309,6 @@ class _RenderSnapshotWidget extends RenderProxyBox {
       _childRasterSize = null;
       painter.paint(context, offset, size, super.paint);
       return;
-    }
-    if (_lastPaintSize != size && autoresize) {
-      _childRaster?.dispose();
-      _childRaster = null;
     }
     if (_childRaster == null) {
       _childRaster = _paintAndDetachToImage();

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -253,18 +253,16 @@ void main() {
       await tester.pumpWidget(
         RepaintBoundary(
           key: key,
-          child: Scaffold(
-            body: MaterialApp(
-              onGenerateRoute: (RouteSettings settings) {
-                return MaterialPageRoute<void>(
-                  builder: (BuildContext context) {
-                    return const Scaffold(
-                      body: Material(child: SizedBox.shrink())
-                    );
-                  },
-                );
-              },
-            ),
+          child: MaterialApp(
+            onGenerateRoute: (RouteSettings settings) {
+              return MaterialPageRoute<void>(
+                builder: (BuildContext context) {
+                  return const Scaffold(body: Scaffold(
+                    body: Material(child: SizedBox.shrink())
+                  ));
+                },
+              );
+            },
           ),
         ),
       );

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+import 'dart:ui' as ui;
+
 import 'package:flutter/cupertino.dart' show CupertinoPageRoute;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -236,25 +238,33 @@ void main() {
     expect(find.text('Page 2'), findsNothing);
   }, variant: TargetPlatformVariant.only(TargetPlatform.android));
 
-  testWidgets('test page transition (_ZoomPageTransition) with rasterization re-rasterizes when window size changes', (WidgetTester tester) async {
-    // Shrink the window size.
+  testWidgets('test page transition (_ZoomPageTransition) with rasterization re-rasterizes when window insets', (WidgetTester tester) async {
     late Size oldSize;
+    late ui.WindowPadding oldInsets;
     try {
       oldSize = tester.binding.window.physicalSize;
+      oldInsets = tester.binding.window.viewInsets;
       tester.binding.window.physicalSizeTestValue = const Size(1000, 1000);
+      tester.binding.window.viewInsetsTestValue = ui.WindowPadding.zero;
 
+      // Intentionally use nested scaffolds to simulate the view insets being
+      // consumed.
       final Key key = GlobalKey();
       await tester.pumpWidget(
         RepaintBoundary(
           key: key,
-          child: MaterialApp(
-            onGenerateRoute: (RouteSettings settings) {
-              return MaterialPageRoute<void>(
-                builder: (BuildContext context) {
-                  return const Material(child: SizedBox.shrink());
-                },
-              );
-            },
+          child: Scaffold(
+            body: MaterialApp(
+              onGenerateRoute: (RouteSettings settings) {
+                return MaterialPageRoute<void>(
+                  builder: (BuildContext context) {
+                    return const Scaffold(
+                      body: Material(child: SizedBox.shrink())
+                    );
+                  },
+                );
+              },
+            ),
           ),
         ),
       );
@@ -265,8 +275,8 @@ void main() {
 
       await expectLater(find.byKey(key), matchesGoldenFile('zoom_page_transition.small.png'));
 
-       // Increase the window size.
-      tester.binding.window.physicalSizeTestValue = const Size(1000, 2000);
+       // Change the view insets
+      tester.binding.window.viewInsetsTestValue = const TestWindowPadding(left: 0, top: 0, right: 0, bottom: 500);
 
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 50));
@@ -274,6 +284,7 @@ void main() {
       await expectLater(find.byKey(key), matchesGoldenFile('zoom_page_transition.big.png'));
     } finally {
       tester.binding.window.physicalSizeTestValue = oldSize;
+      tester.binding.window.viewInsetsTestValue = oldInsets;
     }
   }, variant: TargetPlatformVariant.only(TargetPlatform.android), skip: kIsWeb); // [intended] rasterization is not used on the web.
 
@@ -1235,4 +1246,22 @@ class TestDependencies extends StatelessWidget {
       ),
     );
   }
+}
+
+class TestWindowPadding implements ui.WindowPadding {
+  const TestWindowPadding({
+    required this.left,
+    required this.top,
+    required this.right,
+    required this.bottom,
+  });
+
+  @override
+  final double left;
+  @override
+  final double top;
+  @override
+  final double right;
+  @override
+  final double bottom;
 }


### PR DESCRIPTION
When an application has nested scaffolds, the top scaffold will consume all of the insets to provide a safe area, making the media query inset worthless. Instead, re-rasterize anytime the mediaquery updates.

b/250815292

This works now.

```dart
// Copyright 2014 The Flutter Authors. All rights reserved.
// Use of this source code is governed by a BSD-style license that can be
// found in the LICENSE file.

import 'package:flutter/material.dart';
import 'package:flutter/scheduler.dart';

void main() {
  timeDilation = 10;
  runApp(MaterialApp(
    home: Scaffold(body: Example()),
    routes: {
      '/b': (context) => Scaffold(body: B()),
    },
  ));
}

class Example extends StatefulWidget {
  const Example({super.key});

  @override
  State<Example> createState() => _ExampleState();
}

class _ExampleState extends State<Example> {
  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Container(
        color: Colors.red,
        child: Center(
          child: TextButton(
            child: Text('Forward'),
            onPressed: () {
              Navigator.of(context).pushNamed('/b');
            },
          ),
        ),
      ),
    );
  }
}

class B extends StatelessWidget {
  const B({super.key});

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: Container(
        color: Colors.blue,
        child: Column(
          children: [
            TextField(),
            TextButton(
              child: Text('BACK', style: TextStyle(color: Colors.black),),
              onPressed: () {
                Navigator.of(context).pop();
              },
            )
          ],
        ),
      ),
    );
  }
}
```