### PR TITLE
[macOS] Fix the `run_debug_test_macos` on arm64

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3954,7 +3954,6 @@ targets:
 
   - name: Mac_arm64_ios run_debug_test_macos
     recipe: devicelab/devicelab_drone
-    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3954,6 +3954,7 @@ targets:
 
   - name: Mac_arm64_ios run_debug_test_macos
     recipe: devicelab/devicelab_drone
+    bringup: true
     timeout: 60
     properties:
       tags: >

--- a/examples/hello_world/macos/Runner/DebugProfile.entitlements
+++ b/examples/hello_world/macos/Runner/DebugProfile.entitlements
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>


### PR DESCRIPTION
The `run_debug_test_macos` fails on arm64 on the device lab. This is due to the sandbox entitlement which prevents the mac application from running over SSH. As a result, the runner app crashes immediately at start up with signal `SIGTRAP`.

The same issue previously affected the `hot_mode_dev_cycle_macos_target__benchmark` test. See https://github.com/flutter/flutter/issues/85654 and https://github.com/flutter/flutter/pull/92065

Presubmit test run: https://github.com/flutter/flutter/pull/117250/checks?check_run_id=10152518763, https://ci.chromium.org/ui/p/flutter/builders/try/Mac_arm64_ios%20run_debug_test_macos/23/overview

Fixes https://github.com/flutter/flutter/issues/117000

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
