### PR TITLE
PageView scroll physics to match Android (as an opt-in)

### DIFF
--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1420,6 +1420,7 @@ class TabBarView extends StatefulWidget {
     required this.children,
     this.controller,
     this.physics,
+    this.pageSnappingPhysics,
     this.dragStartBehavior = DragStartBehavior.start,
     this.viewportFraction = 1.0,
     this.clipBehavior = Clip.hardEdge,
@@ -1444,10 +1445,18 @@ class TabBarView extends StatefulWidget {
   /// user stops dragging the page view.
   ///
   /// The physics are modified to snap to page boundaries using
-  /// [PageScrollPhysics] prior to being used.
+  /// [pageSnappingPhysics] prior to being used.
   ///
   /// Defaults to matching platform conventions.
   final ScrollPhysics? physics;
+
+  /// Controls how pages should snap to view boundaries.
+  ///
+  /// Prior being used, ombined with other scroll physics
+  /// passed to [physics].
+  ///
+  /// By default uses [PageScrollPhysics].
+  final PageScrollPhysics? pageSnappingPhysics;
 
   /// {@macro flutter.widgets.scrollable.dragStartBehavior}
   final DragStartBehavior dragStartBehavior;
@@ -1688,9 +1697,8 @@ class _TabBarViewState extends State<TabBarView> {
         dragStartBehavior: widget.dragStartBehavior,
         clipBehavior: widget.clipBehavior,
         controller: _pageController,
-        physics: widget.physics == null
-          ? const PageScrollPhysics().applyTo(const ClampingScrollPhysics())
-          : const PageScrollPhysics().applyTo(widget.physics),
+        physics: widget.physics ?? const ClampingScrollPhysics(),
+        pageSnappingPhysics: widget.pageSnappingPhysics,
         children: _childrenWithKey,
       ),
     );

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -379,7 +379,9 @@ class ScrollPhysics {
     ratio: 1.1,
   );
 
-  /// The spring to use for ballistic simulations.
+  /// The spring which [createBallisticSimulation] should use to create
+  /// a [SpringSimulation] to correct the scroll position when it goes
+  /// out of range.
   SpringDescription get spring => parent?.spring ?? _kDefaultSpring;
 
   /// The default accuracy to which scrolling is computed.

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -282,13 +282,13 @@ class PageScrollSimulation extends Simulation {
 
   @override
   double x(double time) {
-    time = time.clamp(0.0, duration);
+    time = clampDouble(time, 0.0, duration);
     return position + _delta * _interpolate(time * _durationReciprocal);
   }
 
   @override
   double dx(double time) {
-    time = time.clamp(0.0, duration);
+    time = clampDouble(time, 0.0, duration);
     return _delta * _interpolateDx(time * _durationReciprocal);
   }
 

--- a/packages/flutter/test/material/tabs_test.dart
+++ b/packages/flutter/test/material/tabs_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import '../rendering/mock_canvas.dart';
 import '../rendering/recording_canvas.dart';
+import '../widgets/page_scroll_physics_test_util.dart';
 import '../widgets/semantics_tester.dart';
 import 'feedback_tester.dart';
 
@@ -5271,6 +5272,48 @@ void main() {
           color: theme.colorScheme.primary.withOpacity(0.12),
         ),
     );
+  });
+
+  testWidgets('TabBarView uses pageSnapping and supports custom pageSnappingPhysics', (WidgetTester tester) async {
+    const ScrollPhysics physics = BouncingScrollPhysics();
+    const PageScrollPhysics pageSnappingPhysics = CustomPageScrollPhysics();
+
+    final TabController controller = TabController(
+      vsync: const TestVSync(),
+      length: 2,
+    );
+
+    Future<void> pump([PageScrollPhysics? pageSnappingPhysics]) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: TabBarView(
+              physics: physics,
+              pageSnappingPhysics: pageSnappingPhysics,
+              controller: controller,
+              children: const <Widget>[
+                Text('1'),
+                Text('2'),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    await pump();
+
+    final PageView pageView = tester.widget<PageView>(find.byType(PageView));
+    expect(pageView.pageSnapping, true);
+    expect(pageView.physics, physics);
+    expect(pageView.pageSnappingPhysics, null);
+
+    await pump(pageSnappingPhysics);
+
+    final PageView pageView2 = tester.widget<PageView>(find.byType(PageView));
+    expect(pageView2.pageSnapping, true);
+    expect(pageView2.physics, physics);
+    expect(pageView2.pageSnappingPhysics, pageSnappingPhysics);
   });
 
   group('Material 2', () {

--- a/packages/flutter/test/widgets/page_scroll_physics_test_util.dart
+++ b/packages/flutter/test/widgets/page_scroll_physics_test_util.dart
@@ -1,0 +1,35 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+
+class CustomPageScrollPhysics extends PageScrollPhysics {
+  const CustomPageScrollPhysics({super.parent});
+
+  @override
+  CustomPageScrollPhysics applyTo(ScrollPhysics? ancestor) {
+    return CustomPageScrollPhysics(parent: buildParent(ancestor));
+  }
+
+  @override
+  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+    // If we're out of range and not headed back in range, defer to the parent
+    // ballistics, which should put us back in range at a page boundary.
+    if ((velocity <= 0.0 && position.pixels <= position.minScrollExtent) ||
+        (velocity >= 0.0 && position.pixels >= position.maxScrollExtent)) {
+      return super.createBallisticSimulation(position, velocity);
+    }
+    final Tolerance tolerance = this.tolerance;
+    final double target = getTargetPixels(position, tolerance, velocity);
+    if (target != position.pixels) {
+      final SpringDescription simulationSpring = SpringDescription.withDampingRatio(
+        mass: 0.01,
+        stiffness: 500.0,
+        ratio: 2.0,
+      );
+      return ScrollSpringSimulation(simulationSpring, position.pixels, target, velocity, tolerance: tolerance);
+    }
+    return null;
+  }
+}

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -100,7 +100,7 @@ void main() {
     );
   });
 
-  test("ScrollPhysics scrolling subclasses - Creating the simulation doesn't alter the velocity for time 0", () {
+  test('ScrollPhysics scrolling subclasses - initial velocity when creating the simulation', () {
     final ScrollMetrics position = FixedScrollMetrics(
       minScrollExtent: 0.0,
       maxScrollExtent: 100.0,
@@ -111,13 +111,25 @@ void main() {
 
     const BouncingScrollPhysics bounce = BouncingScrollPhysics();
     const ClampingScrollPhysics clamp = ClampingScrollPhysics();
-    const PageScrollPhysics page = PageScrollPhysics();
 
+    // Verify creating these simulations doesn't alter the velocity for time 0.
+    //
     // Calls to createBallisticSimulation may happen on every frame (i.e. when the maxScrollExtent changes)
-    // Changing velocity for time 0 may cause a sudden, unwanted damping/speedup effect
-    expect(bounce.createBallisticSimulation(position, 1000)!.dx(0), moreOrLessEquals(1000));
-    expect(clamp.createBallisticSimulation(position, 1000)!.dx(0), moreOrLessEquals(1000));
-    expect(page.createBallisticSimulation(position, 1000)!.dx(0), moreOrLessEquals(1000));
+    // Changing velocity for time 0 may cause a sudden, unwanted damping/speedup effect.
+    expect(bounce.createBallisticSimulation(position, 1000)!.dx(0), 1000);
+    expect(clamp.createBallisticSimulation(position, 1000)!.dx(0), 1000);
+
+    // Contrary to the other two scroll physics, PageScrollPhysics do intentionally produce
+    // a bigger velocity than supplied to them, but they won't suffer from this, because the simulation
+    // velocity depends on a ratio of velocity / pageDelta, and because they are not affected by
+    // https://github.com/flutter/flutter/issues/11599
+
+    // TODO(nt4f04uNd): remove this test, because it is artificial, in favor of a real one.
+    // Scroll simulations surely should be allowed to modify the speed they receive in whatever way they want.
+    // The proper fix for the original bug https://github.com/flutter/flutter/issues/24715
+    // would be to ensure this is not called too often https://github.com/flutter/flutter/issues/11599
+    // Proper test(s) should ensure the animations of the physics have the same duration
+    // for same fling conditions within different layouts.
   });
 
   group('BouncingScrollPhysics test', () {

--- a/packages/flutter/test/widgets/scroll_simulation_test.dart
+++ b/packages/flutter/test/widgets/scroll_simulation_test.dart
@@ -23,4 +23,45 @@ void main() {
     checkInitialConditions(75.0, 614.2093);
     checkInitialConditions(5469.0, 182.114534);
   });
+
+  test('PageScrollSimulation', () {
+    void checkSimulation(double position, double target, double duration) {
+      final double delta = target - position;
+      final PageScrollSimulation simulation = PageScrollSimulation(position: position, target: target, duration: duration);
+      late double lastX;
+      late double lastDx;
+      void expectX(double t, dynamic expectedValue) {
+        final double x = simulation.x(t);
+        expect(x, expectedValue);
+        lastX = x;
+      }
+      void expectDx(double t, dynamic expectedValue) {
+        final double dx = simulation.dx(t);
+        expect(dx, expectedValue);
+        lastDx = dx;
+      }
+
+      // verify start values
+      expectX(0.0, position);
+      expectDx(0.0, moreOrLessEquals(5 * delta));
+      expect(simulation.isDone(0.0), false);
+
+      // verify intermediate values change monotonically
+      for (double t = 0.01; t < duration; t += 1) {
+        expectX(t, target > position ? greaterThan(lastX) : lessThan(lastX));
+        expectDx(t, target > position ? lessThan(lastDx) : greaterThan(lastDx));
+        expect(simulation.isDone(t), false);
+      }
+
+      // verify end values
+      expectX(duration, target);
+      expectDx(duration, 0.0);
+      expect(simulation.isDone(duration), true);
+    }
+
+    checkSimulation(0, 500, 1000);
+    checkSimulation(0, -500, 1000);
+    checkSimulation(1000, 5000, 100);
+    checkSimulation(100, -5000, 100);
+  });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/38357

So, this is a new reland for a https://github.com/flutter/flutter/pull/95423
Previous reland https://github.com/flutter/flutter/pull/97166

<details>
<summary>Old physics</summary>


https://user-images.githubusercontent.com/39104740/146440807-50e10ab1-628c-4623-a9d3-3704bd5fd0d5.mp4

https://user-images.githubusercontent.com/39104740/205435343-57a338b8-f04c-4d6d-bec5-b677dbb6e1eb.mov

</details>

<details>
<summary>New physics</summary>


https://user-images.githubusercontent.com/39104740/146440570-ba140add-0411-454a-9456-34d6d62e9fc8.mp4

https://user-images.githubusercontent.com/39104740/205434169-8a7197cd-8c00-4d21-8f56-33cf6d58f838.mov

</details>

### Opt-in

This change has been proven to be breaking for the customer tests.
To opt in, users should provide `pageSnappingPhysics: const PageScrollPhysics(useNewPhysics: true)`

If tests are broken, this is likely because of the change in `minFlingVelocity` or `minFlingDistance`.
Previous values are respectively `50.0` and `18.0`.
New values are `400.0` and `25.0`.

To migrate the tests, one should change the drag velocity/distance to match the new minimum values.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
