### PR TITLE
Add documentation for drag/fling offset in WidgetController.

### DIFF
--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -580,7 +580,7 @@ abstract class WidgetController {
   /// {@endtemplate}
   ///
   /// The `offset` and `speed` control the interval between each pointer event.
-  /// For example, if the `offset` is 20moveBy0 pixels down, and the `speed` is 800
+  /// For example, if the `offset` is 200 pixels down, and the `speed` is 800
   /// pixels per second, the pointer events will be sent for each increment
   /// of 4 pixels (200/50), over 250ms (200/800), meaning events will be sent
   /// every 1.25ms (250/200).

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -562,22 +562,22 @@ abstract class WidgetController {
   ///
   /// {@macro flutter.flutter_test.WidgetController.tap.warnIfMissed}
   ///
+  /// {@template flutter.flutter_test.WidgetController.fling.offset}
+  /// The `offset` represents a distance the pointer moves in global coordinate
+  /// system of the screen.
+  ///
+  /// Positive [Offset.dy] values mean pointer moves downward. Negative
+  /// [Offset.dy] values mean pointer moves upwards. Accordingly, positive
+  /// [Offset.dx] values mean pointer moves towards the right. Negative
+  /// [Offset.dx] values mean pointer moves towards left.
+  /// {@endtemplate}
+  ///
   /// {@template flutter.flutter_test.WidgetController.fling}
   /// This can pump frames.
   ///
   /// Exactly 50 pointer events are synthesized.
   ///
   /// The `speed` is in pixels per second in the direction given by `offset`.
-  ///
-  /// {@template flutter.flutter_test.WidgetController.fling.offset}
-  /// The `offset` represents a distance the pointer moves in global coordinate
-  /// system of the screen.
-  ///
-  /// Positive [offset.dy] values mean pointer moves downward. Negative
-  /// [offset.dy] values mean pointer moves upwards. Accordingly, positive
-  /// [offset.dx] values mean pointer moves towards the right. Negative
-  /// [offset.dx] values mean pointer moves towards left.
-  /// {@endtemplate}
   ///
   /// The `offset` and `speed` control the interval between each pointer event.
   /// For example, if the `offset` is 200 pixels down, and the `speed` is 800

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -569,8 +569,18 @@ abstract class WidgetController {
   ///
   /// The `speed` is in pixels per second in the direction given by `offset`.
   ///
+  /// {@template flutter.flutter_test.WidgetController.fling.offset}
+  /// The `offset` represents a distance the pointer moves in global coordinate
+  /// system of the screen.
+  ///
+  /// Positive [offset.dy] values mean pointer moves downward. Negtive
+  /// [offset.dy] values mean pointer moves upwards. Accordingly, positive
+  /// [offset.dx] values mean pointer moves towards the right. Negtive
+  /// [offset.dx] values mean pointer moves towards left.
+  /// {@endtemplate}
+  ///
   /// The `offset` and `speed` control the interval between each pointer event.
-  /// For example, if the `offset` is 200 pixels down, and the `speed` is 800
+  /// For example, if the `offset` is 20moveBy0 pixels down, and the `speed` is 800
   /// pixels per second, the pointer events will be sent for each increment
   /// of 4 pixels (200/50), over 250ms (200/800), meaning events will be sent
   /// every 1.25ms (250/200).
@@ -817,6 +827,8 @@ abstract class WidgetController {
   /// The operation happens at once. If you want the drag to last for a period
   /// of time, consider using [timedDrag].
   ///
+  /// {@macro flutter.flutter_test.WidgetController.fling.offset}
+  ///
   /// {@template flutter.flutter_test.WidgetController.drag}
   /// By default, if the x or y component of offset is greater than
   /// [kDragSlopDefault], the gesture is broken up into two separate moves
@@ -952,6 +964,8 @@ abstract class WidgetController {
   /// time, starting in the middle of the widget.
   ///
   /// {@macro flutter.flutter_test.WidgetController.tap.warnIfMissed}
+  ///
+  /// {@macro flutter.flutter_test.WidgetController.fling.offset}
   ///
   /// This is the timed version of [drag]. This may or may not result in a
   /// [fling] or ballistic animation, depending on the speed from

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -563,13 +563,13 @@ abstract class WidgetController {
   /// {@macro flutter.flutter_test.WidgetController.tap.warnIfMissed}
   ///
   /// {@template flutter.flutter_test.WidgetController.fling.offset}
-  /// The `offset` represents a distance the pointer moves in global coordinate
-  /// system of the screen.
+  /// The `offset` represents a distance the pointer moves in the global
+  /// coordinate system of the screen.
   ///
-  /// Positive [Offset.dy] values mean pointer moves downward. Negative
-  /// [Offset.dy] values mean pointer moves upwards. Accordingly, positive
-  /// [Offset.dx] values mean pointer moves towards the right. Negative
-  /// [Offset.dx] values mean pointer moves towards left.
+  /// Positive [Offset.dy] values mean the pointer moves downward. Negative
+  /// [Offset.dy] values mean the pointer moves upwards. Accordingly, positive
+  /// [Offset.dx] values mean the pointer moves towards the right. Negative
+  /// [Offset.dx] values mean the pointer moves towards left.
   /// {@endtemplate}
   ///
   /// {@template flutter.flutter_test.WidgetController.fling}

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -573,9 +573,9 @@ abstract class WidgetController {
   /// The `offset` represents a distance the pointer moves in global coordinate
   /// system of the screen.
   ///
-  /// Positive [offset.dy] values mean pointer moves downward. Negtive
+  /// Positive [offset.dy] values mean pointer moves downward. Negative
   /// [offset.dy] values mean pointer moves upwards. Accordingly, positive
-  /// [offset.dx] values mean pointer moves towards the right. Negtive
+  /// [offset.dx] values mean pointer moves towards the right. Negative
   /// [offset.dx] values mean pointer moves towards left.
   /// {@endtemplate}
   ///


### PR DESCRIPTION
Add documentation for `offset` in WdigetController to explain the direction on positive/negative coordinate values

Fixes #56150

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
