### PR TITLE
Fix gestures not responding on swipe back

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -765,7 +765,7 @@ class _CupertinoBackGestureController<T> {
     } else {
       animateForward = controller.value > 0.5;
     }
-    
+
     if (animateForward) {
       // The closer the panel is to dismissing, the shorter the animation is.
       // We want to cap the animation time, but we want to use a linear curve

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -765,6 +765,7 @@ class _CupertinoBackGestureController<T> {
     } else {
       animateForward = controller.value > 0.5;
     }
+    
     if (animateForward) {
       // The closer the panel is to dismissing, the shorter the animation is.
       // We want to cap the animation time, but we want to use a linear curve

--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -806,7 +806,7 @@ class _CupertinoBackGestureController<T> {
       };
       // Only apply the value listener if going back to the previous route, as
       // allowing clicks on the top route while in motion may trigger errors
-      // while the route is not fully in the Widget tree.
+      // for going to a route that is already being moved to.
       if (!animateForward) {
         controller.addListener(animationValueCallback);
       }
@@ -818,9 +818,7 @@ class _CupertinoBackGestureController<T> {
           navigator.didStopUserGesture();
         }
         controller.removeStatusListener(animationStatusCallback);
-        if (animationValueCallback != null) {
-          controller.removeListener(animationValueCallback);
-        }
+        controller.removeListener(animationValueCallback);
       };
       controller.addStatusListener(animationStatusCallback);
     } else {

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -763,7 +763,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 240));
     expect(
       tester.getTopLeft(find.ancestor(of: find.text('route'), matching: find.byType(Scaffold))).dx,
-      moreOrLessEquals(798, epsilon: 1),
+      moreOrLessEquals(799, epsilon: 1),
     );
 
     // Use the navigator to push a route instead of tapping the 'push' button.


### PR DESCRIPTION
Addresses #73026 and #92978. Summary of the two issues: during the back swipe animation, users gestures are locked until the animation completes. However, the animation follows [this curve](https://api.flutter.dev/flutter/animation/Curves/fastLinearToSlowEaseIn-constant.html) so during the back half of the animation, it looks to the user that the animation is complete and they can use a gesture, but it is still imperceptibly going.

A possible solution is to adjust the animation curve, but as it was carefully made to match iOS, I decided instead to change the listener for the animation to re-enable gestures near the end of the animation, instead of at it. A side effect of removing the listener while it's in flight is that it seems to very slightly speed it up at the very end to were it theoretically should be, hence some of the value changes in the tests.

Before, the behavior if you tap soon after the animation finishes, the button will not respond:

https://user-images.githubusercontent.com/58190796/206321862-a02a98fa-5fb6-4352-b724-d141607e5b71.mov

After it is responsive much sooner, but will still not respond while the majority of the animation is playing:

https://user-images.githubusercontent.com/58190796/206321918-bd151177-026f-485c-b680-c0f4a0da3116.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
