### PR TITLE
[flutter_tools] disable web compilation of shaders

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -753,19 +753,24 @@ class ManifestAssetBundle implements AssetBundle {
       }
     }
 
-    for (final Uri shaderUri in flutterManifest.shaders) {
-      _parseAssetFromFile(
-        packageConfig,
-        flutterManifest,
-        assetBase,
-        cache,
-        result,
-        shaderUri,
-        packageName: packageName,
-        attributedPackage: attributedPackage,
-        assetKind: AssetKind.shader,
-      );
+    // TODO(jonahwilliams): re-enable this feature once
+    // flutter web is using engine compiled canvaskit.
+    if (targetPlatform != TargetPlatform.web_javascript) {
+      for (final Uri shaderUri in flutterManifest.shaders) {
+        _parseAssetFromFile(
+          packageConfig,
+          flutterManifest,
+          assetBase,
+          cache,
+          result,
+          shaderUri,
+          packageName: packageName,
+          attributedPackage: attributedPackage,
+          assetKind: AssetKind.shader,
+        );
+      }
     }
+
     // Add assets referenced in the fonts section of the manifest.
     for (final Font font in flutterManifest.fonts) {
       for (final FontAsset fontAsset in font.fontAssets) {


### PR DESCRIPTION
Because we're not shipping canvaskit with runtime effect in this release, disable compilation of shaders to work around https://github.com/flutter/flutter/issues/115433