### PR TITLE
Add test target for release scheduler

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4623,7 +4623,11 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: flutter_tool_startup__macos
 
-  # This is used to test the new release scheduler. This will eventually be deleted.
+  # TODO(drewroengoogle): Remove this target when the release scheduler is
+  # confirmed to be working correctly and as intended.
+  # (https://github.com/flutter/flutter/issues/100806)
+  # This target is marked `bringup: true` because this is a temporary target
+  # that is not intended to impact the tree.
   - name: Linux docs_test_with_release_scheduler
     recipe: flutter/flutter
     scheduler: release

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4628,20 +4628,22 @@ targets:
   # (https://github.com/flutter/flutter/issues/100806)
   # This target is marked `bringup: true` because this is a temporary target
   # that is not intended to impact the tree.
-  - name: Linux docs_test_with_release_scheduler
+  - name: Linux docs_deploy_with_release_scheduler
     recipe: flutter/flutter
     scheduler: release
     bringup: true
+    presubmit: false
     timeout: 60
     properties:
       cores: "32"
       dependencies: >-
         [
-          {"dependency": "dashing", "version": "0.4.0"}
+          {"dependency": "dashing", "version": "0.4.0"},
+          {"dependency": "firebase", "version": "v11.0.1"}
         ]
-      firebase_project: ""
-      release_ref: ""
       tags: >
-        ["framework","hostonly", "linux"]
+        ["framework", "hostonly", "linux"]
       validation: docs
       validation_name: Docs
+      firebase_project: master-docs-flutter-dev
+      release_ref: refs/heads/master

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4622,3 +4622,22 @@ targets:
       tags: >
         ["devicelab", "hostonly", "mac"]
       task_name: flutter_tool_startup__macos
+
+  # This is used to test the new release scheduler. This will eventually be deleted.
+  - name: Linux docs_test_with_release_scheduler
+    recipe: flutter/flutter
+    scheduler: release
+    bringup: true
+    timeout: 60
+    properties:
+      cores: "32"
+      dependencies: >-
+        [
+          {"dependency": "dashing", "version": "0.4.0"}
+        ]
+      firebase_project: ""
+      release_ref: ""
+      tags: >
+        ["framework","hostonly", "linux"]
+      validation: docs
+      validation_name: Docs


### PR DESCRIPTION
Adds a target that is used to test the new test scheduler for releases. This will eventually be removed.

Marked as `bringup: true` as this is a new target and will not be part of .ci.yaml for the long term.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
