### PR TITLE
Fix `SliverAppBar.large` and `SliverAppBar.medium` do not use `foregroundColor`

### DIFF
--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1652,6 +1652,7 @@ class SliverAppBar extends StatefulWidget {
       actions: actions,
       flexibleSpace: flexibleSpace ?? _ScrollUnderFlexibleSpace(
         title: title,
+        foregroundColor: foregroundColor,
         variant: _ScrollUnderFlexibleVariant.medium,
         centerCollapsedTitle: centerTitle,
         primary: primary,
@@ -1753,6 +1754,7 @@ class SliverAppBar extends StatefulWidget {
       actions: actions,
       flexibleSpace: flexibleSpace ?? _ScrollUnderFlexibleSpace(
         title: title,
+        foregroundColor: foregroundColor,
         variant: _ScrollUnderFlexibleVariant.large,
         centerCollapsedTitle: centerTitle,
         primary: primary,
@@ -2227,12 +2229,14 @@ enum _ScrollUnderFlexibleVariant { medium, large }
 class _ScrollUnderFlexibleSpace extends StatelessWidget {
   const _ScrollUnderFlexibleSpace({
     this.title,
+    this.foregroundColor,
     required this.variant,
     this.centerCollapsedTitle,
     this.primary = true,
   });
 
   final Widget? title;
+  final Color? foregroundColor;
   final _ScrollUnderFlexibleVariant variant;
   final bool? centerCollapsedTitle;
   final bool primary;
@@ -2240,6 +2244,7 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     late final ThemeData theme = Theme.of(context);
+    late final AppBarTheme appBarTheme = AppBarTheme.of(context);
     final FlexibleSpaceBarSettings settings = context.dependOnInheritedWidgetOfExactType<FlexibleSpaceBarSettings>()!;
     final double topPadding = primary ? MediaQuery.viewPaddingOf(context).top : 0;
     final double collapsedHeight = settings.minExtent - topPadding;
@@ -2259,13 +2264,13 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
     if (title != null) {
       collapsedTitle = config.collapsedTextStyle != null
         ? DefaultTextStyle(
-            style: config.collapsedTextStyle!,
+            style: config.collapsedTextStyle!.copyWith(color: foregroundColor ?? appBarTheme.foregroundColor),
             child: title!,
           )
         : title;
       expandedTitle = config.expandedTextStyle != null
         ? DefaultTextStyle(
-            style: config.expandedTextStyle!,
+            style: config.expandedTextStyle!.copyWith(color: foregroundColor ?? appBarTheme.foregroundColor),
             child: title!,
           )
         : title;
@@ -2286,9 +2291,7 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
             return true;
         }
       }
-      centerTitle = centerCollapsedTitle
-        ?? theme.appBarTheme.centerTitle
-        ?? platformCenter();
+      centerTitle = centerCollapsedTitle ?? appBarTheme.centerTitle ?? platformCenter();
     }
 
     final bool isCollapsed = settings.isScrolledUnder ?? false;
@@ -2307,7 +2310,7 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
                 alignment: centerTitle
                   ? Alignment.center
                   : AlignmentDirectional.centerStart,
-                child: collapsedTitle
+                child: collapsedTitle,
               ),
             ),
           ),

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -574,6 +574,78 @@ void main() {
     expect(navToolbar.middleSpacing, 40);
   });
 
+  testWidgets("SliverAppBar.medium's title uses AppBarTheme.foregroundColor", (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xff00ff00);
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: foregroundColor)),
+      home: CustomScrollView(
+        slivers: <Widget>[
+          SliverAppBar.medium(
+            title: const Text('Medium Title'),
+          ),
+        ],
+      ),
+    ));
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text.text.style!.color, foregroundColor);
+  });
+
+  testWidgets(
+    "SliverAppBar.medium's foregroundColor takes priority over AppBarTheme.foregroundColor", (WidgetTester tester) async {
+      const Color foregroundColor = Color(0xff00ff00);
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: Color(0xffff0000))),
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar.medium(
+              foregroundColor: foregroundColor,
+              title: const Text('Medium Title'),
+            ),
+          ],
+        ),
+      ));
+
+      final RichText text = tester.firstWidget(find.byType(RichText));
+      expect(text.text.style!.color, foregroundColor);
+  });
+
+  testWidgets("SliverAppBar.large's title uses AppBarTheme.foregroundColor", (WidgetTester tester) async {
+    const Color foregroundColor = Color(0xff00ff00);
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: foregroundColor)),
+      home: CustomScrollView(
+        slivers: <Widget>[
+          SliverAppBar.large(
+            title: const Text('Large Title'),
+          ),
+        ],
+      ),
+    ));
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text.text.style!.color, foregroundColor);
+  });
+
+  testWidgets(
+    "SliverAppBar.large's foregroundColor takes priority over AppBarTheme.foregroundColor", (WidgetTester tester) async {
+      const Color foregroundColor = Color(0xff00ff00);
+      await tester.pumpWidget(MaterialApp(
+        theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: Color(0xffff0000))),
+        home: CustomScrollView(
+          slivers: <Widget>[
+            SliverAppBar.large(
+              foregroundColor: foregroundColor,
+              title: const Text('Large Title'),
+            ),
+          ],
+        ),
+      ));
+
+      final RichText text = tester.firstWidget(find.byType(RichText));
+      expect(text.text.style!.color, foregroundColor);
+  });
+
   testWidgets('Default AppBarTheme debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const AppBarTheme().debugFillProperties(builder);


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/110951

### Description

1. Pass the `foregroundColor` from `SliverAppBar.large` and `SliverAppBar.medium` to flexible space for the title and resolve `foregroundColor` with the app bar theme's foregroundColor. 

> `SliverAppBar.large` and `SliverAppBar.medium` don't use the `title` parameter as a result widget's `foregroundColor` needs to be passed to flexible space for the title.

2. Use the new `appBarTheme ` variable in `centerTitle` and fix a missing comma.

<details> 
<summary>code sample (from the issue)</summary> 

```dart
// MIT License
//
// Copyright (c) 2022 Mike Rydstrom
//
// Permission is hereby granted, free of charge, to any person obtaining a copy
// of this software and associated documentation files (the "Software"), to deal
// in the Software without restriction, including without limitation the rights
// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
// copies of the Software, and to permit persons to whom the Software is
// furnished to do so, subject to the following conditions:
//
// The above copyright notice and this permission notice shall be included in all
// copies or substantial portions of the Software.
//
// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
// SOFTWARE.

import 'package:flutter/material.dart';

// Used as M3 seed color
const Color seedColor = Color(0xFF386A20);

// Make a seed generated M3 light mode ColorScheme.
final ColorScheme lightScheme = ColorScheme.fromSeed(
  brightness: Brightness.light,
  seedColor: seedColor,
);

// Make a seed generated M3 dark mode ColorScheme.
final ColorScheme darkScheme = ColorScheme.fromSeed(
  brightness: Brightness.dark,
  seedColor: seedColor,
);

// AppBar colors set via widget properties
const Color appBarBackground = Color(0xFFE9EEB5);
const Color appBarForeground = Color(0xFF1489C0);

// Make AppBarTheme with custom foreground and background colors.
AppBarTheme appBarTheme({required ColorScheme colorScheme}) => AppBarTheme(
      backgroundColor: colorScheme.tertiaryContainer,
      foregroundColor: colorScheme.error,
    );

// A simple custom theme
ThemeData appTheme(Brightness mode, bool useMaterial3) => ThemeData.from(
      colorScheme: mode == Brightness.light ? lightScheme : darkScheme,
      useMaterial3: useMaterial3,
    ).copyWith(
      appBarTheme: appBarTheme(
        colorScheme: mode == Brightness.light ? lightScheme : darkScheme,
      ),
    );

void main() {
  runApp(const IssueDemoApp());
}

class IssueDemoApp extends StatefulWidget {
  const IssueDemoApp({super.key});

  @override
  State<IssueDemoApp> createState() => _IssueDemoAppState();
}

class _IssueDemoAppState extends State<IssueDemoApp> {
  bool useMaterial3 = true;
  ThemeMode themeMode = ThemeMode.light;

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      themeMode: themeMode,
      theme: appTheme(Brightness.light, useMaterial3),
      darkTheme: appTheme(Brightness.dark, useMaterial3),
      home: Scaffold(
        appBar: AppBar(
          title: const Text(('AppBar Issue Demo')),
          actions: [
            IconButton(
              icon: useMaterial3
                  ? const Icon(Icons.filter_3)
                  : const Icon(Icons.filter_2),
              onPressed: () {
                setState(() {
                  useMaterial3 = !useMaterial3;
                });
              },
              tooltip: 'Switch to Material ${useMaterial3 ? 2 : 3}',
            ),
            IconButton(
              icon: themeMode == ThemeMode.dark
                  ? const Icon(Icons.wb_sunny_outlined)
                  : const Icon(Icons.wb_sunny),
              onPressed: () {
                setState(() {
                  if (themeMode == ThemeMode.light) {
                    themeMode = ThemeMode.dark;
                  } else {
                    themeMode = ThemeMode.light;
                  }
                });
              },
              tooltip: "Toggle brightness",
            ),
          ],
        ),
        body: const HomePage(),
      ),
    );
  }
}

class HomePage extends StatelessWidget {
  const HomePage({
    super.key,
  });

  @override
  Widget build(BuildContext context) {
    return ListView(
      padding: const EdgeInsets.symmetric(horizontal: 16),
      children: [
        const SizedBox(height: 8),
        Text(
          'AppBar Issue',
          style: Theme.of(context).textTheme.headlineSmall,
        ),
        Text(
          'Foreground color on SliverAppBar.medium and SliverAppBar.large are '
          'not respected via AppBarTheme or AppBar properties.',
          style: Theme.of(context).textTheme.bodyLarge,
        ),
        const Divider(),
        const ShowAppBarColors(),
        const SizedBox(height: 8),
        const AppBarShowcase(),
        const Divider(),
        const ShowAppBarColors(
          foregroundColor: appBarForeground,
          backgroundColor: appBarBackground,
        ),
        const SizedBox(height: 8),
        const AppBarShowcase(
          foregroundColor: appBarForeground,
          backgroundColor: appBarBackground,
        ),
      ],
    );
  }
}

class AppBarShowcase extends StatelessWidget {
  const AppBarShowcase({super.key, this.foregroundColor, this.backgroundColor});
  final Color? foregroundColor;
  final Color? backgroundColor;

  @override
  Widget build(BuildContext context) {
    return MediaQuery.removePadding(
      context: context,
      removeBottom: true,
      removeTop: true,
      child: Column(
        children: <Widget>[
          AppBar(
            foregroundColor: foregroundColor,
            backgroundColor: backgroundColor,
            leading: IconButton(
              icon: const Icon(Icons.menu),
              onPressed: () {},
            ),
            title: const Text('Normal AppBar'),
            actions: <Widget>[
              IconButton(
                icon: const Icon(Icons.search),
                onPressed: () {},
              ),
            ],
          ),
          const SizedBox(height: 8),
          CustomScrollView(
            // Normally avoid shrinkWrap, but for showing a few demo
            // widgets here, we can get away with it.
            shrinkWrap: true,
            slivers: <Widget>[
              SliverAppBar(
                foregroundColor: foregroundColor,
                backgroundColor: backgroundColor,
                leading: IconButton(
                  icon: const Icon(Icons.menu),
                  onPressed: () {},
                ),
                title: const Text('Sliver AppBar'),
                actions: <Widget>[
                  IconButton(
                    icon: const Icon(Icons.search),
                    onPressed: () {},
                  ),
                ],
              ),
              const SliverToBoxAdapter(child: SizedBox(height: 8)),
              SliverAppBar.medium(
                foregroundColor: foregroundColor,
                backgroundColor: backgroundColor,
                leading: IconButton(
                  icon: const Icon(Icons.menu),
                  onPressed: () {},
                ),
                title: const Text('SliverAppBar.medium'),
                actions: <Widget>[
                  IconButton(
                    icon: const Icon(Icons.search),
                    onPressed: () {},
                  ),
                ],
              ),
              const SliverToBoxAdapter(child: SizedBox(height: 8)),
              SliverAppBar.large(
                foregroundColor: foregroundColor,
                backgroundColor: backgroundColor,
                leading: IconButton(
                  icon: const Icon(Icons.menu),
                  onPressed: () {},
                ),
                title: const Text('SliverAppBar.large'),
                actions: <Widget>[
                  IconButton(
                    icon: const Icon(Icons.search),
                    onPressed: () {},
                  ),
                ],
              )
            ],
          ),
        ],
      ),
    );
  }
}

/// Draw a number of boxes showing the colors of key theme color properties
/// in the ColorScheme of the inherited ThemeData and its color properties.
class ShowAppBarColors extends StatelessWidget {
  const ShowAppBarColors({
    super.key,
    this.foregroundColor,
    this.backgroundColor,
  });
  final Color? foregroundColor;
  final Color? backgroundColor;

  @override
  Widget build(BuildContext context) {
    final ThemeData theme = Theme.of(context);
    final bool useMaterial3 = theme.useMaterial3;
    const double spacing = 6;

    final String colorSource =
        foregroundColor == null ? ' via AppBarTheme' : ' via AppBar properties';

    // Grab the card border from the theme card shape
    ShapeBorder? border = theme.cardTheme.shape;
    // If we had one, copy in a border side to it.
    if (border is RoundedRectangleBorder) {
      border = border.copyWith(
        side: BorderSide(
          color: theme.dividerColor,
          width: 1,
        ),
      );
      // If
    } else {
      // If border was null, make one matching Card default, but with border
      // side, if it was not null, we leave it as it was.
      border ??= RoundedRectangleBorder(
        borderRadius: BorderRadius.all(Radius.circular(useMaterial3 ? 12 : 4)),
        side: BorderSide(
          color: theme.dividerColor,
          width: 1,
        ),
      );
    }

    // Wrap this widget branch in a custom theme where card has a border outline
    // if it did not have one, but retains in ambient themed border radius.
    return Theme(
      data: Theme.of(context).copyWith(
        cardTheme: CardTheme.of(context).copyWith(
          elevation: 0,
          shape: border,
        ),
      ),
      child: Column(
        crossAxisAlignment: CrossAxisAlignment.start,
        children: <Widget>[
          Padding(
            padding: const EdgeInsets.symmetric(vertical: 8),
            child: Text(
              'AppBar Colors$colorSource',
              style: theme.textTheme.titleLarge,
            ),
          ),
          Wrap(
            alignment: WrapAlignment.start,
            crossAxisAlignment: WrapCrossAlignment.center,
            spacing: spacing,
            runSpacing: spacing,
            children: <Widget>[
              ColorCard(
                label: 'AppBar\nBackground',
                color: backgroundColor ?? theme.appBarTheme.backgroundColor!,
                textColor:
                    foregroundColor ?? theme.appBarTheme.foregroundColor!,
              ),
              ColorCard(
                label: 'AppBar\nForeground',
                color: foregroundColor ?? theme.appBarTheme.foregroundColor!,
                textColor:
                    backgroundColor ?? theme.appBarTheme.backgroundColor!,
              ),
            ],
          ),
        ],
      ),
    );
  }
}

/// A [SizedBox] with a [Card] and string text in it. Used in this demo to
/// display theme color boxes.
///
/// Can specify label text color and background color.
class ColorCard extends StatelessWidget {
  const ColorCard({
    super.key,
    required this.label,
    required this.color,
    required this.textColor,
    this.size,
  });

  final String label;
  final Color color;
  final Color textColor;
  final Size? size;

  @override
  Widget build(BuildContext context) {
    const double fontSize = 11;
    const Size effectiveSize = Size(86, 58);

    return SizedBox(
      width: effectiveSize.width,
      height: effectiveSize.height,
      child: Card(
        margin: EdgeInsets.zero,
        clipBehavior: Clip.antiAlias,
        color: color,
        child: Center(
          child: Text(
            label,
            style: TextStyle(color: textColor, fontSize: fontSize),
            textAlign: TextAlign.center,
          ),
        ),
      ),
    );
  }
}


``` 
	
</details>

| Before | After |
| --------------- | --------------- |
| <img src="https://user-images.githubusercontent.com/48603081/211850121-cd3bfa90-cd57-4795-a711-0b8b0a98c00b.png" /> | <img src="https://user-images.githubusercontent.com/48603081/211850104-b2a27e46-6602-4b44-8883-4754202d0092.png" /> |


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
