### PR TITLE
[Android] Fix the `run_debug_test_android` device lab test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3208,8 +3208,6 @@ targets:
 
   - name: Mac_android run_debug_test_android
     recipe: devicelab/devicelab_drone
-    bringup: true
-    presubmit: false
     runIf:
       - dev/**
     timeout: 60
@@ -3220,8 +3218,6 @@ targets:
 
   - name: Mac_arm64_android run_debug_test_android
     recipe: devicelab/devicelab_drone
-    bringup: true
-    presubmit: false
     runIf:
       - dev/**
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3208,6 +3208,8 @@ targets:
 
   - name: Mac_android run_debug_test_android
     recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
     runIf:
       - dev/**
     timeout: 60
@@ -3218,6 +3220,8 @@ targets:
 
   - name: Mac_arm64_android run_debug_test_android
     recipe: devicelab/devicelab_drone
+    bringup: true
+    presubmit: false
     runIf:
       - dev/**
     timeout: 60

--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -102,28 +102,34 @@ class AndroidRunOutputTest extends RunOutputTask {
 
   @override
   TaskResult verify(List<String> stdout, List<String> stderr) {
+    final String gradleTask = release ? 'assembleRelease' : 'assembleDebug';
+    final String apk = release ? 'app-release.apk' : 'app-debug.apk';
+
     _findNextMatcherInList(
       stdout,
-      (String line) => line.startsWith('Launching lib/main.dart on ') && line.endsWith(' in release mode...'),
+      (String line) => line.startsWith('Launching lib/main.dart on ') &&
+        line.endsWith(' in ${release ? 'release' : 'debug'} mode...'),
       'Launching lib/main.dart on',
     );
 
     _findNextMatcherInList(
       stdout,
-      (String line) => line.startsWith("Running Gradle task 'assembleRelease'..."),
-      "Running Gradle task 'assembleRelease'...",
+      (String line) => line.startsWith("Running Gradle task '$gradleTask'..."),
+      "Running Gradle task '$gradleTask'...",
+    );
+
+    // Size information is only included in release builds.
+    _findNextMatcherInList(
+      stdout,
+      (String line) => line.contains('Built build/app/outputs/flutter-apk/$apk') && 
+        (!release || line.contains('MB).')),
+      'Built build/app/outputs/flutter-apk/$apk',
     );
 
     _findNextMatcherInList(
       stdout,
-      (String line) => line.contains('Built build/app/outputs/flutter-apk/app-release.apk (') && line.contains('MB).'),
-      'Built build/app/outputs/flutter-apk/app-release.apk',
-    );
-
-    _findNextMatcherInList(
-      stdout,
-      (String line) => line.startsWith('Installing build/app/outputs/flutter-apk/app-release.apk...'),
-      'Installing build/app/outputs/flutter-apk/app-release.apk...',
+      (String line) => line.startsWith('Installing build/app/outputs/flutter-apk/$apk...'),
+      'Installing build/app/outputs/flutter-apk/$apk...',
     );
 
     _findNextMatcherInList(

--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -121,7 +121,7 @@ class AndroidRunOutputTest extends RunOutputTask {
     // Size information is only included in release builds.
     _findNextMatcherInList(
       stdout,
-      (String line) => line.contains('Built build/app/outputs/flutter-apk/$apk') && 
+      (String line) => line.contains('Built build/app/outputs/flutter-apk/$apk') &&
         (!release || line.contains('MB).')),
       'Built build/app/outputs/flutter-apk/$apk',
     );


### PR DESCRIPTION
Fix the `run_debug_test_android` device lab test. I missed running this locally before merging https://github.com/flutter/flutter/pull/116798 🤦

This was tested by ensuring the following passed locally:

```
cd dev/devicelab
../../bin/cache/dart-sdk/bin/dart bin/test_runner.dart test -t run_release_test
../../bin/cache/dart-sdk/bin/dart bin/test_runner.dart test -t run_debug_test_android
```

Part of https://github.com/flutter/flutter/issues/117000

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
