### PR TITLE
Add MSYS2 detection on Windows Terminal

### DIFF
--- a/bin/dart
+++ b/bin/dart
@@ -48,7 +48,7 @@ BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
 OS="$(uname -s)"
 
 # If we're on Windows, invoke the batch script instead to get proper locking.
-if [[ $OS =~ MINGW.* || $OS =~ CYGWIN.* ]]; then
+if [[ $OS =~ MINGW.* || $OS =~ CYGWIN.* || $OS =~ MSYS.* ]]; then
   exec "${BIN_DIR}/dart.bat" "$@"
 fi
 

--- a/bin/flutter
+++ b/bin/flutter
@@ -53,7 +53,7 @@ BIN_DIR="$(cd "${PROG_NAME%/*}" ; pwd -P)"
 OS="$(uname -s)"
 
 # If we're on Windows, invoke the batch script instead to get proper locking.
-if [[ $OS =~ MINGW.* || $OS =~ CYGWIN.* ]]; then
+if [[ $OS =~ MINGW.* || $OS =~ CYGWIN.* || $OS =~ MSYS.* ]]; then
   exec "${BIN_DIR}/flutter.bat" "$@"
 fi
 

--- a/bin/internal/shared.sh
+++ b/bin/internal/shared.sh
@@ -200,7 +200,7 @@ function shared::execute() {
   # If running over git-bash, overrides the default UNIX executables with win32
   # executables
   case "$(uname -s)" in
-    MINGW*)
+    MINGW* | MSYS* )
       DART="$DART.exe"
       ;;
   esac

--- a/bin/internal/update_dart_sdk.sh
+++ b/bin/internal/update_dart_sdk.sh
@@ -102,7 +102,7 @@ if [ ! -f "$ENGINE_STAMP" ] || [ "$ENGINE_VERSION" != `cat "$ENGINE_STAMP"` ]; t
       DART_ZIP_NAME="dart-sdk-linux-${ARCH}.zip"
       IS_USER_EXECUTABLE="-perm /u+x"
       ;;
-    MINGW*)
+    MINGW* | MSYS* )
       DART_ZIP_NAME="dart-sdk-windows-x64.zip"
       IS_USER_EXECUTABLE="-perm /u+x"
       ;;


### PR DESCRIPTION
As the result of `uname -s` command is like the below on MSYS2 on Windows Terminal,

`MSYS_NT-10.0-22621`

Current OS detection logic doesn't allow this name.

This patch fixes the Flutter command working on this kind of system.

<img width="867" alt="flutter-doctor" src="https://user-images.githubusercontent.com/10906167/209424510-1de1af08-aefb-46e9-9680-4eb161a85988.png">

<img width="1193" alt="flutter-create-and-run" src="https://user-images.githubusercontent.com/10906167/209424509-79ae1a28-61bd-43a6-9377-5840dab01911.png">
