### PR TITLE
Fix Scaffold bottomSheet null exceptions

### DIFF
--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2223,7 +2223,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         assert(_dismissedBottomSheets.isEmpty);
       }
 
-      final Widget bottomSheet = widget.bottomSheet!;
       _currentBottomSheet = _buildBottomSheet<void>(
         (BuildContext context) {
           return NotificationListener<DraggableScrollableNotification>(
@@ -2231,7 +2230,9 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
             child: DraggableScrollableActuator(
               child: StatefulBuilder(
                 key: _currentBottomSheetKey,
-                builder: (BuildContext context, StateSetter setState) => bottomSheet,
+                builder: (BuildContext context, StateSetter setState) {
+                  return widget.bottomSheet ?? const SizedBox.shrink();
+                },
               ),
             ),
           );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2223,6 +2223,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         assert(_dismissedBottomSheets.isEmpty);
       }
 
+      Widget lastBottomSheet = widget.bottomSheet!;
       _currentBottomSheet = _buildBottomSheet<void>(
         (BuildContext context) {
           return NotificationListener<DraggableScrollableNotification>(
@@ -2231,7 +2232,11 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
               child: StatefulBuilder(
                 key: _currentBottomSheetKey,
                 builder: (BuildContext context, StateSetter setState) {
-                  return widget.bottomSheet ?? const SizedBox.shrink();
+                  if (widget.bottomSheet == null) {
+                    return lastBottomSheet;
+                  }
+                  lastBottomSheet = widget.bottomSheet!;
+                  return widget.bottomSheet!;
                 },
               ),
             ),

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2223,6 +2223,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         assert(_dismissedBottomSheets.isEmpty);
       }
 
+      final Widget bottomSheet = widget.bottomSheet!;
       _currentBottomSheet = _buildBottomSheet<void>(
         (BuildContext context) {
           return NotificationListener<DraggableScrollableNotification>(
@@ -2230,7 +2231,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
             child: DraggableScrollableActuator(
               child: StatefulBuilder(
                 key: _currentBottomSheetKey,
-                builder: (BuildContext context, StateSetter setState) => widget.bottomSheet!,
+                builder: (BuildContext context, StateSetter setState) => bottomSheet,
               ),
             ),
           );

--- a/packages/flutter/lib/src/material/scaffold.dart
+++ b/packages/flutter/lib/src/material/scaffold.dart
@@ -2223,7 +2223,6 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
         assert(_dismissedBottomSheets.isEmpty);
       }
 
-      Widget lastBottomSheet = widget.bottomSheet!;
       _currentBottomSheet = _buildBottomSheet<void>(
         (BuildContext context) {
           return NotificationListener<DraggableScrollableNotification>(
@@ -2232,11 +2231,7 @@ class ScaffoldState extends State<Scaffold> with TickerProviderStateMixin, Resto
               child: StatefulBuilder(
                 key: _currentBottomSheetKey,
                 builder: (BuildContext context, StateSetter setState) {
-                  if (widget.bottomSheet == null) {
-                    return lastBottomSheet;
-                  }
-                  lastBottomSheet = widget.bottomSheet!;
-                  return widget.bottomSheet!;
+                  return widget.bottomSheet ?? const SizedBox.shrink();
                 },
               ),
             ),

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2674,6 +2674,48 @@ void main() {
     expect(find.byKey(bottomSheetKey), findsNothing);
     expect(find.byType(StatefulBuilder), findsOneWidget);
   });
+
+  // Regression test for https://github.com/flutter/flutter/issues/117004
+  testWidgets('can rebuild and remove bottomSheet at the same time', (WidgetTester tester) async {
+    bool alternateUI = false;
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return MaterialApp(
+            theme: alternateUI ? ThemeData.light() : ThemeData.dark(),
+            home: Scaffold(
+              bottomSheet: alternateUI
+                  ? null
+                  : Container(
+                      width: double.infinity,
+                      height: 100,
+                      color: Colors.blue,
+                      child: const Text('BottomSheet'),
+                    ),
+              body: Center(
+                child: Text('$alternateUI'),
+              ),
+              floatingActionButton: FloatingActionButton(
+                onPressed: () {
+                  setState(() {
+                    alternateUI = !alternateUI;
+                  });
+                },
+                tooltip: 'Change UI',
+                child: const Icon(Icons.add),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    await tester.tap(find.byType(FloatingActionButton));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+  });
 }
 
 class _GeometryListener extends StatefulWidget {

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2626,59 +2626,6 @@ void main() {
   });
 
   // Regression test for https://github.com/flutter/flutter/issues/117004
-  testWidgets('bottomSheet is not built after being closed', (WidgetTester tester) async {
-    final Key bottomSheetKey = UniqueKey();
-    late StateSetter stateSetter;
-    bool showBottomSheet = true;
-
-    await tester.pumpWidget(MaterialApp(
-      home: StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) {
-          stateSetter = setState;
-          return Scaffold(
-            bottomSheet: showBottomSheet
-                ? Container(
-                  key: bottomSheetKey,
-                  height: 44,
-                  color: Colors.blue,
-                  child: const Text('BottomSheet'),
-                )
-                : null,
-          );
-        },
-      ),
-    ));
-
-    expect(find.byKey(bottomSheetKey), findsOneWidget);
-    expect(find.byType(StatefulBuilder), findsNWidgets(2));
-
-    // Start removing the bottom sheet.
-    stateSetter(() {
-      showBottomSheet = false;
-    });
-    await tester.pump();
-
-    // For now the bottom sheet still exists, because it animates out.
-    expect(find.byKey(bottomSheetKey), findsOneWidget);
-    expect(find.byType(StatefulBuilder), findsNWidgets(2));
-
-    // Cause the bottom sheet to rebuild.
-    final StatefulBuilder statefulBuilder = tester.widget(find.byType(StatefulBuilder).last);
-    final GlobalKey<State<StatefulWidget>> statefulBuilderKey = statefulBuilder.key! as GlobalKey<State<StatefulWidget>>;
-    statefulBuilderKey.currentState!.setState(() {}); // ignore: invalid_use_of_protected_member
-    await tester.pump();
-
-    // The rebuild does not cause an error.
-    expect(tester.takeException(), isNull);
-
-    // Allowing bottom sheet to finish its exit animation results in its being
-    // removed from the widget tree.
-    await tester.pumpAndSettle();
-    expect(find.byKey(bottomSheetKey), findsNothing);
-    expect(find.byType(StatefulBuilder), findsOneWidget);
-  });
-
-  // Regression test for https://github.com/flutter/flutter/issues/117004
   testWidgets('can rebuild and remove bottomSheet at the same time', (WidgetTester tester) async {
     bool themeIsLight = true;
     bool? defaultBottomSheet = true;


### PR DESCRIPTION
Prevents the possibility of null exceptions on `widget.bottomSheet!`.

I was unable to reproduce this "in the wild", but the test does reproduce it by directly calling `setState` on the StatefulBuilder while the bottom sheet is animating out.  Note the use of `ignore: invalid_use_of_protected_member`.

@Piinks Do you have any other ideas about how to reproduce/test this?  I think if I could get that DraggableScrollableActuator to rebuild while its animating out then it would cause the error too.  I tried many different variations of building a DraggableScrollableSheet in my `bottomSheet` and trying to scroll/resize it during the close animation, but couldn't get it to rebuild.

If there is not a better way to test it, are we ok with the `ignore` to be able to call setState?

Closes https://github.com/flutter/flutter/issues/117004