### PR TITLE
[flutter roll] Revert "fixes android_semantics_integration_test to expect long press for too…"

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -439,7 +439,6 @@ void main() {
             ignoredActions: ignoredAccessibilityFocusActions,
             actions: <AndroidSemanticsAction>[
               AndroidSemanticsAction.click,
-              AndroidSemanticsAction.longClick,
             ],
           ),
         );


### PR DESCRIPTION
Reverts flutter/flutter#117547.

revert along with https://github.com/flutter/flutter/pull/117557 to fix tooltip tests.