### PR TITLE
Resolves 112413: Created APIs for triggering Semantics actions in tests.

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -106,19 +106,19 @@ class SemanticsController {
 
   /// Attemps to find a [SemanticsNode] with the given `action` as close to the
   /// [SemanticsNode] of `finder` as possible.
-  /// 
+  ///
   /// The [SemanticsNode] directly related to an [Element] is not necessarily
   /// the one that can be acted upon. This method finds the directly related
   /// node and checks whether it supports the given `action`. If the directly
   /// related node does not support the given `action`, then the closest
   /// descendent of that node that does support the `action` is returned.
-  /// 
+  ///
   /// Will throw a [StateError] if:
   /// * No results are returned from `finder`
   /// * More than result is returned from `finder`
   /// * The [SemanticsNode] of `finder` or its descendant nodes do not support
   ///   `action`
-  /// 
+  ///
   /// See also:
   /// * [find]
   /// * [findWithAnyAction]
@@ -145,20 +145,20 @@ class SemanticsController {
 
   /// Attemps to find a [SemanticsNode] with any of the given `actions` as
   /// close to the [SemanticsNode] of `finder` as possible.
-  /// 
+  ///
   /// The [SemanticsNode] directly related to an [Element] is not necessarily
   /// the one that can be acted upon. This method finds the directly related
   /// node and checks whether it supports any of the given `actions`. If the
   /// directly related node does not support any of the given `actions`, then
   /// the closest descendent of that node that does support at least one of
   /// the `actions` is returned.
-  /// 
+  ///
   /// Will throw a [StateError] if:
   /// * No results are returned from `finder`
   /// * More than result is returned from `finder`
   /// * The [SemanticsNode] of `finder` or its descendant nodes do not support
   ///   at least one action in `actions`
-  /// 
+  ///
   /// See also:
   /// * [find]
   /// * [findWithAction]

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -62,16 +62,21 @@ class SemanticsController {
 
   final WidgetsBinding _binding;
 
-  void _traverse(SemanticsNode node, _VisitSemanticsNodeCallback onNode) {
+  bool _traverse(SemanticsNode node, _VisitSemanticsNodeCallback onNode) {
     final bool complete = onNode(node);
     if (complete) {
-      return;
+      return true;
     }
 
     final List<SemanticsNode> children = node.debugListChildrenInOrder(DebugSemanticsDumpOrder.traversalOrder);
     for (final SemanticsNode child in children) {
-      _traverse(child, onNode);
+      final bool childComplete = _traverse(child, onNode);
+      if (childComplete) {
+        return true;
+      }
     }
+
+    return false;
   }
 
   /// Attempts to find the [SemanticsNode] of first result from `finder`.

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -27,7 +27,7 @@ const String _defaultPlatform = kIsWeb ? 'web' : 'android';
 /// [SemanticsController._traverse] method. The return value determines whether
 /// the traversal is finished or not, so returning `true` will short circuit the
 /// traversal at the current `node`.
-typedef _VisitSemanticsNodeCallback = bool Function(SemanticsNode node); 
+typedef _VisitSemanticsNodeCallback = bool Function(SemanticsNode node);
 
 /// Class that programmatically interacts with the [Semantics] tree.
 ///

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -684,7 +684,7 @@ Matcher matchesSemantics({
 ///
 /// ```dart
 /// final SemanticsHandle handle = tester.ensureSemantics();
-/// expect(tester.getSemantics(find.text('hello')), hasSemantics(label: 'hello'));
+/// expect(tester.getSemantics(find.text('hello')), containsSemantics(label: 'hello'));
 /// handle.dispose();
 /// ```
 ///

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -940,7 +940,13 @@ void main() {
       testWidgets('performAction with unsupported action throws StateError', (WidgetTester tester) async {
         await tester.pumpWidget(Semantics());
 
-        expect(() => tester.semantics.performAction(tester.semantics.find(find.byType(Semantics)), SemanticsAction.tap), throwsStateError);
+        expect(
+          () => tester.semantics.performAction(
+            tester.semantics.find(find.byType(Semantics)),
+            SemanticsAction.tap,
+          ),
+          throwsStateError,
+        );
       });
 
       testWidgets('tap causes semantic tap', (WidgetTester tester) async {
@@ -991,7 +997,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollLeftAction: true, hasScrollRightAction: false),
-          reason: 'When not yet scrolled, a scrollview should only be able to support left scrolls.');
+          reason: 'When not yet scrolled, a scrollview should only be able to support left scrolls.',
+        );
 
         tester.semantics.scrollLeft(find.byType(ListView));
         await tester.pump();
@@ -999,7 +1006,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollLeftAction: true, hasScrollRightAction: true),
-          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.');
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
 
         // This will scroll the listview until it's completely scrolled to the right.
         final double extent = tester.semantics.findScrollable(find.byType(ListView)).scrollExtentMax!;
@@ -1013,7 +1021,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollLeftAction: false, hasScrollRightAction: true),
-          reason: 'When fully scrolled, a scrollview should only support right scrolls.');
+          reason: 'When fully scrolled, a scrollview should only support right scrolls.',
+        );
 
         tester.semantics.scrollRight(find.byType(ListView));
         await tester.pump();
@@ -1021,7 +1030,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollLeftAction: true, hasScrollRightAction: true),
-          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.');
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
       });
 
       testWidgets('scrollUp and scrollDown scrolls up and down respectively', (WidgetTester tester) async {
@@ -1039,7 +1049,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollUpAction: true, hasScrollDownAction: false),
-          reason: 'When not yet scrolled, a scrollview should only be able to support left scrolls.');
+          reason: 'When not yet scrolled, a scrollview should only be able to support left scrolls.',
+        );
 
         tester.semantics.scrollUp(find.byType(ListView));
         await tester.pump();
@@ -1047,7 +1058,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollUpAction: true, hasScrollDownAction: true),
-          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.');
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
 
         // This will scroll the listview until it's completely scrolled to the right.
         final double extent = tester.semantics.findScrollable(find.byType(ListView)).scrollExtentMax!;
@@ -1061,7 +1073,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollUpAction: false, hasScrollDownAction: true),
-          reason: 'When fully scrolled, a scrollview should only support right scrolls.');
+          reason: 'When fully scrolled, a scrollview should only support right scrolls.',
+        );
 
         tester.semantics.scrollDown(find.byType(ListView));
         await tester.pump();
@@ -1069,7 +1082,8 @@ void main() {
         expect(
           tester.semantics.findScrollable(find.byType(ListView)),
           containsSemantics(hasScrollUpAction: true, hasScrollDownAction: true),
-          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.');
+          reason: 'When partially scrolled, a scrollview should be able to support both left and right scrolls.',
+        );
       });
 
       testWidgets('increase causes semantic increase', (WidgetTester tester) async {
@@ -1090,7 +1104,8 @@ void main() {
         expect(invoked, isTrue);
         expect(
           tester.semantics.find(find.byType(Slider)).value,
-          equals(expected));
+          equals(expected),
+        );
       });
 
       testWidgets('decrease causes semantic decrease', (WidgetTester tester) async {
@@ -1111,7 +1126,8 @@ void main() {
         expect(invoked, isTrue);
         expect(
           tester.semantics.find(find.byType(Slider)).value,
-          equals(expected));
+          equals(expected),
+        );
       });
 
       testWidgets('showOnScreen sends showOnScreen action', (WidgetTester tester) async {
@@ -1142,7 +1158,8 @@ void main() {
 
         expect(
           tester.semantics.find(find.text('Test')),
-          containsSemantics(isHidden: false));
+          containsSemantics(isHidden: false),
+        );
       });
 
       testWidgets('actions for moving the cursor without modifying selection can move the cursor forward and back by character and word', (WidgetTester tester) async {

--- a/packages/flutter_test/test/controller_test.dart
+++ b/packages/flutter_test/test/controller_test.dart
@@ -935,7 +935,7 @@ void main() {
           containsAllInOrder(expectedMatchers));
       });
     });
-  
+
     group('actions', () {
       testWidgets('performAction with unsupported action throws StateError', (WidgetTester tester) async {
         await tester.pumpWidget(Semantics());
@@ -1161,7 +1161,7 @@ void main() {
         // Get focus onto the text field
         tester.semantics.tap(find.byType(TextField));
         await tester.pump();
-        
+
         tester.semantics.moveCursorBackwardByCharacter(find.byType(TextField));
         await tester.pump();
         expectUnselectedIndex(currentIndex - 1);
@@ -1176,7 +1176,7 @@ void main() {
         await tester.pump();
         expectUnselectedIndex(currentIndex - 5);
         currentIndex -= 5;
-        
+
         tester.semantics.moveCursorForwardByCharacter(find.byType(TextField));
         await tester.pump();
         expectUnselectedIndex(currentIndex + 1);
@@ -1204,7 +1204,7 @@ void main() {
         // Get focus onto the text field
         tester.semantics.tap(find.byType(TextField));
         await tester.pump();
-        
+
         tester.semantics.moveCursorBackwardByCharacter(find.byType(TextField), true);
         await tester.pump();
         expectSelectedIndex(currentIndex - 1);
@@ -1219,7 +1219,7 @@ void main() {
         await tester.pump();
         expectSelectedIndex(currentIndex - 5);
         currentIndex -= 5;
-        
+
         tester.semantics.moveCursorForwardByCharacter(find.byType(TextField), true);
         await tester.pump();
         expectSelectedIndex(currentIndex + 1);
@@ -1277,7 +1277,7 @@ void main() {
             onCopy: () => invoked = true,
           ),
         ));
-        
+
         tester.semantics.copy(find.bySemanticsLabel('test'));
         expect(invoked, isTrue);
       });
@@ -1290,7 +1290,7 @@ void main() {
             onCut: () => invoked = true,
           ),
         ));
-        
+
         tester.semantics.cut(find.bySemanticsLabel('test'));
         expect(invoked, isTrue);
       });
@@ -1303,7 +1303,7 @@ void main() {
             onPaste: () => invoked = true,
           ),
         ));
-        
+
         tester.semantics.paste(find.bySemanticsLabel('test'));
         expect(invoked, isTrue);
       });
@@ -1364,7 +1364,7 @@ void main() {
         bool invoked = false;
         await tester.pumpWidget(MaterialApp(
           home: Semantics(label: 'test', customSemanticsActions: <CustomSemanticsAction, void Function()>{
-            customAction:() => invoked = true,   
+            customAction:() => invoked = true,
           },),
         ));
 


### PR DESCRIPTION
Adds in support for more easily testing Semantics actions with a general purpose `performAction` method and various methods for invoking specific actions.

Also fixed a reference to an old method name in the doc comments for `containsSemantics`.

Resolves #112413

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
