### PR TITLE
Bump dartdoc to 6.1.4

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 6.1.3
+    "$DART" pub global activate dartdoc 6.1.4
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
Includes the fix for enter not opening full-page search results (https://github.com/dart-lang/dartdoc/issues/3172) as well as [some other improvements](https://pub.dev/packages/dartdoc/changelog#614).

