### PR TITLE
Send text direction in selection rects

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -1316,11 +1316,16 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// Returns a list of rects that bound the given selection.
   ///
   /// See [TextPainter.getBoxesForSelection] for more details.
-  List<Rect> getBoxesForSelection(TextSelection selection) {
+  List<TextBox> getBoxesForSelection(TextSelection selection) {
     _computeTextMetricsIfNeeded();
     return _textPainter.getBoxesForSelection(selection)
-                       .map((TextBox textBox) => textBox.toRect().shift(_paintOffset))
-                       .toList();
+                       .map((TextBox textBox) => TextBox.fromLTRBD(
+                          textBox.left + _paintOffset.dx,
+                          textBox.top + _paintOffset.dy,
+                          textBox.right + _paintOffset.dx,
+                          textBox.bottom + _paintOffset.dy,
+                          textBox.direction
+                        )).toList();
   }
 
   @override

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1211,7 +1211,11 @@ abstract class ScribbleClient {
 class SelectionRect {
   /// Constructor for creating a [SelectionRect] from a text [position] and
   /// [bounds].
-  const SelectionRect({required this.position, required this.bounds});
+  const SelectionRect({
+    required this.position,
+    required this.bounds,
+    this.direction = TextDirection.ltr,
+  });
 
   /// The position of this selection rect within the text String.
   final int position;
@@ -1219,6 +1223,9 @@ class SelectionRect {
   /// The rectangle representing the bounds of this selection rect within the
   /// currently focused [RenderEditable]'s coordinate space.
   final Rect bounds;
+
+  /// The direction text flows within this selection rect.
+  final TextDirection direction;
 
   @override
   bool operator ==(Object other) {
@@ -1230,7 +1237,8 @@ class SelectionRect {
     }
     return other is SelectionRect
         && other.position == position
-        && other.bounds   == bounds;
+        && other.bounds == bounds
+        && other.direction == direction;
   }
 
   @override
@@ -2321,7 +2329,14 @@ class _PlatformTextInputControl with TextInputControl {
     _channel.invokeMethod<void>(
       'TextInput.setSelectionRects',
       selectionRects.map((SelectionRect rect) {
-        return <num>[rect.bounds.left, rect.bounds.top, rect.bounds.width, rect.bounds.height, rect.position];
+        return <num>[
+          rect.bounds.left,
+          rect.bounds.top,
+          rect.bounds.width,
+          rect.bounds.height,
+          rect.position,
+          rect.direction.index,
+        ];
       }).toList(),
     );
   }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3279,7 +3279,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       if (selection.isCollapsed) {
         rectToReveal = targetOffset.rect;
       } else {
-        final List<Rect> selectionBoxes = renderEditable.getBoxesForSelection(selection);
+        final List<TextBox> selectionBoxes = renderEditable.getBoxesForSelection(selection);
         // selectionBoxes may be empty if, for example, the selection does not
         // encompass a full character, like if it only contained part of an
         // extended grapheme cluster.
@@ -3287,7 +3287,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
           rectToReveal = targetOffset.rect;
         } else {
           rectToReveal = selection.baseOffset < selection.extentOffset ?
-            selectionBoxes.last : selectionBoxes.first;
+            selectionBoxes.last.toRect() : selectionBoxes.first.toRect();
         }
       }
 
@@ -3590,11 +3590,11 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
     final CharacterRange characterRange = CharacterRange(plainText);
     while (characterRange.moveNext()) {
       final int graphemeEnd = graphemeStart + characterRange.current.length;
-      final List<Rect> boxes = renderEditable.getBoxesForSelection(
+      final List<TextBox> boxes = renderEditable.getBoxesForSelection(
         TextSelection(baseOffset: graphemeStart, extentOffset: graphemeEnd),
       );
 
-      final Rect? box = boxes.isEmpty ? null : boxes.first;
+      final TextBox? box = boxes.isEmpty ? null : boxes.first;
       if (box != null) {
         final Rect paintBounds = renderEditable.paintBounds;
         // Stop early when characters are already below the bottom edge of the
@@ -3602,8 +3602,8 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
         if (paintBounds.bottom <= box.top) {
           break;
         }
-        if (paintBounds.contains(box.topLeft) || paintBounds.contains(box.bottomRight)) {
-          rects.add(SelectionRect(position: graphemeStart, bounds: box));
+        if (paintBounds.contains(Offset(box.left, box.top)) || paintBounds.contains(Offset(box.right, box.bottom))) {
+          rects.add(SelectionRect(position: graphemeStart, bounds: box.toRect(), direction: box.direction));
         }
       }
       graphemeStart = graphemeEnd;

--- a/packages/flutter/test/services/text_input_test.dart
+++ b/packages/flutter/test/services/text_input_test.dart
@@ -906,10 +906,20 @@ void main() {
       expect(fakeTextChannel.outgoingCalls.length, 6);
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setEditableSizeAndTransform');
 
-      connection.setSelectionRects(const <SelectionRect>[SelectionRect(position: 0, bounds: Rect.zero)]);
+      connection.setSelectionRects(const <SelectionRect>[SelectionRect(position: 1, bounds: Rect.fromLTWH(2, 3, 4, 5), direction: TextDirection.rtl)]);
       expectedMethodCalls.add('setSelectionRects');
       expect(control.methodCalls, expectedMethodCalls);
       expect(fakeTextChannel.outgoingCalls.length, 7);
+      expect(fakeTextChannel.outgoingCalls.last.arguments, const TypeMatcher<List<List<num>>>());
+      final List<List<num>> sentList = fakeTextChannel.outgoingCalls.last.arguments as List<List<num>>;
+      expect(sentList.length, 1);
+      expect(sentList[0].length, 6);
+      expect(sentList[0][0], 2); // left
+      expect(sentList[0][1], 3); // top
+      expect(sentList[0][2], 4); // width
+      expect(sentList[0][3], 5); // height
+      expect(sentList[0][4], 1); // position
+      expect(sentList[0][5], TextDirection.rtl.index); // direction
       expect(fakeTextChannel.outgoingCalls.last.method, 'TextInput.setSelectionRects');
 
       connection.setStyle(


### PR DESCRIPTION
In order to properly calculate the `closestPositionToPoint` in `FlutterTextInputPlugin.mm` in the engine, we need to know the text direction in each selectionrect.

Needed for #30476

Needed for https://github.com/flutter/engine/pull/36643

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
