### PR TITLE
Fix path for require.js

### DIFF
--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -927,9 +927,11 @@ class WebDevFS implements DevFS {
 
   @visibleForTesting
   final File requireJS = (() {
-    // TODO(118119) Remove the initilizing function once the file location 
-    // change in the Dart SDK has landed and rolled to the engine and flutter 
-    // repos. There is no long-term need for the fallback logic.
+    // TODO(nshahan): Remove the initilizing function once the file location
+    //                change in the Dart SDK has landed and rolled to the engine
+    //                and flutter repos. There is no long-term need for the
+    //                fallback logic.
+    //                See https://github.com/flutter/flutter/issues/118119
     final File oldFile = globals.fs.file(globals.fs.path.join(
       globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
       'lib',

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -926,13 +926,29 @@ class WebDevFS implements DevFS {
   }
 
   @visibleForTesting
-  final File requireJS = globals.fs.file(globals.fs.path.join(
-    globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
-    'lib',
-    'dev_compiler',
-    'amd',
-    'require.js',
-  ));
+  late final File requireJS = (() {
+    // TODO(118119) Remove late and the initilizing function once the file
+    // location change in the Dart SDK has landed and rolled to the engine and
+    // flutter repos. There is no long-term need for the fallback logic.
+    final File oldFile = globals.fs.file(globals.fs.path.join(
+      globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
+      'lib',
+      'dev_compiler',
+      'kernel',
+      'amd',
+      'require.js',
+    ));
+
+    return oldFile.existsSync() 
+      ? oldFile 
+      : globals.fs.file(globals.fs.path.join(
+          globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
+          'lib',
+          'dev_compiler',
+          'amd',
+          'require.js',
+        ));
+  })();
 
   @visibleForTesting
   final File stackTraceMapper = globals.fs.file(globals.fs.path.join(

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -926,10 +926,10 @@ class WebDevFS implements DevFS {
   }
 
   @visibleForTesting
-  late final File requireJS = (() {
-    // TODO(118119) Remove late and the initilizing function once the file
-    // location change in the Dart SDK has landed and rolled to the engine and
-    // flutter repos. There is no long-term need for the fallback logic.
+  final File requireJS = (() {
+    // TODO(118119) Remove the initilizing function once the file location 
+    // change in the Dart SDK has landed and rolled to the engine and flutter 
+    // repos. There is no long-term need for the fallback logic.
     final File oldFile = globals.fs.file(globals.fs.path.join(
       globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
       'lib',

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -930,7 +930,6 @@ class WebDevFS implements DevFS {
     globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
     'lib',
     'dev_compiler',
-    'kernel',
     'amd',
     'require.js',
   ));

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -939,8 +939,8 @@ class WebDevFS implements DevFS {
       'require.js',
     ));
 
-    return oldFile.existsSync() 
-      ? oldFile 
+    return oldFile.existsSync()
+      ? oldFile
       : globals.fs.file(globals.fs.path.join(
           globals.artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
           'lib',


### PR DESCRIPTION
Matches new location in the Dart SDK.
https://dart-review.googlesource.com/c/sdk/+/275482

Includes fall back logic so the old file location will continue to be used until the new location change lands. Then we can remove the logic and only use the new location in a future change.

Fixes: https://github.com/flutter/flutter/issues/118119
