### PR TITLE
Fix scroll jump when NestedScrollPosition is inertia-cancelled.

### DIFF
--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -903,7 +903,10 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
     // If an update is made to pointer scrolling here, consider if the same
     // (or similar) change should be made in
     // ScrollPositionWithSingleContext.pointerScroll.
-    assert(delta != 0.0);
+    if (delta == 0.0) {
+      goBallistic(0.0);
+      return;
+    }
 
     goIdle();
     updateUserScrollDirection(

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -212,7 +212,10 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
     // If an update is made to pointer scrolling here, consider if the same
     // (or similar) change should be made in
     // _NestedScrollCoordinator.pointerScroll.
-    assert(delta != 0.0);
+    if (delta == 0.0) {
+      goBallistic(0.0);
+      return;
+    }
 
     final double targetPixels =
         math.min(math.max(pixels + delta, minScrollExtent), maxScrollExtent);

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -780,7 +780,12 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         GestureBinding.instance.pointerSignalResolver.register(event, _handlePointerScroll);
       }
     } else if (event is PointerScrollInertiaCancelEvent) {
-      position.jumpTo(position.pixels);
+      if (position is ScrollActivityDelegate) {
+        (position as ScrollActivityDelegate).goIdle();
+      }
+      else {
+        position.jumpTo(position.pixels);
+      }
       // Don't use the pointer signal resolver, all hit-tested scrollables should stop.
     }
   }

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -780,12 +780,7 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
         GestureBinding.instance.pointerSignalResolver.register(event, _handlePointerScroll);
       }
     } else if (event is PointerScrollInertiaCancelEvent) {
-      if (position is ScrollActivityDelegate) {
-        (position as ScrollActivityDelegate).goIdle();
-      }
-      else {
-        position.jumpTo(position.pixels);
-      }
+      position.pointerScroll(0);
       // Don't use the pointer signal resolver, all hit-tested scrollables should stop.
     }
   }


### PR DESCRIPTION
`ScrollPosition.pointerScroll(delta)` is modified to support a delta of zero to stop inertia instead of issuing a jump to the current pixel value. The pixel value on the outer nested scroll position doesn't contain the information about the inner scroll position.

Fixes #116486

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.