### PR TITLE
Use the name of errors, not the diagnostic messages.

### DIFF
--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -231,7 +231,7 @@ void main() {
         'Analyzing',
         'unused_element',
         'only_throw_errors',
-        'missing_required_param'
+        'missing_required_param',
       ],
       exitMessageContains: '3 issues found.',
       exitCode: 1,

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -229,9 +229,9 @@ void main() {
       arguments: <String>['analyze', '--no-pub'],
       statusTextContains: <String>[
         'Analyzing',
-        "info $analyzerSeparator The declaration '_incrementCounter' isn't",
-        'info $analyzerSeparator Only throw instances of classes extending either Exception or Error',
-        "warning $analyzerSeparator The parameter 'onPressed' is required",
+        'unused_element',
+        'only_throw_errors',
+        'missing_required_param'
       ],
       exitMessageContains: '3 issues found.',
       exitCode: 1,


### PR DESCRIPTION
This resolves some issues we were having with this engine roll: https://github.com/flutter/flutter/pull/117225