### PR TITLE
[docs] Add offline docs documentation, increase the Markdown h2 size

### DIFF
--- a/dev/docs/README.md
+++ b/dev/docs/README.md
@@ -18,6 +18,29 @@ the following locations:
 * [Codelabs](https://flutter.dev/docs/codelabs)
 * [Contributing to Flutter](https://github.com/flutter/flutter/blob/master/CONTRIBUTING.md)
 
+## Offline Documentation
+
+In addition to the online sites above, Flutter's documentation can be downloaded
+as an HTML documentation ZIP file for use when offline or when you have a poor
+internet connection.
+
+**Warning: the offline documentation files are quite large, approximately 700 MB
+to 900 MB.**
+
+Offline HTML documentation ZIP bundles:
+
+ * [Stable channel](https://api.flutter.dev/offline/flutter.docs.zip)
+ * [Master channel](https://master-api.flutter.dev/offline/flutter.docs.zip)
+
+Or, you can add Flutter to the open-source [Zeal](https://zealdocs.org/) app
+using the following XML configurations. Follow the instructions in the
+application for adding a feed.
+
+ * Stable channel Zeal XML configuration URL:
+   <https://api.flutter.dev/offline/flutter.xml>
+ * Master channel Zeal XML configuration URL:
+   <https://master-api.flutter.dev/offline/flutter.xml>
+
 ## Importing a Library
 
 ### Framework Libraries

--- a/dev/docs/assets/overrides.css
+++ b/dev/docs/assets/overrides.css
@@ -19,6 +19,12 @@ h2 {
   font-size: 24px;
 }
 
+/* Specifically make all the Markdown h2 headings slightly
+   bigger, so the Markdown CSS doesn't override it. */
+.markdown h2 {
+  font-size: 24px;
+}
+
 section.summary h2 {
   color: inherit;
   border-bottom: none;


### PR DESCRIPTION
## Description

This increases the size of the markdown H2 headers in the API docs to 24px from 20px. There was an override already for h2, but it was les specific than the Markdown override, so it wasn't being used for markdown headers.

Also, I added documentation and links on the main API docs landing page for the offline documentation zip files and the Zeal feed XML file.

## Related Issues
 - https://github.com/flutter/flutter/issues/61335
 - Fixes https://github.com/flutter/flutter/issues/116039

## Tests
 - No tests here, since the font size is in the CSS, and the rest is just documentation.