### PR TITLE
[flutter_tools] normalize windows file path cases in flutter validator

### DIFF
--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -619,7 +619,7 @@ class FlutterValidator extends DoctorValidator {
       );
     }
     final String resolvedFlutterPath = flutterBin.resolveSymbolicLinksSync();
-    if (!resolvedFlutterPath.contains(flutterRoot)) {
+    if (!_dirPathContainsFilePath(flutterRoot, resolvedFlutterPath)) {
       final String hint = 'Warning: `$binary` on your path resolves to '
           '$resolvedFlutterPath, which is not inside your current Flutter '
           'SDK checkout at $flutterRoot. Consider adding $flutterBinDir to '
@@ -627,6 +627,13 @@ class FlutterValidator extends DoctorValidator {
       return ValidationMessage.hint(hint);
     }
     return null;
+  }
+
+  bool _dirPathContainsFilePath(String directory, String file) {
+    if (_platform.isWindows) {
+      return file.toLowerCase().contains(file.toLowerCase());
+    }
+    return file.contains(directory);
   }
 
   ValidationMessage _getFlutterUpstreamMessage(FlutterVersion version) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -619,7 +619,7 @@ class FlutterValidator extends DoctorValidator {
       );
     }
     final String resolvedFlutterPath = flutterBin.resolveSymbolicLinksSync();
-    if (!_dirPathContainsFilePath(flutterRoot, resolvedFlutterPath)) {
+    if (!_filePathContainsDirPath(flutterRoot, resolvedFlutterPath)) {
       final String hint = 'Warning: `$binary` on your path resolves to '
           '$resolvedFlutterPath, which is not inside your current Flutter '
           'SDK checkout at $flutterRoot. Consider adding $flutterBinDir to '
@@ -629,7 +629,7 @@ class FlutterValidator extends DoctorValidator {
     return null;
   }
 
-  bool _dirPathContainsFilePath(String directory, String file) {
+  bool _filePathContainsDirPath(String directory, String file) {
     if (_platform.isWindows) {
       return file.toLowerCase().startsWith(directory.toLowerCase());
     }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -633,7 +633,7 @@ class FlutterValidator extends DoctorValidator {
     // calling .canonicalize() will normalize for alphabetic case and path
     // separators
     return (_fileSystem.path.canonicalize(file))
-        .startsWith(_fileSystem.path.canonicalize(directory));
+        .startsWith(_fileSystem.path.canonicalize(directory) + _fileSystem.path.separator);
   }
 
   ValidationMessage _getFlutterUpstreamMessage(FlutterVersion version) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -631,9 +631,9 @@ class FlutterValidator extends DoctorValidator {
 
   bool _dirPathContainsFilePath(String directory, String file) {
     if (_platform.isWindows) {
-      return file.toLowerCase().contains(directory.toLowerCase());
+      return file.toLowerCase().startsWith(directory.toLowerCase());
     }
-    return file.contains(directory);
+    return file.startsWith(directory);
   }
 
   ValidationMessage _getFlutterUpstreamMessage(FlutterVersion version) {

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -631,7 +631,7 @@ class FlutterValidator extends DoctorValidator {
 
   bool _dirPathContainsFilePath(String directory, String file) {
     if (_platform.isWindows) {
-      return file.toLowerCase().contains(file.toLowerCase());
+      return file.toLowerCase().contains(directory.toLowerCase());
     }
     return file.contains(directory);
   }

--- a/packages/flutter_tools/lib/src/doctor.dart
+++ b/packages/flutter_tools/lib/src/doctor.dart
@@ -630,10 +630,10 @@ class FlutterValidator extends DoctorValidator {
   }
 
   bool _filePathContainsDirPath(String directory, String file) {
-    if (_platform.isWindows) {
-      return file.toLowerCase().startsWith(directory.toLowerCase());
-    }
-    return file.startsWith(directory);
+    // calling .canonicalize() will normalize for alphabetic case and path
+    // separators
+    return (_fileSystem.path.canonicalize(file))
+        .startsWith(_fileSystem.path.canonicalize(directory));
   }
 
   ValidationMessage _getFlutterUpstreamMessage(FlutterVersion version) {

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -48,7 +48,7 @@ void main() {
       userMessages: UserMessages(),
       artifacts: artifacts,
       fileSystem: fileSystem,
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
       processManager: FakeProcessManager.list(<FakeCommand>[
         const FakeCommand(
@@ -93,7 +93,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Windows'),
       processManager: FakeProcessManager.empty(),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     // gen_snapshot is downloaded on demand, and the doctor should not
@@ -115,14 +115,14 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Windows'),
       processManager: FakeProcessManager.empty(),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
       validationType: ValidationType.partial,
       statusInfo: 'Channel beta, 0.0.0, on Windows, locale en_US.UTF-8',
       messages: containsAll(const <ValidationMessage>[
-        ValidationMessage('Flutter version 0.0.0 on channel beta at sdk/flutter'),
+        ValidationMessage('Flutter version 0.0.0 on channel beta at /sdk/flutter'),
         ValidationMessage.error('version error'),
       ]),
     ));
@@ -152,7 +152,7 @@ void main() {
       fileSystem: fileSystem,
       processManager: FakeProcessManager.any(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Windows'),
-      flutterRoot: () => 'sdk/flutter'
+      flutterRoot: () => '/sdk/flutter'
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -183,7 +183,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       processManager: FakeProcessManager.any(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -213,7 +213,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       processManager: FakeProcessManager.any(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -221,7 +221,7 @@ void main() {
       statusInfo: 'Channel unknown, 1.0.0, on Linux, locale en_US.UTF-8',
       messages: containsAll(<ValidationMessage>[
         const ValidationMessage.hint(
-          'Flutter version 1.0.0 on channel unknown at sdk/flutter\n'
+          'Flutter version 1.0.0 on channel unknown at /sdk/flutter\n'
           'Currently on an unknown channel. Run `flutter channel` to switch to an official channel.\n'
           "If that doesn't fix the issue, reinstall Flutter by following instructions at https://flutter.dev/docs/get-started/install."
         ),
@@ -246,7 +246,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       processManager: FakeProcessManager.any(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -254,7 +254,7 @@ void main() {
       statusInfo: 'Channel beta, 0.0.0-unknown, on Linux, locale en_US.UTF-8',
       messages: containsAll(<ValidationMessage>[
         const ValidationMessage.hint(
-          'Flutter version 0.0.0-unknown on channel beta at sdk/flutter\n'
+          'Flutter version 0.0.0-unknown on channel beta at /sdk/flutter\n'
           'Cannot resolve current version, possibly due to local changes.\n'
           'Reinstall Flutter by following instructions at https://flutter.dev/docs/get-started/install.'
         ),
@@ -280,7 +280,7 @@ void main() {
         fileSystem: MemoryFileSystem.test(),
         processManager: FakeProcessManager.any(),
         operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
-        flutterRoot: () => 'sdk/flutter',
+        flutterRoot: () => '/sdk/flutter',
       );
 
       expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -371,7 +371,7 @@ void main() {
       fileSystem: MemoryFileSystem.test(),
       processManager: FakeProcessManager.any(),
       operatingSystemUtils: FakeOperatingSystemUtils(name: 'Linux'),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -476,7 +476,7 @@ void main() {
           'dart': fs.file('/usr/bin/dart')..createSync(recursive: true),
         },
       ),
-      flutterRoot: () => 'sdk/flutter',
+      flutterRoot: () => '/sdk/flutter',
     );
 
     expect(await flutterValidator.validate(), _matchDoctorValidation(
@@ -484,8 +484,8 @@ void main() {
       statusInfo: 'Channel beta, 1.0.0, on Linux, locale en_US.UTF-8',
       messages: contains(const ValidationMessage.hint(
         'Warning: `flutter` on your path resolves to /usr/bin/flutter, which '
-        'is not inside your current Flutter SDK checkout at sdk/flutter. '
-        'Consider adding sdk/flutter/bin to the front of your path.',
+        'is not inside your current Flutter SDK checkout at /sdk/flutter. '
+        'Consider adding /sdk/flutter/bin to the front of your path.',
       )),
     ));
   });

--- a/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/flutter_validator_test.dart
@@ -513,8 +513,8 @@ void main() {
       operatingSystemUtils: FakeOperatingSystemUtils(
         name: 'Linux',
         whichLookup: <String, File>{
-          'flutter': fs.file('/usr/bin/flutter')..createSync(recursive: true),
-          'dart': fs.file('/usr/bin/dart')..createSync(recursive: true),
+          'flutter': fs.file('/sdk/flutter-beta')..createSync(recursive: true),
+          'dart': fs.file('/sdk/flutter-beta')..createSync(recursive: true),
         },
       ),
       flutterRoot: () => '/sdk/flutter',
@@ -524,7 +524,7 @@ void main() {
       validationType: ValidationType.partial,
       statusInfo: 'Channel beta, 1.0.0, on Linux, locale en_US.UTF-8',
       messages: contains(const ValidationMessage.hint(
-        'Warning: `flutter` on your path resolves to /usr/bin/flutter, which '
+        'Warning: `flutter` on your path resolves to /sdk/flutter-beta, which '
         'is not inside your current Flutter SDK checkout at /sdk/flutter. '
         'Consider adding /sdk/flutter/bin to the front of your path.',
       )),


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/115651

In https://github.com/flutter/flutter/pull/113106/files I added a Flutter doctor validator that checks the `flutter` and `dart` binaries on the host system's path (with `which` on linux/mac, and `where.exe` on Windows) and then compares that to the root of the Flutter repository (determining the flutterRoot happens [here](https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/cache.dart#L228 and first checks for the `FLUTTER_ROOT` env var, then checks various fields on global platform object of the running Dart process).

In https://github.com/flutter/flutter/issues/115651, a user reports that their flutterRoot has a lower-case drive letter, while the path returned by `where.exe` has an upper-case drive letter--even though the paths are equivalent (to NTFS), the validator is failing. This change fixes this by calling `.toLowerCase()` on both strings before comparing when the operating system is Windows.