### PR TITLE
Add Material 3 `Slider` example

### DIFF
--- a/examples/api/lib/material/slider/slider.0.dart
+++ b/examples/api/lib/material/slider/slider.0.dart
@@ -6,47 +6,44 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const SliderApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  static const String _title = 'Flutter Code Sample';
+class SliderApp extends StatelessWidget {
+  const SliderApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: _title,
-      home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const MyStatefulWidget(),
-      ),
+    return const MaterialApp(
+      home: SliderExample(),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({super.key});
+class SliderExample extends StatefulWidget {
+  const SliderExample({super.key});
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<SliderExample> createState() => _SliderExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+class _SliderExampleState extends State<SliderExample> {
   double _currentSliderValue = 20;
 
   @override
   Widget build(BuildContext context) {
-    return Slider(
-      value: _currentSliderValue,
-      max: 100,
-      divisions: 5,
-      label: _currentSliderValue.round().toString(),
-      onChanged: (double value) {
-        setState(() {
-          _currentSliderValue = value;
-        });
-      },
+    return Scaffold(
+      appBar: AppBar(title: const Text('Slider')),
+      body: Slider(
+        value: _currentSliderValue,
+        max: 100,
+        divisions: 5,
+        label: _currentSliderValue.round().toString(),
+        onChanged: (double value) {
+          setState(() {
+            _currentSliderValue = value;
+          });
+        },
+      ),
     );
   }
 }

--- a/examples/api/lib/material/slider/slider.1.dart
+++ b/examples/api/lib/material/slider/slider.1.dart
@@ -6,61 +6,48 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const SliderApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  static const String _title = 'Flutter Code Sample';
+class SliderApp extends StatelessWidget {
+  const SliderApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
-      home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const MyStatefulWidget(),
+      theme: ThemeData(
+        colorSchemeSeed: const Color(0xff6750a4),
+        useMaterial3: true,
       ),
+      home: const SliderExample(),
     );
   }
 }
 
-class MyStatefulWidget extends StatefulWidget {
-  const MyStatefulWidget({super.key});
+class SliderExample extends StatefulWidget {
+  const SliderExample({super.key});
 
   @override
-  State<MyStatefulWidget> createState() => _MyStatefulWidgetState();
+  State<SliderExample> createState() => _SliderExampleState();
 }
 
-class _MyStatefulWidgetState extends State<MyStatefulWidget> {
-  double _currentSliderPrimaryValue = 0.2;
-  double _currentSliderSecondaryValue = 0.5;
+class _SliderExampleState extends State<SliderExample> {
+  double _currentSliderValue = 20;
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: <Widget>[
-        Slider(
-          value: _currentSliderPrimaryValue,
-          secondaryTrackValue: _currentSliderSecondaryValue,
-          label: _currentSliderPrimaryValue.round().toString(),
-          onChanged: (double value) {
-            setState(() {
-              _currentSliderPrimaryValue = value;
-            });
-          },
-        ),
-        Slider(
-          value: _currentSliderSecondaryValue,
-          label: _currentSliderSecondaryValue.round().toString(),
-          onChanged: (double value) {
-            setState(() {
-              _currentSliderSecondaryValue = value;
-            });
-          },
-        ),
-      ],
+    return Scaffold(
+      appBar: AppBar(title: const Text('Slider')),
+      body: Slider(
+        value: _currentSliderValue,
+        max: 100,
+        divisions: 5,
+        label: _currentSliderValue.round().toString(),
+        onChanged: (double value) {
+          setState(() {
+            _currentSliderValue = value;
+          });
+        },
+      ),
     );
   }
 }

--- a/examples/api/lib/material/slider/slider.2.dart
+++ b/examples/api/lib/material/slider/slider.2.dart
@@ -1,0 +1,63 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Flutter code sample for [Slider].
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const SliderApp());
+
+class SliderApp extends StatelessWidget {
+  const SliderApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: SliderExample(),
+    );
+  }
+}
+
+class SliderExample extends StatefulWidget {
+  const SliderExample({super.key});
+
+  @override
+  State<SliderExample> createState() => _SliderExampleState();
+}
+
+class _SliderExampleState extends State<SliderExample> {
+  double _currentSliderPrimaryValue = 0.2;
+  double _currentSliderSecondaryValue = 0.5;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Slider')),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Slider(
+            value: _currentSliderPrimaryValue,
+            secondaryTrackValue: _currentSliderSecondaryValue,
+            label: _currentSliderPrimaryValue.round().toString(),
+            onChanged: (double value) {
+              setState(() {
+                _currentSliderPrimaryValue = value;
+              });
+            },
+          ),
+          Slider(
+            value: _currentSliderSecondaryValue,
+            label: _currentSliderSecondaryValue.round().toString(),
+            onChanged: (double value) {
+              setState(() {
+                _currentSliderSecondaryValue = value;
+              });
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/api/test/material/slider/slider.0_test.dart
+++ b/examples/api/test/material/slider/slider.0_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/material/slider/slider.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Slider can change value', (WidgetTester tester) async {
+  testWidgets('Slider can change its value', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.SliderApp(),
     );

--- a/examples/api/test/material/slider/slider.0_test.dart
+++ b/examples/api/test/material/slider/slider.0_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_api_samples/material/slider/slider.1.dart' as example;
+import 'package:flutter_api_samples/material/slider/slider.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/examples/api/test/material/slider/slider.1_test.dart
+++ b/examples/api/test/material/slider/slider.1_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_api_samples/material/slider/slider.1.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets('Slider can change value', (WidgetTester tester) async {
+  testWidgets('Slider can change its value', (WidgetTester tester) async {
     await tester.pumpWidget(
       const example.SliderApp(),
     );

--- a/examples/api/test/material/slider/slider.2_test.dart
+++ b/examples/api/test/material/slider/slider.2_test.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/slider/slider.2.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Slider shows secondary track', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.SliderApp(),
+    );
+
+    expect(find.byType(Slider), findsNWidgets(2));
+
+    final Finder slider1Finder = find.byType(Slider).at(0);
+    final Finder slider2Finder = find.byType(Slider).at(1);
+
+    Slider slider1 = tester.widget(slider1Finder);
+    Slider slider2 = tester.widget(slider2Finder);
+    expect(slider1.secondaryTrackValue, slider2.value);
+
+    const double targetValue = 0.8;
+    final Rect rect = tester.getRect(slider2Finder);
+    final Offset target = Offset(rect.left + (rect.right - rect.left) * targetValue, rect.top + (rect.bottom - rect.top) / 2);
+    await tester.tapAt(target);
+    await tester.pump();
+
+    slider1 = tester.widget(slider1Finder);
+    slider2 = tester.widget(slider2Finder);
+    expect(slider1.secondaryTrackValue, closeTo(targetValue, 0.05));
+    expect(slider1.secondaryTrackValue, slider2.value);
+  });
+}

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -41,7 +41,7 @@ enum _SliderType { material, adaptive }
 /// {@youtube 560 315 https://www.youtube.com/watch?v=ufb4gIPDmEs}
 ///
 /// {@tool dartpad}
-/// ![A slider widget, consisting of 5 divisions and showing the default value
+/// ![A legacy slider widget, consisting of 5 divisions and showing the default value
 /// indicator.](https://flutter.github.io/assets-for-api-docs/assets/material/slider.png)
 ///
 /// The Sliders value is part of the Stateful widget subclass to change the value
@@ -51,8 +51,8 @@ enum _SliderType { material, adaptive }
 /// {@end-tool}
 ///
 /// {@tool dartpad}
-/// This sample shows the creation of a [Slider], as described in:
-/// https://m3.material.io/components/sliders/overview
+/// This sample shows the creation of a [Slider] using [ThemeData.useMaterial3] flag,
+/// as described in: https://m3.material.io/components/sliders/overview.
 ///
 /// ** See code in examples/api/lib/material/slider/slider.1.dart **
 /// {@end-tool}

--- a/packages/flutter/lib/src/material/slider.dart
+++ b/packages/flutter/lib/src/material/slider.dart
@@ -51,10 +51,17 @@ enum _SliderType { material, adaptive }
 /// {@end-tool}
 ///
 /// {@tool dartpad}
+/// This sample shows the creation of a [Slider], as described in:
+/// https://m3.material.io/components/sliders/overview
+///
+/// ** See code in examples/api/lib/material/slider/slider.1.dart **
+/// {@end-tool}
+///
+/// {@tool dartpad}
 /// This example shows a [Slider] widget using the [Slider.secondaryTrackValue]
 /// to show a secondary track in the slider.
 ///
-/// ** See code in examples/api/lib/material/slider/slider.1.dart **
+/// ** See code in examples/api/lib/material/slider/slider.2.dart **
 /// {@end-tool}
 ///
 /// A slider can be used to select from either a continuous or a discrete set of


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/101048

This PR adds Material 3 `Slider` example since [Material 3 `Slider`](https://github.com/flutter/flutter/issues/111451)  landed.

![Screenshot 2022-11-18 at 12 14 07](https://user-images.githubusercontent.com/48603081/202678258-0b7bc266-eb15-41e9-a31c-317e7ec1bcbc.png)





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
