### PR TITLE
Allow passing in an alignment to BottomSheet

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -77,6 +77,7 @@ class BottomSheet extends StatefulWidget {
     this.onDragStart,
     this.onDragEnd,
     this.backgroundColor,
+    this.alignment,
     this.elevation,
     this.shape,
     this.clipBehavior,
@@ -149,6 +150,9 @@ class BottomSheet extends StatefulWidget {
   ///
   /// Defaults to null and falls back to [Material]'s default.
   final ShapeBorder? shape;
+
+  /// Alignment of the bottom sheet when not full width
+  Alignment? alignment;
 
   /// {@macro flutter.material.Material.clipBehavior}
   ///
@@ -296,7 +300,7 @@ class _BottomSheetState extends State<BottomSheet> {
 
     if (constraints != null) {
       bottomSheet = Align(
-        alignment: Alignment.bottomCenter,
+        alignment: widget.alignment ?? Alignment.bottomCenter,
         heightFactor: 1.0,
         child: ConstrainedBox(
           constraints: constraints,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -605,8 +605,9 @@ class ModalBottomSheetRoute<T> extends PopupRoute<T> {
   /// by its parent (usually a [Scaffold]).
   ///
   /// If constraints are specified (either in this property or in the
-  /// theme), the bottom sheet will be aligned to the bottom-center of
-  /// the available space. Otherwise, no alignment is applied.
+  /// theme), the bottom sheet will be aligned to [alignment] if passed in, 
+  /// or bottom-center in not passed in, of the available space. 
+  /// Otherwise, no alignment is applied.
   final BoxConstraints? constraints;
 
   /// Specifies the color of the modal barrier that darkens everything below the


### PR DESCRIPTION
*Allow passing in an alignment to the BottomSheet. If we pass in constraints which make it less than full width, this PR will allow the developer to align the bottom sheet instead of it always being bottom center.*

Fixes issue [117297](https://github.com/flutter/flutter/issues/117297)
