### PR TITLE
Bump Dartdoc version to 6.1.5

### DIFF
--- a/dev/bots/docs.sh
+++ b/dev/bots/docs.sh
@@ -20,7 +20,7 @@ function generate_docs() {
     # Install and activate dartdoc.
     # NOTE: When updating to a new dartdoc version, please also update
     # `dartdoc_options.yaml` to include newly introduced error and warning types.
-    "$DART" pub global activate dartdoc 6.1.4
+    "$DART" pub global activate dartdoc 6.1.5
 
     # Install and activate the snippets tool, which resides in the
     # assets-for-api-docs repo:


### PR DESCRIPTION
## Description

This bumps the Dartdoc version to 6.1.5

## Related Issues
 - https://github.com/dart-lang/dartdoc/issues/3265
 - https://github.com/dart-lang/dartdoc/issues/3204