### PR TITLE
Add integration_test/example tests to the CI

### DIFF
--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1138,7 +1138,7 @@ Future<void> _runWebUnitTests(String webRenderer) async {
 /// Coarse-grained integration tests running on the Web.
 Future<void> _runWebLongRunningTests() async {
   final List<ShardRunner> tests = <ShardRunner>[
-    for (String buildMode in _kAllBuildModes) ...[
+    for (String buildMode in _kAllBuildModes) ...<ShardRunner>[
       () => _runFlutterDriverWebTest(
         testAppDirectory: path.join('packages', 'integration_test', 'example'),
         target: path.join('test_driver', 'failure.dart'),

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1138,7 +1138,7 @@ Future<void> _runWebUnitTests(String webRenderer) async {
 /// Coarse-grained integration tests running on the Web.
 Future<void> _runWebLongRunningTests() async {
   final List<ShardRunner> tests = <ShardRunner>[
-    for (String buildMode in _kAllBuildModes)
+    for (String buildMode in _kAllBuildModes) ...[
       () => _runFlutterDriverWebTest(
         testAppDirectory: path.join('packages', 'integration_test', 'example'),
         target: path.join('test_driver', 'failure.dart'),
@@ -1148,6 +1148,27 @@ Future<void> _runWebLongRunningTests() async {
         // logs. To avoid confusion, silence browser output.
         silenceBrowserOutput: true,
       ),
+      () => _runFlutterDriverWebTest(
+        testAppDirectory: path.join('packages', 'integration_test', 'example'),
+        target: path.join('integration_test', 'example_test.dart'),
+        driver: path.join('test_driver', 'integration_test.dart'),
+        buildMode: buildMode,
+        renderer: 'canvaskit',
+        // This test intentionally fails and prints stack traces in the browser
+        // logs. To avoid confusion, silence browser output.
+        silenceBrowserOutput: true,
+      ),
+      () => _runFlutterDriverWebTest(
+        testAppDirectory: path.join('packages', 'integration_test', 'example'),
+        target: path.join('integration_test', 'extended_test.dart'),
+        driver: path.join('test_driver', 'extended_integration_test.dart'),
+        buildMode: buildMode,
+        renderer: 'canvaskit',
+        // This test intentionally fails and prints stack traces in the browser
+        // logs. To avoid confusion, silence browser output.
+        silenceBrowserOutput: true,
+      ),
+    ],
 
     // This test specifically tests how images are loaded in HTML mode, so we don't run it in CanvasKit mode.
     () => _runWebE2eTest('image_loading_integration', buildMode: 'debug', renderer: 'html'),
@@ -1281,6 +1302,7 @@ Future<void> _runFlutterDriverWebTest({
   required String buildMode,
   required String renderer,
   required String testAppDirectory,
+  String? driver,
   bool expectFailure = false,
   bool silenceBrowserOutput = false,
 }) async {
@@ -1295,6 +1317,7 @@ Future<void> _runFlutterDriverWebTest({
     <String>[
       ...flutterTestArgs,
       'drive',
+      if (driver != null) '--driver=$driver',
       '--target=$target',
       '--browser-name=chrome',
       '--no-sound-null-safety',

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1154,9 +1154,6 @@ Future<void> _runWebLongRunningTests() async {
         driver: path.join('test_driver', 'integration_test.dart'),
         buildMode: buildMode,
         renderer: 'canvaskit',
-        // This test intentionally fails and prints stack traces in the browser
-        // logs. To avoid confusion, silence browser output.
-        silenceBrowserOutput: true,
       ),
       () => _runFlutterDriverWebTest(
         testAppDirectory: path.join('packages', 'integration_test', 'example'),
@@ -1164,9 +1161,6 @@ Future<void> _runWebLongRunningTests() async {
         driver: path.join('test_driver', 'extended_integration_test.dart'),
         buildMode: buildMode,
         renderer: 'canvaskit',
-        // This test intentionally fails and prints stack traces in the browser
-        // logs. To avoid confusion, silence browser output.
-        silenceBrowserOutput: true,
       ),
     ],
 


### PR DESCRIPTION
This is a PR to demonstrate that the tests in integration_test/example are failing at head for Web. The changes in https://github.com/flutter/flutter/pull/117114 will fix the failing tests, which will be verified by the changes here that will run these tests on the CI.