### PR TITLE
Fix Cupertino text selection toolbar colors

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -139,12 +139,13 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   // Builds a toolbar just like the default iOS toolbar, with the right color
   // background and a rounded cutout with an arrow.
   static Widget _defaultToolbarBuilder(BuildContext context, Offset anchor, bool isAbove, Widget child) {
+    final bool isDarkMode = MediaQuery.of(context).platformBrightness == Brightness.dark;
     final Widget outputChild = _CupertinoTextSelectionToolbarShape(
       anchor: anchor,
       isAbove: isAbove,
       child: DecoratedBox(
-        decoration: const BoxDecoration(
-          color: _kToolbarDividerColor,
+        decoration: BoxDecoration(
+          color: isDarkMode ? _kToolbarDividerColor.darkColor : _kToolbarDividerColor.color,
         ),
         child: child,
       ),

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' show Brightness;
+
 import 'package:flutter/widgets.dart';
 
 import 'button.dart';
@@ -21,8 +23,8 @@ const TextStyle _kToolbarButtonFontStyle = TextStyle(
 const CupertinoDynamicColor _kToolbarBackgroundColor = CupertinoDynamicColor.withBrightness(
   // This value was extracted from a screenshot of iOS 16.0.3, as light mode
   // didn't appear in the Apple design resources assets linked above.
-  color: Color(0xEB202020),
-  darkColor: Color(0xEBF7F7F7),
+  color: Color(0xEBF7F7F7),
+  darkColor: Color(0xEB202020),
 );
 
 const CupertinoDynamicColor _kToolbarTextColor = CupertinoDynamicColor.withBrightness(
@@ -114,20 +116,21 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool isDarkMode = MediaQuery.of(context).platformBrightness == Brightness.dark;
     final Widget child = this.child ?? Text(
-       text ?? getButtonLabel(context, buttonItem!),
-       overflow: TextOverflow.ellipsis,
-       style: _kToolbarButtonFontStyle.copyWith(
-         color: onPressed != null
-             ? _kToolbarTextColor
-             : CupertinoColors.inactiveGray,
-       ),
-     );
+      text ?? getButtonLabel(context, buttonItem!),
+      overflow: TextOverflow.ellipsis,
+      style: _kToolbarButtonFontStyle.copyWith(
+        color: onPressed != null
+            ? isDarkMode ? _kToolbarTextColor.darkColor : _kToolbarTextColor.color
+            : CupertinoColors.inactiveGray,
+      ),
+    );
 
     return CupertinoButton(
       borderRadius: null,
-      color: _kToolbarBackgroundColor,
-      disabledColor: _kToolbarBackgroundColor,
+      color: isDarkMode ? _kToolbarBackgroundColor.darkColor : _kToolbarBackgroundColor.color,
+      disabledColor: isDarkMode ? _kToolbarBackgroundColor.darkColor : _kToolbarBackgroundColor.color,
       onPressed: onPressed,
       padding: _kToolbarButtonPadding,
       pressedOpacity: onPressed == null ? 1.0 : 0.7,


### PR DESCRIPTION
After https://github.com/flutter/flutter/pull/115805, the colors on the original dark toolbar appeared wrong:

![image](https://user-images.githubusercontent.com/389558/204935329-2f64eb04-634a-44ff-a320-945a79fc497a.png)

This appears to be because:

  1. CupertinoDynamicColor doesn't resolve to the proper dark/light mode color when it's not inside of a CupertinoApp.
  2. I totally swapped the light and dark button background colors in the original PR.