### PR TITLE
Enable `dangling_library_doc_comments` and `library_annotations` lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -95,7 +95,7 @@ linter:
     # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
     - control_flow_in_finally
     - curly_braces_in_flow_control_structures
-    # - dangling_library_doc_comments # not yet tested
+    - dangling_library_doc_comments
     - depend_on_referenced_packages
     - deprecated_consistency
     # - diagnostic_describe_all_properties # enabled only at the framework level (packages/flutter/lib)
@@ -116,7 +116,7 @@ linter:
     - iterable_contains_unrelated_type
     # - join_return_with_assignment # not required by flutter style
     - leading_newlines_in_multiline_strings
-    # - library_annotations # not yet tested
+    - library_annotations
     - library_names
     - library_prefixes
     - library_private_types_in_public_api

--- a/dev/bots/test/analyze-snippet-code-test-input/known_broken_documentation.dart
+++ b/dev/bots/test/analyze-snippet-code-test-input/known_broken_documentation.dart
@@ -166,3 +166,4 @@
 /// error (something about backticks)
 /// this must be the last error, since it aborts parsing of this file
 /// ```
+String? foo;

--- a/dev/bots/test/analyze-snippet-code-test-input/short_but_still_broken.dart
+++ b/dev/bots/test/analyze-snippet-code-test-input/short_but_still_broken.dart
@@ -11,7 +11,9 @@
 /// ```dart
 /// print(x);
 /// ```
+String? bar;
 
 /// error: empty dart block
 /// ```dart
 /// ```
+String? foo;

--- a/dev/bots/test/analyze-test-input/root/packages/foo/golden_doc.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/golden_doc.dart
@@ -35,7 +35,7 @@
 /// ```
 /// {@end-tool}
 ///
-
+String? foo;
 // Other comments
 // matchesGoldenFile('comment.png');
 

--- a/dev/bots/test/analyze-test-input/root/packages/foo/golden_ignore.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/golden_ignore.dart
@@ -6,6 +6,7 @@
 // flutter_ignore_for_file: golden_tag (see analyze.dart)
 
 @Tags(<String>['some-other-tag'])
+library;
 
 import 'package:test/test.dart';
 

--- a/dev/bots/test/analyze-test-input/root/packages/foo/golden_missing_tag.dart
+++ b/dev/bots/test/analyze-test-input/root/packages/foo/golden_missing_tag.dart
@@ -4,6 +4,7 @@
 
 // The reduced test set tag is missing. This should fail analysis.
 @Tags(<String>['some-other-tag'])
+library;
 
 import 'package:test/test.dart';
 

--- a/dev/bots/test/analyze_snippet_code_test.dart
+++ b/dev/bots/test/analyze_snippet_code_test.dart
@@ -29,7 +29,7 @@ const List<String> expectedMainErrors = <String>[
   'dev/bots/test/analyze-snippet-code-test-input/known_broken_documentation.dart:161:7: (top-level declaration) (undefined_identifier)',
   'dev/bots/test/analyze-snippet-code-test-input/known_broken_documentation.dart:165: Found "```" in code but it did not match RegExp: pattern=^ */// *```dart\$ flags= so something is wrong. Line was: "/// ```"',
   'dev/bots/test/analyze-snippet-code-test-input/short_but_still_broken.dart:9:12: (statement) (invalid_assignment)',
-  'dev/bots/test/analyze-snippet-code-test-input/short_but_still_broken.dart:17:4: Empty ```dart block in snippet code.',
+  'dev/bots/test/analyze-snippet-code-test-input/short_but_still_broken.dart:18:4: Empty ```dart block in snippet code.',
 ];
 
 const List<String> expectedUiErrors = <String>[

--- a/dev/bots/unpublish_package.dart
+++ b/dev/bots/unpublish_package.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 /// This script removes published archives from the cloud storage and the
 /// corresponding JSON metadata file that the website uses to determine what
 /// releases are available.
@@ -10,6 +9,7 @@
 /// If asked to remove a release that is currently the release on that channel,
 /// it will replace that release with the next most recent release on that
 /// channel.
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/dev/conductor/core/test/codesign_integration_test.dart
+++ b/dev/conductor/core/test/codesign_integration_test.dart
@@ -5,6 +5,7 @@
 // This test clones the framework and downloads pre-built binaries; it sometimes
 // times out with the default 5 minutes: https://github.com/flutter/flutter/issues/100937
 @Timeout(Duration(minutes: 10))
+library;
 
 import 'package:args/command_runner.dart';
 import 'package:conductor_core/src/codesign.dart' show CodesignCommand;

--- a/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery__back_button_memory.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Measure application memory usage after pausing and resuming the app
-/// with the Android back button.
-
 import 'package:flutter_devicelab/framework/devices.dart';
 import 'package:flutter_devicelab/framework/framework.dart';
 import 'package:flutter_devicelab/framework/utils.dart';
@@ -13,6 +10,8 @@ import 'package:flutter_devicelab/tasks/perf_tests.dart';
 const String packageName = 'io.flutter.demo.gallery';
 const String activityName = 'io.flutter.demo.gallery.MainActivity';
 
+/// Measure application memory usage after pausing and resuming the app
+/// with the Android back button.
 class BackButtonMemoryTest extends MemoryTest {
   BackButtonMemoryTest() : super('${flutterDirectory.path}/dev/integration_tests/flutter_gallery', 'test_memory/back_button.dart', packageName);
 

--- a/dev/tools/localization/bin/gen_date_localizations.dart
+++ b/dev/tools/localization/bin/gen_date_localizations.dart
@@ -2,6 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+import '../localizations_utils.dart';
+
+const String _kCommandName = 'gen_date_localizations.dart';
+
+// Used to let _jsonToMap know what locale it's date symbols converting for.
+// Date symbols for the Kannada locale ('kn') are handled specially because
+// some of the strings contain characters that can crash Emacs on Linux.
+// See packages/flutter_localizations/lib/src/l10n/README for more information.
+String? currentLocale;
+
 /// This program extracts localized date symbols and patterns from the intl
 /// package for the subset of locales supported by the flutter_localizations
 /// package.
@@ -25,23 +41,6 @@
 /// ```
 /// dart dev/tools/localization/bin/gen_date_localizations.dart --overwrite
 /// ```
-
-import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-
-import 'package:path/path.dart' as path;
-
-import '../localizations_utils.dart';
-
-const String _kCommandName = 'gen_date_localizations.dart';
-
-// Used to let _jsonToMap know what locale it's date symbols converting for.
-// Date symbols for the Kannada locale ('kn') are handled specially because
-// some of the strings contain characters that can crash Emacs on Linux.
-// See packages/flutter_localizations/lib/src/l10n/README for more information.
-String? currentLocale;
-
 Future<void> main(List<String> rawArgs) async {
   checkCwdIsRepoRoot(_kCommandName);
 

--- a/dev/tools/mega_gallery.dart
+++ b/dev/tools/mega_gallery.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Make `n` copies of flutter_gallery.
-
 import 'dart:io';
 
 import 'package:args/args.dart';
@@ -12,6 +10,7 @@ import 'package:path/path.dart' as path;
 /// If no `copies` param is passed in, we scale the generated app up to 60k lines.
 const int kTargetLineCount = 60 * 1024;
 
+/// Make `n` copies of flutter_gallery.
 void main(List<String> args) {
   // If we're run from the `tools` dir, set the cwd to the repo root.
   if (path.basename(Directory.current.path) == 'tools') {

--- a/examples/api/lib/animation/curves/curve2_d.0.dart
+++ b/examples/api/lib/animation/curves/curve2_d.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Curve2D].
+// Flutter code sample for [Curve2D].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/cupertino/activity_indicator/cupertino_activity_indicator.0.dart
+++ b/examples/api/lib/cupertino/activity_indicator/cupertino_activity_indicator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoActivityIndicator].
+// Flutter code sample for [CupertinoActivityIndicator].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/bottom_tab_bar/cupertino_tab_bar.0.dart
+++ b/examples/api/lib/cupertino/bottom_tab_bar/cupertino_tab_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoTabBar].
+// Flutter code sample for [CupertinoTabBar].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/button/cupertino_button.0.dart
+++ b/examples/api/lib/cupertino/button/cupertino_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoButton].
+// Flutter code sample for [CupertinoButton].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/context_menu/cupertino_context_menu.0.dart
+++ b/examples/api/lib/cupertino/context_menu/cupertino_context_menu.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoContextMenu].
+// Flutter code sample for [CupertinoContextMenu].
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/cupertino/context_menu/cupertino_context_menu.1.dart
+++ b/examples/api/lib/cupertino/context_menu/cupertino_context_menu.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoContextMenu].
+// Flutter code sample for [CupertinoContextMenu].
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/cupertino/date_picker/cupertino_date_picker.0.dart
+++ b/examples/api/lib/cupertino/date_picker/cupertino_date_picker.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoDatePicker].
+// Flutter code sample for [CupertinoDatePicker].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
+++ b/examples/api/lib/cupertino/date_picker/cupertino_timer_picker.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoTimerPicker].
+// Flutter code sample for [CupertinoTimerPicker].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/dialog/cupertino_action_sheet.0.dart
+++ b/examples/api/lib/cupertino/dialog/cupertino_action_sheet.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoActionSheet].
+// Flutter code sample for [CupertinoActionSheet].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/dialog/cupertino_alert_dialog.0.dart
+++ b/examples/api/lib/cupertino/dialog/cupertino_alert_dialog.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoAlertDialog].
+// Flutter code sample for [CupertinoAlertDialog].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/form_row/cupertino_form_row.0.dart
+++ b/examples/api/lib/cupertino/form_row/cupertino_form_row.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoFormRow].
+// Flutter code sample for [CupertinoFormRow].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/list_section/list_section_base.0.dart
+++ b/examples/api/lib/cupertino/list_section/list_section_base.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for base [CupertinoListSection] and [CupertinoListTile].
+// Flutter code sample for base [CupertinoListSection] and [CupertinoListTile].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/list_section/list_section_inset.0.dart
+++ b/examples/api/lib/cupertino/list_section/list_section_inset.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for inset [CupertinoListSection] and [CupertinoListTile].
+// Flutter code sample for inset [CupertinoListSection] and [CupertinoListTile].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/nav_bar/cupertino_navigation_bar.0.dart
+++ b/examples/api/lib/cupertino/nav_bar/cupertino_navigation_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoNavigationBar].
+// Flutter code sample for [CupertinoNavigationBar].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/nav_bar/cupertino_sliver_nav_bar.0.dart
+++ b/examples/api/lib/cupertino/nav_bar/cupertino_sliver_nav_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSliverNavigationBar].
+// Flutter code sample for [CupertinoSliverNavigationBar].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/page_scaffold/cupertino_page_scaffold.0.dart
+++ b/examples/api/lib/cupertino/page_scaffold/cupertino_page_scaffold.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoPageScaffold].
+// Flutter code sample for [CupertinoPageScaffold].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
+++ b/examples/api/lib/cupertino/picker/cupertino_picker.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoPicker].
+// Flutter code sample for [CupertinoPicker].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/refresh/cupertino_sliver_refresh_control.0.dart
+++ b/examples/api/lib/cupertino/refresh/cupertino_sliver_refresh_control.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSliverRefreshControl].
+// Flutter code sample for [CupertinoSliverRefreshControl].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/route/show_cupertino_dialog.0.dart
+++ b/examples/api/lib/cupertino/route/show_cupertino_dialog.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showCupertinoDialog].
+// Flutter code sample for [showCupertinoDialog].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/route/show_cupertino_modal_popup.0.dart
+++ b/examples/api/lib/cupertino/route/show_cupertino_modal_popup.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showCupertinoModalPopup].
+// Flutter code sample for [showCupertinoModalPopup].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/scrollbar/cupertino_scrollbar.0.dart
+++ b/examples/api/lib/cupertino/scrollbar/cupertino_scrollbar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoScrollbar].
+// Flutter code sample for [CupertinoScrollbar].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/scrollbar/cupertino_scrollbar.1.dart
+++ b/examples/api/lib/cupertino/scrollbar/cupertino_scrollbar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoScrollbar].
+// Flutter code sample for [CupertinoScrollbar].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/search_field/cupertino_search_field.0.dart
+++ b/examples/api/lib/cupertino/search_field/cupertino_search_field.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSearchTextField].
+// Flutter code sample for [CupertinoSearchTextField].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/search_field/cupertino_search_field.1.dart
+++ b/examples/api/lib/cupertino/search_field/cupertino_search_field.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSearchTextField].
+// Flutter code sample for [CupertinoSearchTextField].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
+++ b/examples/api/lib/cupertino/segmented_control/cupertino_segmented_control.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSegmentedControl].
+// Flutter code sample for [CupertinoSegmentedControl].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/segmented_control/cupertino_sliding_segmented_control.0.dart
+++ b/examples/api/lib/cupertino/segmented_control/cupertino_sliding_segmented_control.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSlidingSegmentedControl].
+// Flutter code sample for [CupertinoSlidingSegmentedControl].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/slider/cupertino_slider.0.dart
+++ b/examples/api/lib/cupertino/slider/cupertino_slider.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSlider].
+// Flutter code sample for [CupertinoSlider].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/switch/cupertino_switch.0.dart
+++ b/examples/api/lib/cupertino/switch/cupertino_switch.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoSwitch].
+// Flutter code sample for [CupertinoSwitch].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/tab_scaffold/cupertino_tab_controller.0.dart
+++ b/examples/api/lib/cupertino/tab_scaffold/cupertino_tab_controller.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoTabController].
+// Flutter code sample for [CupertinoTabController].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/tab_scaffold/cupertino_tab_scaffold.0.dart
+++ b/examples/api/lib/cupertino/tab_scaffold/cupertino_tab_scaffold.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoTabScaffold].
+// Flutter code sample for [CupertinoTabScaffold].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/text_field/cupertino_text_field.0.dart
+++ b/examples/api/lib/cupertino/text_field/cupertino_text_field.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoTextField].
+// Flutter code sample for [CupertinoTextField].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/cupertino/text_form_field_row/cupertino_text_form_field_row.1.dart
+++ b/examples/api/lib/cupertino/text_form_field_row/cupertino_text_form_field_row.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CupertinoTextFormFieldRow].
+// Flutter code sample for [CupertinoTextFormFieldRow].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/gestures/pointer_signal_resolver/pointer_signal_resolver.0.dart
+++ b/examples/api/lib/gestures/pointer_signal_resolver/pointer_signal_resolver.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PointerSignalResolver].
+// Flutter code sample for [PointerSignalResolver].
 
 import 'package:flutter/gestures.dart';
 

--- a/examples/api/lib/material/about/about_list_tile.0.dart
+++ b/examples/api/lib/material/about/about_list_tile.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AboutListTile].
+// Flutter code sample for [AboutListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/action_chip/action_chip.0.dart
+++ b/examples/api/lib/material/action_chip/action_chip.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample [ActionChip].
+// Flutter code sample [ActionChip].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/animated_icon/animated_icon.0.dart
+++ b/examples/api/lib/material/animated_icon/animated_icon.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedIcon].
+// Flutter code sample for [AnimatedIcon].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/animated_icon/animated_icons_data.0.dart
+++ b/examples/api/lib/material/animated_icon/animated_icons_data.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedIcon].
+// Flutter code sample for [AnimatedIcon].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/app_bar.0.dart
+++ b/examples/api/lib/material/app_bar/app_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AppBar].
+// Flutter code sample for [AppBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/app_bar.1.dart
+++ b/examples/api/lib/material/app_bar/app_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AppBar].
+// Flutter code sample for [AppBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/app_bar.2.dart
+++ b/examples/api/lib/material/app_bar/app_bar.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AppBar].
+// Flutter code sample for [AppBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/app_bar.3.dart
+++ b/examples/api/lib/material/app_bar/app_bar.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AppBar].
+// Flutter code sample for [AppBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/sliver_app_bar.1.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverAppBar].
+// Flutter code sample for [SliverAppBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/sliver_app_bar.2.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverAppBar.medium].
+// Flutter code sample for [SliverAppBar.medium].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/app_bar/sliver_app_bar.3.dart
+++ b/examples/api/lib/material/app_bar/sliver_app_bar.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverAppBar.large].
+// Flutter code sample for [SliverAppBar.large].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/autocomplete/autocomplete.0.dart
+++ b/examples/api/lib/material/autocomplete/autocomplete.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Autocomplete].
+// Flutter code sample for [Autocomplete].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/autocomplete/autocomplete.1.dart
+++ b/examples/api/lib/material/autocomplete/autocomplete.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Autocomplete].
+// Flutter code sample for [Autocomplete].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/banner/material_banner.0.dart
+++ b/examples/api/lib/material/banner/material_banner.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MaterialBanner].
+// Flutter code sample for [MaterialBanner].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/banner/material_banner.1.dart
+++ b/examples/api/lib/material/banner/material_banner.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MaterialBanner].
+// Flutter code sample for [MaterialBanner].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/bottom_app_bar/bottom_app_bar.1.dart
+++ b/examples/api/lib/material/bottom_app_bar/bottom_app_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [BottomAppBar].
+// Flutter code sample for [BottomAppBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.0.dart
+++ b/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [BottomNavigationBar].
+// Flutter code sample for [BottomNavigationBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.1.dart
+++ b/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [BottomNavigationBar].
+// Flutter code sample for [BottomNavigationBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
+++ b/examples/api/lib/material/bottom_navigation_bar/bottom_navigation_bar.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [BottomNavigationBar].
+// Flutter code sample for [BottomNavigationBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.0.dart
+++ b/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showModalBottomSheet].
+// Flutter code sample for [showModalBottomSheet].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.1.dart
+++ b/examples/api/lib/material/bottom_sheet/show_modal_bottom_sheet.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showModalBottomSheet].
+// Flutter code sample for [showModalBottomSheet].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/button_style/button_style.0.dart
+++ b/examples/api/lib/material/button_style/button_style.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ElevatedButton].
+// Flutter code sample for [ElevatedButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/card/card.0.dart
+++ b/examples/api/lib/material/card/card.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Card].
+// Flutter code sample for [Card].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/card/card.1.dart
+++ b/examples/api/lib/material/card/card.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Card].
+// Flutter code sample for [Card].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/card/card.2.dart
+++ b/examples/api/lib/material/card/card.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Card].
+// Flutter code sample for [Card].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/checkbox/checkbox.0.dart
+++ b/examples/api/lib/material/checkbox/checkbox.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Checkbox].
+// Flutter code sample for [Checkbox].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.0.dart
+++ b/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CheckboxListTile].
+// Flutter code sample for [CheckboxListTile].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show timeDilation;

--- a/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.1.dart
+++ b/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CheckboxListTile].
+// Flutter code sample for [CheckboxListTile].
 
 import 'package:flutter/gestures.dart';
 

--- a/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.2.dart
+++ b/examples/api/lib/material/checkbox_list_tile/checkbox_list_tile.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CheckboxListTile].
+// Flutter code sample for [CheckboxListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/chip/deletable_chip_attributes.on_deleted.0.dart
+++ b/examples/api/lib/material/chip/deletable_chip_attributes.on_deleted.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DeletableChipAttributes.onDeleted].
+// Flutter code sample for [DeletableChipAttributes.onDeleted].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/choice_chip/choice_chip.0.dart
+++ b/examples/api/lib/material/choice_chip/choice_chip.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ActionChoice].
+// Flutter code sample for [ActionChoice].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/data_table/data_table.0.dart
+++ b/examples/api/lib/material/data_table/data_table.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DataTable].
+// Flutter code sample for [DataTable].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/data_table/data_table.1.dart
+++ b/examples/api/lib/material/data_table/data_table.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DataTable].
+// Flutter code sample for [DataTable].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/date_picker/show_date_picker.0.dart
+++ b/examples/api/lib/material/date_picker/show_date_picker.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showDatePicker].
+// Flutter code sample for [showDatePicker].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/date_picker/show_date_range_picker.0.dart
+++ b/examples/api/lib/material/date_picker/show_date_range_picker.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showDateRangePicker].
+// Flutter code sample for [showDateRangePicker].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dialog/alert_dialog.0.dart
+++ b/examples/api/lib/material/dialog/alert_dialog.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AlertDialog].
+// Flutter code sample for [AlertDialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dialog/alert_dialog.1.dart
+++ b/examples/api/lib/material/dialog/alert_dialog.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AlertDialog].
+// Flutter code sample for [AlertDialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dialog/dialog.0.dart
+++ b/examples/api/lib/material/dialog/dialog.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Dialog].
+// Flutter code sample for [Dialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dialog/show_dialog.0.dart
+++ b/examples/api/lib/material/dialog/show_dialog.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showDialog].
+// Flutter code sample for [showDialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dialog/show_dialog.1.dart
+++ b/examples/api/lib/material/dialog/show_dialog.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showDialog].
+// Flutter code sample for [showDialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dialog/show_dialog.2.dart
+++ b/examples/api/lib/material/dialog/show_dialog.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showDialog].
+// Flutter code sample for [showDialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/divider/divider.0.dart
+++ b/examples/api/lib/material/divider/divider.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Divider].
+// Flutter code sample for [Divider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/divider/divider.1.dart
+++ b/examples/api/lib/material/divider/divider.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Divider].
+// Flutter code sample for [Divider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/divider/vertical_divider.0.dart
+++ b/examples/api/lib/material/divider/vertical_divider.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [VerticalDivider].
+// Flutter code sample for [VerticalDivider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/divider/vertical_divider.1.dart
+++ b/examples/api/lib/material/divider/vertical_divider.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Divider].
+// Flutter code sample for [Divider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dropdown/dropdown_button.0.dart
+++ b/examples/api/lib/material/dropdown/dropdown_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DropdownButton].
+// Flutter code sample for [DropdownButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dropdown/dropdown_button.selected_item_builder.0.dart
+++ b/examples/api/lib/material/dropdown/dropdown_button.selected_item_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DropdownButton.selectedItemBuilder].
+// Flutter code sample for [DropdownButton.selectedItemBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dropdown/dropdown_button.style.0.dart
+++ b/examples/api/lib/material/dropdown/dropdown_button.style.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DropdownButton.style].
+// Flutter code sample for [DropdownButton.style].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
+++ b/examples/api/lib/material/dropdown_menu/dropdown_menu.0.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DropdownMenu]s. The first dropdown menu has an outlined border
-/// which is the default configuration, and the second one has a filled input decoration.
+// Flutter code sample for [DropdownMenu]s. The first dropdown menu has an outlined border
+// which is the default configuration, and the second one has a filled input decoration.
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/elevated_button/elevated_button.0.dart
+++ b/examples/api/lib/material/elevated_button/elevated_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ElevatedButton].
+// Flutter code sample for [ElevatedButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/expansion_panel/expansion_panel_list.0.dart
+++ b/examples/api/lib/material/expansion_panel/expansion_panel_list.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ExpansionPanelList].
+// Flutter code sample for [ExpansionPanelList].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0.dart
+++ b/examples/api/lib/material/expansion_panel/expansion_panel_list.expansion_panel_list_radio.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ExpansionPanelList.ExpansionPanelList.radio].
+// Flutter code sample for [ExpansionPanelList.ExpansionPanelList.radio].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/expansion_tile/expansion_tile.0.dart
+++ b/examples/api/lib/material/expansion_tile/expansion_tile.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ExpansionTile].
+// Flutter code sample for [ExpansionTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/filled_button/filled_button.0.dart
+++ b/examples/api/lib/material/filled_button/filled_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FilledButton].
+// Flutter code sample for [FilledButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/filter_chip/filter_chip.0.dart
+++ b/examples/api/lib/material/filter_chip/filter_chip.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FilterChip].
+// Flutter code sample for [FilterChip].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/flexible_space_bar/flexible_space_bar.0.dart
+++ b/examples/api/lib/material/flexible_space_bar/flexible_space_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FlexibleSpaceBar].
+// Flutter code sample for [FlexibleSpaceBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/floating_action_button/floating_action_button.0.dart
+++ b/examples/api/lib/material/floating_action_button/floating_action_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FloatingActionButton].
+// Flutter code sample for [FloatingActionButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/floating_action_button/floating_action_button.1.dart
+++ b/examples/api/lib/material/floating_action_button/floating_action_button.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FloatingActionButton].
+// Flutter code sample for [FloatingActionButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/floating_action_button/floating_action_button.2.dart
+++ b/examples/api/lib/material/floating_action_button/floating_action_button.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FloatingActionButton].
+// Flutter code sample for [FloatingActionButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/floating_action_button/floating_action_button.3.dart
+++ b/examples/api/lib/material/floating_action_button/floating_action_button.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FloatingActionButton].
+// Flutter code sample for [FloatingActionButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/floating_action_button_location/standard_fab_location.0.dart
+++ b/examples/api/lib/material/floating_action_button_location/standard_fab_location.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [StandardFabLocation].
+// Flutter code sample for [StandardFabLocation].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/icon_button/icon_button.0.dart
+++ b/examples/api/lib/material/icon_button/icon_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [IconButton].
+// Flutter code sample for [IconButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/icon_button/icon_button.1.dart
+++ b/examples/api/lib/material/icon_button/icon_button.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [IconButton].
+// Flutter code sample for [IconButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/icon_button/icon_button.2.dart
+++ b/examples/api/lib/material/icon_button/icon_button.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [IconButton].
+// Flutter code sample for [IconButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/icon_button/icon_button.3.dart
+++ b/examples/api/lib/material/icon_button/icon_button.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [IconButton] with toggle feature.
+// Flutter code sample for [IconButton] with toggle feature.
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/ink/ink.image_clip.0.dart
+++ b/examples/api/lib/material/ink/ink.image_clip.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Image.frameBuilder].
+// Flutter code sample for [Image.frameBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/ink/ink.image_clip.1.dart
+++ b/examples/api/lib/material/ink/ink.image_clip.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Image.frameBuilder].
+// Flutter code sample for [Image.frameBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/ink_well/ink_well.0.dart
+++ b/examples/api/lib/material/ink_well/ink_well.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InkWell].
+// Flutter code sample for [InkWell].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration].
+// Flutter code sample for [InputDecoration].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.1.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration].
+// Flutter code sample for [InputDecoration].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.2.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration].
+// Flutter code sample for [InputDecoration].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.3.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration].
+// Flutter code sample for [InputDecoration].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.floating_label_style_error.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecorator].
+// Flutter code sample for [InputDecorator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.label.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.label.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration.label].
+// Flutter code sample for [InputDecoration.label].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.label_style_error.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecorator].
+// Flutter code sample for [InputDecorator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.material_state.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.material_state.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration].
+// Flutter code sample for [InputDecoration].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.material_state.1.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.material_state.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration].
+// Flutter code sample for [InputDecoration].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.prefix_icon.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.prefix_icon.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecorator].
+// Flutter code sample for [InputDecorator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.prefix_icon_constraints.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.prefix_icon_constraints.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration.prefixIconConstraints].
+// Flutter code sample for [InputDecoration.prefixIconConstraints].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.suffix_icon.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.suffix_icon.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecorator].
+// Flutter code sample for [InputDecorator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/input_decorator/input_decoration.suffix_icon_constraints.0.dart
+++ b/examples/api/lib/material/input_decorator/input_decoration.suffix_icon_constraints.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InputDecoration.suffixIconConstraints].
+// Flutter code sample for [InputDecoration.suffixIconConstraints].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/list_tile/list_tile.0.dart
+++ b/examples/api/lib/material/list_tile/list_tile.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListTile].
+// Flutter code sample for [ListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/list_tile/list_tile.1.dart
+++ b/examples/api/lib/material/list_tile/list_tile.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListTile].
+// Flutter code sample for [ListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/list_tile/list_tile.4.dart
+++ b/examples/api/lib/material/list_tile/list_tile.4.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListTile].
+// Flutter code sample for [ListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/list_tile/list_tile.5.dart
+++ b/examples/api/lib/material/list_tile/list_tile.5.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListTile].
+// Flutter code sample for [ListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/list_tile/list_tile.selected.0.dart
+++ b/examples/api/lib/material/list_tile/list_tile.selected.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListTile.selected].
+// Flutter code sample for [ListTile.selected].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/material_state/material_state_border_side.0.dart
+++ b/examples/api/lib/material/material_state/material_state_border_side.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MaterialStateBorderSide].
+// Flutter code sample for [MaterialStateBorderSide].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/material_state/material_state_mouse_cursor.0.dart
+++ b/examples/api/lib/material/material_state/material_state_mouse_cursor.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MaterialStateMouseCursor].
+// Flutter code sample for [MaterialStateMouseCursor].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/material_state/material_state_outlined_border.0.dart
+++ b/examples/api/lib/material/material_state/material_state_outlined_border.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MaterialStateOutlinedBorder].
+// Flutter code sample for [MaterialStateOutlinedBorder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/material_state/material_state_property.0.dart
+++ b/examples/api/lib/material/material_state/material_state_property.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MaterialStateProperty].
+// Flutter code sample for [MaterialStateProperty].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/menu_anchor/checkbox_menu_button.0.dart
+++ b/examples/api/lib/material/menu_anchor/checkbox_menu_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CheckboxMenuButton].
+// Flutter code sample for [CheckboxMenuButton].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/menu_anchor/menu_accelerator_label.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_accelerator_label.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MenuAcceleratorLabel].
+// Flutter code sample for [MenuAcceleratorLabel].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MenuAnchor].
+// Flutter code sample for [MenuAnchor].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
+++ b/examples/api/lib/material/menu_anchor/menu_anchor.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MenuAnchor].
+// Flutter code sample for [MenuAnchor].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/menu_anchor/menu_bar.0.dart
+++ b/examples/api/lib/material/menu_anchor/menu_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MenuBar].
+// Flutter code sample for [MenuBar].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/menu_anchor/radio_menu_button.0.dart
+++ b/examples/api/lib/material/menu_anchor/radio_menu_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RadioMenuButton].
+// Flutter code sample for [RadioMenuButton].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/navigation_bar/navigation_bar.0.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigationBar].
+// Flutter code sample for [NavigationBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/navigation_bar/navigation_bar.1.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigationBar].
+// Flutter code sample for [NavigationBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/navigation_bar/navigation_bar.2.dart
+++ b/examples/api/lib/material/navigation_bar/navigation_bar.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigationBar] with nested [Navigator] destinations.
+// Flutter code sample for [NavigationBar] with nested [Navigator] destinations.
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/navigation_rail/navigation_rail.0.dart
+++ b/examples/api/lib/material/navigation_rail/navigation_rail.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigationRail].
+// Flutter code sample for [NavigationRail].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/navigation_rail/navigation_rail.1.dart
+++ b/examples/api/lib/material/navigation_rail/navigation_rail.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigationRail].
+// Flutter code sample for [NavigationRail].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/navigation_rail/navigation_rail.extended_animation.0.dart
+++ b/examples/api/lib/material/navigation_rail/navigation_rail.extended_animation.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigationRail.extendedAnimation].
+// Flutter code sample for [NavigationRail.extendedAnimation].
 
 import 'dart:ui';
 

--- a/examples/api/lib/material/outlined_button/outlined_button.0.dart
+++ b/examples/api/lib/material/outlined_button/outlined_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [OutlinedButton].
+// Flutter code sample for [OutlinedButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
+++ b/examples/api/lib/material/platform_menu_bar/platform_menu_bar.0.dart
@@ -2,11 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PlatformMenuBar].
+// Flutter code sample for [PlatformMenuBar].
 
-////////////////////////////////////
 // THIS SAMPLE ONLY WORKS ON MACOS.
-////////////////////////////////////
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/popup_menu/popup_menu.0.dart
+++ b/examples/api/lib/material/popup_menu/popup_menu.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PopupMenuButton].
+// Flutter code sample for [PopupMenuButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/popup_menu/popup_menu.1.dart
+++ b/examples/api/lib/material/popup_menu/popup_menu.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PopupMenuButton].
+// Flutter code sample for [PopupMenuButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/progress_indicator/circular_progress_indicator.0.dart
+++ b/examples/api/lib/material/progress_indicator/circular_progress_indicator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CircularProgressIndicator].
+// Flutter code sample for [CircularProgressIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/progress_indicator/circular_progress_indicator.1.dart
+++ b/examples/api/lib/material/progress_indicator/circular_progress_indicator.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CircularProgressIndicator].
+// Flutter code sample for [CircularProgressIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/progress_indicator/linear_progress_indicator.0.dart
+++ b/examples/api/lib/material/progress_indicator/linear_progress_indicator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [LinearProgressIndicator].
+// Flutter code sample for [LinearProgressIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/progress_indicator/linear_progress_indicator.1.dart
+++ b/examples/api/lib/material/progress_indicator/linear_progress_indicator.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [LinearProgressIndicator].
+// Flutter code sample for [LinearProgressIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/radio/radio.0.dart
+++ b/examples/api/lib/material/radio/radio.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Radio].
+// Flutter code sample for [Radio].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/radio/radio.toggleable.0.dart
+++ b/examples/api/lib/material/radio/radio.toggleable.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Radio.toggleable].
+// Flutter code sample for [Radio.toggleable].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/radio_list_tile/radio_list_tile.0.dart
+++ b/examples/api/lib/material/radio_list_tile/radio_list_tile.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RadioListTile].
+// Flutter code sample for [RadioListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/radio_list_tile/radio_list_tile.1.dart
+++ b/examples/api/lib/material/radio_list_tile/radio_list_tile.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RadioListTile].
+// Flutter code sample for [RadioListTile].
 
 import 'package:flutter/gestures.dart';
 

--- a/examples/api/lib/material/radio_list_tile/radio_list_tile.2.dart
+++ b/examples/api/lib/material/radio_list_tile/radio_list_tile.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RadioListTile].
+// Flutter code sample for [RadioListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/radio_list_tile/radio_list_tile.toggleable.0.dart
+++ b/examples/api/lib/material/radio_list_tile/radio_list_tile.toggleable.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RadioListTile.toggleable].
+// Flutter code sample for [RadioListTile.toggleable].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/range_slider/range_slider.0.dart
+++ b/examples/api/lib/material/range_slider/range_slider.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RangeSlider].
+// Flutter code sample for [RangeSlider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
+++ b/examples/api/lib/material/refresh_indicator/refresh_indicator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RefreshIndicator].
+// Flutter code sample for [RefreshIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/refresh_indicator/refresh_indicator.1.dart
+++ b/examples/api/lib/material/refresh_indicator/refresh_indicator.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RefreshIndicator].
+// Flutter code sample for [RefreshIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ReorderableListView].
+// Flutter code sample for [ReorderableListView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ReorderableListView].
+// Flutter code sample for [ReorderableListView].
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.build_default_drag_handles.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ReorderableListView.buildDefaultDragHandles].
+// Flutter code sample for [ReorderableListView.buildDefaultDragHandles].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart
+++ b/examples/api/lib/material/reorderable_list/reorderable_list_view.reorderable_list_view_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ReorderableListView.ReorderableListView.builder].
+// Flutter code sample for [ReorderableListView.ReorderableListView.builder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold].
+// Flutter code sample for [Scaffold].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.1.dart
+++ b/examples/api/lib/material/scaffold/scaffold.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold].
+// Flutter code sample for [Scaffold].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.2.dart
+++ b/examples/api/lib/material/scaffold/scaffold.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold].
+// Flutter code sample for [Scaffold].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.drawer.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold.drawer.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold.drawer].
+// Flutter code sample for [Scaffold.drawer].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.end_drawer.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold.end_drawer.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold.endDrawer].
+// Flutter code sample for [Scaffold.endDrawer].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.of.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold.of.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold.of].
+// Flutter code sample for [Scaffold.of].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold.of.1.dart
+++ b/examples/api/lib/material/scaffold/scaffold.of.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scaffold.of].
+// Flutter code sample for [Scaffold.of].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_messenger.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold_messenger.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldMessenger].
+// Flutter code sample for [ScaffoldMessenger].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_messenger.of.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold_messenger.of.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldMessenger.of].
+// Flutter code sample for [ScaffoldMessenger.of].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_messenger.of.1.dart
+++ b/examples/api/lib/material/scaffold/scaffold_messenger.of.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldMessenger.of].
+// Flutter code sample for [ScaffoldMessenger.of].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_messenger_state.show_material_banner.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold_messenger_state.show_material_banner.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldMessengerState.showMaterialBanner].
+// Flutter code sample for [ScaffoldMessengerState.showMaterialBanner].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldMessengerState.showSnackBar].
+// Flutter code sample for [ScaffoldMessengerState.showSnackBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.1.dart
+++ b/examples/api/lib/material/scaffold/scaffold_messenger_state.show_snack_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SnackBar].
+// Flutter code sample for [SnackBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_state.show_bottom_sheet.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold_state.show_bottom_sheet.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldState.showBottomSheet].
+// Flutter code sample for [ScaffoldState.showBottomSheet].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scaffold/scaffold_state.show_snack_bar.0.dart
+++ b/examples/api/lib/material/scaffold/scaffold_state.show_snack_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaffoldState.showSnackBar].
+// Flutter code sample for [ScaffoldState.showSnackBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scrollbar/scrollbar.0.dart
+++ b/examples/api/lib/material/scrollbar/scrollbar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scrollbar].
+// Flutter code sample for [Scrollbar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/scrollbar/scrollbar.1.dart
+++ b/examples/api/lib/material/scrollbar/scrollbar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scrollbar].
+// Flutter code sample for [Scrollbar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/segmented_button/segmented_button.0.dart
+++ b/examples/api/lib/material/segmented_button/segmented_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SegmentedButton].
+// Flutter code sample for [SegmentedButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/selectable_region/selectable_region.0.dart
+++ b/examples/api/lib/material/selectable_region/selectable_region.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SelectableRegion].
+// Flutter code sample for [SelectableRegion].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/examples/api/lib/material/selection_area/selection_area.0.dart
+++ b/examples/api/lib/material/selection_area/selection_area.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SelectionArea].
+// Flutter code sample for [SelectionArea].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/selection_container/selection_container.0.dart
+++ b/examples/api/lib/material/selection_container/selection_container.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SelectionContainer].
+// Flutter code sample for [SelectionContainer].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/examples/api/lib/material/selection_container/selection_container_disabled.0.dart
+++ b/examples/api/lib/material/selection_container/selection_container_disabled.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter example for [SelectionContainer.disabled].
+// Flutter example for [SelectionContainer.disabled].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/slider/slider.0.dart
+++ b/examples/api/lib/material/slider/slider.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Slider].
+// Flutter code sample for [Slider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/slider/slider.1.dart
+++ b/examples/api/lib/material/slider/slider.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Slider].
+// Flutter code sample for [Slider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/slider/slider.2.dart
+++ b/examples/api/lib/material/slider/slider.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Slider].
+// Flutter code sample for [Slider].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/snack_bar/snack_bar.0.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SnackBar].
+// Flutter code sample for [SnackBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/snack_bar/snack_bar.1.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SnackBar].
+// Flutter code sample for [SnackBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SnackBar] with Material 3 specifications.
+// Flutter code sample for [SnackBar] with Material 3 specifications.
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/stepper/stepper.0.dart
+++ b/examples/api/lib/material/stepper/stepper.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Stepper].
+// Flutter code sample for [Stepper].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/stepper/stepper.controls_builder.0.dart
+++ b/examples/api/lib/material/stepper/stepper.controls_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Stepper.controlsBuilder].
+// Flutter code sample for [Stepper.controlsBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/switch/switch.0.dart
+++ b/examples/api/lib/material/switch/switch.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Switch].
+// Flutter code sample for [Switch].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/switch/switch.1.dart
+++ b/examples/api/lib/material/switch/switch.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Switch].
+// Flutter code sample for [Switch].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/switch/switch.3.dart
+++ b/examples/api/lib/material/switch/switch.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Switch].
+// Flutter code sample for [Switch].
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/switch_list_tile/switch_list_tile.0.dart
+++ b/examples/api/lib/material/switch_list_tile/switch_list_tile.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SwitchListTile].
+// Flutter code sample for [SwitchListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/switch_list_tile/switch_list_tile.1.dart
+++ b/examples/api/lib/material/switch_list_tile/switch_list_tile.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SwitchListTile].
+// Flutter code sample for [SwitchListTile].
 
 import 'package:flutter/gestures.dart';
 

--- a/examples/api/lib/material/switch_list_tile/switch_list_tile.2.dart
+++ b/examples/api/lib/material/switch_list_tile/switch_list_tile.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SwitchListTile].
+// Flutter code sample for [SwitchListTile].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tab_controller/tab_controller.1.dart
+++ b/examples/api/lib/material/tab_controller/tab_controller.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TabController].
+// Flutter code sample for [TabController].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tabs/tab_bar.0.dart
+++ b/examples/api/lib/material/tabs/tab_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TabBar].
+// Flutter code sample for [TabBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tabs/tab_bar.1.dart
+++ b/examples/api/lib/material/tabs/tab_bar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TabBar].
+// Flutter code sample for [TabBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/text_button/text_button.0.dart
+++ b/examples/api/lib/material/text_button/text_button.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TextButton].
+// Flutter code sample for [TextButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/text_button/text_button.1.dart
+++ b/examples/api/lib/material/text_button/text_button.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TextButton].
+// Flutter code sample for [TextButton].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/text_field/text_field.1.dart
+++ b/examples/api/lib/material/text_field/text_field.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TextField].
+// Flutter code sample for [TextField].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/text_field/text_field.2.dart
+++ b/examples/api/lib/material/text_field/text_field.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for Material Design 3 [TextField]s.
+// Flutter code sample for Material Design 3 [TextField]s.
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/text_form_field/text_form_field.1.dart
+++ b/examples/api/lib/material/text_form_field/text_form_field.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TextFormField].
+// Flutter code sample for [TextFormField].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/material/theme/theme_extension.1.dart
+++ b/examples/api/lib/material/theme/theme_extension.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ThemeExtension].
+// Flutter code sample for [ThemeExtension].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';

--- a/examples/api/lib/material/time_picker/show_time_picker.0.dart
+++ b/examples/api/lib/material/time_picker/show_time_picker.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showTimePicker].
+// Flutter code sample for [showTimePicker].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/toggle_buttons/toggle_buttons.0.dart
+++ b/examples/api/lib/material/toggle_buttons/toggle_buttons.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ToggleButtons].
+// Flutter code sample for [ToggleButtons].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tooltip/tooltip.0.dart
+++ b/examples/api/lib/material/tooltip/tooltip.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Tooltip].
+// Flutter code sample for [Tooltip].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tooltip/tooltip.1.dart
+++ b/examples/api/lib/material/tooltip/tooltip.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Tooltip].
+// Flutter code sample for [Tooltip].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tooltip/tooltip.2.dart
+++ b/examples/api/lib/material/tooltip/tooltip.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Tooltip].
+// Flutter code sample for [Tooltip].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/material/tooltip/tooltip.3.dart
+++ b/examples/api/lib/material/tooltip/tooltip.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Tooltip].
+// Flutter code sample for [Tooltip].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/painting/borders/border_side.stroke_align.0.dart
+++ b/examples/api/lib/painting/borders/border_side.stroke_align.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [BorderSide.strokeAlign].
+// Flutter code sample for [BorderSide.strokeAlign].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/painting/gradient/linear_gradient.0.dart
+++ b/examples/api/lib/painting/gradient/linear_gradient.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [LinearGradient].
+// Flutter code sample for [LinearGradient].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/painting/star_border/star_border.0.dart
+++ b/examples/api/lib/painting/star_border/star_border.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// An example showing usage of [StarBorder].
+// An example showing usage of [StarBorder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart
+++ b/examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverGridDelegateWithFixedCrossAxisCount].
+// Flutter code sample for [SliverGridDelegateWithFixedCrossAxisCount].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1.dart
+++ b/examples/api/lib/rendering/sliver_grid/sliver_grid_delegate_with_fixed_cross_axis_count.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverGridDelegateWithFixedCrossAxisCount].
+// Flutter code sample for [SliverGridDelegateWithFixedCrossAxisCount].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/sample_templates/cupertino.0.dart
+++ b/examples/api/lib/sample_templates/cupertino.0.dart
@@ -29,7 +29,7 @@
 // is referenced more than once, link back to the instance the example file is
 // named for.
 
-/// Flutter code sample for [Placeholder].
+// Flutter code sample for [Placeholder].
 
 import 'package:flutter/cupertino.dart';
 

--- a/examples/api/lib/sample_templates/material.0.dart
+++ b/examples/api/lib/sample_templates/material.0.dart
@@ -29,7 +29,7 @@
 // is referenced more than once, link back to the instance the example file is
 // named for.
 
-/// Flutter code sample for [Placeholder].
+// Flutter code sample for [Placeholder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/sample_templates/widgets.0.dart
+++ b/examples/api/lib/sample_templates/widgets.0.dart
@@ -29,7 +29,7 @@
 // is referenced more than once, link back to the instance the example file is
 // named for.
 
-/// Flutter code sample for [Placeholder].
+// Flutter code sample for [Placeholder].
 
 import 'package:flutter/widgets.dart';
 

--- a/examples/api/lib/services/keyboard_key/logical_keyboard_key.0.dart
+++ b/examples/api/lib/services/keyboard_key/logical_keyboard_key.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [LogicalKeyboardKey].
+// Flutter code sample for [LogicalKeyboardKey].
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/services/keyboard_key/physical_keyboard_key.0.dart
+++ b/examples/api/lib/services/keyboard_key/physical_keyboard_key.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PhysicalKeyboardKey].
+// Flutter code sample for [PhysicalKeyboardKey].
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/services/mouse_cursor/mouse_cursor.0.dart
+++ b/examples/api/lib/services/mouse_cursor/mouse_cursor.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MouseCursor].
+// Flutter code sample for [MouseCursor].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/services/system_chrome/system_chrome.set_system_u_i_overlay_style.1.dart
+++ b/examples/api/lib/services/system_chrome/system_chrome.set_system_u_i_overlay_style.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SystemChrome.setSystemUIOverlayStyle].
+// Flutter code sample for [SystemChrome.setSystemUIOverlayStyle].
 
 import 'dart:math' as math;
 

--- a/examples/api/lib/ui/text/font_feature.0.dart
+++ b/examples/api/lib/ui/text/font_feature.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature].
+// Flutter code sample for [FontFeature].
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_alternative.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_alternative.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.alternative].
+// Flutter code sample for [FontFeature.FontFeature.alternative].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_alternative_fractions.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_alternative_fractions.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.alternativeFractions].
+// Flutter code sample for [FontFeature.FontFeature.alternativeFractions].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_case_sensitive_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_case_sensitive_forms.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.caseSensitiveForms].
+// Flutter code sample for [FontFeature.FontFeature.caseSensitiveForms].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_character_variant.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_character_variant.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.characterVariant].
+// Flutter code sample for [FontFeature.FontFeature.characterVariant].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_contextual_alternates.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_contextual_alternates.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.contextualAlternates].
+// Flutter code sample for [FontFeature.FontFeature.contextualAlternates].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_denominator.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_denominator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.denominator].
+// Flutter code sample for [FontFeature.FontFeature.denominator].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_fractions.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_fractions.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.fractions].
+// Flutter code sample for [FontFeature.FontFeature.fractions].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_historical_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_historical_forms.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.historicalForms].
+// Flutter code sample for [FontFeature.FontFeature.historicalForms].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_historical_ligatures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_historical_ligatures.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.historicalLigatures].
+// Flutter code sample for [FontFeature.FontFeature.historicalLigatures].
 
 import 'dart:ui';
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_lining_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_lining_figures.0.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.liningFigures].
+// Flutter code sample for [FontFeature.FontFeature.liningFigures].
+
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_locale_aware.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_locale_aware.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.localeAware].
+// Flutter code sample for [FontFeature.FontFeature.localeAware].
 
 import 'package:flutter/widgets.dart';
 

--- a/examples/api/lib/ui/text/font_feature.font_feature_notational_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_notational_forms.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.notationalForms].
+// Flutter code sample for [FontFeature.FontFeature.notationalForms].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_numerators.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_numerators.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.numerators].
+// Flutter code sample for [FontFeature.FontFeature.numerators].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_oldstyle_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_oldstyle_figures.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.oldstyleFigures].
+// Flutter code sample for [FontFeature.FontFeature.oldstyleFigures].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_ordinal_forms.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_ordinal_forms.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.ordinalForms].
+// Flutter code sample for [FontFeature.FontFeature.ordinalForms].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_proportional_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_proportional_figures.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.proportionalFigures].
+// Flutter code sample for [FontFeature.FontFeature.proportionalFigures].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_scientific_inferiors.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_scientific_inferiors.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.scientificInferiors].
+// Flutter code sample for [FontFeature.FontFeature.scientificInferiors].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_slashed_zero.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_slashed_zero.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.slashedZero].
+// Flutter code sample for [FontFeature.FontFeature.slashedZero].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_stylistic_alternates.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_stylistic_alternates.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.stylisticAlternates].
+// Flutter code sample for [FontFeature.FontFeature.stylisticAlternates].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.stylisticSet].
+// Flutter code sample for [FontFeature.FontFeature.stylisticSet].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.1.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_stylistic_set.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.stylisticSet].
+// Flutter code sample for [FontFeature.FontFeature.stylisticSet].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_subscripts.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_subscripts.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.subscripts].
+// Flutter code sample for [FontFeature.FontFeature.subscripts].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_superscripts.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_superscripts.0.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.superscripts].
+// Flutter code sample for [FontFeature.FontFeature.superscripts].
+
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_swash.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_swash.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FontFeature.FontFeature.swash].
+// Flutter code sample for [FontFeature.FontFeature.swash].
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/ui/text/font_feature.font_feature_tabular_figures.0.dart
+++ b/examples/api/lib/ui/text/font_feature.font_feature_tabular_figures.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [dart]:ui FontFeature.FontFeature.tabularFigures.
+// Flutter code sample for [dart]:ui FontFeature.FontFeature.tabularFigures.
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';

--- a/examples/api/lib/widgets/actions/action.action_overridable.0.dart
+++ b/examples/api/lib/widgets/actions/action.action_overridable.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Action.Action.overridable].
+// Flutter code sample for [Action.Action.overridable].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/actions/action_listener.0.dart
+++ b/examples/api/lib/widgets/actions/action_listener.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ActionListener].
+// Flutter code sample for [ActionListener].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/actions/actions.0.dart
+++ b/examples/api/lib/widgets/actions/actions.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Actions].
+// Flutter code sample for [Actions].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/actions/focusable_action_detector.0.dart
+++ b/examples/api/lib/widgets/actions/focusable_action_detector.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FocusableActionDetector].
+// Flutter code sample for [FocusableActionDetector].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/animated_grid/animated_grid.0.dart
+++ b/examples/api/lib/widgets/animated_grid/animated_grid.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedGrid].
+// Flutter code sample for [AnimatedGrid].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/animated_grid/sliver_animated_grid.0.dart
+++ b/examples/api/lib/widgets/animated_grid/sliver_animated_grid.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverAnimatedGrid].
+// Flutter code sample for [SliverAnimatedGrid].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/animated_list/animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/animated_list.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedList].
+// Flutter code sample for [AnimatedList].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverAnimatedList].
+// Flutter code sample for [SliverAnimatedList].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/animated_size/animated_size.0.dart
+++ b/examples/api/lib/widgets/animated_size/animated_size.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedSize].
+// Flutter code sample for [AnimatedSize].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/animated_switcher/animated_switcher.0.dart
+++ b/examples/api/lib/widgets/animated_switcher/animated_switcher.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedSwitcher].
+// Flutter code sample for [AnimatedSwitcher].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/app/widgets_app.widgets_app.0.dart
+++ b/examples/api/lib/widgets/app/widgets_app.widgets_app.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [WidgetsApp].
+// Flutter code sample for [WidgetsApp].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/async/future_builder.0.dart
+++ b/examples/api/lib/widgets/async/future_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FutureBuilder].
+// Flutter code sample for [FutureBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/async/stream_builder.0.dart
+++ b/examples/api/lib/widgets/async/stream_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [StreamBuilder].
+// Flutter code sample for [StreamBuilder].
 
 import 'dart:async';
 

--- a/examples/api/lib/widgets/autocomplete/raw_autocomplete.0.dart
+++ b/examples/api/lib/widgets/autocomplete/raw_autocomplete.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawAutocomplete].
+// Flutter code sample for [RawAutocomplete].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/autocomplete/raw_autocomplete.1.dart
+++ b/examples/api/lib/widgets/autocomplete/raw_autocomplete.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawAutocomplete].
+// Flutter code sample for [RawAutocomplete].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/autocomplete/raw_autocomplete.2.dart
+++ b/examples/api/lib/widgets/autocomplete/raw_autocomplete.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawAutocomplete].
+// Flutter code sample for [RawAutocomplete].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/autocomplete/raw_autocomplete.focus_node.0.dart
+++ b/examples/api/lib/widgets/autocomplete/raw_autocomplete.focus_node.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawAutocomplete.focusNode].
+// Flutter code sample for [RawAutocomplete.focusNode].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/autofill/autofill_group.0.dart
+++ b/examples/api/lib/widgets/autofill/autofill_group.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AutofillGroup].
+// Flutter code sample for [AutofillGroup].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/absorb_pointer.0.dart
+++ b/examples/api/lib/widgets/basic/absorb_pointer.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AbsorbPointer].
+// Flutter code sample for [AbsorbPointer].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/aspect_ratio.0.dart
+++ b/examples/api/lib/widgets/basic/aspect_ratio.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AspectRatio].
+// Flutter code sample for [AspectRatio].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/aspect_ratio.1.dart
+++ b/examples/api/lib/widgets/basic/aspect_ratio.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AspectRatio].
+// Flutter code sample for [AspectRatio].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/aspect_ratio.2.dart
+++ b/examples/api/lib/widgets/basic/aspect_ratio.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AspectRatio].
+// Flutter code sample for [AspectRatio].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/clip_rrect.0.dart
+++ b/examples/api/lib/widgets/basic/clip_rrect.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ClipRRect].
+// Flutter code sample for [ClipRRect].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/clip_rrect.1.dart
+++ b/examples/api/lib/widgets/basic/clip_rrect.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ClipRRect].
+// Flutter code sample for [ClipRRect].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/custom_multi_child_layout.0.dart
+++ b/examples/api/lib/widgets/basic/custom_multi_child_layout.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CustomMultiChildLayout].
+// Flutter code sample for [CustomMultiChildLayout].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/expanded.0.dart
+++ b/examples/api/lib/widgets/basic/expanded.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Expanded].
+// Flutter code sample for [Expanded].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/expanded.1.dart
+++ b/examples/api/lib/widgets/basic/expanded.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Expanded].
+// Flutter code sample for [Expanded].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/fitted_box.0.dart
+++ b/examples/api/lib/widgets/basic/fitted_box.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FittedBox].
+// Flutter code sample for [FittedBox].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/flow.0.dart
+++ b/examples/api/lib/widgets/basic/flow.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Flow].
+// Flutter code sample for [Flow].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/fractionally_sized_box.0.dart
+++ b/examples/api/lib/widgets/basic/fractionally_sized_box.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FractionallySizedBox].
+// Flutter code sample for [FractionallySizedBox].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/ignore_pointer.0.dart
+++ b/examples/api/lib/widgets/basic/ignore_pointer.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [IgnorePointer].
+// Flutter code sample for [IgnorePointer].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/indexed_stack.0.dart
+++ b/examples/api/lib/widgets/basic/indexed_stack.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [IndexedStack.].
+// Flutter code sample for [IndexedStack.].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/listener.0.dart
+++ b/examples/api/lib/widgets/basic/listener.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Listener].
+// Flutter code sample for [Listener].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/mouse_region.0.dart
+++ b/examples/api/lib/widgets/basic/mouse_region.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MouseRegion].
+// Flutter code sample for [MouseRegion].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/mouse_region.on_exit.0.dart
+++ b/examples/api/lib/widgets/basic/mouse_region.on_exit.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MouseRegion.onExit].
+// Flutter code sample for [MouseRegion.onExit].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/mouse_region.on_exit.1.dart
+++ b/examples/api/lib/widgets/basic/mouse_region.on_exit.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MouseRegion.onExit].
+// Flutter code sample for [MouseRegion.onExit].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/offstage.0.dart
+++ b/examples/api/lib/widgets/basic/offstage.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Offstage].
+// Flutter code sample for [Offstage].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/basic/physical_shape.0.dart
+++ b/examples/api/lib/widgets/basic/physical_shape.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PhysicalShape].
+// Flutter code sample for [PhysicalShape].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/binding/widget_binding_observer.0.dart
+++ b/examples/api/lib/widgets/binding/widget_binding_observer.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [WidgetBindingsObserver].
+// Flutter code sample for [WidgetBindingsObserver].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/color_filter/color_filtered.0.dart
+++ b/examples/api/lib/widgets/color_filter/color_filtered.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ColorFiltered].
+// Flutter code sample for [ColorFiltered].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/dismissible/dismissible.0.dart
+++ b/examples/api/lib/widgets/dismissible/dismissible.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Dismissible].
+// Flutter code sample for [Dismissible].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/drag_target/draggable.0.dart
+++ b/examples/api/lib/widgets/drag_target/draggable.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Draggable].
+// Flutter code sample for [Draggable].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/editable_text/editable_text.on_changed.0.dart
+++ b/examples/api/lib/widgets/editable_text/editable_text.on_changed.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [EditableText.onChanged].
+// Flutter code sample for [EditableText.onChanged].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/editable_text/text_editing_controller.0.dart
+++ b/examples/api/lib/widgets/editable_text/text_editing_controller.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TextEditingController].
+// Flutter code sample for [TextEditingController].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/focus_manager/focus_node.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FocusNode].
+// Flutter code sample for [FocusNode].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.unfocus.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FocusNode.unfocus].
+// Flutter code sample for [FocusNode.unfocus].
 
 
 import 'package:flutter/material.dart';

--- a/examples/api/lib/widgets/focus_scope/focus.0.dart
+++ b/examples/api/lib/widgets/focus_scope/focus.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Focus].
+// Flutter code sample for [Focus].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/focus_scope/focus.1.dart
+++ b/examples/api/lib/widgets/focus_scope/focus.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Focus].
+// Flutter code sample for [Focus].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/focus_scope/focus.2.dart
+++ b/examples/api/lib/widgets/focus_scope/focus.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Focus].
+// Flutter code sample for [Focus].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/focus_scope/focus_scope.0.dart
+++ b/examples/api/lib/widgets/focus_scope/focus_scope.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FocusScope].
+// Flutter code sample for [FocusScope].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/focus_traversal/focus_traversal_group.0.dart
+++ b/examples/api/lib/widgets/focus_traversal/focus_traversal_group.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FocusTraversalGroup].
+// Flutter code sample for [FocusTraversalGroup].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/focus_traversal/ordered_traversal_policy.0.dart
+++ b/examples/api/lib/widgets/focus_traversal/ordered_traversal_policy.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [OrderedTraversalPolicy].
+// Flutter code sample for [OrderedTraversalPolicy].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/form/form.0.dart
+++ b/examples/api/lib/widgets/form/form.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Form].
+// Flutter code sample for [Form].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/framework/build_owner.0.dart
+++ b/examples/api/lib/widgets/framework/build_owner.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [BuildOwner].
+// Flutter code sample for [BuildOwner].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/examples/api/lib/widgets/framework/error_widget.0.dart
+++ b/examples/api/lib/widgets/framework/error_widget.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ErrorWidget].
+// Flutter code sample for [ErrorWidget].
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/widgets/gesture_detector/gesture_detector.0.dart
+++ b/examples/api/lib/widgets/gesture_detector/gesture_detector.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [GestureDetector].
+// Flutter code sample for [GestureDetector].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/gesture_detector/gesture_detector.1.dart
+++ b/examples/api/lib/widgets/gesture_detector/gesture_detector.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [GestureDetector].
+// Flutter code sample for [GestureDetector].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/gesture_detector/gesture_detector.2.dart
+++ b/examples/api/lib/widgets/gesture_detector/gesture_detector.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [GestureDetector].
+// Flutter code sample for [GestureDetector].
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
+++ b/examples/api/lib/widgets/hardware_keyboard/key_event_manager.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [KeyEventManager.keyMessageHandler].
+// Flutter code sample for [KeyEventManager.keyMessageHandler].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/heroes/hero.0.dart
+++ b/examples/api/lib/widgets/heroes/hero.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Hero].
+// Flutter code sample for [Hero].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/heroes/hero.1.dart
+++ b/examples/api/lib/widgets/heroes/hero.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Hero].
+// Flutter code sample for [Hero].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';

--- a/examples/api/lib/widgets/image/image.error_builder.0.dart
+++ b/examples/api/lib/widgets/image/image.error_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Image.errorBuilder].
+// Flutter code sample for [Image.errorBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/image/image.frame_builder.0.dart
+++ b/examples/api/lib/widgets/image/image.frame_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Image.frameBuilder].
+// Flutter code sample for [Image.frameBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/image/image.loading_builder.0.dart
+++ b/examples/api/lib/widgets/image/image.loading_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Image.loadingBuilder].
+// Flutter code sample for [Image.loadingBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/animated_align.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_align.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedAlign].
+// Flutter code sample for [AnimatedAlign].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/animated_container.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_container.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedContainer].
+// Flutter code sample for [AnimatedContainer].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/animated_fractionally_sized_box.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_fractionally_sized_box.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedFractionallySizedBox].
+// Flutter code sample for [AnimatedFractionallySizedBox].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/animated_padding.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_padding.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedPadding].
+// Flutter code sample for [AnimatedPadding].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/animated_positioned.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_positioned.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedPositioned].
+// Flutter code sample for [AnimatedPositioned].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/animated_slide.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/animated_slide.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedSlide].
+// Flutter code sample for [AnimatedSlide].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/implicit_animations/sliver_animated_opacity.0.dart
+++ b/examples/api/lib/widgets/implicit_animations/sliver_animated_opacity.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverAnimatedOpacity].
+// Flutter code sample for [SliverAnimatedOpacity].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/inherited_model/inherited_model.0.dart
+++ b/examples/api/lib/widgets/inherited_model/inherited_model.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InheritedModel].
+// Flutter code sample for [InheritedModel].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/inherited_notifier/inherited_notifier.0.dart
+++ b/examples/api/lib/widgets/inherited_notifier/inherited_notifier.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InheritedNotifier].
+// Flutter code sample for [InheritedNotifier].
 
 import 'dart:math' as math;
 

--- a/examples/api/lib/widgets/inherited_theme/inherited_theme.0.dart
+++ b/examples/api/lib/widgets/inherited_theme/inherited_theme.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InheritedTheme].
+// Flutter code sample for [InheritedTheme].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InteractiveViewer].
+// Flutter code sample for [InteractiveViewer].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InteractiveViewer.builder].
+// Flutter code sample for [InteractiveViewer.builder].
 
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart' show Quad, Vector3;

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.constrained.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.constrained.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InteractiveViewer.constrained].
+// Flutter code sample for [InteractiveViewer.constrained].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/interactive_viewer/interactive_viewer.transformation_controller.0.dart
+++ b/examples/api/lib/widgets/interactive_viewer/interactive_viewer.transformation_controller.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [InteractiveViewer.transformationController].
+// Flutter code sample for [InteractiveViewer.transformationController].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/layout_builder/layout_builder.0.dart
+++ b/examples/api/lib/widgets/layout_builder/layout_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [LayoutBuilder].
+// Flutter code sample for [LayoutBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/media_query/media_query_data.system_gesture_insets.0.dart
+++ b/examples/api/lib/widgets/media_query/media_query_data.system_gesture_insets.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [MediaQueryData.systemGestureInsets].
+// Flutter code sample for [MediaQueryData.systemGestureInsets].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Navigator].
+// Flutter code sample for [Navigator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Navigator.restorablePush].
+// Flutter code sample for [Navigator.restorablePush].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Navigator.restorablePushAndRemoveUntil].
+// Flutter code sample for [Navigator.restorablePushAndRemoveUntil].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Navigator.restorablePushReplacement].
+// Flutter code sample for [Navigator.restorablePushReplacement].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigatorState.restorablePush].
+// Flutter code sample for [NavigatorState.restorablePush].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push_and_remove_until.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigatorState.restorablePushAndRemoveUntil].
+// Flutter code sample for [NavigatorState.restorablePushAndRemoveUntil].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push_replacement.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NavigatorState.restorablePushReplacement].
+// Flutter code sample for [NavigatorState.restorablePushReplacement].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/navigator/restorable_route_future.0.dart
+++ b/examples/api/lib/widgets/navigator/restorable_route_future.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RestorableRouteFuture].
+// Flutter code sample for [RestorableRouteFuture].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NestedScrollView].
+// Flutter code sample for [NestedScrollView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.1.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NestedScrollView].
+// Flutter code sample for [NestedScrollView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.2.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NestedScrollView].
+// Flutter code sample for [NestedScrollView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view_state.0.dart
+++ b/examples/api/lib/widgets/nested_scroll_view/nested_scroll_view_state.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [NestedScrollViewState].
+// Flutter code sample for [NestedScrollViewState].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/notification_listener/notification.0.dart
+++ b/examples/api/lib/widgets/notification_listener/notification.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Notification].
+// Flutter code sample for [Notification].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/overflow_bar/overflow_bar.0.dart
+++ b/examples/api/lib/widgets/overflow_bar/overflow_bar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [OverflowBar].
+// Flutter code sample for [OverflowBar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/overlay/overlay.0.dart
+++ b/examples/api/lib/widgets/overlay/overlay.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Overlay].
+// Flutter code sample for [Overlay].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [GlowingOverscrollIndicator].
+// Flutter code sample for [GlowingOverscrollIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
+++ b/examples/api/lib/widgets/overscroll_indicator/glowing_overscroll_indicator.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [GlowingOverscrollIndicator].
+// Flutter code sample for [GlowingOverscrollIndicator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/page_storage/page_storage.0.dart
+++ b/examples/api/lib/widgets/page_storage/page_storage.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PageStorage].
+// Flutter code sample for [PageStorage].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/page_view/page_view.0.dart
+++ b/examples/api/lib/widgets/page_view/page_view.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PageView].
+// Flutter code sample for [PageView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/preferred_size/preferred_size.0.dart
+++ b/examples/api/lib/widgets/preferred_size/preferred_size.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PreferredSize].
+// Flutter code sample for [PreferredSize].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/restoration/restoration_mixin.0.dart
+++ b/examples/api/lib/widgets/restoration/restoration_mixin.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RestorationMixin].
+// Flutter code sample for [RestorationMixin].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/restoration_properties/restorable_value.0.dart
+++ b/examples/api/lib/widgets/restoration_properties/restorable_value.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RestorableValue].
+// Flutter code sample for [RestorableValue].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/routes/popup_route.0.dart
+++ b/examples/api/lib/widgets/routes/popup_route.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PopupRoute].
+// Flutter code sample for [PopupRoute].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/routes/show_general_dialog.0.dart
+++ b/examples/api/lib/widgets/routes/show_general_dialog.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [showGeneralDialog].
+// Flutter code sample for [showGeneralDialog].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scroll_position/scroll_metrics_notification.0.dart
+++ b/examples/api/lib/widgets/scroll_position/scroll_metrics_notification.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScrollMetricsNotification].
+// Flutter code sample for [ScrollMetricsNotification].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scroll_view/custom_scroll_view.1.dart
+++ b/examples/api/lib/widgets/scroll_view/custom_scroll_view.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CustomScrollView].
+// Flutter code sample for [CustomScrollView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scroll_view/listview_select.1.dart
+++ b/examples/api/lib/widgets/scroll_view/listview_select.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListTile] selection in a ListView or GridView.
+// Flutter code sample for [ListTile] selection in a ListView or GridView.
 // Long press any ListTile to enable selection mode.
 
 import 'package:flutter/material.dart';

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.0.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawScrollbar].
+// Flutter code sample for [RawScrollbar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.1.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawScrollbar].
+// Flutter code sample for [RawScrollbar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.2.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawScrollbar].
+// Flutter code sample for [RawScrollbar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.desktop.0.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.desktop.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Scrollbar].
+// Flutter code sample for [Scrollbar].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/scrollbar/raw_scrollbar.shape.0.dart
+++ b/examples/api/lib/widgets/scrollbar/raw_scrollbar.shape.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RawScrollbar.shape].
+// Flutter code sample for [RawScrollbar.shape].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/shared_app_data/shared_app_data.0.dart
+++ b/examples/api/lib/widgets/shared_app_data/shared_app_data.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SharedAppData].
+// Flutter code sample for [SharedAppData].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/shared_app_data/shared_app_data.1.dart
+++ b/examples/api/lib/widgets/shared_app_data/shared_app_data.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SharedAppData].
+// Flutter code sample for [SharedAppData].
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/examples/api/lib/widgets/shortcuts/character_activator.0.dart
+++ b/examples/api/lib/widgets/shortcuts/character_activator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [CharacterActivator].
+// Flutter code sample for [CharacterActivator].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/shortcuts/logical_key_set.0.dart
+++ b/examples/api/lib/widgets/shortcuts/logical_key_set.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [LogicalKeySet].
+// Flutter code sample for [LogicalKeySet].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/shortcuts/shortcuts.0.dart
+++ b/examples/api/lib/widgets/shortcuts/shortcuts.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Shortcuts].
+// Flutter code sample for [Shortcuts].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/shortcuts/shortcuts.1.dart
+++ b/examples/api/lib/widgets/shortcuts/shortcuts.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Shortcuts].
+// Flutter code sample for [Shortcuts].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/shortcuts/single_activator.single_activator.0.dart
+++ b/examples/api/lib/widgets/shortcuts/single_activator.single_activator.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SingleActivator.SingleActivator].
+// Flutter code sample for [SingleActivator.SingleActivator].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.0.dart
+++ b/examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SingleChildScrollView].
+// Flutter code sample for [SingleChildScrollView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.1.dart
+++ b/examples/api/lib/widgets/single_child_scroll_view/single_child_scroll_view.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SingleChildScrollView].
+// Flutter code sample for [SingleChildScrollView].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/sliver/sliver_opacity.1.dart
+++ b/examples/api/lib/widgets/sliver/sliver_opacity.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverOpacity].
+// Flutter code sample for [SliverOpacity].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.0.dart
+++ b/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverFillRemaining].
+// Flutter code sample for [SliverFillRemaining].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.1.dart
+++ b/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverFillRemaining].
+// Flutter code sample for [SliverFillRemaining].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.2.dart
+++ b/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.2.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverFillRemaining].
+// Flutter code sample for [SliverFillRemaining].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.3.dart
+++ b/examples/api/lib/widgets/sliver_fill/sliver_fill_remaining.3.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverFillRemaining].
+// Flutter code sample for [SliverFillRemaining].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/slotted_render_object_widget/slotted_multi_child_render_object_widget_mixin.0.dart
+++ b/examples/api/lib/widgets/slotted_render_object_widget/slotted_multi_child_render_object_widget_mixin.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SlottedMultiChildRenderObjectWidgetMixin].
+// Flutter code sample for [SlottedMultiChildRenderObjectWidgetMixin].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/examples/api/lib/widgets/table/table.0.dart
+++ b/examples/api/lib/widgets/table/table.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [Table].
+// Flutter code sample for [Table].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/tap_region/text_field_tap_region.0.dart
+++ b/examples/api/lib/widgets/tap_region/text_field_tap_region.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TextFieldTapRegion].
+// Flutter code sample for [TextFieldTapRegion].
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/examples/api/lib/widgets/transitions/align_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/align_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AlignTransition].
+// Flutter code sample for [AlignTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/animated_builder.0.dart
+++ b/examples/api/lib/widgets/transitions/animated_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedBuilder].
+// Flutter code sample for [AnimatedBuilder].
 
 import 'dart:math' as math;
 

--- a/examples/api/lib/widgets/transitions/animated_widget.0.dart
+++ b/examples/api/lib/widgets/transitions/animated_widget.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [AnimatedWidget].
+// Flutter code sample for [AnimatedWidget].
 
 import 'dart:math' as math;
 

--- a/examples/api/lib/widgets/transitions/decorated_box_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/decorated_box_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DecoratedBoxTransition].
+// Flutter code sample for [DecoratedBoxTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/default_text_style_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/default_text_style_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [DefaultTextStyleTransition].
+// Flutter code sample for [DefaultTextStyleTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/fade_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/fade_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [FadeTransition].
+// Flutter code sample for [FadeTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/listenable_builder.0.dart
+++ b/examples/api/lib/widgets/transitions/listenable_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ListenableBuilder].
+// Flutter code sample for [ListenableBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/listenable_builder.1.dart
+++ b/examples/api/lib/widgets/transitions/listenable_builder.1.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for a [ChangeNotifier] with a [ListenableBuilder].
+// Flutter code sample for a [ChangeNotifier] with a [ListenableBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/positioned_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/positioned_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [PositionedTransition].
+// Flutter code sample for [PositionedTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/relative_positioned_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/relative_positioned_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RelativePositionedTransition].
+// Flutter code sample for [RelativePositionedTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/rotation_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/rotation_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [RotationTransition].
+// Flutter code sample for [RotationTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/scale_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/scale_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [ScaleTransition].
+// Flutter code sample for [ScaleTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/size_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/size_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SizeTransition].
+// Flutter code sample for [SizeTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/slide_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/slide_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SlideTransition].
+// Flutter code sample for [SlideTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
+++ b/examples/api/lib/widgets/transitions/sliver_fade_transition.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [SliverFadeTransition].
+// Flutter code sample for [SliverFadeTransition].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/tween_animation_builder/tween_animation_builder.0.dart
+++ b/examples/api/lib/widgets/tween_animation_builder/tween_animation_builder.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [TweenAnimationBuilder].
+// Flutter code sample for [TweenAnimationBuilder].
 
 import 'package:flutter/material.dart';
 

--- a/examples/api/lib/widgets/will_pop_scope/will_pop_scope.0.dart
+++ b/examples/api/lib/widgets/will_pop_scope/will_pop_scope.0.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Flutter code sample for [WillPopScope].
+// Flutter code sample for [WillPopScope].
 
 import 'package:flutter/material.dart';
 

--- a/packages/flutter/lib/src/widgets/async.dart
+++ b/packages/flutter/lib/src/widgets/async.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Widgets that handle interaction with asynchronous computations.
-///
-/// Asynchronous computations are represented by [Future]s and [Stream]s.
-
 import 'dart:async' show StreamSubscription;
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/animation/animation_sheet_test.dart
+++ b/packages/flutter/test/animation/animation_sheet_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/animation/live_binding_test.dart
+++ b/packages/flutter/test/animation/live_binding_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/cupertino/action_sheet_test.dart
+++ b/packages/flutter/test/cupertino/action_sheet_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=123"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/cupertino/activity_indicator_test.dart
+++ b/packages/flutter/test/cupertino/activity_indicator_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/scheduler.dart';

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -11,6 +11,7 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
+library;
 
 import 'dart:ui';
 

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:math';
 import 'dart:ui';

--- a/packages/flutter/test/cupertino/magnifier_test.dart
+++ b/packages/flutter/test/cupertino/magnifier_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -2,12 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('!chrome')
 // TODO(gspencergoog): Remove this tag once this test's state leaks/test
 // dependencies have been fixed.
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=456"
 @Tags(<String>['no-shuffle'])
+@TestOn('!chrome')
+library;
 
 import 'dart:ui';
 

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
 import 'dart:async';
 
 import 'package:flutter/cupertino.dart';

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';

--- a/packages/flutter/test/cupertino/segmented_control_test.dart
+++ b/packages/flutter/test/cupertino/segmented_control_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui' as ui;
 

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/cupertino/text_field_test.dart
+++ b/packages/flutter/test/cupertino/text_field_test.dart
@@ -11,6 +11,7 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
+library;
 
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, Color;
 

--- a/packages/flutter/test/cupertino/text_selection_test.dart
+++ b/packages/flutter/test/cupertino/text_selection_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui' as ui show BoxHeightStyle;
 

--- a/packages/flutter/test/dart/browser_environment_test.dart
+++ b/packages/flutter/test/dart/browser_environment_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('browser')
+library;
 
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/examples/sector_layout_test.dart
+++ b/packages/flutter/test/examples/sector_layout_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../examples/layers/rendering/custom_coordinate_systems.dart';

--- a/packages/flutter/test/foundation/consolidate_response_test.dart
+++ b/packages/flutter/test/foundation/consolidate_response_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/flutter/test/foundation/error_reporting_test.dart
+++ b/packages/flutter/test/foundation/error_reporting_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/foundation/service_extensions_test.dart
+++ b/packages/flutter/test/foundation/service_extensions_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=123"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/flutter/test/foundation/stack_trace_test.dart
+++ b/packages/flutter/test/foundation/stack_trace_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/animated_icons_test.dart
+++ b/packages/flutter/test/material/animated_icons_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:math' as math show pi;
 

--- a/packages/flutter/test/material/app_test.dart
+++ b/packages/flutter/test/material/app_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=123"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui';
 

--- a/packages/flutter/test/material/card_theme_test.dart
+++ b/packages/flutter/test/material/card_theme_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/circle_avatar_test.dart
+++ b/packages/flutter/test/material/circle_avatar_test.dart
@@ -5,6 +5,8 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
+
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -11,6 +11,7 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
+library;
 
 import 'dart:math' as math;
 

--- a/packages/flutter/test/material/flexible_space_bar_stretch_mode_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_stretch_mode_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/flexible_space_bar_test.dart
+++ b/packages/flutter/test/material/flexible_space_bar_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/floating_action_button_test.dart
+++ b/packages/flutter/test/material/floating_action_button_test.dart
@@ -5,8 +5,9 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
-
 @TestOn('!chrome')
+library;
+
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/flutter_logo_test.dart
+++ b/packages/flutter/test/material/flutter_logo_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/material/icons_test.dart
+++ b/packages/flutter/test/material/icons_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';

--- a/packages/flutter/test/material/ink_sparkle_test.dart
+++ b/packages/flutter/test/material/ink_sparkle_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/src/foundation/constants.dart';

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:async';
 

--- a/packages/flutter/test/material/magnifier_test.dart
+++ b/packages/flutter/test/material/magnifier_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/material_test.dart
+++ b/packages/flutter/test/material/material_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+library;
 import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart' show CupertinoPageRoute;

--- a/packages/flutter/test/material/paginated_data_table_test.dart
+++ b/packages/flutter/test/material/paginated_data_table_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=1000"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/gestures.dart' show DragStartBehavior;
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/progress_indicator_test.dart
+++ b/packages/flutter/test/material/progress_indicator_test.dart
@@ -11,6 +11,7 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
+library;
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/radio_test.dart
+++ b/packages/flutter/test/material/radio_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui';
 

--- a/packages/flutter/test/material/reorderable_list_test.dart
+++ b/packages/flutter/test/material/reorderable_list_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=382757700"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'dart:ui' as ui;
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui';
 

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:async';
 import 'dart:ui' as ui;

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -11,6 +11,7 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
+library;
 
 import 'dart:math' as math;
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle, WindowPadding;

--- a/packages/flutter/test/material/text_selection_test.dart
+++ b/packages/flutter/test/material/text_selection_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'dart:ui';
 
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/toggle_buttons_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/material/value_indicating_slider_test.dart
+++ b/packages/flutter/test/material/value_indicating_slider_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/painting/box_painter_test.dart
+++ b/packages/flutter/test/painting/box_painter_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/painting/continuous_rectangle_border_test.dart
+++ b/packages/flutter/test/painting/continuous_rectangle_border_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:math' as math;
 

--- a/packages/flutter/test/painting/star_border_test.dart
+++ b/packages/flutter/test/painting/star_border_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/physics/newton_test.dart
+++ b/packages/flutter/test/physics/newton_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=123"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/physics.dart';

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=20210704"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/flutter/test/rendering/localized_fonts_test.dart
+++ b/packages/flutter/test/rendering/localized_fonts_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/rendering/viewport_test.dart
+++ b/packages/flutter/test/rendering/viewport_test.dart
@@ -8,6 +8,7 @@
 // (or vice versa).
 
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui' as ui;
 

--- a/packages/flutter/test/services/message_codecs_vm_test.dart
+++ b/packages/flutter/test/services/message_codecs_vm_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';

--- a/packages/flutter/test/services/platform_channel_test.dart
+++ b/packages/flutter/test/services/platform_channel_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=20210826"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/services/platform_messages_test.dart
+++ b/packages/flutter/test/services/platform_messages_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/widgets/backdrop_filter_test.dart
+++ b/packages/flutter/test/widgets/backdrop_filter_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui';
 

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:math' as math;
 import 'dart:ui' as ui;

--- a/packages/flutter/test/widgets/clip_test.dart
+++ b/packages/flutter/test/widgets/clip_test.dart
@@ -6,6 +6,7 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/color_filter_test.dart
+++ b/packages/flutter/test/widgets/color_filter_test.dart
@@ -5,8 +5,9 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
-
 @TestOn('!chrome')
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/container_test.dart
+++ b/packages/flutter/test/widgets/container_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/draggable_test.dart
+++ b/packages/flutter/test/widgets/draggable_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=123"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/widgets/editable_text_cursor_test.dart
+++ b/packages/flutter/test/widgets/editable_text_cursor_test.dart
@@ -5,8 +5,9 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
-
 @TestOn('!chrome')
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/html_element_view_test.dart
+++ b/packages/flutter/test/widgets/html_element_view_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('chrome')
+library;
+
 import 'dart:async';
 
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/image_filter_quality_test.dart
+++ b/packages/flutter/test/widgets/image_filter_quality_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:async';
 import 'dart:ui' as ui;

--- a/packages/flutter/test/widgets/image_filter_test.dart
+++ b/packages/flutter/test/widgets/image_filter_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:math';
 import 'dart:ui';

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'dart:ui' as ui show Image;
 
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:async';
 import 'dart:io';

--- a/packages/flutter/test/widgets/invert_colors_test.dart
+++ b/packages/flutter/test/widgets/invert_colors_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/list_wheel_scroll_view_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/magnifier_test.dart
+++ b/packages/flutter/test/widgets/magnifier_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/flutter/test/widgets/opacity_test.dart
+++ b/packages/flutter/test/widgets/opacity_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_stretch_indicator_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/flutter/test/widgets/page_route_builder_test.dart
+++ b/packages/flutter/test/widgets/page_route_builder_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/physical_model_test.dart
+++ b/packages/flutter/test/widgets/physical_model_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
 
 import 'dart:async';
 import 'dart:ui';

--- a/packages/flutter/test/widgets/route_notification_messages_test.dart
+++ b/packages/flutter/test/widgets/route_notification_messages_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_context_menu_test.dart
@@ -5,6 +5,7 @@
 // ignore_for_file: undefined_class, undefined_getter, undefined_setter
 
 @TestOn('browser') // This file contains web-only library.
+library;
 
 import 'dart:html' as html;
 

--- a/packages/flutter/test/widgets/selectable_text_test.dart
+++ b/packages/flutter/test/widgets/selectable_text_test.dart
@@ -5,8 +5,9 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
-
 @TestOn('!chrome')
+library;
+
 import 'dart:ui' as ui show BoxHeightStyle, BoxWidthStyle;
 import 'dart:ui';
 

--- a/packages/flutter/test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
+++ b/packages/flutter/test/widgets/semantics_tester_generate_test_semantics_expression_for_current_semantics_tree_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('!chrome')
+library;
+
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/packages/flutter/test/widgets/shader_mask_test.dart
+++ b/packages/flutter/test/widgets/shader_mask_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/shadow_test.dart
+++ b/packages/flutter/test/widgets/shadow_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/flutter/test/widgets/snapshot_widget_test.dart
+++ b/packages/flutter/test/widgets/snapshot_widget_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:ui' as ui;
 

--- a/packages/flutter/test/widgets/text_golden_test.dart
+++ b/packages/flutter/test/widgets/text_golden_test.dart
@@ -5,8 +5,9 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
-
 @TestOn('!chrome')
+library;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/flutter/test/widgets/transform_test.dart
+++ b/packages/flutter/test/widgets/transform_test.dart
@@ -5,6 +5,7 @@
 // This file is run as part of a reduced test set in CI on Mac and Windows
 // machines.
 @Tags(<String>['reduced-test-set'])
+library;
 
 import 'dart:math' as math;
 import 'dart:ui' as ui;

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -11,8 +11,8 @@
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
 @Tags(<String>['reduced-test-set', 'no-shuffle'])
-
 @TestOn('!chrome')
+library;
 
 import 'dart:convert';
 import 'dart:math';

--- a/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
+++ b/packages/flutter_driver/lib/src/common/fuchsia_compat.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-/// Convenience methods for Flutter application driving on Fuchsia. Can
-/// be run on either a host machine (making a remote connection to a Fuchsia
-/// device), or on the target Fuchsia machine.
 import 'dart:io';
 
 import 'package:fuchsia_remote_debug_protocol/fuchsia_remote_debug_protocol.dart';

--- a/packages/flutter_driver/test/src/real_tests/extension_test.dart
+++ b/packages/flutter_driver/test/src/real_tests/extension_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=20210721"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -7,6 +7,8 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=20210721"
 @Tags(<String>['no-shuffle'])
+library;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/packages/flutter_test/test/test_text_input_test.dart
+++ b/packages/flutter_test/test/test_text_input_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=20210721"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -25,6 +25,7 @@
 /// about any additional exports that you add to this file, as doing so will
 /// increase the API surface that we have to test in Flutter tools, and the APIs
 /// in `dart:io` can sometimes be hard to use in tests.
+library;
 
 // We allow `print()` in this file as a fallback for writing to the terminal via
 // regular stdout/stderr/stdio paths. Everything else in the flutter_tools

--- a/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
+++ b/packages/flutter_tools/test/commands.shard/permeable/packages_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=1000"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
+++ b/packages/flutter_tools/test/general.shard/dart/language_version_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=456"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:file/memory.dart';
 import 'package:flutter_tools/src/base/file_system.dart';

--- a/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
+++ b/packages/flutter_tools/test/integration.shard/break_on_framework_exceptions_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=1000"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'package:file/file.dart';
 

--- a/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
+++ b/packages/flutter_tools/test/integration.shard/overall_experience_test.dart
@@ -24,6 +24,7 @@
 
 // This file intentionally assumes the tests run in order.
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/flutter_tools/test/integration.shard/test_data/migrate_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/migrate_project.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Timeout(Duration(seconds: 600))
+library;
 
 import 'dart:io';
 import 'package:file/file.dart';

--- a/packages/flutter_tools/test/integration.shard/test_test.dart
+++ b/packages/flutter_tools/test/integration.shard/test_test.dart
@@ -7,6 +7,7 @@
 // https://github.com/flutter/flutter/issues/85160
 // Fails with "flutter test --test-randomize-ordering-seed=1000"
 @Tags(<String>['no-shuffle'])
+library;
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/url_strategy_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('chrome') // Uses web-only Flutter SDK
+library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';

--- a/packages/flutter_web_plugins/test/navigation/utils_test.dart
+++ b/packages/flutter_web_plugins/test/navigation/utils_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('browser') // Uses web-only Flutter SDK
+library;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_web_plugins/src/navigation/utils.dart';

--- a/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_event_channel_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('chrome') // Uses web-only Flutter SDK
+library;
 
 import 'dart:async';
 import 'dart:ui' as ui;

--- a/packages/flutter_web_plugins/test/plugin_registry_test.dart
+++ b/packages/flutter_web_plugins/test/plugin_registry_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('chrome') // Uses web-only Flutter SDK
+library;
 
 import 'dart:ui' as ui;
 

--- a/packages/integration_test/test/web_extension_test.dart
+++ b/packages/integration_test/test/web_extension_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @Tags(<String>['web'])
+library;
+
 import 'dart:js' as js;
 
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
Cleans up the code base so we can enable `dangling_library_doc_comments` and `library_annotations` lints in a follow-up.