### PR TITLE
gen_l10n warning and error logging improvements

### DIFF
--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -90,8 +90,6 @@ String _syntheticL10nPackagePath(FileSystem fileSystem) => fileSystem.path.join(
 // For example, if placeholders are used for plurals and no type was specified, then the type will
 // automatically set to 'num'. Similarly, if such placeholders are used for selects, then the type
 // will be set to 'String'. For such placeholders that are used for both, we should throw an error.
-// TODO(thkim1011): Let's store the output of this function in the Message class, so that we don't
-// recompute this. See https://github.com/flutter/flutter/issues/112709
 List<String> generateMethodParameters(Message message) {
   return message.placeholders.values.map((Placeholder placeholder) {
     return '${placeholder.type} ${placeholder.name}';
@@ -852,7 +850,7 @@ class LocalizationsGenerator {
   // files in inputDirectory. Also initialized: supportedLocales.
   void loadResources() {
     _allMessages = _templateBundle.resourceIds.map((String id) => Message(
-       _templateBundle, _allBundles, id, areResourceAttributesRequired, useEscaping: useEscaping,
+       _templateBundle, _allBundles, id, areResourceAttributesRequired, logger, useEscaping: useEscaping,
     ));
     for (final String resourceId in _templateBundle.resourceIds) {
       if (!_isValidGetterAndMethodName(resourceId)) {
@@ -900,21 +898,17 @@ class LocalizationsGenerator {
     String className,
     String fileName,
     String header,
-    final LocaleInfo locale,
+    LocaleInfo locale,
   ) {
     final Iterable<String> methods = _allMessages.map((Message message) {
       if (message.messages[locale] == null) {
         _addUnimplementedMessage(locale, message.resourceId);
-        return _generateMethod(
-          message,
-          _templateArbLocale,
-        );
+        locale = _templateArbLocale;
       }
-      return _generateMethod(
-        message,
-        locale,
-      );
+      return _generateMethod(message, locale);
     });
+
+    print('generating class file');
 
     return classFileTemplate
       .replaceAll('@(header)', header.isEmpty ? '' : '$header\n\n')
@@ -1012,6 +1006,7 @@ class LocalizationsGenerator {
     final String fileName = outputFileName.substring(0, extensionIndex);
     final String fileExtension = outputFileName.substring(extensionIndex + 1);
     for (final LocaleInfo locale in allLocales) {
+      print('parsing locale $locale');
       if (isBaseClassLocale(locale, locale.languageCode)) {
         final File languageMessageFile = outputDirectory.childFile('${fileName}_$locale.$fileExtension');
 
@@ -1040,6 +1035,10 @@ class LocalizationsGenerator {
           return languageBaseClassFile.replaceAll('@(subclasses)', subclasses.join());
         });
       }
+    }
+
+    if (logger.hadErrorOutput) {
+      throw L10nException('Found ICU syntax errors.');
     }
 
     final List<String> sortedClassImports = supportedLocales
@@ -1083,208 +1082,213 @@ class LocalizationsGenerator {
   }
 
   String _generateMethod(Message message, LocaleInfo locale) {
-    // Determine if we must import intl for date or number formatting.
-    if (message.placeholdersRequireFormatting) {
-      requiresIntlImport = true;
-    }
-
-    final String translationForMessage = message.messages[locale]!;
-    final Node node = message.parsedMessages[locale]!;
-    // If parse tree is only a string, then return a getter method.
-    if (node.children.every((Node child) => child.type == ST.string)) {
-      // Use the parsed translation to handle escaping with the same behavior.
-      return getterTemplate
-        .replaceAll('@(name)', message.resourceId)
-        .replaceAll('@(message)', "'${generateString(node.children.map((Node child) => child.value!).join())}'");
-    }
-
-    final List<String> helperMethods = <String>[];
-
-    // Get a unique helper method name.
-    int methodNameCount = 0;
-    String getHelperMethodName() {
-      return '_${message.resourceId}${methodNameCount++}';
-    }
-
-    // Do a DFS post order traversal, generating dependent
-    // placeholder, plural, select helper methods, and combine these into
-    // one message. Returns the method/placeholder to use in parent string.
-    HelperMethod generateHelperMethods(Node node, { bool isRoot = false }) {
-      final Set<Placeholder> dependentPlaceholders = <Placeholder>{};
-      switch (node.type) {
-        case ST.message:
-          final List<HelperMethod> helpers = node.children.map<HelperMethod>((Node node) {
-            if (node.type == ST.string) {
-              return HelperMethod(<Placeholder>{}, string: node.value);
-            }
-            final HelperMethod helper = generateHelperMethods(node);
-            dependentPlaceholders.addAll(helper.dependentPlaceholders);
-            return helper;
-          }).toList();
-          final String messageString = generateReturnExpr(helpers);
-
-          // If the message is just a normal string, then only return the string.
-          if (dependentPlaceholders.isEmpty) {
-            return HelperMethod(dependentPlaceholders, string: messageString);
-          }
-
-          // For messages, if we are generating the actual overridden method, then we should also deal with
-          // date and number formatting here.
-          final String helperMethodName = getHelperMethodName();
-          final HelperMethod messageHelper = HelperMethod(dependentPlaceholders, helper: helperMethodName);
-          if (isRoot) {
-            helperMethods.add(methodTemplate
-              .replaceAll('@(name)', message.resourceId)
-              .replaceAll('@(parameters)', generateMethodParameters(message).join(', '))
-              .replaceAll('@(dateFormatting)', generateDateFormattingLogic(message))
-              .replaceAll('@(numberFormatting)', generateNumberFormattingLogic(message))
-              .replaceAll('@(message)', messageString)
-              .replaceAll('@(none)\n', '')
-            );
-          } else {
-            helperMethods.add(messageHelperTemplate
-              .replaceAll('@(name)', helperMethodName)
-              .replaceAll('@(parameters)', messageHelper.methodParameters)
-              .replaceAll('@(message)', messageString)
-            );
-          }
-          return messageHelper;
-
-        case ST.placeholderExpr:
-          assert(node.children[1].type == ST.identifier);
-          final Node identifier = node.children[1];
-          // Check that placeholders exist.
-          final Placeholder? placeholder = message.placeholders[identifier.value];
-          if (placeholder == null) {
-            throw L10nParserException(
-              'Make sure that the specified placeholder is defined in your arb file.',
-              _inputFileNames[locale]!,
-              message.resourceId,
-              translationForMessage,
-              identifier.positionInMessage,
-            );
-          }
-          dependentPlaceholders.add(placeholder);
-          return HelperMethod(dependentPlaceholders, placeholder: placeholder);
-
-        case ST.pluralExpr:
-          requiresIntlImport = true;
-          final Map<String, String> pluralLogicArgs = <String, String>{};
-          // Recall that pluralExpr are of the form
-          // pluralExpr := "{" ID "," "plural" "," pluralParts "}"
-          assert(node.children[1].type == ST.identifier);
-          assert(node.children[5].type == ST.pluralParts);
-
-          final Node identifier = node.children[1];
-          final Node pluralParts = node.children[5];
-
-          // Check that placeholders exist and is of type int or num.
-          final Placeholder? placeholder = message.placeholders[identifier.value];
-          if (placeholder == null) {
-            throw L10nParserException(
-              'Make sure that the specified placeholder is defined in your arb file.',
-              _inputFileNames[locale]!,
-              message.resourceId,
-              translationForMessage,
-              identifier.positionInMessage,
-            );
-          }
-          if (placeholder.type != 'num' && placeholder.type != 'int') {
-            throw L10nParserException(
-              'The specified placeholder must be of type int or num.',
-              _inputFileNames[locale]!,
-              message.resourceId,
-              translationForMessage,
-              identifier.positionInMessage,
-            );
-          }
-          dependentPlaceholders.add(placeholder);
-
-          for (final Node pluralPart in pluralParts.children.reversed) {
-            String pluralCase;
-            Node pluralMessage;
-            if (pluralPart.children[0].value == '=') {
-              assert(pluralPart.children[1].type == ST.number);
-              assert(pluralPart.children[3].type == ST.message);
-              pluralCase = pluralPart.children[1].value!;
-              pluralMessage = pluralPart.children[3];
-            } else {
-              assert(pluralPart.children[0].type == ST.identifier || pluralPart.children[0].type == ST.other);
-              assert(pluralPart.children[2].type == ST.message);
-              pluralCase = pluralPart.children[0].value!;
-              pluralMessage = pluralPart.children[2];
-            }
-            if (!pluralLogicArgs.containsKey(pluralCases[pluralCase])) {
-              final HelperMethod pluralPartHelper = generateHelperMethods(pluralMessage);
-              pluralLogicArgs[pluralCases[pluralCase]!] = '      ${pluralCases[pluralCase]}: ${pluralPartHelper.helperOrPlaceholder},';
-              dependentPlaceholders.addAll(pluralPartHelper.dependentPlaceholders);
-            } else {
-              logger.printWarning('''
-The plural part specified below is overrided by a later plural part.
-$translationForMessage
-${Parser.indentForError(pluralPart.positionInMessage)}
-''');
-            }
-          }
-          final String helperMethodName = getHelperMethodName();
-          final HelperMethod pluralHelper = HelperMethod(dependentPlaceholders, helper: helperMethodName);
-          helperMethods.add(pluralHelperTemplate
-            .replaceAll('@(name)', helperMethodName)
-            .replaceAll('@(parameters)', pluralHelper.methodParameters)
-            .replaceAll('@(count)', identifier.value!)
-            .replaceAll('@(pluralLogicArgs)', pluralLogicArgs.values.join('\n'))
-          );
-          return pluralHelper;
-
-        case ST.selectExpr:
-          requiresIntlImport = true;
-          // Recall that pluralExpr are of the form
-          // pluralExpr := "{" ID "," "plural" "," pluralParts "}"
-          assert(node.children[1].type == ST.identifier);
-          assert(node.children[5].type == ST.selectParts);
-
-          final Node identifier = node.children[1];
-          // Check that placeholders exist.
-          final Placeholder? placeholder = message.placeholders[identifier.value];
-          if (placeholder == null) {
-            throw L10nParserException(
-              'Make sure that the specified placeholder is defined in your arb file.',
-              _inputFileNames[locale]!,
-              message.resourceId,
-              translationForMessage,
-              identifier.positionInMessage,
-            );
-          }
-          dependentPlaceholders.add(placeholder);
-          final List<String> selectLogicArgs = <String>[];
-          final Node selectParts = node.children[5];
-
-          for (final Node selectPart in selectParts.children) {
-            assert(selectPart.children[0].type == ST.identifier || selectPart.children[0].type == ST.other);
-            assert(selectPart.children[2].type == ST.message);
-            final String selectCase = selectPart.children[0].value!;
-            final Node selectMessage = selectPart.children[2];
-            final HelperMethod selectPartHelper = generateHelperMethods(selectMessage);
-            selectLogicArgs.add("        '$selectCase': ${selectPartHelper.helperOrPlaceholder},");
-            dependentPlaceholders.addAll(selectPartHelper.dependentPlaceholders);
-          }
-          final String helperMethodName = getHelperMethodName();
-          final HelperMethod selectHelper = HelperMethod(dependentPlaceholders, helper: helperMethodName);
-
-          helperMethods.add(selectHelperTemplate
-            .replaceAll('@(name)', helperMethodName)
-            .replaceAll('@(parameters)', selectHelper.methodParameters)
-            .replaceAll('@(choice)', identifier.value!)
-            .replaceAll('@(selectCases)', selectLogicArgs.join('\n'))
-          );
-          return HelperMethod(dependentPlaceholders, helper: helperMethodName);
-        // ignore: no_default_cases
-        default:
-          throw Exception('Cannot call "generateHelperMethod" on node type ${node.type}');
+    try {
+      // Determine if we must import intl for date or number formatting.
+      if (message.placeholdersRequireFormatting) {
+        requiresIntlImport = true;
       }
+  
+      final String translationForMessage = message.messages[locale]!;
+      final Node node = message.parsedMessages[locale]!;
+      // If parse tree is only a string, then return a getter method.
+      if (node.children.every((Node child) => child.type == ST.string)) {
+        // Use the parsed translation to handle escaping with the same behavior.
+        return getterTemplate
+          .replaceAll('@(name)', message.resourceId)
+          .replaceAll('@(message)', "'${generateString(node.children.map((Node child) => child.value!).join())}'");
+      }
+  
+      final List<String> helperMethods = <String>[];
+  
+      // Get a unique helper method name.
+      int methodNameCount = 0;
+      String getHelperMethodName() {
+        return '_${message.resourceId}${methodNameCount++}';
+      }
+  
+      // Do a DFS post order traversal, generating dependent
+      // placeholder, plural, select helper methods, and combine these into
+      // one message. Returns the method/placeholder to use in parent string.
+      HelperMethod generateHelperMethods(Node node, { bool isRoot = false }) {
+        final Set<Placeholder> dependentPlaceholders = <Placeholder>{};
+        switch (node.type) {
+          case ST.message:
+            final List<HelperMethod> helpers = node.children.map<HelperMethod>((Node node) {
+              if (node.type == ST.string) {
+                return HelperMethod(<Placeholder>{}, string: node.value);
+              }
+              final HelperMethod helper = generateHelperMethods(node);
+              dependentPlaceholders.addAll(helper.dependentPlaceholders);
+              return helper;
+            }).toList();
+            final String messageString = generateReturnExpr(helpers);
+  
+            // If the message is just a normal string, then only return the string.
+            if (dependentPlaceholders.isEmpty) {
+              return HelperMethod(dependentPlaceholders, string: messageString);
+            }
+  
+            // For messages, if we are generating the actual overridden method, then we should also deal with
+            // date and number formatting here.
+            final String helperMethodName = getHelperMethodName();
+            final HelperMethod messageHelper = HelperMethod(dependentPlaceholders, helper: helperMethodName);
+            if (isRoot) {
+              helperMethods.add(methodTemplate
+                .replaceAll('@(name)', message.resourceId)
+                .replaceAll('@(parameters)', generateMethodParameters(message).join(', '))
+                .replaceAll('@(dateFormatting)', generateDateFormattingLogic(message))
+                .replaceAll('@(numberFormatting)', generateNumberFormattingLogic(message))
+                .replaceAll('@(message)', messageString)
+                .replaceAll('@(none)\n', '')
+              );
+            } else {
+              helperMethods.add(messageHelperTemplate
+                .replaceAll('@(name)', helperMethodName)
+                .replaceAll('@(parameters)', messageHelper.methodParameters)
+                .replaceAll('@(message)', messageString)
+              );
+            }
+            return messageHelper;
+  
+          case ST.placeholderExpr:
+            assert(node.children[1].type == ST.identifier);
+            final Node identifier = node.children[1];
+            // Check that placeholders exist.
+            final Placeholder? placeholder = message.placeholders[identifier.value];
+            if (placeholder == null) {
+              throw L10nParserException(
+                'Make sure that the specified placeholder is defined in your arb file.',
+                _inputFileNames[locale]!,
+                message.resourceId,
+                translationForMessage,
+                identifier.positionInMessage,
+              );
+            }
+            dependentPlaceholders.add(placeholder);
+            return HelperMethod(dependentPlaceholders, placeholder: placeholder);
+  
+          case ST.pluralExpr:
+            requiresIntlImport = true;
+            final Map<String, String> pluralLogicArgs = <String, String>{};
+            // Recall that pluralExpr are of the form
+            // pluralExpr := "{" ID "," "plural" "," pluralParts "}"
+            assert(node.children[1].type == ST.identifier);
+            assert(node.children[5].type == ST.pluralParts);
+  
+            final Node identifier = node.children[1];
+            final Node pluralParts = node.children[5];
+  
+            // Check that placeholders exist and is of type int or num.
+            final Placeholder? placeholder = message.placeholders[identifier.value];
+            if (placeholder == null) {
+              throw L10nParserException(
+                'Make sure that the specified placeholder is defined in your arb file.',
+                _inputFileNames[locale]!,
+                message.resourceId,
+                translationForMessage,
+                identifier.positionInMessage,
+              );
+            }
+            if (placeholder.type != 'num' && placeholder.type != 'int') {
+              throw L10nParserException(
+                'The specified placeholder must be of type int or num.',
+                _inputFileNames[locale]!,
+                message.resourceId,
+                translationForMessage,
+                identifier.positionInMessage,
+              );
+            }
+            dependentPlaceholders.add(placeholder);
+  
+            for (final Node pluralPart in pluralParts.children.reversed) {
+              String pluralCase;
+              Node pluralMessage;
+              if (pluralPart.children[0].value == '=') {
+                assert(pluralPart.children[1].type == ST.number);
+                assert(pluralPart.children[3].type == ST.message);
+                pluralCase = pluralPart.children[1].value!;
+                pluralMessage = pluralPart.children[3];
+              } else {
+                assert(pluralPart.children[0].type == ST.identifier || pluralPart.children[0].type == ST.other);
+                assert(pluralPart.children[2].type == ST.message);
+                pluralCase = pluralPart.children[0].value!;
+                pluralMessage = pluralPart.children[2];
+              }
+              if (!pluralLogicArgs.containsKey(pluralCases[pluralCase])) {
+                final HelperMethod pluralPartHelper = generateHelperMethods(pluralMessage);
+                pluralLogicArgs[pluralCases[pluralCase]!] = '      ${pluralCases[pluralCase]}: ${pluralPartHelper.helperOrPlaceholder},';
+                dependentPlaceholders.addAll(pluralPartHelper.dependentPlaceholders);
+              } else {
+                logger.printWarning('''
+[${_inputFileNames[locale]}:${message.resourceId}] The plural part specified below is overrided by a later plural part.
+    $translationForMessage
+    ${Parser.indentForError(pluralPart.positionInMessage)}''');
+              }
+            }
+            final String helperMethodName = getHelperMethodName();
+            final HelperMethod pluralHelper = HelperMethod(dependentPlaceholders, helper: helperMethodName);
+            helperMethods.add(pluralHelperTemplate
+              .replaceAll('@(name)', helperMethodName)
+              .replaceAll('@(parameters)', pluralHelper.methodParameters)
+              .replaceAll('@(count)', identifier.value!)
+              .replaceAll('@(pluralLogicArgs)', pluralLogicArgs.values.join('\n'))
+            );
+            return pluralHelper;
+  
+          case ST.selectExpr:
+            requiresIntlImport = true;
+            // Recall that pluralExpr are of the form
+            // pluralExpr := "{" ID "," "plural" "," pluralParts "}"
+            assert(node.children[1].type == ST.identifier);
+            assert(node.children[5].type == ST.selectParts);
+  
+            final Node identifier = node.children[1];
+            // Check that placeholders exist.
+            final Placeholder? placeholder = message.placeholders[identifier.value];
+            if (placeholder == null) {
+              throw L10nParserException(
+                'Make sure that the specified placeholder is defined in your arb file.',
+                _inputFileNames[locale]!,
+                message.resourceId,
+                translationForMessage,
+                identifier.positionInMessage,
+              );
+            }
+            dependentPlaceholders.add(placeholder);
+            final List<String> selectLogicArgs = <String>[];
+            final Node selectParts = node.children[5];
+  
+            for (final Node selectPart in selectParts.children) {
+              assert(selectPart.children[0].type == ST.identifier || selectPart.children[0].type == ST.other);
+              assert(selectPart.children[2].type == ST.message);
+              final String selectCase = selectPart.children[0].value!;
+              final Node selectMessage = selectPart.children[2];
+              final HelperMethod selectPartHelper = generateHelperMethods(selectMessage);
+              selectLogicArgs.add("        '$selectCase': ${selectPartHelper.helperOrPlaceholder},");
+              dependentPlaceholders.addAll(selectPartHelper.dependentPlaceholders);
+            }
+            final String helperMethodName = getHelperMethodName();
+            final HelperMethod selectHelper = HelperMethod(dependentPlaceholders, helper: helperMethodName);
+  
+            helperMethods.add(selectHelperTemplate
+              .replaceAll('@(name)', helperMethodName)
+              .replaceAll('@(parameters)', selectHelper.methodParameters)
+              .replaceAll('@(choice)', identifier.value!)
+              .replaceAll('@(selectCases)', selectLogicArgs.join('\n'))
+            );
+            return HelperMethod(dependentPlaceholders, helper: helperMethodName);
+          // ignore: no_default_cases
+          default:
+            throw Exception('Cannot call "generateHelperMethod" on node type ${node.type}');
+        }
+      }
+      generateHelperMethods(node, isRoot: true);
+      return helperMethods.last.replaceAll('@(helperMethods)', helperMethods.sublist(0, helperMethods.length - 1).join('\n\n'));
+    } on L10nParserException catch (error, stacktrace) {
+      logger.printError(error.toString());
+      print(stacktrace);
+      return '';
     }
-    generateHelperMethods(node, isRoot: true);
-    return helperMethods.last.replaceAll('@(helperMethods)', helperMethods.sublist(0, helperMethods.length - 1).join('\n\n'));
   }
 
   List<String> writeOutputFiles({ bool isFromYaml = false }) {

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n.dart
@@ -1006,7 +1006,6 @@ class LocalizationsGenerator {
     final String fileName = outputFileName.substring(0, extensionIndex);
     final String fileExtension = outputFileName.substring(extensionIndex + 1);
     for (final LocaleInfo locale in allLocales) {
-      print('parsing locale $locale');
       if (isBaseClassLocale(locale, locale.languageCode)) {
         final File languageMessageFile = outputDirectory.childFile('${fileName}_$locale.$fileExtension');
 
@@ -1284,9 +1283,8 @@ class LocalizationsGenerator {
       }
       generateHelperMethods(node, isRoot: true);
       return helperMethods.last.replaceAll('@(helperMethods)', helperMethods.sublist(0, helperMethods.length - 1).join('\n\n'));
-    } on L10nParserException catch (error, stacktrace) {
+    } on L10nParserException catch (error) {
       logger.printError(error.toString());
-      print(stacktrace);
       return '';
     }
   }
@@ -1333,7 +1331,6 @@ class LocalizationsGenerator {
       _generateUntranslatedMessagesFile(logger, messagesFile);
     } else if (_unimplementedMessages.isNotEmpty) {
       _unimplementedMessages.forEach((LocaleInfo locale, List<String> messages) {
-        logger.printStatus('"$locale": ${messages.length} untranslated message(s).');
       });
       if (isFromYaml) {
         logger.printStatus(

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter_tools/src/base/logger.dart';
 import 'package:intl/locale.dart';
 
 import '../base/file_system.dart';
@@ -138,9 +139,9 @@ class L10nParserException extends L10nException {
     this.messageString,
     this.charNumber
   ): super('''
-$error
-[$fileName:$messageId] $messageString
-${List<String>.filled(4 + fileName.length + messageId.length + charNumber, ' ').join()}^''');
+[$fileName:$messageId] $error
+    $messageString
+    ${List<String>.filled(charNumber, ' ').join()}^''');
 
   final String error;
   final String fileName;
@@ -319,6 +320,7 @@ class Message {
     AppResourceBundleCollection allBundles,
     this.resourceId,
     bool isResourceAttributeRequired,
+    Logger logger,
     { this.useEscaping = false }
   ) : assert(templateBundle != null),
       assert(allBundles != null),
@@ -335,7 +337,7 @@ class Message {
       filenames[bundle.locale] = bundle.file.basename;
       final String? translation = bundle.translationFor(resourceId);
       messages[bundle.locale] = translation;
-      parsedMessages[bundle.locale] = translation == null ? null : Parser(resourceId, bundle.file.basename, translation, useEscaping: useEscaping).parse();
+      parsedMessages[bundle.locale] = translation == null ? null : Parser(resourceId, bundle.file.basename, translation, useEscaping: useEscaping).parse(logger);
     }
     // Using parsed translations, attempt to infer types of placeholders used by plurals and selects.
     for (final LocaleInfo locale in parsedMessages.keys) {

--- a/packages/flutter_tools/lib/src/localizations/message_parser.dart
+++ b/packages/flutter_tools/lib/src/localizations/message_parser.dart
@@ -6,6 +6,8 @@
 // See https://flutter.dev/go/icu-message-parser.
 
 // Symbol Types
+import 'package:flutter_tools/src/base/logger.dart';
+
 import 'gen_l10n_types.dart';
 
 enum ST {
@@ -565,9 +567,15 @@ class Parser {
     children.forEach(checkExtraRules);
   }
 
-  Node parse() {
-    final Node syntaxTree = compress(parseIntoTree());
-    checkExtraRules(syntaxTree);
-    return syntaxTree;
+  Node parse(Logger logger) {
+    try {
+      final Node syntaxTree = compress(parseIntoTree());
+      checkExtraRules(syntaxTree);
+      return syntaxTree;
+    } on L10nParserException catch (error) {
+      logger.printError(error.toString());
+      // Return an empty node in this case.
+      return Node(ST.empty, 0, value: '');
+    }
   }
 }


### PR DESCRIPTION
Couple changes
* We show all the errors for each message on one run of `flutter gen-l10n` instead of providing one at a time.
```
[intl_fr_CA.arb:demoTwoPaneTabletDescription] ICU Lexing Error: Unmatched single quotes.
    Voici comment TwoPane s'affiche sur un écran plus grand, comme une tablette ou un ordinateur de bureau.
                           ^
[intl_pa.arb:demoTwoPaneTabletDescription] ICU Lexing Error: Unmatched single quotes.
    ਵੱਡੀ ਸਕ੍ਰੀਨ ਵਾਲੇ ਡੀਵਾਈਸ, ਜਿਵੇਂ ਕਿ ਟੈਬਲੈੱਟ ਜਾਂ ਡੈਸਕਟਾਪ 'ਤੇ TwoPane ਇਸ ਤਰ੍ਹਾਂ ਕੰਮ ਕਰਦਾ ਹੈ।
                                                          ^
[intl_pa.arb:demoTwoPaneSubtitle] ICU Lexing Error: Unmatched single quotes.
    ਮੋੜਨਯੋਗ, ਵੱਡੀਆਂ ਅਤੇ ਛੋਟੀਆਂ ਸਕ੍ਰੀਨਾਂ 'ਤੇ ਪ੍ਰਤਿਕਿਰਿਆਤਮਕ ਖਾਕੇ
                                        ^
[intl_ca.arb:demoTwoPaneItemDetails] ICU Lexing Error: Unmatched single quotes.
    Detalls de l'element {value}
                ^
[intl_fr.arb:demoTwoPaneItemDetails] ICU Lexing Error: Unmatched single quotes.
    Détails de l'élément {value}
                ^
[intl_fr_CA.arb:demoTwoPaneItemDetails] ICU Lexing Error: Unmatched single quotes.
    Détails de l'élément {value}
                ^
[intl_fr_CH.arb:demoTwoPaneItemDetails] ICU Lexing Error: Unmatched single quotes.
    Détails de l'élément {value}
                ^
Found ICU syntax errors.
```
* Improves the multiple plural parts warning to be more descriptive.
```
[intl_zu.arb:craneSleepProperties] The plural part specified below is overrided by a later plural part.
    {totalProperties,plural, =0{Azikho izici ezitholakalayo}=1{1 isici esitholakalayo}one{{totalProperties} Izici ezitholakalayo}other{{totalProperties}
    Izici ezitholakalayo}}
                                                            ^
[intl_zu.arb:craneEatRestaurants] The plural part specified below is overrided by a later plural part.
    {totalRestaurants,plural, =0{Awekho amarestshurenti}=1{1 irestshurenti}one{{totalRestaurants} Amarestshurenti}other{{totalRestaurants} Amarestshurenti}}
                                                        ^
[intl_as.arb:craneFly7] ICU Lexing Error: Unmatched single quotes.
    মাউণ্ট ৰাশ্বম'ৰ, মাৰ্কিন যুক্তৰাষ্ট্ৰ
                 ^
[intl_ca.arb:craneFly9] ICU Lexing Error: Unmatched single quotes.
    L'Havana, Cuba
     ^
```

Tested above my turning on the "use-escaping" flag in `l10n.yaml` of flutter/gallery.