### PR TITLE
Bump min SDK to 2.19.0-0

### DIFF
--- a/dev/automated_tests/pubspec.yaml
+++ b/dev/automated_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_automated_tests
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/complex_layout/pubspec.yaml
+++ b/dev/benchmarks/complex_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: complex_layout
 description: A benchmark of a relatively complex layout.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/macrobenchmarks/pubspec.yaml
+++ b/dev/benchmarks/macrobenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: macrobenchmarks
 description: Performance benchmarks using flutter drive.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/microbenchmarks/pubspec.yaml
+++ b/dev/benchmarks/microbenchmarks/pubspec.yaml
@@ -2,7 +2,7 @@ name: microbenchmarks
 description: Small benchmarks for very specific parts of the Flutter framework.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   meta: 1.8.0

--- a/dev/benchmarks/multiple_flutters/module/pubspec.yaml
+++ b/dev/benchmarks/multiple_flutters/module/pubspec.yaml
@@ -4,7 +4,7 @@ description: A module that is embedded in the multiple_flutters benchmark test.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
+++ b/dev/benchmarks/platform_channels_benchmarks/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout
 description: A benchmark for platform views.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_views_layout_hybrid_composition
 description: A benchmark for platform views, using hybrid composition on android.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/benchmarks/test_apps/stocks/pubspec.yaml
+++ b/dev/benchmarks/test_apps/stocks/pubspec.yaml
@@ -1,7 +1,7 @@
 name: stocks
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/bots/pubspec.yaml
+++ b/dev/bots/pubspec.yaml
@@ -2,7 +2,7 @@ name: tests_on_bots
 description: Scripts which run on bots.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1

--- a/dev/conductor/core/pubspec.yaml
+++ b/dev/conductor/core/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter Automated Release Tool
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   archive: 3.3.2

--- a/dev/customer_testing/pubspec.yaml
+++ b/dev/customer_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: customer_testing
 description: Tool to run the tests listed in the flutter/tests repository.
 
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1

--- a/dev/devicelab/pubspec.yaml
+++ b/dev/devicelab/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter continuous integration performance and correctness tests.
 homepage: https://github.com/flutter/flutter
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   archive: 3.3.2

--- a/dev/docs/platform_integration/pubspec.yaml
+++ b/dev/docs/platform_integration/pubspec.yaml
@@ -1,4 +1,4 @@
 name: platform_integration
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'

--- a/dev/forbidden_from_release_tests/pubspec.yaml
+++ b/dev/forbidden_from_release_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: forbidden_from_release_tests
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1

--- a/dev/integration_tests/abstract_method_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/abstract_method_smoke_test/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/android_embedding_v2_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/android_embedding_v2_smoke_test/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/android_semantics_testing/pubspec.yaml
+++ b/dev/integration_tests/android_semantics_testing/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_semantics_testing
 description: Integration testing library for Android semantics
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/android_views/pubspec.yaml
+++ b/dev/integration_tests/android_views/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 description: An integration test for embedded platform views
 version: 1.0.0+1
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/channels/pubspec.yaml
+++ b/dev/integration_tests/channels/pubspec.yaml
@@ -2,7 +2,7 @@ name: channels
 description: Integration test for platform channels.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/deferred_components_test/pubspec.yaml
+++ b/dev/integration_tests/deferred_components_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration test application for basic deferred components function
 publish_to: 'none'
 version: 1.0.0+1
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/external_ui/pubspec.yaml
+++ b/dev/integration_tests/external_ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: external_ui
 description: A test of Flutter integrating external UIs.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/flavors/pubspec.yaml
+++ b/dev/integration_tests/flavors/pubspec.yaml
@@ -2,7 +2,7 @@ name: flavors
 description: Integration test for build flavors.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/flutter_gallery/lib/gallery/example_code.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/example_code.dart
@@ -117,7 +117,7 @@ DropdownButton<String>(
 
 // START buttons_icon
 // Member variable holding toggle value.
-bool value = true;
+late bool value = true;
 
 // Toggleable icon button.
 IconButton(

--- a/dev/integration_tests/flutter_gallery/lib/gallery/example_code.dart
+++ b/dev/integration_tests/flutter_gallery/lib/gallery/example_code.dart
@@ -117,7 +117,7 @@ DropdownButton<String>(
 
 // START buttons_icon
 // Member variable holding toggle value.
-late bool value;
+bool value = true;
 
 // Toggleable icon button.
 IconButton(

--- a/dev/integration_tests/flutter_gallery/pubspec.yaml
+++ b/dev/integration_tests/flutter_gallery/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gallery
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/gradle_deprecated_settings/pubspec.yaml
+++ b/dev/integration_tests/gradle_deprecated_settings/pubspec.yaml
@@ -2,7 +2,7 @@ name: gradle_deprecated_settings
 description: Integration test for the current settings.gradle.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/hybrid_android_views/pubspec.yaml
+++ b/dev/integration_tests/hybrid_android_views/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 description: An integration test for hybrid composition on Android
 version: 1.0.0+1
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
+++ b/dev/integration_tests/ios_add2app_life_cycle/flutterapp/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new flutter module project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
+++ b/dev/integration_tests/ios_app_with_extensions/pubspec.yaml
@@ -13,7 +13,7 @@ name: ios_app_with_extensions
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
+++ b/dev/integration_tests/ios_platform_view_tests/pubspec.yaml
@@ -3,7 +3,7 @@ name: ios_platform_view_tests
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/non_nullable/pubspec.yaml
+++ b/dev/integration_tests/non_nullable/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/platform_interaction/pubspec.yaml
+++ b/dev/integration_tests/platform_interaction/pubspec.yaml
@@ -2,7 +2,7 @@ name: platform_interaction
 description: Integration test for platform interactions.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/release_smoke_test/pubspec.yaml
+++ b/dev/integration_tests/release_smoke_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: release_smoke_test
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/spell_check/pubspec.yaml
+++ b/dev/integration_tests/spell_check/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.18.0-149.0.dev <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/dev/integration_tests/ui/pubspec.yaml
+++ b/dev/integration_tests/ui/pubspec.yaml
@@ -2,7 +2,7 @@ name: integration_ui
 description: Flutter non-plugin UI integration tests.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/web/pubspec.yaml
+++ b/dev/integration_tests/web/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_integration
 description: Integration test for web compilation.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 flutter:
   assets:

--- a/dev/integration_tests/web_compile_tests/pubspec.yaml
+++ b/dev/integration_tests/web_compile_tests/pubspec.yaml
@@ -1,6 +1,6 @@
 name: web_compile_tests
 environment:
-  sdk: '>=2.17.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/integration_tests/web_e2e_tests/pubspec.yaml
+++ b/dev/integration_tests/web_e2e_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: web_e2e_tests
 publish_to: none
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 flutter:
   assets:

--- a/dev/integration_tests/windows_startup_test/pubspec.yaml
+++ b/dev/integration_tests/windows_startup_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: windows_startup_test
 description: Integration test for Windows app's startup.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/manual_tests/pubspec.yaml
+++ b/dev/manual_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: manual_tests
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/missing_dependency_tests/pubspec.yaml
+++ b/dev/missing_dependency_tests/pubspec.yaml
@@ -1,7 +1,7 @@
 name: missing_dependency_tests
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -59,7 +59,7 @@ Future<void> main(List<String> arguments) async {
   buf.writeln('homepage: https://flutter.dev');
   buf.writeln('version: 0.0.0');
   buf.writeln('environment:');
-  buf.writeln("  sdk: '>=2.12.0 <4.0.0'");
+  buf.writeln("  sdk: '>=2.19.0 <4.0.0'");
   buf.writeln('dependencies:');
   for (final String package in findPackageNames()) {
     buf.writeln('  $package:');

--- a/dev/tools/gen_defaults/pubspec.yaml
+++ b/dev/tools/gen_defaults/pubspec.yaml
@@ -3,7 +3,7 @@ description: A command line script to generate Material component defaults from 
 version: 1.0.0
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
 

--- a/dev/tools/gen_keycodes/pubspec.yaml
+++ b/dev/tools/gen_keycodes/pubspec.yaml
@@ -2,7 +2,7 @@ name: gen_keycodes
 description: Generates keycode source files from various resources.
 
 environment:
-  sdk: ">=2.18.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   args: 2.3.1

--- a/dev/tools/pubspec.yaml
+++ b/dev/tools/pubspec.yaml
@@ -2,7 +2,7 @@ name: dev_tools
 description: Various repository development tools for flutter.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   archive: 3.3.2

--- a/dev/tools/vitool/pubspec.yaml
+++ b/dev/tools/vitool/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.1
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/dev/tracing_tests/pubspec.yaml
+++ b/dev/tracing_tests/pubspec.yaml
@@ -2,7 +2,7 @@ name: tracing_tests
 description: Various tests for tracing in flutter/flutter
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/api/pubspec.yaml
+++ b/examples/api/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
   flutter: ">=2.5.0-6.0.pre.30 <3.0.0"
 
 dependencies:

--- a/examples/flutter_view/pubspec.yaml
+++ b/examples/flutter_view/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_view
 description: A new flutter project.
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/hello_world/pubspec.yaml
+++ b/examples/hello_world/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hello_world
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/image_list/pubspec.yaml
+++ b/examples/image_list/pubspec.yaml
@@ -4,7 +4,7 @@ description: Simple Flutter project used for benchmarking image loading over net
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/layers/pubspec.yaml
+++ b/examples/layers/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_examples_layers
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_channel/pubspec.yaml
+++ b/examples/platform_channel/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_channel_swift/pubspec.yaml
+++ b/examples/platform_channel_swift/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_channel_swift
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/platform_view/pubspec.yaml
+++ b/examples/platform_view/pubspec.yaml
@@ -1,7 +1,7 @@
 name: platform_view
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/examples/splash/pubspec.yaml
+++ b/examples/splash/pubspec.yaml
@@ -1,7 +1,7 @@
 name: splash
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/flutter/pubspec.yaml
+++ b/packages/flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: A framework for writing Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test_private/pubspec.yaml
+++ b/packages/flutter/test_private/pubspec.yaml
@@ -2,7 +2,7 @@ name: flutter_test_private
 description: Tests private interfaces of the flutter
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter/test_private/test/pubspec.yaml
+++ b/packages/flutter/test_private/test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: animated_icons_private_test
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_driver/pubspec.yaml
+++ b/packages/flutter_driver/pubspec.yaml
@@ -3,7 +3,7 @@ description: Integration and performance test API for Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   file: 6.1.4

--- a/packages/flutter_goldens/pubspec.yaml
+++ b/packages/flutter_goldens/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_goldens
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_goldens_client/pubspec.yaml
+++ b/packages/flutter_goldens_client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_goldens_client
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_localizations/pubspec.yaml
+++ b/packages/flutter_localizations/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_localizations
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_test/pubspec.yaml
+++ b/packages/flutter_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_test
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_test/test/test_config/project_root/pubspec.yaml
+++ b/packages/flutter_test/test/test_config/project_root/pubspec.yaml
@@ -4,6 +4,6 @@
 name: dummy
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 # PUBSPEC CHECKSUM: 0000

--- a/packages/flutter_tools/pubspec.yaml
+++ b/packages/flutter_tools/pubspec.yaml
@@ -3,7 +3,7 @@ description: Tools for building Flutter applications
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   # To update these, use "flutter update-packages --force-upgrade".

--- a/packages/flutter_tools/test/data/asset_test/font/pubspec.yaml
+++ b/packages/flutter_tools/test/data/asset_test/font/pubspec.yaml
@@ -2,7 +2,7 @@ name: font
 description: A test project that contains a font.
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 flutter:
   uses-material-design: true

--- a/packages/flutter_tools/test/data/asset_test/main/pubspec.yaml
+++ b/packages/flutter_tools/test/data/asset_test/main/pubspec.yaml
@@ -2,7 +2,7 @@ name: main
 description: A test project that has a package with a font as a dependency.
 
 environment:
-  sdk: ">=2.12.0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   font:

--- a/packages/flutter_web_plugins/pubspec.yaml
+++ b/packages/flutter_web_plugins/pubspec.yaml
@@ -3,7 +3,7 @@ description: Library to register Flutter Web plugins
 homepage: https://flutter.dev
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/fuchsia_remote_debug_protocol/pubspec.yaml
+++ b/packages/fuchsia_remote_debug_protocol/pubspec.yaml
@@ -4,7 +4,7 @@ description: Provides an API to test/debug Flutter applications on remote Fuchsi
 homepage: https://flutter.dev
 
 environment:
-  sdk: '>=2.12.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   process: 4.2.4

--- a/packages/integration_test/example/lib/my_app.dart
+++ b/packages/integration_test/example/lib/my_app.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 void startApp() => runApp(const MyApp());
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/packages/integration_test/example/lib/my_web_app.dart
+++ b/packages/integration_test/example/lib/my_web_app.dart
@@ -10,7 +10,7 @@ import 'package:flutter/material.dart';
 void startApp() => runApp(const MyWebApp());
 
 class MyWebApp extends StatefulWidget {
-  const MyWebApp({Key? key}) : super(key: key);
+  const MyWebApp({super.key});
 
   @override
   State<MyWebApp> createState() => _MyWebAppState();

--- a/packages/integration_test/example/pubspec.yaml
+++ b/packages/integration_test/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the integration_test plugin.
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.12.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
   flutter: ">=1.6.7"
 
 dependencies:

--- a/packages/integration_test/integration_test_macos/pubspec.yaml
+++ b/packages/integration_test/integration_test_macos/pubspec.yaml
@@ -10,7 +10,7 @@ flutter:
         pluginClass: IntegrationTestPlugin
 
 environment:
-  sdk: ">=2.17.0-0 <4.0.0"
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:

--- a/packages/integration_test/pubspec.yaml
+++ b/packages/integration_test/pubspec.yaml
@@ -3,7 +3,7 @@ description: Runs tests that use the flutter_test API as integration tests.
 publish_to: none
 
 environment:
-  sdk: '>=2.12.0-0 <4.0.0'
+  sdk: '>=2.19.0-0 <4.0.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
This gives us access to the unnamed library statement (`library;`) which will be handy for enforcing the new `dangling_library_doc_comments`/`library_annotations` lints.