### PR TITLE
Documentation fix to set initial value of cupertino-picker

### DIFF
--- a/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
+++ b/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
@@ -86,6 +86,10 @@ class _CupertinoPickerExampleState extends State<CupertinoPickerExample> {
                     squeeze: 1.2,
                     useMagnifier: true,
                     itemExtent: _kItemExtent,
+                    // This is used to give initial value
+                    scrollController: FixedExtentScrollController(
+                      initialItem: _selectedFruit,
+                    ),
                     // This is called when selected item is changed.
                     onSelectedItemChanged: (int selectedItem) {
                       setState(() {


### PR DESCRIPTION
Updated documentation for the button should be updated to the selected value when the picker is dismissed
#110732

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.