### PR TITLE
Tweak directional focus traversal

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -595,10 +595,8 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
   Iterable<FocusNode> _sortAndFilterHorizontally(
     TraversalDirection direction,
     Rect target,
-    FocusNode nearestScope,
+    Iterable<FocusNode> nodes,
   ) {
-    final Iterable<FocusNode> nodes = nearestScope.traversalDescendants;
-    assert(!nodes.contains(nearestScope));
     final Iterable<FocusNode> filtered;
     switch (direction) {
       case TraversalDirection.left:
@@ -796,6 +794,9 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
             eligibleNodes = filteredEligibleNodes;
           }
         }
+        if (direction == TraversalDirection.up) {
+          eligibleNodes = eligibleNodes.toList().reversed;
+        }
         // Find any nodes that intersect the band of the focused child.
         final Rect band = Rect.fromLTRB(focusedChild.rect.left, -double.infinity, focusedChild.rect.right, double.infinity);
         final Iterable<FocusNode> inBand = eligibleNodes.where((FocusNode node) => !node.rect.intersect(band).isEmpty);
@@ -809,7 +810,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         break;
       case TraversalDirection.right:
       case TraversalDirection.left:
-        Iterable<FocusNode> eligibleNodes = _sortAndFilterHorizontally(direction, focusedChild.rect, nearestScope);
+        Iterable<FocusNode> eligibleNodes = _sortAndFilterHorizontally(direction, focusedChild.rect, nearestScope.traversalDescendants);
         if (eligibleNodes.isEmpty) {
           break;
         }
@@ -818,6 +819,9 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
           if (filteredEligibleNodes.isNotEmpty) {
             eligibleNodes = filteredEligibleNodes;
           }
+        }
+        if (direction == TraversalDirection.left) {
+          eligibleNodes = eligibleNodes.toList().reversed;
         }
         // Find any nodes that intersect the band of the focused child.
         final Rect band = Rect.fromLTRB(-double.infinity, focusedChild.rect.top, double.infinity, focusedChild.rect.bottom);

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -564,7 +564,9 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     final Iterable<FocusNode> nodes = nearestScope.traversalDescendants;
     assert(!nodes.contains(nearestScope));
     final List<FocusNode> sorted = nodes.toList();
-    mergeSort<FocusNode>(sorted, compare: (FocusNode a, FocusNode b) => a.rect.center.dx.compareTo(b.rect.center.dx));
+    mergeSort<FocusNode>(sorted, compare: (FocusNode a, FocusNode b) {
+      return (a.rect.center - target.center).distanceSquared.compareTo((b.rect.center - target.center).distanceSquared);
+    });
     Iterable<FocusNode>? result;
     switch (direction) {
       case TraversalDirection.left:
@@ -576,6 +578,12 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
       case TraversalDirection.up:
       case TraversalDirection.down:
         break;
+    }
+    debugPrint('Candidates:');
+    if (result != null) {
+      for (FocusNode node  in result) {
+        debugPrint('Rect: ${node.rect}');
+      }
     }
     return result;
   }
@@ -589,7 +597,9 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     Iterable<FocusNode> nodes,
   ) {
     final List<FocusNode> sorted = nodes.toList();
-    mergeSort<FocusNode>(sorted, compare: (FocusNode a, FocusNode b) => a.rect.center.dy.compareTo(b.rect.center.dy));
+    mergeSort<FocusNode>(sorted, compare: (FocusNode a, FocusNode b) {
+      return (a.rect.center - target.center).distanceSquared.compareTo((b.rect.center - target.center).distanceSquared);
+    });
     switch (direction) {
       case TraversalDirection.up:
         return sorted.where((FocusNode node) => node.rect != target && node.rect.center.dy <= target.top);

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -597,6 +597,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     Rect target,
     Iterable<FocusNode> nodes,
   ) {
+    assert(direction == TraversalDirection.left || direction == TraversalDirection.right);
     final Iterable<FocusNode> filtered;
     switch (direction) {
       case TraversalDirection.left:
@@ -607,8 +608,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         break;
       case TraversalDirection.up:
       case TraversalDirection.down:
-        assert(direction == TraversalDirection.left || direction == TraversalDirection.right);
-        throw ArgumentError();
+        throw ArgumentError('Invalid direction $direction');
     }
     final List<FocusNode> sorted = filtered.toList();
     // Sort all nodes from left to right.
@@ -624,6 +624,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
     Rect target,
     Iterable<FocusNode> nodes,
   ) {
+    assert(direction == TraversalDirection.up || direction == TraversalDirection.down);
     final Iterable<FocusNode> filtered;
     switch (direction) {
       case TraversalDirection.up:
@@ -634,8 +635,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
         break;
       case TraversalDirection.left:
       case TraversalDirection.right:
-        assert(direction == TraversalDirection.up || direction == TraversalDirection.down);
-        throw ArgumentError();
+        throw ArgumentError('Invalid direction $direction');
     }
     final List<FocusNode> sorted = filtered.toList();
     mergeSort<FocusNode>(sorted, compare: (FocusNode a, FocusNode b) => a.rect.center.dy.compareTo(b.rect.center.dy));

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1421,24 +1421,24 @@ void main() {
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[null, true, null, null, false, null], 'stage 2');
+      expectState(<bool?>[null, null, true, null, false, null], 'stage 2');
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[true, false, null, null, null, null], 'stage 3');
+      expectState(<bool?>[true, null, false, null, null, null], 'stage 3');
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[false, true, null, null, null, null], 'stage 4');
+      expectState(<bool?>[false, null, true, null, null, null], 'stage 4');
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
-      expectState(<bool?>[null, false, null, null, true, null], 'stage 5');
+      expectState(<bool?>[null, null, false, null, true, null], 'stage 5');
       clear();
 
       // Make sure that moving in a different axis clears the history.

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1743,14 +1743,14 @@ void main() {
 
       // These should not cause a scroll.
       final double lowestOffset = controller.offset;
-      for (int i = 10; i >= 7; --i) {
+      for (int i = 10; i >= 8; --i) {
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
         await tester.pump();
         expect(controller.offset, equals(lowestOffset), reason: 'Focusing item $i caused a scroll');
       }
 
       // These should all cause a scroll.
-      for (int i = 6; i >= 1; --i) {
+      for (int i = 7; i >= 1; --i) {
         await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
         await tester.pump();
         final double expectedOffset = 100.0 * (i - 1);

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -1397,77 +1397,61 @@ void main() {
       final FocusNode scope = nodes[0].enclosingScope!;
       nodes[4].requestFocus();
 
-      void expectState(List<bool?> states, String stage) {
-        expect(focus, orderedEquals(states), reason: 'for $stage');
-        for (int index = 0; index < states.length; ++index) {
-          expect(focus[index], states[index] == null ? isNull : (states[index]! ? isTrue : isFalse),
-            reason: 'focus $index for $stage is ${focus[index]}, not ${states[index]}, states: $states');
-          if (states[index] == null) {
-            expect(nodes[index].hasFocus, isFalse,
-            reason: "node $index for $stage has focus when it shouldn't");
-          } else {
-            expect(nodes[index].hasFocus, states[index],
-              reason: "node $index focus for $stage isn't the expected value of ${states[index]}");
-          }
-        }
-        expect(scope.hasFocus, isTrue, reason: "Scope in $stage doesn't have focus");
-      }
-
       // Test to make sure that the same path is followed backwards and forwards.
       await tester.pump();
-      expectState(<bool?>[null, null, null, null, true, null], 'stage 1');
+      expect(focus, orderedEquals(<bool?>[null, null, null, null, true, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[null, null, true, null, false, null], 'stage 2');
+      expect(focus, orderedEquals(<bool?>[null, null, true, null, false, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[true, null, false, null, null, null], 'stage 3');
+      expect(focus, orderedEquals(<bool?>[true, null, false, null, null, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[false, null, true, null, null, null], 'stage 4');
+      expect(focus, orderedEquals(<bool?>[false, null, true, null, null, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
-      expectState(<bool?>[null, null, false, null, true, null], 'stage 5');
+      expect(focus, orderedEquals(<bool?>[null, null, false, null, true, null]));
       clear();
 
       // Make sure that moving in a different axis clears the history.
       expect(scope.focusInDirection(TraversalDirection.left), isTrue);
       await tester.pump();
-      expectState(<bool?>[null, null, null, true, false, null], 'stage 6');
+      expect(focus, orderedEquals(<bool?>[null, null, null, true, false, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[null, true, null, false, null, null], 'stage 7');
+      expect(focus, orderedEquals(<bool?>[null, true, null, false, null, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.up), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[true, false, null, null, null, null], 'stage 8');
+      expect(focus, orderedEquals(<bool?>[true, false, null, null, null, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
 
-      expectState(<bool?>[false, true, null, null, null, null], 'stage 9');
+      expect(focus, orderedEquals(<bool?>[false, true, null, null, null, null]));
       clear();
 
       expect(scope.focusInDirection(TraversalDirection.down), isTrue);
       await tester.pump();
-      expectState(<bool?>[null, false, null, true, null, null], 'stage 10');
+      expect(focus, orderedEquals(<bool?>[null, false, null, true, null, null]));
       clear();
     });
 


### PR DESCRIPTION
## Description

This fixes an issue in the directional focus traversal algorithm where it would arbitrarily order the destination nodes if they  had the same vertical or horizontal distance from the currently focused node instead of sorting them by their manhattan distance.

This sometimes had the effect of picking a destination whose center was further away from the currently focused node than necessary.

Now, if two nodes have the same distance from the current node along the traversal axis, it will sort them according to how far they are away from the center of the "band" (the infinite rectangle extended from the sides of the bounding box of the selected node).  This only applies to nodes that are not "in the band" for the currently selected node, and plain euclidean distance can sometimes skip nodes that are closer in the axis of travel but further in the cross-axis in favor of nodes that are further away in the axis of travel but closer in the cross-axis.

In addition, I normalized and optimized some of the directional traversal code, which had rotted a bit and was doing some unnecessary work (performing extra sorts, not returning early enough in some cases).

Before:
<video src="https://user-images.githubusercontent.com/8867023/204704126-8eb2e673-d6a8-4e95-8c9c-0e32dfbd6bc0.mp4" controls="controls" style="max-width: 730px;">
</video>

After:
<video src="https://user-images.githubusercontent.com/8867023/204704169-0b003f08-c387-4c32-b7d7-b4967df109f2.mp4" controls="controls" style="max-width: 730px;">
</video>

## Related Issues
 - Fixes https://github.com/flutter/flutter/issues/115550

## Tests
 - Updated some tests to be a bit simpler, and added a test for an irregular grid.