### PR TITLE
re-enable firebase release smoke test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -349,7 +349,6 @@ targets:
 
   - name: Linux firebase_release_smoke_test
     recipe: firebaselab/firebaselab
-    bringup: true # https://github.com/flutter/flutter/issues/115170
     timeout: 60
     properties:
       dependencies: >-


### PR DESCRIPTION
The upstream infra outage from https://github.com/flutter/flutter/issues/115170 is now resolved.