### PR TITLE
Remove shrinkWrap from samples that don't need it

### DIFF
--- a/examples/api/lib/material/app_bar/app_bar.1.dart
+++ b/examples/api/lib/material/app_bar/app_bar.1.dart
@@ -49,7 +49,6 @@ class _AppBarExampleState extends State<AppBarExample> {
         shadowColor: shadowColor ? Theme.of(context).colorScheme.shadow : null,
       ),
       body: GridView.builder(
-        shrinkWrap: true,
         itemCount: _items.length,
         padding: const EdgeInsets.all(8.0),
         gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(

--- a/packages/flutter/lib/src/widgets/scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/scroll_view.dart
@@ -946,7 +946,6 @@ abstract class BoxScrollView extends ScrollView {
 ///
 /// ```dart
 /// ListView(
-///   shrinkWrap: true,
 ///   padding: const EdgeInsets.all(20.0),
 ///   children: const <Widget>[
 ///     Text("I'm dedicating every day to you"),
@@ -961,7 +960,6 @@ abstract class BoxScrollView extends ScrollView {
 ///
 /// ```dart
 /// CustomScrollView(
-///   shrinkWrap: true,
 ///   slivers: <Widget>[
 ///     SliverPadding(
 ///       padding: const EdgeInsets.all(20.0),


### PR DESCRIPTION
`shrinkWrap` isn't needed, we shouldn't be using it to avoid that people accidentally copy it into their apps.