### PR TITLE
[Tooltip] Exposed long press action to accessibility users when available

### DIFF
--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -738,10 +738,25 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     _triggerMode = widget.triggerMode ?? tooltipTheme.triggerMode ?? _defaultTriggerMode;
     _enableFeedback = widget.enableFeedback ?? tooltipTheme.enableFeedback ?? _defaultEnableFeedback;
 
+    void Function()? onLongPressCallback;
+    void Function()? onTapCallback;
+    if (!_excludeFromSemantics) {
+      switch (_triggerMode) {
+        case TooltipTriggerMode.longPress:
+          onLongPressCallback = _handlePress;
+          break;
+        case TooltipTriggerMode.tap:
+          onTapCallback = _handleTap;
+          break;
+        case TooltipTriggerMode.manual:
+          break;
+      }
+    }
+
     Widget result = Semantics(
       container: true,
-      onLongPress: (_triggerMode == TooltipTriggerMode.longPress) ? _handlePress : null,
-      onTap: (_triggerMode == TooltipTriggerMode.tap) ? _handleTap : null,
+      onLongPress: onLongPressCallback,
+      onTap: onTapCallback,
       tooltip: _excludeFromSemantics
           ? null
           : _tooltipMessage,

--- a/packages/flutter/lib/src/material/tooltip.dart
+++ b/packages/flutter/lib/src/material/tooltip.dart
@@ -739,6 +739,9 @@ class TooltipState extends State<Tooltip> with SingleTickerProviderStateMixin {
     _enableFeedback = widget.enableFeedback ?? tooltipTheme.enableFeedback ?? _defaultEnableFeedback;
 
     Widget result = Semantics(
+      container: true,
+      onLongPress: (_triggerMode == TooltipTriggerMode.longPress) ? _handlePress : null,
+      onTap: (_triggerMode == TooltipTriggerMode.tap) ? _handleTap : null,
       tooltip: _excludeFromSemantics
           ? null
           : _tooltipMessage,

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1450,6 +1450,7 @@ void main() {
           id: 1,
           tooltip: 'TIP',
           textDirection: TextDirection.ltr,
+          actions: <SemanticsAction>[SemanticsAction.longPress],
         ),
       ],
     );
@@ -1650,6 +1651,7 @@ void main() {
                       tooltip: 'Foo',
                       label: 'Bar',
                       textDirection: TextDirection.ltr,
+                      actions: <SemanticsAction>[SemanticsAction.longPress],
                     ),
                   ],
                 ),


### PR DESCRIPTION
This PR fixed the issue that long press action is not exposed to accessibility users when the Tooltip can be triggered by long press.

Issues fixed:
[b/239703139]

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
