### PR TITLE
Fix tap/drag callbacks firing when TapAndDragGestureRecognizer has not won the arena

### DIFF
--- a/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
+++ b/packages/flutter/lib/src/widgets/tap_and_drag_gestures.dart
@@ -850,6 +850,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
   // Tap related state.
   bool _pastSlopTolerance = false;
   bool _sentTapDown = false;
+  bool _wonArenaForPrimaryPointer = false;
 
   // Primary pointer being tracked by this recognizer.
   int? _primaryPointer;
@@ -934,7 +935,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
   void handleNonAllowedPointer(PointerDownEvent event) {
     // There can be multiple drags simultaneously. Their effects are combined.
     if (event.buttons != kPrimaryButton) {
-      if (!_sentTapDown) {
+      if (!_wonArenaForPrimaryPointer) {
         super.handleNonAllowedPointer(event);
       }
     }
@@ -956,6 +957,8 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
       _checkTapDown(currentDown!);
     }
 
+    _wonArenaForPrimaryPointer = true;
+
     if (_start != null) {
       _acceptDrag(_start!);
     }
@@ -976,7 +979,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
       case _DragState.possible:
         if (_pastSlopTolerance) {
           // This means the pointer was not accepted as a tap.
-          if (_sentTapDown) {
+          if (_wonArenaForPrimaryPointer) {
             // If the recognizer has already won the arena for the primary pointer being tracked
             // but the pointer has exceeded the tap tolerance, then the pointer is accepted as a
             // drag gesture.
@@ -1043,7 +1046,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
 
         // This can occur when the recognizer is accepted before a [PointerMoveEvent] has been
         // received that moves the pointer a sufficient global distance to be considered a drag.
-        if (_start != null && _sentTapDown) {
+        if (_start != null) {
           _acceptDrag(_start!);
         }
       }
@@ -1085,6 +1088,9 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
   String get debugDescription => 'tap_and_drag';
 
   void _acceptDrag(PointerEvent event) {
+    if (!_wonArenaForPrimaryPointer) {
+      return;
+    }
     _dragState = _DragState.accepted;
     if (dragStartBehavior == DragStartBehavior.start) {
       _initialPosition = _initialPosition + OffsetPair(global: event.delta, local: event.localDelta);
@@ -1138,7 +1144,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
   }
 
   void _checkTapUp(PointerUpEvent event) {
-    if (!_sentTapDown) {
+    if (!_wonArenaForPrimaryPointer) {
       return;
     }
 
@@ -1265,6 +1271,7 @@ class TapAndDragGestureRecognizer extends OneSequenceGestureRecognizer with _Tap
 
   void _resetTaps() {
     _sentTapDown = false;
+    _wonArenaForPrimaryPointer = false;
     _primaryPointer = null;
   }
 

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -12485,7 +12485,7 @@ void main() {
           pointer: 7,
           kind: PointerDeviceKind.mouse,
         );
-    await tester.pumpAndSettle(kPressTimeout);
+    await tester.pumpAndSettle();
     await gesture.up();
     expect(textFieldTapCount, 0);
     expect(prefixTapCount, 1);
@@ -12496,7 +12496,7 @@ void main() {
       pointer: 7,
       kind: PointerDeviceKind.mouse,
     );
-    await tester.pumpAndSettle(kPressTimeout);
+    await tester.pumpAndSettle();
     await gesture.up();
     expect(textFieldTapCount, 0);
     expect(prefixTapCount, 1);

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -12452,6 +12452,57 @@ void main() {
     });
   });
 
+  testWidgets('TextField does not leak touch events when deadline has exceeded', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/118340.
+    int textFieldTapCount = 0;
+    int prefixTapCount = 0;
+    int suffixTapCount = 0;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TextField(
+            onTap: () { textFieldTapCount += 1; },
+            decoration: InputDecoration(
+              labelText: 'Label',
+              prefix: ElevatedButton(
+                onPressed: () { prefixTapCount += 1; },
+                child: const Text('prefix'),
+              ),
+              suffix: ElevatedButton(
+                onPressed: () { suffixTapCount += 1; },
+                child: const Text('suffix'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    TestGesture gesture =
+        await tester.startGesture(
+          tester.getRect(find.text('prefix')).center,
+          pointer: 7,
+          kind: PointerDeviceKind.mouse,
+        );
+    await tester.pumpAndSettle(kPressTimeout);
+    await gesture.up();
+    expect(textFieldTapCount, 0);
+    expect(prefixTapCount, 1);
+    expect(suffixTapCount, 0);
+
+    gesture = await tester.startGesture(
+      tester.getRect(find.text('suffix')).center,
+      pointer: 7,
+      kind: PointerDeviceKind.mouse,
+    );
+    await tester.pumpAndSettle(kPressTimeout);
+    await gesture.up();
+    expect(textFieldTapCount, 0);
+    expect(prefixTapCount, 1);
+    expect(suffixTapCount, 1);
+  });
+
   testWidgets('prefix/suffix buttons do not leak touch events', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/39376.
 


### PR DESCRIPTION
This change fixes #118340 and #118249 by changing the assumption in `TapAndDragGestureRecognizer` that assumed when a tap down is sent that the recognizer won the arena (this is incorrect because the recognizer will send a tap down when it has exceeded `kPressTimeout` or when it has won the arena). This was allowing other callbacks through, even though the recognizer had not won the arena, like `TextField-onTap` which is not the expected behavior.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.