### PR TITLE
[flutter_tools] add deprecation message for "flutter format"

### DIFF
--- a/packages/flutter_tools/lib/src/commands/format.dart
+++ b/packages/flutter_tools/lib/src/commands/format.dart
@@ -33,6 +33,17 @@ class FormatCommand extends FlutterCommand {
   String get invocation => '${runner?.executableName} $name <one or more paths>';
 
   @override
+  final bool deprecated = true;
+
+  @override
+  String get deprecationWarning {
+    return '${globals.logger.terminal.warningMark} The "format" command is '
+           'deprecated and will be removed in a future version of Flutter. '
+           'Please use the "dart format" sub-command instead, which takes all '
+           'of the same command-line arguments as "flutter format".\n';
+  }
+
+  @override
   Future<FlutterCommandResult> runCommand() async {
     final String dartBinary = globals.artifacts!.getHostArtifact(HostArtifact.engineDartBinary).path;
     final List<String> command = <String>[

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1269,14 +1269,17 @@ abstract class FlutterCommand extends Command<void> {
     );
   }
 
+  @visibleForOverriding
+  String get deprecationWarning {
+    return '${globals.logger.terminal.warningMark} The "$name" command is '
+           'deprecated and will be removed in a future version of Flutter. '
+           'See https://flutter.dev/docs/development/tools/sdk/releases '
+           'for previous releases of Flutter.\n';
+  }
+
   void _printDeprecationWarning() {
     if (deprecated) {
-      globals.printWarning(
-        '${globals.logger.terminal.warningMark} The "$name" command is deprecated and '
-        'will be removed in a future version of Flutter. '
-        'See https://flutter.dev/docs/development/tools/sdk/releases '
-        'for previous releases of Flutter.\n',
-      );
+      globals.printWarning(deprecationWarning);
     }
   }
 

--- a/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
-import 'package:flutter_tools/src/base/io.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/format.dart';
@@ -12,7 +11,6 @@ import 'package:flutter_tools/src/globals.dart' as globals;
 
 import '../../src/common.dart';
 import '../../src/context.dart';
-import '../../src/fakes.dart';
 import '../../src/test_flutter_command_runner.dart';
 
 void main() {

--- a/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/format_test.dart
@@ -5,6 +5,7 @@
 import 'package:args/command_runner.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/io.dart';
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/format.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
@@ -17,16 +18,34 @@ import '../../src/test_flutter_command_runner.dart';
 void main() {
   group('format', () {
     late Directory tempDir;
-    late FakeStdio mockStdio;
+    late BufferLogger logger;
 
     setUp(() {
       Cache.disableLocking();
       tempDir = globals.fs.systemTempDirectory.createTempSync('flutter_tools_format_test.');
-      mockStdio = FakeStdio();
+      logger = BufferLogger.test();
     });
 
     tearDown(() {
       tryToDelete(tempDir);
+    });
+
+    testUsingContext('shows deprecation warning', () async {
+      final String projectPath = await createProject(tempDir);
+
+      final File srcFile = globals.fs.file(globals.fs.path.join(projectPath, 'lib', 'main.dart'));
+      final String original = srcFile.readAsStringSync();
+      srcFile.writeAsStringSync(original);
+
+      final FormatCommand command = FormatCommand(verboseHelp: false);
+      final CommandRunner<void> runner = createTestCommandRunner(command);
+      await runner.run(<String>['format', srcFile.path]);
+      expect(
+        logger.warningText,
+        contains('The "format" command is deprecated and will be removed in a future version of Flutter'),
+      );
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
     });
 
     testUsingContext('a file', () async {
@@ -43,7 +62,7 @@ void main() {
       final String formatted = srcFile.readAsStringSync();
       expect(formatted, original);
     }, overrides: <Type, Generator>{
-      Stdio: () => mockStdio,
+      Logger: () => logger,
     });
 
     testUsingContext('dry-run', () async {
@@ -61,6 +80,8 @@ void main() {
 
       final String shouldNotFormatted = srcFile.readAsStringSync();
       expect(shouldNotFormatted, nonFormatted);
+    }, overrides: <Type, Generator>{
+      Logger: () => logger,
     });
 
     testUsingContext('dry-run with -n', () async {


### PR DESCRIPTION
Usage looks like:

```
~/git/flutter/packages/flutter_tools$ flutter format ./lib/executable.dart
[!] The "format" command is deprecated and will be removed in a future version of Flutter. Please use the "dart format" sub-command instead, which takes all of the same command-line arguments as "flutter format".


Formatted ./lib/executable.dart
Formatted 1 file (1 changed) in 0.14 seconds.
```