### PR TITLE
[flutter_tools] dont include material shaders in web builds (#116538)

### DIFF
--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -412,7 +412,8 @@ class ManifestAssetBundle implements AssetBundle {
       // For all platforms, include the shaders unconditionally. They are
       // small, and whether they're used is determined only by the app source
       // code and not by the Flutter manifest.
-      ..._getMaterialShaders(),
+      if (targetPlatform != TargetPlatform.web_javascript)
+        ..._getMaterialShaders(),
     ];
     for (final _Asset asset in materialAssets) {
       final File assetFile = asset.lookupAssetFile(_fileSystem);

--- a/packages/flutter_tools/test/general.shard/asset_test.dart
+++ b/packages/flutter_tools/test/general.shard/asset_test.dart
@@ -2,8 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:file/memory.dart';
 import 'package:flutter_tools/src/asset.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/build_info.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/globals.dart' as globals;
 
@@ -80,6 +82,64 @@ void main() {
         <String>[],
       );
     });
+  });
+
+const String packageConfig = '''
+{
+  "configVersion": 2,
+  "packages":[
+    {
+      "name": "my_package",
+      "rootUri": "file:///",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    }
+  ]
+}
+''';
+
+const String pubspecDotYaml = '''
+name: my_package
+''';
+
+  testUsingContext('Bundles material shaders on non-web platforms', () async {
+    final String shaderPath = globals.fs.path.join(
+      Cache.flutterRoot!,
+      'packages', 'flutter', 'lib', 'src', 'material', 'shaders', 'ink_sparkle.frag'
+    );
+    globals.fs.file(shaderPath).createSync(recursive: true);
+    globals.fs.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(packageConfig);
+    globals.fs.file('pubspec.yaml').writeAsStringSync(pubspecDotYaml);
+    final AssetBundle asset = AssetBundleFactory.instance.createBundle();
+
+    await asset.build(packagesPath: '.packages', targetPlatform: TargetPlatform.android_arm);
+
+    expect(asset.entries.keys, contains('shaders/ink_sparkle.frag'));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.empty(),
+  });
+
+  testUsingContext('Does not bundles material shaders on web platforms', () async {
+    final String shaderPath = globals.fs.path.join(
+      Cache.flutterRoot!,
+      'packages', 'flutter', 'lib', 'src', 'material', 'shaders', 'ink_sparkle.frag'
+    );
+    globals.fs.file(shaderPath).createSync(recursive: true);
+    globals.fs.file('.dart_tool/package_config.json')
+      ..createSync(recursive: true)
+      ..writeAsStringSync(packageConfig);
+    globals.fs.file('pubspec.yaml').writeAsStringSync(pubspecDotYaml);
+    final AssetBundle asset = AssetBundleFactory.instance.createBundle();
+
+    await asset.build(packagesPath: '.packages', targetPlatform: TargetPlatform.web_javascript);
+
+    expect(asset.entries.keys, isNot(contains('shaders/ink_sparkle.frag')));
+  }, overrides: <Type, Generator>{
+    FileSystem: () => MemoryFileSystem.test(),
+    ProcessManager: () => FakeProcessManager.empty(),
   });
 }
 


### PR DESCRIPTION
CP for https://github.com/flutter/flutter/issues/116555

Removes ink_sparkle shader from web builds
