### PR TITLE
Add support for Gradle Kotlin DSL

### DIFF
--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -486,11 +486,13 @@ class FlutterPlugin implements Plugin<Project> {
     }
 
     /**
-     * Returns `true` if the given path contains an `android/build.gradle` file.
+     * Returns `true` if the given path contains an `android` directory
+     * containing a `build.gradle` or `build.gradle.kts` file.
      */
     private Boolean doesSupportAndroidPlatform(String path) {
-        File editableAndroidProject = new File(path, 'android' + File.separator + 'build.gradle')
-        return editableAndroidProject.exists()
+        File buildGradle = new File(path, 'android' + File.separator + 'build.gradle')
+        File buildGradleKts = new File(path, 'android' + File.separator + 'build.gradle.kts')
+        return buildGradle.exists() || buildGradleKts.exists()
     }
 
     /**

--- a/packages/flutter_tools/gradle/flutter.gradle
+++ b/packages/flutter_tools/gradle/flutter.gradle
@@ -27,7 +27,8 @@ import org.gradle.api.tasks.bundling.Jar
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.util.VersionNumber
 
-/** For apps only. Provides the flutter extension used in app/build.gradle.
+/** For apps only. Provides the flutter extension used in the app-level Gradle
+ * build file (app/build.gradle or app/build.gradle.kts).
  * The versions specified here should match the values used in
  * ../lib/src/android/gradle_utils.dart, so when bumping, make sure to update
  * the versions specified there.
@@ -51,7 +52,7 @@ class FlutterExtension {
 
     /**
      * Specifies the relative directory to the Flutter project directory.
-     * In an app project, this is ../.. since the app's build.gradle is under android/app.
+     * In an app project, this is ../.. since the app's Gradle build file is under android/app.
      */
     String source
 
@@ -74,7 +75,7 @@ buildscript {
 
 /**
  * Some apps don't set default compile options.
- * Apps can change these values in android/app/build.gradle.
+ * Apps can change these values in android/app/build.gradle (or build.gradle.kts).
  * This just ensures that default values are set.
  */
 android {

--- a/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
@@ -225,9 +225,16 @@ class _DeferredComponentAndroidFiles {
   Directory get componentDir => androidDir.childDirectory(name);
 
   File get androidManifestFile => componentDir.childDirectory('src').childDirectory('main').childFile('AndroidManifest.xml');
-  File get buildGradleFile => componentDir.childFile('build.gradle');
+  File get buildGradleFile {
+    if (componentDir.childFile('build.gradle.kts').existsSync()) {
+      return componentDir.childFile('build.gradle.kts');
+    }
 
-  // True when AndroidManifest.xml and build.gradle exist for the android dynamic feature.
+     return componentDir.childFile('build.gradle');
+  }
+
+  // True when AndroidManifest.xml and build.gradle/build.gradle.kts exist for
+  // the android dynamic feature.
   bool verifyFilesExist() {
     return androidManifestFile.existsSync() && buildGradleFile.existsSync();
   }

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -129,19 +129,27 @@ distributionUrl=https\\://services.gradle.org/distributions/gradle-$gradleVersio
 /// The Android plugin version is specified in the [build.gradle] file within
 /// the project's Android directory.
 String getGradleVersionForAndroidPlugin(Directory directory, Logger logger) {
-  final File buildFile = directory.childFile('build.gradle');
+  const String buildFileName = 'build.gradle/build.gradle.kts';
+
+  final File buildFile;
+  if (directory.childFile('build.gradle.kts').existsSync()) {
+    buildFile = directory.childFile('build.gradle.kts');
+  } else {
+    buildFile = directory.childFile('build.gradle');
+  }
+
   if (!buildFile.existsSync()) {
-    logger.printTrace("$buildFile doesn't exist, assuming Gradle version: $templateDefaultGradleVersion");
+    logger.printTrace("$buildFileName doesn't exist, assuming Gradle version: $templateDefaultGradleVersion");
     return templateDefaultGradleVersion;
   }
   final String buildFileContent = buildFile.readAsStringSync();
   final Iterable<Match> pluginMatches = _androidPluginRegExp.allMatches(buildFileContent);
   if (pluginMatches.isEmpty) {
-    logger.printTrace("$buildFile doesn't provide an AGP version, assuming Gradle version: $templateDefaultGradleVersion");
+    logger.printTrace("$buildFileName doesn't provide an AGP version, assuming Gradle version: $templateDefaultGradleVersion");
     return templateDefaultGradleVersion;
   }
   final String? androidPluginVersion = pluginMatches.first.group(1);
-  logger.printTrace('$buildFile provides AGP version: $androidPluginVersion');
+  logger.printTrace('$buildFileName provides AGP version: $androidPluginVersion');
   return getGradleVersionFor(androidPluginVersion ?? 'unknown');
 }
 

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -443,7 +443,7 @@ class AndroidProject extends FlutterProjectPlatform {
   }
 
   /// The top-level Gradle build file.
-  /// 
+  ///
   /// It can be written in Groovy (build.gradle) or Kotlin (build.gradle.kts).
   File get gradleBuildFile {
     if (hostAppGradleRoot.childFile('build.gradle.kts').existsSync()) {
@@ -454,7 +454,7 @@ class AndroidProject extends FlutterProjectPlatform {
 
 
   /// The app-level Gradle build file.
-  /// 
+  ///
   /// It can be written in Groovy (build.gradle) or Kotlin (build.gradle.kts).
   File get appGradleBuildFile {
     final Directory appDir = hostAppGradleRoot.childDirectory('app');

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -442,6 +442,17 @@ class AndroidProject extends FlutterProjectPlatform {
     return ephemeralDirectory;
   }
 
+  /// The Gradle build file, which can be Groovy or Kotlin DSL based on the
+  /// extension.
+  File get gradleBuildFile {
+    if (hostAppGradleRoot.childFile('build.gradle.kts').existsSync()) {
+      return hostAppGradleRoot
+          .childDirectory('app')
+          .childFile('build.gradle.kts');
+    }
+    return hostAppGradleRoot.childDirectory('app').childFile('build.gradle');
+  }
+
   /// The Gradle root directory of the Android wrapping of Flutter and plugins.
   /// This is the same as [hostAppGradleRoot] except when the project is
   /// a Flutter module with an editable host app.
@@ -469,12 +480,11 @@ class AndroidProject extends FlutterProjectPlatform {
     if (plugin.existsSync()) {
       return false;
     }
-    final File appGradle = hostAppGradleRoot.childFile(
-        fileSystem.path.join('app', 'build.gradle'));
-    if (!appGradle.existsSync()) {
+    if (!gradleBuildFile.existsSync()) {
       return false;
     }
-    for (final String line in appGradle.readAsLinesSync()) {
+
+    for (final String line in gradleBuildFile.readAsLinesSync()) {
       if (line.contains(RegExp(r'apply from: .*/flutter.gradle')) ||
           line.contains("def flutterPluginVersion = 'managed'")) {
         return true;
@@ -485,12 +495,11 @@ class AndroidProject extends FlutterProjectPlatform {
 
   /// True, if the app project is using Kotlin.
   bool get isKotlin {
-    final File gradleFile = hostAppGradleRoot.childDirectory('app').childFile('build.gradle');
-    return firstMatchInFile(gradleFile, _kotlinPluginPattern) != null;
+    return firstMatchInFile(gradleBuildFile, _kotlinPluginPattern) != null;
   }
 
   File get appManifestFile {
-    return isUsingGradle
+    return gradleBuildFile.existsSync()
         ? globals.fs.file(globals.fs.path.join(hostAppGradleRoot.path, 'app', 'src', 'main', 'AndroidManifest.xml'))
         : hostAppGradleRoot.childFile('AndroidManifest.xml');
   }
@@ -508,17 +517,15 @@ class AndroidProject extends FlutterProjectPlatform {
   }
 
   bool get isUsingGradle {
-    return hostAppGradleRoot.childFile('build.gradle').existsSync();
+    return gradleBuildFile.existsSync();
   }
 
   String? get applicationId {
-    final File gradleFile = hostAppGradleRoot.childDirectory('app').childFile('build.gradle');
-    return firstMatchInFile(gradleFile, _applicationIdPattern)?.group(1);
+    return firstMatchInFile(gradleBuildFile, _applicationIdPattern)?.group(1);
   }
 
   String? get group {
-    final File gradleFile = hostAppGradleRoot.childFile('build.gradle');
-    return firstMatchInFile(gradleFile, _groupPattern)?.group(1);
+    return firstMatchInFile(gradleBuildFile, _groupPattern)?.group(1);
   }
 
   /// The build directory where the Android artifacts are placed.

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -445,7 +445,7 @@ class AndroidProject extends FlutterProjectPlatform {
   /// The top-level Gradle build file.
   ///
   /// It can be written in Groovy (build.gradle) or Kotlin (build.gradle.kts).
-  File get gradleBuildFile {
+  File get hostAppGradleBuildFile {
     if (hostAppGradleRoot.childFile('build.gradle.kts').existsSync()) {
       return hostAppGradleRoot.childFile('build.gradle.kts');
     }
@@ -510,7 +510,7 @@ class AndroidProject extends FlutterProjectPlatform {
   }
 
   File get appManifestFile {
-    return gradleBuildFile.existsSync()
+    return hostAppGradleBuildFile.existsSync()
         ? globals.fs.file(globals.fs.path.join(hostAppGradleRoot.path, 'app', 'src', 'main', 'AndroidManifest.xml'))
         : hostAppGradleRoot.childFile('AndroidManifest.xml');
   }
@@ -528,7 +528,7 @@ class AndroidProject extends FlutterProjectPlatform {
   }
 
   bool get isUsingGradle {
-    return gradleBuildFile.existsSync();
+    return hostAppGradleBuildFile.existsSync();
   }
 
   String? get applicationId {
@@ -536,7 +536,7 @@ class AndroidProject extends FlutterProjectPlatform {
   }
 
   String? get group {
-    return firstMatchInFile(gradleBuildFile, _groupPattern)?.group(1);
+    return firstMatchInFile(hostAppGradleBuildFile, _groupPattern)?.group(1);
   }
 
   /// The build directory where the Android artifacts are placed.

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -436,6 +436,24 @@ apply plugin: 'kotlin-android'
         XcodeProjectInterpreter: () => xcodeProjectInterpreter,
         FlutterProjectFactory: () => flutterProjectFactory,
       });
+
+       testUsingContext('kotlin host app language with Gradle Kotlin DSL', () async {
+        final FlutterProject project = await someProject();
+
+        addAndroidGradleFile(project.directory,
+          gradleFileContent: () {
+            return '''
+apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
+''';
+        }, kotlinDsl: true);
+        expect(project.android.isKotlin, isTrue);
+      }, overrides: <Type, Generator>{
+        FileSystem: () => fs,
+        ProcessManager: () => FakeProcessManager.any(),
+        XcodeProjectInterpreter: () => xcodeProjectInterpreter,
+        FlutterProjectFactory: () => flutterProjectFactory,
+      });
     });
 
     group('product bundle identifier', () {
@@ -1128,17 +1146,19 @@ void addIosProjectFile(Directory directory, {required String Function() projectF
     ..writeAsStringSync(projectFileContent());
 }
 
-void addAndroidGradleFile(Directory directory, { required String Function() gradleFileContent }) {
+void addAndroidGradleFile(Directory directory, { 
+  required String Function() gradleFileContent, bool kotlinDsl = false,
+}) {
   directory
       .childDirectory('android')
       .childDirectory('app')
-      .childFile('build.gradle')
+      .childFile(kotlinDsl ? 'build.gradle.kts' : 'build.gradle')
         ..createSync(recursive: true)
         ..writeAsStringSync(gradleFileContent());
 }
 
-void addAndroidWithGroup(Directory directory, String id) {
-  directory.childDirectory('android').childFile('build.gradle')
+void addAndroidWithGroup(Directory directory, String id, {bool kotlinDsl = false}) {
+  directory.childDirectory('android').childFile(kotlinDsl ? 'build.gradle.kts' : 'build.gradle')
     ..createSync(recursive: true)
     ..writeAsStringSync(gradleFileWithGroupId(id));
 }

--- a/packages/flutter_tools/test/general.shard/project_test.dart
+++ b/packages/flutter_tools/test/general.shard/project_test.dart
@@ -1146,7 +1146,7 @@ void addIosProjectFile(Directory directory, {required String Function() projectF
     ..writeAsStringSync(projectFileContent());
 }
 
-void addAndroidGradleFile(Directory directory, { 
+void addAndroidGradleFile(Directory directory, {
   required String Function() gradleFileContent, bool kotlinDsl = false,
 }) {
   directory


### PR DESCRIPTION
Attempts to fix #93238.

Gradle Kotlin DSL, at least for me, makes the experience of editing build scripts 10x better. Flutter developers should be able to harness this power :)

With this PR I'm aiming to make it possible to use `build.gradle.kts` instead of `build.gradle`, but there's more work to be done:
- update all documentation on the website to mention `build.gradle/build.gradle.kts` instead of only `build.gradle`
- update flutter tool's error messages to mention `build.gradle/build.gradle.kts` instead of only `build.gradle`
- add more tests for KTS buildscripts

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
