### PR TITLE
Bump dartdoc to 6.1.3

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 6.1.2
+    "$DART" pub global activate dartdoc 6.1.3
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
No longer includes constructor-like calls interspersed in enum doc generation by updating to the latest dartdoc version.

Fixes https://github.com/dart-lang/dartdoc/issues/3201