### PR TITLE
Fix Finnish TimeOfDate format

### DIFF
--- a/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
+++ b/packages/flutter_localizations/lib/src/l10n/generated_material_localizations.dart
@@ -13227,7 +13227,7 @@ class MaterialLocalizationFi extends GlobalMaterialLocalizations {
   String get tabLabelRaw => r'Välilehti $tabIndex/$tabCount';
 
   @override
-  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_colon_mm;
+  TimeOfDayFormat get timeOfDayFormatRaw => TimeOfDayFormat.HH_dot_mm;
 
   @override
   String get timePickerDialHelpText => 'VALITSE AIKA';

--- a/packages/flutter_localizations/lib/src/l10n/material_fi.arb
+++ b/packages/flutter_localizations/lib/src/l10n/material_fi.arb
@@ -1,6 +1,6 @@
 {
   "scriptCategory": "English-like",
-  "timeOfDayFormat": "HH:mm",
+  "timeOfDayFormat": "HH.mm",
   "openAppDrawerTooltip": "Avaa navigointivalikko",
   "backButtonTooltip": "Takaisin",
   "closeButtonTooltip": "Sulje",

--- a/packages/flutter_localizations/test/material/date_time_test.dart
+++ b/packages/flutter_localizations/test/material/date_time_test.dart
@@ -107,6 +107,11 @@ void main() {
         expect(await formatTimeOfDay(tester, const Locale('ja'), const TimeOfDay(hour: 20, minute: 32)), '20:32');
       });
 
+      testWidgets('formats ${TimeOfDayFormat.HH_dot_mm}', (WidgetTester tester) async {
+        expect(await formatTimeOfDay(tester, const Locale('fi'), const TimeOfDay(hour: 20, minute: 32)), '20.32');
+        expect(await formatTimeOfDay(tester, const Locale('fi'), const TimeOfDay(hour: 9, minute: 32)), '09.32');
+      });
+
       testWidgets('formats ${TimeOfDayFormat.frenchCanadian}', (WidgetTester tester) async {
         expect(await formatTimeOfDay(tester, const Locale('fr', 'CA'), const TimeOfDay(hour: 9, minute: 32)), '09 h 32');
       });


### PR DESCRIPTION
From an issue filed internally. TimeOfDateFormat for locale `fi` should be `HH.mm` not `HH:mm` as per this [link](https://st.unicode.org/cldr-apps/v#/fi/Gregorian/). For TimeOfDateFormat only, I think it should be ok to directly modify the `material_*.arb` files as the source of truth isn't from Translation Console.