### PR TITLE
115574 android selection haptics feedback should respect android settings

### DIFF
--- a/packages/flutter/lib/src/services/haptic_feedback.dart
+++ b/packages/flutter/lib/src/services/haptic_feedback.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 
+import 'package:meta/meta.dart';
+
 import 'system_channels.dart';
 
 /// Allows access to the haptic feedback interface on the device.
@@ -78,6 +80,20 @@ class HapticFeedback {
     await SystemChannels.platform.invokeMethod<void>(
       'HapticFeedback.vibrate',
       'HapticFeedbackType.selectionClick',
+    );
+  }
+
+  @visibleForTesting
+  // ignore: public_member_api_docs
+  static const String isHapticEnabledMethodName = 'HapticFeedback.isEnabled';
+
+  /// Provides value for haptic feedback user setting.
+  ///
+  /// {@code false} indicates the user has opted out of haptic feedback.
+  /// If user preference is unknown or unknowable defaults to {@code true}.
+  static Future<bool?> isHapticFeedbackEnabled() async {
+    return SystemChannels.platform.invokeMethod<bool>(
+      isHapticEnabledMethodName,
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -319,6 +320,8 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   /// {@macro flutter.rendering.RenderEditable.lastSecondaryTapDownPosition}
   Offset? lastSecondaryTapDownPosition;
 
+  bool _hapticFeedbackEnabled = true;
+
   @override
   void initState() {
     super.initState();
@@ -333,6 +336,11 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
         instance.onSecondaryTapDown = _handleRightClickDown;
       },
     );
+    unawaited(() async {
+      // Overrite the default value with the actual value when it is available.
+      final bool? newValue = await HapticFeedback.isHapticFeedbackEnabled();
+      _hapticFeedbackEnabled = newValue ?? _hapticFeedbackEnabled;
+    }());
   }
 
   @override
@@ -467,7 +475,9 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
   }
 
   void _handleTouchLongPressStart(LongPressStartDetails details) {
-    HapticFeedback.selectionClick();
+    if (_hapticFeedbackEnabled) {
+      HapticFeedback.selectionClick();
+    }
     widget.focusNode.requestFocus();
     _selectWordAt(offset: details.globalPosition);
     _showToolbar();

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -953,7 +953,11 @@ class SelectionOverlay {
        _lineHeightAtEnd = lineHeightAtEnd,
        _selectionEndpoints = selectionEndpoints,
        _toolbarLocation = toolbarLocation,
-       assert(debugCheckHasOverlay(context));
+        hapticFeedbackEnabled = true,
+        assert(debugCheckHasOverlay(context)) {
+    HapticFeedback.isHapticFeedbackEnabled().then((bool? enabled) =>
+        hapticFeedbackEnabled = enabled ?? hapticFeedbackEnabled);
+  }
 
   /// {@macro flutter.widgets.SelectionOverlay.context}
   final BuildContext context;
@@ -975,6 +979,11 @@ class SelectionOverlay {
   ///
   /// {@macro flutter.widgets.magnifier.TextMagnifierConfiguration.details}
   final TextMagnifierConfiguration magnifierConfiguration;
+
+
+  @visibleForTesting
+  // ignore: public_member_api_docs
+  bool hapticFeedbackEnabled;
 
   /// {@template flutter.widgets.SelectionOverlay.showMagnifier}
   /// Shows the magnifier, and hides the toolbar if it was showing when [showMagnifier]
@@ -1164,9 +1173,12 @@ class SelectionOverlay {
     if (!listEquals(_selectionEndpoints, value)) {
       markNeedsBuild();
       if (_isDraggingEndHandle || _isDraggingStartHandle) {
+
         switch(defaultTargetPlatform) {
           case TargetPlatform.android:
-            HapticFeedback.selectionClick();
+            if (hapticFeedbackEnabled) {
+              HapticFeedback.selectionClick();
+            }
             break;
           case TargetPlatform.fuchsia:
           case TargetPlatform.iOS:

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -955,8 +955,11 @@ class SelectionOverlay {
        _toolbarLocation = toolbarLocation,
         hapticFeedbackEnabled = true,
         assert(debugCheckHasOverlay(context)) {
-    HapticFeedback.isHapticFeedbackEnabled().then((bool? enabled) =>
-        hapticFeedbackEnabled = enabled ?? hapticFeedbackEnabled);
+    unawaited(() async {
+      // Overrite the default value with the actual value when it is available.
+      final bool? newValue = await HapticFeedback.isHapticFeedbackEnabled();
+      hapticFeedbackEnabled = newValue ?? hapticFeedbackEnabled;
+    }());
   }
 
   /// {@macro flutter.widgets.SelectionOverlay.context}

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -1309,7 +1309,7 @@ void main() {
         return null;
       });
 
-      // Drag handle setup and execution.
+      // Drag handle setup.
       DragStartDetails? startDragStartDetails;
       DragUpdateDetails? startDragUpdateDetails;
       DragEndDetails? startDragEndDetails;
@@ -1349,15 +1349,8 @@ void main() {
         ];
       selectionOverlay.showHandles();
       await tester.pump();
-      expect(find.byKey(spy.leftHandleKey), findsOneWidget);
-      expect(find.byKey(spy.rightHandleKey), findsOneWidget);
-      expect(startDragStartDetails, isNull);
-      expect(startDragUpdateDetails, isNull);
-      expect(startDragEndDetails, isNull);
-      expect(endDragStartDetails, isNull);
-      expect(endDragUpdateDetails, isNull);
-      expect(endDragEndDetails, isNull);
 
+      // Drag handle execution.
       final TestGesture gesture = await tester
           .startGesture(tester.getCenter(find.byKey(spy.leftHandleKey)));
       await tester.pump(const Duration(milliseconds: 200));


### PR DESCRIPTION
Uses newly exposed haptic feedback preference from pr https://github.com/flutter/engine/pull/38102 to not send haptic feedback when the user has disabled it on android api 29 and below. 

Both PR's resolve https://github.com/flutter/flutter/issues/115574 


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
