### PR TITLE
Revert "[devicelab] measure entire release folder size, zipped"

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1513,29 +1513,19 @@ class CompileTest {
         watch.start();
         await flutter('build', options: options);
         watch.stop();
-        final String buildPath = path.join(
+        final String basename = path.basename(cwd);
+        final String exePath = path.join(
           cwd,
           'build',
           'windows',
           'runner',
           'release',
-        );
+          '$basename.exe');
+        final File exe = file(exePath);
         // On Windows, we do not produce a single installation package file,
-        // rather a directory containing an .exe and .dll files. Zip them all
-        // together to get an approximate release size.
-        final int result = await exec('tar.exe', <String>['-zcf', 'build/app.tar.gz', '"$buildPath"']);
-        if (result == 0) {
-          final File outputFile = file('build/app.tar.gz');
-          if (outputFile.existsSync()) {
-            releaseSizeInBytes = outputFile.lengthSync();
-          } else {
-            print('tar completed successfully, but ${outputFile.path} does not exist!');
-            releaseSizeInBytes = 0;
-          }
-        } else {
-          print('Failed to run tar.exe: $result');
-          releaseSizeInBytes = 0;
-        }
+        // rather a directory containing an .exe and .dll files.
+        // The release size is set to the size of the produced .exe file
+        releaseSizeInBytes = exe.lengthSync();
         break;
     }
 


### PR DESCRIPTION
Reverts flutter/flutter#115612


```
[complex_layout_win_desktop__compile] [STDOUT] Executing "tar.exe -zcf build/app.tar.gz "C:\b\s\w\ir\x\w\recipe_cleanup\tmp8kcw9x56\flutter sdk/dev/benchmarks/complex_layout\build\windows\runner\release"" in "C:\b\s\w\ir\x\w\recipe_cleanup\tmp8kcw9x56\flutter sdk/dev/benchmarks/complex_layout" with environment {BOT: true, LANG: en_US.UTF-8}
[complex_layout_win_desktop__compile] [STDOUT] stderr: tar.exe: "C:/b/s/w/ir/x/w/recipe_cleanup/tmp8kcw9x56/flutter sdk/dev/benchmarks/complex_layout/build/windows/runner/release": Couldn't find file: Invalid argument
[complex_layout_win_desktop__compile] [STDOUT] stderr: tar.exe: Error exit delayed from previous errors.
[complex_layout_win_desktop__compile] [STDOUT] Checking for reboot
[complex_layout_win_desktop__compile] Process terminated with exit code 0.
Task result:
{
  "success": false,
  "reason": "Task failed: Executable \"tar.exe\" failed with exit code 1."
}
```