### PR TITLE
Reland iOS 16 context menu

### DIFF
--- a/packages/flutter/lib/src/cupertino/colors.dart
+++ b/packages/flutter/lib/src/cupertino/colors.dart
@@ -990,7 +990,7 @@ class CupertinoDynamicColor extends Color with Diagnosticable {
   CupertinoDynamicColor resolveFrom(BuildContext context) {
     Brightness brightness = Brightness.light;
     if (_isPlatformBrightnessDependent) {
-      brightness =  CupertinoTheme.maybeBrightnessOf(context) ?? Brightness.light;
+      brightness = CupertinoTheme.maybeBrightnessOf(context) ?? Brightness.light;
     }
     bool isHighContrastEnabled = false;
     if (_isHighContrastDependent) {

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -143,8 +143,8 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
       anchor: anchor,
       isAbove: isAbove,
       child: DecoratedBox(
-        decoration: const BoxDecoration(
-          color: _kToolbarDividerColor,
+        decoration: BoxDecoration(
+          color: _kToolbarDividerColor.resolveFrom(context),
         ),
         child: child,
       ),

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar.dart
@@ -5,11 +5,13 @@
 import 'dart:collection';
 import 'dart:ui' as ui;
 
-import 'package:flutter/foundation.dart' show clampDouble;
+import 'package:flutter/foundation.dart' show Brightness, clampDouble;
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import 'colors.dart';
 import 'text_selection_toolbar_button.dart';
+import 'theme.dart';
 
 // Values extracted from https://developer.apple.com/design/resources/.
 // The height of the toolbar, including the arrow.
@@ -29,9 +31,27 @@ const double _kArrowScreenPadding = 26.0;
 // Values extracted from https://developer.apple.com/design/resources/.
 const Radius _kToolbarBorderRadius = Radius.circular(8);
 
-// Colors extracted from https://developer.apple.com/design/resources/.
-// TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/41507.
-const Color _kToolbarDividerColor = Color(0xFF808080);
+const CupertinoDynamicColor _kToolbarDividerColor = CupertinoDynamicColor.withBrightness(
+  // This value was extracted from a screenshot of iOS 16.0.3, as light mode
+  // didn't appear in the Apple design resources assets linked below.
+  color: Color(0xFFB6B6B6),
+  // Color extracted from https://developer.apple.com/design/resources/.
+  // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/41507.
+  darkColor: Color(0xFF808080),
+);
+
+// These values were extracted from a screenshot of iOS 16.0.3, as light mode
+// didn't appear in the Apple design resources assets linked above.
+final BoxDecoration _kToolbarShadow = BoxDecoration(
+  borderRadius: const BorderRadius.all(_kToolbarBorderRadius),
+  boxShadow: <BoxShadow>[
+    BoxShadow(
+      color: CupertinoColors.black.withOpacity(0.1),
+      blurRadius: 16.0,
+      offset: Offset(0, _kToolbarArrowSize.height / 2),
+    ),
+  ],
+);
 
 /// The type for a Function that builds a toolbar's container with the given
 /// child.
@@ -119,13 +139,22 @@ class CupertinoTextSelectionToolbar extends StatelessWidget {
   // Builds a toolbar just like the default iOS toolbar, with the right color
   // background and a rounded cutout with an arrow.
   static Widget _defaultToolbarBuilder(BuildContext context, Offset anchor, bool isAbove, Widget child) {
-    return _CupertinoTextSelectionToolbarShape(
+    final Widget outputChild = _CupertinoTextSelectionToolbarShape(
       anchor: anchor,
       isAbove: isAbove,
       child: DecoratedBox(
-        decoration: const BoxDecoration(color: _kToolbarDividerColor),
+        decoration: const BoxDecoration(
+          color: _kToolbarDividerColor,
+        ),
         child: child,
       ),
+    );
+    if (CupertinoTheme.brightnessOf(context) == Brightness.dark) {
+      return outputChild;
+    }
+    return DecoratedBox(
+      decoration: _kToolbarShadow,
+      child: outputChild,
     );
   }
 
@@ -225,7 +254,6 @@ class _RenderCupertinoTextSelectionToolbarShape extends RenderShiftedBox {
     this._isAbove,
     super.child,
   );
-
 
   @override
   bool get isRepaintBoundary => true;
@@ -485,7 +513,7 @@ class _CupertinoTextSelectionToolbarContentState extends State<_CupertinoTextSel
           onPressed: _handleNextPage,
           text: '▶',
         ),
-        nextButtonDisabled: CupertinoTextSelectionToolbarButton.text(
+        nextButtonDisabled: const CupertinoTextSelectionToolbarButton.text(
           text: '▶',
         ),
         children: widget.children,

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
@@ -21,8 +21,8 @@ const TextStyle _kToolbarButtonFontStyle = TextStyle(
 const CupertinoDynamicColor _kToolbarBackgroundColor = CupertinoDynamicColor.withBrightness(
   // This value was extracted from a screenshot of iOS 16.0.3, as light mode
   // didn't appear in the Apple design resources assets linked above.
-  color: Color(0xEB202020),
-  darkColor: Color(0xEBF7F7F7),
+  color: Color(0xEBF7F7F7),
+  darkColor: Color(0xEB202020),
 );
 
 const CupertinoDynamicColor _kToolbarTextColor = CupertinoDynamicColor.withBrightness(

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
@@ -18,7 +18,17 @@ const TextStyle _kToolbarButtonFontStyle = TextStyle(
 
 // Colors extracted from https://developer.apple.com/design/resources/.
 // TODO(LongCatIsLooong): https://github.com/flutter/flutter/issues/41507.
-const Color _kToolbarBackgroundColor = Color(0xEB202020);
+const CupertinoDynamicColor _kToolbarBackgroundColor = CupertinoDynamicColor.withBrightness(
+  // This value was extracted from a screenshot of iOS 16.0.3, as light mode
+  // didn't appear in the Apple design resources assets linked above.
+  color: Color(0xEB202020),
+  darkColor: Color(0xEBF7F7F7),
+);
+
+const CupertinoDynamicColor _kToolbarTextColor = CupertinoDynamicColor.withBrightness(
+  color: CupertinoColors.black,
+  darkColor: CupertinoColors.white,
+);
 
 // Eyeballed value.
 const EdgeInsets _kToolbarButtonPadding = EdgeInsets.symmetric(vertical: 16.0, horizontal: 18.0);
@@ -33,22 +43,17 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
     this.onPressed,
     required Widget this.child,
   }) : assert(child != null),
+       text = null,
        buttonItem = null;
 
   /// Create an instance of [CupertinoTextSelectionToolbarButton] whose child is
   /// a [Text] widget styled like the default iOS text selection toolbar button.
-  CupertinoTextSelectionToolbarButton.text({
+  const CupertinoTextSelectionToolbarButton.text({
     super.key,
     this.onPressed,
-    required String text,
+    required this.text,
   }) : buttonItem = null,
-       child = Text(
-         text,
-         overflow: TextOverflow.ellipsis,
-         style: _kToolbarButtonFontStyle.copyWith(
-           color: onPressed != null ? CupertinoColors.white : CupertinoColors.inactiveGray,
-         ),
-       );
+       child = null;
 
   /// Create an instance of [CupertinoTextSelectionToolbarButton] from the given
   /// [ContextMenuButtonItem].
@@ -59,6 +64,7 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
     required ContextMenuButtonItem this.buttonItem,
   }) : assert(buttonItem != null),
        child = null,
+       text = null,
        onPressed = buttonItem.onPressed;
 
   /// {@template flutter.cupertino.CupertinoTextSelectionToolbarButton.child}
@@ -78,6 +84,10 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
   /// [CupertinoTextSelectionToolbarButton.buttonItem].
   /// {@endtemplate}
   final ContextMenuButtonItem? buttonItem;
+
+  /// The text used in the button's label when using
+  /// [CupertinoTextSelectionToolbarButton.text].
+  final String? text;
 
   /// Returns the default button label String for the button of the given
   /// [ContextMenuButtonItem]'s [ContextMenuButtonType].
@@ -105,12 +115,15 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final Widget child = this.child ?? Text(
-      getButtonLabel(context, buttonItem!),
-      overflow: TextOverflow.ellipsis,
-      style: _kToolbarButtonFontStyle.copyWith(
-        color: onPressed != null ? CupertinoColors.white : CupertinoColors.inactiveGray,
-      ),
-    );
+       text ?? getButtonLabel(context, buttonItem!),
+       overflow: TextOverflow.ellipsis,
+       style: _kToolbarButtonFontStyle.copyWith(
+         color: onPressed != null
+             ? _kToolbarTextColor
+             : CupertinoColors.inactiveGray,
+       ),
+     );
+
     return CupertinoButton(
       borderRadius: null,
       color: _kToolbarBackgroundColor,

--- a/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
+++ b/packages/flutter/lib/src/cupertino/text_selection_toolbar_button.dart
@@ -119,7 +119,7 @@ class CupertinoTextSelectionToolbarButton extends StatelessWidget {
        overflow: TextOverflow.ellipsis,
        style: _kToolbarButtonFontStyle.copyWith(
          color: onPressed != null
-             ? _kToolbarTextColor
+             ? _kToolbarTextColor.resolveFrom(context)
              : CupertinoColors.inactiveGray,
        ),
      );

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1499,7 +1499,7 @@ void main() {
     expect(controller.text, 'abcdef');
   });
 
-  testWidgets('toolbar has the same visual regardless of theming', (WidgetTester tester) async {
+  testWidgets('toolbar colors change with theme brightness, but nothing else', (WidgetTester tester) async {
     final TextEditingController controller = TextEditingController(
       text: "j'aime la poutine",
     );
@@ -1523,11 +1523,7 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     Text text = tester.widget<Text>(find.text('Paste'));
-    const CupertinoDynamicColor toolbarTextColor = CupertinoDynamicColor.withBrightness(
-      color: CupertinoColors.black,
-      darkColor: CupertinoColors.white,
-    );
-    expect(text.style!.color, toolbarTextColor);
+    expect(text.style!.color!.value, CupertinoColors.black.value);
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);
@@ -1559,7 +1555,7 @@ void main() {
 
     text = tester.widget<Text>(find.text('Paste'));
     // The toolbar buttons' text are still the same style.
-    expect(text.style!.color, toolbarTextColor);
+    expect(text.style!.color!.value, CupertinoColors.white.value);
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -1523,7 +1523,11 @@ void main() {
     await tester.pump(const Duration(milliseconds: 200));
 
     Text text = tester.widget<Text>(find.text('Paste'));
-    expect(text.style!.color, CupertinoColors.white);
+    const CupertinoDynamicColor toolbarTextColor = CupertinoDynamicColor.withBrightness(
+      color: CupertinoColors.black,
+      darkColor: CupertinoColors.white,
+    );
+    expect(text.style!.color, toolbarTextColor);
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);
@@ -1555,7 +1559,7 @@ void main() {
 
     text = tester.widget<Text>(find.text('Paste'));
     // The toolbar buttons' text are still the same style.
-    expect(text.style!.color, CupertinoColors.white);
+    expect(text.style!.color, toolbarTextColor);
     expect(text.style!.fontSize, 14);
     expect(text.style!.letterSpacing, -0.15);
     expect(text.style!.fontWeight, FontWeight.w400);

--- a/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_toolbar_test.dart
@@ -60,6 +60,11 @@ class TestBox extends SizedBox {
   static const double itemWidth = 100.0;
 }
 
+const CupertinoDynamicColor _kToolbarBackgroundColor = CupertinoDynamicColor.withBrightness(
+  color: Color(0xEB202020),
+  darkColor: Color(0xEBF7F7F7),
+);
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -288,5 +293,41 @@ void main() {
     expect(find.text('Copy'), findsNothing);
     expect(find.text('Paste'), findsNothing);
     expect(find.text('Select all'), findsNothing);
+  }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
+
+  testWidgets('draws dark buttons in dark mode and light button in light mode', (WidgetTester tester) async {
+    for (final Brightness brightness in Brightness.values) {
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: Center(
+            child: Builder(
+              builder: (BuildContext context) {
+                return MediaQuery(
+                  data: MediaQuery.of(context).copyWith(platformBrightness: brightness),
+                  child: CupertinoTextSelectionToolbar(
+                    anchorAbove: const Offset(100.0, 0.0),
+                    anchorBelow: const Offset(100.0, 0.0),
+                    children: <Widget>[
+                      CupertinoTextSelectionToolbarButton.text(
+                        onPressed: () {},
+                        text: 'Button',
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+
+      final Finder buttonFinder = find.byType(CupertinoButton);
+      expect(find.byType(CupertinoButton), findsOneWidget);
+      final CupertinoButton button = tester.widget(buttonFinder);
+      expect(
+        button.color,
+        _kToolbarBackgroundColor,
+      );
+    }
   }, skip: kIsWeb); // [intended] We do not use Flutter-rendered context menu on the Web.
 }


### PR DESCRIPTION
This is a reland of flutter/flutter#115805, which had a bug where the button text color used the wrong brightness in some cases (reverted in https://github.com/flutter/flutter/pull/116312).  This fixes that problem by using the right brightness value.

| Platform | Native iOS 16 light mode | Native iOS 16 dark mode |
| --- | --- | --- |
| Flutter (this branch) | <img width="354" alt="Screenshot 2022-11-21 at 4 50 36 PM" src="https://user-images.githubusercontent.com/389558/203187711-188a79c6-93cf-4d44-b1e4-e1b22786550f.png"> | <img width="354" alt="Screenshot 2022-11-21 at 4 44 41 PM" src="https://user-images.githubusercontent.com/389558/203187021-fcd3e074-b16e-428a-9a4c-d73553934786.png"> |
| Native iOS 16 | ![image](https://user-images.githubusercontent.com/389558/197072104-65dbee59-40b9-4472-9747-e2cffc2e5025.png) | ![image](https://user-images.githubusercontent.com/389558/197072249-87f06945-9fd9-4836-87f2-ad4ee1c047bf.png) |

<details>

<summary>Test app</summary>

```dart
import 'package:flutter/cupertino.dart';
import 'package:flutter/foundation.dart';
import 'package:flutter/material.dart';

void main() {
  debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
  runApp(const MyApp());
}

class MyApp extends StatefulWidget {
  const MyApp({super.key});

  @override
  State<MyApp> createState() => _MyAppState();
}

class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
  Brightness _brightness = Brightness.light;

  @override
  void initState() {
    super.initState();
    WidgetsBinding.instance.addObserver(this);
    _brightness = WidgetsBinding.instance.window.platformBrightness;
  }

  @override
  void didChangePlatformBrightness() {
    if (mounted) {
      setState(() {
        _brightness = WidgetsBinding.instance.window.platformBrightness;
      });
    }

    super.didChangePlatformBrightness();
  }

  @override
  void dispose() {
    WidgetsBinding.instance.removeObserver(this);
    super.dispose();
  }

  @override
  Widget build(BuildContext context) {
    return CupertinoApp(
      debugShowCheckedModeBanner: false,
      theme: CupertinoThemeData(
        brightness: _brightness,
      ),
      home: const CupertinoPageScaffold(
        navigationBar: CupertinoNavigationBar(
          middle: Text('Flutter Forward 2023'),
        ),
        child: _MyPage(),
      ),
    );
  }
}

class _MyPage extends StatelessWidget {
  const _MyPage();

  @override
  Widget build(BuildContext context) {
    return Center(
      child: Column(
        mainAxisAlignment: MainAxisAlignment.center,
        children: <Widget>[
          Icon(
            CupertinoTheme.of(context).brightness == Brightness.light
                ? Icons.light_mode
                : Icons.dark_mode,
            color: const CupertinoDynamicColor.withBrightness(
              color: CupertinoColors.black,
              darkColor: CupertinoColors.white,
            ).resolveFrom(context),
            size: 100.0,
          ),
          Text(
            'Im using CupertinoDynamicColor',
            style: TextStyle(
              color: const CupertinoDynamicColor.withBrightness(
                color: Color(0xFFFF0000),
                darkColor: Color(0xFF00FF00),
              ).resolveFrom(context),
            ),
          ),
          CupertinoTextField(
            contextMenuBuilder: (BuildContext context, EditableTextState editableTextState) {
              return AdaptiveTextSelectionToolbar(
                anchors: editableTextState.contextMenuAnchors,
                children: <Widget>[
                  ...AdaptiveTextSelectionToolbar.getAdaptiveButtons(context, editableTextState.contextMenuButtonItems),
                  CupertinoTextSelectionToolbarButton.text(
                    text: 'I am disabled',
                    onPressed: null,
                  ),
                ],
              );
            },
          ),
        ],
      ),
    );
  }
}
```

</details>