### PR TITLE
Defer `systemFontsDidChange` to the transientCallbacks phase

### DIFF
--- a/packages/flutter/lib/src/rendering/object.dart
+++ b/packages/flutter/lib/src/rendering/object.dart
@@ -10,6 +10,7 @@ import 'package:flutter/animation.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/painting.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 
 import 'debug.dart';
@@ -3945,12 +3946,17 @@ mixin ContainerRenderObjectMixin<ChildType extends RenderObject, ParentDataType 
 /// Mixin for [RenderObject] that will call [systemFontsDidChange] whenever the
 /// system fonts change.
 ///
-/// System fonts can change when the OS install or remove a font. Use this mixin if
-/// the [RenderObject] uses [TextPainter] or [Paragraph] to correctly update the
-/// text when it happens.
+/// System fonts can change when the OS installs or removes a font. Use this
+/// mixin if the [RenderObject] uses [TextPainter] or [Paragraph] to correctly
+/// update the text when it happens.
 mixin RelayoutWhenSystemFontsChangeMixin on RenderObject {
 
   /// A callback that is called when system fonts have changed.
+  ///
+  /// The framework defers the invocation of the callback to the
+  /// [SchedulerPhase.transientCallbacks] phase to ensure that the
+  /// [RenderObject]'s text layout is still valid when user interactions are in
+  /// progress (which usually take place during the [SchedulerPhase.idle] phase).
   ///
   /// By default, [markNeedsLayout] is called on the [RenderObject]
   /// implementing this mixin.
@@ -3963,15 +3969,44 @@ mixin RelayoutWhenSystemFontsChangeMixin on RenderObject {
     markNeedsLayout();
   }
 
+  bool _hasPendingSystemFontsDidChangeCallBack = false;
+  void _scheduleSystemFontsUpdate() {
+    assert(
+      SchedulerBinding.instance.schedulerPhase == SchedulerPhase.idle,
+      '${objectRuntimeType(this, "RelayoutWhenSystemFontsChangeMixin")}._scheduleSystemFontsUpdate() '
+      'called during ${SchedulerBinding.instance.schedulerPhase}.',
+    );
+    if (_hasPendingSystemFontsDidChangeCallBack) {
+      return;
+    }
+    _hasPendingSystemFontsDidChangeCallBack = true;
+    SchedulerBinding.instance.scheduleFrameCallback((Duration timeStamp) {
+      assert(_hasPendingSystemFontsDidChangeCallBack);
+      _hasPendingSystemFontsDidChangeCallBack = false;
+      assert(
+        attached || (debugDisposed ?? true),
+        '$this is detached during ${SchedulerBinding.instance.schedulerPhase} but is not disposed.',
+      );
+      if (attached) {
+        systemFontsDidChange();
+      }
+    });
+  }
+
   @override
-  void attach(covariant PipelineOwner owner) {
+  void attach(PipelineOwner owner) {
     super.attach(owner);
-    PaintingBinding.instance.systemFonts.addListener(systemFontsDidChange);
+    // If there's a pending callback that would imply this node was detached
+    // between the idle phase and the next transientCallbacks phase. The tree
+    // can not be mutated between those two phases so that should never happen.
+    assert(!_hasPendingSystemFontsDidChangeCallBack);
+    PaintingBinding.instance.systemFonts.addListener(_scheduleSystemFontsUpdate);
   }
 
   @override
   void detach() {
-    PaintingBinding.instance.systemFonts.removeListener(systemFontsDidChange);
+    assert(!_hasPendingSystemFontsDidChangeCallBack);
+    PaintingBinding.instance.systemFonts.removeListener(_scheduleSystemFontsUpdate);
     super.detach();
   }
 }

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -8,7 +8,6 @@ import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, Gradient, LineMetrics
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/flutter/lib/src/rendering/paragraph.dart
+++ b/packages/flutter/lib/src/rendering/paragraph.dart
@@ -650,37 +650,10 @@ class RenderParagraph extends RenderBox
     );
   }
 
-  bool _systemFontsChangeScheduled = false;
   @override
   void systemFontsDidChange() {
-    final SchedulerPhase phase = SchedulerBinding.instance.schedulerPhase;
-    switch (phase) {
-      case SchedulerPhase.idle:
-      case SchedulerPhase.postFrameCallbacks:
-        if (_systemFontsChangeScheduled) {
-          return;
-        }
-        _systemFontsChangeScheduled = true;
-        SchedulerBinding.instance.scheduleFrameCallback((Duration timeStamp) {
-          assert(_systemFontsChangeScheduled);
-          _systemFontsChangeScheduled = false;
-          assert(
-            attached || (debugDisposed ?? true),
-            '$this is detached during $phase but not disposed.',
-          );
-          if (attached) {
-            super.systemFontsDidChange();
-            _textPainter.markNeedsLayout();
-          }
-        });
-        break;
-      case SchedulerPhase.transientCallbacks:
-      case SchedulerPhase.midFrameMicrotasks:
-      case SchedulerPhase.persistentCallbacks:
-        super.systemFontsDidChange();
-        _textPainter.markNeedsLayout();
-        break;
-    }
+    super.systemFontsDidChange();
+    _textPainter.markNeedsLayout();
   }
 
   // Placeholder dimensions representing the sizes of child inline widgets.

--- a/packages/flutter/test/painting/system_fonts_test.dart
+++ b/packages/flutter/test/painting/system_fonts_test.dart
@@ -11,6 +11,30 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+Future<void> verifyMarkedNeedsLayoutDuringTransientCallbacksPhase(WidgetTester tester, RenderObject renderObject) async {
+  assert(!renderObject.debugNeedsLayout);
+
+  const Map<String, dynamic> data = <String, dynamic>{
+    'type': 'fontsChange',
+  };
+  await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    'flutter/system',
+    SystemChannels.system.codec.encodeMessage(data),
+    (ByteData? data) { },
+  );
+
+  final Completer<bool> animation = Completer<bool>();
+  tester.binding.scheduleFrameCallback((Duration timeStamp) {
+    animation.complete(renderObject.debugNeedsLayout);
+  });
+
+  // The fonts change does not mark the render object as needing layout
+  // immediately.
+  expect(renderObject.debugNeedsLayout, isFalse);
+  await tester.pump();
+  expect(await animation.future, isTrue);
+}
+
 void main() {
   testWidgets('RenderParagraph relayout upon system fonts changes', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -19,49 +43,30 @@ void main() {
       ),
     );
     final RenderObject renderObject = tester.renderObject(find.text('text widget'));
-
-    const Map<String, dynamic> data = <String, dynamic>{
-      'type': 'fontsChange',
-    };
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-      'flutter/system',
-      SystemChannels.system.codec.encodeMessage(data),
-      (ByteData? data) { },
-    );
-
-    final Completer<bool> animation = Completer<bool>();
-    tester.binding.scheduleFrameCallback((Duration timeStamp) {
-      animation.complete(renderObject.debugNeedsLayout);
-    });
-    expect(renderObject.debugNeedsLayout, isFalse);
-    await tester.pump();
-    expect(await animation.future, isTrue);
+    await verifyMarkedNeedsLayoutDuringTransientCallbacksPhase(tester, renderObject);
   });
 
-  testWidgets('Safe to query RenderParagraph for text layout after system fonts changes', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Text('text widget'),
-      ),
-    );
-    const Map<String, dynamic> data = <String, dynamic>{
-      'type': 'fontsChange',
-    };
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-      'flutter/system',
-      SystemChannels.system.codec.encodeMessage(data),
-      (ByteData? data) { },
-    );
-    final RenderParagraph paragraph = tester.renderObject<RenderParagraph>(find.text('text widget'));
-    Object? exception;
-    try {
-      paragraph.getPositionForOffset(Offset.zero);
-      paragraph.hitTest(BoxHitTestResult(), position: Offset.zero);
-    } catch (e) {
-      exception = e;
-    }
-    expect(exception, isNull);
-  });
+  testWidgets(
+    'Safe to query a RelayoutWhenSystemFontsChangeMixin for text layout after system fonts changes',
+    (WidgetTester tester) async {
+      final _RenderCustomRelayoutWhenSystemFontsChange child = _RenderCustomRelayoutWhenSystemFontsChange();
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: WidgetToRenderBoxAdapter(renderBox: child),
+        ),
+      );
+      const Map<String, dynamic> data = <String, dynamic>{
+        'type': 'fontsChange',
+      };
+      await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+        'flutter/system',
+        SystemChannels.system.codec.encodeMessage(data),
+        (ByteData? data) { },
+      );
+      expect(child.hasValidTextLayout, isTrue);
+    },
+  );
 
   testWidgets('RenderEditable relayout upon system fonts changes', (WidgetTester tester) async {
     await tester.pumpWidget(
@@ -69,16 +74,9 @@ void main() {
         home: SelectableText('text widget'),
       ),
     );
-    const Map<String, dynamic> data = <String, dynamic>{
-      'type': 'fontsChange',
-    };
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-      'flutter/system',
-      SystemChannels.system.codec.encodeMessage(data),
-        (ByteData? data) { },
-    );
+
     final EditableTextState state = tester.state(find.byType(EditableText));
-    expect(state.renderEditable.debugNeedsLayout, isTrue);
+    await verifyMarkedNeedsLayoutDuringTransientCallbacksPhase(tester, state.renderEditable);
   });
 
   testWidgets('Banner repaint upon system fonts changes', (WidgetTester tester) async {
@@ -210,11 +208,8 @@ void main() {
       SystemChannels.system.codec.encodeMessage(data),
         (ByteData? data) { },
     );
-    final RenderObject renderObject = tester.renderObject(find.byType(RangeSlider));
-
-    late bool sliderBoxNeedsLayout;
-    renderObject.visitChildren((RenderObject child) {sliderBoxNeedsLayout = child.debugNeedsLayout;});
-    expect(sliderBoxNeedsLayout, isTrue);
+    final RenderObject renderObject = tester.renderObject(find.byWidgetPredicate((Widget widget) => widget.runtimeType.toString() == '_RangeSliderRenderObjectWidget'));
+    await verifyMarkedNeedsLayoutDuringTransientCallbacksPhase(tester, renderObject);
   });
 
   testWidgets('Slider relayout upon system fonts changes', (WidgetTester tester) async {
@@ -228,17 +223,9 @@ void main() {
         ),
       ),
     );
-    const Map<String, dynamic> data = <String, dynamic>{
-      'type': 'fontsChange',
-    };
-    await ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
-      'flutter/system',
-      SystemChannels.system.codec.encodeMessage(data),
-        (ByteData? data) { },
-    );
     // _RenderSlider is the last render object in the tree.
     final RenderObject renderObject = tester.allRenderObjects.last;
-    expect(renderObject.debugNeedsLayout, isTrue);
+    await verifyMarkedNeedsLayoutDuringTransientCallbacksPhase(tester, renderObject);
   });
 
   testWidgets('TimePicker relayout upon system fonts changes', (WidgetTester tester) async {
@@ -288,4 +275,20 @@ void main() {
     );
     expect(renderObject.debugNeedsPaint, isTrue);
   });
+}
+
+class _RenderCustomRelayoutWhenSystemFontsChange extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
+  bool hasValidTextLayout = false;
+
+  @override
+  void systemFontsDidChange() {
+    super.systemFontsDidChange();
+    hasValidTextLayout = false;
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+    hasValidTextLayout = true;
+  }
 }


### PR DESCRIPTION
https://paste.googleplex.com/5721253343133696 shows that a `RenderEditable.systemFontsDidChange` call invalidated a text painter and it threw during hit-test. 

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
