### PR TITLE
Revert "Use semantics label for backbutton and closebutton for Android"

### DIFF
--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'debug.dart';
@@ -28,39 +27,22 @@ class BackButtonIcon extends StatelessWidget {
   /// the current platform (as obtained from the [Theme]).
   const BackButtonIcon({ super.key });
 
-  @override
-  Widget build(BuildContext context) {
-    final String? semanticsLabel;
-    final IconData data;
-    switch (Theme.of(context).platform) {
+  /// Returns the appropriate "back" icon for the given `platform`.
+  static IconData _getIconData(TargetPlatform platform) {
+    switch (platform) {
       case TargetPlatform.android:
       case TargetPlatform.fuchsia:
       case TargetPlatform.linux:
       case TargetPlatform.windows:
-        data = Icons.arrow_back;
-        break;
+        return Icons.arrow_back;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        data = Icons.arrow_back_ios;
-        break;
+        return Icons.arrow_back_ios;
     }
-    // This can't use the platform from Theme because it is the Android OS that
-    // expects the duplicated tooltip and label.
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-        semanticsLabel = MaterialLocalizations.of(context).backButtonTooltip;
-        break;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        semanticsLabel = null;
-        break;
-    }
-
-    return Icon(data, semanticLabel: semanticsLabel);
   }
+
+  @override
+  Widget build(BuildContext context) => Icon(_getIconData(Theme.of(context).platform));
 }
 
 /// A Material Design back button.
@@ -167,23 +149,8 @@ class CloseButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterialLocalizations(context));
-    final String? semanticsLabel;
-    // This can't use the platform from Theme because it is the Android OS that
-    // expects the duplicated tooltip and label.
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.android:
-        semanticsLabel = MaterialLocalizations.of(context).closeButtonTooltip;
-        break;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.linux:
-      case TargetPlatform.windows:
-      case TargetPlatform.iOS:
-      case TargetPlatform.macOS:
-        semanticsLabel = null;
-        break;
-    }
     return IconButton(
-      icon: Icon(Icons.close, semanticLabel: semanticsLabel),
+      icon: const Icon(Icons.close),
       color: color,
       tooltip: MaterialLocalizations.of(context).closeButtonTooltip,
       onPressed: () {

--- a/packages/flutter/lib/src/widgets/semantics_debugger.dart
+++ b/packages/flutter/lib/src/widgets/semantics_debugger.dart
@@ -288,14 +288,10 @@ class _SemanticsDebuggerPainter extends CustomPainter {
 
     assert(data.attributedLabel != null);
     final String message;
-    // Android will avoid pronouncing duplicating tooltip and label.
-    // Therefore, having two identical strings is the same as having a single
-    // string.
-    final bool shouldIgnoreDuplicatedLabel = defaultTargetPlatform == TargetPlatform.android && data.attributedLabel.string == data.tooltip;
     final String tooltipAndLabel = <String>[
       if (data.tooltip.isNotEmpty)
         data.tooltip,
-      if (data.attributedLabel.string.isNotEmpty && !shouldIgnoreDuplicatedLabel)
+      if (data.attributedLabel.string.isNotEmpty)
         data.attributedLabel.string,
     ].join('\n');
     if (tooltipAndLabel.isEmpty) {

--- a/packages/flutter/test/material/back_button_test.dart
+++ b/packages/flutter/test/material/back_button_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -153,21 +152,9 @@ void main() {
     tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
 
     await tester.pumpAndSettle();
-    final String? expectedLabel;
-    switch(defaultTargetPlatform) {
-      case TargetPlatform.android:
-        expectedLabel = 'Back';
-        break;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        expectedLabel = null;
-    }
+
     expect(tester.getSemantics(find.byType(BackButton)), matchesSemantics(
       tooltip: 'Back',
-      label: expectedLabel,
       isButton: true,
       hasEnabledState: true,
       isEnabled: true,
@@ -175,51 +162,7 @@ void main() {
       isFocusable: true,
     ));
     handle.dispose();
-  }, variant: TargetPlatformVariant.all());
-
-  testWidgets('CloseButton semantics', (WidgetTester tester) async {
-    final SemanticsHandle handle = tester.ensureSemantics();
-    await tester.pumpWidget(
-      MaterialApp(
-        home: const Material(child: Text('Home')),
-        routes: <String, WidgetBuilder>{
-          '/next': (BuildContext context) {
-            return const Material(
-              child: Center(
-                child: CloseButton(),
-              ),
-            );
-          },
-        },
-      ),
-    );
-
-    tester.state<NavigatorState>(find.byType(Navigator)).pushNamed('/next');
-
-    await tester.pumpAndSettle();
-    final String? expectedLabel;
-    switch(defaultTargetPlatform) {
-      case TargetPlatform.android:
-        expectedLabel = 'Close';
-        break;
-      case TargetPlatform.fuchsia:
-      case TargetPlatform.iOS:
-      case TargetPlatform.linux:
-      case TargetPlatform.macOS:
-      case TargetPlatform.windows:
-        expectedLabel = null;
-    }
-    expect(tester.getSemantics(find.byType(CloseButton)), matchesSemantics(
-      tooltip: 'Close',
-      label: expectedLabel,
-      isButton: true,
-      hasEnabledState: true,
-      isEnabled: true,
-      hasTapAction: true,
-      isFocusable: true,
-    ));
-    handle.dispose();
-  }, variant: TargetPlatformVariant.all());
+  });
 
   testWidgets('CloseButton color', (WidgetTester tester) async {
     await tester.pumpWidget(

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -438,33 +437,6 @@ void main() {
       'unchecked; disabled',
     );
   });
-
-  testWidgets('SemanticsDebugger ignores duplicated label and tooltip for Android', (WidgetTester tester) async {
-    final Key child = UniqueKey();
-    final Key debugger = UniqueKey();
-    final bool isPlatformAndroid = defaultTargetPlatform == TargetPlatform.android;
-    await tester.pumpWidget(
-      Directionality(
-        textDirection: TextDirection.ltr,
-        child: SemanticsDebugger(
-          key: debugger,
-          child: Material(
-            child: Semantics(
-              container: true,
-              key: child,
-              label: 'text',
-              tooltip: 'text',
-            ),
-          ),
-        ),
-      ),
-    );
-
-    expect(
-      _getMessageShownInSemanticsDebugger(widgetKey: child, debuggerKey: debugger, tester: tester),
-      isPlatformAndroid ? 'text' : 'text\ntext',
-    );
-  }, variant: TargetPlatformVariant.all());
 
   testWidgets('SemanticsDebugger textfield', (WidgetTester tester) async {
     final UniqueKey textField = UniqueKey();


### PR DESCRIPTION
This reverts commit 68ce1aeaeb33ad960fb5195852e4dc66f680d4ff.

The previous pr broke the tree due to bad merge. reverting

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
