### PR TITLE
[flutter roll] Revert "Remove single-view assumption from ScrollPhysics"

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
@@ -371,14 +371,14 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
     return _SnappingScrollPhysics(parent: buildParent(ancestor), midScrollOffset: midScrollOffset);
   }
 
-  Simulation _toMidScrollOffsetSimulation(double offset, double dragVelocity, ScrollMetrics metrics) {
+  Simulation _toMidScrollOffsetSimulation(double offset, double dragVelocity) {
     final double velocity = math.max(dragVelocity, minFlingVelocity);
-    return ScrollSpringSimulation(spring, offset, midScrollOffset, velocity, tolerance: toleranceFor(metrics));
+    return ScrollSpringSimulation(spring, offset, midScrollOffset, velocity, tolerance: tolerance);
   }
 
-  Simulation _toZeroScrollOffsetSimulation(double offset, double dragVelocity, ScrollMetrics metrics) {
+  Simulation _toZeroScrollOffsetSimulation(double offset, double dragVelocity) {
     final double velocity = math.max(dragVelocity, minFlingVelocity);
-    return ScrollSpringSimulation(spring, offset, 0.0, velocity, tolerance: toleranceFor(metrics));
+    return ScrollSpringSimulation(spring, offset, 0.0, velocity, tolerance: tolerance);
   }
 
   @override
@@ -396,10 +396,10 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
         return simulation;
       }
       if (dragVelocity > 0.0) {
-        return _toMidScrollOffsetSimulation(offset, dragVelocity, position);
+        return _toMidScrollOffsetSimulation(offset, dragVelocity);
       }
       if (dragVelocity < 0.0) {
-        return _toZeroScrollOffsetSimulation(offset, dragVelocity, position);
+        return _toZeroScrollOffsetSimulation(offset, dragVelocity);
       }
     } else {
       // The user ended the drag with little or no velocity. If they
@@ -408,10 +408,10 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
       // otherwise snap to zero.
       final double snapThreshold = midScrollOffset / 2.0;
       if (offset >= snapThreshold && offset < midScrollOffset) {
-        return _toMidScrollOffsetSimulation(offset, dragVelocity, position);
+        return _toMidScrollOffsetSimulation(offset, dragVelocity);
       }
       if (offset > 0.0 && offset < snapThreshold) {
-        return _toZeroScrollOffsetSimulation(offset, dragVelocity, position);
+        return _toZeroScrollOffsetSimulation(offset, dragVelocity);
       }
     }
     return simulation;

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -902,7 +902,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
   bool get _isAtSnapSize {
     return extent.snapSizes.any(
       (double snapSize) {
-        return (extent.currentSize - snapSize).abs() <= extent.pixelsToSize(physics.toleranceFor(this).distance);
+        return (extent.currentSize - snapSize).abs() <= extent.pixelsToSize(physics.tolerance.distance);
       },
     );
   }
@@ -937,7 +937,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
         initialVelocity: velocity,
         pixelSnapSize: extent.pixelSnapSizes,
         snapAnimationDuration: extent.snapAnimationDuration,
-        tolerance: physics.toleranceFor(this),
+        tolerance: physics.tolerance,
       );
     } else {
       // The iOS bouncing simulation just isn't right here - once we delegate
@@ -946,7 +946,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
         // Run the simulation in terms of pixels, not extent.
         position: extent.currentPixels,
         velocity: velocity,
-        tolerance: physics.toleranceFor(this),
+        tolerance: physics.tolerance,
       );
     }
 
@@ -965,7 +965,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
         // Make sure we pass along enough velocity to keep scrolling - otherwise
         // we just "bounce" off the top making it look like the list doesn't
         // have more to scroll.
-        velocity = ballisticController.velocity + (physics.toleranceFor(this).velocity * ballisticController.velocity.sign);
+        velocity = ballisticController.velocity + (physics.tolerance.velocity * ballisticController.velocity.sign);
         super.goBallistic(velocity);
         ballisticController.stop();
       } else if (ballisticController.isCompleted) {

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -316,7 +316,6 @@ class FixedExtentMetrics extends FixedScrollMetrics {
     required super.viewportDimension,
     required super.axisDirection,
     required this.itemIndex,
-    required super.devicePixelRatio,
   });
 
   @override
@@ -327,7 +326,6 @@ class FixedExtentMetrics extends FixedScrollMetrics {
     double? viewportDimension,
     AxisDirection? axisDirection,
     int? itemIndex,
-    double? devicePixelRatio,
   }) {
     return FixedExtentMetrics(
       minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
@@ -336,7 +334,6 @@ class FixedExtentMetrics extends FixedScrollMetrics {
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
       itemIndex: itemIndex ?? this.itemIndex,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
 
@@ -402,7 +399,6 @@ class _FixedExtentScrollPosition extends ScrollPositionWithSingleContext impleme
     double? viewportDimension,
     AxisDirection? axisDirection,
     int? itemIndex,
-    double? devicePixelRatio,
   }) {
     return FixedExtentMetrics(
       minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
@@ -411,7 +407,6 @@ class _FixedExtentScrollPosition extends ScrollPositionWithSingleContext impleme
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
       itemIndex: itemIndex ?? this.itemIndex,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
 }
@@ -510,8 +505,8 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
     // Scenario 3:
     // If there's no velocity and we're already at where we intend to land,
     // do nothing.
-    if (velocity.abs() < toleranceFor(position).velocity
-        && (settlingPixels - metrics.pixels).abs() < toleranceFor(position).distance) {
+    if (velocity.abs() < tolerance.velocity
+        && (settlingPixels - metrics.pixels).abs() < tolerance.distance) {
       return null;
     }
 
@@ -524,7 +519,7 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
         metrics.pixels,
         settlingPixels,
         velocity,
-        tolerance: toleranceFor(position),
+        tolerance: tolerance,
       );
     }
 
@@ -535,7 +530,7 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
       metrics.pixels,
       settlingPixels,
       velocity,
-      toleranceFor(position).velocity * velocity.sign,
+      tolerance.velocity * velocity.sign,
     );
   }
 }

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -526,7 +526,6 @@ class _NestedScrollMetrics extends FixedScrollMetrics {
     required super.pixels,
     required super.viewportDimension,
     required super.axisDirection,
-    required super.devicePixelRatio,
     required this.minRange,
     required this.maxRange,
     required this.correctionOffset,
@@ -539,7 +538,6 @@ class _NestedScrollMetrics extends FixedScrollMetrics {
     double? pixels,
     double? viewportDimension,
     AxisDirection? axisDirection,
-    double? devicePixelRatio,
     double? minRange,
     double? maxRange,
     double? correctionOffset,
@@ -550,7 +548,6 @@ class _NestedScrollMetrics extends FixedScrollMetrics {
       pixels: pixels ?? (hasPixels ? this.pixels : null),
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
       minRange: minRange ?? this.minRange,
       maxRange: maxRange ?? this.maxRange,
       correctionOffset: correctionOffset ?? this.correctionOffset,
@@ -818,7 +815,6 @@ class _NestedScrollCoordinator implements ScrollActivityDelegate, ScrollHoldCont
       minRange: minRange,
       maxRange: maxRange,
       correctionOffset: correctionOffset,
-      devicePixelRatio: _outerPosition!.devicePixelRatio,
     );
   }
 

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -273,7 +273,6 @@ class PageMetrics extends FixedScrollMetrics {
     required super.viewportDimension,
     required super.axisDirection,
     required this.viewportFraction,
-    required super.devicePixelRatio,
   });
 
   @override
@@ -284,7 +283,6 @@ class PageMetrics extends FixedScrollMetrics {
     double? viewportDimension,
     AxisDirection? axisDirection,
     double? viewportFraction,
-    double? devicePixelRatio,
   }) {
     return PageMetrics(
       minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
@@ -293,7 +291,6 @@ class PageMetrics extends FixedScrollMetrics {
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
       viewportFraction: viewportFraction ?? this.viewportFraction,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
 
@@ -496,7 +493,6 @@ class _PagePosition extends ScrollPositionWithSingleContext implements PageMetri
     double? viewportDimension,
     AxisDirection? axisDirection,
     double? viewportFraction,
-    double? devicePixelRatio,
   }) {
     return PageMetrics(
       minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
@@ -505,7 +501,6 @@ class _PagePosition extends ScrollPositionWithSingleContext implements PageMetri
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
       viewportFraction: viewportFraction ?? this.viewportFraction,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
 }
@@ -578,7 +573,7 @@ class PageScrollPhysics extends ScrollPhysics {
         (velocity >= 0.0 && position.pixels >= position.maxScrollExtent)) {
       return super.createBallisticSimulation(position, velocity);
     }
-    final Tolerance tolerance = toleranceFor(position);
+    final Tolerance tolerance = this.tolerance;
     final double target = _getTargetPixels(position, tolerance, velocity);
     if (target != position.pixels) {
       return ScrollSpringSimulation(spring, position.pixels, target, velocity, tolerance: tolerance);

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -46,7 +46,6 @@ mixin ScrollMetrics {
     double? pixels,
     double? viewportDimension,
     AxisDirection? axisDirection,
-    double? devicePixelRatio,
   }) {
     return FixedScrollMetrics(
       minScrollExtent: minScrollExtent ?? (hasContentDimensions ? this.minScrollExtent : null),
@@ -54,7 +53,6 @@ mixin ScrollMetrics {
       pixels: pixels ?? (hasPixels ? this.pixels : null),
       viewportDimension: viewportDimension ?? (hasViewportDimension ? this.viewportDimension : null),
       axisDirection: axisDirection ?? this.axisDirection,
-      devicePixelRatio: devicePixelRatio ?? this.devicePixelRatio,
     );
   }
 
@@ -126,10 +124,6 @@ mixin ScrollMetrics {
   /// The quantity of content conceptually "below" the viewport in the scrollable.
   /// This is the content below the content described by [extentInside].
   double get extentAfter => math.max(maxScrollExtent - pixels, 0.0);
-
-  /// The [FlutterView.devicePixelRatio] of the view that the [Scrollable]
-  /// associated with this metrics object is drawn into.
-  double get devicePixelRatio;
 }
 
 /// An immutable snapshot of values associated with a [Scrollable] viewport.
@@ -143,7 +137,6 @@ class FixedScrollMetrics with ScrollMetrics {
     required double? pixels,
     required double? viewportDimension,
     required this.axisDirection,
-    required this.devicePixelRatio,
   }) : _minScrollExtent = minScrollExtent,
        _maxScrollExtent = maxScrollExtent,
        _pixels = pixels,
@@ -176,9 +169,6 @@ class FixedScrollMetrics with ScrollMetrics {
 
   @override
   final AxisDirection axisDirection;
-
-  @override
-  final double devicePixelRatio;
 
   @override
   String toString() {

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/painting.dart' show AxisDirection;
 import 'package:flutter/physics.dart';
 
 import 'binding.dart' show WidgetsBinding;
@@ -384,29 +383,16 @@ class ScrollPhysics {
   /// The spring to use for ballistic simulations.
   SpringDescription get spring => parent?.spring ?? _kDefaultSpring;
 
-  /// Deprecated. Call [toleranceFor] instead.
-  @Deprecated(
-    'Call toleranceFor instead. '
-    'This feature was deprecated after v3.7.0-13.0.pre.',
-  )
-  Tolerance get tolerance {
-    return toleranceFor(FixedScrollMetrics(
-      minScrollExtent: null,
-      maxScrollExtent: null,
-      pixels: null,
-      viewportDimension: null,
-      axisDirection: AxisDirection.down,
-      devicePixelRatio: WidgetsBinding.instance.window.devicePixelRatio,
-    ));
-  }
+  /// The default accuracy to which scrolling is computed.
+  static final Tolerance _kDefaultTolerance = Tolerance(
+    // TODO(ianh): Handle the case of the device pixel ratio changing.
+    // TODO(ianh): Get this from the local MediaQuery not dart:ui's window object.
+    velocity: 1.0 / (0.050 * WidgetsBinding.instance.window.devicePixelRatio), // logical pixels per second
+    distance: 1.0 / WidgetsBinding.instance.window.devicePixelRatio, // logical pixels
+  );
 
   /// The tolerance to use for ballistic simulations.
-  Tolerance toleranceFor(ScrollMetrics metrics) {
-    return parent?.toleranceFor(metrics) ?? Tolerance(
-      velocity: 1.0 / (0.050 * metrics.devicePixelRatio), // logical pixels per second
-      distance: 1.0 / metrics.devicePixelRatio, // logical pixels
-    );
-  }
+  Tolerance get tolerance => parent?.tolerance ?? _kDefaultTolerance;
 
   /// The minimum distance an input pointer drag must have moved to
   /// to be considered a scroll fling gesture.
@@ -710,7 +696,7 @@ class BouncingScrollPhysics extends ScrollPhysics {
 
   @override
   Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
-    final Tolerance tolerance = toleranceFor(position);
+    final Tolerance tolerance = this.tolerance;
     if (velocity.abs() >= tolerance.velocity || position.outOfRange) {
       double constantDeceleration;
       switch (decelerationRate) {
@@ -854,7 +840,7 @@ class ClampingScrollPhysics extends ScrollPhysics {
 
   @override
   Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
-    final Tolerance tolerance = toleranceFor(position);
+    final Tolerance tolerance = this.tolerance;
     if (position.outOfRange) {
       double? end;
       if (position.pixels > position.maxScrollExtent) {

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -12,7 +12,6 @@ import 'package:flutter/scheduler.dart';
 
 import 'basic.dart';
 import 'framework.dart';
-import 'media_query.dart';
 import 'notification_listener.dart';
 import 'page_storage.dart';
 import 'scroll_activity.dart';
@@ -20,7 +19,6 @@ import 'scroll_context.dart';
 import 'scroll_metrics.dart';
 import 'scroll_notification.dart';
 import 'scroll_physics.dart';
-import 'view.dart';
 
 export 'scroll_activity.dart' show ScrollHoldController;
 
@@ -243,9 +241,6 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     context.setIgnorePointer(activity!.shouldIgnorePointer);
     isScrollingNotifier.value = activity!.isScrolling;
   }
-
-  @override
-  double get devicePixelRatio => MediaQuery.maybeDevicePixelRatioOf(context.storageContext) ?? View.of(context.storageContext).devicePixelRatio;
 
   /// Update the scroll position ([pixels]) to a given pixel value.
   ///

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -176,7 +176,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
     required Duration duration,
     required Curve curve,
   }) {
-    if (nearEqual(to, pixels, physics.toleranceFor(this).distance)) {
+    if (nearEqual(to, pixels, physics.tolerance.distance)) {
       // Skip the animation, go straight to the position as we are already close.
       jumpTo(to);
       return Future<void>.value();

--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -727,12 +727,6 @@ class ScrollableState extends State<Scrollable> with TickerProviderStateMixin, R
   }
 
   void _handleDragCancel() {
-    if (_gestureDetectorKey.currentContext == null) {
-      // The cancel was caused by the GestureDetector getting disposed, which
-      // means we will get disposed momentarily as well and shouldn't do
-      // any work.
-      return;
-    }
     // _hold might be null if the drag started.
     // _drag might be null if the drag activity ended and called _disposeDrag.
     assert(_hold == null || _drag == null);

--- a/packages/flutter/test/material/scrollbar_test.dart
+++ b/packages/flutter/test/material/scrollbar_test.dart
@@ -148,7 +148,6 @@ void main() {
       pixels: 0.0,
       viewportDimension: 100.0,
       axisDirection: AxisDirection.down,
-      devicePixelRatio: tester.binding.window.devicePixelRatio,
     );
     scrollPainter!.update(metrics, AxisDirection.down);
 

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -1048,7 +1048,6 @@ void main() {
       viewportDimension: 25.0,
       axisDirection: AxisDirection.right,
       viewportFraction: 1.0,
-      devicePixelRatio: tester.binding.window.devicePixelRatio,
     );
     expect(page.page, 6);
     final PageMetrics page2 = page.copyWith(

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -107,7 +107,6 @@ void main() {
       pixels: 20.0,
       viewportDimension: 500.0,
       axisDirection: AxisDirection.down,
-      devicePixelRatio: 3.0,
     );
 
     const BouncingScrollPhysics bounce = BouncingScrollPhysics();
@@ -130,12 +129,11 @@ void main() {
 
     test('overscroll is progressively harder', () {
       final ScrollMetrics lessOverscrolledPosition = FixedScrollMetrics(
-        minScrollExtent: 0.0,
-        maxScrollExtent: 1000.0,
-        pixels: -20.0,
-        viewportDimension: 100.0,
-        axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
+          minScrollExtent: 0.0,
+          maxScrollExtent: 1000.0,
+          pixels: -20.0,
+          viewportDimension: 100.0,
+          axisDirection: AxisDirection.down,
       );
 
       final ScrollMetrics moreOverscrolledPosition = FixedScrollMetrics(
@@ -144,7 +142,6 @@ void main() {
         pixels: -40.0,
         viewportDimension: 100.0,
         axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
       );
 
       final double lessOverscrollApplied =
@@ -173,7 +170,6 @@ void main() {
         pixels: -20.0,
         viewportDimension: 100.0,
         axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
       );
 
       final double easingApplied =
@@ -190,7 +186,6 @@ void main() {
         pixels: 300.0,
         viewportDimension: 100.0,
         axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
       );
 
       expect(
@@ -210,7 +205,6 @@ void main() {
         pixels: -20.0,
         viewportDimension: 100.0,
         axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
       );
 
       final double easingApplied =
@@ -223,12 +217,11 @@ void main() {
 
     test('overscroll a small list and a big list works the same way', () {
       final ScrollMetrics smallListOverscrolledPosition = FixedScrollMetrics(
-        minScrollExtent: 0.0,
-        maxScrollExtent: 10.0,
-        pixels: -20.0,
-        viewportDimension: 100.0,
-        axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
+          minScrollExtent: 0.0,
+          maxScrollExtent: 10.0,
+          pixels: -20.0,
+          viewportDimension: 100.0,
+          axisDirection: AxisDirection.down,
       );
 
       final ScrollMetrics bigListOverscrolledPosition = FixedScrollMetrics(
@@ -237,7 +230,6 @@ void main() {
         pixels: -20.0,
         viewportDimension: 100.0,
         axisDirection: AxisDirection.down,
-        devicePixelRatio: 3.0,
       );
 
       final double smallListOverscrollApplied =
@@ -262,7 +254,6 @@ void main() {
       maxScrollExtent: 1000,
       viewportDimension: 0,
       axisDirection: AxisDirection.down,
-      devicePixelRatio: 3.0,
     );
     expect(position.pixels, pixels);
     late FlutterError error;

--- a/packages/flutter/test/widgets/scrollable_animations_test.dart
+++ b/packages/flutter/test/widgets/scrollable_animations_test.dart
@@ -41,7 +41,7 @@ void main() {
 
     expectNoAnimation();
 
-    final double halfTolerance = controller.position.physics.toleranceFor(controller.position).distance / 2;
+    final double halfTolerance = controller.position.physics.tolerance.distance / 2;
     expect(halfTolerance, isNonZero);
     final double targetPosition = controller.position.pixels + halfTolerance;
     controller.position.animateTo(targetPosition, duration: const Duration(seconds: 10), curve: Curves.linear);
@@ -64,7 +64,7 @@ void main() {
 
     expectNoAnimation();
 
-    final double doubleTolerance = controller.position.physics.toleranceFor(controller.position).distance * 2;
+    final double doubleTolerance = controller.position.physics.tolerance.distance * 2;
     expect(doubleTolerance, isNonZero);
     final double targetPosition = controller.position.pixels + doubleTolerance;
     controller.position.animateTo(targetPosition, duration: const Duration(seconds: 10), curve: Curves.linear);

--- a/packages/flutter/test/widgets/scrollbar_test.dart
+++ b/packages/flutter/test/widgets/scrollbar_test.dart
@@ -83,7 +83,6 @@ void main() {
     pixels: 0,
     viewportDimension: 100,
     axisDirection: AxisDirection.down,
-    devicePixelRatio: 3.0,
   );
 
   test(

--- a/packages/flutter/test/widgets/slivers_evil_test.dart
+++ b/packages/flutter/test/widgets/slivers_evil_test.dart
@@ -53,7 +53,7 @@ class TestScrollPhysics extends ClampingScrollPhysics {
   }
 
   @override
-  Tolerance toleranceFor(ScrollMetrics metrics) => const Tolerance(velocity: 20.0, distance: 1.0);
+  Tolerance get tolerance => const Tolerance(velocity: 20.0, distance: 1.0);
 }
 
 void main() {


### PR DESCRIPTION
Reverts flutter/flutter#117503, context: https://b.corp.google.com/issues/263555070.

umm I was looking at a g3 fix for the breakages but I am not sure what would be the default value to use for devicePixelRatio. Looks like Michael will come back in January. Putting up a revert for now.