### PR TITLE
Provide an option to update `Focus` semantics under `FocusableActionDetector`

### DIFF
--- a/packages/flutter/lib/src/widgets/actions.dart
+++ b/packages/flutter/lib/src/widgets/actions.dart
@@ -1077,6 +1077,7 @@ class FocusableActionDetector extends StatefulWidget {
     this.onShowHoverHighlight,
     this.onFocusChange,
     this.mouseCursor = MouseCursor.defer,
+    this.includeFocusSemantics = true,
     required this.child,
   })  : assert(enabled != null),
         assert(autofocus != null),
@@ -1132,6 +1133,11 @@ class FocusableActionDetector extends StatefulWidget {
   /// The [mouseCursor] defaults to [MouseCursor.defer], deferring the choice of
   /// cursor to the next region behind it in hit-test order.
   final MouseCursor mouseCursor;
+
+  /// Whether to include semantics from [Focus].
+  ///
+  /// Defaults to true.
+  final bool includeFocusSemantics;
 
   /// The child widget for this [FocusableActionDetector] widget.
   ///
@@ -1293,6 +1299,7 @@ class _FocusableActionDetectorState extends State<FocusableActionDetector> {
         descendantsAreTraversable: widget.descendantsAreTraversable,
         canRequestFocus: _canRequestFocus,
         onFocusChange: _handleFocusChange,
+        includeSemantics: widget.includeFocusSemantics,
         child: widget.child,
       ),
     );

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -28,6 +28,7 @@ void main() {
       expect(invoked, isTrue);
     });
   });
+
   group(Actions, () {
     Intent? invokedIntent;
     Action<Intent>? invokedAction;
@@ -99,6 +100,7 @@ void main() {
       expect(result, isTrue);
       expect(invoked, isTrue);
     });
+
     testWidgets('maybeInvoke returns null when no action is found', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -125,6 +127,7 @@ void main() {
       expect(result, isNull);
       expect(invoked, isFalse);
     });
+
     testWidgets('invoke throws when no action is found', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -151,6 +154,7 @@ void main() {
       expect(result, isNull);
       expect(invoked, isFalse);
     });
+
     testWidgets('Actions widget can invoke actions with custom dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -181,6 +185,7 @@ void main() {
       expect(invoked, isTrue);
       expect(invokedIntent, equals(intent));
     });
+
     testWidgets('Actions can invoke actions in ancestor dispatcher', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -217,6 +222,7 @@ void main() {
       expect(invokedAction, equals(testAction));
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
     });
+
     testWidgets("Actions can invoke actions in ancestor dispatcher if a lower one isn't specified", (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -252,6 +258,7 @@ void main() {
       expect(invokedAction, equals(testAction));
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
     });
+
     testWidgets('Actions widget can be found with of', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final ActionDispatcher testDispatcher = TestDispatcher1(postInvoke: collect);
@@ -268,6 +275,7 @@ void main() {
       final ActionDispatcher dispatcher = Actions.of(containerKey.currentContext!);
       expect(dispatcher, equals(testDispatcher));
     });
+
     testWidgets('Action can be found with find', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final ActionDispatcher testDispatcher = TestDispatcher1(postInvoke: collect);
@@ -314,6 +322,7 @@ void main() {
       expect(() => Actions.find<DoNothingIntent>(containerKey.currentContext!), throwsAssertionError);
       expect(Actions.maybeFind<DoNothingIntent>(containerKey.currentContext!), isNull);
     });
+
     testWidgets('FocusableActionDetector keeps track of focus and hover even when disabled.', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
@@ -383,6 +392,7 @@ void main() {
       expect(hovering, isFalse);
       expect(focusing, isFalse);
     });
+
     testWidgets('FocusableActionDetector changes mouse cursor when hovered', (WidgetTester tester) async {
       await tester.pumpWidget(
         MouseRegion(
@@ -415,6 +425,7 @@ void main() {
 
       expect(RendererBinding.instance.mouseTracker.debugDeviceActiveCursor(1), SystemMouseCursors.forbidden);
     });
+
     testWidgets('Actions.invoke returns the value of Action.invoke', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       final Object sentinel = Object();
@@ -445,6 +456,7 @@ void main() {
       expect(identical(result, sentinel), isTrue);
       expect(invoked, isTrue);
     });
+
     testWidgets('ContextAction can return null', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       const TestIntent intent = TestIntent();
@@ -471,6 +483,7 @@ void main() {
       expect(invokedDispatcher.runtimeType, equals(TestDispatcher1));
       expect(testAction.capturedContexts.single, containerKey.currentContext);
     });
+
     testWidgets('Disabled actions stop propagation to an ancestor', (WidgetTester tester) async {
       final GlobalKey containerKey = GlobalKey();
       bool invoked = false;
@@ -775,6 +788,7 @@ void main() {
       expect(hovering, isFalse);
       expect(focusing, isFalse);
     });
+
     testWidgets('FocusableActionDetector shows focus highlight appropriately when focused and disabled', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
@@ -805,6 +819,7 @@ void main() {
       await tester.pump();
       expect(focusing, isTrue);
     });
+
     testWidgets('FocusableActionDetector can be used without callbacks', (WidgetTester tester) async {
       FocusManager.instance.highlightStrategy = FocusHighlightStrategy.alwaysTraditional;
       final GlobalKey containerKey = GlobalKey();
@@ -951,6 +966,110 @@ void main() {
         expect(buttonNode2.hasFocus, isFalse);
       },
     );
+
+    testWidgets('FocusableActionDetector can exclude Focus semantics', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FocusableActionDetector(
+            child: Column(
+              children: <Widget>[
+                TextButton(
+                  onPressed: () {},
+                  child: const Text('Button 1'),
+                ),
+                TextButton(
+                  onPressed: () {},
+                  child: const Text('Button 2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      expect(
+        tester.getSemantics(find.byType(FocusableActionDetector)),
+        matchesSemantics(
+          scopesRoute: true,
+          children: <Matcher>[
+            // This semantic is from `Focus` widget under `FocusableActionDetector`.
+            matchesSemantics(
+              isFocusable: true,
+              children: <Matcher>[
+                matchesSemantics(
+                  hasTapAction: true,
+                  isButton: true,
+                  hasEnabledState: true,
+                  isEnabled: true,
+                  isFocusable: true,
+                  label: 'Button 1',
+                  textDirection: TextDirection.ltr,
+                ),
+                matchesSemantics(
+                  hasTapAction: true,
+                  isButton: true,
+                  hasEnabledState: true,
+                  isEnabled: true,
+                  isFocusable: true,
+                  label: 'Button 2',
+                  textDirection: TextDirection.ltr,
+                ),
+              ],
+            ),
+          ],
+        ),
+      );
+
+      // Set `includeFocusSemantics` to false to exclude semantics
+      // from `Focus` widget under `FocusableActionDetector`.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: FocusableActionDetector(
+            includeFocusSemantics: false,
+            child: Column(
+              children: <Widget>[
+                TextButton(
+                  onPressed: () {},
+                  child: const Text('Button 1'),
+                ),
+                TextButton(
+                  onPressed: () {},
+                  child: const Text('Button 2'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      // Semantics from the `Focus` widget will be removed.
+      expect(
+        tester.getSemantics(find.byType(FocusableActionDetector)),
+        matchesSemantics(
+          scopesRoute: true,
+          children: <Matcher>[
+            matchesSemantics(
+              hasTapAction: true,
+              isButton: true,
+              hasEnabledState: true,
+              isEnabled: true,
+              isFocusable: true,
+              label: 'Button 1',
+              textDirection: TextDirection.ltr,
+            ),
+            matchesSemantics(
+              hasTapAction: true,
+              isButton: true,
+              hasEnabledState: true,
+              isEnabled: true,
+              isFocusable: true,
+              label: 'Button 2',
+              textDirection: TextDirection.ltr,
+            ),
+          ],
+        ),
+      );
+    });
   });
 
   group('Action subclasses', () {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/115831
context: https://github.com/flutter/flutter/pull/115285#issuecomment-1323680781

### Description
This PR adds an option to update `Focus` semantics under `FocusableActionDetector`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
