### PR TITLE
Lookup Boundary

### DIFF
--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -46,6 +46,8 @@ export 'package:flutter/rendering.dart' show RenderBox, RenderObject, debugDumpL
 // late Object? _myState, newValue;
 // int _counter = 0;
 // Future<Directory> getApplicationDocumentsDirectory() async => Directory('');
+// class MyWidget extends StatelessWidget { const MyWidget({super.key, required this.child}); final Widget child; @override Widget build(BuildContext context) => child; }
+// class MyLookUpBoundary extends StatelessWidget { const MyLookUpBoundary({super.key, required this.child}); final Widget child; @override Widget build(BuildContext context) => child; }
 
 // An annotation used by test_analysis package to verify patterns are followed
 // that allow for tree-shaking of both fields and their initializers. This
@@ -4400,8 +4402,8 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// {@tool snippet}
   ///
-  /// In the example below, the [BuildContext.findAncestorWidgetOfExactType] call
-  /// returns null because the lookup boundary "hides" `MyWidget` from the
+  /// In the example below, the [BuildContext.findAncestorWidgetOfExactType]
+  /// call returns null because the lookup boundary "hides" `MyWidget` from the
   /// [BuildContext] that was queried.
   ///
   /// ```dart
@@ -4410,7 +4412,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///     child: Builder(
   ///       builder: (BuildContext context) {
   ///         MyWidget? widget = context.findAncestorWidgetOfExactType<MyWidget>(
-  ///           findAncestorWidgetOfExactType: true,
+  ///           stopAtLookUpBoundary: true,
   ///         );
   ///         return Text('$widget'); // "null"
   ///       },
@@ -4420,26 +4422,26 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   /// ```
   /// {@end-tool}
   ///
-  /// Lookup boundaries are used in locations of the element tree where the render
-  /// tree diverges from the element tree, which is rather uncommon. Such
+  /// Lookup boundaries are used in locations of the element tree where the
+  /// render tree diverges from the element tree, which is rather uncommon. Such
   /// anomalies are created by [RenderObjectElement]s that don't attach their
-  /// [RenderObject] to the closest ancestor [RenderObjectElement]. This behavior
-  /// breaks the assumption some widgets have about the structure of the render
-  /// tree. These widgets may try to reach out to an ancestor widget, assuming
-  /// that their associated [RenderObject]s are also ancestors. However, due to
-  /// the anomaly in the trees this may not be the case. At the point where the
-  /// divergence in the two trees is introduced, a lookup boundary can be used to
-  /// hide that ancestor from the querying widget.
+  /// [RenderObject] to the closest ancestor [RenderObjectElement]. This
+  /// behavior breaks the assumption some widgets have about the structure of
+  /// the render tree. These widgets may try to reach out to an ancestor widget,
+  /// assuming that their associated [RenderObject]s are also ancestors.
+  /// However, due to the anomaly in the trees this may not be the case. At the
+  /// point where the divergence in the two trees is introduced, a lookup
+  /// boundary can be used to hide that ancestor from the querying widget.
 // TODO(goderbauer): Mention the View widget and the OverlayPortal here as an
 //   example for diverging element and render trees once those are available.
   ///
   /// As an example, [Material.of] relies on lookup boundaries to hide the
   /// [Material] widget from certain descendant button widget. Buttons reach out
   /// to their [Material] ancestor to draw ink splashes on its associated render
-  /// object. This only produces the desired effect if the button render object is
-  /// a descendant of the [Material] render object. If the element tree and the
-  /// render tree are not in sync due to anomalies described above, this may not
-  /// be the case. To avoid incorrect visuals, the [Material] relies on
+  /// object. This only produces the desired effect if the button render object
+  /// is a descendant of the [Material] render object. If the element tree and
+  /// the render tree are not in sync due to anomalies described above, this may
+  /// not be the case. To avoid incorrect visuals, the [Material] relies on
   /// lookup boundaries to hide itself from descendants in subtrees with such
   /// anomalies. Those subtrees are expected to introduce their own [Material]
   /// widget that buttons there can utilize without crossing a lookup boundary.

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -6681,9 +6681,8 @@ bool _debugShouldReassemble(DebugReassembleConfig? config, Widget? widget) {
   return config == null || config.widgetName == null || widget?.runtimeType.toString() == config.widgetName;
 }
 
-/// A [LookUpBoundary] controls what entities are available for lookup by
-/// descendants of the boundary via the various lookup methods provided on
-/// [BuildContext].
+/// A [LookUpBoundary] controls what entities are visible to descendants of the
+/// boundary via the various lookup methods provided on [BuildContext].
 ///
 /// The lookup methods affected by a [LookUpBoundary] are:
 ///
@@ -6695,14 +6694,15 @@ bool _debugShouldReassemble(DebugReassembleConfig? config, Widget? widget) {
 ///  * [BuildContext.findAncestorRenderObjectOfType].
 ///
 /// When these methods are called with their `stopAtLookUpBoundary` parameter
-/// set to true, they do not return any ancestor entities of the [LookUpBoundary]
-/// closest to the [BuildContext] queried. If `stopAtLookUpBoundary` is set to
-/// false (the default), the [LookupBoundary] has no effect on the query.
+/// set to true, they do not return any ancestor entities of the
+/// [LookUpBoundary] closest to the [BuildContext] queried. If
+/// `stopAtLookUpBoundary` is set to false (the default), the [LookupBoundary]
+/// has no effect on the query.
 ///
 /// {@tool snippet}
 ///
 /// In the example below, the [BuildContext.findAncestorWidgetOfExactType] call
-/// returns null because the LookUpBoundary "hides" `MyWidget` from the
+/// returns null because the [LookUpBoundary] "hides" `MyWidget` from the
 /// [BuildContext] that was queried.
 ///
 /// ```dart
@@ -6721,20 +6721,29 @@ bool _debugShouldReassemble(DebugReassembleConfig? config, Widget? widget) {
 /// ```
 /// {@end-tool}
 ///
-/// [LookUpBoundary]s are used in locations of the element tree where the
-/// render tree diverges from the element tree, which is rather uncommon.
-/// Such divergences are created by [RenderObjectElement]s that don't attach
-/// their [RenderObject] to the closest ancestor [RenderObjectElement]. This
-/// behavior breaks the assumption some widgets have about the structure of the
-/// render tree. These widgets may try to reach out to an ancestor widget,
-/// assuming that their associated [RenderObject]s are also ancestors. However,
-/// due to the divergence in the trees this may not be the case. At the point of
-/// the divergence a [LookUpBoundary] can be used to hide that ancestor from the
-/// querying widget.
+/// [LookUpBoundary]s are used in locations of the element tree where the render
+/// tree diverges from the element tree, which is rather uncommon. Such
+/// anomalies are created by [RenderObjectElement]s that don't attach their
+/// [RenderObject] to the closest ancestor [RenderObjectElement]. This behavior
+/// breaks the assumption some widgets have about the structure of the render
+/// tree. These widgets may try to reach out to an ancestor widget, assuming
+/// that their associated [RenderObject]s are also ancestors. However, due to
+/// the anomaly in the trees this may not be the case. At the point where the
+/// divergence in the two trees is introduced, a [LookUpBoundary] can be used to
+/// hide that ancestor from the querying widget.
 // TODO(goderbauer): Mention the View widget and the OverlayPortal here as an
 //   example for diverging element and render trees once those are available.
 ///
-/// [Material.of] makes use of []
+/// As an example, [Material.of] relies on [LookUpBoundary]s to hide the
+/// [Material] widget from certain descendant button widget. Buttons reach out
+/// to their [Material] ancestor to draw ink splashes on its associated render
+/// object. This only produces the desired effect if the button render object is
+/// a descendant of the [Material] render object. If the element tree and the
+/// render tree are not in sync due to anomalies described above, this may not
+/// be the case. To avoid incorrect visuals, the [Material] relies on
+/// [LookUpBoundary]s to hide itself from descendants in subtrees with such
+/// anomalies. Those subtrees are expected to introduce their own [Material]
+/// widget that buttons there can utilize without crossing a [LookUpBoundary].
 mixin LookUpBoundary on Element {
   // Left empty, this is just a marker interface used by the [Element] class.
 }

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -4408,7 +4408,7 @@ abstract class Element extends DiagnosticableTree implements BuildContext {
   ///
   /// ```dart
   /// MyWidget(
-  ///   child: MyLookUpBoundary( // Uses an Element with the LookUpBoundary mixin.
+  ///   child: MyLookUpBoundary( // Has Element.isLookUpBoundary set to true.
   ///     child: Builder(
   ///       builder: (BuildContext context) {
   ///         MyWidget? widget = context.findAncestorWidgetOfExactType<MyWidget>(

--- a/packages/flutter/test/widgets/look_up_boundary_test.dart
+++ b/packages/flutter/test/widgets/look_up_boundary_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -45,9 +43,11 @@ void main() {
     Widget? containerThroughBoundary;
     Widget? containerStoppedAtBoundary;
 
+    final Key outerContainerKey = UniqueKey();
     final Key innerContainerKey = UniqueKey();
 
     await tester.pumpWidget(Container(
+      key: outerContainerKey,
       child: MyStatelessLookupBoundary(
         child: Container(
           key: innerContainerKey,
@@ -81,8 +81,8 @@ void main() {
         key: boundaryKey,
         child: Builder(
           builder: (BuildContext context) {
-            containerThroughBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>();
-            containerStoppedAtBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+            containerThroughBoundary = context.findAncestorStateOfType<MyStatefulContainerState>();
+            containerStoppedAtBoundary = context.findAncestorStateOfType<MyStatefulContainerState>(stopAtLookUpBoundary: true);
             boundaryThroughBoundary = context.findAncestorStateOfType<MyStatefulLookupBoundaryState>();
             boundaryStoppedAtBoundary = context.findAncestorStateOfType<MyStatefulLookupBoundaryState>(stopAtLookUpBoundary: true);
             return const SizedBox.expand();
@@ -109,8 +109,8 @@ void main() {
           key: innerKey,
           child: Builder(
             builder: (BuildContext context) {
-              containerThroughBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>();
-              containerStoppedAtBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+              containerThroughBoundary = context.findAncestorStateOfType<MyStatefulContainerState>();
+              containerStoppedAtBoundary = context.findAncestorStateOfType<MyStatefulContainerState>(stopAtLookUpBoundary: true);
               return const SizedBox.expand();
             },
           ),
@@ -178,8 +178,6 @@ void main() {
     expect(containerStoppedAtBoundary, equals(tester.renderObject(find.byKey(innerKey))));
   });
 
-  ///
-
   testWidgets('findRootAncestorStateOfType respects stopAtLookUpBoundary', (WidgetTester tester) async {
     State? containerThroughBoundary;
     State? containerStoppedAtBoundary;
@@ -199,8 +197,8 @@ void main() {
             key: innerBoundaryKey,
             child: Builder(
               builder: (BuildContext context) {
-                containerThroughBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>();
-                containerStoppedAtBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+                containerThroughBoundary = context.findRootAncestorStateOfType<MyStatefulContainerState>();
+                containerStoppedAtBoundary = context.findRootAncestorStateOfType<MyStatefulContainerState>(stopAtLookUpBoundary: true);
                 boundaryThroughBoundary = context.findRootAncestorStateOfType<MyStatefulLookupBoundaryState>();
                 boundaryStoppedAtBoundary = context.findRootAncestorStateOfType<MyStatefulLookupBoundaryState>(stopAtLookUpBoundary: true);
                 return const SizedBox.expand();
@@ -232,8 +230,8 @@ void main() {
           child: MyStatefulContainer(
             child: Builder(
               builder: (BuildContext context) {
-                containerThroughBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>();
-                containerStoppedAtBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+                containerThroughBoundary = context.findRootAncestorStateOfType<MyStatefulContainerState>();
+                containerStoppedAtBoundary = context.findRootAncestorStateOfType<MyStatefulContainerState>(stopAtLookUpBoundary: true);
                 return const SizedBox.expand();
               },
             ),
@@ -244,6 +242,118 @@ void main() {
 
     expect(containerThroughBoundary, equals(tester.state(find.byKey(outerRootKey))));
     expect(containerStoppedAtBoundary, equals(tester.state(find.byKey(innerRootKey))));
+  });
+
+  testWidgets('dependOnInheritedWidgetOfExactType respects stopAtLookUpBoundary', (WidgetTester tester) async {
+    InheritedWidget? containerThroughBoundary;
+    InheritedWidget? containerStoppedAtBoundary;
+    InheritedWidget? boundaryThroughBoundary;
+    InheritedWidget? boundaryStoppedAtBoundary;
+
+    final Key boundaryKey = UniqueKey();
+    final Key inheritedKey = UniqueKey();
+
+    await tester.pumpWidget(MyInheritedWidget(
+      key: inheritedKey,
+      child: MyInheritedLookUpBoundary(
+        key: boundaryKey,
+        child: Builder(
+          builder: (BuildContext context) {
+            containerThroughBoundary = context.dependOnInheritedWidgetOfExactType<MyInheritedWidget>();
+            containerStoppedAtBoundary = context.dependOnInheritedWidgetOfExactType<MyInheritedWidget>(stopAtLookUpBoundary: true);
+            boundaryThroughBoundary = context.dependOnInheritedWidgetOfExactType<MyInheritedLookUpBoundary>();
+            boundaryStoppedAtBoundary = context.dependOnInheritedWidgetOfExactType<MyInheritedLookUpBoundary>(stopAtLookUpBoundary: true);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.widget(find.byKey(inheritedKey))));
+    expect(containerStoppedAtBoundary, isNull);
+    expect(boundaryThroughBoundary, equals(tester.widget(find.byKey(boundaryKey))));
+    expect(boundaryStoppedAtBoundary, equals(tester.widget(find.byKey(boundaryKey))));
+  });
+
+  testWidgets('dependOnInheritedWidgetOfExactType finds state before boundary', (WidgetTester tester) async {
+    InheritedWidget? containerThroughBoundary;
+    InheritedWidget? containerStoppedAtBoundary;
+
+    final Key inheritedKey = UniqueKey();
+
+    await tester.pumpWidget(MyInheritedWidget(
+      child: MyInheritedLookUpBoundary(
+        child: MyInheritedWidget(
+          key: inheritedKey,
+          child: Builder(
+            builder: (BuildContext context) {
+              containerThroughBoundary = context.dependOnInheritedWidgetOfExactType<MyInheritedWidget>();
+              containerStoppedAtBoundary = context.dependOnInheritedWidgetOfExactType<MyInheritedWidget>(stopAtLookUpBoundary: true);
+              return const SizedBox.expand();
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.widget(find.byKey(inheritedKey))));
+    expect(containerStoppedAtBoundary, equals(tester.widget(find.byKey(inheritedKey))));
+  });
+
+  testWidgets('getElementForInheritedWidgetOfExactType respects stopAtLookUpBoundary', (WidgetTester tester) async {
+    InheritedElement? containerThroughBoundary;
+    InheritedElement? containerStoppedAtBoundary;
+    InheritedElement? boundaryThroughBoundary;
+    InheritedElement? boundaryStoppedAtBoundary;
+
+    final Key boundaryKey = UniqueKey();
+    final Key inheritedKey = UniqueKey();
+
+    await tester.pumpWidget(MyInheritedWidget(
+      key: inheritedKey,
+      child: MyInheritedLookUpBoundary(
+        key: boundaryKey,
+        child: Builder(
+          builder: (BuildContext context) {
+            containerThroughBoundary = context.getElementForInheritedWidgetOfExactType<MyInheritedWidget>();
+            containerStoppedAtBoundary = context.getElementForInheritedWidgetOfExactType<MyInheritedWidget>(stopAtLookUpBoundary: true);
+            boundaryThroughBoundary = context.getElementForInheritedWidgetOfExactType<MyInheritedLookUpBoundary>();
+            boundaryStoppedAtBoundary = context.getElementForInheritedWidgetOfExactType<MyInheritedLookUpBoundary>(stopAtLookUpBoundary: true);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.element(find.byKey(inheritedKey))));
+    expect(containerStoppedAtBoundary, isNull);
+    expect(boundaryThroughBoundary, equals(tester.element(find.byKey(boundaryKey))));
+    expect(boundaryStoppedAtBoundary, equals(tester.element(find.byKey(boundaryKey))));
+  });
+
+  testWidgets('getElementForInheritedWidgetOfExactType finds state before boundary', (WidgetTester tester) async {
+    InheritedElement? containerThroughBoundary;
+    InheritedElement? containerStoppedAtBoundary;
+
+    final Key inheritedKey = UniqueKey();
+
+    await tester.pumpWidget(MyInheritedWidget(
+      child: MyInheritedLookUpBoundary(
+        child: MyInheritedWidget(
+          key: inheritedKey,
+          child: Builder(
+            builder: (BuildContext context) {
+              containerThroughBoundary = context.getElementForInheritedWidgetOfExactType<MyInheritedWidget>();
+              containerStoppedAtBoundary = context.getElementForInheritedWidgetOfExactType<MyInheritedWidget>(stopAtLookUpBoundary: true);
+              return const SizedBox.expand();
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.element(find.byKey(inheritedKey))));
+    expect(containerStoppedAtBoundary, equals(tester.element(find.byKey(inheritedKey))));
   });
 }
 
@@ -294,10 +404,10 @@ class MyStatefulContainer extends StatefulWidget {
   final Widget child;
 
   @override
-  State<MyStatefulContainer> createState() => _MyStatefulContainerState();
+  State<MyStatefulContainer> createState() => MyStatefulContainerState();
 }
 
-class _MyStatefulContainerState extends State<MyStatefulContainer> {
+class MyStatefulContainerState extends State<MyStatefulContainer> {
   @override
   Widget build(BuildContext context) {
     return widget.child;
@@ -316,4 +426,25 @@ class MyRenderObjectWidgetLookupBoundary extends SingleChildRenderObjectWidget {
 
 class MyRenderObjectWidgetLookupBoundaryElement extends SingleChildRenderObjectElement with LookUpBoundary {
   MyRenderObjectWidgetLookupBoundaryElement(super.widget);
+}
+
+class MyInheritedWidget extends InheritedWidget {
+  const MyInheritedWidget({super.key, required super.child});
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => true;
+}
+
+class MyInheritedLookUpBoundary extends InheritedWidget {
+  const MyInheritedLookUpBoundary({super.key, required super.child});
+
+  @override
+  InheritedElement createElement() => MyInheritedElement(this);
+
+  @override
+  bool updateShouldNotify(covariant InheritedWidget oldWidget) => true;
+}
+
+class MyInheritedElement extends InheritedElement with LookUpBoundary {
+  MyInheritedElement(super.widget);
 }

--- a/packages/flutter/test/widgets/look_up_boundary_test.dart
+++ b/packages/flutter/test/widgets/look_up_boundary_test.dart
@@ -1,0 +1,319 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('findAncestorWidgetOfExactType respects stopAtLookUpBoundary', (WidgetTester tester) async {
+    Widget? containerThroughBoundary;
+    Widget? containerStoppedAtBoundary;
+    Widget? boundaryThroughBoundary;
+    Widget? boundaryStoppedAtBoundary;
+
+    final Key containerKey = UniqueKey();
+    final Key boundaryKey = UniqueKey();
+
+    await tester.pumpWidget(Container(
+      key: containerKey,
+      child: MyStatelessLookupBoundary(
+        key: boundaryKey,
+        child: Builder(
+          builder: (BuildContext context) {
+            containerThroughBoundary = context.findAncestorWidgetOfExactType<Container>();
+            containerStoppedAtBoundary = context.findAncestorWidgetOfExactType<Container>(stopAtLookUpBoundary: true);
+            boundaryThroughBoundary = context.findAncestorWidgetOfExactType<MyStatelessLookupBoundary>();
+            boundaryStoppedAtBoundary = context.findAncestorWidgetOfExactType<MyStatelessLookupBoundary>(stopAtLookUpBoundary: true);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.widget(find.byKey(containerKey))));
+    expect(containerStoppedAtBoundary, isNull);
+    expect(boundaryThroughBoundary, equals(tester.widget(find.byKey(boundaryKey))));
+    expect(boundaryStoppedAtBoundary, equals(tester.widget(find.byKey(boundaryKey))));
+  });
+
+  testWidgets('findAncestorWidgetOfExactType finds widget before boundary', (WidgetTester tester) async {
+    Widget? containerThroughBoundary;
+    Widget? containerStoppedAtBoundary;
+
+    final Key innerContainerKey = UniqueKey();
+
+    await tester.pumpWidget(Container(
+      child: MyStatelessLookupBoundary(
+        child: Container(
+          key: innerContainerKey,
+          child: Builder(
+            builder: (BuildContext context) {
+              containerThroughBoundary = context.findAncestorWidgetOfExactType<Container>();
+              containerStoppedAtBoundary = context.findAncestorWidgetOfExactType<Container>(stopAtLookUpBoundary: true);
+              return const SizedBox.expand();
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.widget(find.byKey(innerContainerKey))));
+    expect(containerStoppedAtBoundary, equals(tester.widget(find.byKey(innerContainerKey))));
+  });
+
+  testWidgets('findAncestorStateOfType respects stopAtLookUpBoundary', (WidgetTester tester) async {
+    State? containerThroughBoundary;
+    State? containerStoppedAtBoundary;
+    State? boundaryThroughBoundary;
+    State? boundaryStoppedAtBoundary;
+
+    final Key containerKey = UniqueKey();
+    final Key boundaryKey = UniqueKey();
+
+    await tester.pumpWidget(MyStatefulContainer(
+      key: containerKey,
+      child: MyStatefulLookupBoundary(
+        key: boundaryKey,
+        child: Builder(
+          builder: (BuildContext context) {
+            containerThroughBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>();
+            containerStoppedAtBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+            boundaryThroughBoundary = context.findAncestorStateOfType<MyStatefulLookupBoundaryState>();
+            boundaryStoppedAtBoundary = context.findAncestorStateOfType<MyStatefulLookupBoundaryState>(stopAtLookUpBoundary: true);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.state(find.byKey(containerKey))));
+    expect(containerStoppedAtBoundary, isNull);
+    expect(boundaryThroughBoundary, equals(tester.state(find.byKey(boundaryKey))));
+    expect(boundaryStoppedAtBoundary, equals(tester.state(find.byKey(boundaryKey))));
+  });
+
+  testWidgets('findAncestorStateOfType finds state before boundary', (WidgetTester tester) async {
+    State? containerThroughBoundary;
+    State? containerStoppedAtBoundary;
+
+    final Key innerKey = UniqueKey();
+
+    await tester.pumpWidget(MyStatefulContainer(
+      child: MyStatefulLookupBoundary(
+        child: MyStatefulContainer(
+          key: innerKey,
+          child: Builder(
+            builder: (BuildContext context) {
+              containerThroughBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>();
+              containerStoppedAtBoundary = context.findAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+              return const SizedBox.expand();
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.state(find.byKey(innerKey))));
+    expect(containerStoppedAtBoundary, equals(tester.state(find.byKey(innerKey))));
+  });
+
+  testWidgets('findAncestorRenderObjectOfType respects stopAtLookUpBoundary', (WidgetTester tester) async {
+    RenderObject? containerThroughBoundary;
+    RenderObject? containerStoppedAtBoundary;
+    RenderObject? boundaryThroughBoundary;
+    RenderObject? boundaryStoppedAtBoundary;
+
+    final Key containerKey = UniqueKey();
+    final Key boundaryKey = UniqueKey();
+
+    await tester.pumpWidget(SizedBox.expand(
+      key: containerKey,
+      child: MyRenderObjectWidgetLookupBoundary(
+        key: boundaryKey,
+        child: Builder(
+          builder: (BuildContext context) {
+            containerThroughBoundary = context.findAncestorRenderObjectOfType<RenderConstrainedBox>();
+            containerStoppedAtBoundary = context.findAncestorRenderObjectOfType<RenderConstrainedBox>(stopAtLookUpBoundary: true);
+            boundaryThroughBoundary = context.findAncestorRenderObjectOfType<RenderPadding>();
+            boundaryStoppedAtBoundary = context.findAncestorRenderObjectOfType<RenderPadding>(stopAtLookUpBoundary: true);
+            return const SizedBox.expand();
+          },
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.renderObject(find.byKey(containerKey))));
+    expect(containerStoppedAtBoundary, isNull);
+    expect(boundaryThroughBoundary, equals(tester.renderObject(find.byKey(boundaryKey))));
+    expect(boundaryStoppedAtBoundary, equals(tester.renderObject(find.byKey(boundaryKey))));
+  });
+
+  testWidgets('findAncestorRenderObjectOfType finds render object before boundary', (WidgetTester tester) async {
+    RenderObject? containerThroughBoundary;
+    RenderObject? containerStoppedAtBoundary;
+
+    final Key innerKey = UniqueKey();
+
+    await tester.pumpWidget(SizedBox.expand(
+      child: MyRenderObjectWidgetLookupBoundary(
+        child: SizedBox.expand(
+          key: innerKey,
+          child: Builder(
+            builder: (BuildContext context) {
+              containerThroughBoundary = context.findAncestorRenderObjectOfType<RenderConstrainedBox>();
+              containerStoppedAtBoundary = context.findAncestorRenderObjectOfType<RenderConstrainedBox>(stopAtLookUpBoundary: true);
+              return const SizedBox.expand();
+            },
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.renderObject(find.byKey(innerKey))));
+    expect(containerStoppedAtBoundary, equals(tester.renderObject(find.byKey(innerKey))));
+  });
+
+  ///
+
+  testWidgets('findRootAncestorStateOfType respects stopAtLookUpBoundary', (WidgetTester tester) async {
+    State? containerThroughBoundary;
+    State? containerStoppedAtBoundary;
+    State? boundaryThroughBoundary;
+    State? boundaryStoppedAtBoundary;
+
+    final Key rootContainerKey = UniqueKey();
+    final Key rootBoundaryKey = UniqueKey();
+    final Key innerBoundaryKey = UniqueKey();
+
+    await tester.pumpWidget(MyStatefulContainer(
+      key: rootContainerKey,
+      child: MyStatefulLookupBoundary(
+        key: rootBoundaryKey,
+        child: MyStatefulContainer(
+          child: MyStatefulLookupBoundary(
+            key: innerBoundaryKey,
+            child: Builder(
+              builder: (BuildContext context) {
+                containerThroughBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>();
+                containerStoppedAtBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+                boundaryThroughBoundary = context.findRootAncestorStateOfType<MyStatefulLookupBoundaryState>();
+                boundaryStoppedAtBoundary = context.findRootAncestorStateOfType<MyStatefulLookupBoundaryState>(stopAtLookUpBoundary: true);
+                return const SizedBox.expand();
+              },
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.state(find.byKey(rootContainerKey))));
+    expect(containerStoppedAtBoundary, isNull);
+    expect(boundaryThroughBoundary, equals(tester.state(find.byKey(rootBoundaryKey))));
+    expect(boundaryStoppedAtBoundary, equals(tester.state(find.byKey(innerBoundaryKey))));
+  });
+
+  testWidgets('findRootAncestorStateOfType finds state before boundary', (WidgetTester tester) async {
+    State? containerThroughBoundary;
+    State? containerStoppedAtBoundary;
+
+    final Key outerRootKey = UniqueKey();
+    final Key innerRootKey = UniqueKey();
+
+    await tester.pumpWidget(MyStatefulContainer(
+      key: outerRootKey,
+      child: MyStatefulLookupBoundary(
+        child: MyStatefulContainer(
+          key: innerRootKey,
+          child: MyStatefulContainer(
+            child: Builder(
+              builder: (BuildContext context) {
+                containerThroughBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>();
+                containerStoppedAtBoundary = context.findRootAncestorStateOfType<_MyStatefulContainerState>(stopAtLookUpBoundary: true);
+                return const SizedBox.expand();
+              },
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    expect(containerThroughBoundary, equals(tester.state(find.byKey(outerRootKey))));
+    expect(containerStoppedAtBoundary, equals(tester.state(find.byKey(innerRootKey))));
+  });
+}
+
+class MyStatelessLookupBoundary extends StatelessWidget {
+  const MyStatelessLookupBoundary({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  StatelessElement createElement() => MyStatelessLookupBoundaryElement(this);
+
+  @override
+  Widget build(BuildContext context) {
+    return child;
+  }
+}
+
+class MyStatelessLookupBoundaryElement extends StatelessElement with LookUpBoundary {
+  MyStatelessLookupBoundaryElement(super.widget);
+}
+
+class MyStatefulLookupBoundary extends StatefulWidget {
+  const MyStatefulLookupBoundary({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  StatefulElement createElement() => MyStatefulLookupBoundaryElement(this);
+
+  @override
+  State<StatefulWidget> createState() => MyStatefulLookupBoundaryState();
+}
+
+class MyStatefulLookupBoundaryState extends State<MyStatefulLookupBoundary> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class MyStatefulLookupBoundaryElement extends StatefulElement with LookUpBoundary {
+  MyStatefulLookupBoundaryElement(super.widget);
+}
+
+class MyStatefulContainer extends StatefulWidget {
+  const MyStatefulContainer({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<MyStatefulContainer> createState() => _MyStatefulContainerState();
+}
+
+class _MyStatefulContainerState extends State<MyStatefulContainer> {
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class MyRenderObjectWidgetLookupBoundary extends SingleChildRenderObjectWidget {
+  const MyRenderObjectWidgetLookupBoundary({super.key, super.child});
+
+  @override
+  SingleChildRenderObjectElement createElement() => MyRenderObjectWidgetLookupBoundaryElement(this);
+
+  @override
+  RenderObject createRenderObject(BuildContext context) => RenderPadding(padding: EdgeInsets.zero);
+}
+
+class MyRenderObjectWidgetLookupBoundaryElement extends SingleChildRenderObjectElement with LookUpBoundary {
+  MyRenderObjectWidgetLookupBoundaryElement(super.widget);
+}

--- a/packages/flutter/test/widgets/look_up_boundary_test.dart
+++ b/packages/flutter/test/widgets/look_up_boundary_test.dart
@@ -371,8 +371,11 @@ class MyStatelessLookupBoundary extends StatelessWidget {
   }
 }
 
-class MyStatelessLookupBoundaryElement extends StatelessElement with LookUpBoundary {
+class MyStatelessLookupBoundaryElement extends StatelessElement {
   MyStatelessLookupBoundaryElement(super.widget);
+
+  @override
+  bool get isLookUpBoundary => true;
 }
 
 class MyStatefulLookupBoundary extends StatefulWidget {
@@ -394,8 +397,11 @@ class MyStatefulLookupBoundaryState extends State<MyStatefulLookupBoundary> {
   }
 }
 
-class MyStatefulLookupBoundaryElement extends StatefulElement with LookUpBoundary {
+class MyStatefulLookupBoundaryElement extends StatefulElement {
   MyStatefulLookupBoundaryElement(super.widget);
+
+  @override
+  bool get isLookUpBoundary => true;
 }
 
 class MyStatefulContainer extends StatefulWidget {
@@ -424,8 +430,11 @@ class MyRenderObjectWidgetLookupBoundary extends SingleChildRenderObjectWidget {
   RenderObject createRenderObject(BuildContext context) => RenderPadding(padding: EdgeInsets.zero);
 }
 
-class MyRenderObjectWidgetLookupBoundaryElement extends SingleChildRenderObjectElement with LookUpBoundary {
+class MyRenderObjectWidgetLookupBoundaryElement extends SingleChildRenderObjectElement {
   MyRenderObjectWidgetLookupBoundaryElement(super.widget);
+
+  @override
+  bool get isLookUpBoundary => true;
 }
 
 class MyInheritedWidget extends InheritedWidget {
@@ -445,6 +454,9 @@ class MyInheritedLookUpBoundary extends InheritedWidget {
   bool updateShouldNotify(covariant InheritedWidget oldWidget) => true;
 }
 
-class MyInheritedElement extends InheritedElement with LookUpBoundary {
+class MyInheritedElement extends InheritedElement {
   MyInheritedElement(super.widget);
+
+  @override
+  bool get isLookUpBoundary => true;
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/115381.

## Design Discussion

This change introduces a `stopAtLookUpBoundary` parameter to the various lookup methods on `BuildContext` and offers a consistent API between all lookup methods, which I really like. However, it comes at the cost of adding a field (`_lookUpBoundary`) to every `Element`. This could probably be slightly optimized by replacing the `_inheritedWidgets` with an immutable data object that incorporates the hashmap of inherited elements and the lookUpBoundary field. That way, most Elements would just point to the same data object and not need storage for an extra field. Only Elements of InheritedWidgets and Elements who are actually lookup boundaries would have slightly increased memory needs because they will have to create a new data object with that extra field for the lookup boundary.

An alternative approach would forego a common API among all lookup methods. It would keep the `stopAtLookUpBoundary` parameter on the various `find*` lookup methods, but remove it from the `dependOn*` and `get*` lookup methods. Instead of deciding at lookup time whether to retrieve InheritedWidgets past the lookup boundary, the InheritedWidgets themselves would decide whether they want to be visible through the lookup boundary. This would be controlled via a constructor argument to InheritedWidget or an overridable getter. At a lookup boundary, we would filter the hashmap of inherited widgets to remove those who have specified that they don't want to be visible through the lookup boundary. This would make adding and moving lookup boundaries more expensive because it requires filtering a potentially long list of inherited widgets and the lookup APIs on BuildContext would be less consistent. But it would remove the extra check from the lookup implementation for inherited widgets.

| Approach in PR      | Alternative Approach |
| ----------- | ----------- |
| + consistent API for all lookup methods      | - `find` methods have different API from `depend`/`get` methods       |
| - requires extra memory (1 field per element, can be optimized to one per InheritedWidget/LookupBoundary)   | + no extra memory        |
| - requires extra check for lookup of inherited widgets | + no extra check for inherited widget lookup |
| - each element needs to copy lookupboundary reference from parent in mount/activate | - adding/moving lookup boundaries is slower due to filtering |
| + flexible (at lookup it is decided whether an InheritedWidget should be seen) | - less flexible (InheritedWidget decides wether it wants to be seen) |
| | - requires extending the `PersistentHashMap` interface to allow for iteration for filtering |