### PR TITLE
[flutter_tools] Ensure service worker starts caching assets since first load 

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -382,9 +382,8 @@ Future<void> runWebServiceWorkerTest({
       'index.html': 2,
       if (shouldExpectFlutterJs)
         'flutter.js': 1,
-      // We still download some resources multiple times if the server is non-caching.
-      'main.dart.js': 2,
-      'assets/FontManifest.json': 2,
+      'main.dart.js': 1,
+      'assets/FontManifest.json': 1,
       'flutter_service_worker.js': 1,
       'assets/AssetManifest.json': 1,
       'assets/fonts/MaterialIcons-Regular.otf': 1,
@@ -413,7 +412,6 @@ Future<void> runWebServiceWorkerTest({
       if (shouldExpectFlutterJs)
         'flutter.js': 1,
       'flutter_service_worker.js': 1,
-      'assets/fonts/MaterialIcons-Regular.otf': 1,
       'CLOSE': 1,
       if (!headless)
         'manifest.json': 1,
@@ -439,10 +437,9 @@ Future<void> runWebServiceWorkerTest({
       if (shouldExpectFlutterJs)
         'flutter.js': 1,
       'flutter_service_worker.js': 2,
-      'main.dart.js': 2,
+      'main.dart.js': 1,
       'assets/AssetManifest.json': 1,
-      'assets/FontManifest.json': 2,
-      'assets/fonts/MaterialIcons-Regular.otf': 1,
+      'assets/FontManifest.json': 1,
       'CLOSE': 1,
       if (!headless)
         ...<String, int>{

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_service_worker_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_service_worker_js.dart
@@ -70,6 +70,7 @@ self.addEventListener("activate", function(event) {
         await caches.delete(TEMP);
         // Save the manifest to make future upgrades efficient.
         await manifestCache.put('manifest', new Response(JSON.stringify(RESOURCES)));
+        self.clients.claim();
         return;
       }
       var oldManifest = await manifest.json();
@@ -95,6 +96,7 @@ self.addEventListener("activate", function(event) {
       await caches.delete(TEMP);
       // Save the manifest to make future upgrades efficient.
       await manifestCache.put('manifest', new Response(JSON.stringify(RESOURCES)));
+      self.clients.claim();
       return;
     } catch (err) {
       // On an unhandled exception the state of the cache cannot be guaranteed.

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_service_worker_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_service_worker_js.dart
@@ -97,6 +97,7 @@ self.addEventListener("activate", function(event) {
       await caches.delete(TEMP);
       // Save the manifest to make future upgrades efficient.
       await manifestCache.put('manifest', new Response(JSON.stringify(RESOURCES)));
+      // Claim client to enable caching on first launch
       self.clients.claim();
       return;
     } catch (err) {

--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_service_worker_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_service_worker_js.dart
@@ -70,6 +70,7 @@ self.addEventListener("activate", function(event) {
         await caches.delete(TEMP);
         // Save the manifest to make future upgrades efficient.
         await manifestCache.put('manifest', new Response(JSON.stringify(RESOURCES)));
+        // Claim client to enable caching on first launch
         self.clients.claim();
         return;
       }


### PR DESCRIPTION
As a performance improvement, this PR ensure service worker starts caching assets since the very first load by calling `self.clients.claim()`,

Fixes: https://github.com/flutter/flutter/issues/115336

This is how the service worker behaves now:
- Load page for the first time, and service worker gets installed
- Request asset cat.jpg and service worker caches it right away
- Load the page for the 2nd time and it must be taken from the cache.

https://user-images.githubusercontent.com/79719460/201992435-843172da-3f5e-4904-afd5-e8c53b47853f.mp4

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I updated existing tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat