### PR TITLE
Added `controller` and `onSelected` properties to DropdownMenu

### DIFF
--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -50,6 +50,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
                     DropdownMenu<ColorLabel>(
+                      selectedValue: ColorLabel.green,
                       controller: colorController,
                       label: const Text('Color'),
                       dropdownMenuEntries: colorEntries,

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -50,7 +50,7 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
                     DropdownMenu<ColorLabel>(
-                      selectedValue: ColorLabel.green,
+                      initialSelection: ColorLabel.green,
                       controller: colorController,
                       label: const Text('Color'),
                       dropdownMenuEntries: colorEntries,

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -9,23 +9,45 @@ import 'package:flutter/material.dart';
 
 void main() => runApp(const DropdownMenuExample());
 
-class DropdownMenuExample extends StatelessWidget {
+class DropdownMenuExample extends StatefulWidget {
   const DropdownMenuExample({super.key});
 
-  List<DropdownMenuEntry> getEntryList() {
-    final List<DropdownMenuEntry> entries = <DropdownMenuEntry>[];
+  @override
+  State<DropdownMenuExample> createState() => _DropdownMenuExampleState();
+}
 
-    for (int index = 0; index < EntryLabel.values.length; index++) {
-      // Disabled item 1, 2 and 6.
-      final bool enabled = index != 1 && index != 2 && index != 6;
-      entries.add(DropdownMenuEntry(label: EntryLabel.values[index].label, enabled: enabled));
+class _DropdownMenuExampleState extends State<DropdownMenuExample> {
+  final TextEditingController colorController = TextEditingController();
+  final TextEditingController iconController = TextEditingController();
+  bool hasColor = false;
+  bool hasIcon = false;
+
+  Map<String, Color> colors = <String, Color>{
+    'Blue': Colors.blue,
+    'Pink': Colors.pink,
+    'Green': Colors.green,
+    'Yellow': Colors.yellow,
+    'Grey': Colors.grey,
+  };
+  Map<String, IconData> icons = <String, IconData>{
+    'Smile': Icons.sentiment_satisfied_outlined,
+    'Cloud': Icons.cloud_outlined,
+    'Brush': Icons.brush_outlined,
+    'Heart': Icons.favorite,
+  };
+
+  List<DropdownMenuEntry> getEntry(List<String> labels, {String? disabledLabel}) {
+    final List<DropdownMenuEntry> entries = <DropdownMenuEntry>[];
+    for (final String label in labels) {
+      entries.add(DropdownMenuEntry(label: label, enabled: label != disabledLabel));
     }
     return entries;
   }
 
   @override
   Widget build(BuildContext context) {
-    final List<DropdownMenuEntry> dropdownMenuEntries = getEntryList();
+    final List<DropdownMenuEntry> colorEntries = getEntry(colors.keys.toList(), disabledLabel: 'Grey');
+    final List<DropdownMenuEntry> iconEntries = getEntry(icons.keys.toList());
 
     return MaterialApp(
       theme: ThemeData(
@@ -34,41 +56,55 @@ class DropdownMenuExample extends StatelessWidget {
       ),
       home: Scaffold(
         body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.only(top: 20),
-            child: Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                DropdownMenu(
-                  label: const Text('Label'),
-                  dropdownMenuEntries: dropdownMenuEntries,
+          child: Column(
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 20),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    DropdownMenu(
+                      controller: colorController,
+                      label: const Text('Color'),
+                      dropdownMenuEntries: colorEntries,
+                      onChanged: (String text) {
+                        setState(() {
+                          hasColor = colors.containsKey(text);
+                        });
+                      },
+                    ),
+                    const SizedBox(width: 20),
+                    DropdownMenu(
+                      controller: iconController,
+                      enableFilter: true,
+                      leadingIcon: const Icon(Icons.search),
+                      label: const Text('Icon'),
+                      dropdownMenuEntries: iconEntries,
+                      inputDecorationTheme: const InputDecorationTheme(filled: true),
+                      onChanged: (String text) {
+                        setState(() {
+                          hasIcon = icons.containsKey(text);
+                        });
+                      },
+                    )
+                  ],
                 ),
-                const SizedBox(width: 20),
-                DropdownMenu(
-                  enableFilter: true,
-                  leadingIcon: const Icon(Icons.search),
-                  label: const Text('Label'),
-                  dropdownMenuEntries: dropdownMenuEntries,
-                  inputDecorationTheme: const InputDecorationTheme(filled: true),
+              ),
+              if (hasColor && hasIcon)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Text('You selected a ${colorController.text} ${iconController.text}'),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 5),
+                      child: Icon(icons[iconController.text], color: colors[colorController.text],))
+                  ],
                 )
-              ],
-            ),
+              else const Text('Please select a color and an icon.')
+            ],
           )
         ),
       ),
     );
   }
-}
-
-enum EntryLabel {
-  item0('Item 0'),
-  item1('Item 1'),
-  item2('Item 2'),
-  item3('Item 3'),
-  item4('Item 4'),
-  item5('Item 5'),
-  item6('Item 6');
-
-  const EntryLabel(this.label);
-  final String label;
 }

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -19,35 +19,21 @@ class DropdownMenuExample extends StatefulWidget {
 class _DropdownMenuExampleState extends State<DropdownMenuExample> {
   final TextEditingController colorController = TextEditingController();
   final TextEditingController iconController = TextEditingController();
-  bool hasColor = false;
-  bool hasIcon = false;
-
-  Map<String, Color> colors = <String, Color>{
-    'Blue': Colors.blue,
-    'Pink': Colors.pink,
-    'Green': Colors.green,
-    'Yellow': Colors.yellow,
-    'Grey': Colors.grey,
-  };
-  Map<String, IconData> icons = <String, IconData>{
-    'Smile': Icons.sentiment_satisfied_outlined,
-    'Cloud': Icons.cloud_outlined,
-    'Brush': Icons.brush_outlined,
-    'Heart': Icons.favorite,
-  };
-
-  List<DropdownMenuEntry> getEntry(List<String> labels, {String? disabledLabel}) {
-    final List<DropdownMenuEntry> entries = <DropdownMenuEntry>[];
-    for (final String label in labels) {
-      entries.add(DropdownMenuEntry(label: label, enabled: label != disabledLabel));
-    }
-    return entries;
-  }
+  ColorLabel? selectedColor;
+  IconLabel? selectedIcon;
 
   @override
   Widget build(BuildContext context) {
-    final List<DropdownMenuEntry> colorEntries = getEntry(colors.keys.toList(), disabledLabel: 'Grey');
-    final List<DropdownMenuEntry> iconEntries = getEntry(icons.keys.toList());
+    final List<DropdownMenuEntry<ColorLabel>> colorEntries = <DropdownMenuEntry<ColorLabel>>[];
+    for (final ColorLabel color in ColorLabel.values) {
+      colorEntries.add(
+        DropdownMenuEntry<ColorLabel>(value: color, label: color.label, enabled: color.label != 'Grey'));
+    }
+
+    final List<DropdownMenuEntry<IconLabel>> iconEntries = <DropdownMenuEntry<IconLabel>>[];
+    for (final IconLabel icon in IconLabel.values) {
+      iconEntries.add(DropdownMenuEntry<IconLabel>(value: icon, label: icon.label));
+    }
 
     return MaterialApp(
       theme: ThemeData(
@@ -63,41 +49,41 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
-                    DropdownMenu(
+                    DropdownMenu<ColorLabel>(
                       controller: colorController,
                       label: const Text('Color'),
                       dropdownMenuEntries: colorEntries,
-                      onChanged: (String text) {
+                      onSelected: (ColorLabel? color) {
                         setState(() {
-                          hasColor = colors.containsKey(text);
+                          selectedColor = color;
                         });
                       },
                     ),
                     const SizedBox(width: 20),
-                    DropdownMenu(
+                    DropdownMenu<IconLabel>(
                       controller: iconController,
                       enableFilter: true,
                       leadingIcon: const Icon(Icons.search),
                       label: const Text('Icon'),
                       dropdownMenuEntries: iconEntries,
                       inputDecorationTheme: const InputDecorationTheme(filled: true),
-                      onChanged: (String text) {
+                      onSelected: (IconLabel? icon) {
                         setState(() {
-                          hasIcon = icons.containsKey(text);
+                          selectedIcon = icon;
                         });
                       },
                     )
                   ],
                 ),
               ),
-              if (hasColor && hasIcon)
+              if (selectedColor != null && selectedIcon != null)
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: <Widget>[
-                    Text('You selected a ${colorController.text} ${iconController.text}'),
+                    Text('You selected a ${selectedColor?.label} ${selectedIcon?.label}'),
                     Padding(
                       padding: const EdgeInsets.symmetric(horizontal: 5),
-                      child: Icon(icons[iconController.text], color: colors[colorController.text],))
+                      child: Icon(selectedIcon?.icon, color: selectedColor?.color,))
                   ],
                 )
               else const Text('Please select a color and an icon.')
@@ -107,4 +93,27 @@ class _DropdownMenuExampleState extends State<DropdownMenuExample> {
       ),
     );
   }
+}
+
+enum ColorLabel {
+  blue('Blue', Colors.blue),
+  pink('Pink', Colors.pink),
+  green('Green', Colors.green),
+  yellow('Yellow', Colors.yellow),
+  grey('Grey', Colors.grey);
+
+  const ColorLabel(this.label, this.color);
+  final String label;
+  final Color color;
+}
+
+enum IconLabel {
+  smile('Smile', Icons.sentiment_satisfied_outlined),
+  cloud('Cloud', Icons.cloud_outlined,),
+  brush('Brush', Icons.brush_outlined),
+  heart('Heart', Icons.favorite);
+
+  const IconLabel(this.label, this.icon);
+  final String label;
+  final IconData icon;
 }

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -218,7 +218,9 @@ class DropdownMenu<T> extends StatefulWidget {
   /// If null, this widget will create its own [TextEditingController].
   final TextEditingController? controller;
 
+  /// The value used to for an initial selection.
   ///
+  /// Defaults to null.
   final T? selectedValue;
 
   /// The callback is called when a selection is made.

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -133,6 +133,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.inputDecorationTheme,
     this.menuStyle,
     this.controller,
+    this.selectedValue,
     this.onSelected,
     required this.dropdownMenuEntries,
   });
@@ -217,6 +218,9 @@ class DropdownMenu<T> extends StatefulWidget {
   /// If null, this widget will create its own [TextEditingController].
   final TextEditingController? controller;
 
+  ///
+  final T? selectedValue;
+
   /// The callback is called when a selection is made.
   ///
   /// Defaults to null. If null, only the text field is updated.
@@ -254,6 +258,12 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     filteredEntries = widget.dropdownMenuEntries;
     _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
 
+    final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.selectedValue);
+    if (index != -1) {
+      _textEditingController.text = filteredEntries[index].label;
+      _textEditingController.selection =
+          TextSelection.collapsed(offset: _textEditingController.text.length);
+    }
     refreshLeadingPadding();
   }
 
@@ -265,6 +275,14 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     }
     if (oldWidget.leadingIcon != widget.leadingIcon) {
       refreshLeadingPadding();
+    }
+    if (oldWidget.selectedValue != widget.selectedValue) {
+      final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.selectedValue);
+      if (index != -1) {
+        _textEditingController.text = filteredEntries[index].label;
+        _textEditingController.selection =
+            TextSelection.collapsed(offset: _textEditingController.text.length);
+      }
     }
   }
 

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -517,10 +517,12 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                   onEditingComplete: () {
                     if (currentHighlight != null) {
                       final DropdownMenuEntry<T> entry = filteredEntries[currentHighlight!];
-                      _textEditingController.text = entry.label;
-                      _textEditingController.selection =
-                        TextSelection.collapsed(offset: _textEditingController.text.length);
-                      widget.onSelected?.call(entry.value);
+                      if (entry.enabled) {
+                        _textEditingController.text = entry.label;
+                        _textEditingController.selection =
+                            TextSelection.collapsed(offset: _textEditingController.text.length);
+                        widget.onSelected?.call(entry.value);
+                      }
                     } else {
                       widget.onSelected?.call(null);
                     }

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -369,9 +369,11 @@ class _DropdownMenuState extends State<DropdownMenu> {
     while (!filteredEntries[currentHighlight!].enabled) {
       currentHighlight = (currentHighlight! - 1) % filteredEntries.length;
     }
-    _textEditingController.text = filteredEntries[currentHighlight!].label;
+    final String currentLabel = filteredEntries[currentHighlight!].label;
+    _textEditingController.text = currentLabel;
     _textEditingController.selection =
       TextSelection.collapsed(offset: _textEditingController.text.length);
+    widget.onChanged?.call(currentLabel);
   });
 
   void handleDownKeyInvoke(_) => setState(() {
@@ -384,9 +386,11 @@ class _DropdownMenuState extends State<DropdownMenu> {
     while (!filteredEntries[currentHighlight!].enabled) {
       currentHighlight = (currentHighlight! + 1) % filteredEntries.length;
     }
-    _textEditingController.text = filteredEntries[currentHighlight!].label;
+    final String currentLabel = filteredEntries[currentHighlight!].label;
+    _textEditingController.text = currentLabel;
     _textEditingController.selection =
       TextSelection.collapsed(offset: _textEditingController.text.length);
+    widget.onChanged?.call(currentLabel);
   });
 
   void handlePressed(MenuController controller) {

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -133,7 +133,7 @@ class DropdownMenu<T> extends StatefulWidget {
     this.inputDecorationTheme,
     this.menuStyle,
     this.controller,
-    this.selectedValue,
+    this.initialSelection,
     this.onSelected,
     required this.dropdownMenuEntries,
   });
@@ -221,7 +221,7 @@ class DropdownMenu<T> extends StatefulWidget {
   /// The value used to for an initial selection.
   ///
   /// Defaults to null.
-  final T? selectedValue;
+  final T? initialSelection;
 
   /// The callback is called when a selection is made.
   ///
@@ -260,7 +260,7 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     filteredEntries = widget.dropdownMenuEntries;
     _menuHasEnabledItem = filteredEntries.any((DropdownMenuEntry<T> entry) => entry.enabled);
 
-    final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.selectedValue);
+    final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
     if (index != -1) {
       _textEditingController.text = filteredEntries[index].label;
       _textEditingController.selection =
@@ -278,8 +278,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
     if (oldWidget.leadingIcon != widget.leadingIcon) {
       refreshLeadingPadding();
     }
-    if (oldWidget.selectedValue != widget.selectedValue) {
-      final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.selectedValue);
+    if (oldWidget.initialSelection != widget.initialSelection) {
+      final int index = filteredEntries.indexWhere((DropdownMenuEntry<T> entry) => entry.value == widget.initialSelection);
       if (index != -1) {
         _textEditingController.text = filteredEntries[index].label;
         _textEditingController.selection =
@@ -521,6 +521,8 @@ class _DropdownMenuState<T> extends State<DropdownMenu<T>> {
                       _textEditingController.selection =
                         TextSelection.collapsed(offset: _textEditingController.text.length);
                       widget.onSelected?.call(entry.value);
+                    } else {
+                      widget.onSelected?.call(null);
                     }
                     if (!widget.enableSearch) {
                       currentHighlight = null;

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -15,12 +15,12 @@ void main() {
     menuChildren.add(entry);
   }
 
-  Widget buildTest(ThemeData themeData, List<DropdownMenuEntry<dynamic>> entries,
+  Widget buildTest<T extends Enum>(ThemeData themeData, List<DropdownMenuEntry<T>> entries,
       {double? width, double? menuHeight, Widget? leadingIcon, Widget? label}) {
     return MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu<dynamic>(
+        body: DropdownMenu<T>(
           label: label,
           leadingIcon: leadingIcon,
           width: width,
@@ -167,10 +167,10 @@ void main() {
 
     const double customBigWidth = 250.0;
     await tester.pumpWidget(buildTest(themeData, shortMenuItems, width: customBigWidth));
-    RenderBox box = tester.firstRenderObject(find.byType(DropdownMenu<dynamic>));
+    RenderBox box = tester.firstRenderObject(find.byType(DropdownMenu<ShortMenu>));
     expect(box.size.width, customBigWidth);
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<ShortMenu>));
     await tester.pump();
     expect(find.byType(MenuItemButton), findsNWidgets(6));
     Size buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').last);
@@ -180,10 +180,10 @@ void main() {
     await tester.pumpWidget(Container());
     const double customSmallWidth = 100.0;
     await tester.pumpWidget(buildTest(themeData, shortMenuItems, width: customSmallWidth));
-    box = tester.firstRenderObject(find.byType(DropdownMenu<dynamic>));
+    box = tester.firstRenderObject(find.byType(DropdownMenu<ShortMenu>));
     expect(box.size.width, customSmallWidth);
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<ShortMenu>));
     await tester.pump();
     expect(find.byType(MenuItemButton), findsNWidgets(6));
     buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').last);
@@ -195,7 +195,7 @@ void main() {
     final ThemeData themeData = ThemeData();
     await tester.pumpWidget(buildTest(themeData, menuChildren));
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
     final Element firstItem = tester.element(find.widgetWithText(MenuItemButton, 'Item 0').last);
@@ -219,7 +219,7 @@ void main() {
     await tester.pumpWidget(buildTest(themeData, menuChildren, menuHeight: 100));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
     final Finder updatedMenu = find.ancestor(
@@ -240,7 +240,7 @@ void main() {
     final Finder label = find.text('label');
     final Offset labelTopLeft = tester.getTopLeft(label);
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
     final Finder itemText = find.text('Item 0').last;
     final Offset itemTextTopLeft = tester.getTopLeft(itemText);
@@ -259,7 +259,7 @@ void main() {
     final Finder updatedLabel = find.text('label');
     final Offset updatedLabelTopLeft = tester.getTopLeft(updatedLabel);
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
     final Finder updatedItemText = find.text('Item 0').last;
     final Offset updatedItemTextTopLeft = tester.getTopLeft(updatedItemText);
@@ -282,7 +282,7 @@ void main() {
     final Finder updatedLabel1 = find.text('label');
     final Offset updatedLabelTopLeft1 = tester.getTopLeft(updatedLabel1);
 
-    await tester.tap(find.byType(DropdownMenu<dynamic>));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
     final Finder updatedItemText1 = find.text('Item 0').last;
     final Offset updatedItemTextTopLeft1 = tester.getTopLeft(updatedItemText1);

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -802,40 +802,46 @@ void main() {
     ));
 
     // Open the menu
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(DropdownMenu));
     await tester.pump();
+
+    // Test onChanged on key press
+    await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    expect(selectionCount, 1);
 
     // Disabled item doesn't trigger onChanged callback.
     final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 1').last;
     await tester.tap(item1);
     await tester.pumpAndSettle();
 
-    expect(controller.text.isEmpty, true);
-    expect(selectionCount, 0);
+    expect(controller.text, 'Item 0');
+    expect(selectionCount, 1);
 
     final Finder item2 = find.widgetWithText(MenuItemButton, 'Item 2').last;
     await tester.tap(item2);
     await tester.pumpAndSettle();
 
     expect(controller.text, 'Item 2');
-    expect(selectionCount, 1);
+    expect(selectionCount, 2);
 
-    await tester.tap(find.byType(TextField));
+    await tester.tap(find.byType(DropdownMenu));
     await tester.pump();
     final Finder item3 = find.widgetWithText(MenuItemButton, 'Item 3').last;
     await tester.tap(item3);
     await tester.pumpAndSettle();
 
     expect(controller.text, 'Item 3');
-    expect(selectionCount, 2);
+    expect(selectionCount, 3);
 
     // When typing something in the text field without selecting any of the options,
     // the onChanged gets called.
     await tester.enterText(find.byType(TextField).first, 'New Item');
     expect(controller.text, 'New Item');
-    expect(selectionCount, 3);
+    expect(selectionCount, 4);
     expect(find.widgetWithText(TextField, 'New Item'), findsOneWidget);
-    controller.clear();
+    await tester.enterText(find.byType(TextField).first, '');
+    expect(selectionCount, 5);
     expect(controller.text.isEmpty, true);
   });
 }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -8,19 +8,19 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  final List<DropdownMenuEntry> menuChildren = <DropdownMenuEntry>[];
+  final List<DropdownMenuEntry<TestMenu>> menuChildren = <DropdownMenuEntry<TestMenu>>[];
 
   for (final TestMenu value in TestMenu.values) {
-    final DropdownMenuEntry entry = DropdownMenuEntry(label: value.label);
+    final DropdownMenuEntry<TestMenu> entry = DropdownMenuEntry<TestMenu>(value: value, label: value.label);
     menuChildren.add(entry);
   }
 
-  Widget buildTest(ThemeData themeData, List<DropdownMenuEntry> entries,
+  Widget buildTest(ThemeData themeData, List<DropdownMenuEntry<dynamic>> entries,
       {double? width, double? menuHeight, Widget? leadingIcon, Widget? label}) {
     return MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<dynamic>(
           label: label,
           leadingIcon: leadingIcon,
           width: width,
@@ -80,7 +80,7 @@ void main() {
         theme: themeData,
         home: Scaffold(
           body: SafeArea(
-            child: DropdownMenu(
+            child: DropdownMenu<TestMenu>(
               enabled: false,
               dropdownMenuEntries: menuChildren,
             ),
@@ -115,7 +115,7 @@ void main() {
         theme: themeData,
         home: Scaffold(
           body: SafeArea(
-            child: DropdownMenu(
+            child: DropdownMenu<TestMenu>(
               dropdownMenuEntries: menuChildren,
             ),
           ),
@@ -127,7 +127,7 @@ void main() {
     final Size anchorSize = tester.getSize(textField);
     expect(anchorSize, const Size(180.0, 54.0));
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
     final Finder menuMaterial = find.ancestor(
@@ -145,7 +145,7 @@ void main() {
     final Size size = tester.getSize(anchor);
     expect(size, const Size(200.0, 54.0));
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(anchor);
     await tester.pumpAndSettle();
 
     final Finder updatedMenu = find.ancestor(
@@ -158,19 +158,19 @@ void main() {
 
   testWidgets('The width property can customize the width of the dropdown menu', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();
-    final List<DropdownMenuEntry> shortMenuItems = <DropdownMenuEntry>[];
+    final List<DropdownMenuEntry<ShortMenu>> shortMenuItems = <DropdownMenuEntry<ShortMenu>>[];
 
     for (final ShortMenu value in ShortMenu.values) {
-      final DropdownMenuEntry entry = DropdownMenuEntry(label: value.label);
+      final DropdownMenuEntry<ShortMenu> entry = DropdownMenuEntry<ShortMenu>(value: value, label: value.label);
       shortMenuItems.add(entry);
     }
 
     const double customBigWidth = 250.0;
     await tester.pumpWidget(buildTest(themeData, shortMenuItems, width: customBigWidth));
-    RenderBox box = tester.firstRenderObject(find.byType(DropdownMenu));
+    RenderBox box = tester.firstRenderObject(find.byType(DropdownMenu<dynamic>));
     expect(box.size.width, customBigWidth);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pump();
     expect(find.byType(MenuItemButton), findsNWidgets(6));
     Size buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').last);
@@ -180,10 +180,10 @@ void main() {
     await tester.pumpWidget(Container());
     const double customSmallWidth = 100.0;
     await tester.pumpWidget(buildTest(themeData, shortMenuItems, width: customSmallWidth));
-    box = tester.firstRenderObject(find.byType(DropdownMenu));
+    box = tester.firstRenderObject(find.byType(DropdownMenu<dynamic>));
     expect(box.size.width, customSmallWidth);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pump();
     expect(find.byType(MenuItemButton), findsNWidgets(6));
     buttonSize = tester.getSize(find.widgetWithText(MenuItemButton, 'I0').last);
@@ -195,7 +195,7 @@ void main() {
     final ThemeData themeData = ThemeData();
     await tester.pumpWidget(buildTest(themeData, menuChildren));
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pumpAndSettle();
 
     final Element firstItem = tester.element(find.widgetWithText(MenuItemButton, 'Item 0').last);
@@ -219,7 +219,7 @@ void main() {
     await tester.pumpWidget(buildTest(themeData, menuChildren, menuHeight: 100));
     await tester.pumpAndSettle();
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pumpAndSettle();
 
     final Finder updatedMenu = find.ancestor(
@@ -240,7 +240,7 @@ void main() {
     final Finder label = find.text('label');
     final Offset labelTopLeft = tester.getTopLeft(label);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pumpAndSettle();
     final Finder itemText = find.text('Item 0').last;
     final Offset itemTextTopLeft = tester.getTopLeft(itemText);
@@ -259,7 +259,7 @@ void main() {
     final Finder updatedLabel = find.text('label');
     final Offset updatedLabelTopLeft = tester.getTopLeft(updatedLabel);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pumpAndSettle();
     final Finder updatedItemText = find.text('Item 0').last;
     final Offset updatedItemTextTopLeft = tester.getTopLeft(updatedItemText);
@@ -282,7 +282,7 @@ void main() {
     final Finder updatedLabel1 = find.text('label');
     final Offset updatedLabelTopLeft1 = tester.getTopLeft(updatedLabel1);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<dynamic>));
     await tester.pumpAndSettle();
     final Finder updatedItemText1 = find.text('Item 0').last;
     final Offset updatedItemTextTopLeft1 = tester.getTopLeft(updatedItemText1);
@@ -301,7 +301,7 @@ void main() {
       home: Scaffold(
         body: Directionality(
           textDirection: TextDirection.rtl,
-          child: DropdownMenu(
+          child: DropdownMenu<TestMenu>(
             label: const Text('label'),
             dropdownMenuEntries: menuChildren,
           ),
@@ -312,7 +312,7 @@ void main() {
     final Finder label = find.text('label');
     final Offset labelTopRight = tester.getTopRight(label);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
     final Finder itemText = find.text('Item 0').last;
     final Offset itemTextTopRight = tester.getTopRight(itemText);
@@ -326,7 +326,7 @@ void main() {
       home: Scaffold(
         body: Directionality(
           textDirection: TextDirection.rtl,
-          child: DropdownMenu(
+          child: DropdownMenu<TestMenu>(
             leadingIcon: const Icon(Icons.search),
             label: const Text('label'),
             dropdownMenuEntries: menuChildren,
@@ -338,11 +338,11 @@ void main() {
 
     final Finder leadingIcon = find.widgetWithIcon(Container, Icons.search);
     final double iconWidth = tester.getSize(leadingIcon).width;
-    final Offset dropdownMenuTopRight = tester.getTopRight(find.byType(DropdownMenu));
+    final Offset dropdownMenuTopRight = tester.getTopRight(find.byType(DropdownMenu<TestMenu>));
     final Finder updatedLabel = find.text('label');
     final Offset updatedLabelTopRight = tester.getTopRight(updatedLabel);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
     final Finder updatedItemText = find.text('Item 0').last;
     final Offset updatedItemTextTopRight = tester.getTopRight(updatedItemText);
@@ -358,7 +358,7 @@ void main() {
       home: Scaffold(
         body: Directionality(
           textDirection: TextDirection.rtl,
-          child: DropdownMenu(
+          child: DropdownMenu<TestMenu>(
             leadingIcon: const SizedBox(width: 75.0, child: Icon(Icons.search)),
             label: const Text('label'),
             dropdownMenuEntries: menuChildren,
@@ -370,11 +370,11 @@ void main() {
 
     final Finder largeLeadingIcon = find.widgetWithIcon(Container, Icons.search);
     final double largeIconWidth = tester.getSize(largeLeadingIcon).width;
-    final Offset updatedDropdownMenuTopRight = tester.getTopRight(find.byType(DropdownMenu));
+    final Offset updatedDropdownMenuTopRight = tester.getTopRight(find.byType(DropdownMenu<TestMenu>));
     final Finder updatedLabel1 = find.text('label');
     final Offset updatedLabelTopRight1 = tester.getTopRight(updatedLabel1);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
     final Finder updatedItemText1 = find.text('Item 0').last;
     final Offset updatedItemTextTopRight1 = tester.getTopRight(updatedItemText1);
@@ -407,7 +407,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           trailingIcon: const Icon(Icons.ac_unit),
           dropdownMenuEntries: menuChildren,
         ),
@@ -433,14 +433,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           trailingIcon: const Icon(Icons.ac_unit),
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
@@ -475,13 +475,13 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
@@ -517,14 +517,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
@@ -547,14 +547,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowUp);
@@ -574,18 +574,18 @@ void main() {
 
   testWidgets('Disabled button will be skipped while pressing up/down key', (WidgetTester tester) async {
     final ThemeData themeData = ThemeData();
-    final List<DropdownMenuEntry> menuWithDisabledItems = <DropdownMenuEntry>[
-      const DropdownMenuEntry(label: 'Item 0'),
-      const DropdownMenuEntry(label: 'Item 1', enabled: false),
-      const DropdownMenuEntry(label: 'Item 2', enabled: false),
-      const DropdownMenuEntry(label: 'Item 3'),
-      const DropdownMenuEntry(label: 'Item 4'),
-      const DropdownMenuEntry(label: 'Item 5', enabled: false),
+    final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu1, label: 'Item 1', enabled: false),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu2, label: 'Item 2', enabled: false),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu3, label: 'Item 3'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu4, label: 'Item 4'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu5, label: 'Item 5', enabled: false),
     ];
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuWithDisabledItems,
         ),
       ),
@@ -593,7 +593,7 @@ void main() {
     await tester.pump();
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pumpAndSettle();
 
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
@@ -621,14 +621,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
     await tester.enterText(find.byType(TextField).first, 'Menu 1');
     await tester.pumpAndSettle();
@@ -645,14 +645,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
     await tester.enterText(find.byType(TextField).first, 'Menu 1');
     await tester.pumpAndSettle();
@@ -691,14 +691,14 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           dropdownMenuEntries: menuChildren,
         ),
       ),
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
     await tester.enterText(find.byType(TextField).first, 'Menu 1');
@@ -714,7 +714,7 @@ void main() {
     await tester.pumpWidget(MaterialApp(
       theme: themeData,
       home: Scaffold(
-        body: DropdownMenu(
+        body: DropdownMenu<TestMenu>(
           enableFilter: true,
           dropdownMenuEntries: menuChildren,
         ),
@@ -722,7 +722,7 @@ void main() {
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
     await tester.enterText(find
@@ -747,7 +747,7 @@ void main() {
       home: StatefulBuilder(
         builder: (BuildContext context, StateSetter setState) {
           return Scaffold(
-            body: DropdownMenu(
+            body: DropdownMenu<TestMenu>(
               enableFilter: true,
               dropdownMenuEntries: menuChildren,
               controller: controller,
@@ -758,7 +758,7 @@ void main() {
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
     final Finder item3 = find.widgetWithText(MenuItemButton, 'Item 3').last;
     await tester.tap(item3);
@@ -770,16 +770,15 @@ void main() {
     expect(controller.text, 'New Item');
   });
 
-  testWidgets('The onChanged gets called when a selection is made or there is '
-      'a change in the text field', (WidgetTester tester) async {
+  testWidgets('The onSelected gets called only when a selection is made', (WidgetTester tester) async {
     int selectionCount = 0;
 
     final ThemeData themeData = ThemeData();
-    final List<DropdownMenuEntry> menuWithDisabledItems = <DropdownMenuEntry>[
-      const DropdownMenuEntry(label: 'Item 0'),
-      const DropdownMenuEntry(label: 'Item 1', enabled: false),
-      const DropdownMenuEntry(label: 'Item 2'),
-      const DropdownMenuEntry(label: 'Item 3'),
+    final List<DropdownMenuEntry<TestMenu>> menuWithDisabledItems = <DropdownMenuEntry<TestMenu>>[
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 0'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 1', enabled: false),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 2'),
+      const DropdownMenuEntry<TestMenu>(value: TestMenu.mainMenu0, label: 'Item 3'),
     ];
     final TextEditingController controller = TextEditingController();
     await tester.pumpWidget(MaterialApp(
@@ -787,10 +786,10 @@ void main() {
       home: StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(
-              body: DropdownMenu(
+              body: DropdownMenu<TestMenu>(
                 dropdownMenuEntries: menuWithDisabledItems,
                 controller: controller,
-                onChanged: (_) {
+                onSelected: (_) {
                   setState(() {
                     selectionCount++;
                   });
@@ -802,15 +801,19 @@ void main() {
     ));
 
     // Open the menu
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
 
-    // Test onChanged on key press
+    // Test onSelected on key press
     await simulateKeyDownEvent(LogicalKeyboardKey.arrowDown);
+    await tester.pumpAndSettle();
+    await tester.testTextInput.receiveAction(TextInputAction.done);
     await tester.pumpAndSettle();
     expect(selectionCount, 1);
 
-    // Disabled item doesn't trigger onChanged callback.
+    // Disabled item doesn't trigger onSelected callback.
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
     final Finder item1 = find.widgetWithText(MenuItemButton, 'Item 1').last;
     await tester.tap(item1);
     await tester.pumpAndSettle();
@@ -825,7 +828,7 @@ void main() {
     expect(controller.text, 'Item 2');
     expect(selectionCount, 2);
 
-    await tester.tap(find.byType(DropdownMenu));
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
     await tester.pump();
     final Finder item3 = find.widgetWithText(MenuItemButton, 'Item 3').last;
     await tester.tap(item3);
@@ -835,13 +838,13 @@ void main() {
     expect(selectionCount, 3);
 
     // When typing something in the text field without selecting any of the options,
-    // the onChanged gets called.
+    // the onSelected should not be called.
     await tester.enterText(find.byType(TextField).first, 'New Item');
     expect(controller.text, 'New Item');
-    expect(selectionCount, 4);
+    expect(selectionCount, 3);
     expect(find.widgetWithText(TextField, 'New Item'), findsOneWidget);
     await tester.enterText(find.byType(TextField).first, '');
-    expect(selectionCount, 5);
+    expect(selectionCount, 3);
     expect(controller.text.isEmpty, true);
   });
 }

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -847,6 +847,41 @@ void main() {
     expect(selectionCount, 3);
     expect(controller.text.isEmpty, true);
   });
+
+
+  testWidgets('The selectedValue gives an initial text and highlights the according item', (WidgetTester tester) async {
+    final ThemeData themeData = ThemeData();
+    final TextEditingController controller = TextEditingController();
+    await tester.pumpWidget(MaterialApp(
+      theme: themeData,
+      home: StatefulBuilder(
+          builder: (BuildContext context, StateSetter setState) {
+            return Scaffold(
+              body: DropdownMenu<TestMenu>(
+                selectedValue: TestMenu.mainMenu3,
+                dropdownMenuEntries: menuChildren,
+                controller: controller,
+              ),
+            );
+          }
+      ),
+    ));
+
+    expect(find.widgetWithText(TextField, 'Item 3'), findsOneWidget);
+
+    // Open the menu
+    await tester.tap(find.byType(DropdownMenu<TestMenu>));
+    await tester.pump();
+
+    final Finder buttonMaterial = find.descendant(
+      of: find.widgetWithText(MenuItemButton, 'Item 3'),
+      matching: find.byType(Material),
+    ).last;
+
+    // Validate the item 3 is highlighted.
+    final Material itemMaterial = tester.widget<Material>(buttonMaterial);
+    expect(itemMaterial.color, themeData.colorScheme.onSurface.withOpacity(0.12));
+  });
 }
 
 enum TestMenu {

--- a/packages/flutter/test/material/dropdown_menu_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_test.dart
@@ -858,7 +858,7 @@ void main() {
           builder: (BuildContext context, StateSetter setState) {
             return Scaffold(
               body: DropdownMenu<TestMenu>(
-                selectedValue: TestMenu.mainMenu3,
+                initialSelection: TestMenu.mainMenu3,
                 dropdownMenuEntries: menuChildren,
                 controller: controller,
               ),

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -43,11 +43,11 @@ void main() {
         theme: themeData,
         home: const Scaffold(
           body: Center(
-            child: DropdownMenu(
-              dropdownMenuEntries: <DropdownMenuEntry>[
-                DropdownMenuEntry(label: 'Item 0'),
-                DropdownMenuEntry(label: 'Item 1'),
-                DropdownMenuEntry(label: 'Item 2'),
+            child: DropdownMenu<int>(
+              dropdownMenuEntries: <DropdownMenuEntry<int>>[
+                DropdownMenuEntry<int>(value: 0, label: 'Item 0'),
+                DropdownMenuEntry<int>(value: 1, label: 'Item 1'),
+                DropdownMenuEntry<int>(value: 2, label: 'Item 2'),
               ],
             ),
           ),
@@ -122,11 +122,11 @@ void main() {
         theme: theme,
         home: const Scaffold(
           body: Center(
-            child: DropdownMenu(
-              dropdownMenuEntries: <DropdownMenuEntry>[
-                DropdownMenuEntry(label: 'Item 0'),
-                DropdownMenuEntry(label: 'Item 1'),
-                DropdownMenuEntry(label: 'Item 2'),
+            child: DropdownMenu<int>(
+              dropdownMenuEntries: <DropdownMenuEntry<int>>[
+                DropdownMenuEntry<int>(value: 0, label: 'Item 0'),
+                DropdownMenuEntry<int>(value: 1, label: 'Item 1'),
+                DropdownMenuEntry<int>(value: 2, label: 'Item 2'),
               ],
             ),
           ),
@@ -223,11 +223,11 @@ void main() {
           data: dropdownMenuTheme,
           child: const Scaffold(
             body: Center(
-              child: DropdownMenu(
-                dropdownMenuEntries: <DropdownMenuEntry>[
-                  DropdownMenuEntry(label: 'Item 0'),
-                  DropdownMenuEntry(label: 'Item 1'),
-                  DropdownMenuEntry(label: 'Item 2'),
+              child: DropdownMenu<int>(
+                dropdownMenuEntries: <DropdownMenuEntry<int>>[
+                  DropdownMenuEntry<int>(value: 0, label: 'Item 0'),
+                  DropdownMenuEntry<int>(value: 1, label: 'Item 1'),
+                  DropdownMenuEntry<int>(value: 2, label: 'Item 2'),
                 ],
               ),
             ),
@@ -326,7 +326,7 @@ void main() {
           data: dropdownMenuTheme,
           child: Scaffold(
             body: Center(
-              child: DropdownMenu(
+              child: DropdownMenu<int>(
                 textStyle: TextStyle(
                   color: Colors.pink,
                   backgroundColor: Colors.cyan,
@@ -345,10 +345,10 @@ void main() {
                   ),
                 ),
                 inputDecorationTheme: const InputDecorationTheme(filled: true, fillColor: Colors.deepPurple),
-                dropdownMenuEntries: const <DropdownMenuEntry>[
-                  DropdownMenuEntry(label: 'Item 0'),
-                  DropdownMenuEntry(label: 'Item 1'),
-                  DropdownMenuEntry(label: 'Item 2'),
+                dropdownMenuEntries: const <DropdownMenuEntry<int>>[
+                  DropdownMenuEntry<int>(value: 0, label: 'Item 0'),
+                  DropdownMenuEntry<int>(value: 1, label: 'Item 1'),
+                  DropdownMenuEntry<int>(value: 2, label: 'Item 2'),
                 ],
               ),
             ),


### PR DESCRIPTION
Fixed: #115005

This PR is to update the `DropdownMenu` with 2 new optional properties: `controller` and `onSelected`.

The `controller` enables users to access the value in the text field, and the `onSelected` is a callback when a selection is made or text changes in the text field.

The example is also updated as below:


https://user-images.githubusercontent.com/36861262/204921931-63ea1cae-26d8-494c-81c9-00f946af117b.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
