### PR TITLE
Audit `covariant` usage in tool

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device.dart
+++ b/packages/flutter_tools/lib/src/android/android_device.dart
@@ -366,7 +366,7 @@ class AndroidDevice extends Device {
 
   @override
   Future<bool> isAppInstalled(
-    AndroidApk app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async {
     // This call takes 400ms - 600ms.
@@ -388,14 +388,14 @@ class AndroidDevice extends Device {
   }
 
   @override
-  Future<bool> isLatestBuildInstalled(AndroidApk app) async {
+  Future<bool> isLatestBuildInstalled(covariant AndroidApk app) async {
     final String installedSha1 = await _getDeviceApkSha1(app);
     return installedSha1.isNotEmpty && installedSha1 == _getSourceSha1(app);
   }
 
   @override
   Future<bool> installApp(
-    AndroidApk app, {
+    covariant AndroidApk app, {
     String? userIdentifier,
   }) async {
     if (!await _adbIsValid) {
@@ -478,7 +478,7 @@ class AndroidDevice extends Device {
 
   @override
   Future<bool> uninstallApp(
-    AndroidApk app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async {
     if (!await _adbIsValid) {
@@ -519,7 +519,7 @@ class AndroidDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    AndroidApk package, {
+    AndroidApk? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -721,11 +721,11 @@ class AndroidDevice extends Device {
 
   @override
   Future<bool> stopApp(
-    AndroidApk? app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
-  }) {
+  }) async {
     if (app == null) {
-      return Future<bool>.value(false);
+      return false;
     }
     final List<String> command = adbCommandForDevice(<String>[
       'shell',
@@ -767,7 +767,7 @@ class AndroidDevice extends Device {
 
   @override
   FutureOr<DeviceLogReader> getLogReader({
-    AndroidApk? app,
+    ApplicationPackage? app,
     bool includePastLogs = false,
   }) async {
     // The Android log reader isn't app-specific. The `app` parameter isn't used.

--- a/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
+++ b/packages/flutter_tools/lib/src/custom_devices/custom_device.dart
@@ -475,7 +475,7 @@ class CustomDevice extends Device {
   @override
   final DevicePortForwarder portForwarder;
 
-  CustomDeviceAppSession _getOrCreateAppSession(covariant ApplicationPackage app) {
+  CustomDeviceAppSession _getOrCreateAppSession(ApplicationPackage app) {
     return _sessions.putIfAbsent(
       app,
       () {
@@ -663,7 +663,7 @@ class CustomDevice extends Device {
 
   @override
   FutureOr<DeviceLogReader> getLogReader({
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     bool includePastLogs = false
   }) {
     if (app != null) {
@@ -674,7 +674,7 @@ class CustomDevice extends Device {
   }
 
   @override
-  Future<bool> installApp(covariant ApplicationPackage app, {String? userIdentifier}) async {
+  Future<bool> installApp(ApplicationPackage app, {String? userIdentifier}) async {
     final String? appName = app.name;
     if (appName == null || !await tryUninstall(appName: appName)) {
       return false;
@@ -689,12 +689,12 @@ class CustomDevice extends Device {
   }
 
   @override
-  Future<bool> isAppInstalled(covariant ApplicationPackage app, {String? userIdentifier}) async {
+  Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async {
     return false;
   }
 
   @override
-  Future<bool> isLatestBuildInstalled(covariant ApplicationPackage app) async {
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async {
     return false;
   }
 
@@ -742,7 +742,7 @@ class CustomDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant ApplicationPackage package, {
+    ApplicationPackage package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -796,7 +796,10 @@ class CustomDevice extends Device {
   }
 
   @override
-  Future<bool> stopApp(covariant ApplicationPackage app, {String? userIdentifier}) {
+  Future<bool> stopApp(ApplicationPackage? app, {String? userIdentifier}) async {
+    if (app == null) {
+      return false;
+    }
     return _getOrCreateAppSession(app).stop();
   }
 
@@ -804,7 +807,7 @@ class CustomDevice extends Device {
   Future<TargetPlatform> get targetPlatform async => _config.platform ?? TargetPlatform.linux_arm64;
 
   @override
-  Future<bool> uninstallApp(covariant ApplicationPackage app, {String? userIdentifier}) async {
+  Future<bool> uninstallApp(ApplicationPackage app, {String? userIdentifier}) async {
     final String? appName = app.name;
     if (appName == null) {
       return false;

--- a/packages/flutter_tools/lib/src/desktop_device.dart
+++ b/packages/flutter_tools/lib/src/desktop_device.dart
@@ -44,7 +44,7 @@ abstract class DesktopDevice extends Device {
   final DesktopLogReader _deviceLogReader = DesktopLogReader();
 
   @override
-  DevFSWriter createDevFSWriter(covariant ApplicationPackage? app, String? userIdentifier) {
+  DevFSWriter createDevFSWriter(ApplicationPackage? app, String? userIdentifier) {
     return LocalDevFSWriter(fileSystem: _fileSystem);
   }
 
@@ -117,7 +117,6 @@ abstract class DesktopDevice extends Device {
   }) async {
     if (!prebuiltApplication) {
       await buildForDevice(
-        package,
         buildInfo: debuggingOptions.buildInfo,
         mainPath: mainPath,
       );
@@ -179,7 +178,7 @@ abstract class DesktopDevice extends Device {
 
   @override
   Future<bool> stopApp(
-    ApplicationPackage app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     bool succeeded = true;
@@ -197,8 +196,7 @@ abstract class DesktopDevice extends Device {
   }
 
   /// Builds the current project for this device, with the given options.
-  Future<void> buildForDevice(
-    ApplicationPackage package, {
+  Future<void> buildForDevice({
     required BuildInfo buildInfo,
     String? mainPath,
   });

--- a/packages/flutter_tools/lib/src/device.dart
+++ b/packages/flutter_tools/lib/src/device.dart
@@ -470,18 +470,18 @@ abstract class Device {
   ///
   /// Specify [userIdentifier] to check if installed for a particular user (Android only).
   Future<bool> isAppInstalled(
-    covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   });
 
   /// Check if the latest build of the [app] is already installed.
-  Future<bool> isLatestBuildInstalled(covariant ApplicationPackage app);
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app);
 
   /// Install an app package on the current device.
   ///
   /// Specify [userIdentifier] to install for a particular user (Android only).
   Future<bool> installApp(
-    covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   });
 
@@ -490,7 +490,7 @@ abstract class Device {
   /// Specify [userIdentifier] to uninstall for a particular user,
   /// defaults to all users (Android only).
   Future<bool> uninstallApp(
-    covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   });
 
@@ -516,7 +516,7 @@ abstract class Device {
   /// For example, the desktop device classes can use a writer which
   /// copies the files across the local file system.
   DevFSWriter? createDevFSWriter(
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     String? userIdentifier,
   ) {
     return null;
@@ -531,7 +531,7 @@ abstract class Device {
   /// reader will also include log messages from before the invocation time.
   /// Defaults to false.
   FutureOr<DeviceLogReader> getLogReader({
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     bool includePastLogs = false,
   });
 
@@ -583,7 +583,7 @@ abstract class Device {
   ///
   /// Specify [userIdentifier] to stop app installed to a profile (Android only).
   Future<bool> stopApp(
-    covariant ApplicationPackage? app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   });
 

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -171,12 +171,13 @@ class FlutterDriverService extends DriverService {
       buildInfo: buildInfo,
       applicationBinary: applicationBinary,
     );
+    final ApplicationPackage? package = _applicationPackage;
     int attempt = 0;
     LaunchResult? result;
     bool prebuiltApplication = applicationBinary != null;
-    while (attempt < _kLaunchAttempts) {
+    while (attempt < _kLaunchAttempts && package != null) {
       result = await device.startApp(
-        _applicationPackage,
+        package,
         mainPath: mainPath,
         route: route,
         debuggingOptions: debuggingOptions,
@@ -296,11 +297,12 @@ class FlutterDriverService extends DriverService {
       await sharedSkSlWriter(_device!, result, outputFile: writeSkslOnExit, logger: _logger);
     }
     // If the application package is available, stop and uninstall.
-    if (_applicationPackage != null) {
-      if (!await _device!.stopApp(_applicationPackage, userIdentifier: userIdentifier)) {
+    final ApplicationPackage? package = _applicationPackage;
+    if (package != null) {
+      if (!await _device!.stopApp(package, userIdentifier: userIdentifier)) {
         _logger.printError('Failed to stop app');
       }
-      if (!await _device!.uninstallApp(_applicationPackage!, userIdentifier: userIdentifier)) {
+      if (!await _device!.uninstallApp(package, userIdentifier: userIdentifier)) {
         _logger.printError('Failed to uninstall app');
       }
     } else if (_device!.supportsFlutterExit) {

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -171,13 +171,12 @@ class FlutterDriverService extends DriverService {
       buildInfo: buildInfo,
       applicationBinary: applicationBinary,
     );
-    final ApplicationPackage? package = _applicationPackage;
     int attempt = 0;
     LaunchResult? result;
     bool prebuiltApplication = applicationBinary != null;
-    while (attempt < _kLaunchAttempts && package != null) {
+    while (attempt < _kLaunchAttempts) {
       result = await device.startApp(
-        package,
+        _applicationPackage,
         mainPath: mainPath,
         route: route,
         debuggingOptions: debuggingOptions,

--- a/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
+++ b/packages/flutter_tools/lib/src/fuchsia/fuchsia_device.dart
@@ -293,7 +293,7 @@ class FuchsiaDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant FuchsiaApp package, {
+    FuchsiaApp package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -471,7 +471,7 @@ class FuchsiaDevice extends Device {
 
   @override
   Future<bool> stopApp(
-    covariant FuchsiaApp app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     if (await isSession) {

--- a/packages/flutter_tools/lib/src/ios/devices.dart
+++ b/packages/flutter_tools/lib/src/ios/devices.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 import 'package:process/process.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
+import '../application_package.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../base/logger.dart';
@@ -225,7 +226,7 @@ class IOSDevice extends Device {
 
   @override
   Future<bool> isAppInstalled(
-    IOSApp app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async {
     bool result;
@@ -242,11 +243,11 @@ class IOSDevice extends Device {
   }
 
   @override
-  Future<bool> isLatestBuildInstalled(IOSApp app) async => false;
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
 
   @override
   Future<bool> installApp(
-    IOSApp app, {
+    covariant IOSApp app, {
     String? userIdentifier,
   }) async {
     final Directory bundle = _fileSystem.directory(app.deviceBundlePath);
@@ -280,7 +281,7 @@ class IOSDevice extends Device {
 
   @override
   Future<bool> uninstallApp(
-    IOSApp app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async {
     int uninstallationResult;
@@ -434,7 +435,7 @@ class IOSDevice extends Device {
 
   @override
   Future<bool> stopApp(
-    IOSApp app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     // If the debugger is not attached, killing the ios-deploy process won't stop the app.
@@ -453,7 +454,7 @@ class IOSDevice extends Device {
 
   @override
   DeviceLogReader getLogReader({
-    IOSApp? app,
+    covariant IOSApp? app,
     bool includePastLogs = false,
   }) {
     assert(!includePastLogs, 'Past log reading not supported on iOS devices.');

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -327,7 +327,7 @@ class IOSSimulator extends Device {
   final SimControl _simControl;
 
   @override
-  DevFSWriter createDevFSWriter(covariant ApplicationPackage? app, String? userIdentifier) {
+  DevFSWriter createDevFSWriter(ApplicationPackage? app, String? userIdentifier) {
     return LocalDevFSWriter(fileSystem: globals.fs);
   }
 
@@ -369,8 +369,7 @@ class IOSSimulator extends Device {
     String? userIdentifier,
   }) async {
     try {
-      final IOSApp iosApp = app;
-      await _simControl.install(id, iosApp.simulatorBundlePath);
+      await _simControl.install(id, app.simulatorBundlePath);
       return true;
     } on Exception {
       return false;
@@ -420,7 +419,7 @@ class IOSSimulator extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant IOSApp package, {
+    IOSApp package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -506,7 +505,7 @@ class IOSSimulator extends Device {
     return LaunchResult.failed();
   }
 
-  Future<void> _setupUpdatedApplicationBundle(covariant BuildableIOSApp app, BuildInfo buildInfo, String? mainPath) async {
+  Future<void> _setupUpdatedApplicationBundle(BuildableIOSApp app, BuildInfo buildInfo, String? mainPath) async {
     // Step 1: Build the Xcode project.
     // The build mode for the simulator is always debug.
     assert(buildInfo.isDebug);
@@ -574,7 +573,7 @@ class IOSSimulator extends Device {
 
   @override
   DeviceLogReader getLogReader({
-    IOSApp? app,
+    covariant IOSApp? app,
     bool includePastLogs = false,
   }) {
     assert(!includePastLogs, 'Past log reading not supported on iOS simulators.');

--- a/packages/flutter_tools/lib/src/linux/linux_device.dart
+++ b/packages/flutter_tools/lib/src/linux/linux_device.dart
@@ -57,8 +57,7 @@ class LinuxDevice extends DesktopDevice {
   }
 
   @override
-  Future<void> buildForDevice(
-    covariant LinuxApp package, {
+  Future<void> buildForDevice({
     String? mainPath,
     required BuildInfo buildInfo,
   }) async {

--- a/packages/flutter_tools/lib/src/macos/macos_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_device.dart
@@ -65,8 +65,7 @@ class MacOSDevice extends DesktopDevice {
   }
 
   @override
-  Future<void> buildForDevice(
-    covariant MacOSApp package, {
+  Future<void> buildForDevice({
     required BuildInfo buildInfo,
     String? mainPath,
   }) async {

--- a/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
+++ b/packages/flutter_tools/lib/src/macos/macos_ipad_device.dart
@@ -14,7 +14,6 @@ import '../base/platform.dart';
 import '../build_info.dart';
 import '../desktop_device.dart';
 import '../device.dart';
-import '../ios/application_package.dart';
 import '../ios/ios_workflow.dart';
 import '../project.dart';
 
@@ -59,7 +58,7 @@ class MacOSDesignedForIPadDevice extends DesktopDevice {
 
   @override
   Future<LaunchResult> startApp(
-    IOSApp package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -74,13 +73,12 @@ class MacOSDesignedForIPadDevice extends DesktopDevice {
 
   @override
   Future<bool> stopApp(
-    IOSApp app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async => false;
 
   @override
-  Future<void> buildForDevice(
-    covariant IOSApp package, {
+  Future<void> buildForDevice({
     String? mainPath,
     required BuildInfo buildInfo,
   }) async {

--- a/packages/flutter_tools/lib/src/preview_device.dart
+++ b/packages/flutter_tools/lib/src/preview_device.dart
@@ -65,16 +65,16 @@ class PreviewDevice extends Device {
   final DesktopLogReader _logReader = DesktopLogReader();
 
   @override
-  FutureOr<DeviceLogReader> getLogReader({covariant ApplicationPackage? app, bool includePastLogs = false}) => _logReader;
+  FutureOr<DeviceLogReader> getLogReader({ApplicationPackage? app, bool includePastLogs = false}) => _logReader;
 
   @override
-  Future<bool> installApp(covariant ApplicationPackage? app, {String? userIdentifier}) async => true;
+  Future<bool> installApp(ApplicationPackage? app, {String? userIdentifier}) async => true;
 
   @override
-  Future<bool> isAppInstalled(covariant ApplicationPackage app, {String? userIdentifier}) async => false;
+  Future<bool> isAppInstalled(ApplicationPackage app, {String? userIdentifier}) async => false;
 
   @override
-  Future<bool> isLatestBuildInstalled(covariant ApplicationPackage app) async => false;
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) async => false;
 
   @override
   Future<bool> get isLocalEmulator async => false;
@@ -97,7 +97,7 @@ class PreviewDevice extends Device {
   Process? _process;
 
   @override
-  Future<LaunchResult> startApp(covariant ApplicationPackage package, {
+  Future<LaunchResult> startApp(ApplicationPackage? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -163,7 +163,7 @@ class PreviewDevice extends Device {
   }
 
   @override
-  Future<bool> stopApp(covariant ApplicationPackage app, {String? userIdentifier}) async {
+  Future<bool> stopApp(ApplicationPackage? app, {String? userIdentifier}) async {
     return _process?.kill() ?? false;
   }
 
@@ -176,12 +176,12 @@ class PreviewDevice extends Device {
   }
 
   @override
-  Future<bool> uninstallApp(covariant ApplicationPackage app, {String? userIdentifier}) async {
+  Future<bool> uninstallApp(ApplicationPackage app, {String? userIdentifier}) async {
     return true;
   }
 
   @override
-  DevFSWriter createDevFSWriter(covariant ApplicationPackage? app, String? userIdentifier) {
+  DevFSWriter createDevFSWriter(ApplicationPackage? app, String? userIdentifier) {
     return LocalDevFSWriter(fileSystem: _fileSystem);
   }
 }

--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -172,22 +172,22 @@ class ProxiedDevice extends Device {
 
   @override
   Future<bool> isAppInstalled(
-    covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) => throw UnimplementedError();
 
   @override
-  Future<bool> isLatestBuildInstalled(covariant ApplicationPackage app) => throw UnimplementedError();
+  Future<bool> isLatestBuildInstalled(ApplicationPackage app) => throw UnimplementedError();
 
   @override
   Future<bool> installApp(
-    covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) => throw UnimplementedError();
 
   @override
   Future<bool> uninstallApp(
-    covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) => throw UnimplementedError();
 
@@ -224,7 +224,7 @@ class ProxiedDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant PrebuiltApplicationPackage package, {
+    PrebuiltApplicationPackage package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -424,8 +424,9 @@ class FlutterDevice {
       buildInfo: hotRunner.debuggingOptions.buildInfo,
       applicationBinary: hotRunner.applicationBinary,
     );
+    final ApplicationPackage? applicationPackage = package;
 
-    if (package == null) {
+    if (applicationPackage == null) {
       String message = 'No application found for $targetPlatform.';
       final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null) {
@@ -434,7 +435,7 @@ class FlutterDevice {
       globals.printError(message);
       return 1;
     }
-    devFSWriter = device!.createDevFSWriter(package, userIdentifier);
+    devFSWriter = device!.createDevFSWriter(applicationPackage, userIdentifier);
 
     final Map<String, dynamic> platformArgs = <String, dynamic>{
       'multidex': hotRunner.multidexEnabled,
@@ -444,7 +445,7 @@ class FlutterDevice {
 
     // Start the application.
     final Future<LaunchResult> futureResult = device!.startApp(
-      package,
+      applicationPackage,
       mainPath: hotRunner.mainPath,
       debuggingOptions: hotRunner.debuggingOptions,
       platformArgs: platformArgs,
@@ -483,24 +484,9 @@ class FlutterDevice {
       buildInfo: coldRunner.debuggingOptions.buildInfo,
       applicationBinary: coldRunner.applicationBinary,
     );
-    devFSWriter = device!.createDevFSWriter(package, userIdentifier);
+    final ApplicationPackage? applicationPackage = package;
 
-    final String modeName = coldRunner.debuggingOptions.buildInfo.friendlyModeName;
-    final bool prebuiltMode = coldRunner.applicationBinary != null;
-    if (coldRunner.mainPath == null) {
-      assert(prebuiltMode);
-      globals.printStatus(
-        'Launching ${package!.displayName} '
-        'on ${device!.name} in $modeName mode...',
-      );
-    } else {
-      globals.printStatus(
-        'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
-        'on ${device!.name} in $modeName mode...',
-      );
-    }
-
-    if (package == null) {
+    if (applicationPackage == null) {
       String message = 'No application found for $targetPlatform.';
       final String? hint = await getMissingPackageHintForPlatform(targetPlatform);
       if (hint != null) {
@@ -508,6 +494,23 @@ class FlutterDevice {
       }
       globals.printError(message);
       return 1;
+    }
+
+    devFSWriter = device!.createDevFSWriter(applicationPackage, userIdentifier);
+
+    final String modeName = coldRunner.debuggingOptions.buildInfo.friendlyModeName;
+    final bool prebuiltMode = coldRunner.applicationBinary != null;
+    if (coldRunner.mainPath == null) {
+      assert(prebuiltMode);
+      globals.printStatus(
+        'Launching ${applicationPackage.displayName} '
+        'on ${device!.name} in $modeName mode...',
+      );
+    } else {
+      globals.printStatus(
+        'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
+        'on ${device!.name} in $modeName mode...',
+      );
     }
 
     final Map<String, dynamic> platformArgs = <String, dynamic>{};
@@ -519,7 +522,7 @@ class FlutterDevice {
     await startEchoingDeviceLog();
 
     final LaunchResult result = await device!.startApp(
-      package,
+      applicationPackage,
       mainPath: coldRunner.mainPath,
       debuggingOptions: coldRunner.debuggingOptions,
       platformArgs: platformArgs,

--- a/packages/flutter_tools/lib/src/test/integration_test_device.dart
+++ b/packages/flutter_tools/lib/src/test/integration_test_device.dart
@@ -47,12 +47,13 @@ class IntegrationTestTestDevice implements TestDevice {
       targetPlatform,
       buildInfo: debuggingOptions.buildInfo,
     );
-    if (_applicationPackage == null) {
+    final ApplicationPackage? package = _applicationPackage;
+    if (package == null) {
       throw TestDeviceException('No application found for $targetPlatform.', StackTrace.current);
     }
 
     final LaunchResult launchResult = await device.startApp(
-      _applicationPackage,
+      package,
       mainPath: entrypointPath,
       platformArgs: <String, dynamic>{},
       debuggingOptions: debuggingOptions,

--- a/packages/flutter_tools/lib/src/tester/flutter_tester.dart
+++ b/packages/flutter_tools/lib/src/tester/flutter_tester.dart
@@ -130,7 +130,7 @@ class FlutterTesterDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    ApplicationPackage package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,
@@ -217,7 +217,7 @@ class FlutterTesterDevice extends Device {
 
   @override
   Future<bool> stopApp(
-    ApplicationPackage app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     _process?.kill();
@@ -236,7 +236,7 @@ class FlutterTesterDevice extends Device {
 
   @override
   DevFSWriter createDevFSWriter(
-    covariant ApplicationPackage app,
+    ApplicationPackage? app,
     String? userIdentifier,
   ) {
     return LocalDevFSWriter(

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -118,7 +118,7 @@ abstract class ChromiumDevice extends Device {
 
   @override
   Future<LaunchResult> startApp(
-    WebApplicationPackage? package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     required DebuggingOptions debuggingOptions,

--- a/packages/flutter_tools/lib/src/windows/windows_device.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_device.dart
@@ -49,8 +49,7 @@ class WindowsDevice extends DesktopDevice {
   }
 
   @override
-  Future<void> buildForDevice(
-    covariant WindowsApp package, {
+  Future<void> buildForDevice({
     String? mainPath,
     required BuildInfo buildInfo,
   }) async {

--- a/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/attach_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
-import 'package:flutter_tools/src/android/application_package.dart';
+import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/common.dart';
 import 'package:flutter_tools/src/base/dds.dart';
@@ -947,7 +947,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   FutureOr<DeviceLogReader> getLogReader({
-    AndroidApk? app,
+    ApplicationPackage? app,
     bool includePastLogs = false,
   }) {
     if (onGetLogReader == null) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -10,7 +10,6 @@ import 'package:fake_async/fake_async.dart';
 import 'package:file/src/interface/file.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
-import 'package:flutter_tools/src/android/application_package.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/utils.dart';
@@ -896,7 +895,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   Future<LaunchResult> startApp(
-    AndroidApk package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     DebuggingOptions? debuggingOptions,

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -10,6 +10,7 @@ import 'package:fake_async/fake_async.dart';
 import 'package:file/src/interface/file.dart';
 import 'package:flutter_tools/src/android/android_device.dart';
 import 'package:flutter_tools/src/android/android_workflow.dart';
+import 'package:flutter_tools/src/android/application_package.dart';
 import 'package:flutter_tools/src/application_package.dart';
 import 'package:flutter_tools/src/base/logger.dart';
 import 'package:flutter_tools/src/base/utils.dart';
@@ -886,15 +887,16 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   late DeviceLogReader logReader;
   @override
   FutureOr<DeviceLogReader> getLogReader({
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     bool includePastLogs = false,
   }) => logReader;
 
   ApplicationPackage? startAppPackage;
   late LaunchResult launchResult;
+
   @override
   Future<LaunchResult> startApp(
-    ApplicationPackage package, {
+    AndroidApk package, {
     String? mainPath,
     String? route,
     DebuggingOptions? debuggingOptions,

--- a/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/install_test.dart
@@ -148,7 +148,7 @@ class FakeIOSDevice extends Fake implements IOSDevice {
 
   @override
   Future<bool> isAppInstalled(
-    IOSApp app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async => false;
 
@@ -168,7 +168,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
 
   @override
   Future<bool> isAppInstalled(
-    AndroidApk app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async => false;
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/proxied_devices_test.dart
@@ -302,7 +302,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   late DeviceLogReader logReader;
   @override
   FutureOr<DeviceLogReader> getLogReader({
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     bool includePastLogs = false,
   }) => logReader;
 
@@ -310,7 +310,7 @@ class FakeAndroidDevice extends Fake implements AndroidDevice {
   late LaunchResult launchResult;
   @override
   Future<LaunchResult> startApp(
-    ApplicationPackage package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     DebuggingOptions? debuggingOptions,

--- a/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/run_test.dart
@@ -990,7 +990,7 @@ class FakeDevice extends Fake implements Device {
 
   @override
   DevFSWriter? createDevFSWriter(
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     String? userIdentifier,
   ) {
     return null;

--- a/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/custom_devices/custom_device_test.dart
@@ -137,6 +137,7 @@ void main() {
       expect(await device.isLatestBuildInstalled(linuxApp), false);
       expect(await device.isAppInstalled(linuxApp), false);
       expect(await device.stopApp(linuxApp), false);
+      expect(await device.stopApp(null), false);
       expect(device.category, Category.mobile);
 
       expect(device.supportsRuntimeMode(BuildMode.debug), true);

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -357,8 +357,7 @@ class FakeDesktopDevice extends DesktopDevice {
   bool isSupportedForProject(FlutterProject flutterProject) => true;
 
   @override
-  Future<void> buildForDevice(
-    ApplicationPackage package, {
+  Future<void> buildForDevice({
     String? mainPath,
     BuildInfo? buildInfo,
   }) async {

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -427,11 +427,10 @@ FlutterDriverService setUpDriverService({
   ProcessManager? processManager,
   FlutterVmService? vmService,
   DevtoolsLauncher? devtoolsLauncher,
-  ApplicationPackageFactory? applicationPackageFactory,
 }) {
   logger ??= BufferLogger.test();
   return FlutterDriverService(
-    applicationPackageFactory: applicationPackageFactory ?? FakeApplicationPackageFactory(FakeApplicationPackage()),
+    applicationPackageFactory: FakeApplicationPackageFactory(FakeApplicationPackage()),
     logger: logger,
     processUtils: ProcessUtils(
       logger: logger,
@@ -472,17 +471,6 @@ class FakeApplicationPackageFactory extends Fake implements ApplicationPackageFa
     BuildInfo? buildInfo,
     File? applicationBinary,
   }) async => applicationPackage;
-}
-
-class NullFakeApplicationPackageFactory extends Fake implements ApplicationPackageFactory {
-  NullFakeApplicationPackageFactory();
-
-  @override
-  Future<ApplicationPackage?> getPackageForPlatform(
-    TargetPlatform platform, {
-    BuildInfo? buildInfo,
-    File? applicationBinary,
-  }) async => null;
 }
 
 class FakeApplicationPackage extends Fake implements ApplicationPackage { }

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -98,20 +98,6 @@ void main() {
     );
   });
 
-  testWithoutContext('Exits if package not found fails to start', () {
-    final DriverService driverService = setUpDriverService(
-      applicationPackageFactory: NullFakeApplicationPackageFactory(),
-    );
-    final Device device = FakeDevice(LaunchResult.succeeded(
-      observatoryUri: Uri.parse('http://127.0.0.1:63426/1UasC_ihpXY=/'),
-    ));
-
-    expect(
-          () => driverService.start(BuildInfo.profile, device, DebuggingOptions.enabled(BuildInfo.profile), true),
-      throwsToolExit(message: 'Application failed to start. Will not run test. Quitting.'),
-    );
-  });
-
   testWithoutContext('Retries application launch if it fails the first time', () async {
     final FakeVmServiceHost fakeVmServiceHost = FakeVmServiceHost(requests: <FakeVmServiceRequest>[
       getVM,

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -607,7 +607,7 @@ class FakeDevice extends Fake implements Device {
 
   @override
   Future<bool> stopApp(
-    covariant ApplicationPackage? app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     return true;

--- a/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/macos_ipad_device_test.dart
@@ -141,7 +141,7 @@ void main() {
       ),
       throwsA(isA<UnimplementedError>()),
     );
-    await expectLater(() => device.buildForDevice(FakeIOSApp(), buildInfo: BuildInfo.debug), throwsA(isA<UnimplementedError>()));
+    await expectLater(() => device.buildForDevice(buildInfo: BuildInfo.debug), throwsA(isA<UnimplementedError>()));
     expect(device.executablePathForDevice(FakeIOSApp(), BuildMode.debug), null);
   });
 }

--- a/packages/flutter_tools/test/general.shard/resident_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_runner_test.dart
@@ -2649,7 +2649,7 @@ class FakeDevice extends Fake implements Device {
   }
 
   @override
-  Future<bool> stopApp(covariant ApplicationPackage? app, {String? userIdentifier}) async {
+  Future<bool> stopApp(ApplicationPackage? app, {String? userIdentifier}) async {
     appStopped = true;
     return true;
   }
@@ -2664,7 +2664,7 @@ class FakeDevice extends Fake implements Device {
 
   @override
   FutureOr<DeviceLogReader> getLogReader({
-    covariant ApplicationPackage? app,
+    ApplicationPackage? app,
     bool includePastLogs = false,
   }) => NoOpDeviceLogReader(name);
 

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_cold_test.dart
@@ -189,7 +189,7 @@ class FakeWebDevice extends Fake implements Device {
 
   @override
   Future<bool> stopApp(
-    covariant ApplicationPackage? app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     return true;
@@ -197,7 +197,7 @@ class FakeWebDevice extends Fake implements Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant ApplicationPackage? package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     DebuggingOptions? debuggingOptions,

--- a/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
+++ b/packages/flutter_tools/test/general.shard/resident_web_runner_test.dart
@@ -1273,7 +1273,7 @@ class FakeDevice extends Fake implements Device {
 
   @override
   Future<LaunchResult> startApp(
-    covariant ApplicationPackage? package, {
+    ApplicationPackage? package, {
     String? mainPath,
     String? route,
     DebuggingOptions? debuggingOptions,
@@ -1287,7 +1287,7 @@ class FakeDevice extends Fake implements Device {
 
   @override
   Future<bool> stopApp(
-    covariant ApplicationPackage? app, {
+    ApplicationPackage? app, {
     String? userIdentifier,
   }) async {
     if (count > 0) {

--- a/packages/flutter_tools/test/src/fake_devices.dart
+++ b/packages/flutter_tools/test/src/fake_devices.dart
@@ -82,7 +82,7 @@ class FakeDevice extends Device {
   final String name;
 
   @override
-  Future<LaunchResult> startApp(covariant ApplicationPackage package, {
+  Future<LaunchResult> startApp(ApplicationPackage? package, {
     String? mainPath,
     String? route,
     DebuggingOptions? debuggingOptions,
@@ -93,13 +93,13 @@ class FakeDevice extends Device {
   }) async => _launchResult;
 
   @override
-  Future<bool> stopApp(covariant ApplicationPackage app, {
+  Future<bool> stopApp(ApplicationPackage? app, {
     String? userIdentifier,
   }) async => true;
 
   @override
   Future<bool> uninstallApp(
-  covariant ApplicationPackage app, {
+    ApplicationPackage app, {
     String? userIdentifier,
   }) async => true;
 


### PR DESCRIPTION
Same as https://github.com/flutter/flutter/pull/114112 but kicking google testing again.

_____
Remove `covariant` where possible to avoid subtle null safety issue.  Where it's still useful, remove from base class and push `covariant` into overrides to by-default enforce nullability where `covariant` isn't needed.

See https://dart.dev/guides/language/sound-problems#the-covariant-keyword about how this suppresses the analyzer.

> Some (rarely used) coding patterns rely on tightening a type by overriding a parameter’s type with a subtype, which is invalid. In this case, you can use the `covariant` keyword to tell the analyzer that you are doing this intentionally. This removes the static error and instead checks for an invalid argument type at runtime.

This will need a g3fix.

Note I left the `covariant` in `startApp`.  That one is really a mess since most subclasses do expect it to be non-null, but it is legitimately called as null in the web case.  I guess we can leave that one for now until it causes issues...

https://github.com/flutter/flutter/blob/156c313219a21ac97ff84fe76743c35463ef0fdb/packages/flutter_tools/lib/src/isolated/resident_web_runner.dart#L242-L245

Fixes https://github.com/flutter/flutter/issues/114090

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
