### PR TITLE
Add preferredSizeFor so inherited widgets can influence sizing

### DIFF
--- a/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
+++ b/packages/flutter/lib/src/cupertino/bottom_tab_bar.dart
@@ -145,6 +145,9 @@ class CupertinoTabBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Size get preferredSize => Size.fromHeight(height);
 
+  @override
+  Size preferredSizeFor(BuildContext context) => preferredSize;
+
   /// Indicates whether the tab bar is fully opaque or can have contents behind
   /// it show through it.
   bool opaque(BuildContext context) {

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -431,6 +431,9 @@ class CupertinoNavigationBar extends StatefulWidget implements ObstructingPrefer
   }
 
   @override
+  Size preferredSizeFor(BuildContext context) => preferredSize;
+
+  @override
   State<CupertinoNavigationBar> createState() => _CupertinoNavigationBarState();
 }
 

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -240,7 +240,7 @@ class AppBar extends StatefulWidget implements PreferredSizeWidget {
   )
   static double preferredHeightFor(BuildContext context, Size preferredSize) {
     if (preferredSize is _PreferredAppBarSize && preferredSize.toolbarHeight == null) {
-      return (AppBarTheme.of(context).toolbarHeight ?? kToolbarHeight) + (preferredSize.bottom?.preferredSize.height ?? 0);
+      return (AppBarTheme.of(context).toolbarHeight ?? kToolbarHeight) + (preferredSize.bottom?.preferredSizeFor(context).height ?? 0);
     }
     return preferredSize.height;
   }

--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -194,7 +194,7 @@ class AppBarTheme with Diagnosticable {
   ///
   /// See also:
   ///
-  ///  * [AppBar.preferredHeightFor], which computes the overall
+  ///  * [AppBar.preferredSizeFor], which computes the overall
   ///    height of an AppBar widget, taking this value into account.
   final double? toolbarHeight;
 

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2794,7 +2794,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
 
     if (widget.appBar != null) {
       final double topPadding = widget.primary ? MediaQuery.paddingOf(context).top : 0.0;
-      _appBarMaxHeight = AppBar.preferredHeightFor(context, widget.appBar!.preferredSize) + topPadding;
+      _appBarMaxHeight = widget.appBar!.preferredSizeFor(context).height + topPadding;
       assert(_appBarMaxHeight! >= 0.0 && _appBarMaxHeight!.isFinite);
       _addIfNonNull(
         children,

--- a/packages/flutter/lib/src/widgets/preferred_size.dart
+++ b/packages/flutter/lib/src/widgets/preferred_size.dart
@@ -34,6 +34,16 @@ abstract class PreferredSizeWidget implements Widget {
   /// height. In that case implementations of this method can just return
   /// `Size.fromHeight(myAppBarHeight)`.
   Size get preferredSize;
+
+  /// Allows subclasses to return a preferred size with access to the current
+  /// [BuildContext].
+  ///
+  /// This method allows for inherited widgets to influence the preferred size
+  /// of the widget. For example, the [AppBar] uses this method to allow the
+  /// [AppBarTheme] to designate the preferred size.
+  ///
+  /// By default, this will return the current [preferredSize].
+  Size preferredSizeFor(BuildContext context) => preferredSize;
 }
 
 /// A widget with a preferred size.
@@ -80,6 +90,9 @@ class PreferredSize extends StatelessWidget implements PreferredSizeWidget {
 
   @override
   final Size preferredSize;
+
+  @override
+  Size preferredSizeFor(BuildContext context) => preferredSize;
 
   @override
   Widget build(BuildContext context) => child;

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3651,6 +3651,7 @@ void main() {
   testWidgets('AppBar.preferredHeightFor', (WidgetTester tester) async {
     late double preferredHeight;
     late Size preferredSize;
+    late Size preferredContextSize;
 
     Widget buildFrame({ double? themeToolbarHeight, double? appBarToolbarHeight }) {
       final AppBar appBar = AppBar(
@@ -3666,6 +3667,7 @@ void main() {
           builder: (BuildContext context) {
             preferredHeight = AppBar.preferredHeightFor(context, appBar.preferredSize);
             preferredSize = appBar.preferredSize;
+            preferredContextSize = appBar.preferredSizeFor(context);
             return Scaffold(
               appBar: appBar,
               body: const Placeholder(),
@@ -3679,6 +3681,7 @@ void main() {
     expect(tester.getSize(find.byType(AppBar)).height, kToolbarHeight);
     expect(preferredHeight, kToolbarHeight);
     expect(preferredSize.height, kToolbarHeight);
+    expect(preferredContextSize.height, kToolbarHeight);
 
     await tester.pumpWidget(buildFrame(themeToolbarHeight: 96));
     await tester.pumpAndSettle(); // Animate MaterialApp theme change.
@@ -3687,18 +3690,21 @@ void main() {
     // Special case: AppBarTheme.toolbarHeight specified,
     // AppBar.theme.toolbarHeight is null.
     expect(preferredSize.height, kToolbarHeight);
+    expect(preferredContextSize.height, 96);
 
     await tester.pumpWidget(buildFrame(appBarToolbarHeight: 64));
     await tester.pumpAndSettle(); // Animate MaterialApp theme change.
     expect(tester.getSize(find.byType(AppBar)).height, 64);
     expect(preferredHeight, 64);
     expect(preferredSize.height, 64);
+    expect(preferredContextSize.height, 64);
 
     await tester.pumpWidget(buildFrame(appBarToolbarHeight: 64, themeToolbarHeight: 96));
     await tester.pumpAndSettle(); // Animate MaterialApp theme change.
     expect(tester.getSize(find.byType(AppBar)).height, 64);
     expect(preferredHeight, 64);
     expect(preferredSize.height, 64);
+    expect(preferredContextSize.height, 64);
   });
 
   testWidgets('AppBar title with actions should have the same position regardless of centerTitle', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/preferred_size_test.dart
+++ b/packages/flutter/test/widgets/preferred_size_test.dart
@@ -1,0 +1,28 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('PreferredSize default', (WidgetTester tester) async {
+    final PreferredSize widget = PreferredSize(
+      preferredSize: const Size.square(100),
+      child: Container(color: const Color(0x00FF00FF))
+    );
+    late final Size size;
+
+    await tester.pumpWidget(
+      Builder(
+        builder: (BuildContext context) {
+          size = widget.preferredSizeFor(context);
+          return SizedBox.fromSize(size: size);
+        },
+      ),
+    );
+
+    expect(size, const Size.square(100));
+    expect(widget.preferredSize, const Size.square(100));
+  });
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/116136

Adds the ability to use a BuildContext for preferredSize in widgets that are influenced by a theme, like ThemeData.useMaterial3.
This is done by using the similar implementation in AppBar, where AppBar.preferredHeightFor allows the AppBarTheme to influence the preferredSize.

That method is deprecated here, since this adds `preferredSizeFor` to the super class. This allows all subclasses to take advantage of the same idea.

This has been carried through to the Tab and TabBar widgets, which motivated this. The new M3 spec has new preferred sizes, and rather than making a hard break (and especially since the spec will inevitable change in the future), this facilitates a backwards compatible migration for now and future updates.

Dart fixes did not work for the deprecated API here, so I filed for follow up:
- https://github.com/dart-lang/sdk/issues/50698
- https://github.com/dart-lang/sdk/issues/50699


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
