### PR TITLE
[devicelab] measure entire release folder size, zipped

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1529,7 +1529,7 @@ class CompileTest {
           if (outputFile.existsSync()) {
             releaseSizeInBytes = outputFile.lengthSync();
           } else {
-            print('does not exist');
+            print('tar completed successfully, but ${outputFile.path} does not exist!');
             releaseSizeInBytes = 0;
           }
         } else {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1523,8 +1523,18 @@ class CompileTest {
         // On Windows, we do not produce a single installation package file,
         // rather a directory containing an .exe and .dll files. Zip them all
         // together to get an approximate release size.
-        await exec('tar.exe', <String>['-zcf', 'build/app.tar.gz', buildPath]);
-        releaseSizeInBytes = file('build/app.tar.gz').lengthSync();
+        final int result = await exec('tar.exe', <String>['-zcf', '$cwd/build/app.tar.gz', buildPath]);
+        if (result == 0) {
+          final File outputFile = file('$cwd/build/app.tar.gz');
+          if (outputFile.existsSync()) {
+            releaseSizeInBytes = outputFile.lengthSync();
+          } else {
+            releaseSizeInBytes = 0;
+          }
+        } else {
+          print('Failed to run tar.exe: $result');
+          releaseSizeInBytes = 0;
+        }
         break;
     }
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1523,12 +1523,13 @@ class CompileTest {
         // On Windows, we do not produce a single installation package file,
         // rather a directory containing an .exe and .dll files. Zip them all
         // together to get an approximate release size.
-        final int result = await exec('tar.exe', <String>['-zcf', '$cwd/build/app.tar.gz', buildPath]);
+        final int result = await exec('tar.exe', <String>['-zcf', 'build/app.tar.gz', '"$buildPath"']);
         if (result == 0) {
-          final File outputFile = file('$cwd/build/app.tar.gz');
+          final File outputFile = file('build/app.tar.gz');
           if (outputFile.existsSync()) {
             releaseSizeInBytes = outputFile.lengthSync();
           } else {
+            print('does not exist');
             releaseSizeInBytes = 0;
           }
         } else {

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1513,19 +1513,18 @@ class CompileTest {
         watch.start();
         await flutter('build', options: options);
         watch.stop();
-        final String basename = path.basename(cwd);
-        final String exePath = path.join(
+        final String buildPath = path.join(
           cwd,
           'build',
           'windows',
           'runner',
           'release',
-          '$basename.exe');
-        final File exe = file(exePath);
+        );
         // On Windows, we do not produce a single installation package file,
-        // rather a directory containing an .exe and .dll files.
-        // The release size is set to the size of the produced .exe file
-        releaseSizeInBytes = exe.lengthSync();
+        // rather a directory containing an .exe and .dll files. Zip them all
+        // together to get an approximate release size.
+        await exec('tar.exe', <String>['-zcf', 'build/app.tar.gz', buildPath]);
+        releaseSizeInBytes = file('build/app.tar.gz').lengthSync();
         break;
     }
 


### PR DESCRIPTION
Reland with some defensive fallbacks. if there are spaces in the paths provided to tar, they need to be quoted or else the command hangs