### PR TITLE
Use program during attach if provided

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -148,6 +148,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
       customTool: args.customTool,
       customToolReplacesArgs: args.customToolReplacesArgs,
       userToolArgs: args.toolArgs,
+      targetProgram: args.program,
     );
   }
 

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter_args.dart
@@ -17,6 +17,7 @@ class FlutterAttachRequestArguments
     this.customTool,
     this.customToolReplacesArgs,
     this.vmServiceUri,
+    this.program,
     super.restart,
     super.name,
     super.cwd,
@@ -35,6 +36,7 @@ class FlutterAttachRequestArguments
         customTool = obj['customTool'] as String?,
         customToolReplacesArgs = obj['customToolReplacesArgs'] as int?,
         vmServiceUri = obj['vmServiceUri'] as String?,
+        program = obj['program'] as String?,
         super.fromMap();
 
   static FlutterAttachRequestArguments fromJson(Map<String, Object?> obj) =>
@@ -63,6 +65,9 @@ class FlutterAttachRequestArguments
 
   /// The VM Service URI of the running Flutter app to connect to.
   final String? vmServiceUri;
+
+  /// The program/Flutter app to be run.
+  final String? program;
 
   @override
   Map<String, Object?> toJson() => <String, Object?>{
@@ -151,7 +156,8 @@ class FlutterLaunchRequestArguments
         if (args != null) 'args': args,
         if (toolArgs != null) 'toolArgs': toolArgs,
         if (customTool != null) 'customTool': customTool,
-        if (customToolReplacesArgs != null) 'customToolReplacesArgs': customToolReplacesArgs,
+        if (customToolReplacesArgs != null)
+          'customToolReplacesArgs': customToolReplacesArgs,
       };
 
   static FlutterLaunchRequestArguments fromJson(Map<String, Object?> obj) =>

--- a/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/general.shard/dap/flutter_adapter_test.dart
@@ -209,6 +209,34 @@ void main() {
         expect(adapter.processArgs, containsAllInOrder(<String>['attach', '--machine']));
       });
 
+      test('runs "flutter attach" with program if passed in', () async {
+        final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
+          fileSystem: MemoryFileSystem.test(style: fsStyle),
+          platform: platform,
+        );
+        final Completer<void> responseCompleter = Completer<void>();
+
+        final FlutterAttachRequestArguments args =
+            FlutterAttachRequestArguments(
+          cwd: '/project',
+          program: 'program/main.dart',
+        );
+
+        await adapter.configurationDoneRequest(MockRequest(), null, () {});
+        await adapter.attachRequest(
+            MockRequest(), args, responseCompleter.complete);
+        await responseCompleter.future;
+
+        expect(
+            adapter.processArgs,
+            containsAllInOrder(<String>[
+              'attach',
+              '--machine',
+              '--target',
+              'program/main.dart'
+            ]));
+      });
+
       test('does not record the VMs PID for terminating', () async {
         final MockFlutterDebugAdapter adapter = MockFlutterDebugAdapter(
           fileSystem: MemoryFileSystem.test(style: fsStyle),


### PR DESCRIPTION
This allows `flutter attach` to use a program if provided, which is needed for internal users.

cc @chingjun 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above. (not available for an internal use case)
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
