### PR TITLE
Add Material 3 support for `TabBar`

### DIFF
--- a/dev/tools/gen_defaults/bin/gen_defaults.dart
+++ b/dev/tools/gen_defaults/bin/gen_defaults.dart
@@ -46,6 +46,7 @@ import 'package:gen_defaults/segmented_button_template.dart';
 import 'package:gen_defaults/slider_template.dart';
 import 'package:gen_defaults/surface_tint.dart';
 import 'package:gen_defaults/switch_template.dart';
+import 'package:gen_defaults/tabs_template.dart';
 import 'package:gen_defaults/text_field_template.dart';
 import 'package:gen_defaults/typography_template.dart';
 
@@ -165,5 +166,6 @@ Future<void> main(List<String> args) async {
   SurfaceTintTemplate('SurfaceTint', '$materialLib/elevation_overlay.dart', tokens).updateFile();
   SwitchTemplate('Switch', '$materialLib/switch.dart', tokens).updateFile();
   TextFieldTemplate('TextField', '$materialLib/text_field.dart', tokens).updateFile();
+  TabsTemplate('Tabs', '$materialLib/tabs.dart', tokens).updateFile();
   TypographyTemplate('Typography', '$materialLib/typography.dart', tokens).updateFile();
 }

--- a/dev/tools/gen_defaults/lib/tabs_template.dart
+++ b/dev/tools/gen_defaults/lib/tabs_template.dart
@@ -1,0 +1,73 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'template.dart';
+
+class TabsTemplate extends TokenTemplate {
+  const TabsTemplate(super.blockName, super.fileName, super.tokens, {
+    super.colorSchemePrefix = '_colors.',
+    super.textThemePrefix = '_textTheme.',
+  });
+
+  @override
+  String generate() => '''
+class _${blockName}DefaultsM3 extends TabBarTheme {
+  _${blockName}DefaultsM3(this.context)
+    : super(indicatorSize: TabBarIndicatorSize.label);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+  late final TextTheme _textTheme = Theme.of(context).textTheme;
+
+  @override
+  Color? get dividerColor => ${componentColor("md.comp.primary-navigation-tab.divider")};
+
+  @override
+  Color? get indicatorColor => ${componentColor("md.comp.primary-navigation-tab.active-indicator")};
+
+  @override
+  Color? get labelColor => ${componentColor("md.comp.primary-navigation-tab.with-label-text.active.label-text")};
+
+  @override
+  TextStyle? get labelStyle => ${textStyle("md.comp.primary-navigation-tab.with-label-text.label-text")};
+
+  @override
+  Color? get unselectedLabelColor => ${componentColor("md.comp.primary-navigation-tab.with-label-text.inactive.label-text")};
+
+  @override
+  TextStyle? get unselectedLabelStyle => ${textStyle("md.comp.primary-navigation-tab.with-label-text.label-text")};
+
+  @override
+  MaterialStateProperty<Color?> get overlayColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.hovered)) {
+          return ${componentColor('md.comp.primary-navigation-tab.active.hover.state-layer')};
+        }
+        if (states.contains(MaterialState.focused)) {
+          return ${componentColor('md.comp.primary-navigation-tab.active.focus.state-layer')};
+        }
+        if (states.contains(MaterialState.pressed)) {
+          return ${componentColor('md.comp.primary-navigation-tab.active.pressed.state-layer')};
+        }
+        return null;
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return ${componentColor('md.comp.primary-navigation-tab.inactive.hover.state-layer')};
+      }
+      if (states.contains(MaterialState.focused)) {
+        return ${componentColor('md.comp.primary-navigation-tab.inactive.focus.state-layer')};
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return ${componentColor('md.comp.primary-navigation-tab.inactive.pressed.state-layer')};
+      }
+      return null;
+    });
+  }
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+''';
+}

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -29,7 +29,9 @@ class TabBarTheme with Diagnosticable {
   /// Creates a tab bar theme that can be used with [ThemeData.tabBarTheme].
   const TabBarTheme({
     this.indicator,
+    this.indicatorColor,
     this.indicatorSize,
+    this.dividerColor,
     this.labelColor,
     this.labelPadding,
     this.labelStyle,
@@ -43,8 +45,14 @@ class TabBarTheme with Diagnosticable {
   /// Overrides the default value for [TabBar.indicator].
   final Decoration? indicator;
 
+  /// Overrides the default value for [TabBar.indicatorColor].
+  final Color? indicatorColor;
+
   /// Overrides the default value for [TabBar.indicatorSize].
   final TabBarIndicatorSize? indicatorSize;
+
+  /// Overrides the default value for [TabBar.dividerColor].
+  final Color? dividerColor;
 
   /// Overrides the default value for [TabBar.labelColor].
   final Color? labelColor;
@@ -80,7 +88,9 @@ class TabBarTheme with Diagnosticable {
   /// new values.
   TabBarTheme copyWith({
     Decoration? indicator,
+    Color? indicatorColor,
     TabBarIndicatorSize? indicatorSize,
+    Color? dividerColor,
     Color? labelColor,
     EdgeInsetsGeometry? labelPadding,
     TextStyle? labelStyle,
@@ -92,7 +102,9 @@ class TabBarTheme with Diagnosticable {
   }) {
     return TabBarTheme(
       indicator: indicator ?? this.indicator,
+      indicatorColor: indicatorColor ?? this.indicatorColor,
       indicatorSize: indicatorSize ?? this.indicatorSize,
+      dividerColor: dividerColor ?? this.dividerColor,
       labelColor: labelColor ?? this.labelColor,
       labelPadding: labelPadding ?? this.labelPadding,
       labelStyle: labelStyle ?? this.labelStyle,
@@ -120,13 +132,15 @@ class TabBarTheme with Diagnosticable {
     assert(t != null);
     return TabBarTheme(
       indicator: Decoration.lerp(a.indicator, b.indicator, t),
+      indicatorColor: Color.lerp(a.indicatorColor, b.indicatorColor, t),
       indicatorSize: t < 0.5 ? a.indicatorSize : b.indicatorSize,
+      dividerColor: Color.lerp(a.dividerColor, b.dividerColor, t),
       labelColor: Color.lerp(a.labelColor, b.labelColor, t),
       labelPadding: EdgeInsetsGeometry.lerp(a.labelPadding, b.labelPadding, t),
       labelStyle: TextStyle.lerp(a.labelStyle, b.labelStyle, t),
       unselectedLabelColor: Color.lerp(a.unselectedLabelColor, b.unselectedLabelColor, t),
       unselectedLabelStyle: TextStyle.lerp(a.unselectedLabelStyle, b.unselectedLabelStyle, t),
-      overlayColor: _LerpColors(a.overlayColor, b.overlayColor, t),
+      overlayColor: MaterialStateProperty.lerp<Color?>(a.overlayColor, b.overlayColor, t, Color.lerp),
       splashFactory: t < 0.5 ? a.splashFactory : b.splashFactory,
       mouseCursor: t < 0.5 ? a.mouseCursor : b.mouseCursor,
     );
@@ -135,7 +149,9 @@ class TabBarTheme with Diagnosticable {
   @override
   int get hashCode => Object.hash(
     indicator,
+    indicatorColor,
     indicatorSize,
+    dividerColor,
     labelColor,
     labelPadding,
     labelStyle,
@@ -156,7 +172,9 @@ class TabBarTheme with Diagnosticable {
     }
     return other is TabBarTheme
         && other.indicator == indicator
+        && other.indicatorColor == indicatorColor
         && other.indicatorSize == indicatorSize
+        && other.dividerColor == dividerColor
         && other.labelColor == labelColor
         && other.labelPadding == labelPadding
         && other.labelStyle == labelStyle
@@ -165,41 +183,5 @@ class TabBarTheme with Diagnosticable {
         && other.overlayColor == overlayColor
         && other.splashFactory == splashFactory
         && other.mouseCursor == mouseCursor;
-  }
-}
-
-
-@immutable
-class _LerpColors implements MaterialStateProperty<Color?> {
-  const _LerpColors(this.a, this.b, this.t);
-
-  final MaterialStateProperty<Color?>? a;
-  final MaterialStateProperty<Color?>? b;
-  final double t;
-
-  @override
-  Color? resolve(Set<MaterialState> states) {
-    final Color? resolvedA = a?.resolve(states);
-    final Color? resolvedB = b?.resolve(states);
-    return Color.lerp(resolvedA, resolvedB, t);
-  }
-
-  @override
-  int get hashCode {
-    return Object.hash(a, b, t);
-  }
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) {
-      return true;
-    }
-    if (other.runtimeType != runtimeType) {
-      return false;
-    }
-    return other is _LerpColors
-      && other.a == a
-      && other.b == b
-      && other.t == t;
   }
 }

--- a/packages/flutter/lib/src/material/tab_indicator.dart
+++ b/packages/flutter/lib/src/material/tab_indicator.dart
@@ -20,10 +20,17 @@ class UnderlineTabIndicator extends Decoration {
   ///
   /// The [borderSide] and [insets] arguments must not be null.
   const UnderlineTabIndicator({
+    this.borderRadius,
     this.borderSide = const BorderSide(width: 2.0, color: Colors.white),
     this.insets = EdgeInsets.zero,
   }) : assert(borderSide != null),
        assert(insets != null);
+
+  /// The radius of the indicator's corners.
+  ///
+  /// If this value is non-null, rounded rectangular tab indicator is
+  /// drawn, otherwise rectangular tab indictor is drawn.
+  final BorderRadius? borderRadius;
 
   /// The color and weight of the horizontal line drawn below the selected tab.
   final BorderSide borderSide;
@@ -60,7 +67,7 @@ class UnderlineTabIndicator extends Decoration {
 
   @override
   BoxPainter createBoxPainter([ VoidCallback? onChanged ]) {
-    return _UnderlinePainter(this, onChanged);
+    return _UnderlinePainter(this, borderRadius, onChanged);
   }
 
   Rect _indicatorRectFor(Rect rect, TextDirection textDirection) {
@@ -77,15 +84,25 @@ class UnderlineTabIndicator extends Decoration {
 
   @override
   Path getClipPath(Rect rect, TextDirection textDirection) {
+    if (borderRadius != null) {
+      return Path()..addRRect(
+        borderRadius!.toRRect(_indicatorRectFor(rect, textDirection))
+      );
+    }
     return Path()..addRect(_indicatorRectFor(rect, textDirection));
   }
 }
 
 class _UnderlinePainter extends BoxPainter {
-  _UnderlinePainter(this.decoration, super.onChanged)
+  _UnderlinePainter(
+    this.decoration,
+    this.borderRadius,
+    super.onChanged,
+  )
     : assert(decoration != null);
 
   final UnderlineTabIndicator decoration;
+  final BorderRadius? borderRadius;
 
   @override
   void paint(Canvas canvas, Offset offset, ImageConfiguration configuration) {
@@ -93,8 +110,24 @@ class _UnderlinePainter extends BoxPainter {
     assert(configuration.size != null);
     final Rect rect = offset & configuration.size!;
     final TextDirection textDirection = configuration.textDirection!;
-    final Rect indicator = decoration._indicatorRectFor(rect, textDirection).deflate(decoration.borderSide.width / 2.0);
-    final Paint paint = decoration.borderSide.toPaint()..strokeCap = StrokeCap.square;
-    canvas.drawLine(indicator.bottomLeft, indicator.bottomRight, paint);
+    final Paint paint;
+    if (borderRadius != null) {
+      paint = Paint()..color = decoration.borderSide.color;
+      final Rect indicator = decoration._indicatorRectFor(rect, textDirection)
+        .inflate(decoration.borderSide.width / 4.0);
+      final RRect rrect = RRect.fromRectAndCorners(
+        indicator,
+        topLeft: borderRadius!.topLeft,
+        topRight: borderRadius!.topRight,
+        bottomRight: borderRadius!.bottomRight,
+        bottomLeft: borderRadius!.bottomLeft,
+      );
+      canvas.drawRRect(rrect, paint);
+    } else {
+      paint = decoration.borderSide.toPaint()..strokeCap = StrokeCap.square;
+      final Rect indicator = decoration._indicatorRectFor(rect, textDirection)
+        .deflate(decoration.borderSide.width / 2.0);
+      canvas.drawLine(indicator.bottomLeft, indicator.bottomRight, paint);
+    }
   }
 }

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -11,6 +11,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'app_bar.dart';
+import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
 import 'debug.dart';
@@ -21,6 +22,7 @@ import 'material_state.dart';
 import 'tab_bar_theme.dart';
 import 'tab_controller.dart';
 import 'tab_indicator.dart';
+import 'text_theme.dart';
 import 'theme.dart';
 
 const double _kTabHeight = 46.0;
@@ -183,18 +185,19 @@ class _TabStyle extends AnimatedWidget {
   Widget build(BuildContext context) {
     final ThemeData themeData = Theme.of(context);
     final TabBarTheme tabBarTheme = TabBarTheme.of(context);
+    final TabBarTheme defaults = themeData.useMaterial3 ? _TabsDefaultsM3(context) : _TabsDefaultsM2(context);
     final Animation<double> animation = listenable as Animation<double>;
 
     // To enable TextStyle.lerp(style1, style2, value), both styles must have
     // the same value of inherit. Force that to be inherit=true here.
     final TextStyle defaultStyle = (labelStyle
       ?? tabBarTheme.labelStyle
-      ?? themeData.primaryTextTheme.bodyLarge!
+      ?? defaults.labelStyle!
     ).copyWith(inherit: true);
     final TextStyle defaultUnselectedStyle = (unselectedLabelStyle
       ?? tabBarTheme.unselectedLabelStyle
       ?? labelStyle
-      ?? themeData.primaryTextTheme.bodyLarge!
+      ?? defaults.unselectedLabelStyle!
     ).copyWith(inherit: true);
     final TextStyle textStyle = selected
       ? TextStyle.lerp(defaultStyle, defaultUnselectedStyle, animation.value)!
@@ -202,10 +205,10 @@ class _TabStyle extends AnimatedWidget {
 
     final Color selectedColor = labelColor
        ?? tabBarTheme.labelColor
-       ?? themeData.primaryTextTheme.bodyLarge!.color!;
+       ?? defaults.labelColor!;
     final Color unselectedColor = unselectedLabelColor
       ?? tabBarTheme.unselectedLabelColor
-      ?? selectedColor.withAlpha(0xB2); // 70% alpha
+      ?? defaults.unselectedLabelColor!;
     final Color color = selected
       ? Color.lerp(selectedColor, unselectedColor, animation.value)!
       : Color.lerp(unselectedColor, selectedColor, animation.value)!;
@@ -327,6 +330,7 @@ class _IndicatorPainter extends CustomPainter {
     required this.tabKeys,
     required _IndicatorPainter? old,
     required this.indicatorPadding,
+    this.dividerColor,
   }) : assert(controller != null),
        assert(indicator != null),
        super(repaint: controller.animation) {
@@ -340,6 +344,7 @@ class _IndicatorPainter extends CustomPainter {
   final TabBarIndicatorSize? indicatorSize;
   final EdgeInsetsGeometry indicatorPadding;
   final List<GlobalKey> tabKeys;
+  final Color? dividerColor;
 
   // _currentTabOffsets and _currentTextDirection are set each time TabBar
   // layout is completed. These values can be null when TabBar contains no
@@ -431,6 +436,10 @@ class _IndicatorPainter extends CustomPainter {
       size: _currentRect!.size,
       textDirection: _currentTextDirection,
     );
+    if (dividerColor != null) {
+      final Paint dividerPaint = Paint()..color = dividerColor!..strokeWidth = 1;
+      canvas.drawLine(Offset(0, size.height), Offset(size.width, size.height), dividerPaint);
+    }
     _painter!.paint(canvas, _currentRect!.topLeft, configuration);
   }
 
@@ -630,6 +639,7 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
     this.indicatorPadding = EdgeInsets.zero,
     this.indicator,
     this.indicatorSize,
+    this.dividerColor,
     this.labelColor,
     this.labelStyle,
     this.labelPadding,
@@ -743,6 +753,13 @@ class TabBar extends StatefulWidget implements PreferredSizeWidget {
   /// the [indicatorColor], [indicatorWeight], [indicatorPadding], and
   /// [indicator] properties.
   final TabBarIndicatorSize? indicatorSize;
+
+  /// The color of the divider.
+  ///
+  /// If null and [ThemeData.useMaterial3] is true, [TabBarTheme.dividerColor]
+  /// color is used. If that is null and [ThemeData.useMaterial3] is true,
+  /// [ColorScheme.surfaceVariant] will be used, otherwise divider will not be drawn.
+  final Color? dividerColor;
 
   /// The color of selected tab labels.
   ///
@@ -939,16 +956,22 @@ class _TabBarState extends State<TabBar> {
     _tabKeys = widget.tabs.map((Widget tab) => GlobalKey()).toList();
   }
 
-  Decoration get _indicator {
+  Decoration _getIndicator() {
+    final ThemeData theme = Theme.of(context);
+    final TabBarTheme tabBarTheme = TabBarTheme.of(context);
+    final TabBarTheme defaults = theme.useMaterial3 ? _TabsDefaultsM3(context) : _TabsDefaultsM2(context);
+
     if (widget.indicator != null) {
       return widget.indicator!;
     }
-    final TabBarTheme tabBarTheme = TabBarTheme.of(context);
     if (tabBarTheme.indicator != null) {
       return tabBarTheme.indicator!;
     }
 
-    Color color = widget.indicatorColor ?? Theme.of(context).indicatorColor;
+    Color color = widget.indicatorColor
+      ?? (theme.useMaterial3
+         ? tabBarTheme.indicatorColor ?? defaults.indicatorColor!
+         : Theme.of(context).indicatorColor);
     // ThemeData tries to avoid this by having indicatorColor avoid being the
     // primaryColor. However, it's possible that the tab bar is on a
     // Material that isn't the primaryColor. In that case, if the indicator
@@ -968,6 +991,16 @@ class _TabBarState extends State<TabBar> {
     }
 
     return UnderlineTabIndicator(
+      borderRadius: theme.useMaterial3
+        // TODO(tahatesser): Make sure this value matches Material 3 Tabs spec
+        // when `preferredSize`and `indicatorWeight` are updated to support Material 3
+        // https://m3.material.io/components/tabs/specs#149a189f-9039-4195-99da-15c205d20e30,
+        // https://github.com/flutter/flutter/issues/116136
+        ? const BorderRadius.only(
+            topLeft: Radius.circular(3.0),
+            topRight: Radius.circular(3.0),
+          )
+        : null,
       borderSide: BorderSide(
         width: widget.indicatorWeight,
         color: color,
@@ -1012,13 +1045,18 @@ class _TabBarState extends State<TabBar> {
   }
 
   void _initIndicatorPainter() {
+    final ThemeData theme = Theme.of(context);
+    final TabBarTheme tabBarTheme = TabBarTheme.of(context);
+    final TabBarTheme defaults = theme.useMaterial3 ? _TabsDefaultsM3(context) : _TabsDefaultsM2(context);
+
     _indicatorPainter = !_controllerIsValid ? null : _IndicatorPainter(
       controller: _controller!,
-      indicator: _indicator,
-      indicatorSize: widget.indicatorSize ?? TabBarTheme.of(context).indicatorSize,
+      indicator: _getIndicator(),
+      indicatorSize: widget.indicatorSize ?? tabBarTheme.indicatorSize ?? defaults.indicatorSize!,
       indicatorPadding: widget.indicatorPadding,
       tabKeys: _tabKeys,
       old: _indicatorPainter,
+      dividerColor: theme.useMaterial3 ? widget.dividerColor ?? defaults.dividerColor : null,
     );
   }
 
@@ -1210,7 +1248,9 @@ class _TabBarState extends State<TabBar> {
       );
     }
 
+    final ThemeData theme = Theme.of(context);
     final TabBarTheme tabBarTheme = TabBarTheme.of(context);
+    final TabBarTheme defaults = theme.useMaterial3 ? _TabsDefaultsM3(context) : _TabsDefaultsM2(context);
 
     final List<Widget> wrappedTabs = List<Widget>.generate(widget.tabs.length, (int index) {
       const double verticalAdjustment = (_kTextAndIconTabHeight - _kTabHeight)/2.0;
@@ -1275,20 +1315,26 @@ class _TabBarState extends State<TabBar> {
     // the same share of the tab bar's overall width.
     final int tabCount = widget.tabs.length;
     for (int index = 0; index < tabCount; index += 1) {
-      final Set<MaterialState> states = <MaterialState>{
+      final Set<MaterialState> selectedState = <MaterialState>{
         if (index == _currentIndex) MaterialState.selected,
       };
 
-      final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, states)
-        ?? tabBarTheme.mouseCursor?.resolve(states)
-        ?? MaterialStateMouseCursor.clickable.resolve(states);
+      final MouseCursor effectiveMouseCursor = MaterialStateProperty.resolveAs<MouseCursor?>(widget.mouseCursor, selectedState)
+        ?? tabBarTheme.mouseCursor?.resolve(selectedState)
+        ?? MaterialStateMouseCursor.clickable.resolve(selectedState);
 
+      final MaterialStateProperty<Color?> defaultOverlay = MaterialStateProperty.resolveWith<Color?>(
+        (Set<MaterialState> states) {
+          final Set<MaterialState> effectiveStates = selectedState..addAll(states);
+          return defaults.overlayColor?.resolve(effectiveStates);
+        },
+      );
       wrappedTabs[index] = InkWell(
         mouseCursor: effectiveMouseCursor,
         onTap: () { _handleTap(index); },
         enableFeedback: widget.enableFeedback ?? true,
-        overlayColor: widget.overlayColor ?? tabBarTheme.overlayColor,
-        splashFactory: widget.splashFactory ?? tabBarTheme.splashFactory,
+        overlayColor: widget.overlayColor ?? tabBarTheme.overlayColor ?? defaultOverlay,
+        splashFactory: widget.splashFactory ?? tabBarTheme.splashFactory ?? defaults.splashFactory,
         borderRadius: widget.splashBorderRadius,
         child: Padding(
           padding: EdgeInsets.only(bottom: widget.indicatorWeight),
@@ -1818,3 +1864,99 @@ class TabPageSelector extends StatelessWidget {
     );
   }
 }
+
+// Hand coded defaults based on Material Design 2.
+class _TabsDefaultsM2 extends TabBarTheme {
+  _TabsDefaultsM2(this.context)
+    : super(indicatorSize: TabBarIndicatorSize.tab);
+
+  final BuildContext context;
+  late final TextTheme _textTheme = Theme.of(context).textTheme;
+
+  @override
+  Color? get indicatorColor => Theme.of(context).indicatorColor;
+
+  @override
+  Color? get labelColor => Theme.of(context).primaryTextTheme.bodyLarge!.color!;
+
+  @override
+  TextStyle? get labelStyle => _textTheme.bodyLarge;
+
+  @override
+  Color? get unselectedLabelColor => Theme.of(context).primaryTextTheme.bodyLarge!.color!.withAlpha(0xB2); // 70% alpha
+
+  @override
+  TextStyle? get unselectedLabelStyle => _textTheme.bodyLarge;
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+
+// BEGIN GENERATED TOKEN PROPERTIES - Tabs
+
+// Do not edit by hand. The code between the "BEGIN GENERATED" and
+// "END GENERATED" comments are generated from data in the Material
+// Design token database by the script:
+//   dev/tools/gen_defaults/bin/gen_defaults.dart.
+
+// Token database version: v0_143
+
+class _TabsDefaultsM3 extends TabBarTheme {
+  _TabsDefaultsM3(this.context)
+    : super(indicatorSize: TabBarIndicatorSize.label);
+
+  final BuildContext context;
+  late final ColorScheme _colors = Theme.of(context).colorScheme;
+  late final TextTheme _textTheme = Theme.of(context).textTheme;
+
+  @override
+  Color? get dividerColor => _colors.surfaceVariant;
+
+  @override
+  Color? get indicatorColor => _colors.primary;
+
+  @override
+  Color? get labelColor => _colors.primary;
+
+  @override
+  TextStyle? get labelStyle => _textTheme.titleSmall;
+
+  @override
+  Color? get unselectedLabelColor => _colors.onSurfaceVariant;
+
+  @override
+  TextStyle? get unselectedLabelStyle => _textTheme.titleSmall;
+
+  @override
+  MaterialStateProperty<Color?> get overlayColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        if (states.contains(MaterialState.hovered)) {
+          return _colors.primary.withOpacity(0.08);
+        }
+        if (states.contains(MaterialState.focused)) {
+          return _colors.primary.withOpacity(0.12);
+        }
+        if (states.contains(MaterialState.pressed)) {
+          return _colors.primary.withOpacity(0.12);
+        }
+        return null;
+      }
+      if (states.contains(MaterialState.hovered)) {
+        return _colors.onSurface.withOpacity(0.08);
+      }
+      if (states.contains(MaterialState.focused)) {
+        return _colors.onSurface.withOpacity(0.12);
+      }
+      if (states.contains(MaterialState.pressed)) {
+        return _colors.primary.withOpacity(0.12);
+      }
+      return null;
+    });
+  }
+
+  @override
+  InteractiveInkFeatureFactory? get splashFactory => Theme.of(context).splashFactory;
+}
+
+// END GENERATED TOKEN PROPERTIES - Tabs

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import '../rendering/mock_canvas.dart';
+
 const String _tab1Text = 'tab 1';
 const String _tab2Text = 'tab 2';
 const String _tab3Text = 'tab 3';
@@ -32,9 +34,10 @@ Widget _withTheme(
   TabBarTheme? theme, {
   List<Widget> tabs = _tabs,
   bool isScrollable = false,
+  bool useMaterial3 = false,
 }) {
   return MaterialApp(
-    theme: ThemeData(tabBarTheme: theme),
+    theme: ThemeData(tabBarTheme: theme, useMaterial3: useMaterial3),
     home: Scaffold(
       body: RepaintBoundary(
         key: _painterKey,
@@ -60,7 +63,9 @@ void main() {
     expect(const TabBarTheme().hashCode, const TabBarTheme().copyWith().hashCode);
 
     expect(const TabBarTheme().indicator, null);
+    expect(const TabBarTheme().indicatorColor, null);
     expect(const TabBarTheme().indicatorSize, null);
+    expect(const TabBarTheme().dividerColor, null);
     expect(const TabBarTheme().labelColor, null);
     expect(const TabBarTheme().labelPadding, null);
     expect(const TabBarTheme().labelStyle, null);
@@ -71,18 +76,19 @@ void main() {
     expect(const TabBarTheme().mouseCursor, null);
   });
 
-  testWidgets('Tab bar defaults - label style and selected/unselected label colors', (WidgetTester tester) async {
+  testWidgets('Tab bar defaults', (WidgetTester tester) async {
     // tests for the default label color and label styles when tabBarTheme and tabBar do not provide any
-    await tester.pumpWidget(_withTheme(null));
+    await tester.pumpWidget(_withTheme(null, useMaterial3: true));
 
+    final ThemeData theme = ThemeData(useMaterial3: true);
     final RenderParagraph selectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab1Text));
-    expect(selectedRenderObject.text.style!.fontFamily, equals('Roboto'));
+    expect(selectedRenderObject.text.style!.fontFamily, equals(theme.textTheme.titleSmall!.fontFamily));
     expect(selectedRenderObject.text.style!.fontSize, equals(14.0));
-    expect(selectedRenderObject.text.style!.color, equals(Colors.white));
+    expect(selectedRenderObject.text.style!.color, equals(theme.colorScheme.primary));
     final RenderParagraph unselectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab2Text));
-    expect(unselectedRenderObject.text.style!.fontFamily, equals('Roboto'));
+    expect(unselectedRenderObject.text.style!.fontFamily, equals(theme.textTheme.titleSmall!.fontFamily));
     expect(unselectedRenderObject.text.style!.fontSize, equals(14.0));
-    expect(unselectedRenderObject.text.style!.color, equals(Colors.white.withAlpha(0xB2)));
+    expect(unselectedRenderObject.text.style!.color, equals(theme.colorScheme.onSurfaceVariant));
 
     // tests for the default value of labelPadding when tabBarTheme and tabBar do not provide one
     await tester.pumpWidget(_withTheme(null, tabs: _sizedTabs, isScrollable: true));
@@ -104,7 +110,16 @@ void main() {
 
     // verify tabOne and tabTwo is separated by right padding of tabOne and left padding of tabTwo
     expect(tabOneRect.right, equals(tabTwoRect.left - kTabLabelPadding.left - kTabLabelPadding.right));
+
+    final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+    expect(
+      tabBarBox,
+      paints
+        ..line(color: theme.colorScheme.surfaceVariant)
+        ..rrect(color: theme.colorScheme.primary),
+    );
   });
+
   testWidgets('Tab bar theme overrides label color (selected)', (WidgetTester tester) async {
     const Color labelColor = Colors.black;
     const TabBarTheme tabBarTheme = TabBarTheme(labelColor: labelColor);
@@ -282,6 +297,15 @@ void main() {
     expect(iconRenderObject.text.style!.color, equals(unselectedLabelColor));
   });
 
+  testWidgets('Tab bar default tab indicator size', (WidgetTester tester) async {
+    await tester.pumpWidget(_withTheme(null, useMaterial3: true, isScrollable: true));
+
+    await expectLater(
+      find.byKey(_painterKey),
+      matchesGoldenFile('tab_bar.default.tab_indicator_size.png'),
+    );
+  });
+
   testWidgets('Tab bar theme overrides tab indicator size (tab)', (WidgetTester tester) async {
     const TabBarTheme tabBarTheme = TabBarTheme(indicatorSize: TabBarIndicatorSize.tab);
 
@@ -348,5 +372,57 @@ void main() {
       find.byKey(_painterKey),
       matchesGoldenFile('tab_bar_theme.beveled_rect_indicator.png'),
     );
+  });
+
+  group('Material 2', () {
+    // Tests that are only relevant for Material 2. Once ThemeData.useMaterial3
+    // is turned on by default, these tests can be removed.
+
+    testWidgets('Tab bar defaults', (WidgetTester tester) async {
+      // tests for the default label color and label styles when tabBarTheme and tabBar do not provide any
+      await tester.pumpWidget(_withTheme(null));
+
+      final RenderParagraph selectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab1Text));
+      expect(selectedRenderObject.text.style!.fontFamily, equals('Roboto'));
+      expect(selectedRenderObject.text.style!.fontSize, equals(14.0));
+      expect(selectedRenderObject.text.style!.color, equals(Colors.white));
+      final RenderParagraph unselectedRenderObject = tester.renderObject<RenderParagraph>(find.text(_tab2Text));
+      expect(unselectedRenderObject.text.style!.fontFamily, equals('Roboto'));
+      expect(unselectedRenderObject.text.style!.fontSize, equals(14.0));
+      expect(unselectedRenderObject.text.style!.color, equals(Colors.white.withAlpha(0xB2)));
+
+      // tests for the default value of labelPadding when tabBarTheme and tabBar do not provide one
+      await tester.pumpWidget(_withTheme(null, tabs: _sizedTabs, isScrollable: true));
+
+      const double indicatorWeight = 2.0;
+      final Rect tabBar = tester.getRect(find.byType(TabBar));
+      final Rect tabOneRect = tester.getRect(find.byKey(_sizedTabs[0].key!));
+      final Rect tabTwoRect = tester.getRect(find.byKey(_sizedTabs[1].key!));
+
+      // verify coordinates of tabOne
+      expect(tabOneRect.left, equals(kTabLabelPadding.left));
+      expect(tabOneRect.top, equals(kTabLabelPadding.top));
+      expect(tabOneRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
+
+      // verify coordinates of tabTwo
+      expect(tabTwoRect.right, equals(tabBar.width - kTabLabelPadding.right));
+      expect(tabTwoRect.top, equals(kTabLabelPadding.top));
+      expect(tabTwoRect.bottom, equals(tabBar.bottom - kTabLabelPadding.bottom - indicatorWeight));
+
+      // verify tabOne and tabTwo is separated by right padding of tabOne and left padding of tabTwo
+      expect(tabOneRect.right, equals(tabTwoRect.left - kTabLabelPadding.left - kTabLabelPadding.right));
+
+      final RenderBox tabBarBox = tester.firstRenderObject<RenderBox>(find.byType(TabBar));
+      expect(tabBarBox, paints..line(color: const Color(0xff2196f3)));
+    });
+
+    testWidgets('Tab bar default tab indicator size', (WidgetTester tester) async {
+      await tester.pumpWidget(_withTheme(null));
+
+      await expectLater(
+        find.byKey(_painterKey),
+        matchesGoldenFile('tab_bar.m2.default.tab_indicator_size.png'),
+      );
+    });
   });
 }


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/111962 
fixes https://github.com/flutter/flutter/issues/103642

### Description

- This PR adds support Material 3 (except `preferredSize` and `indicatorWeight`, this will be done in a separate issue). 
- Added support for creating a rounded tab indicator for Material 3.  
- Added support selected state for M3 overlay. 
- Added the `indicatorColor`  and new  `dividerColor` property for the theme.  
- Also  `_LerpColors` is removed, it's no longer needed. 


### Preview
 <img src="https://user-images.githubusercontent.com/48603081/204324072-39a0f29e-8fbb-4a09-bdb9-80f506baf8f0.png" height="450" />
 


 ### Close up of M3 indicator and divider  

![Screenshot 2022-11-28 at 18 05 00](https://user-images.githubusercontent.com/48603081/204325030-28a23395-2315-4f3c-8b5e-5130cf007fa3.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
