### PR TITLE
Use `double.isNaN` instead of `... == double.nan` (which is always false)

### DIFF
--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -597,7 +597,7 @@ class _ContrastReport {
       count += entry.value;
     }
     final double averageLightness = totalLightness / count;
-    assert(averageLightness != double.nan);
+    assert(!averageLightness.isNaN);
 
     MapEntry<Color, int>? lightColor;
     MapEntry<Color, int>? darkColor;


### PR DESCRIPTION
This is needed after analyzer introduced a new warning in https://github.com/dart-lang/sdk/commit/254da6749515d03abb7b7e37f342b161e9c6fdac