### PR TITLE
Fix language version check logic to determine nullsafe soundness.

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1089,7 +1089,8 @@ abstract class FlutterCommand extends Command<void> {
         );
         // Extra frontend options are only provided if explicitly
         // requested.
-        if (languageVersion.major >= nullSafeVersion.major && languageVersion.minor >= nullSafeVersion.minor) {
+        if ((languageVersion.major > nullSafeVersion.major) ||
+            (languageVersion.major == nullSafeVersion.major && languageVersion.minor >= nullSafeVersion.minor)) {
           nullSafetyMode = NullSafetyMode.sound;
         } else {
           nullSafetyMode = NullSafetyMode.unsound;


### PR DESCRIPTION
Fix language version check logic to determine nullsafe soundness, with bump to version 3.0 the existing logic fails.