### PR TITLE
[customer_testing] Remove required updates line

### DIFF
--- a/dev/customer_testing/lib/customer_test.dart
+++ b/dev/customer_testing/lib/customer_test.dart
@@ -24,6 +24,9 @@ class CustomerTest {
         contacts.add(line.substring(8));
       } else if (line.startsWith('fetch=')) {
         fetch.add(line.substring(6));
+      } else if (line.startsWith('update=')) {
+        // Add once https://github.com/flutter/tests/blob/main/scripts/update_tests.dart
+        // is implemented
       } else if (line.startsWith('test=')) {
         hasTests = true;
         test.add(line.substring(5));

--- a/dev/customer_testing/lib/customer_test.dart
+++ b/dev/customer_testing/lib/customer_test.dart
@@ -24,8 +24,6 @@ class CustomerTest {
         contacts.add(line.substring(8));
       } else if (line.startsWith('fetch=')) {
         fetch.add(line.substring(6));
-      } else if (line.startsWith('update=')) {
-        update.add(Directory(line.substring(7)));
       } else if (line.startsWith('test=')) {
         hasTests = true;
         test.add(line.substring(5));

--- a/dev/customer_testing/lib/customer_test.dart
+++ b/dev/customer_testing/lib/customer_test.dart
@@ -73,9 +73,6 @@ class CustomerTest {
     if (!fetch[1].contains(_fetch2)) {
       throw FormatException('${errorPrefix}Second "fetch" directive does not match expected pattern (expected "git -C tests checkout HASH").');
     }
-    if (update.isEmpty) {
-      throw FormatException('${errorPrefix}No "update" directives specified. At least one directory must be specified. (It can be "." to just upgrade the root of the repository.)');
-    }
     if (!hasTests) {
       throw FormatException('${errorPrefix}No "test" directives specified. At least one command must be specified to run tests.');
     }

--- a/dev/customer_testing/test/customer_test_test.dart
+++ b/dev/customer_testing/test/customer_test_test.dart
@@ -16,7 +16,6 @@ void main() {
 contact=abc@gmail.com
 fetch=git clone https://github.com/flutter/cocoon.git tests
 fetch=git -C tests checkout abc123
-update=.
 # Runs flutter analyze, flutter test, and builds web platform
 test.posix=./test_utilities/bin/flutter_test_runner.sh app_flutter
 test.posix=./test_utilities/bin/flutter_test_runner.sh repo_dashboard
@@ -41,6 +40,7 @@ test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dashboard
     } else if (Platform.isWindows) {
       expect(test.tests, containsAllInOrder(<String>['.\test_utilities\bin\flutter_test_runner.bat repo_dashboard']));
     }
+    expect(test.update, isEmtpy);
   });
 
   test('throws exception when unknown field is passed', () async {

--- a/dev/customer_testing/test/customer_test_test.dart
+++ b/dev/customer_testing/test/customer_test_test.dart
@@ -40,7 +40,7 @@ test.windows=.\test_utilities\bin\flutter_test_runner.bat repo_dashboard
     } else if (Platform.isWindows) {
       expect(test.tests, containsAllInOrder(<String>['.\test_utilities\bin\flutter_test_runner.bat repo_dashboard']));
     }
-    expect(test.update, isEmtpy);
+    expect(test.update, isEmpty);
   });
 
   test('throws exception when unknown field is passed', () async {


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/116671

A few updated tests seem to modify the path they are on, causing this to fail. For example, gallery fails:

```
ERROR: Could not run "flutter pub get" in ., which was specified as an update directory.
```

Since this isn't actively used, a quick way to unblock the Dart 3 roll is to remove the check, and the various update lines.

See also https://github.com/flutter/tests/blob/main/scripts/update_tests.dart

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
