### PR TITLE
[Android] Increase timeout duration for spell check integration test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2185,9 +2185,9 @@ targets:
       task_name: routing_test
 
   - name: Linux_android spell_check_test
-    # bringup: true -- TESTING ONLY
+    bringup: true
     recipe: devicelab/devicelab_drone
-    presubmit: true # -- TESTING ONLY
+    presubmit: false
     timeout: 60
     properties:
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2185,9 +2185,9 @@ targets:
       task_name: routing_test
 
   - name: Linux_android spell_check_test
-    bringup: true
+    # bringup: true -- TESTING ONLY
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    presubmit: true # -- TESTING ONLY
     timeout: 60
     properties:
       tags: >

--- a/dev/integration_tests/spell_check/integration_test/integration_test.dart
+++ b/dev/integration_tests/spell_check/integration_test/integration_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @Timeout(Duration(seconds: 60))
+library;
 
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/dev/integration_tests/spell_check/integration_test/integration_test.dart
+++ b/dev/integration_tests/spell_check/integration_test/integration_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@Timeout(Duration(seconds: 60))
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';

--- a/dev/integration_tests/spell_check/integration_test/integration_test.dart
+++ b/dev/integration_tests/spell_check/integration_test/integration_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(camsim99): Revert this timeout change after effects are investigated.
 @Timeout(Duration(seconds: 60))
 library;
 


### PR DESCRIPTION
Increases timeout duration for spell check integration test to attempt to reduce its flakiness as reported in https://github.com/flutter/flutter/issues/113710.

Part of https://github.com/flutter/flutter/issues/117498.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
