### PR TITLE
Added missing isLabelVisible parameter to Badge.count

### DIFF
--- a/packages/flutter/lib/src/material/badge.dart
+++ b/packages/flutter/lib/src/material/badge.dart
@@ -55,6 +55,7 @@ class Badge extends StatelessWidget {
     this.padding,
     this.alignment,
     required int count,
+    this.isLabelVisible = true,
     this.child,
   }) : label = Text(count > 999 ? '999+' : '$count');
 


### PR DESCRIPTION
Fixes a problem that was reported by a new Lint:
```
f74e269 2022-11-11 20:37 +0000 Konstantin Shcheglov Add isVariableFinal(), move isFinal to Var.
```

The new Badge.count constructor failed to include the (new) Badge.isLabel parameter.

Thanks to @cbracken for tracking this down.

