### PR TITLE
Add test for RenderProxyBoxMixin; clarify doc, resolve TODO

### DIFF
--- a/packages/flutter/lib/src/rendering/proxy_box.dart
+++ b/packages/flutter/lib/src/rendering/proxy_box.dart
@@ -53,8 +53,10 @@ class RenderProxyBox extends RenderBox with RenderObjectWithChildMixin<RenderBox
 ///
 /// Use this mixin in situations where the proxying behavior
 /// of [RenderProxyBox] is desired but inheriting from [RenderProxyBox] is
-/// impractical (e.g. because you want to mix in other classes as well).
-// TODO(ianh): Remove this class once https://github.com/dart-lang/sdk/issues/31543 is fixed
+/// impractical (e.g. because you want to inherit from a different class).
+///
+/// If a class already inherits from [RenderProxyBox] and also uses this mixin,
+/// you can safely delete the use of the mixin.
 @optionalTypeArgs
 mixin RenderProxyBoxMixin<T extends RenderBox> on RenderBox, RenderObjectWithChildMixin<T> {
   @override
@@ -1095,7 +1097,7 @@ mixin RenderAnimatedOpacityMixin<T extends RenderObject> on RenderObjectWithChil
 ///
 /// This is a variant of [RenderOpacity] that uses an [Animation<double>] rather
 /// than a [double] to control the opacity.
-class RenderAnimatedOpacity extends RenderProxyBox with RenderProxyBoxMixin, RenderAnimatedOpacityMixin<RenderBox> {
+class RenderAnimatedOpacity extends RenderProxyBox with RenderAnimatedOpacityMixin<RenderBox> {
   /// Creates a partially transparent render object.
   ///
   /// The [opacity] argument must not be null.

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -963,6 +963,15 @@ void main() {
     expect(debugPaintClipOval(Clip.none), paintsExactlyCountTimes(#drawPath, 0));
     expect(debugPaintClipOval(Clip.none), paintsExactlyCountTimes(#drawParagraph, 0));
   });
+
+  test('RenderProxyBox behavior can be mixed in along with another base class', () {
+    final RenderFancyProxyBox fancyProxyBox = RenderFancyProxyBox(fancy: 6);
+    // Box has behavior from its base class:
+    expect(fancyProxyBox.fancyMethod(), 36);
+    // Box has behavior from RenderProxyBox:
+    expect(fancyProxyBox.computeDryLayout(const BoxConstraints(minHeight: 8)),
+        const Size(0, 8));
+  });
 }
 
 class _TestRectClipper extends CustomClipper<Rect> {
@@ -1060,6 +1069,29 @@ class ConditionalRepaintBoundary extends RenderProxyBox {
 }
 
 class TestOffsetLayerA extends OffsetLayer {}
+
+// This class stands in for a class in an out-of-tree library or application
+// that contains a large swath of functionality and is used as a base class
+// for many subclasses.  For example:
+//   https://github.com/openwebf/webf/blob/793684612ea0/webf/lib/src/rendering/box_model.dart#L660-L1595
+class RenderFancyBox extends RenderBox {
+  RenderFancyBox({required this.fancy}) : super();
+
+  late int fancy;
+
+  int fancyMethod() {
+    return fancy * fancy;
+  }
+}
+
+// This stands in for an out-of-tree class that needs the functionality of both
+// RenderFancyBox and RenderProxyBox, and uses RenderProxyBoxMixin to get the
+// latter.  For example:
+//   https://github.com/openwebf/webf/blob/793684612ea0/webf/lib/src/rendering/widget.dart#L13-L14
+class RenderFancyProxyBox extends RenderFancyBox
+    with RenderObjectWithChildMixin<RenderBox>, RenderProxyBoxMixin<RenderBox> {
+  RenderFancyProxyBox({required super.fancy});
+}
 
 void expectAssertionError() {
   final FlutterErrorDetails errorDetails = TestRenderingFlutterBinding.instance.takeFlutterErrorDetails()!;

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -969,8 +969,10 @@ void main() {
     // Box has behavior from its base class:
     expect(fancyProxyBox.fancyMethod(), 36);
     // Box has behavior from RenderProxyBox:
-    expect(fancyProxyBox.computeDryLayout(const BoxConstraints(minHeight: 8)),
-        const Size(0, 8));
+    expect(
+      fancyProxyBox.computeDryLayout(const BoxConstraints(minHeight: 8)),
+      const Size(0, 8),
+    );
   });
 }
 

--- a/packages/flutter/test/rendering/proxy_box_test.dart
+++ b/packages/flutter/test/rendering/proxy_box_test.dart
@@ -1072,10 +1072,6 @@ class ConditionalRepaintBoundary extends RenderProxyBox {
 
 class TestOffsetLayerA extends OffsetLayer {}
 
-// This class stands in for a class in an out-of-tree library or application
-// that contains a large swath of functionality and is used as a base class
-// for many subclasses.  For example:
-//   https://github.com/openwebf/webf/blob/793684612ea0/webf/lib/src/rendering/box_model.dart#L660-L1595
 class RenderFancyBox extends RenderBox {
   RenderFancyBox({required this.fancy}) : super();
 
@@ -1086,10 +1082,6 @@ class RenderFancyBox extends RenderBox {
   }
 }
 
-// This stands in for an out-of-tree class that needs the functionality of both
-// RenderFancyBox and RenderProxyBox, and uses RenderProxyBoxMixin to get the
-// latter.  For example:
-//   https://github.com/openwebf/webf/blob/793684612ea0/webf/lib/src/rendering/widget.dart#L13-L14
 class RenderFancyProxyBox extends RenderFancyBox
     with RenderObjectWithChildMixin<RenderBox>, RenderProxyBoxMixin<RenderBox> {
   RenderFancyProxyBox({required super.fancy});


### PR DESCRIPTION
The TODO comment suggested this mixin would no longer be needed once a Dart issue on inherited constructors was fixed:
  https://github.com/dart-lang/sdk/issues/31543
That issue is now long since fixed, so I went to go carry out the TODO.

But in doing so, I realized that the mixin's documentation was more right than the TODO comment: even with that issue fixed, there is a legitimate use case for this mixin, namely to reuse the implementation of RenderProxyBox in a class that also inherits from some other base class.  Moreover, searching GitHub I found an example of a library that makes real use of that capability:
https://github.com/openwebf/webf/blob/793684612ea0/webf/lib/src/rendering/box_model.dart#L660-L1595
https://github.com/openwebf/webf/blob/793684612ea0/webf/lib/src/rendering/widget.dart#L13-L14

So I think the right resolution is to accept that this separation is useful and delete the TODO.

Then, add a test with an extremely simplified sketch of that real-world example.  In case someone in the future attempts to simplify this mixin away, the test will point us at the use case that would be broken by such a change.

Also remove the only in-tree use of the mixin, which was redundant; and expand the mixin's documentation to advise about that case.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
