### PR TITLE
Revert "iOS 16 context menu" due to theme color mix up

### DIFF
--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -5,13 +5,11 @@
 import 'dart:collection';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart' show Brightness, clampDouble;
+import 'package:flutter/foundation.dart' show clampDouble;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
-import 'colors.dart';
 import 'text_selection_toolbar_button.dart';
-import 'theme.dart';
 
 // Values extracted from https://developer.apple.com/design/resources/.
 // The height of the toolbar, including the arrow.
@@ -31,27 +29,9 @@ const double _kArrowScreenPadding = 26.0;
 // Values extracted from https://developer.apple.com/design/resources/.
 const Radius _kToolbarBorderRadius = Radius.circular(8);
 
-const CupertinoDynamicColor _kToolbarDividerColor = CupertinoDynamicColor.withBrightness(
-  // This value was extracted from a screenshot of iOS 16.0.3, as light mode
-  // didn't appear in the Apple design resources assets linked below.
-  color: Color(0xFFB6B6B6),
-  // Color extracted from https://developer.apple.com/design/resources/.
-  // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/41507.
-  darkColor: Color(0xFF808080),
-);
-
-// These values were extracted from a screenshot of iOS 16.0.3, as light mode
-// didn't appear in the Apple design resources assets linked above.
-final BoxDecoration _kToolbarShadow = BoxDecoration(
-  borderRadius: const BorderRadius.all(_kToolbarBorderRadius),
-  boxShadow: <BoxShadow>[
-    BoxShadow(
-      color: CupertinoColors.black.withOpacity(0.1),
-      blurRadius: 16.0,
-      offset: Offset(0, _kToolbarArrowSize.height / 2),
-    ),
-  ],
-);
+// Colors extracted from https://developer.apple.com/design/resources/.
+// TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/41507.
+const Color _kToolbarDividerColor = Color(0xFF808080);
 
 /// The type for a Function that builds a toolbar's container with the given
 /// child.
@@ -139,22 +119,13 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   // Builds a toolbar just like the default iOS toolbar, with the right color
   // background and a rounded cutout with an arrow.
   static Widget _defaultToolbarBuilder(BuildContext context, Offset anchor, bool isAbove, Widget child) {
-    final Widget outputChild = _CupertinoTextSelectionToolbarShape(
+    return _CupertinoTextSelectionToolbarShape(
       anchor: anchor,
       isAbove: isAbove,
       child: DecoratedBox(
-        decoration: const BoxDecoration(
-          color: _kToolbarDividerColor,
-        ),
+        decoration: const BoxDecoration(color: _kToolbarDividerColor),
         child: child,
       ),
-    );
-    if (CupertinoTheme.brightnessOf(context) == Brightness.dark) {
-      return outputChild;
-    }
-    return DecoratedBox(
-      decoration: _kToolbarShadow,
-      child: outputChild,
     );
   }
 
@@ -254,6 +225,7 @@ class _RenderCupertinoTextSelectionToolbarShape extends RenderShiftedBox {
     this._isAbove,
     super.child,
   );
+
 
   @override
   bool get isRepaintBoundary => true;
@@ -513,7 +485,7 @@ class _CupertinoTextSelectionToolbarContentState extends State<_CupertinoTextSel
           onPressed: _handleNextPage,
           text: '▶',
         ),
-        nextButtonDisabled: const CupertinoTextSelectionToolbarButton.text(
+        nextButtonDisabled: CupertinoTextSelectionToolbarButton.text(
           text: '▶',
         ),
         children: widget.children,

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
@@ -18,17 +18,7 @@ const TextStyle _kToolbarButtonFontStyle = TextStyle(
 
 // Colors extracted from https://developer.apple.com/design/resources/.
 // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/41507.
-const CupertinoDynamicColor _kToolbarBackgroundColor = CupertinoDynamicColor.withBrightness(
-  // This value was extracted from a screenshot of iOS 16.0.3, as light mode
-  // didn't appear in the Apple design resources assets linked above.
-  color: Color(0xEB202020),
-  darkColor: Color(0xEBF7F7F7),
-);
-
-const CupertinoDynamicColor _kToolbarTextColor = CupertinoDynamicColor.withBrightness(
-  color: CupertinoColors.black,
-  darkColor: CupertinoColors.white,
-);
+const Color _kToolbarBackgroundColor = Color(0xEB202020);
 
 // Eyeballed value.
 const EdgeInsets _kToolbarButtonPadding = EdgeInsets.symmetric(vertical: 16.0, horizontal: 18.0);
@@ -43,17 +33,22 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
     this.onPressed,
     required Widget this.child,
   }) : assert(child != null),
-       text = null,
        buttonItem = null;
 
   /// Create an instance of [CupertinoTextSelectionToolbarButton] whose child is
   /// a [Text] widget styled like the default iOS text selection toolbar button.
-  const CupertinoTextSelectionToolbarButton.text({
+  CupertinoTextSelectionToolbarButton.text({
     super.key,
     this.onPressed,
-    required this.text,
+    required String text,
   }) : buttonItem = null,
-       child = null;
+       child = Text(
+         text,
+         overflow: TextOverflow.ellipsis,
+         style: _kToolbarButtonFontStyle.copyWith(
+           color: onPressed != null ? CupertinoColors.white : CupertinoColors.inactiveGray,
+         ),
+       );
 
   /// Create an instance of [CupertinoTextSelectionToolbarButton] from the given
   /// [ContextMenuButtonItem].
@@ -64,7 +59,6 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
     required ContextMenuButtonItem this.buttonItem,
   }) : assert(buttonItem != null),
        child = null,
-       text = null,
        onPressed = buttonItem.onPressed;
 
   /// {@template flutter.cupertino.CupertinoTextSelectionToolbarButton.child}
@@ -84,10 +78,6 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
   /// [CupertinoTextSelectionToolbarButton.buttonItem].
   /// {@endtemplate}
   final ContextMenuButtonItem? buttonItem;
-
-  /// The text used in the button's label when using
-  /// [CupertinoTextSelectionToolbarButton.text].
-  final String? text;
 
   /// Returns the default button label String for the button of the given
   /// [ContextMenuButtonItem]'s [ContextMenuButtonType].
@@ -115,15 +105,12 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Widget child = this.child ?? Text(
-       text ?? getButtonLabel(context, buttonItem!),
-       overflow: TextOverflow.ellipsis,
-       style: _kToolbarButtonFontStyle.copyWith(
-         color: onPressed != null
-             ? _kToolbarTextColor
-             : CupertinoColors.inactiveGray,
-       ),
-     );
-
+      getButtonLabel(context, buttonItem!),
+      overflow: TextOverflow.ellipsis,
+      style: _kToolbarButtonFontStyle.copyWith(
+        color: onPressed != null ? CupertinoColors.white : CupertinoColors.inactiveGray,
+      ),
+    );
     return CupertinoButton(
       borderRadius: null,
       color: _kToolbarBackgroundColor,

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1523,11 +1523,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     Text text = tester.widget<Text>(find.text('Paste'));
-    const CupertinoDynamicColor toolbarTextColor = CupertinoDynamicColor.withBrightness(
-      color: CupertinoColors.black,
-      darkColor: CupertinoColors.white,
-    );
-    expect(text.style!.color, toolbarTextColor);
+    expect(text.style!.color, CupertinoColors.white);
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);
@@ -1559,7 +1555,7 @@ void main() {
 
     text = tester.widget<Text>(find.text('Paste'));
     // The toolbar buttons' text are still the same style.
-    expect(text.style!.color, toolbarTextColor);
+    expect(text.style!.color, CupertinoColors.white);
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -60,11 +60,6 @@ class TestBox extends SizedBox {
   static const double itemWidth = 100.0;
 }
 
-const CupertinoDynamicColor _kToolbarBackgroundColor = CupertinoDynamicColor.withBrightness(
-  color: Color(0xEB202020),
-  darkColor: Color(0xEBF7F7F7),
-);
-
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -266,41 +261,5 @@ void main() {
     expect(find.text('Copy'), findsNothing);
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Select all'), findsNothing);
-  }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
-
-  testWidgets('draws dark buttons in dark mode and light button in light mode', (WidgetTester tester) async {
-    for (final Brightness brightness in Brightness.values) {
-      await tester.pumpWidget(
-        CupertinoApp(
-          home: Center(
-            child: Builder(
-              builder: (BuildContext context) {
-                return MediaQuery(
-                  data: MediaQuery.of(context).copyWith(platformBrightness: brightness),
-                  child: CupertinoTextSelectionToolbar(
-                    anchorAbove: const Offset(100.0, 0.0),
-                    anchorBelow: const Offset(100.0, 0.0),
-                    children: <Widget>[
-                      CupertinoTextSelectionToolbarButton.text(
-                        onPressed: () {},
-                        text: 'Button',
-                      ),
-                    ],
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
-      );
-
-      final Finder buttonFinder = find.byType(CupertinoButton);
-      expect(find.byType(CupertinoButton), findsOneWidget);
-      final CupertinoButton button = tester.widget(buttonFinder);
-      expect(
-        button.color,
-        _kToolbarBackgroundColor,
-      );
-    }
   }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 }


### PR DESCRIPTION
The iOS 16 light mode context menu was introduced in https://github.com/flutter/flutter/pull/115805, however, it resulted in some strange colors when used outside of a CupertinoApp:

![image](https://user-images.githubusercontent.com/389558/204936589-63c604b3-4533-49dd-a7bb-2b581e2375ee.png)

I'm going to revert this rather than fix it since we're so close to the stable release cutoff and I don't want to break it.