### PR TITLE
Do not parse stack traces in _findResponsibleMethod on Web platforms that use a different format

### DIFF
--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -267,6 +267,11 @@ class TestAsyncUtils {
         '\nWhen the first $originalName was called, this was the stack',
         scope.creationStack,
       ));
+    } else {
+      information.add(DiagnosticsStackTrace(
+        '\nWhen the first function was called, this was the stack',
+        scope.creationStack,
+      ));
     }
     throw FlutterError.fromParts(information);
   }
@@ -302,6 +307,10 @@ class TestAsyncUtils {
 
   static _StackEntry? _findResponsibleMethod(StackTrace rawStack, String method, List<DiagnosticsNode> information) {
     assert(method == 'guard' || method == 'guardSync');
+    // Web/JavaScript stack traces use a different format.
+    if (kIsWeb) {
+      return null;
+    }
     final List<String> stack = rawStack.toString().split('\n').where(_stripAsynchronousSuspensions).toList();
     assert(stack.last == '');
     stack.removeLast();

--- a/packages/flutter_test/test/test_async_utils_test.dart
+++ b/packages/flutter_test/test/test_async_utils_test.dart
@@ -60,7 +60,7 @@ void main() {
     }
     expect(await f1, isNull);
     expect(f2, isNull);
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   test('TestAsyncUtils - two classes, all callers in superclass', () async {
     final TestAPI testAPI = TestAPISubclass();
@@ -82,7 +82,7 @@ void main() {
     }
     expect(await f1, isNull);
     expect(f2, isNull);
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   test('TestAsyncUtils - two classes, mixed callers', () async {
     final TestAPISubclass testAPI = TestAPISubclass();
@@ -104,7 +104,7 @@ void main() {
     }
     expect(await f1, isNull);
     expect(f2, isNull);
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   test('TestAsyncUtils - expect() catches pending async work', () async {
     final TestAPI testAPI = TestAPISubclass();
@@ -126,7 +126,7 @@ void main() {
       real_test.expect(lines.length, greaterThan(7));
     }
     expect(await f1, isNull);
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   testWidgets('TestAsyncUtils - expect() catches pending async work', (WidgetTester tester) async {
     Future<Object?>? f1, f2;
@@ -168,7 +168,7 @@ void main() {
     }
     await f1;
     await f2;
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   testWidgets('TestAsyncUtils - expect() catches pending async work', (WidgetTester tester) async {
     Future<Object?>? f1;
@@ -193,7 +193,7 @@ void main() {
       real_test.expect(information[3].level, DiagnosticLevel.info);
     }
     await f1;
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   testWidgets('TestAsyncUtils - expect() catches pending async work', (WidgetTester tester) async {
     Future<Object?>? f1;
@@ -218,7 +218,7 @@ void main() {
       real_test.expect(information[3].level, DiagnosticLevel.info);
     }
     await f1;
-  });
+  }, skip: kIsWeb); // [intended] depends on platform-specific stack traces.
 
   testWidgets('TestAsyncUtils - guard body can throw', (WidgetTester tester) async {
     try {
@@ -228,6 +228,25 @@ void main() {
       expect(e, const RecognizableTestException());
     }
   });
+
+  test('TestAsyncUtils - web', () async {
+    final TestAPI testAPI = TestAPI();
+    Future<Object?>? f1, f2;
+    f1 = testAPI.testGuard1();
+    try {
+      f2 = testAPI.testGuard2();
+      fail('unexpectedly did not throw');
+    } on FlutterError catch (e) {
+      final List<String> lines = e.message.split('\n');
+      real_test.expect(lines[0], 'Guarded function conflict.');
+      real_test.expect(lines[1], 'You must use "await" with all Future-returning test APIs.');
+      real_test.expect(lines[2], '');
+      real_test.expect(lines[3], 'When the first function was called, this was the stack:');
+      real_test.expect(lines.length, greaterThan(3));
+    }
+    expect(await f1, isNull);
+    expect(f2, isNull);
+  }, skip: !kIsWeb); // [intended] depends on platform-specific stack traces.
 
   // see also dev/manual_tests/test_data which contains tests run by the flutter_tools tests for 'flutter test'
 }


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/107099