### PR TITLE
[Android][WIP] Turn spell check on by default

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1216,7 +1216,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     // uses the Material text style for misspeleld words unless a custom style
     // is specified and (ii) ensure that configuration uses the Material spell
     // check suggestions toolbar builder unless a custom builder is specified.
-    final SpellCheckConfiguration spellCheckConfiguration = 
+    final SpellCheckConfiguration spellCheckConfiguration =
       widget.spellCheckConfiguration == null
         ? SpellCheckConfiguration(
             spellCheckService: DefaultSpellCheckService(),

--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1211,20 +1211,25 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
         ),
     ];
 
-    // Set configuration as disabled if not otherwise specified. If specified,
-    // ensure that configuration uses Material text style for misspelled words
-    // unless a custom style is specified.
-    final SpellCheckConfiguration spellCheckConfiguration =
-      widget.spellCheckConfiguration != null &&
-      widget.spellCheckConfiguration != const SpellCheckConfiguration.disabled()
-        ? widget.spellCheckConfiguration!.copyWith(
-            misspelledTextStyle: widget.spellCheckConfiguration!.misspelledTextStyle
-              ?? TextField.materialMisspelledTextStyle,
-            spellCheckSuggestionsToolbarBuilder:
-              widget.spellCheckConfiguration!.spellCheckSuggestionsToolbarBuilder
-                ?? TextField.defaultSpellCheckSuggestionsToolbarBuilder
-          )
-        : const SpellCheckConfiguration.disabled();
+    // Set the spell check configuration if not otherwise disabled. If a
+    // configuration was specified in the widget, (i) ensure that configuration
+    // uses the Material text style for misspeleld words unless a custom style
+    // is specified and (ii) ensure that configuration uses the Material spell
+    // check suggestions toolbar builder unless a custom builder is specified.
+    final SpellCheckConfiguration spellCheckConfiguration = 
+      widget.spellCheckConfiguration == null
+        ? SpellCheckConfiguration(
+            spellCheckService: DefaultSpellCheckService(),
+            misspelledTextStyle: TextField.materialMisspelledTextStyle,
+            spellCheckSuggestionsToolbarBuilder: TextField.defaultSpellCheckSuggestionsToolbarBuilder,
+        )
+        : widget.spellCheckConfiguration!.copyWith(
+              misspelledTextStyle: widget.spellCheckConfiguration!.misspelledTextStyle
+                ?? TextField.materialMisspelledTextStyle,
+              spellCheckSuggestionsToolbarBuilder:
+                widget.spellCheckConfiguration!.spellCheckSuggestionsToolbarBuilder
+                  ?? TextField.defaultSpellCheckSuggestionsToolbarBuilder
+        );
 
     TextSelectionControls? textSelectionControls = widget.selectionControls;
     final bool paintCursorAboveText;

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -14012,7 +14012,7 @@ void main() {
       await tester.pumpWidget(
         overlay(
           child: const TextField(
-            spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
+            spellCheckConfiguration: SpellCheckConfiguration.disabled(),
           ),
         ),
       );
@@ -14028,7 +14028,7 @@ void main() {
       await tester.pumpWidget(
         overlay(
           child: const TextField(
-            spellCheckConfiguration: const SpellCheckConfiguration(),
+            spellCheckConfiguration: SpellCheckConfiguration(),
           ),
         ),
       );

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -13982,6 +13982,74 @@ void main() {
       }, variant: TargetPlatformVariant.all());
     }
   });
+
+  group('Spell check configuration', () {
+    testWidgets('Spell check configuration properly enabled by default', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        overlay(
+          child: TextField(),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+
+      expect(editableTextState.spellCheckEnabled, isTrue);
+      expect(
+        editableTextState.spellCheckConfiguration.spellCheckService.runtimeType,
+        equals(DefaultSpellCheckService),
+      );
+      expect(
+        editableTextState.spellCheckConfiguration.misspelledTextStyle,
+        equals(TextField.materialMisspelledTextStyle),
+      );
+      expect(
+        editableTextState.spellCheckConfiguration.spellCheckSuggestionsToolbarBuilder,
+        equals(TextField.defaultSpellCheckSuggestionsToolbarBuilder),
+      );
+    });
+
+    testWidgets('Spell check configuration disabled when disabled manually', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        overlay(
+          child: TextField(
+            spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+
+      expect(editableTextState.spellCheckEnabled, isFalse);
+    });
+
+    testWidgets('Spell check configuration fields properly inferred when not fully specified', (WidgetTester tester) async {
+      tester.binding.platformDispatcher.nativeSpellCheckServiceDefinedTestValue = true;
+
+      await tester.pumpWidget(
+        overlay(
+          child: TextField(
+            spellCheckConfiguration: const SpellCheckConfiguration(),
+          ),
+        ),
+      );
+
+      final EditableTextState editableTextState = tester.firstState(find.byType(EditableText));
+
+      expect(editableTextState.spellCheckEnabled, isTrue);
+      expect(
+        editableTextState.spellCheckConfiguration.spellCheckService.runtimeType,
+        equals(DefaultSpellCheckService),
+      );
+      expect(
+        editableTextState.spellCheckConfiguration.misspelledTextStyle,
+        equals(TextField.materialMisspelledTextStyle),
+      );
+      expect(
+        editableTextState.spellCheckConfiguration.spellCheckSuggestionsToolbarBuilder,
+        equals(TextField.defaultSpellCheckSuggestionsToolbarBuilder),
+      );
+    });
+  });
 }
 
 /// A Simple widget for testing the obscure text.

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -13987,7 +13987,7 @@ void main() {
     testWidgets('Spell check configuration properly enabled by default', (WidgetTester tester) async {
       await tester.pumpWidget(
         overlay(
-          child: TextField(),
+          child: const TextField(),
         ),
       );
 
@@ -14011,7 +14011,7 @@ void main() {
     testWidgets('Spell check configuration disabled when disabled manually', (WidgetTester tester) async {
       await tester.pumpWidget(
         overlay(
-          child: TextField(
+          child: const TextField(
             spellCheckConfiguration: const SpellCheckConfiguration.disabled(),
           ),
         ),
@@ -14027,7 +14027,7 @@ void main() {
 
       await tester.pumpWidget(
         overlay(
-          child: TextField(
+          child: const TextField(
             spellCheckConfiguration: const SpellCheckConfiguration(),
           ),
         ),


### PR DESCRIPTION
**Status: Proof of concept.**

Defaults spell check to be enabled for Material `TextField`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
