### PR TITLE
fix: #110342 unable to update rich text widget gesture recognizer

### DIFF
--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -139,6 +139,8 @@ class RenderParagraph extends RenderBox
         return;
       case RenderComparison.metadata:
         _textPainter.text = value;
+        _cachedCombinedSemanticsInfos = null;
+        markNeedsSemanticsUpdate();
         break;
       case RenderComparison.paint:
         _textPainter.text = value;

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -136,8 +136,10 @@ class RenderParagraph extends RenderBox
     assert(value != null);
     switch (_textPainter.text!.compareTo(value)) {
       case RenderComparison.identical:
-      case RenderComparison.metadata:
         return;
+      case RenderComparison.metadata:
+        _textPainter.text = value;
+        break;
       case RenderComparison.paint:
         _textPainter.text = value;
         _cachedAttributedLabel = null;

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1303,15 +1303,15 @@ void main() {
   test('can just update the gesture recognizer', () async {
     final TapGestureRecognizer recognizerBefore = TapGestureRecognizer();
     final RenderParagraph paragraph = RenderParagraph(
-         TextSpan(text: 'How are you \n', recognizer: recognizerBefore),
-         textDirection: TextDirection.ltr,
-      );
-      layout(paragraph);
-      expect(recognizerBefore, (paragraph.text as TextSpan).recognizer);
-      final TapGestureRecognizer recognizerAfter = TapGestureRecognizer();
-      paragraph.text = TextSpan(text: 'How are you \n', recognizer: recognizerAfter);
-      pumpFrame(phase: EnginePhase.paint);
-      expect(recognizerAfter, (paragraph.text as TextSpan).recognizer);
+      TextSpan(text: 'How are you \n', recognizer: recognizerBefore),
+      textDirection: TextDirection.ltr,
+    );
+    layout(paragraph);
+    expect((paragraph.text as TextSpan).recognizer, same(recognizerBefore));
+    final TapGestureRecognizer recognizerAfter = TapGestureRecognizer();
+    paragraph.text = TextSpan(text: 'How are you \n', recognizer: recognizerAfter);
+    pumpFrame(phase: EnginePhase.paint);
+    expect((paragraph.text as TextSpan).recognizer, same(recognizerAfter));
   });
 }
 

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1299,6 +1299,20 @@ void main() {
       expect(selection.end, 31);
     });
   });
+
+  test('can just update the gesture recognizer', () async {
+    final TapGestureRecognizer recognizerBefore = TapGestureRecognizer();
+    final RenderParagraph paragraph = RenderParagraph(
+         TextSpan(text: 'How are you \n', recognizer: recognizerBefore),
+         textDirection: TextDirection.ltr,
+      );
+      layout(paragraph);
+      expect(recognizerBefore, (paragraph.text as TextSpan).recognizer);
+      final TapGestureRecognizer recognizerAfter = TapGestureRecognizer();
+      paragraph.text = TextSpan(text: 'How are you \n', recognizer: recognizerAfter);
+      pumpFrame(phase: EnginePhase.paint);
+      expect(recognizerAfter, (paragraph.text as TextSpan).recognizer);
+  });
 }
 
 class MockCanvas extends Fake implements Canvas {

--- a/packages/flutter/test/rendering/paragraph_test.dart
+++ b/packages/flutter/test/rendering/paragraph_test.dart
@@ -1301,17 +1301,51 @@ void main() {
   });
 
   test('can just update the gesture recognizer', () async {
-    final TapGestureRecognizer recognizerBefore = TapGestureRecognizer();
+    final TapGestureRecognizer recognizerBefore = TapGestureRecognizer()..onTap = () {};
     final RenderParagraph paragraph = RenderParagraph(
       TextSpan(text: 'How are you \n', recognizer: recognizerBefore),
       textDirection: TextDirection.ltr,
     );
+
+    int semanticsUpdateCount = 0;
+    TestRenderingFlutterBinding.instance.pipelineOwner.ensureSemantics(
+      listener: () {
+        ++semanticsUpdateCount;
+      },
+    );
+
     layout(paragraph);
+
     expect((paragraph.text as TextSpan).recognizer, same(recognizerBefore));
-    final TapGestureRecognizer recognizerAfter = TapGestureRecognizer();
+    final SemanticsNode nodeBefore = SemanticsNode();
+    paragraph.assembleSemanticsNode(nodeBefore, SemanticsConfiguration(), <SemanticsNode>[]);
+    expect(semanticsUpdateCount, 0);
+    List<SemanticsNode> children = <SemanticsNode>[];
+    nodeBefore.visitChildren((SemanticsNode child) {
+      children.add(child);
+      return true;
+    });
+    SemanticsData data = children.single.getSemanticsData();
+    expect(data.hasAction(SemanticsAction.longPress), false);
+    expect(data.hasAction(SemanticsAction.tap), true);
+
+    final LongPressGestureRecognizer recognizerAfter = LongPressGestureRecognizer()..onLongPress = () {};
     paragraph.text = TextSpan(text: 'How are you \n', recognizer: recognizerAfter);
-    pumpFrame(phase: EnginePhase.paint);
+
+    pumpFrame(phase: EnginePhase.flushSemantics);
+
     expect((paragraph.text as TextSpan).recognizer, same(recognizerAfter));
+    final SemanticsNode nodeAfter = SemanticsNode();
+    paragraph.assembleSemanticsNode(nodeAfter, SemanticsConfiguration(), <SemanticsNode>[]);
+    expect(semanticsUpdateCount, 1);
+    children = <SemanticsNode>[];
+    nodeAfter.visitChildren((SemanticsNode child) {
+      children.add(child);
+      return true;
+    });
+    data = children.single.getSemanticsData();
+    expect(data.hasAction(SemanticsAction.longPress), true);
+    expect(data.hasAction(SemanticsAction.tap), false);
   });
 }
 


### PR DESCRIPTION
In the `compare to` function of `text_span.dart`, if only the value of the gesture recognizer changes in both `textspan`, this function returns `RenderComparison.metadata`. However, in `paragraph.dart`, there is no change made to the metadata change. So it is not possible to update only the gesture of Richtext.

Resolves #110342.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
