### PR TITLE
Fix `StretchingOverscrollIndicator` not handling directional changes correctly

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,3 +102,4 @@ Tomasz Gucio <tgucio@gmail.com>
 Jason C.H <ctrysbita@outlook.com>
 Hubert Jóźwiak <hjozwiakdx@gmail.com>
 Eli Albert <crasowas@gmail.com>
+Jan Kuß <jan@kuss.dev>

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -602,8 +602,12 @@ class _GlowingOverscrollIndicatorPainter extends CustomPainter {
 }
 
 enum _StretchDirection {
-  down,
-  up
+  /// The [trailing] direction indicates that the content will be stretched toward 
+  /// the trailing edge.
+  trailing,
+  /// The [leading] direction indicates that the content will be stretched toward
+  /// the leading edge.
+  leading,
 }
 
 /// A Material Design visual indication that a scroll view has overscrolled.
@@ -696,7 +700,7 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
   OverscrollNotification? _lastOverscrollNotification;
 
   double _totalOverscroll = 0.0;
-  _StretchDirection _stretchDirection = _StretchDirection.down;
+  _StretchDirection _stretchDirection = _StretchDirection.trailing;
 
   bool _accepted = true;
 
@@ -722,7 +726,7 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
           assert(notification.overscroll != 0.0);
           if (notification.dragDetails != null) {
             _totalOverscroll += notification.overscroll;
-            _stretchDirection = _totalOverscroll > 0 ? _StretchDirection.down : _StretchDirection.up;
+            _stretchDirection = _totalOverscroll > 0 ? _StretchDirection.trailing : _StretchDirection.leading;
 
             // We clamp the overscroll amount relative to the length of the viewport,
             // which is the furthest distance a single pointer could pull on the
@@ -749,19 +753,19 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
     // Accounts for reversed scrollables by checking the AxisDirection
     switch (widget.axisDirection) {
       case AxisDirection.up:
-        return stretchDirection == _StretchDirection.down
+        return stretchDirection == _StretchDirection.trailing
             ? AlignmentDirectional.topCenter
             : AlignmentDirectional.bottomCenter;
       case AxisDirection.right:
-        return stretchDirection == _StretchDirection.down
+        return stretchDirection == _StretchDirection.trailing
             ? Alignment.centerRight
             : Alignment.centerLeft;
       case AxisDirection.down:
-        return stretchDirection == _StretchDirection.down
+        return stretchDirection == _StretchDirection.trailing
             ? AlignmentDirectional.bottomCenter
             : AlignmentDirectional.topCenter;
       case AxisDirection.left:
-        return stretchDirection == _StretchDirection.down
+        return stretchDirection == _StretchDirection.trailing
             ? Alignment.centerLeft
             : Alignment.centerRight;
     }

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -719,15 +719,15 @@ class _StretchingOverscrollIndicatorState extends State<StretchingOverscrollIndi
 
       assert(notification.metrics.axis == widget.axis);
       if (_accepted) {
+        _totalOverscroll += notification.overscroll;
+        _stretchDirection = _totalOverscroll > 0 ? _StretchDirection.trailing : _StretchDirection.leading;
+
         if (notification.velocity != 0.0) {
           assert(notification.dragDetails == null);
           _stretchController.absorbImpact(notification.velocity.abs());
         } else {
           assert(notification.overscroll != 0.0);
           if (notification.dragDetails != null) {
-            _totalOverscroll += notification.overscroll;
-            _stretchDirection = _totalOverscroll > 0 ? _StretchDirection.trailing : _StretchDirection.leading;
-
             // We clamp the overscroll amount relative to the length of the viewport,
             // which is the furthest distance a single pointer could pull on the
             // screen. This is because more than one pointer will multiply the

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -885,7 +885,7 @@ class _StretchController extends ChangeNotifier {
   void pull(double normalizedOverscroll, double totalOverscroll) {
     assert(normalizedOverscroll >= 0.0);
 
-    final _StretchDirection newStretchDirection = totalOverscroll > 0 ? _StretchDirection.trailing : _StretchDirection.leading; 
+    final _StretchDirection newStretchDirection = totalOverscroll > 0 ? _StretchDirection.trailing : _StretchDirection.leading;
     if (_stretchDirection != newStretchDirection && _state == _StretchState.recede) {
       // When the stretch direction changes while we are in the recede state, we need to ignore the change.
       // If we don't, the stretch will instantly jump to the new direction with the recede animation still playing, which causes

--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -602,7 +602,7 @@ class _GlowingOverscrollIndicatorPainter extends CustomPainter {
 }
 
 enum _StretchDirection {
-  /// The [trailing] direction indicates that the content will be stretched toward 
+  /// The [trailing] direction indicates that the content will be stretched toward
   /// the trailing edge.
   trailing,
   /// The [leading] direction indicates that the content will be stretched toward

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -781,13 +781,13 @@ void main() {
     final ScrollController controller = ScrollController();
     await tester.pumpWidget(
       buildTest(
-        box1Key, 
-        box2Key, 
-        box3Key, 
-        controller, 
+        box1Key,
+        box2Key,
+        box3Key,
+        controller,
         // Setting the `boxHeight` to 100.0 will make the boxes fit in the
         // scrollable viewport.
-        boxHeight: 100, 
+        boxHeight: 100,
         // To make the scroll view in the test still scrollable, we need to add
         // the `AlwaysScrollableScrollPhysics`.
         physics: const AlwaysScrollableScrollPhysics(),

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -820,7 +820,6 @@ void main() {
     await gesture.moveBy(const Offset(0.0, -20.0));
     await tester.pumpAndSettle();
 
-
     // The boxes should remain roughly at the same locations, since the pointer
     // didn't move far.
     expect(box1.localToGlobal(Offset.zero), Offset.zero);
@@ -891,7 +890,6 @@ void main() {
     await gesture.moveBy(const Offset(-20.0, 0.0));
     await tester.pumpAndSettle();
 
-
     // The boxes should remain roughly at the same locations, since the pointer
     // didn't move far.
     expect(box1.localToGlobal(Offset.zero), Offset.zero);
@@ -915,7 +913,6 @@ void main() {
     expect(box2.localToGlobal(Offset.zero), const Offset(100.0, 0.0));
     expect(box3.localToGlobal(Offset.zero), const Offset(200.0, 0.0));
   });
-
 
   testWidgets('Fling toward the trailing edge causes stretch toward the leading edge', (WidgetTester tester) async {
     final GlobalKey box1Key = GlobalKey();


### PR DESCRIPTION
This PR fixes #116522
Fixes https://github.com/flutter/flutter/issues/88741
Fixes https://github.com/flutter/flutter/issues/118145

When using a `StrechingOverscrollIndicator` in combination with `AlwaysScrollableScrollPhysics`, in the case the content doesn't fill the viewport, there is some kind of jump when changing the scroll direction while overscrolling.

This video shows this unwanted behaviour:

https://user-images.githubusercontent.com/1659532/205745277-52c70354-153e-4569-849f-a9e5254d4cda.mov

This PR makes changes on how `distanceForPull` is calculated, as well as how the alignment for the transform is determined.

After this change is made, the `StrechingOverscrollIndicator` will behave like this:

https://user-images.githubusercontent.com/1659532/205746098-56cd77b7-c89d-44c8-95a8-64d7540af098.mov

This behaves much smoother, and is much more in line with how it works in native android apps on Android 12.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.