### PR TITLE
[devicelab] measure entire release folder size, zipped

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1513,19 +1513,18 @@ class CompileTest {
         watch.start();
         await flutter('build', options: options);
         watch.stop();
-        final String basename = path.basename(cwd);
-        final String exePath = path.join(
+        final String buildPath = path.join(
           cwd,
           'build',
           'windows',
           'runner',
           'release',
-          '$basename.exe');
-        final File exe = file(exePath);
+        );
         // On Windows, we do not produce a single installation package file,
-        // rather a directory containing an .exe and .dll files.
-        // The release size is set to the size of the produced .exe file
-        releaseSizeInBytes = exe.lengthSync();
+        // rather a directory containing an .exe and .dll files. Zip them all
+        // together to get an approximate release size.
+        await exec('tar.exe', <String>['-zcf', 'build/app.tar.gz', buildPath]);
+        releaseSizeInBytes = file('build/app.tar.gz').lengthSync();
         break;
     }
 


### PR DESCRIPTION
Right now we're only measuring the exe, which depends on the plugins selected but basically no other part of a windows app (dart code, engine size, assets). Zip up the entire folder and measure that instead