### PR TITLE
[web] Maintain text selection state in semantics config

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1326,6 +1326,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   @override
   void describeSemanticsConfiguration(SemanticsConfiguration config) {
     super.describeSemanticsConfiguration(config);
+    final bool isValidSelection = selection?.isValid ?? false;
     _semanticsInfo = _textPainter.text!.getSemanticsInformation();
     // TODO(chunhtai): the macOS does not provide a public API to support text
     // selections across multiple semantics nodes. Remove this platform check
@@ -1381,8 +1382,11 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
       config.onSetText = _handleSetText;
     }
 
-    if (selectionEnabled && (selection?.isValid ?? false)) {
+    if (isValidSelection) {
       config.textSelection = selection;
+    }
+
+    if (selectionEnabled && isValidSelection) {
       if (_textPainter.getOffsetBefore(selection!.extentOffset) != null) {
         config
           ..onMoveCursorBackwardByWord = _handleMoveCursorBackwardByWord

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -1725,6 +1725,31 @@ void main() {
     editable.forceLine = false;
     expect(editable.computeDryLayout(constraints).width, lessThan(initialWidth));
   });
+
+  test(
+      'does not lose semantics config text selection state when interactive selection is disabled',
+      () {
+    final TextSelectionDelegate delegate = _FakeEditableTextState();
+    final SemanticsConfiguration config = SemanticsConfiguration();
+    const TextSelection textSelection = TextSelection.collapsed(offset: 3);
+    final RenderEditable editable = RenderEditable(
+      text: const TextSpan(
+        style: TextStyle(height: 1.0, fontSize: 10.0, fontFamily: 'Ahem'),
+        text: 'A',
+      ),
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+      textDirection: TextDirection.ltr,
+      offset: ViewportOffset.fixed(10.0),
+      textSelectionDelegate: delegate,
+      enableInteractiveSelection: false, // disabling interactive selection
+      selection: textSelection,
+    );
+
+    expect(config.textSelection, null);
+    editable.describeSemanticsConfiguration(config);
+    expect(config.textSelection, textSelection);
+  });
 }
 
 class _TestRenderEditable extends RenderEditable {


### PR DESCRIPTION
When `enableInteractiveSelection` is disabled, we don't maintain `textSelection` state when setting up the semantics config.  In semantic mode for web, we derive the `selectionBase` and `selectionExtent` from semantic updates, so we need to preserve this state even when `enableInteractiveSelection` is disabled. 

Fixes https://github.com/flutter/flutter/issues/107634

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.