### PR TITLE
[flutter_tool] Adds --enable-dart-profiling flag

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -626,7 +626,8 @@ class AndroidDevice extends Device {
       '-a', 'android.intent.action.MAIN',
       '-c', 'android.intent.category.LAUNCHER',
       '-f', '0x20000000', // FLAG_ACTIVITY_SINGLE_TOP
-      '--ez', 'enable-dart-profiling', 'true',
+      if (debuggingOptions.enableDartProfiling)
+        ...<String>['--ez', 'enable-dart-profiling', 'true'],
       if (traceStartup)
         ...<String>['--ez', 'trace-startup', 'true'],
       if (route != null)

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -135,6 +135,11 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
               'this comma separated list of allowed prefixes.',
         valueHelp: 'skia.gpu,skia.shaders',
       )
+      ..addFlag('enable-dart-profiling',
+        defaultsTo: true,
+        help: 'Whether the Dart VM sampling CPU profiler is enabled. This flag '
+              'is only meaningnful in debug and profile builds.',
+      )
       ..addFlag('enable-software-rendering',
         negatable: false,
         help: 'Enable rendering using the Skia software backend. '
@@ -178,6 +183,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
   }
 
   bool get traceStartup => boolArgDeprecated('trace-startup');
+  bool get enableDartProfiling => boolArgDeprecated('enable-dart-profiling');
   bool get cacheSkSL => boolArgDeprecated('cache-sksl');
   bool get dumpSkpOnShaderCompilation => boolArgDeprecated('dump-skp-on-shader-compilation');
   bool get purgePersistentCache => boolArgDeprecated('purge-persistent-cache');
@@ -224,6 +230,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         webBrowserFlags: webBrowserFlags,
         enableImpeller: enableImpeller,
         uninstallFirst: uninstallFirst,
+        enableDartProfiling: enableDartProfiling,
       );
     } else {
       return DebuggingOptions.enabled(
@@ -270,6 +277,7 @@ abstract class RunCommandBase extends FlutterCommand with DeviceBasedDevelopment
         nativeNullAssertions: boolArgDeprecated('native-null-assertions'),
         enableImpeller: enableImpeller,
         uninstallFirst: uninstallFirst,
+        enableDartProfiling: enableDartProfiling,
       );
     }
   }

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -282,78 +282,50 @@ class CustomDeviceAppSession {
   /// For example, `_getEngineOptions(null, false, null)` will return
   /// `['enable-dart-profiling=true']`
   List<String> _getEngineOptions(DebuggingOptions debuggingOptions, bool traceStartup, String? route) {
-    final List<String> options = <String>[];
-
-    void addFlag(String value) {
-      options.add(value);
-    }
-
-    addFlag('enable-dart-profiling=true');
-
-    if (traceStartup) {
-      addFlag('trace-startup=true');
-    }
-    if (route != null) {
-      addFlag('route=$route');
-    }
-    if (debuggingOptions != null) {
-      if (debuggingOptions.enableSoftwareRendering) {
-        addFlag('enable-software-rendering=true');
-      }
-      if (debuggingOptions.skiaDeterministicRendering) {
-        addFlag('skia-deterministic-rendering=true');
-      }
-      if (debuggingOptions.traceSkia) {
-        addFlag('trace-skia=true');
-      }
-      if (debuggingOptions.traceAllowlist != null) {
-        addFlag('trace-allowlist=${debuggingOptions.traceAllowlist}');
-      }
-      if (debuggingOptions.traceSystrace) {
-        addFlag('trace-systrace=true');
-      }
-      if (debuggingOptions.endlessTraceBuffer) {
-        addFlag('endless-trace-buffer=true');
-      }
-      if (debuggingOptions.dumpSkpOnShaderCompilation) {
-        addFlag('dump-skp-on-shader-compilation=true');
-      }
-      if (debuggingOptions.cacheSkSL) {
-        addFlag('cache-sksl=true');
-      }
-      if (debuggingOptions.purgePersistentCache) {
-        addFlag('purge-persistent-cache=true');
-      }
-      // Options only supported when there is a VM Service connection between the
-      // tool and the device, usually in debug or profile mode.
-      if (debuggingOptions.debuggingEnabled) {
-        if (debuggingOptions.deviceVmServicePort != null) {
-          addFlag('observatory-port=${debuggingOptions.deviceVmServicePort}');
-        }
-        if (debuggingOptions.buildInfo.isDebug) {
-          addFlag('enable-checked-mode=true');
-          addFlag('verify-entry-points=true');
-        }
-        if (debuggingOptions.startPaused) {
-          addFlag('start-paused=true');
-        }
-        if (debuggingOptions.disableServiceAuthCodes) {
-          addFlag('disable-service-auth-codes=true');
-        }
-        final String dartVmFlags = computeDartVmFlags(debuggingOptions);
-        if (dartVmFlags.isNotEmpty) {
-          addFlag('dart-flags=$dartVmFlags');
-        }
-        if (debuggingOptions.useTestFonts) {
-          addFlag('use-test-fonts=true');
-        }
-        if (debuggingOptions.verboseSystemLogs) {
-          addFlag('verbose-logging=true');
-        }
-      }
-    }
-
-    return options;
+    final String dartVmFlags = computeDartVmFlags(debuggingOptions);
+    return <String>[
+      if (traceStartup)
+        'trace-startup=true',
+      if (route != null)
+        'route=$route',
+      if (debuggingOptions.enableDartProfiling)
+        'enable-dart-profiling=true',
+      if (debuggingOptions.enableSoftwareRendering)
+        'enable-software-rendering=true',
+      if (debuggingOptions.skiaDeterministicRendering)
+        'skia-deterministic-rendering=true',
+      if (debuggingOptions.traceSkia)
+        'trace-skia=true',
+      if (debuggingOptions.traceAllowlist != null)
+        'trace-allowlist=${debuggingOptions.traceAllowlist}',
+      if (debuggingOptions.traceSystrace)
+        'trace-systrace=true',
+      if (debuggingOptions.endlessTraceBuffer)
+        'endless-trace-buffer=true',
+      if (debuggingOptions.dumpSkpOnShaderCompilation)
+        'dump-skp-on-shader-compilation=true',
+      if (debuggingOptions.cacheSkSL) 'cache-sksl=true',
+      if (debuggingOptions.purgePersistentCache)
+        'purge-persistent-cache=true',
+      if (debuggingOptions.debuggingEnabled) ...<String>[
+        if (debuggingOptions.deviceVmServicePort != null)
+          'observatory-port=${debuggingOptions.deviceVmServicePort}',
+        if (debuggingOptions.buildInfo.isDebug) ...<String>[
+          'enable-checked-mode=true',
+          'verify-entry-points=true',
+        ],
+        if (debuggingOptions.startPaused)
+          'start-paused=true',
+        if (debuggingOptions.disableServiceAuthCodes)
+          'disable-service-auth-codes=true',
+        if (dartVmFlags.isNotEmpty)
+          'dart-flags=$dartVmFlags',
+        if (debuggingOptions.useTestFonts)
+          'use-test-fonts=true',
+        if (debuggingOptions.verboseSystemLogs)
+          'verbose-logging=true',
+      ],
+    ];
   }
 
   /// Get the engine options for the given [debuggingOptions],

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -753,6 +753,7 @@ class DebuggingOptions {
     this.nativeNullAssertions = false,
     this.enableImpeller = false,
     this.uninstallFirst = false,
+    this.enableDartProfiling = true,
    }) : debuggingEnabled = true;
 
   DebuggingOptions.disabled(this.buildInfo, {
@@ -771,6 +772,7 @@ class DebuggingOptions {
       this.traceAllowlist,
       this.enableImpeller = false,
       this.uninstallFirst = false,
+      this.enableDartProfiling = true,
     }) : debuggingEnabled = false,
       useTestFonts = false,
       startPaused = false,
@@ -841,6 +843,7 @@ class DebuggingOptions {
     required this.nativeNullAssertions,
     required this.enableImpeller,
     required this.uninstallFirst,
+    required this.enableDartProfiling,
   });
 
   final bool debuggingEnabled;
@@ -876,6 +879,7 @@ class DebuggingOptions {
   final bool webUseSseForDebugBackend;
   final bool webUseSseForInjectedClient;
   final bool enableImpeller;
+  final bool enableDartProfiling;
 
   /// Whether the tool should try to uninstall a previously installed version of the app.
   ///
@@ -916,7 +920,7 @@ class DebuggingOptions {
   List<String> getIOSLaunchArguments(EnvironmentType environmentType, String? route,  Map<String, Object?> platformArgs) {
     final String dartVmFlags = computeDartVmFlags(this);
     return <String>[
-      '--enable-dart-profiling',
+      if (enableDartProfiling) '--enable-dart-profiling',
       if (disableServiceAuthCodes) '--disable-service-auth-codes',
       if (disablePortPublication) '--disable-observatory-publication',
       if (startPaused) '--start-paused',
@@ -994,6 +998,7 @@ class DebuggingOptions {
     'nullAssertions': nullAssertions,
     'nativeNullAssertions': nativeNullAssertions,
     'enableImpeller': enableImpeller,
+    'enableDartProfiling': enableDartProfiling,
   };
 
   static DebuggingOptions fromJson(Map<String, Object?> json, BuildInfo buildInfo) =>
@@ -1040,6 +1045,7 @@ class DebuggingOptions {
       nativeNullAssertions: (json['nativeNullAssertions'] as bool?)!,
       enableImpeller: (json['enableImpeller'] as bool?) ?? false,
       uninstallFirst: (json['uninstallFirst'] as bool?) ?? false,
+      enableDartProfiling: (json['enableDartProfiling'] as bool?) ?? true,
     );
 }
 

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -111,7 +111,8 @@ class FlutterTesterTestDevice extends TestDevice {
       '--verify-entry-points',
       '--enable-software-rendering',
       '--skia-deterministic-rendering',
-      '--enable-dart-profiling',
+      if (debuggingOptions.enableDartProfiling)
+        '--enable-dart-profiling',
       '--non-interactive',
       '--use-test-fonts',
       '--disable-asset-fonts',

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -165,7 +165,8 @@ class FlutterTesterDevice extends Device {
       _artifacts.getArtifactPath(Artifact.flutterTester),
       '--run-forever',
       '--non-interactive',
-      '--enable-dart-profiling',
+      if (debuggingOptions.enableDartProfiling)
+        '--enable-dart-profiling',
       '--packages=${debuggingOptions.buildInfo.packagesPath}',
       '--flutter-assets-dir=${assetDirectory.path}',
       if (debuggingOptions.startPaused)

--- a/packages/flutter_tools/test/general.shard/device_test.dart
+++ b/packages/flutter_tools/test/general.shard/device_test.dart
@@ -453,6 +453,7 @@ void main() {
         dartFlags: 'c',
         deviceVmServicePort: 1234,
         enableImpeller: true,
+        enableDartProfiling: false,
       );
       final String jsonString = json.encode(original.toJson());
       final Map<String, dynamic> decoded = castStringKeyedMap(json.decode(jsonString))!;
@@ -464,6 +465,7 @@ void main() {
       expect(deserialized.dartFlags, original.dartFlags);
       expect(deserialized.deviceVmServicePort, original.deviceVmServicePort);
       expect(deserialized.enableImpeller, original.enableImpeller);
+      expect(deserialized.enableDartProfiling, original.enableDartProfiling);
     });
   });
 
@@ -659,6 +661,27 @@ void main() {
         launchArguments.join(' '),
         <String>[
           '--enable-dart-profiling',
+          '--enable-checked-mode',
+          '--verify-entry-points',
+        ].join(' '),
+      );
+    });
+
+    testWithoutContext('No --enable-dart-profiling flag when option is false', () {
+      final DebuggingOptions original = DebuggingOptions.enabled(
+        BuildInfo.debug,
+        enableDartProfiling: false,
+      );
+
+      final List<String> launchArguments = original.getIOSLaunchArguments(
+        EnvironmentType.physical,
+        null,
+        <String, Object?>{},
+      );
+
+      expect(
+        launchArguments.join(' '),
+        <String>[
           '--enable-checked-mode',
           '--verify-entry-points',
         ].join(' '),


### PR DESCRIPTION
Adds an explicit `flutter run` flag for enabling the Dart VM's sampling CPU profiler, which defaults to `true`. It can then be disabled by passing `--no-enable-dart-profiling`.