### PR TITLE
Add LookupBoundary to TapRegionRegistry

### DIFF
--- a/packages/flutter/lib/src/widgets/tap_region.dart
+++ b/packages/flutter/lib/src/widgets/tap_region.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 
 import 'editable_text.dart';
 import 'framework.dart';
+import 'lookup_boundary.dart';
 
 // Enable if you want verbose logging about tap region changes.
 const bool _kDebugTapRegion = false;
@@ -42,14 +43,23 @@ abstract class TapRegionRegistry {
   /// Unregister the given [RenderTapRegion] with the registry.
   void unregisterTapRegion(RenderTapRegion region);
 
-  /// Allows finding of the nearest [TapRegionRegistry], such as a
-  /// [RenderTapRegionSurface].
+  /// Allows finding of the nearest [TapRegionRegistry] within the closest
+  /// [LookupBoundary], such as a [RenderTapRegionSurface].
   ///
   /// Will throw if a [TapRegionRegistry] isn't found.
   static TapRegionRegistry of(BuildContext context) {
     final TapRegionRegistry? registry = maybeOf(context);
     assert(() {
       if (registry == null) {
+        if (LookupBoundary.debugIsHidingAncestorRenderObjectOfType<RenderTapRegionSurface>(context)) {
+          throw FlutterError(
+            'TapRegionRegistry.of() was called with a context that does not have access to a TapRegionSurface widget.\n'
+            'The context provided to TapRegionRegistry.of() does have a TapRegionSurface widget ancestor, but it is '
+            'hidden by a LookupBoundary.\n'
+            'The context used was:\n'
+            '  $context',
+          );
+        }
         throw FlutterError(
           'TapRegionRegistry.of() was called with a context that does not contain a TapRegionSurface widget.\n'
           'No TapRegionSurface widget ancestor could be found starting from the context that was passed to '
@@ -63,10 +73,10 @@ abstract class TapRegionRegistry {
     return registry!;
   }
 
-  /// Allows finding of the nearest [TapRegionRegistry], such as a
-  /// [RenderTapRegionSurface].
+  /// Allows finding of the nearest [TapRegionRegistry] within the closest
+  /// [LookupBoundary], such as a [RenderTapRegionSurface].
   static TapRegionRegistry? maybeOf(BuildContext context) {
-    return context.findAncestorRenderObjectOfType<RenderTapRegionSurface>();
+    return LookupBoundary.findAncestorRenderObjectOfType<RenderTapRegionSurface>(context);
   }
 }
 

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -375,4 +375,55 @@ void main() {
         ]));
     tappedOutside.clear();
   });
+
+  group('LookupBoundary', () {
+    testWidgets('hides TapRegionRegistry from TapRegionRegistry.maybeOf', (WidgetTester tester) async {
+      TapRegionRegistry? registry;
+
+      await tester.pumpWidget(
+        TapRegionSurface(
+          child: LookupBoundary(
+            child: Builder(
+              builder: (BuildContext context) {
+                registry = TapRegionRegistry.maybeOf(context);
+                return Container();
+              },
+            ),
+          ),
+        ),
+      );
+
+      expect(registry, isNull);
+    });
+
+    testWidgets('hides TapRegionRegistry from TapRegionRegistry.of', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TapRegionSurface(
+          child: LookupBoundary(
+            child: Builder(
+              builder: (BuildContext context) {
+                TapRegionRegistry.of(context);
+                return Container();
+              },
+            ),
+          ),
+        ),
+      );
+      final Object? exception = tester.takeException();
+      expect(exception, isFlutterError);
+      final FlutterError error = exception! as FlutterError;
+
+      expect(
+        error.toStringDeep(),
+        'FlutterError\n'
+        '   TapRegionRegistry.of() was called with a context that does not\n'
+        '   have access to a TapRegionSurface widget.\n'
+        '   The context provided to TapRegionRegistry.of() does have a\n'
+        '   TapRegionSurface widget ancestor, but it is hidden by a\n'
+        '   LookupBoundary.\n'
+        '   The context used was:\n'
+        '     Builder(dirty)\n'
+      );
+    });
+  });
 }


### PR DESCRIPTION
~Blocked on https://github.com/flutter/flutter/pull/116736 and https://github.com/flutter/flutter/pull/116741.~

TapRegionRegistry.of and TapRegionRegistry.maybeOf cannot find TapRegionRegistry that are past a lookup boundary.