### PR TITLE
[flutter_tools] Update DAP progress when waiting for Dart Debug extension connection

### DIFF
--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -18,6 +18,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     required FileSystem fileSystem,
     required Platform platform,
     bool simulateAppStarted = true,
+    FutureOr<void> Function(MockFlutterDebugAdapter adapter)? preAppStart,
   }) {
     final StreamController<List<int>> stdinController = StreamController<List<int>>();
     final StreamController<List<int>> stdoutController = StreamController<List<int>>();
@@ -30,6 +31,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
       fileSystem: fileSystem,
       platform: platform,
       simulateAppStarted: simulateAppStarted,
+      preAppStart: preAppStart,
     );
   }
 
@@ -39,6 +41,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     required super.fileSystem,
     required super.platform,
     this.simulateAppStarted = true,
+    this.preAppStart,
   }) {
     clientChannel.listen((ProtocolMessage message) {
       _handleDapToClientMessage(message);
@@ -48,13 +51,24 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   int _seq = 1;
   final ByteStreamServerChannel clientChannel;
   final bool simulateAppStarted;
+  final FutureOr<void> Function(MockFlutterDebugAdapter adapter)? preAppStart;
 
   late String executable;
   late List<String> processArgs;
   late Map<String, String>? env;
 
-  /// A list of all messages sent from the adapter back to the client.
-  final List<Map<String, Object?>> dapToClientMessages = <Map<String, Object?>>[];
+  final StreamController<Map<String, Object?>> _dapToClientMessagesController = StreamController<Map<String, Object?>>.broadcast();
+
+  /// A stream of all messages sent from the adapter back to the client.
+  Stream<Map<String, Object?>> get dapToClientMessages => _dapToClientMessagesController.stream;
+
+  /// A stream of all progress events sent from the adapter back to the client.
+  Stream<Map<String, Object?>> get dapToClientProgressEvents {
+    const List<String> progressEventTypes = <String>['progressStart', 'progressUpdate', 'progressEnd'];
+
+    return dapToClientMessages
+        .where((Map<String, Object?> message) => progressEventTypes.contains(message['event'] as String?));
+  }
 
   /// A list of all messages sent from the adapter to the `flutter run` processes `stdin`.
   final List<Map<String, Object?>> dapToFlutterMessages = <Map<String, Object?>>[];
@@ -79,6 +93,8 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     this.processArgs = processArgs;
     this.env = env;
 
+    await preAppStart?.call(this);
+
     // Simulate the app starting by triggering handling of events that Flutter
     // would usually write to stdout.
     if (simulateAppStarted) {
@@ -96,7 +112,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
 
   /// Handles messages sent from the debug adapter back to the client.
   void _handleDapToClientMessage(ProtocolMessage message) {
-    dapToClientMessages.add(message.toJson());
+    _dapToClientMessagesController.add(message.toJson());
 
     // Pretend to be the client, delegating any reverse-requests to the relevant
     // handler that is provided by the test.
@@ -131,10 +147,20 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
 
   /// Simulates a message emitted by the `flutter run` process by directly
   /// calling the debug adapters [handleStdout] method.
+  ///
+  /// Use [simulateRawStdout] to simulate non-daemon text output.
   void simulateStdoutMessage(Map<String, Object?> message) {
     // Messages are wrapped in a list because Flutter only processes messages
     // wrapped in brackets.
     handleStdout(jsonEncode(<Object?>[message]));
+  }
+
+  /// Simulates a string emitted by the `flutter run` process by directly
+  /// calling the debug adapters [handleStdout] method.
+  ///
+  /// Use [simulateStdoutMessage] to simulate a daemon JSON message.
+  void simulateRawStdout(String output) {
+    handleStdout(output);
   }
 
   @override


### PR DESCRIPTION
When using the Web-Server device, it's easy to miss the text stating that Flutter is waiting for a Dart Debug Extension connection (if in verbose mode, it can scroll off the window because more output is printed, but you might also run with the Debug Console not visible).

In the legacy DAP, we'd detect this message and update the progress notification so this was clearer. This change makes the new SDK DAP do the same thing - when the relevant text is printed, we update the existing launch progress to make it clearer we're waiting on the user and not for the build (see bottom right of screenshot).

![Screenshot 2022-12-12 at 13 25 53](https://user-images.githubusercontent.com/1078012/207087124-bb3249e4-16a5-4423-a558-5394858f8185.png)

@christopherfujino my only slight concern with how this works is that if the text changes, this could fail. We could add a specific event to the `flutter run` daemon for this, but it might be overkill. Another option would be to try and put this text somewhere in a constant that both `flutter run` and the DAP could both use directly?

Fixes https://github.com/Dart-Code/Dart-Code/issues/4293.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
