### PR TITLE
Fix Material 3 `BottomSheet` example

### DIFF
--- a/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.0.dart
+++ b/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.0.dart
@@ -6,27 +6,24 @@
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const BottomSheetApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
-
-  static const String _title = 'Flutter Code Sample';
+class BottomSheetApp extends StatelessWidget {
+  const BottomSheetApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: _title,
       home: Scaffold(
-        appBar: AppBar(title: const Text(_title)),
-        body: const MyStatelessWidget(),
+        appBar: AppBar(title: const Text('Bottom Sheet Sample')),
+        body: const BottomSheetExample(),
       ),
     );
   }
 }
 
-class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({super.key});
+class BottomSheetExample extends StatelessWidget {
+  const BottomSheetExample({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.1.dart
+++ b/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.1.dart
@@ -2,30 +2,32 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// Flutter code sample for  Material Design 3 TextFields.
 /// Flutter code sample for [showModalBottomSheet].
 
 import 'package:flutter/material.dart';
 
-void main() => runApp(const MyApp());
+void main() => runApp(const BottomSheetApp());
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class BottomSheetApp extends StatelessWidget {
+  const BottomSheetApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      theme: ThemeData(colorSchemeSeed: const Color(0xff6750a4), useMaterial3: true),
+      theme: ThemeData(
+        colorSchemeSeed: const Color(0xff6750a4),
+        useMaterial3: true,
+      ),
       home: Scaffold(
         appBar: AppBar(title: const Text('Bottom Sheet Sample')),
-        body: const MyStatelessWidget(),
+        body: const BottomSheetExample(),
       ),
     );
   }
 }
 
-class MyStatelessWidget extends StatelessWidget {
-  const MyStatelessWidget({super.key});
+class BottomSheetExample extends StatelessWidget {
+  const BottomSheetExample({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/examples/api/test/material/bottom_sheet/show_modal_bottom_sheet.0_test.dart
+++ b/examples/api/test/material/bottom_sheet/show_modal_bottom_sheet.0_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/bottom_sheet/show_modal_bottom_sheet.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BottomSheet can be opened and closed', (WidgetTester tester) async {
+    const String titleText = 'Modal BottomSheet';
+    const String closeText = 'Close BottomSheet';
+
+    await tester.pumpWidget(
+      const example.BottomSheetApp(),
+    );
+
+    expect(find.text(titleText), findsNothing);
+    expect(find.text(closeText), findsNothing);
+
+    // Open the bottom sheet.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'showModalBottomSheet'));
+    await tester.pumpAndSettle();
+
+    // Verify that the bottom sheet is open.
+    expect(find.text(titleText), findsOneWidget);
+    expect(find.text(closeText), findsOneWidget);
+  });
+}

--- a/examples/api/test/material/bottom_sheet/show_modal_bottom_sheet.1_test.dart
+++ b/examples/api/test/material/bottom_sheet/show_modal_bottom_sheet.1_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/bottom_sheet/show_modal_bottom_sheet.1.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('BottomSheet can be opened and closed', (WidgetTester tester) async {
+    const String titleText = 'Modal BottomSheet';
+    const String closeText = 'Close BottomSheet';
+
+    await tester.pumpWidget(
+      const example.BottomSheetApp(),
+    );
+
+    expect(find.text(titleText), findsNothing);
+    expect(find.text(closeText), findsNothing);
+
+    // Open the bottom sheet.
+    await tester.tap(find.widgetWithText(ElevatedButton, 'showModalBottomSheet'));
+    await tester.pumpAndSettle();
+
+    // Verify that the bottom sheet is open.
+    expect(find.text(titleText), findsOneWidget);
+    expect(find.text(closeText), findsOneWidget);
+  });
+}

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -799,6 +799,13 @@ class _BottomSheetSuspendedCurve extends ParametricCurve<double> {
 /// ** See code in examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.0.dart **
 /// {@end-tool}
 ///
+/// {@tool dartpad}
+/// This sample shows the creation of [showModalBottomSheet], as described in:
+/// https://m3.material.io/components/bottom-sheets/overview
+///
+/// ** See code in examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.1.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [BottomSheet], which becomes the parent of the widget returned by the


### PR DESCRIPTION
part of https://github.com/flutter/flutter/issues/101048

https://github.com/flutter/flutter/pull/112466 added Material 3 support for `BottomSheet` and an M3 example to `examples/api`. 

The example wasn't added to the `bottom_sheet.dart` class, as a result, it's not available to test in the [showModalBottomSheet](https://api.flutter.dev/flutter/material/showModalBottomSheet.html) API docs.

This PR adds the example to the source class and adds example tests.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
