### PR TITLE
added optional labelText and semanticLabel to Checkbox

### DIFF
--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -342,11 +342,11 @@ class Checkbox extends StatefulWidget {
   /// Must not be null. Defaults to false.
   final bool isError;
 
-  /// The label text that will be rendered side by side with the [Checkbox].
-  /// Serves as default semantics label for the [Checkbox] if provided.
-  ///
+  // The label text that will be rendered side by side with the [Checkbox].
+  // Serves as default semantics label for the [Checkbox] if provided.
+  //
   // TODO(harperl-lgtm): Add to constructor parameters and actually render it.
-  final String? labelText;
+  // final String? labelText;
 
   /// The semantic label for the checkobox that will be announced by screen readers.
   ///

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -353,7 +353,7 @@ class Checkbox extends StatefulWidget {
   /// Announced in accessibility modes (e.g TalkBack/VoiceOver).
   /// This label does not show in the UI.
   ///
-  /// Defaults to [labelText], if specified.
+  /// Defaults to labelText, if specified.
   final String? semanticLabel;
 
   /// The width of a checkbox widget.

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -88,7 +88,6 @@ class Checkbox extends StatefulWidget {
     this.shape,
     this.side,
     this.isError = false,
-    this.labelText,
     this.semanticLabel,
   }) : assert(tristate != null),
        assert(tristate || value != null),
@@ -346,13 +345,15 @@ class Checkbox extends StatefulWidget {
   /// The label text that will be rendered side by side with the [Checkbox].
   /// Serves as default semantics label for the [Checkbox] if provided.
   ///
-  // TODO(harperl-lgtm): Actually render the labelText in build method.
+  // TODO(harperl-lgtm): Add to constructor parameters and actually render it.
   final String? labelText;
 
-  /// The semantics label that will be announced by a screen reader.
+  /// The semantic label for the checkobox that will be announced by screen readers.
   ///
-  /// Overrides labelText in terms of semantic labeling of the [Checkbox]
-  /// if they are provided at the same time.
+  /// Announced in accessibility modes (e.g TalkBack/VoiceOver).
+  /// This label does not show in the UI.
+  ///
+  /// Defaults to [labelText], if specified.
   final String? semanticLabel;
 
   /// The width of a checkbox widget.

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -88,7 +88,50 @@ class Checkbox extends StatefulWidget {
     this.shape,
     this.side,
     this.isError = false,
-    this.semanticLabel,
+  }) : assert(tristate != null),
+       assert(tristate || value != null),
+       assert(autofocus != null),
+       semanticLabel = null;
+
+  /// Creates a Material Design checkbox with a semantic label.
+  ///
+  /// The checkbox itself does not maintain any state. Instead, when the state of
+  /// the checkbox changes, the widget calls the [onChanged] callback. Most
+  /// widgets that use a checkbox will listen for the [onChanged] callback and
+  /// rebuild the checkbox with a new [value] to update the visual appearance of
+  /// the checkbox.
+  ///
+  /// The following arguments are required:
+  ///
+  /// * [value], which determines whether the checkbox is checked. The [value]
+  ///   can only be null if [tristate] is true.
+  /// * [onChanged], which is called when the value of the checkbox should
+  ///   change. It can be set to null to disable the checkbox.
+  /// * [semanticLabel], which is announced when the checkbox received accessibility
+  ///   focus.
+  ///
+  /// The values of [tristate] and [autofocus] must not be null.
+  const Checkbox.withSemanticLabel({
+    super.key,
+    required this.value,
+    this.tristate = false,
+    required this.onChanged,
+    this.mouseCursor,
+    this.activeColor,
+    this.fillColor,
+    this.checkColor,
+    this.focusColor,
+    this.hoverColor,
+    this.overlayColor,
+    this.splashRadius,
+    this.materialTapTargetSize,
+    this.visualDensity,
+    this.focusNode,
+    this.autofocus = false,
+    this.shape,
+    this.side,
+    this.isError = false,
+    required this.semanticLabel,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(autofocus != null);

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -385,18 +385,10 @@ class Checkbox extends StatefulWidget {
   /// Must not be null. Defaults to false.
   final bool isError;
 
-  // The label text that will be rendered side by side with the [Checkbox].
-  // Serves as default semantics label for the [Checkbox] if provided.
-  //
-  // TODO(harperl-lgtm): Add to constructor parameters and actually render it.
-  // final String? labelText;
-
   /// The semantic label for the checkobox that will be announced by screen readers.
   ///
   /// Announced in accessibility modes (e.g TalkBack/VoiceOver).
   /// This label does not show in the UI.
-  ///
-  /// Defaults to labelText, if specified.
   final String? semanticLabel;
 
   /// The width of a checkbox widget.

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -88,6 +88,8 @@ class Checkbox extends StatefulWidget {
     this.shape,
     this.side,
     this.isError = false,
+    this.labelText,
+    this.semanticLabel,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(autofocus != null);
@@ -341,6 +343,18 @@ class Checkbox extends StatefulWidget {
   /// Must not be null. Defaults to false.
   final bool isError;
 
+  /// The label text that will be rendered side by side with the [CheckBox].
+  /// Serves as default semantics label for the [CheckBox] if provided.
+  ///
+  /// TODO: Actually render the labelText in build method.
+  final String? labelText;
+
+  /// The semantics label that will be announced by a screen reader.
+  ///
+  /// Overrides labelText in terms of semantic labeling of the [CheckBox]
+  /// if they are provided at the same time.
+  final String? semanticLabel;
+
   /// The width of a checkbox widget.
   static const double width = 18.0;
 
@@ -493,6 +507,7 @@ class _CheckboxState extends State<Checkbox> with TickerProviderStateMixin, Togg
       ?? defaults.splashRadius!;
 
     return Semantics(
+      label: widget.semanticLabel,
       checked: widget.value ?? false,
       mixed: widget.tristate ? widget.value == null : null,
       child: buildToggleable(

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -343,15 +343,15 @@ class Checkbox extends StatefulWidget {
   /// Must not be null. Defaults to false.
   final bool isError;
 
-  /// The label text that will be rendered side by side with the [CheckBox].
-  /// Serves as default semantics label for the [CheckBox] if provided.
+  /// The label text that will be rendered side by side with the [Checkbox].
+  /// Serves as default semantics label for the [Checkbox] if provided.
   ///
-  /// TODO: Actually render the labelText in build method.
+  /// TODO(harperl-lgtm): Actually render the labelText in build method.
   final String? labelText;
 
   /// The semantics label that will be announced by a screen reader.
   ///
-  /// Overrides labelText in terms of semantic labeling of the [CheckBox]
+  /// Overrides labelText in terms of semantic labeling of the [Checkbox]
   /// if they are provided at the same time.
   final String? semanticLabel;
 

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -88,50 +88,7 @@ class Checkbox extends StatefulWidget {
     this.shape,
     this.side,
     this.isError = false,
-  }) : assert(tristate != null),
-       assert(tristate || value != null),
-       assert(autofocus != null),
-       semanticLabel = null;
-
-  /// Creates a Material Design checkbox with a semantic label.
-  ///
-  /// The checkbox itself does not maintain any state. Instead, when the state of
-  /// the checkbox changes, the widget calls the [onChanged] callback. Most
-  /// widgets that use a checkbox will listen for the [onChanged] callback and
-  /// rebuild the checkbox with a new [value] to update the visual appearance of
-  /// the checkbox.
-  ///
-  /// The following arguments are required:
-  ///
-  /// * [value], which determines whether the checkbox is checked. The [value]
-  ///   can only be null if [tristate] is true.
-  /// * [onChanged], which is called when the value of the checkbox should
-  ///   change. It can be set to null to disable the checkbox.
-  /// * [semanticLabel], which is announced when the checkbox received accessibility
-  ///   focus.
-  ///
-  /// The values of [tristate] and [autofocus] must not be null.
-  const Checkbox.withSemanticLabel({
-    super.key,
-    required this.value,
-    this.tristate = false,
-    required this.onChanged,
-    this.mouseCursor,
-    this.activeColor,
-    this.fillColor,
-    this.checkColor,
-    this.focusColor,
-    this.hoverColor,
-    this.overlayColor,
-    this.splashRadius,
-    this.materialTapTargetSize,
-    this.visualDensity,
-    this.focusNode,
-    this.autofocus = false,
-    this.shape,
-    this.side,
-    this.isError = false,
-    required this.semanticLabel,
+    this.semanticLabel,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(autofocus != null);

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -346,7 +346,7 @@ class Checkbox extends StatefulWidget {
   /// The label text that will be rendered side by side with the [Checkbox].
   /// Serves as default semantics label for the [Checkbox] if provided.
   ///
-  /// TODO(harperl-lgtm): Actually render the labelText in build method.
+  // TODO(harperl-lgtm): Actually render the labelText in build method.
   final String? labelText;
 
   /// The semantics label that will be announced by a screen reader.

--- a/packages/flutter/lib/src/material/checkbox.dart
+++ b/packages/flutter/lib/src/material/checkbox.dart
@@ -342,10 +342,12 @@ class Checkbox extends StatefulWidget {
   /// Must not be null. Defaults to false.
   final bool isError;
 
+  /// {@template flutter.material.checkbox.semanticLabel}
   /// The semantic label for the checkobox that will be announced by screen readers.
   ///
   /// Announced in accessibility modes (e.g TalkBack/VoiceOver).
   /// This label does not show in the UI.
+  /// {@endtemplate}
   final String? semanticLabel;
 
   /// The width of a checkbox widget.

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -178,60 +178,7 @@ class CheckboxListTile extends StatelessWidget {
     this.focusNode,
     this.onFocusChange,
     this.enableFeedback,
-  }) : assert(tristate != null),
-       assert(tristate || value != null),
-       assert(isThreeLine != null),
-       assert(!isThreeLine || subtitle != null),
-       assert(selected != null),
-       assert(controlAffinity != null),
-       assert(autofocus != null),
-       checkboxSemanticLabel = null;
-
-  /// Creates a combination of a list tile and a checkbox.
-  ///
-  /// The checkbox tile itself does not maintain any state. Instead, when the
-  /// state of the checkbox changes, the widget calls the [onChanged] callback.
-  /// Most widgets that use a checkbox will listen for the [onChanged] callback
-  /// and rebuild the checkbox tile with a new [value] to update the visual
-  /// appearance of the checkbox.
-  ///
-  /// The following arguments are required:
-  ///
-  /// * [value], which determines whether the checkbox is checked. The [value]
-  ///   can only be null if [tristate] is true.
-  /// * [onChanged], which is called when the value of the checkbox should
-  ///   change. It can be set to null to disable the checkbox.
-  /// * [checkboxSemanticLabel], which is announced in addition to title to
-  ///   if provided to provide more information.
-  ///
-  /// The value of [tristate] must not be null.
-  const CheckboxListTile.withCheckboxSemanticLabel({
-    super.key,
-    required this.value,
-    required this.onChanged,
-    this.activeColor,
-    this.checkColor,
-    this.enabled,
-    this.tileColor,
-    this.title,
-    this.subtitle,
-    this.isThreeLine = false,
-    this.dense,
-    this.secondary,
-    this.selected = false,
-    this.controlAffinity = ListTileControlAffinity.platform,
-    this.autofocus = false,
-    this.contentPadding,
-    this.tristate = false,
-    this.shape,
-    this.checkboxShape,
-    this.selectedTileColor,
-    this.side,
-    this.visualDensity,
-    this.focusNode,
-    this.onFocusChange,
-    this.enableFeedback,
-    required this.checkboxSemanticLabel,
+    this.checkboxSemanticLabel,
   }) : assert(tristate != null),
        assert(tristate || value != null),
        assert(isThreeLine != null),
@@ -392,7 +339,7 @@ class CheckboxListTile extends StatelessWidget {
   /// inoperative.
   final bool? enabled;
 
-  /// {@template flutter.material.checkbox.semanticLabel}
+  /// {@macro flutter.material.checkbox.semanticLabel}
   final String? checkboxSemanticLabel;
 
   void _handleValueChange() {

--- a/packages/flutter/lib/src/material/checkbox_list_tile.dart
+++ b/packages/flutter/lib/src/material/checkbox_list_tile.dart
@@ -184,6 +184,60 @@ class CheckboxListTile extends StatelessWidget {
        assert(!isThreeLine || subtitle != null),
        assert(selected != null),
        assert(controlAffinity != null),
+       assert(autofocus != null),
+       checkboxSemanticLabel = null;
+
+  /// Creates a combination of a list tile and a checkbox.
+  ///
+  /// The checkbox tile itself does not maintain any state. Instead, when the
+  /// state of the checkbox changes, the widget calls the [onChanged] callback.
+  /// Most widgets that use a checkbox will listen for the [onChanged] callback
+  /// and rebuild the checkbox tile with a new [value] to update the visual
+  /// appearance of the checkbox.
+  ///
+  /// The following arguments are required:
+  ///
+  /// * [value], which determines whether the checkbox is checked. The [value]
+  ///   can only be null if [tristate] is true.
+  /// * [onChanged], which is called when the value of the checkbox should
+  ///   change. It can be set to null to disable the checkbox.
+  /// * [checkboxSemanticLabel], which is announced in addition to title to
+  ///   if provided to provide more information.
+  ///
+  /// The value of [tristate] must not be null.
+  const CheckboxListTile.withCheckboxSemanticLabel({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.activeColor,
+    this.checkColor,
+    this.enabled,
+    this.tileColor,
+    this.title,
+    this.subtitle,
+    this.isThreeLine = false,
+    this.dense,
+    this.secondary,
+    this.selected = false,
+    this.controlAffinity = ListTileControlAffinity.platform,
+    this.autofocus = false,
+    this.contentPadding,
+    this.tristate = false,
+    this.shape,
+    this.checkboxShape,
+    this.selectedTileColor,
+    this.side,
+    this.visualDensity,
+    this.focusNode,
+    this.onFocusChange,
+    this.enableFeedback,
+    required this.checkboxSemanticLabel,
+  }) : assert(tristate != null),
+       assert(tristate || value != null),
+       assert(isThreeLine != null),
+       assert(!isThreeLine || subtitle != null),
+       assert(selected != null),
+       assert(controlAffinity != null),
        assert(autofocus != null);
 
   /// Whether this checkbox is checked.
@@ -338,6 +392,9 @@ class CheckboxListTile extends StatelessWidget {
   /// inoperative.
   final bool? enabled;
 
+  /// {@template flutter.material.checkbox.semanticLabel}
+  final String? checkboxSemanticLabel;
+
   void _handleValueChange() {
     assert(onChanged != null);
     switch (value) {
@@ -365,6 +422,7 @@ class CheckboxListTile extends StatelessWidget {
       tristate: tristate,
       shape: checkboxShape,
       side: side,
+      semanticLabel: checkboxSemanticLabel,
     );
     Widget? leading, trailing;
     switch (controlAffinity) {

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -545,7 +545,7 @@ void main() {
     final List<dynamic> log = <dynamic>[];
     final SemanticsHandle handle = tester.ensureSemantics();
     await tester.pumpWidget(wrap(
-      child: CheckboxListTile.withCheckboxSemanticLabel(
+      child: CheckboxListTile(
         value: true,
         onChanged: (bool? value) { log.add(value); },
         title: const Text('Hello'),

--- a/packages/flutter/test/material/checkbox_list_tile_test.dart
+++ b/packages/flutter/test/material/checkbox_list_tile_test.dart
@@ -540,4 +540,29 @@ void main() {
       expect(feedback.hapticCount, 0);
     });
   });
+
+  testWidgets('CheckboxListTile has proper semantics', (WidgetTester tester) async {
+    final List<dynamic> log = <dynamic>[];
+    final SemanticsHandle handle = tester.ensureSemantics();
+    await tester.pumpWidget(wrap(
+      child: CheckboxListTile.withCheckboxSemanticLabel(
+        value: true,
+        onChanged: (bool? value) { log.add(value); },
+        title: const Text('Hello'),
+        checkboxSemanticLabel: 'there',
+      ),
+    ));
+
+    expect(tester.getSemantics(find.byType(CheckboxListTile)), matchesSemantics(
+      hasCheckedState: true,
+      isChecked: true,
+      hasEnabledState: true,
+      isEnabled: true,
+      hasTapAction: true,
+      isFocusable: true,
+      label: 'Hello\nthere',
+    ));
+
+    handle.dispose();
+  });
 }

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -196,7 +196,7 @@ void main() {
       child: Theme(
         data: theme,
         child: Material(
-          child: Checkbox(
+          child: Checkbox.withSemanticLabel(
             semanticLabel: 'checkbox',
             value: true,
             onChanged: (bool? b) { },

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -190,6 +190,32 @@ void main() {
       hasEnabledState: true,
     ));
 
+    // Check if semanticLabel is there.
+    await tester.pumpWidget(Directionality(
+      textDirection: TextDirection.ltr,
+      child: Theme(
+        data: theme,
+        child: Material(
+          child: Checkbox(
+            semanticLabel: 'checkbox',
+            value: true,
+            onChanged: (bool? b) { },
+          ),
+        ),
+      ),
+    ));
+
+    expect(tester.getSemantics(find.byType(Focus)), matchesSemantics(
+      label: 'checkbox',
+      textDirection: TextDirection.ltr,
+      hasCheckedState: true,
+      hasEnabledState: true,
+      isChecked: true,
+      isEnabled: true,
+      hasTapAction: true,
+      isFocusable: true,
+    ));
+
     handle.dispose();
   });
 

--- a/packages/flutter/test/material/checkbox_test.dart
+++ b/packages/flutter/test/material/checkbox_test.dart
@@ -196,7 +196,7 @@ void main() {
       child: Theme(
         data: theme,
         child: Material(
-          child: Checkbox.withSemanticLabel(
+          child: Checkbox(
             semanticLabel: 'checkbox',
             value: true,
             onChanged: (bool? b) { },


### PR DESCRIPTION
This PR added optional labelText (which will be  rendered side by side with Checkbox in the future, and thus is also announced by default by screen readers), and semanticLabel(which will be announced by screen reader if provided, overrides labelText, in order to do that we might want to wrap the Text widget inside ExcludeSemantics in the future).

Issues fixed:
[b/239564167]

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
