### PR TITLE
Add semantic label to widget inspector button

### DIFF
--- a/packages/flutter/lib/src/cupertino/app.dart
+++ b/packages/flutter/lib/src/cupertino/app.dart
@@ -520,6 +520,7 @@ class _CupertinoAppState extends State<CupertinoApp> {
         CupertinoIcons.search,
         size: 28.0,
         color: CupertinoColors.white,
+        semanticLabel: 'Enter select widget mode',
       ),
     );
   }

--- a/packages/flutter/lib/src/material/app.dart
+++ b/packages/flutter/lib/src/material/app.dart
@@ -907,7 +907,10 @@ class _MaterialAppState extends State<MaterialApp> {
     return FloatingActionButton(
       onPressed: onPressed,
       mini: true,
-      child: const Icon(Icons.search),
+      child: const Icon(
+        Icons.search,
+        semanticLabel: 'Enter select widget mode',
+      ),
     );
   }
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -642,6 +642,38 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(paragraphText(selection.current! as RenderParagraph), equals('Child 2'));
     });
 
+    testWidgets('MaterialApp inspector select button has a semantics label',
+        (WidgetTester tester) async {
+      WidgetsApp.debugShowWidgetInspectorOverride = true;
+
+      await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+      // Select the scaffold widget to show the inspector select button
+      await tester.tap(find.byType(Scaffold), warnIfMissed: false);
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('Enter select widget mode'), findsOneWidget);
+
+      WidgetsApp.debugShowWidgetInspectorOverride = false;
+    });
+
+    testWidgets('CupertinoApp inspector select button has a semantics label',
+        (WidgetTester tester) async {
+      WidgetsApp.debugShowWidgetInspectorOverride = true;
+
+      await tester.pumpWidget(
+        const CupertinoApp(home: CupertinoPageScaffold(child: SizedBox())),
+      );
+
+      // Select the scaffold widget to show the inspector select button
+      await tester.tap(find.byType(CupertinoPageScaffold), warnIfMissed: false);
+      await tester.pump();
+
+      expect(find.bySemanticsLabel('Enter select widget mode'), findsOneWidget);
+
+      WidgetsApp.debugShowWidgetInspectorOverride = false;
+    });
+
     test('WidgetInspectorService null id', () {
       service.disposeAllGroups();
       expect(service.toObject(null), isNull);


### PR DESCRIPTION
Adds a semantic label to the widget inspector button, which is currently missing on both `MaterialApp` and `CupertinoApp`:

<img width="292" alt="Screenshot showing an accessibility warning that the select widget button has no semantic label" src="https://user-images.githubusercontent.com/756862/209310120-b5088649-bc4a-45c8-b39e-977f41d3c3f2.png">

Fixes #117583

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
