### PR TITLE
Pass drone_dimensions as part of the main target.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4690,8 +4690,8 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-    dimensions: ["cpu=arm64"]
-
+    dimensions:
+      cpu: "arm64"
 
   - name: Windows flutter_packaging
     recipe: packaging_v2/packaging_v2

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4690,8 +4690,7 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-    drone_dimensions: >
-      ["cpu=arm64"]
+    dimensions: ["cpu=arm64"]
 
 
   - name: Windows flutter_packaging

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -4690,8 +4690,8 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-      drone_dimensions: >
-        ["cpu=arm64"]
+    drone_dimensions: >
+      ["cpu=arm64"]
 
 
   - name: Windows flutter_packaging


### PR DESCRIPTION
Drone dimensions were passed as properties when the sharding utility is expecting them in the target.

Bug: https://github.com/flutter/flutter/issues/116794

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
