### PR TITLE
Update `window` documentation

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -187,10 +187,9 @@ abstract class BindingBase {
   /// such as a [TestWindow].
   ///
   /// The [window] is a singleton meant for use by applications that only have a
-  /// single main window. In addition to the properties of
-  /// [ui.SingletonFlutterWindow], [window] provides access to
-  /// platform-specific properties and callbacks available on the
-  /// [platformDispatcher].
+  /// single main window. In addition to the properties of [ui.FlutterView],
+  /// [window] provides access to platform-specific properties and callbacks
+  /// available on the [platformDispatcher].
   ///
   /// For applications designed for more than one main window, prefer using the
   /// [platformDispatcher] to access available views via


### PR DESCRIPTION
https://github.com/flutter/engine/pull/38453 broke the engine roll and was later fixed by https://github.com/flutter/flutter/pull/118064. @flar updated the docs that broke the roll. The docs need to be updated one more time. 

Since `window` is already a `SingletonFlutterWindow`, the following cannot be true
> In addition to the properties of [ui.SingletonFlutterWindow] ...
since a `SingletonFlutterWindow` cannot have any more or any fewer properties than another `SingletonFlutterWindow`.

The changes in the [breaking PR](https://github.com/flutter/engine/pull/38453) made `FlutterView` concrete and implement the same features as `FlutterWindow`; therefore, the correct doc string is
> In addition to the properties of [ui.FlutterView],

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
