### PR TITLE
Bottom App Bar M3 background color fix

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -196,6 +196,7 @@ class _BottomAppBarState extends State<BottomAppBar> {
           key: materialKey,
           type: isMaterial3 ? MaterialType.canvas : MaterialType.transparency,
           elevation: elevation,
+          color: isMaterial3 ? effectiveColor : null,
           surfaceTintColor: surfaceTintColor,
           child: child == null
             ? null

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -187,7 +187,6 @@ void main() {
                 ),
                 bottomNavigationBar: BottomAppBar(
                   color: Color(0xff0000ff),
-                  surfaceTintColor: Colors.transparent,
                 ),
               ),
             );
@@ -218,7 +217,6 @@ void main() {
                 ),
                 bottomNavigationBar: BottomAppBar(
                   color: Color(0xff0000ff),
-                  surfaceTintColor: Colors.transparent,
                 ),
               
             );

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -170,8 +170,10 @@ void main() {
 
     final PhysicalShape physicalShape =
       tester.widget(find.byType(PhysicalShape).at(0));
+    final Material material = tester.widget(find.byType(Material).at(0));
 
     expect(physicalShape.color, const Color(0xffffff00));
+   // expect(material.color, const Color(0xffffff00));
   });
 
   testWidgets('color overrides theme color', (WidgetTester tester) async {
@@ -187,6 +189,7 @@ void main() {
                 ),
                 bottomNavigationBar: BottomAppBar(
                   color: Color(0xff0000ff),
+                  surfaceTintColor: Colors.transparent,
                 ),
               ),
             );
@@ -197,8 +200,41 @@ void main() {
 
     final PhysicalShape physicalShape =
       tester.widget(find.byType(PhysicalShape).at(0));
+    final Material material = tester.widget(find.byType(Material).at(1));
 
     expect(physicalShape.color, const Color(0xff0000ff));
+    expect(material.color, null); /* no value in Material 2. */
+  });
+
+
+  testWidgets('color overrides theme color with Material 3', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.light(useMaterial3: true).copyWith(
+          bottomAppBarColor: const Color(0xffffff00)),
+        home: Builder(
+          builder: (BuildContext context) {
+            return const Scaffold(
+                floatingActionButton: FloatingActionButton(
+                  onPressed: null,
+                ),
+                bottomNavigationBar: BottomAppBar(
+                  color: Color(0xff0000ff),
+                  surfaceTintColor: Colors.transparent,
+                ),
+              
+            );
+          },
+        ),
+      ),
+    );
+
+    final PhysicalShape physicalShape =
+      tester.widget(find.byType(PhysicalShape).at(0));
+    final Material material = tester.widget(find.byType(Material).at(1));
+
+    expect(physicalShape.color, const Color(0xff0000ff));
+    expect(material.color, const Color(0xff0000ff));
   });
 
   testWidgets('dark theme applies an elevation overlay color', (WidgetTester tester) async {

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -218,7 +218,6 @@ void main() {
                 bottomNavigationBar: BottomAppBar(
                   color: Color(0xff0000ff),
                 ),
-              
             );
           },
         ),

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -170,10 +170,8 @@ void main() {
 
     final PhysicalShape physicalShape =
       tester.widget(find.byType(PhysicalShape).at(0));
-    final Material material = tester.widget(find.byType(Material).at(0));
 
     expect(physicalShape.color, const Color(0xffffff00));
-   // expect(material.color, const Color(0xffffff00));
   });
 
   testWidgets('color overrides theme color', (WidgetTester tester) async {


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/114439 introduced a small bug where on Material 3, setting the background color wouldn't take effect. This was discovered while doing an M3 migration.  I think it's due to the introduction of a Material widget which is type `canvas` if Material 3 (for tinting purposes), and this opaque widget isn't setting the desired color.

See demo pre-fix, where a Green color and Red tint have been set on the widget:

[Screen recording 2022-12-14 5.50.48 PM.webm](https://user-images.githubusercontent.com/15033982/207674574-f4b5442e-42e8-48a8-be8d-d517fbbb2425.webm)

And post-fix, with the same color values:

[Screen recording 2022-12-14 5.51.27 PM.webm](https://user-images.githubusercontent.com/15033982/207674644-25ded5ed-ffaf-46f0-9abc-2b5f87818b43.webm)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
