### PR TITLE
Update IntegrationTestPlugin.m

### DIFF
--- a/packages/integration_test/ios/Classes/IntegrationTestPlugin.m
+++ b/packages/integration_test/ios/Classes/IntegrationTestPlugin.m
@@ -46,10 +46,6 @@ static NSString *const kMethodRevertImage = @"revertFlutterImage";
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   [[IntegrationTestPlugin instance] setupChannels:registrar.messenger];
-  // No initialization happens here because of the way XCTest loads the testing
-  // bundles.  Setup on static variables can be disregarded when a new static
-  // instance of IntegrationTestPlugin is allocated when the bundle is reloaded.
-  // See also: https://github.com/flutter/plugins/pull/2465
 }
 
 - (void)setupChannels:(id<FlutterBinaryMessenger>)binaryMessenger {

--- a/packages/integration_test/ios/Classes/IntegrationTestPlugin.m
+++ b/packages/integration_test/ios/Classes/IntegrationTestPlugin.m
@@ -45,6 +45,7 @@ static NSString *const kMethodRevertImage = @"revertFlutterImage";
 }
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+  [[IntegrationTestPlugin instance] setupChannels:registrar.messenger];
   // No initialization happens here because of the way XCTest loads the testing
   // bundles.  Setup on static variables can be disregarded when a new static
   // instance of IntegrationTestPlugin is allocated when the bundle is reloaded.


### PR DESCRIPTION
The integration_test native plugin is not being correctly registered on iOS when running tests via `flutter drive`. Adding an 
`IntegrationTestPlugin` instance to `registerWithRegistrar` method in `IntegrationTestPlugin.m`.

This [plugin instance was previously removed](https://github.com/flutter/plugins/pull/2465) before [`integration_test` was migrated from `e2e`](https://pub.dev/documentation/e2e/latest/) to prevent an error where the `e2e` plugin would not exit testing. This does not appear to be an issue with `integration_test` and my tests exit properly regardless of run with `flutter drive` or through XCode.

*List which issues are fixed by this PR. You must list at least one issue.*
https://github.com/flutter/flutter/issues/91668

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
