### PR TITLE
Fix a few typos

### DIFF
--- a/dev/conductor/core/dart_test.yaml
+++ b/dev/conductor/core/dart_test.yaml
@@ -1,6 +1,6 @@
 # codesign_integration_test takes longer than the default timeout which is 30s
 # since it has to clone both the engine and framework repos, and that test is running
 # asynchronously. The async function is being awaited more than 30s which counts as inactivity
-# The default timeout needs to be extended to accomodate codesign_integration_test
+# The default timeout needs to be extended to accommodate codesign_integration_test
 
 timeout: 5m

--- a/packages/flutter_tools/templates/plugin_ffi/linux.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/linux.tmpl/CMakeLists.txt.tmpl
@@ -8,7 +8,7 @@ set(PROJECT_NAME "{{projectName}}")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 # Invoke the build for native code shared with the other target platforms.
-# This can be changed to accomodate different builds.
+# This can be changed to accommodate different builds.
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DIR}/shared")
 
 # List of absolute paths to libraries that should be bundled with the plugin.
@@ -16,7 +16,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DI
 # external build triggered from this build file.
 set({{projectName}}_bundled_libraries
   # Defined in ../src/CMakeLists.txt.
-  # This can be changed to accomodate different builds.
+  # This can be changed to accommodate different builds.
   $<TARGET_FILE:{{projectName}}>
   PARENT_SCOPE
 )

--- a/packages/flutter_tools/templates/plugin_ffi/windows.tmpl/CMakeLists.txt.tmpl
+++ b/packages/flutter_tools/templates/plugin_ffi/windows.tmpl/CMakeLists.txt.tmpl
@@ -9,7 +9,7 @@ set(PROJECT_NAME "{{projectName}}")
 project(${PROJECT_NAME} LANGUAGES CXX)
 
 # Invoke the build for native code shared with the other target platforms.
-# This can be changed to accomodate different builds.
+# This can be changed to accommodate different builds.
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DIR}/shared")
 
 # List of absolute paths to libraries that should be bundled with the plugin.
@@ -17,7 +17,7 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../src" "${CMAKE_CURRENT_BINARY_DI
 # external build triggered from this build file.
 set({{projectName}}_bundled_libraries
   # Defined in ../src/CMakeLists.txt.
-  # This can be changed to accomodate different builds.
+  # This can be changed to accommodate different builds.
   $<TARGET_FILE:{{projectName}}>
   PARENT_SCOPE
 )


### PR DESCRIPTION
replace instances of 'accomodate' with 'accommodate'