### PR TITLE
Fix "flutter pub get" output test

### DIFF
--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -211,7 +211,7 @@ void main() {
       expect(mockStdio.stdout.writes.map(utf8.decode),
         allOf(
           contains(matches(RegExp(r'Resolving dependencies in .+flutter_project\.\.\.'))),
-          contains(matches(RegExp(r'\+ flutter 0.0.0 from sdk flutter\n'))),
+          contains(matches(RegExp(r'\+ flutter 0\.0\.0 from sdk flutter'))),
           contains(matches(RegExp(r'Changed \d+ dependencies in .+flutter_project!'))),
         ),
       );


### PR DESCRIPTION
Example failure: https://ci.chromium.org/ui/p/flutter/builders/try/Windows%20tool_tests_commands/18936/overview

```
09:00 +675: test\commands.shard\permeable\packages_test.dart: packages get/upgrade get fetches packages and has output from pub
Expected: (contains match 'Resolving dependencies in .+flutter_project\.\.\.' and contains match '\+ flutter 0.0.0 from sdk flutter\n' and contains match 'Changed \d+ dependencies in .+flutter_project!')
  Actual: MappedListIterable<List<int>, String>:[
            'Resolving dependencies in ..\\..\\..\\..\\t\\flutter_tools.f5d139ca\\flutter_tools_packages_test.50c1f047\\flutter_project...\n'
              '',
            '+ async 2.10.0',
            '\n'
              '+ boolean_selector 2.1.1\n'
              '+ characters 1.2.1\n'
              '+ clock 1.1.1\n'
              '+ collection 1.17.0\n'
              '+ cupertino_icons 1.0.5\n'
              '+ fake_async 1.3.1\n'
              '+ flutter 0.0.0 from sdk flutter',
            '\n'
              '+ flutter_lints 2.0.1\n'
              '+ flutter_test 0.0.0 from sdk flutter\n'
              '+ js 0.6.5\n'
              '+ lints 2.0.1\n'
              '+ matcher 0.12.13',
            '\n'
              '',
            '+ material_color_utilities 0.2.0',
            '\n'
              '+ meta 1.8.0',
            '\n'
              '+ path 1.8.2 (1.8.3 available)\n'
              '+ sky_engine 0.0.99 from sdk flutter\n'
              '+ source_span 1.9.1',
            '\n'
              '+ stack_trace 1.11.0\n'
              '+ stream_channel 2.1.1\n'
              '',
            '+ string_scanner 1.2.0\n'
              '+ term_glyph 1.2.1\n'
              '+ test_api 0.4.16 (0.4.17 available)\n'
              '',
            '+ vector_math 2.1.4\n'
              '',
            'Changed 24 dependencies in ..\\..\\..\\..\\t\\flutter_tools.f5d139ca\\flutter_tools_packages_test.50c1f047\\flutter_project!',
            '\n'
              ''
          ]

#0      fail (package:test_api/src/expect/expect.dart:134:31)
#1      _expect (package:test_api/src/expect/expect.dart:129:3)
#2      expect (package:test_api/src/expect/expect.dart:46:3)
#3      main.<anonymous closure>.<anonymous closure> (file:///C:/b/s/w/ir/x/w/flutter/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart:211:7)
<asynchronous suspension>
#4      testUsingContext.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure>.<anonymous closure> (file:///C:/b/s/w/ir/x/w/flutter/packages/flutter_tools/test/src/context.dart:138:26)
<asynchronous suspension>
#5      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
<asynchronous suspension>
#6      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
<asynchronous suspension>
#7      AppContext.run.<anonymous closure> (package:flutter_tools/src/base/context.dart:150:19)
<asynchronous suspension>
#8      testUsingContext.<anonymous closure> (file:///C:/b/s/w/ir/x/w/flutter/packages/flutter_tools/test/src/context.dart:100:5)
<asynchronous suspension>
#9      Declarer.test.<anonymous closure>.<anonymous closure> (package:test_api/src/backend/declarer.dart:215:9)
<asynchronous suspension>
#10     Declarer.test.<anonymous closure> (package:test_api/src/backend/declarer.dart:213:7)
<asynchronous suspension>
#11     Invoker._waitForOutstandingCallbacks.<anonymous closure> (package:test_api/src/backend/invoker.dart:257:7)
<asynchronous suspension>

09:02 +675 -1: test\commands.shard\permeable\packages_test.dart: packages get/upgrade get fetches packages and has output from pub [E]
  Expected: (contains match 'Resolving dependencies in .+flutter_project\.\.\.' and contains match '\+ flutter 0.0.0 from sdk flutter\n' and contains match 'Changed \d+ dependencies in .+flutter_project!')
    Actual: MappedListIterable<List<int>, String>:[
              'Resolving dependencies in ..\\..\\..\\..\\t\\flutter_tools.f5d139ca\\flutter_tools_packages_test.50c1f047\\flutter_project...\n'
                '',
              '+ async 2.10.0',
              '\n'
                '+ boolean_selector 2.1.1\n'
                '+ characters 1.2.1\n'
                '+ clock 1.1.1\n'
                '+ collection 1.17.0\n'
                '+ cupertino_icons 1.0.5\n'
                '+ fake_async 1.3.1\n'
                '+ flutter 0.0.0 from sdk flutter',
              '\n'
                '+ flutter_lints 2.0.1\n'
                '+ flutter_test 0.0.0 from sdk flutter\n'
                '+ js 0.6.5\n'
                '+ lints 2.0.1\n'
                '+ matcher 0.12.13',
              '\n'
                '',
              '+ material_color_utilities 0.2.0',
              '\n'
                '+ meta 1.8.0',
              '\n'
                '+ path 1.8.2 (1.8.3 available)\n'
                '+ sky_engine 0.0.99 from sdk flutter\n'
                '+ source_span 1.9.1',
              '\n'
                '+ stack_trace 1.11.0\n'
                '+ stream_channel 2.1.1\n'
                '',
              '+ string_scanner 1.2.0\n'
                '+ term_glyph 1.2.1\n'
                '+ test_api 0.4.16 (0.4.17 available)\n'
                '',
              '+ vector_math 2.1.4\n'
                '',
              'Changed 24 dependencies in ..\\..\\..\\..\\t\\flutter_tools.f5d139ca\\flutter_tools_packages_test.50c1f047\\flutter_project!',
              '\n'
                ''
            ]
  
  package:test_api                                        expect
  test\commands.shard\permeable\packages_test.dart 211:7  main.<fn>.<fn>
  ===== asynchronous gap ===========================
  test\src\context.dart 138:26                            testUsingContext.<fn>.<fn>.<fn>.<fn>.<fn>
  ===== asynchronous gap ===========================
  package:flutter_tools/src/base/context.dart 150:19      AppContext.run.<fn>
  ===== asynchronous gap ===========================
  package:flutter_tools/src/base/context.dart 150:19      AppContext.run.<fn>
  ===== asynchronous gap ===========================
  package:flutter_tools/src/base/context.dart 150:19      AppContext.run.<fn>
  ===== asynchronous gap ===========================
  test\src\context.dart 100:5                             testUsingContext.<fn>
```

Introduced by https://github.com/flutter/flutter/pull/115801