### PR TITLE
Add LookupBoundary to Material

### DIFF
--- a/packages/flutter/lib/src/material/debug.dart
+++ b/packages/flutter/lib/src/material/debug.dart
@@ -11,7 +11,8 @@ import 'scaffold.dart' show Scaffold, ScaffoldMessenger;
 // Examples can assume:
 // late BuildContext context;
 
-/// Asserts that the given context has a [Material] ancestor.
+/// Asserts that the given context has a [Material] ancestor within the closest
+/// [LookupBoundary].
 ///
 /// Used by many Material Design widgets to make sure that they are
 /// only used in contexts where they can print ink onto some material.
@@ -32,12 +33,17 @@ import 'scaffold.dart' show Scaffold, ScaffoldMessenger;
 /// Does nothing if asserts are disabled. Always returns true.
 bool debugCheckHasMaterial(BuildContext context) {
   assert(() {
-    if (context.widget is! Material && context.findAncestorWidgetOfExactType<Material>() == null) {
+    if (LookupBoundary.findAncestorWidgetOfExactType<Material>(context) == null) {
+      final bool hiddenByBoundary = LookupBoundary.debugIsHidingAncestorWidgetOfExactType<Material>(context);
       throw FlutterError.fromParts(<DiagnosticsNode>[
-        ErrorSummary('No Material widget found.'),
+        ErrorSummary('No Material widget found${hiddenByBoundary ? ' within the closest LookupBoundary' : ''}.'),
+        if (hiddenByBoundary)
+          ErrorDescription(
+            'There is an ancestor Material widget, but it is hidden by a LookupBoundary.'
+          ),
         ErrorDescription(
           '${context.widget.runtimeType} widgets require a Material '
-          'widget ancestor.\n'
+          'widget ancestor within the closest LookupBoundary.\n'
           'In Material Design, most widgets are conceptually "printed" on '
           "a sheet of material. In Flutter's material library, that "
           'material is represented by the Material widget. It is the '

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -343,7 +343,7 @@ class Material extends StatefulWidget {
   final BorderRadiusGeometry? borderRadius;
 
   /// The ink controller from the closest instance of this class that
-  /// encloses the given context.
+  /// encloses the given context within the closest [LookupBoundary].
   ///
   /// Typical usage is as follows:
   ///
@@ -358,11 +358,11 @@ class Material extends StatefulWidget {
   /// * [Material.of], which is similar to this method, but asserts if
   ///   no [Material] ancestor is found.
   static MaterialInkController? maybeOf(BuildContext context) {
-    return context.findAncestorRenderObjectOfType<_RenderInkFeatures>();
+    return LookupBoundary.findAncestorRenderObjectOfType<_RenderInkFeatures>(context);
   }
 
   /// The ink controller from the closest instance of [Material] that encloses
-  /// the given context.
+  /// the given context within the closest [LookupBoundary].
   ///
   /// If no [Material] widget ancestor can be found then this method will assert
   /// in debug mode, and throw an exception in release mode.
@@ -383,6 +383,16 @@ class Material extends StatefulWidget {
     final MaterialInkController? controller = maybeOf(context);
     assert(() {
       if (controller == null) {
+        if (LookupBoundary.debugIsHidingAncestorRenderObjectOfType<_RenderInkFeatures>(context)) {
+          throw FlutterError(
+            'Material.of() was called with a context that does not have access to a Material widget.\n'
+            'While there is a Material widget ancestor, it was hidden by a LookupBoundary. '
+            'This can happen because you are using a widget that looks for a Material '
+            'ancestor, but no such ancestor exists within the closest LookupBoundary.\n'
+            'The context used was:\n'
+            '  $context',
+          );
+        }
         throw FlutterError(
           'Material.of() was called with a context that does not contain a Material widget.\n'
           'No Material widget ancestor could be found starting from the context that was passed to '

--- a/packages/flutter/lib/src/material/material.dart
+++ b/packages/flutter/lib/src/material/material.dart
@@ -386,9 +386,9 @@ class Material extends StatefulWidget {
         if (LookupBoundary.debugIsHidingAncestorRenderObjectOfType<_RenderInkFeatures>(context)) {
           throw FlutterError(
             'Material.of() was called with a context that does not have access to a Material widget.\n'
-            'While there is a Material widget ancestor, it was hidden by a LookupBoundary. '
-            'This can happen because you are using a widget that looks for a Material '
-            'ancestor, but no such ancestor exists within the closest LookupBoundary.\n'
+            'The context provided to Material.of() does have a Material widget ancestor, but it is '
+            'hidden by a LookupBoundary. This can happen because you are using a widget that looks '
+            'for a Material ancestor, but no such ancestor exists within the closest LookupBoundary.\n'
             'The context used was:\n'
             '  $context',
           );

--- a/packages/flutter/lib/src/widgets/lookup_boundary.dart
+++ b/packages/flutter/lib/src/widgets/lookup_boundary.dart
@@ -274,7 +274,7 @@ class LookupBoundary extends InheritedWidget {
   }
 
   /// Returns true if a [LookupBoundary] is hiding the nearest
-  /// [RenderObjectWidget] with the [RenderObject] of the specified type `T`
+  /// [RenderObjectWidget] with a [RenderObject] of the specified type `T`
   /// from the provided [BuildContext].
   ///
   /// This method throws when asserts are disabled.

--- a/packages/flutter/lib/src/widgets/lookup_boundary.dart
+++ b/packages/flutter/lib/src/widgets/lookup_boundary.dart
@@ -250,6 +250,53 @@ class LookupBoundary extends InheritedWidget {
     });
   }
 
+  /// Returns true if a [LookupBoundary] is hiding the nearest
+  /// [Widget] of the specified type `T` from the provided [BuildContext].
+  ///
+  /// This method throws when asserts are disabled.
+  static bool debugIsHidingAncestorWidgetOfExactType<T extends Widget>(BuildContext context) {
+    bool? result;
+    assert(() {
+      bool hiddenByBoundary = false;
+      bool ancestorFound = false;
+      context.visitAncestorElements((Element ancestor) {
+        if (ancestor.widget.runtimeType == T) {
+          ancestorFound = true;
+          return false;
+        }
+        hiddenByBoundary = hiddenByBoundary || ancestor.widget.runtimeType == LookupBoundary;
+        return true;
+      });
+      result = ancestorFound & hiddenByBoundary;
+      return true;
+    } ());
+    return result!;
+  }
+
+  /// Returns true if a [LookupBoundary] is hiding the nearest
+  /// [RenderObjectWidget] with the [RenderObject] of the specified type `T`
+  /// from the provided [BuildContext].
+  ///
+  /// This method throws when asserts are disabled.
+  static bool debugIsHidingAncestorRenderObjectOfType<T extends RenderObject>(BuildContext context) {
+    bool? result;
+    assert(() {
+      bool hiddenByBoundary = false;
+      bool ancestorFound = false;
+      context.visitAncestorElements((Element ancestor) {
+        if (ancestor is RenderObjectElement && ancestor.renderObject is T) {
+          ancestorFound = true;
+          return false;
+        }
+        hiddenByBoundary = hiddenByBoundary || ancestor.widget.runtimeType == LookupBoundary;
+        return true;
+      });
+      result = ancestorFound & hiddenByBoundary;
+      return true;
+    } ());
+    return result!;
+  }
+
   @override
   bool updateShouldNotify(covariant InheritedWidget oldWidget) => false;
 }

--- a/packages/flutter/test/material/debug_test.dart
+++ b/packages/flutter/test/material/debug_test.dart
@@ -28,7 +28,8 @@ void main() {
       error.toStringDeep(),
       'FlutterError\n'
       '   No Material widget found.\n'
-      '   Chip widgets require a Material widget ancestor.\n'
+      '   Chip widgets require a Material widget ancestor within the\n'
+      '   closest LookupBoundary.\n'
       '   In Material Design, most widgets are conceptually "printed" on a\n'
       "   sheet of material. In Flutter's material library, that material\n"
       '   is represented by the Material widget. It is the Material widget\n'

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -1077,12 +1077,13 @@ void main() {
         'FlutterError\n'
         '   Material.of() was called with a context that does not have access\n'
         '   to a Material widget.\n'
-        '   While there is a Material widget ancestor, it was hidden by a\n'
-        '   LookupBoundary. This can happen because you are using a widget\n'
-        '   that looks for a Material ancestor, but no such ancestor exists\n'
-        '   within the closest LookupBoundary.\n'
+        '   The context provided to Material.of() does have a Material widget\n'
+        '   ancestor, but it is hidden by a LookupBoundary. This can happen\n'
+        '   because you are using a widget that looks for a Material\n'
+        '   ancestor, but no such ancestor exists within the closest\n'
+        '   LookupBoundary.\n'
         '   The context used was:\n'
-        '     Builder(dirty)\n',
+        '     Builder(dirty)\n'
       );
     });
 

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -1128,8 +1128,6 @@ void main() {
       );
     });
   });
-
-
 }
 
 class TrackPaintInkFeature extends InkFeature {

--- a/packages/flutter/test/widgets/lookup_boundary_test.dart
+++ b/packages/flutter/test/widgets/lookup_boundary_test.dart
@@ -958,6 +958,130 @@ void main() {
 
     });
   });
+
+  group('LookupBoundary.debugIsHidingAncestorWidgetOfExactType', () {
+    testWidgets('is hiding', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Container(
+        color: Colors.blue,
+        child: LookupBoundary(
+          child: Builder(
+            builder: (BuildContext context) {
+              isHidden = LookupBoundary.debugIsHidingAncestorWidgetOfExactType<Container>(context);
+              return Container();
+            },
+          ),
+        ),
+      ));
+      expect(isHidden, isTrue);
+    });
+
+    testWidgets('is not hiding entity within boundary', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Container(
+        color: Colors.blue,
+        child: LookupBoundary(
+          child: Container(
+            color: Colors.red,
+            child: Builder(
+              builder: (BuildContext context) {
+                isHidden = LookupBoundary.debugIsHidingAncestorWidgetOfExactType<Container>(context);
+                return Container();
+              },
+            ),
+          ),
+        ),
+      ));
+      expect(isHidden, isFalse);
+    });
+
+    testWidgets('is not hiding if no boundary exists', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Container(
+        color: Colors.blue,
+        child: Builder(
+          builder: (BuildContext context) {
+            isHidden = LookupBoundary.debugIsHidingAncestorWidgetOfExactType<Container>(context);
+            return Container();
+          },
+        ),
+      ));
+      expect(isHidden, isFalse);
+    });
+
+    testWidgets('is not hiding if no boundary and no entity exists', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Builder(
+        builder: (BuildContext context) {
+          isHidden = LookupBoundary.debugIsHidingAncestorWidgetOfExactType<Container>(context);
+          return Container();
+        },
+      ));
+      expect(isHidden, isFalse);
+    });
+  });
+
+  group('LookupBoundary.debugIsHidingAncestorRenderObjectOfType', () {
+    testWidgets('is hiding', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Padding(
+        padding: EdgeInsets.zero,
+        child: LookupBoundary(
+          child: Builder(
+            builder: (BuildContext context) {
+              isHidden = LookupBoundary.debugIsHidingAncestorRenderObjectOfType<RenderPadding>(context);
+              return Container();
+            },
+          ),
+        ),
+      ));
+      expect(isHidden, isTrue);
+    });
+
+    testWidgets('is not hiding entity within boundary', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Padding(
+        padding: EdgeInsets.zero,
+        child: LookupBoundary(
+          child: Padding(
+            padding: EdgeInsets.zero,
+            child: Builder(
+              builder: (BuildContext context) {
+                isHidden = LookupBoundary.debugIsHidingAncestorRenderObjectOfType<RenderPadding>(context);
+                return Container();
+              },
+            ),
+          ),
+        ),
+      ));
+      expect(isHidden, isFalse);
+    });
+
+    testWidgets('is not hiding if no boundary exists', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Padding(
+        padding: EdgeInsets.zero,
+        child: Builder(
+          builder: (BuildContext context) {
+            isHidden = LookupBoundary.debugIsHidingAncestorRenderObjectOfType<RenderPadding>(context);
+            return Container();
+          },
+        ),
+      ));
+      expect(isHidden, isFalse);
+    });
+
+    testWidgets('is not hiding if no boundary and no entity exists', (WidgetTester tester) async {
+      bool? isHidden;
+      await tester.pumpWidget(Builder(
+        builder: (BuildContext context) {
+          isHidden = LookupBoundary.debugIsHidingAncestorRenderObjectOfType<RenderPadding>(context);
+          return Container();
+        },
+      ));
+      expect(isHidden, isFalse);
+    });
+  });
 }
 
 class MyStatefulContainer extends StatefulWidget {


### PR DESCRIPTION
Material.of and Material.maybeOf (as well as debugCheckHasMaterial) cannot find Materials that are past a lookup boundary.