### PR TITLE
Remove duped fix rules

### DIFF
--- a/packages/flutter/lib/fix_data/fix_cupertino.yaml
+++ b/packages/flutter/lib/fix_data/fix_cupertino.yaml
@@ -18,17 +18,6 @@
 # * Fixes in this file are from the Cupertino library. *
 version: 1
 transforms:
-  # Changes made in https://github.com/flutter/flutter/pull/114459
-  - title: "Migrate to 'boldTextOf'"
-    date: 2022-10-28
-    element:
-      uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
-      method: 'boldTextOverride'
-      inClass: 'MediaQuery'
-    changes:
-      - kind: 'rename'
-        newName: 'boldTextOf'
-
   # Change made in https://github.com/flutter/flutter/pull/20649
   # TODO(Piinks): Add tests when `bulkApply:false` testing is supported, https://github.com/dart-lang/sdk/issues/44639
   - title: "Replace with 'CupertinoPopupSurface'"

--- a/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
+++ b/packages/flutter/lib/fix_data/fix_material/fix_material.yaml
@@ -25,17 +25,6 @@
 #     * ThemeData: fix_theme_data.yaml
 version: 1
 transforms:
-  # Changes made in https://github.com/flutter/flutter/pull/114459
-  - title: "Migrate to 'boldTextOf'"
-    date: 2022-10-28
-    element:
-      uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
-      method: 'boldTextOverride'
-      inClass: 'MediaQuery'
-    changes:
-      - kind: 'rename'
-        newName: 'boldTextOf'
-
   # Changes made in https://github.com/flutter/flutter/pull/15303
   - title: "Replace 'child' with 'builder'"
     date: 2020-12-17


### PR DESCRIPTION
Came across some dupes in the fix files. They can be removed since they are already defined in `fix_widgets.yaml`

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
