### PR TITLE
Fix path name to discover debug apk on add2app builds

### DIFF
--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -117,7 +117,7 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
 
     if (androidProject.isUsingGradle && androidProject.isSupportedVersion) {
       Directory apkDirectory = getApkDirectory(androidProject.parent);
-      if (androidProject.parent.isModule && buildInfo?.mode == BuildMode.debug) {
+      if (androidProject.parent.isModule) {
         apkDirectory = apkDirectory.childDirectory(buildInfo!.mode.name);
       }
       apkFile = apkDirectory.childFile(filename);

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -116,7 +116,11 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
     }
 
     if (androidProject.isUsingGradle && androidProject.isSupportedVersion) {
-      apkFile = getApkDirectory(androidProject.parent).childFile(filename);
+      Directory apkDirectory = getApkDirectory(androidProject.parent);
+      if (androidProject.parent.isModule && buildInfo?.mode == BuildMode.debug) {
+        apkDirectory = apkDirectory.childDirectory(buildInfo!.mode.name);
+      }
+      apkFile = apkDirectory.childFile(filename);
       if (apkFile.existsSync()) {
         // Grab information from the .apk. The gradle build script might alter
         // the application Id, so we need to look at what was actually built.

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -118,6 +118,8 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
     if (androidProject.isUsingGradle && androidProject.isSupportedVersion) {
       Directory apkDirectory = getApkDirectory(androidProject.parent);
       if (androidProject.parent.isModule) {
+        // Module builds output the apk in a subdirectory that corresponds
+        // to the buildmode of the apk.
         apkDirectory = apkDirectory.childDirectory(buildInfo!.mode.name);
       }
       apkFile = apkDirectory.childFile(filename);

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -21,7 +21,6 @@ import 'package:flutter_tools/src/ios/plist_parser.dart';
 import 'package:flutter_tools/src/project.dart';
 import 'package:test/fake.dart';
 
-import '../general.shard/project_test.dart';
 import '../src/common.dart';
 import '../src/context.dart';
 import '../src/fake_process_manager.dart';
@@ -963,3 +962,20 @@ class FakeAndroidSdkVersion extends Fake implements AndroidSdkVersion {
   @override
   late String aaptPath;
 }
+
+Future<FlutterProject> aModuleProject() async {
+  final Directory directory = globals.fs.directory('module_project');
+  directory
+    .childDirectory('.dart_tool')
+    .childFile('package_config.json')
+    ..createSync(recursive: true)
+    ..writeAsStringSync('{"configVersion":2,"packages":[]}');
+  directory.childFile('pubspec.yaml').writeAsStringSync('''
+name: my_module
+flutter:
+  module:
+    androidPackage: com.example
+''');
+  return FlutterProject.fromDirectory(directory);
+}
+

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -978,4 +978,3 @@ flutter:
 ''');
   return FlutterProject.fromDirectory(directory);
 }
-

--- a/packages/flutter_tools/test/general.shard/application_package_test.dart
+++ b/packages/flutter_tools/test/general.shard/application_package_test.dart
@@ -91,10 +91,10 @@ void main() {
         )
       );
 
-      final ApplicationPackage applicationPackage = (await ApplicationPackageFactory.instance!.getPackageForPlatform(
+      await ApplicationPackageFactory.instance!.getPackageForPlatform(
         TargetPlatform.android_arm,
         applicationBinary: apkFile,
-      ))!;
+      );
       final BufferLogger logger = BufferLogger.test();
       final FlutterProject project = await aModuleProject();
       project.android.hostAppGradleRoot.childFile('build.gradle').createSync(recursive: true);


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/117570

This issue was introduced by https://github.com/flutter/flutter/pull/113622

Android Add2app builds output the debug APK in `build/host/outputs/apk/debug/app-debug.apk` but we were searching in the directory without `/debug/`

This doesn't occur with the other build modes (profile, release)
