### PR TITLE
impl2: change focus size based on sheet size

### DIFF
--- a/packages/flutter/lib/src/widgets/routes.dart
+++ b/packages/flutter/lib/src/widgets/routes.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
+//import 'package:flutter/widgets.dart';
 
 import 'actions.dart';
 import 'basic.dart';
@@ -1624,6 +1625,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   void changedInternalState() {
     super.changedInternalState();
     setState(() { /* internal state already changed */ });
+    print('Internal State Changed!');
     _modalBarrier.markNeedsBuild();
     _modalScope.maintainState = maintainState;
   }
@@ -1631,6 +1633,7 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   @override
   void changedExternalState() {
     super.changedExternalState();
+    print('External State Changed');
     _modalBarrier.markNeedsBuild();
     if (_scopeKey.currentState != null) {
       _scopeKey.currentState!._forceRebuildPage();
@@ -1661,6 +1664,13 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
   final GlobalKey _subtreeKey = GlobalKey();
   final PageStorageBucket _storageBucket = PageStorageBucket();
 
+  final ValueNotifier<Size> sheetSizeNotifier = ValueNotifier<Size>(Size.zero);
+
+  // void didChangeBarrierSemanticsInsets() {
+  //   print('barrierNeedsRebuild: new size: ${sheetSizeNotifier.value}');
+  //   _modalBarrier.markNeedsBuild();
+  // }
+
   // one of the builders
   late OverlayEntry _modalBarrier;
   Widget _buildModalBarrier(BuildContext context) {
@@ -1673,17 +1683,28 @@ abstract class ModalRoute<T> extends TransitionRoute<T> with LocalHistoryRoute<T
           end: barrierColor, // changedInternalState is called if barrierColor updates
         ).chain(CurveTween(curve: barrierCurve)), // changedInternalState is called if barrierCurve updates
       );
-      barrier = AnimatedModalBarrier(
-        color: color,
-        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
-        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
-        barrierSemanticsDismissible: semanticsDismissible,
+      barrier = 
+      BarrierClipper(
+        clipDirection: ClipDirection.bottom,
+        topLayerSizeNotifier: sheetSizeNotifier,
+        child: AnimatedModalBarrier(
+          color: color,
+          dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+          semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
+          barrierSemanticsDismissible: semanticsDismissible,
+          clipDirection: ClipDirection.bottom,
+          topLayerSizeNotifier: sheetSizeNotifier,
+        ),
       );
     } else {
-      barrier = ModalBarrier(
-        dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
-        semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
-        barrierSemanticsDismissible: semanticsDismissible,
+      barrier = BarrierClipper(
+        clipDirection: ClipDirection.bottom,
+        topLayerSizeNotifier: sheetSizeNotifier,
+        child: ModalBarrier(
+          dismissible: barrierDismissible, // changedInternalState is called if barrierDismissible updates
+          semanticsLabel: barrierLabel, // changedInternalState is called if barrierLabel updates
+          barrierSemanticsDismissible: semanticsDismissible,
+        ),
       );
     }
     if (filter != null) {


### PR DESCRIPTION
This PR implemented scrim focus for BottomSheet that serves as a means to close the bottom sheet for accessibility users, the focus's size changes according to sheet size.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
