### PR TITLE
[flutter_tools] Forward app.webLaunchUrl event from Flutter to DAP clients

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -65,6 +65,14 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     'app.exposeUrl',
   };
 
+  /// A list of events from `flutter run --machine` that should be forwarded to the client.
+  final Set<String> _eventsToForwardToClient = <String>{
+    // The 'app.webLaunchUrl' event is sent to the client to tell it about a URL
+    // that should be launched (including a flag for whether it has been
+    // launched by the tool or needs launching by the editor).
+    'app.webLaunchUrl',
+  };
+
   /// Completers for reverse requests from Flutter that may need to be handled by the client.
   final Map<Object, Completer<Object?>> _reverseRequestCompleters = <Object, Completer<Object?>>{};
 
@@ -453,6 +461,17 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
       case 'app.started':
         _handleAppStarted();
         break;
+    }
+
+    if (_eventsToForwardToClient.contains(event)) {
+      // Forward the event to the client.
+      sendEvent(
+        RawEventBody(<String, Object?>{
+          'event': event,
+          'params': params,
+        }),
+        eventType: 'flutter.forwardedEvent',
+      );
     }
   }
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -51,7 +51,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
   bool get supportsRestartRequest => true;
 
   /// A list of reverse-requests from `flutter run --machine` that should be forwarded to the client.
-  final Set<String> _requestsToForwardToClient = <String>{
+  static const Set<String> _requestsToForwardToClient = <String>{
     // The 'app.exposeUrl' request is sent by Flutter to request the client
     // exposes a URL to the user and return the public version of that URL.
     //

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -66,7 +66,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
   };
 
   /// A list of events from `flutter run --machine` that should be forwarded to the client.
-  final Set<String> _eventsToForwardToClient = <String>{
+  static const Set<String> _eventsToForwardToClient = <String>{
     // The 'app.webLaunchUrl' event is sent to the client to tell it about a URL
     // that should be launched (including a flag for whether it has been
     // launched by the tool or needs launching by the editor).

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -121,7 +121,7 @@ void main() {
         await adapter.terminateRequest(MockRequest(), TerminateArguments(restart: false), terminateCompleter.complete);
         await terminateCompleter.future;
 
-        expect(adapter.flutterRequests, contains('app.stop'));
+        expect(adapter.dapToFlutterRequests, contains('app.stop'));
       });
 
       test('does not call "app.stop" on terminateRequest if app was not started', () async {
@@ -145,7 +145,7 @@ void main() {
         await adapter.terminateRequest(MockRequest(), TerminateArguments(restart: false), terminateCompleter.complete);
         await terminateCompleter.future;
 
-        expect(adapter.flutterRequests, isNot(contains('app.stop')));
+        expect(adapter.dapToFlutterRequests, isNot(contains('app.stop')));
       });
     });
 
@@ -210,7 +210,39 @@ void main() {
         await adapter.terminateRequest(MockRequest(), TerminateArguments(restart: false), terminateCompleter.complete);
         await terminateCompleter.future;
 
-        expect(adapter.flutterRequests, contains('app.detach'));
+        expect(adapter.dapToFlutterRequests, contains('app.detach'));
+      });
+    });
+
+    group('forwards events', () {
+      test('app.webLaunchUrl', () async {
+        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+
+        // Simulate Flutter asking for a URL to be launched.
+        adapter.simulateStdoutMessage(<String, Object?>{
+          'event': 'app.webLaunchUrl',
+          'params': <String, Object?>{
+            'url': 'http://localhost:123/',
+            'launched': false,
+          }
+        });
+
+        // Allow the handler to be processed.
+        await pumpEventQueue(times: 5000);
+
+        // Find the forwarded event.
+        final Map<String, Object?> message = adapter.dapToClientMessages.singleWhere((Map<String, Object?> data) => data['event'] == 'flutter.forwardedEvent');
+        // Ensure the body of the event matches the original event sent by Flutter.
+        expect(message['body'], <String, Object?>{
+          'event': 'app.webLaunchUrl',
+          'params': <String, Object?>{
+            'url': 'http://localhost:123/',
+            'launched': false,
+          }
+        });
       });
     });
 
@@ -238,7 +270,7 @@ void main() {
         // Allow the handler to be processed.
         await pumpEventQueue(times: 5000);
 
-        final Map<String, Object?> message = adapter.flutterMessages.singleWhere((Map<String, Object?> data) => data['id'] == requestId);
+        final Map<String, Object?> message = adapter.dapToFlutterMessages.singleWhere((Map<String, Object?> data) => data['id'] == requestId);
         expect(message['result'], 'http://mapped-host:123/');
       });
     });

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -53,11 +53,15 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   late List<String> processArgs;
   late Map<String, String>? env;
 
-  /// A list of all messages sent to the `flutter run` processes `stdin`.
-  final List<Map<String, Object?>> flutterMessages = <Map<String, Object?>>[];
+  /// A list of all messages sent from the adapter back to the client.
+  final List<Map<String, Object?>> dapToClientMessages = <Map<String, Object?>>[];
 
-  /// The `method`s of all requests send to the `flutter run` processes `stdin`.
-  List<String> get flutterRequests => flutterMessages
+  /// A list of all messages sent from the adapter to the `flutter run` processes `stdin`.
+  final List<Map<String, Object?>> dapToFlutterMessages = <Map<String, Object?>>[];
+
+  /// The `method`s of all mesages sent to the `flutter run` processes `stdin`
+  /// by the debug adapter.
+  List<String> get dapToFlutterRequests => dapToFlutterMessages
       .map((Map<String, Object?> message) => message['method'] as String?)
       .whereNotNull()
       .toList();
@@ -92,6 +96,8 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
 
   /// Handles messages sent from the debug adapter back to the client.
   void _handleDapToClientMessage(ProtocolMessage message) {
+    dapToClientMessages.add(message.toJson());
+
     // Pretend to be the client, delegating any reverse-requests to the relevant
     // handler that is provided by the test.
     if (message is Event && message.event == 'flutter.forwardedRequest') {
@@ -133,7 +139,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
 
   @override
   void sendFlutterMessage(Map<String, Object?> message) {
-    flutterMessages.add(message);
+    dapToFlutterMessages.add(message);
     // Don't call super because it will try to write to the process that we
     // didn't actually spawn.
   }


### PR DESCRIPTION
This is similar to https://github.com/flutter/flutter/pull/114539, which added support for forwarding some requests from the `flutter` tool over to the DAP client and collecting their response. This is used to expose URLs through proxies/firewalls in remote workspaces.

There is a very similar (but simpler) need to also forward events (which require no response) for launching browser windows (in this case, the URL is implicitly exposed, but then the client needs to launch it in a browser). This is required because in remote workspaces where the `flutter` tool is on another machine and using `web-server`, it can't launch the browser itself.

The change is essentially a simpler version of https://github.com/flutter/flutter/pull/114539 handling events (not requests).

Fixes https://github.com/Dart-Code/Dart-Code/issues/4292.

With this change (and [the matching change in Dart-Code](https://github.com/Dart-Code/Dart-Code/commit/88a2e9fa8a8c0349d1e1079a90e8b91fdb5af7be)), using the web-server device locally correctly exposes and launches the expected URLs.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
