### PR TITLE
Track entire web build directory size in web_size__compile_test

### DIFF
--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1356,6 +1356,7 @@ class WebCompileTest {
     Map<String, String> files = const <String, String>{},
     required String metric,
   }) async {
+    const String kGzipCompressionLevel = '-9';
     final Map<String, int> sizeMetrics = <String, int>{};
 
     final Directory tempDir = Directory.systemTemp.createTempSync('perf_tests_gzips');
@@ -1364,7 +1365,7 @@ class WebCompileTest {
       final String filePath = entry.value;
       sizeMetrics['${metric}_${key}_uncompressed_bytes'] = File(filePath).lengthSync();
 
-      await Process.run('gzip',<String>['--keep', '-9', filePath]);
+      await Process.run('gzip',<String>['--keep', kGzipCompressionLevel, filePath]);
       // gzip does not provide a CLI option to specify an output file, so
       // instead just move the output file to the temp dir
       final File compressedFile = File('$filePath.gz')
@@ -1389,9 +1390,10 @@ class WebCompileTest {
       final String tarball = path.join(tempDir.absolute.path, '$key.tar.gz');
       await Process.run('tar', <String>[
         '--create',
-        '--gzip',
         '--verbose',
         '--file=$tarball',
+        '--use-compress-program',
+        'gzip $kGzipCompressionLevel',
         dirPath,
       ]);
       sizeMetrics['${metric}_${key}_compressed_bytes'] = File(tarball).lengthSync();

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -1362,7 +1362,7 @@ class WebCompileTest {
     for (final MapEntry<String, String> entry in files.entries) {
       final String key = entry.key;
       final String filePath = entry.value;
-      ProcessResult result = await Process.run('du', <String>['-k', filePath]);
+      ProcessResult result = await Process.run('du', <String>['--bytes', filePath]);
       sizeMetrics['${metric}_${key}_size'] = _parseDu(result.stdout as String);
 
       await Process.run('gzip',<String>['--keep', '-9', filePath]);
@@ -1370,7 +1370,7 @@ class WebCompileTest {
       // instead just move the output file to the temp dir
       final File compressedFile = File('$filePath.gz')
           .renameSync(path.join(tempDir.absolute.path, '$key.gz'));
-      result = await Process.run('du', <String>['-k', compressedFile.path]);
+      result = await Process.run('du', <String>['--bytes', compressedFile.path]);
       sizeMetrics['${metric}_${key}_size_gzip'] = _parseDu(result.stdout as String);
 
     }
@@ -1378,7 +1378,7 @@ class WebCompileTest {
     for (final MapEntry<String, String> entry in directories.entries) {
       final String key = entry.key;
       final String dirPath = entry.value;
-      ProcessResult result = await Process.run('du', <String>['-k', dirPath]);
+      ProcessResult result = await Process.run('du', <String>['--bytes', dirPath]);
 
       // when calling `du` on a directory, the last line is the sum of all its
       // contents, thus the total size of the directory
@@ -1394,7 +1394,7 @@ class WebCompileTest {
         '--file=$tarball',
         dirPath,
       ]);
-      result = await Process.run('du', <String>['-k', tarball]);
+      result = await Process.run('du', <String>['--bytes', tarball]);
       sizeMetrics['${metric}_${key}_size_gzip'] = _parseDu(result.stdout as String);
     }
 


### PR DESCRIPTION
Similar to https://github.com/flutter/flutter/pull/115612/files, include the entire build output directory when measuring build size.

Also, previously the optimization flag to `gzip` was incorrect (`9` which is an input file path, rather than `-9` which is an optimization level), however the size diff was just a few bytes.