### PR TITLE
Add Remaining Packaging Builders

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4630,105 +4630,57 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: flutter_tool_startup__macos
 
-  - name: Linux flutter_packaging_beta
+  - name: Linux flutter_packaging
     recipe: packaging_v2/packaging_v2
     timeout: 60
     scheduler: release
     bringup: true
     enabled_branches:
       - beta
+      - stable
     properties:
-      task_name: flutter_packaging_beta
+      task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "linux"]
 
-
-  - name: Mac flutter_packaging_beta
+  - name: Mac flutter_packaging
     recipe: packaging_v2/packaging_v2
     timeout: 60
     scheduler: release
     bringup: true
     enabled_branches:
       - beta
+      - stable
     properties:
-      task_name: flutter_packaging_beta
+      task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
 
 
-  - name: Mac_arm64 flutter_packaging_beta
+  - name: Mac_arm64 flutter_packaging
     recipe: packaging_v2/packaging_v2
     timeout: 60
     scheduler: release
     bringup: true
     enabled_branches:
       - beta
+      - stable
     properties:
-      task_name: flutter_packaging_beta
+      task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
 
 
-  - name: Windows flutter_packaging_beta
+  - name: Windows flutter_packaging
     recipe: packaging_v2/packaging_v2
     timeout: 60
     scheduler: release
     bringup: true
     enabled_branches:
       - beta
-    properties:
-      task_name: flutter_packaging_beta
-      tags: >
-        ["framework", "hostonly", "shard", "windows"]
-
-  - name: Linux flutter_packaging_stable
-    recipe: packaging_v2/packaging_v2
-    timeout: 60
-    scheduler: release
-    bringup: true
-    enabled_branches:
       - stable
     properties:
-      task_name: flutter_packaging_stable
-      tags: >
-        ["framework", "hostonly", "shard", "linux"]
-
-
-  - name: Mac flutter_packaging_stable
-    recipe: packaging_v2/packaging_v2
-    timeout: 60
-    scheduler: release
-    bringup: true
-    enabled_branches:
-      - stable
-    properties:
-      task_name: flutter_packaging_stable
-      tags: >
-        ["framework", "hostonly", "shard", "mac"]
-
-
-  - name: Mac_arm64 flutter_packaging_stable
-    recipe: packaging_v2/packaging_v2
-    timeout: 60
-    scheduler: release
-    bringup: true
-    enabled_branches:
-      - stable
-    properties:
-      task_name: flutter_packaging_stable
-      tags: >
-        ["framework", "hostonly", "shard", "mac"]
-
-
-  - name: Windows flutter_packaging_stable
-    recipe: packaging_v2/packaging_v2
-    timeout: 60
-    scheduler: release
-    bringup: true
-    enabled_branches:
-      - stable
-    properties:
-      task_name: flutter_packaging_stable
+      task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "windows"]
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4681,6 +4681,57 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "windows"]
 
+  - name: Linux flutter_packaging_stable
+    recipe: packaging_v2/packaging_v2
+    timeout: 60
+    scheduler: release
+    bringup: true
+    enabled_branches:
+      - stable
+    properties:
+      task_name: flutter_packaging_stable
+      tags: >
+        ["framework", "hostonly", "shard", "linux"]
+
+
+  - name: Mac flutter_packaging_stable
+    recipe: packaging_v2/packaging_v2
+    timeout: 60
+    scheduler: release
+    bringup: true
+    enabled_branches:
+      - stable
+    properties:
+      task_name: flutter_packaging_stable
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+
+
+  - name: Mac_arm64 flutter_packaging_stable
+    recipe: packaging_v2/packaging_v2
+    timeout: 60
+    scheduler: release
+    bringup: true
+    enabled_branches:
+      - stable
+    properties:
+      task_name: flutter_packaging_stable
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+
+
+  - name: Windows flutter_packaging_stable
+    recipe: packaging_v2/packaging_v2
+    timeout: 60
+    scheduler: release
+    bringup: true
+    enabled_branches:
+      - stable
+    properties:
+      task_name: flutter_packaging_stable
+      tags: >
+        ["framework", "hostonly", "shard", "windows"]
+
 
   - name: Linux docs_deploy
     recipe: flutter/flutter

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -302,5 +302,4 @@
 # skp_generator @Hixie
 # test_ownership @keyonghan
 # verify_binaries_codesigned @christopherfujino @flutter/releases
-# flutter_packaging_beta @godofredoc @flutter/infra
-# flutter_packaging_stable @godofredoc @flutter/infra
+# flutter_packaging @godofredoc @flutter/infra

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -303,3 +303,4 @@
 # test_ownership @keyonghan
 # verify_binaries_codesigned @christopherfujino @flutter/releases
 # flutter_packaging_beta @godofredoc @flutter/infra
+# flutter_packaging_stable @godofredoc @flutter/infra


### PR DESCRIPTION
This change adds the remaining packaging builders needed for the stable branch.

Addresses issue https://github.com/flutter/flutter/issues/115489

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
