### PR TITLE
Fix idle priority task during animation

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -528,8 +528,14 @@ mixin SchedulerBinding on BindingBase {
         ));
       }
       return _taskQueue.isNotEmpty;
+    } else {
+      addPostFrameCallback((Duration timeStamp) {
+        if (_taskQueue.isNotEmpty && !locked) {
+          _ensureEventLoopCallback();
+        }
+      });
+      return false;
     }
-    return false;
   }
 
   int _nextFrameCallbackId = 0; // positive

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -57,7 +57,9 @@ typedef TaskCallback<T> = FutureOr<T> Function();
 /// priority needs to be run.
 ///
 /// Return true if a task with the given priority should be executed at this
-/// time, false otherwise.
+/// time, false otherwise. Outstanding tasks after returning false are
+/// re-evaluated after the next (or current) frame, or after a new task is
+/// scheduled.
 ///
 /// See also:
 ///

--- a/packages/flutter/test/scheduler/scheduler_test.dart
+++ b/packages/flutter/test/scheduler/scheduler_test.dart
@@ -191,7 +191,9 @@ void main() {
   });
 
   test('currentSystemFrameTimeStamp is the raw timestamp', () {
-    // Undo epoch set by previous tests.
+    // Undo epoch set by previous tests. This is not entirely hermetic as
+    // tick/handleBeginFrame still have an expectation of monotonic raw time, so
+    // other tests should avoid advancing time if possible.
     scheduler.resetEpoch();
 
     late Duration lastTimeStamp;
@@ -316,17 +318,17 @@ void main() {
       scheduler.scheduleTask(() => taskExecuted = true, Priority.idle);
       drainTimers();
 
-      tick(const Duration(milliseconds: 20));
+      tick(null);
       drainTimers();
       expect(outstandingFrames, 2);
       expect(taskExecuted, isFalse);
 
-      tick(const Duration(milliseconds: 20));
+      tick(null);
       drainTimers();
       expect(outstandingFrames, 1);
       expect(taskExecuted, isFalse);
 
-      tick(const Duration(milliseconds: 20));
+      tick(null);
       drainTimers();
       expect(outstandingFrames, 0);
       expect(taskExecuted, isTrue);

--- a/packages/flutter/test/scheduler/scheduler_tester.dart
+++ b/packages/flutter/test/scheduler/scheduler_tester.dart
@@ -7,7 +7,7 @@ import 'package:flutter/scheduler.dart';
 @Deprecated('scheduler_tester is not compatible with dart:async') // flutter_ignore: deprecation_syntax (see analyze.dart)
 class Future { } // so that people can't import us and dart:async
 
-void tick(Duration duration) {
+void tick(Duration? duration) {
   // We don't bother running microtasks between these two calls
   // because we don't use Futures in these tests and so don't care.
   SchedulerBinding.instance.handleBeginFrame(duration);


### PR DESCRIPTION
This PR is based on https://github.com/flutter/flutter/pull/82781 but takes a slightly different approach where instead of polling the task queue on the `Timer` queue, it waits until after the post-frame callback so that it doesn't compete with animation tasks scheduled via `scheduleFrameCallback`.

This also attempts to address the comments on the test by mimicking the calls at work and cleaning up earlier tests rather than using a real animator, at the expense of possible fidelity. An integration test may be warranted.

https://user-images.githubusercontent.com/13222934/205311407-82fd5676-e8fb-4b9d-b2e0-20b6b6fe929f.mp4

This video shows this patch at work in https://github.com/AsturaPhoenix/trip_planner_aquamarine / http://34.83.198.158/trip_planner_aquamarine. Here, the marker z-ordering is changed depending on which tab is active, and the change is an expensive operation that is scheduled with `Priority.animation - 1`.

**Issues:** https://github.com/flutter/flutter/issues/82016

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
