### PR TITLE
Add a Small Padding on the Right for the AppBar Actions

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:material_color_utilities/material_color_utilities.dart';
 
 import 'app_bar_theme.dart';
 import 'back_button.dart';
@@ -1085,13 +1086,20 @@ class _AppBarState extends State<AppBar> {
 
     // Allow the trailing actions to have their own theme if necessary.
     if (actions != null) {
-      actions = Padding(
-        padding: const EdgeInsets.only(right: 4.0),
-        child: IconTheme.merge(
-          data: actionsIconTheme,
-          child: actions,
-        ),
+      actions = IconTheme.merge(
+        data: actionsIconTheme,
+        child: actions,
       );
+
+      final TextDirection textDirection = Directionality.of(context);
+      if (Theme.of(context).useMaterial3) {
+        actions = Padding(
+          padding: textDirection == TextDirection.rtl
+            ? const EdgeInsets.only(left: 4.0)
+            : const EdgeInsets.only(right: 4.0),
+          child: actions,
+        );
+      }
     }
 
     final Widget toolbar = NavigationToolbar(

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:material_color_utilities/material_color_utilities.dart';
 
 import 'app_bar_theme.dart';
 import 'back_button.dart';

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1085,9 +1085,12 @@ class _AppBarState extends State<AppBar> {
 
     // Allow the trailing actions to have their own theme if necessary.
     if (actions != null) {
-      actions = IconTheme.merge(
-        data: actionsIconTheme,
-        child: actions,
+      actions = Padding(
+        padding: const EdgeInsets.only(right: 4.0),
+        child: IconTheme.merge(
+          data: actionsIconTheme,
+          child: actions,
+        ),
       );
     }
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3760,4 +3760,28 @@ void main() {
     expect(tester.getTopLeft(find.byKey(titleKey)).dx, leadingWidth + 16.0);
     expect(tester.getSize(find.byKey(leadingKey)).width, leadingWidth);
   });
+
+  testWidgets('The AppBar actions should have a 4dp space for padding on the right by default', (WidgetTester tester) async {
+    Widget buildApp() {
+      return MaterialApp(
+        home: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return Scaffold(
+                appBar: AppBar(
+                  title: const Text('Title'),
+                  actions: <Widget>[
+                    IconButton(icon: const Icon(Icons.more_vert), onPressed: () {},)
+                  ],
+                ),
+              );
+            }
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    final Offset actionTopRight = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.more_vert));
+    final Offset appBarTopRight = tester.getTopRight(find.byType(AppBar));
+    expect(appBarTopRight.dx, actionTopRight.dx + 4.0);
+  });
 }

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -296,12 +296,15 @@ void main() {
     // The app bar's title should be constrained to fit within the available space
     // between the leading and actions widgets.
 
+    final ThemeData theme = ThemeData();
+    final bool material3 = theme.useMaterial3;
     final Key titleKey = UniqueKey();
     Widget leading = Container();
     List<Widget> actions = <Widget>[];
 
     Widget buildApp() {
       return MaterialApp(
+        theme: theme,
         home: Scaffold(
           appBar: AppBar(
             leading: leading,
@@ -343,14 +346,15 @@ void main() {
       - 56.0 // Leading button width.
       - 16.0 // Leading button to title padding.
       - 16.0 // Title to actions padding
-      - 200.0,
+      - 200.0
+      - (material3 ? 4.0 : 0.0) // actions right side padding,
     )); // Actions' width.
 
     leading = Container(); // AppBar will constrain the width to 24.0
     await tester.pumpWidget(buildApp());
     expect(tester.getTopLeft(title).dx, 72.0);
     // Adding a leading widget shouldn't effect the title's size
-    expect(tester.getSize(title).width, equals(800.0 - 56.0 - 16.0 - 16.0 - 200.0));
+    expect(tester.getSize(title).width, equals(800.0 - 56.0 - 16.0 - 16.0 - 200.0 - (material3 ? 4.0 : 0.0)));
   });
 
   testWidgets('AppBar centerTitle:true title overflow OK (LTR)', (WidgetTester tester) async {
@@ -358,6 +362,8 @@ void main() {
     // between the leading and actions widgets. When it's also centered it may
     // also be start or end justified if it doesn't fit in the overall center.
 
+    final ThemeData theme = ThemeData();
+    final bool material3 = theme.useMaterial3;
     final Key titleKey = UniqueKey();
     double titleWidth = 700.0;
     Widget? leading = Container();
@@ -401,7 +407,7 @@ void main() {
       const SizedBox(width: 48.0),
     ];
     await tester.pumpWidget(buildApp());
-    expect(tester.getTopLeft(title).dx, 800 - 620 - 48 - 48 - 16);
+    expect(tester.getTopLeft(title).dx, 800 - 620 - 48 - 48 - 16 - (material3 ? 4 : 0));
     expect(tester.getSize(title).width, equals(620.0));
   });
 
@@ -410,6 +416,8 @@ void main() {
     // between the leading and actions widgets. When it's also centered it may
     // also be start or end justified if it doesn't fit in the overall center.
 
+    final ThemeData theme = ThemeData();
+    final bool material3 = theme.useMaterial3;
     final Key titleKey = UniqueKey();
     double titleWidth = 700.0;
     Widget? leading = Container();
@@ -417,6 +425,7 @@ void main() {
 
     Widget buildApp() {
       return MaterialApp(
+        theme: theme,
         home: Directionality(
           textDirection: TextDirection.rtl,
           child: Scaffold(
@@ -456,7 +465,7 @@ void main() {
       const SizedBox(width: 48.0),
     ];
     await tester.pumpWidget(buildApp());
-    expect(tester.getTopRight(title).dx, 620 + 48 + 48 + 16);
+    expect(tester.getTopRight(title).dx, 620 + 48 + 48 + 16 + (material3 ? 4 : 0));
     expect(tester.getSize(title).width, equals(620.0));
   });
 
@@ -3761,9 +3770,11 @@ void main() {
     expect(tester.getSize(find.byKey(leadingKey)).width, leadingWidth);
   });
 
-  testWidgets('The AppBar actions should have a 4dp space for padding on the right by default', (WidgetTester tester) async {
+  testWidgets('The M3 AppBar actions should have a 4dp space for padding to edge by default - LTR', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
     Widget buildApp() {
       return MaterialApp(
+        theme: theme,
         home: LayoutBuilder(
             builder: (BuildContext context, BoxConstraints constraints) {
               return Scaffold(
@@ -3783,5 +3794,34 @@ void main() {
     final Offset actionTopRight = tester.getTopRight(find.widgetWithIcon(IconButton, Icons.more_vert));
     final Offset appBarTopRight = tester.getTopRight(find.byType(AppBar));
     expect(appBarTopRight.dx, actionTopRight.dx + 4.0);
+  });
+
+  testWidgets('The M3 AppBar actions should have a 4dp space for padding to edge by default - RTL', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    Widget buildApp() {
+      return MaterialApp(
+        theme: theme,
+        home: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+              return Directionality(
+                textDirection: TextDirection.rtl,
+                child: Scaffold(
+                  appBar: AppBar(
+                    title: const Text('Title'),
+                    actions: <Widget>[
+                      IconButton(icon: const Icon(Icons.more_vert), onPressed: () {},)
+                    ],
+                  ),
+                ),
+              );
+            }
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildApp());
+    final Offset actionTopLeft = tester.getTopLeft(find.widgetWithIcon(IconButton, Icons.more_vert));
+    final Offset appBarTopLeft = tester.getTopLeft(find.byType(AppBar));
+    expect(appBarTopLeft.dx, actionTopLeft.dx - 4.0);
   });
 }


### PR DESCRIPTION
Based on the AppBar spec, there should be a small padding (4dp) on the right of the actions.
<img width="439" alt="Screen Shot 2022-12-01 at 3 04 26 PM" src="https://user-images.githubusercontent.com/36861262/205177609-9b97afd2-95a4-4c1c-b2e8-637e69c29362.png">

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
