### PR TITLE
docs: update docs about color property in material card

### DIFF
--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -79,7 +79,7 @@ class Card extends StatelessWidget {
   /// Defines the card's [Material.color].
   ///
   /// If this property is null then the ambient [CardTheme.color] is used. If that is null,
-  /// and [ThemeData.useMaterial3] is true, then [ColorScheme.surface] of 
+  /// and [ThemeData.useMaterial3] is true, then [ColorScheme.surface] of
   /// [ThemeData.colorScheme] is used. Otherwise, [ThemeData.cardColor] is used.
   final Color? color;
 

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -80,7 +80,7 @@ class Card extends StatelessWidget {
   ///
   /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
   /// is used. If that's null, then [ThemeData.cardColor] is used when material2
-  /// is enabled, [ColorScheme.surface] of [Themedata.colorScheme] is used when
+  /// is enabled, [ColorScheme.surface] of [ThemeData.colorScheme] is used when
   /// material 3 enabled.
   final Color? color;
 

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -71,8 +71,8 @@ class Card extends StatelessWidget {
     this.clipBehavior,
     this.child,
     this.semanticContainer = true,
-  }) : assert(elevation == null || elevation >= 0.0),
-       assert(borderOnForeground != null);
+  })  : assert(elevation == null || elevation >= 0.0),
+        assert(borderOnForeground != null);
 
   /// The card's background color.
   ///
@@ -80,7 +80,7 @@ class Card extends StatelessWidget {
   ///
   /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
   /// is used. If that's null, then [ThemeData.cardColor] is used when material2
-  /// is enabled, [ColorScheme.surface] of [Themedata.colorScheme] is used when
+  /// is enabled, [ColorScheme.surface] of [ThemeData.colorScheme] is used when
   /// material 3 enabled.
   final Color? color;
 
@@ -163,7 +163,9 @@ class Card extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final CardTheme cardTheme = CardTheme.of(context);
-    final CardTheme defaults = Theme.of(context).useMaterial3 ? _CardDefaultsM3(context) : _CardDefaultsM2(context);
+    final CardTheme defaults = Theme.of(context).useMaterial3
+        ? _CardDefaultsM3(context)
+        : _CardDefaultsM2(context);
 
     return Semantics(
       container: semanticContainer,
@@ -172,12 +174,16 @@ class Card extends StatelessWidget {
         child: Material(
           type: MaterialType.card,
           color: color ?? cardTheme.color ?? defaults.color,
-          shadowColor: shadowColor ?? cardTheme.shadowColor ?? defaults.shadowColor,
-          surfaceTintColor: surfaceTintColor ?? cardTheme.surfaceTintColor ?? defaults.surfaceTintColor,
+          shadowColor:
+              shadowColor ?? cardTheme.shadowColor ?? defaults.shadowColor,
+          surfaceTintColor: surfaceTintColor ??
+              cardTheme.surfaceTintColor ??
+              defaults.surfaceTintColor,
           elevation: elevation ?? cardTheme.elevation ?? defaults.elevation!,
           shape: shape ?? cardTheme.shape ?? defaults.shape,
           borderOnForeground: borderOnForeground,
-          clipBehavior: clipBehavior ?? cardTheme.clipBehavior ?? defaults.clipBehavior!,
+          clipBehavior:
+              clipBehavior ?? cardTheme.clipBehavior ?? defaults.clipBehavior!,
           child: Semantics(
             explicitChildNodes: !semanticContainer,
             child: child,
@@ -191,14 +197,13 @@ class Card extends StatelessWidget {
 // Hand coded defaults based on Material Design 2.
 class _CardDefaultsM2 extends CardTheme {
   const _CardDefaultsM2(this.context)
-    : super(
-        clipBehavior: Clip.none,
-        elevation: 1.0,
-        margin: const EdgeInsets.all(4.0),
-        shape: const RoundedRectangleBorder(
-          borderRadius: BorderRadius.all(Radius.circular(4.0)),
-        )
-    );
+      : super(
+            clipBehavior: Clip.none,
+            elevation: 1.0,
+            margin: const EdgeInsets.all(4.0),
+            shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(4.0)),
+            ));
 
   final BuildContext context;
 
@@ -220,12 +225,13 @@ class _CardDefaultsM2 extends CardTheme {
 
 class _CardDefaultsM3 extends CardTheme {
   const _CardDefaultsM3(this.context)
-    : super(
-        clipBehavior: Clip.none,
-        elevation: 1.0,
-        margin: const EdgeInsets.all(4.0),
-        shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
-      );
+      : super(
+          clipBehavior: Clip.none,
+          elevation: 1.0,
+          margin: const EdgeInsets.all(4.0),
+          shape: const RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(12.0))),
+        );
 
   final BuildContext context;
 

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -79,7 +79,9 @@ class Card extends StatelessWidget {
   /// Defines the card's [Material.color].
   ///
   /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
-  /// is used. If that's null then [ThemeData.cardColor] is used.
+  /// is used. If that's null, then [ThemeData.cardColor] is used when material2
+  /// is enabled, [Themedata.colorScheme.surface] is used when material 3
+  /// enabled.
   final Color? color;
 
   /// The color to paint the shadow below the card.

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -71,8 +71,8 @@ class Card extends StatelessWidget {
     this.clipBehavior,
     this.child,
     this.semanticContainer = true,
-  })  : assert(elevation == null || elevation >= 0.0),
-        assert(borderOnForeground != null);
+  }) : assert(elevation == null || elevation >= 0.0),
+       assert(borderOnForeground != null);
 
   /// The card's background color.
   ///
@@ -80,7 +80,7 @@ class Card extends StatelessWidget {
   ///
   /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
   /// is used. If that's null, then [ThemeData.cardColor] is used when material2
-  /// is enabled, [ColorScheme.surface] of [ThemeData.colorScheme] is used when
+  /// is enabled, [ColorScheme.surface] of [Themedata.colorScheme] is used when
   /// material 3 enabled.
   final Color? color;
 
@@ -163,9 +163,7 @@ class Card extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final CardTheme cardTheme = CardTheme.of(context);
-    final CardTheme defaults = Theme.of(context).useMaterial3
-        ? _CardDefaultsM3(context)
-        : _CardDefaultsM2(context);
+    final CardTheme defaults = Theme.of(context).useMaterial3 ? _CardDefaultsM3(context) : _CardDefaultsM2(context);
 
     return Semantics(
       container: semanticContainer,
@@ -174,16 +172,12 @@ class Card extends StatelessWidget {
         child: Material(
           type: MaterialType.card,
           color: color ?? cardTheme.color ?? defaults.color,
-          shadowColor:
-              shadowColor ?? cardTheme.shadowColor ?? defaults.shadowColor,
-          surfaceTintColor: surfaceTintColor ??
-              cardTheme.surfaceTintColor ??
-              defaults.surfaceTintColor,
+          shadowColor: shadowColor ?? cardTheme.shadowColor ?? defaults.shadowColor,
+          surfaceTintColor: surfaceTintColor ?? cardTheme.surfaceTintColor ?? defaults.surfaceTintColor,
           elevation: elevation ?? cardTheme.elevation ?? defaults.elevation!,
           shape: shape ?? cardTheme.shape ?? defaults.shape,
           borderOnForeground: borderOnForeground,
-          clipBehavior:
-              clipBehavior ?? cardTheme.clipBehavior ?? defaults.clipBehavior!,
+          clipBehavior: clipBehavior ?? cardTheme.clipBehavior ?? defaults.clipBehavior!,
           child: Semantics(
             explicitChildNodes: !semanticContainer,
             child: child,
@@ -197,13 +191,14 @@ class Card extends StatelessWidget {
 // Hand coded defaults based on Material Design 2.
 class _CardDefaultsM2 extends CardTheme {
   const _CardDefaultsM2(this.context)
-      : super(
-            clipBehavior: Clip.none,
-            elevation: 1.0,
-            margin: const EdgeInsets.all(4.0),
-            shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(4.0)),
-            ));
+    : super(
+        clipBehavior: Clip.none,
+        elevation: 1.0,
+        margin: const EdgeInsets.all(4.0),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.all(Radius.circular(4.0)),
+        )
+    );
 
   final BuildContext context;
 
@@ -225,13 +220,12 @@ class _CardDefaultsM2 extends CardTheme {
 
 class _CardDefaultsM3 extends CardTheme {
   const _CardDefaultsM3(this.context)
-      : super(
-          clipBehavior: Clip.none,
-          elevation: 1.0,
-          margin: const EdgeInsets.all(4.0),
-          shape: const RoundedRectangleBorder(
-              borderRadius: BorderRadius.all(Radius.circular(12.0))),
-        );
+    : super(
+        clipBehavior: Clip.none,
+        elevation: 1.0,
+        margin: const EdgeInsets.all(4.0),
+        shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(12.0))),
+      );
 
   final BuildContext context;
 

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -78,10 +78,9 @@ class Card extends StatelessWidget {
   ///
   /// Defines the card's [Material.color].
   ///
-  /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
-  /// is used. If that's null, then [ThemeData.cardColor] is used when material2
-  /// is enabled, [ColorScheme.surface] of [ThemeData.colorScheme] is used when
-  /// material 3 enabled.
+  /// If this property is null then the ambient [CardTheme.color] is used. If that is null,
+  /// and [ThemeData.useMaterial3] is true, then [ColorScheme.surface] of 
+  /// [ThemeData.colorScheme] is used. Otherwise, [ThemeData.cardColor] is used.
   final Color? color;
 
   /// The color to paint the shadow below the card.

--- a/packages/flutter/lib/src/material/card.dart
+++ b/packages/flutter/lib/src/material/card.dart
@@ -80,8 +80,8 @@ class Card extends StatelessWidget {
   ///
   /// If this property is null then [CardTheme.color] of [ThemeData.cardTheme]
   /// is used. If that's null, then [ThemeData.cardColor] is used when material2
-  /// is enabled, [Themedata.colorScheme.surface] is used when material 3
-  /// enabled.
+  /// is enabled, [ColorScheme.surface] of [Themedata.colorScheme] is used when
+  /// material 3 enabled.
   final Color? color;
 
   /// The color to paint the shadow below the card.


### PR DESCRIPTION
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If material 3 is enabled, default color of material card is `Themedata.colorScheme.surface`, when `ThemeData.cardTheme.color` is null.
But document is explain only default value when material 2 is enabled.

```dart
  Color? get color => Theme.of(context).colorScheme.surface;
```