### PR TITLE
cacheWidth cacheHeight support for canvaskit on web

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1182,6 +1182,11 @@ Future<void> _runWebLongRunningTests() async {
     () => _runWebE2eTest('capabilities_integration_canvaskit', buildMode: 'profile', renderer: 'canvaskit'),
     () => _runWebE2eTest('capabilities_integration_html', buildMode: 'release', renderer: 'html'),
 
+    // This test doesn't do anything interesting w.r.t. rendering, so we don't run the full build mode x renderer matrix.
+    // CacheWidth and CacheHeight are only currently supported in CanvasKit mode, so we don't run the test in HTML mode.
+    () => _runWebE2eTest('cache_width_cache_height_integration', buildMode: 'debug', renderer: 'auto'),
+    () => _runWebE2eTest('cache_width_cache_height_integration', buildMode: 'profile', renderer: 'canvaskit'),
+
     () => _runWebTreeshakeTest(),
 
     () => _runFlutterDriverWebTest(

--- a/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+
+class LoadTestImageProvider extends ImageProvider<Object> {
+  LoadTestImageProvider(this.provider);
+
+  final ImageProvider provider;
+
+  ImageStreamCompleter testLoad(Object key, DecoderBufferCallback decode) {
+    return provider.loadBuffer(key, decode);
+  }
+
+  @override
+  Future<Object> obtainKey(ImageConfiguration configuration) {
+    throw UnimplementedError();
+  }
+
+  @override
+  ImageStreamCompleter loadBuffer(Object key, DecoderBufferCallback decode) {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('Image.network uses cacheWidth and cacheHeight',
+          (WidgetTester tester) async {
+
+    const int expectedCacheHeight = 9;
+    const int expectedCacheWidth = 11;
+    await tester.pumpAndSettle();
+
+    final Image image = Image.network(
+      'assets/packages/flutter_gallery_assets/assets/icons/material/material.png',
+      cacheHeight: 9,
+      cacheWidth: 11,
+    );
+
+    bool called = false;
+
+    Future<ui.Codec> decode(ui.ImmutableBuffer buffer, {int? cacheWidth, int? cacheHeight, bool allowUpscaling = false}) {
+      expect(cacheHeight, expectedCacheHeight);
+      expect(cacheWidth, expectedCacheWidth);
+      expect(allowUpscaling, false);
+      called = true;
+      return PaintingBinding.instance.instantiateImageCodecFromBuffer(buffer, cacheWidth: cacheWidth, cacheHeight: cacheHeight, allowUpscaling: allowUpscaling);
+    }
+
+    final ImageProvider resizeImage = image.image;
+    expect(image.image, isA<ResizeImage>());
+    expect(called, false);
+
+    final LoadTestImageProvider testProvider = LoadTestImageProvider(image.image);
+    final ImageStreamCompleter streamCompleter = testProvider.testLoad(await resizeImage.obtainKey(ImageConfiguration.empty), decode);
+
+    final Completer<void> completer = Completer<void>();
+    int? imageInfoCachedWidth;
+    int? imageInfoCachedHeight;
+    streamCompleter.addListener(ImageStreamListener((ImageInfo imageInfo, bool syncCall) {
+      imageInfoCachedWidth = imageInfo.image.width;
+      imageInfoCachedHeight = imageInfo.image.height;
+      completer.complete();
+    }));
+    await completer.future;
+
+    expect(imageInfoCachedHeight, isNotNull);
+    expect(imageInfoCachedHeight, expectedCacheHeight);
+    expect(imageInfoCachedWidth, isNotNull);
+    expect(imageInfoCachedWidth, expectedCacheWidth);
+    expect(called, true);
+  });
+}

--- a/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
@@ -9,7 +9,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-
+// This class allows loadBuffer, a protected method, to be called with a custom
+// DecoderBufferCallback function.
 class LoadTestImageProvider extends ImageProvider<Object> {
   LoadTestImageProvider(this.provider);
 

--- a/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
@@ -33,9 +33,7 @@ class LoadTestImageProvider extends ImageProvider<Object> {
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  testWidgets('Image.network uses cacheWidth and cacheHeight',
-          (WidgetTester tester) async {
-
+  testWidgets('Image.network uses cacheWidth and cacheHeight', (WidgetTester tester) async {
     const int expectedCacheHeight = 9;
     const int expectedCacheWidth = 11;
     await tester.pumpAndSettle();
@@ -58,7 +56,6 @@ void main() {
 
     final ImageProvider resizeImage = image.image;
     expect(image.image, isA<ResizeImage>());
-    expect(called, false);
 
     final LoadTestImageProvider testProvider = LoadTestImageProvider(image.image);
     final ImageStreamCompleter streamCompleter = testProvider.testLoad(await resizeImage.obtainKey(ImageConfiguration.empty), decode);

--- a/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration_test.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration_test.dart
@@ -1,0 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:integration_test/integration_test_driver.dart' as test;
+
+Future<void> main() async => test.integrationDriver();

--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -103,10 +103,7 @@ class NetworkImage
     return collector;
   }
 
-  // TODO(garyq): We should eventually support custom decoding of network images on Web as
-  // well, see https://github.com/flutter/flutter/issues/42789.
-  //
-  // Web does not support decoding network images to a specified size. The decode parameter
+  // Html renderer does not support decoding network images to a specified size. The decode parameter
   // here is ignored and the web-only `ui.webOnlyInstantiateImageCodecFromUrl` will be used
   // directly in place of the typical `instantiateImageCodec` method.
   Future<ui.Codec> _loadAsync(
@@ -121,16 +118,18 @@ class NetworkImage
 
     // We use a different method when headers are set because the
     // `ui.webOnlyInstantiateImageCodecFromUrl` method is not capable of handling headers.
-    if (key.headers?.isNotEmpty ?? false) {
+    if (isCanvasKit || (key.headers?.isNotEmpty ?? false)) {
       final Completer<DomXMLHttpRequest> completer =
           Completer<DomXMLHttpRequest>();
       final DomXMLHttpRequest request = httpRequestFactory();
 
       request.open('GET', key.url, true);
       request.responseType = 'arraybuffer';
-      key.headers!.forEach((String header, String value) {
-        request.setRequestHeader(header, value);
-      });
+      if (key.headers?.isNotEmpty ?? false) {
+        key.headers!.forEach((String header, String value) {
+          request.setRequestHeader(header, value);
+        });
+      }
 
       request.addEventListener('load', allowInterop((DomEvent e) {
         final int? status = request.status;

--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -116,16 +116,18 @@ class NetworkImage
 
     final Uri resolved = Uri.base.resolve(key.url);
 
+    final bool containsNetworkImageHeaders = key.headers?.isNotEmpty ?? false;
+
     // We use a different method when headers are set because the
     // `ui.webOnlyInstantiateImageCodecFromUrl` method is not capable of handling headers.
-    if (isCanvasKit || (key.headers?.isNotEmpty ?? false)) {
+    if (isCanvasKit || containsNetworkImageHeaders) {
       final Completer<DomXMLHttpRequest> completer =
           Completer<DomXMLHttpRequest>();
       final DomXMLHttpRequest request = httpRequestFactory();
 
       request.open('GET', key.url, true);
       request.responseType = 'arraybuffer';
-      if (key.headers?.isNotEmpty ?? false) {
+      if (containsNetworkImageHeaders) {
         key.headers!.forEach((String header, String value) {
           request.setRequestHeader(header, value);
         });

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -901,9 +901,10 @@ class ResizeImage extends ImageProvider<ResizeImageKey> {
 /// The image will be cached regardless of cache headers from the server.
 ///
 /// When a network image is used on the Web platform, the `cacheWidth` and
-/// `cacheHeight` parameters of the [DecoderCallback] are ignored as the Web
-/// engine delegates image decoding of network images to the Web, which does
-/// not support custom decode sizes.
+/// `cacheHeight` parameters of the [DecoderCallback] are only supported when the
+/// application is running with the CanvasKit renderer. When the application is using
+/// the HTML renderer, the web engine delegates image decoding of network images to the Web,
+/// which does not support custom decode sizes.
 ///
 /// See also:
 ///

--- a/packages/flutter/lib/src/widgets/image.dart
+++ b/packages/flutter/lib/src/widgets/image.dart
@@ -288,8 +288,9 @@ typedef ImageErrorWidgetBuilder = Widget Function(
 /// memory usage of [ImageCache].
 ///
 /// In the case where a network image is used on the Web platform, the
-/// `cacheWidth` and `cacheHeight` parameters are ignored as the Web engine
-/// delegates image decoding of network images to the Web, which does not support
+/// `cacheWidth` and `cacheHeight` parameters are only supported when the application is
+/// running with the CanvasKit renderer. When the application is using the HTML renderer,
+/// the web engine delegates image decoding of network images to the Web, which does not support
 /// custom decode sizes.
 ///
 /// See also:


### PR DESCRIPTION
This PR is the framework side fix for adding`cacheWidth` and `cacheHeight` support to web canvaskit. 

Previously, `cacheWidth` and `cacheHeight` parameters for `Image.network` were not supported on the web. A fix to add support for canvaskit on the engine side was made here: https://github.com/flutter/engine/pull/38028 

This PR, along with the engine side fix, fixes: https://github.com/flutter/flutter/issues/88704

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
