### PR TITLE
IconButtonTheme should be overridden by the AppBar/AppBarTheme's iconTheme and actionsIconTheme

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1035,6 +1035,10 @@ class _AppBarState extends State<AppBar> {
 
           leading = Center(
             child: IconButtonTheme(
+              // This comparison is to check if there is a custom iconTheme. If true, it means that no
+              // custom iconTheme is provided, so iconButtonTheme is applied. Otherwise, we generate
+              // a new IconButtonThemeData based on the values from overallIconTheme. If iconButtonTheme only
+              // has null values, the default overallIconTheme will be applied below by IconTheme.merge
               data: overallIconTheme == defaults.iconTheme ? iconButtonTheme : IconButtonThemeData(
                 style: iconButtonTheme.style?.copyWith(
                   foregroundColor: leadingIconButtonStyle.foregroundColor,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1027,7 +1027,7 @@ class _AppBarState extends State<AppBar> {
       // type of widgets on leading with the original config.
       if (theme.useMaterial3) {
         if (leading is IconButton) {
-          // styleFrom method is used to generate a correct overlayColor based on the foregroundColor.
+          // The [IconButton.styleFrom] method is used to generate a correct [overlayColor] based on the [foregroundColor].
           final ButtonStyle leadingIconButtonStyle = IconButton.styleFrom(
             foregroundColor: overallIconTheme.color,
             iconSize: overallIconTheme.size,
@@ -1035,10 +1035,10 @@ class _AppBarState extends State<AppBar> {
 
           leading = Center(
             child: IconButtonTheme(
-              // This comparison is to check if there is a custom iconTheme. If true, it means that no
-              // custom iconTheme is provided, so iconButtonTheme is applied. Otherwise, we generate
-              // a new IconButtonThemeData based on the values from overallIconTheme. If iconButtonTheme only
-              // has null values, the default overallIconTheme will be applied below by IconTheme.merge
+              // This comparison is to check if there is a custom [overallIconTheme]. If true, it means that no
+              // custom [overallIconTheme] is provided, so [iconButtonTheme] is applied. Otherwise, we generate
+              // a new [IconButtonThemeData] based on the values from [overallIconTheme]. If [iconButtonTheme] only
+              // has null values, the default [overallIconTheme] will be applied below by [IconTheme.merge]
               data: overallIconTheme == defaults.iconTheme ? iconButtonTheme : IconButtonThemeData(
                 style: iconButtonTheme.style?.copyWith(
                   foregroundColor: leadingIconButtonStyle.foregroundColor,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1022,34 +1022,43 @@ class _AppBarState extends State<AppBar> {
       }
     }
     if (leading != null) {
-      // Based on the Material Design 3 specs, the leading IconButton should have
-      // a size of 48x48, and a highlight size of 40x40. Users can also put other
-      // type of widgets on leading with the original config.
       if (theme.useMaterial3) {
         if (leading is IconButton) {
-          // The [IconButton.styleFrom] method is used to generate a correct [overlayColor] based on the [foregroundColor].
-          final ButtonStyle leadingIconButtonStyle = IconButton.styleFrom(
-            foregroundColor: overallIconTheme.color,
-            iconSize: overallIconTheme.size,
-          );
+          final IconButtonThemeData effectiveIconButtonTheme;
+
+          // This comparison is to check if there is a custom [overallIconTheme]. If true, it means that no
+          // custom [overallIconTheme] is provided, so [iconButtonTheme] is applied. Otherwise, we generate
+          // a new [IconButtonThemeData] based on the values from [overallIconTheme]. If [iconButtonTheme] only
+          // has null values, the default [overallIconTheme] will be applied below by [IconTheme.merge]
+          if (overallIconTheme == defaults.iconTheme) {
+            effectiveIconButtonTheme = iconButtonTheme;
+          } else {
+            // The [IconButton.styleFrom] method is used to generate a correct [overlayColor] based on the [foregroundColor].
+            final ButtonStyle leadingIconButtonStyle = IconButton.styleFrom(
+              foregroundColor: overallIconTheme.color,
+              iconSize: overallIconTheme.size,
+            );
+
+            effectiveIconButtonTheme = IconButtonThemeData(
+              style: iconButtonTheme.style?.copyWith(
+                foregroundColor: leadingIconButtonStyle.foregroundColor,
+                overlayColor: leadingIconButtonStyle.overlayColor,
+                iconSize: leadingIconButtonStyle.iconSize,
+              )
+            );
+          }
 
           leading = Center(
             child: IconButtonTheme(
-              // This comparison is to check if there is a custom [overallIconTheme]. If true, it means that no
-              // custom [overallIconTheme] is provided, so [iconButtonTheme] is applied. Otherwise, we generate
-              // a new [IconButtonThemeData] based on the values from [overallIconTheme]. If [iconButtonTheme] only
-              // has null values, the default [overallIconTheme] will be applied below by [IconTheme.merge]
-              data: overallIconTheme == defaults.iconTheme ? iconButtonTheme : IconButtonThemeData(
-                style: iconButtonTheme.style?.copyWith(
-                  foregroundColor: leadingIconButtonStyle.foregroundColor,
-                  overlayColor: leadingIconButtonStyle.overlayColor,
-                  iconSize: leadingIconButtonStyle.iconSize,
-                ),
-              ),
+              data: effectiveIconButtonTheme,
               child: leading
             )
           );
         }
+
+        // Based on the Material Design 3 specs, the leading IconButton should have
+        // a size of 48x48, and a highlight size of 40x40. Users can also put other
+        // type of widgets on leading with the original config.
         leading = ConstrainedBox(
           constraints: BoxConstraints.tightFor(width: widget.leadingWidth ?? _kLeadingWidth),
           child: leading,
@@ -1128,18 +1137,26 @@ class _AppBarState extends State<AppBar> {
 
     // Allow the trailing actions to have their own theme if necessary.
     if (actions != null) {
-      final ButtonStyle actionsIconButtonStyle = IconButton.styleFrom(
-        foregroundColor: actionsIconTheme.color,
-        iconSize: actionsIconTheme.size,
-      );
-      actions = IconButtonTheme(
-        data: actionsIconTheme == defaults.actionsIconTheme ? iconButtonTheme : IconButtonThemeData(
+      final IconButtonThemeData effectiveActionsIconButtonTheme;
+      if (actionsIconTheme == defaults.actionsIconTheme) {
+        effectiveActionsIconButtonTheme = iconButtonTheme;
+      } else {
+        final ButtonStyle actionsIconButtonStyle = IconButton.styleFrom(
+          foregroundColor: actionsIconTheme.color,
+          iconSize: actionsIconTheme.size,
+        );
+
+        effectiveActionsIconButtonTheme = IconButtonThemeData(
           style: iconButtonTheme.style?.copyWith(
             foregroundColor: actionsIconButtonStyle.foregroundColor,
             overlayColor: actionsIconButtonStyle.overlayColor,
             iconSize: actionsIconButtonStyle.iconSize,
           )
-        ),
+        );
+      }
+
+      actions = IconButtonTheme(
+        data: effectiveActionsIconButtonTheme,
         child: IconTheme.merge(
           data: actionsIconTheme,
           child: actions,

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -11,12 +11,14 @@ import 'package:flutter/widgets.dart';
 
 import 'app_bar_theme.dart';
 import 'back_button.dart';
+import 'button_style.dart';
 import 'color_scheme.dart';
 import 'colors.dart';
 import 'constants.dart';
 import 'debug.dart';
 import 'flexible_space_bar.dart';
 import 'icon_button.dart';
+import 'icon_button_theme.dart';
 import 'icons.dart';
 import 'material.dart';
 import 'material_localizations.dart';
@@ -909,6 +911,7 @@ class _AppBarState extends State<AppBar> {
     assert(!widget.primary || debugCheckHasMediaQuery(context));
     assert(debugCheckHasMaterialLocalizations(context));
     final ThemeData theme = Theme.of(context);
+    final IconButtonThemeData iconButtonTheme = IconButtonTheme.of(context);
     final AppBarTheme appBarTheme = AppBarTheme.of(context);
     final AppBarTheme defaults = theme.useMaterial3 ? _AppBarDefaultsM3(context) : _AppBarDefaultsM2(context);
     final ScaffoldState? scaffold = Scaffold.maybeOf(context);
@@ -1023,9 +1026,29 @@ class _AppBarState extends State<AppBar> {
       // a size of 48x48, and a highlight size of 40x40. Users can also put other
       // type of widgets on leading with the original config.
       if (theme.useMaterial3) {
-        leading =  ConstrainedBox(
+        if (leading is IconButton) {
+          // styleFrom method is used to generate a correct overlayColor based on the foregroundColor.
+          final ButtonStyle leadingIconButtonStyle = IconButton.styleFrom(
+            foregroundColor: overallIconTheme.color,
+            iconSize: overallIconTheme.size,
+          );
+
+          leading = Center(
+            child: IconButtonTheme(
+              data: overallIconTheme == defaults.iconTheme ? iconButtonTheme : IconButtonThemeData(
+                style: iconButtonTheme.style?.copyWith(
+                  foregroundColor: leadingIconButtonStyle.foregroundColor,
+                  overlayColor: leadingIconButtonStyle.overlayColor,
+                  iconSize: leadingIconButtonStyle.iconSize,
+                ),
+              ),
+              child: leading
+            )
+          );
+        }
+        leading = ConstrainedBox(
           constraints: BoxConstraints.tightFor(width: widget.leadingWidth ?? _kLeadingWidth),
-          child: leading is IconButton ? Center(child: leading) : leading,
+          child: leading,
         );
       } else {
         leading = ConstrainedBox(
@@ -1101,9 +1124,22 @@ class _AppBarState extends State<AppBar> {
 
     // Allow the trailing actions to have their own theme if necessary.
     if (actions != null) {
-      actions = IconTheme.merge(
-        data: actionsIconTheme,
-        child: actions,
+      final ButtonStyle actionsIconButtonStyle = IconButton.styleFrom(
+        foregroundColor: actionsIconTheme.color,
+        iconSize: actionsIconTheme.size,
+      );
+      actions = IconButtonTheme(
+        data: actionsIconTheme == defaults.actionsIconTheme ? iconButtonTheme : IconButtonThemeData(
+          style: iconButtonTheme.style?.copyWith(
+            foregroundColor: actionsIconButtonStyle.foregroundColor,
+            overlayColor: actionsIconButtonStyle.overlayColor,
+            iconSize: actionsIconButtonStyle.iconSize,
+          )
+        ),
+        child: IconTheme.merge(
+          data: actionsIconTheme,
+          child: actions,
+        ),
       );
     }
 

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3196,7 +3196,7 @@ void main() {
       expect(actionIconButtonColor(), actionsIconColor);
     });
 
-    testWidgets('The iconTheme property of the AppBar overrides any IconButtonTheme that is present in the theme - M3', (WidgetTester tester) async {
+    testWidgets('AppBar.iconTheme should override any IconButtonTheme present in the theme - M3', (WidgetTester tester) async {
       final ThemeData themeData = ThemeData(
         iconButtonTheme: IconButtonThemeData(
           style: IconButton.styleFrom(
@@ -3235,7 +3235,7 @@ void main() {
       expect(actionIconButtonSize(), 30.0);
     });
 
-    testWidgets('The actionsIconTheme property of the AppBar overrides any IconButtonTheme that is present in the theme - M3', (WidgetTester tester) async {
+    testWidgets('AppBar.actionsIconTheme should override any IconButtonTheme present in the theme - M3', (WidgetTester tester) async {
       final ThemeData themeData = ThemeData(
         iconButtonTheme: IconButtonThemeData(
           style: IconButton.styleFrom(
@@ -3275,7 +3275,7 @@ void main() {
       expect(actionIconButtonSize(), 30.0);
     });
 
-    testWidgets('The foregroundColor property of the AppBar overrides any IconButtonTheme that is present in the theme - M3', (WidgetTester tester) async {
+    testWidgets('The foregroundColor property of the AppBar overrides any IconButtonTheme present in the theme - M3', (WidgetTester tester) async {
       final ThemeData themeData = ThemeData(
         iconButtonTheme: IconButtonThemeData(
           style: IconButton.styleFrom(

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3195,6 +3195,118 @@ void main() {
       expect(actionIconColor(), actionsIconColor);
       expect(actionIconButtonColor(), actionsIconColor);
     });
+
+    testWidgets('The iconTheme property of the AppBar overrides any IconButtonTheme that is present in the theme - M3', (WidgetTester tester) async {
+      final ThemeData themeData = ThemeData(
+        iconButtonTheme: IconButtonThemeData(
+          style: IconButton.styleFrom(
+            foregroundColor: Colors.red,
+            iconSize: 32.0,
+          ),
+        ),
+        useMaterial3: true,
+      );
+
+      const IconThemeData overallIconTheme = IconThemeData(color: Colors.yellow, size: 30.0);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: themeData,
+          home: Scaffold(
+            appBar: AppBar(
+              iconTheme: overallIconTheme,
+              leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {}),
+              title: const Text('title'),
+              actions: <Widget>[
+                IconButton(icon: const Icon(Icons.add), onPressed: () {}),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      Color? leadingIconButtonColor() => iconStyle(tester, Icons.menu)?.color;
+      double? leadingIconButtonSize() => iconStyle(tester, Icons.menu)?.fontSize;
+      Color? actionIconButtonColor() => iconStyle(tester, Icons.add)?.color;
+      double? actionIconButtonSize() => iconStyle(tester, Icons.menu)?.fontSize;
+
+      expect(leadingIconButtonColor(), Colors.yellow);
+      expect(leadingIconButtonSize(), 30.0);
+      expect(actionIconButtonColor(), Colors.yellow);
+      expect(actionIconButtonSize(), 30.0);
+    });
+
+    testWidgets('The actionsIconTheme property of the AppBar overrides any IconButtonTheme that is present in the theme - M3', (WidgetTester tester) async {
+      final ThemeData themeData = ThemeData(
+        iconButtonTheme: IconButtonThemeData(
+          style: IconButton.styleFrom(
+            foregroundColor: Colors.red,
+            iconSize: 32.0,
+          ),
+        ),
+        useMaterial3: true,
+      );
+
+      const IconThemeData actionsIconTheme = IconThemeData(color: Colors.yellow, size: 30.0);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: themeData,
+          home: Scaffold(
+            appBar: AppBar(
+              actionsIconTheme: actionsIconTheme,
+              title: const Text('title'),
+              leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {}),
+              actions: <Widget>[
+                IconButton(icon: const Icon(Icons.add), onPressed: () {}),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      Color? leadingIconButtonColor() => iconStyle(tester, Icons.menu)?.color;
+      double? leadingIconButtonSize() => iconStyle(tester, Icons.menu)?.fontSize;
+      Color? actionIconButtonColor() => iconStyle(tester, Icons.add)?.color;
+      double? actionIconButtonSize() => iconStyle(tester, Icons.add)?.fontSize;
+
+      // The leading icon button uses the style in the IconButtonTheme because only actionsIconTheme is provided.
+      expect(leadingIconButtonColor(), Colors.red);
+      expect(leadingIconButtonSize(), 32.0);
+      expect(actionIconButtonColor(), Colors.yellow);
+      expect(actionIconButtonSize(), 30.0);
+    });
+
+    testWidgets('The foregroundColor property of the AppBar overrides any IconButtonTheme that is present in the theme - M3', (WidgetTester tester) async {
+      final ThemeData themeData = ThemeData(
+        iconButtonTheme: IconButtonThemeData(
+          style: IconButton.styleFrom(
+            foregroundColor: Colors.red,
+          ),
+        ),
+        useMaterial3: true,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: themeData,
+          home: Scaffold(
+            appBar: AppBar(
+              foregroundColor: Colors.purple,
+              title: const Text('title'),
+              leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {}),
+              actions: <Widget>[
+                IconButton(icon: const Icon(Icons.add), onPressed: () {}),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      Color? leadingIconButtonColor() => iconStyle(tester, Icons.menu)?.color;
+      Color? actionIconButtonColor() => iconStyle(tester, Icons.add)?.color;
+
+      expect(leadingIconButtonColor(), Colors.purple);
+      expect(actionIconButtonColor(), Colors.purple);
+    });
   });
 
   testWidgets('AppBarTheme.backwardsCompatibility', (WidgetTester tester) async {

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -508,6 +508,149 @@ void main() {
     expect(appBar.surfaceTintColor, Colors.yellow);
   });
 
+  testWidgets('AppBarTheme.iconTheme.color takes priority over IconButtonTheme.foregroundColor - M3', (WidgetTester tester) async {
+    const IconThemeData overallIconTheme = IconThemeData(color: Colors.yellow);
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        iconButtonTheme: IconButtonThemeData(
+          style: IconButton.styleFrom(foregroundColor: Colors.red),
+        ),
+        appBarTheme: const AppBarTheme(iconTheme: overallIconTheme),
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {},),
+          actions: <Widget>[ IconButton(icon: const Icon(Icons.add), onPressed: () {},) ],
+          title: const Text('Title'),
+        ),
+      ),
+    ));
+
+    final Color? leadingIconButtonColor = _iconStyle(tester, Icons.menu)?.color;
+    final Color? actionIconButtonColor = _iconStyle(tester, Icons.add)?.color;
+
+    expect(leadingIconButtonColor, overallIconTheme.color);
+    expect(actionIconButtonColor, overallIconTheme.color);
+  });
+
+  testWidgets('AppBarTheme.iconTheme.size takes priority over IconButtonTheme.iconSize - M3', (WidgetTester tester) async {
+    const IconThemeData overallIconTheme = IconThemeData(size: 30.0);
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        iconButtonTheme: IconButtonThemeData(
+          style: IconButton.styleFrom(iconSize: 32.0),
+        ),
+        appBarTheme: const AppBarTheme(iconTheme: overallIconTheme),
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {},),
+          actions: <Widget>[ IconButton(icon: const Icon(Icons.add), onPressed: () {},) ],
+          title: const Text('Title'),
+        ),
+      ),
+    ));
+
+    final double? leadingIconButtonSize = _iconStyle(tester, Icons.menu)?.fontSize;
+    final double? actionIconButtonSize = _iconStyle(tester, Icons.add)?.fontSize;
+
+    expect(leadingIconButtonSize, overallIconTheme.size);
+    expect(actionIconButtonSize, overallIconTheme.size);
+  });
+
+
+  testWidgets('AppBarTheme.actionsIconTheme.color takes priority over IconButtonTheme.foregroundColor - M3', (WidgetTester tester) async {
+    const IconThemeData actionsIconTheme = IconThemeData(color: Colors.yellow);
+    final IconButtonThemeData iconButtonTheme = IconButtonThemeData(
+      style: IconButton.styleFrom(foregroundColor: Colors.red),
+    );
+
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        iconButtonTheme: iconButtonTheme,
+        appBarTheme: const AppBarTheme(actionsIconTheme: actionsIconTheme),
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {},),
+          actions: <Widget>[ IconButton(icon: const Icon(Icons.add), onPressed: () {},) ],
+          title: const Text('Title'),
+        ),
+      ),
+    ));
+
+    final Color? leadingIconButtonColor = _iconStyle(tester, Icons.menu)?.color;
+    final Color? actionIconButtonColor = _iconStyle(tester, Icons.add)?.color;
+
+    expect(leadingIconButtonColor, Colors.red); // leading color should come from iconButtonTheme
+    expect(actionIconButtonColor, actionsIconTheme.color);
+  });
+
+  testWidgets('AppBarTheme.actionsIconTheme.size takes priority over IconButtonTheme.iconSize - M3', (WidgetTester tester) async {
+    const IconThemeData actionsIconTheme = IconThemeData(size: 30.0);
+    final IconButtonThemeData iconButtonTheme = IconButtonThemeData(
+      style: IconButton.styleFrom(iconSize: 32.0),
+    );
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        iconButtonTheme: iconButtonTheme,
+        appBarTheme: const AppBarTheme(actionsIconTheme: actionsIconTheme),
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {},),
+          actions: <Widget>[ IconButton(icon: const Icon(Icons.add), onPressed: () {},) ],
+          title: const Text('Title'),
+        ),
+      ),
+    ));
+
+    final double? leadingIconButtonSize = _iconStyle(tester, Icons.menu)?.fontSize;
+    final double? actionIconButtonSize = _iconStyle(tester, Icons.add)?.fontSize;
+
+    expect(leadingIconButtonSize, 32.0); // The size of leading icon button should come from iconButtonTheme
+    expect(actionIconButtonSize, actionsIconTheme.size);
+  });
+
+  testWidgets('AppBarTheme.foregroundColor takes priority over IconButtonTheme.foregroundColor - M3', (WidgetTester tester) async {
+    final IconButtonThemeData iconButtonTheme = IconButtonThemeData(
+      style: IconButton.styleFrom(foregroundColor: Colors.red),
+    );
+    const AppBarTheme appBarTheme = AppBarTheme(
+      foregroundColor: Colors.green,
+    );
+    final ThemeData themeData = ThemeData(
+      iconButtonTheme: iconButtonTheme,
+      appBarTheme: appBarTheme,
+      useMaterial3: true,
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: themeData,
+        home: Scaffold(
+          appBar: AppBar(
+            title: const Text('title'),
+            leading: IconButton(icon: const Icon(Icons.menu), onPressed: () {}),
+            actions: <Widget>[
+              IconButton(icon: const Icon(Icons.add), onPressed: () {}),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    final Color? leadingIconButtonColor = _iconStyle(tester, Icons.menu)?.color;
+    final Color? actionIconButtonColor = _iconStyle(tester, Icons.add)?.color;
+
+    expect(leadingIconButtonColor, appBarTheme.foregroundColor);
+    expect(actionIconButtonColor, appBarTheme.foregroundColor);
+  });
+
   testWidgets('AppBar uses AppBarTheme.titleSpacing', (WidgetTester tester) async {
     const double kTitleSpacing = 10;
     await tester.pumpWidget(MaterialApp(
@@ -687,4 +830,11 @@ DefaultTextStyle _getAppBarText(WidgetTester tester) {
       matching: find.byType(DefaultTextStyle),
     ).first,
   );
+}
+
+TextStyle? _iconStyle(WidgetTester tester, IconData icon) {
+  final RichText iconRichText = tester.widget<RichText>(
+    find.descendant(of: find.byIcon(icon).first, matching: find.byType(RichText)),
+  );
+  return iconRichText.text.style;
 }


### PR DESCRIPTION
Fixes #117918.

On AppBar, the `iconTheme` and `actionsIconTheme` properties should be able to control the color and size of icon buttons. But for M3 IconButtons, the color and size from the `IconButtonTheme` always override the values from `IconTheme` if both themes exist. So this PR is to firstly get the color/size of the iconTheme/actionsIconTheme if any of them are not null and copy these values into the IconButtonTheme, then apply the iconButtonTheme to the icon buttons on the app bar.

When `iconButtonTheme` is provided in ThemeData:
 * If no `appBarTheme` is provided, the icon buttons on AppBar will follow the style of `iconButtonTheme`.
 * If `appBarTheme.foregroundColor` is provided, the color of iconButtons on AppBar will be the same as `appBarTheme.foregroundColor`.
 * If `appBarTheme.iconTheme` is provided, the color and size of iconButtons on AppBar will come from `appBarTheme.iconTheme`.
 * If `appBarTheme.actionsIconTheme` is provided, the style of the leading icon button on AppBar will be the same as `iconButtonTheme.style`, and the color and size of action icon buttons on AppBar will come from `appBarTheme.actionsIconTheme`.
 * To override the `iconTheme` / `actionsIconTheme` for a specific icon button on AppBar, use `color` property of `IconButton` or wrap the icon button with `IconButtonTheme`.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
