### PR TITLE
Use new centered iOS back button icon

### DIFF
--- a/packages/flutter/lib/src/material/back_button.dart
+++ b/packages/flutter/lib/src/material/back_button.dart
@@ -41,7 +41,7 @@ class BackButtonIcon extends StatelessWidget {
         break;
       case TargetPlatform.iOS:
       case TargetPlatform.macOS:
-        data = Icons.arrow_back_ios;
+        data = Icons.arrow_back_ios_new;
         break;
     }
     // This can't use the platform from Theme because it is the Android OS that


### PR DESCRIPTION
`arrow_back_ios` is not centered (see https://github.com/google/material-design-icons/issues/824). Changing it to `arrow_back_ios_new`, which is centered: https://github.com/mui/material-ui/issues/17425

`arrow_back_ios`
<img width="214" alt="image" src="https://user-images.githubusercontent.com/12447726/208542425-3e7b45bb-90c1-4614-8339-dcddb9030af5.png">

`arrow_back_ios_new`
<img width="214" alt="image" src="https://user-images.githubusercontent.com/12447726/208542419-a4393cda-6cf8-4155-876b-53f6cf8168b4.png">
