### PR TITLE
[web] Allow shift + left/right keyboard shortcuts to be handled by framework on web

### DIFF
--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -420,8 +420,6 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
     SingleActivator(LogicalKeyboardKey.arrowUp, meta: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, meta: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, meta: true): DoNothingAndStopPropagationTextIntent(),
-    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true): DoNothingAndStopPropagationTextIntent(),
-    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.pageUp, shift: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.pageDown, shift: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.end, shift: true): DoNothingAndStopPropagationTextIntent(),
@@ -452,6 +450,8 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
     const SingleActivator(LogicalKeyboardKey.tab, shift: true): const DoNothingAndStopPropagationTextIntent(),
     const SingleActivator(LogicalKeyboardKey.arrowDown, shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true): const DoNothingAndStopPropagationTextIntent(),
   };
 
   // Hand backspace/delete events that do not depend on text layout (delete

--- a/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
+++ b/packages/flutter/lib/src/widgets/default_text_editing_shortcuts.dart
@@ -412,14 +412,10 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
     SingleActivator(LogicalKeyboardKey.arrowLeft, alt: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowRight, alt: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowUp, alt: true): DoNothingAndStopPropagationTextIntent(),
-    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true): DoNothingAndStopPropagationTextIntent(),
-    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, alt: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowDown, meta: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowLeft, meta: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowRight, meta: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.arrowUp, meta: true): DoNothingAndStopPropagationTextIntent(),
-    SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, meta: true): DoNothingAndStopPropagationTextIntent(),
-    SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, meta: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.pageUp, shift: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.pageDown, shift: true): DoNothingAndStopPropagationTextIntent(),
     SingleActivator(LogicalKeyboardKey.end, shift: true): DoNothingAndStopPropagationTextIntent(),
@@ -452,6 +448,10 @@ class DefaultTextEditingShortcuts extends StatelessWidget {
     const SingleActivator(LogicalKeyboardKey.arrowUp, shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
     const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true): const DoNothingAndStopPropagationTextIntent(),
     const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, alt: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowLeft, shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
+    const SingleActivator(LogicalKeyboardKey.arrowRight, shift: true, meta: true): const DoNothingAndStopPropagationTextIntent(),
   };
 
   // Hand backspace/delete events that do not depend on text layout (delete

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -2357,5 +2357,53 @@ void main() {
         reason: selectRight.toString(),
       );
     }, variant: TargetPlatformVariant.desktop());
+
+    testWidgets('select all left', (WidgetTester tester) async {
+      final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
+      final SingleActivator selectAllLeft = isMacOS
+          ? const SingleActivator(LogicalKeyboardKey.arrowLeft,
+              shift: true, meta: true)
+          : const SingleActivator(LogicalKeyboardKey.arrowLeft,
+              shift: true, alt: true);
+      controller.text = 'testing';
+      controller.selection = const TextSelection.collapsed(
+        offset: 5,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, selectAllLeft);
+      await tester.pump();
+
+      expect(controller.text, 'testing');
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 5, extentOffset: 0),
+        reason: selectAllLeft.toString(),
+      );
+    }, variant: TargetPlatformVariant.desktop());
+
+    testWidgets('select all right', (WidgetTester tester) async {
+      final bool isMacOS = defaultTargetPlatform == TargetPlatform.macOS;
+      final SingleActivator selectAllRight = isMacOS
+          ? const SingleActivator(LogicalKeyboardKey.arrowRight,
+              shift: true, meta: true)
+          : const SingleActivator(LogicalKeyboardKey.arrowRight,
+              shift: true, alt: true);
+      controller.text = 'testing';
+      controller.selection = const TextSelection.collapsed(
+        offset: 5,
+      );
+
+      await tester.pumpWidget(buildEditableText());
+      await sendKeyCombination(tester, selectAllRight);
+      await tester.pump();
+
+      expect(controller.text, 'testing');
+      expect(
+        controller.selection,
+        const TextSelection(baseOffset: 5, extentOffset: 7),
+        reason: selectAllRight.toString(),
+      );
+    }, variant: TargetPlatformVariant.desktop());
   }, skip: !kIsWeb); // [intended] specific tests target web.
 }

--- a/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
+++ b/packages/flutter/test/widgets/editable_text_shortcuts_test.dart
@@ -57,7 +57,7 @@ void main() {
     bool readOnly = false,
     bool obscured = false,
     TextStyle style = const TextStyle(fontSize: 10.0),
-      bool enableInteractiveSelection = true
+    bool enableInteractiveSelection = true
   }) {
     return MaterialApp(
       home: Align(


### PR DESCRIPTION
When `enableInteractiveSelection` is set to `false`, users shouldn't be able to highlight/expand text selection in the given TextFields.  This currently works as expected with pointer events, but keyboard shortcuts still allow text selection to be expanded on the web.  This is inconsistent with how it behaves on other platforms where keyboard shortcuts come into play such as Desktop. 

Fixes https://github.com/flutter/flutter/issues/117165

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
