### PR TITLE
Add focus detector to CupertinoSwitch

### DIFF
--- a/dev/benchmarks/complex_layout/windows/flutter/generated_plugins.cmake
+++ b/dev/benchmarks/complex_layout/windows/flutter/generated_plugins.cmake
@@ -1,0 +1,23 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/windows plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/examples/flutter_view/windows/flutter/generated_plugins.cmake
+++ b/examples/flutter_view/windows/flutter/generated_plugins.cmake
@@ -1,0 +1,23 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/windows plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/examples/platform_view/windows/flutter/generated_plugins.cmake
+++ b/examples/platform_view/windows/flutter/generated_plugins.cmake
@@ -1,0 +1,23 @@
+#
+# Generated file, do not edit.
+#
+
+list(APPEND FLUTTER_PLUGIN_LIST
+)
+
+list(APPEND FLUTTER_FFI_PLUGIN_LIST
+)
+
+set(PLUGIN_BUNDLED_LIBRARIES)
+
+foreach(plugin ${FLUTTER_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${plugin}/windows plugins/${plugin})
+  target_link_libraries(${BINARY_NAME} PRIVATE ${plugin}_plugin)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES $<TARGET_FILE:${plugin}_plugin>)
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${plugin}_bundled_libraries})
+endforeach(plugin)
+
+foreach(ffi_plugin ${FLUTTER_FFI_PLUGIN_LIST})
+  add_subdirectory(flutter/ephemeral/.plugin_symlinks/${ffi_plugin}/windows plugins/${ffi_plugin})
+  list(APPEND PLUGIN_BUNDLED_LIBRARIES ${${ffi_plugin}_bundled_libraries})
+endforeach(ffi_plugin)

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -365,8 +365,15 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
             activeColor: activeColor,
             trackColor: CupertinoDynamicColor.resolve(widget.trackColor ?? CupertinoColors.secondarySystemFill, context),
             thumbColor: CupertinoDynamicColor.resolve(widget.thumbColor ?? CupertinoColors.white, context),
-            // Opacity value was eyeballed by looking at a switch in the macOS settings.
-            focusColor: CupertinoDynamicColor.resolve(widget.focusColor ?? activeColor.withOpacity(0.7), context),
+            // Opacity, lightness, and saturation values were aproximated with
+            // color pickers on the switches in the macOS settings.
+            focusColor: CupertinoDynamicColor.resolve(
+              widget.focusColor ??
+              HSLColor
+                    .fromColor(activeColor.withOpacity(0.80))
+                    .withLightness(0.69).withSaturation(0.835)
+                    .toColor(),
+              context),
             onChanged: widget.onChanged,
             textDirection: Directionality.of(context),
             isFocused: isFocused,
@@ -633,12 +640,12 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
 
     if(_isFocused) {
       // Paints a border around the switch in the focus color.
-      final RRect borderTrackRRect = trackRRect.inflate(2.0);
+      final RRect borderTrackRRect = trackRRect.inflate(1.75);
 
       final Paint borderPaint = Paint()
         ..color = focusColor
         ..style = PaintingStyle.stroke
-        ..strokeWidth = 4.0;
+        ..strokeWidth = 3.5;
 
       canvas.drawRRect(borderTrackRRect, borderPaint);
     }

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -632,8 +632,8 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
     canvas.drawRRect(trackRRect, paint);
 
     if(_isFocused) {
-      // Paints a border with a slight gap around the switch in the active color.
-      final RRect borderTrackRRect = trackRRect.inflate(2.5);
+      // Paints a border around the switch in the focus color.
+      final RRect borderTrackRRect = trackRRect.inflate(2.0);
 
       final Paint borderPaint = Paint()
         ..color = focusColor

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -343,7 +343,7 @@ class _CupertinoSwitchState extends State<CupertinoSwitch> with TickerProviderSt
   @override
   Widget build(BuildContext context) {
     final CupertinoThemeData theme = CupertinoTheme.of(context);
-    final activeColor = CupertinoDynamicColor.resolve(
+    final Color activeColor = CupertinoDynamicColor.resolve(
       widget.activeColor
       ?? ((widget.applyTheme ?? theme.applyThemeToAll) ? theme.primaryColor : null)
       ?? CupertinoColors.systemGreen,

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -606,6 +606,7 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
     canvas.drawRRect(trackRRect, paint);
 
     if(_isFocused) {
+      // Paints a border with a slight gap around the switch in the active color.
       final RRect borderTrackRRect = trackRRect.inflate(2.5);
 
       final Paint borderPaint = Paint()

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -127,7 +127,7 @@ class CupertinoSwitch extends StatefulWidget {
   final Color? thumbColor;
 
   /// The color to use for the focus highlight for keyboard interactions.
-  /// 
+  ///
   /// Defaults to a a slightly transparent [activeColor].
   final Color? focusColor;
 

--- a/packages/flutter/lib/src/cupertino/switch.dart
+++ b/packages/flutter/lib/src/cupertino/switch.dart
@@ -614,7 +614,7 @@ class _RenderCupertinoSwitch extends RenderConstrainedBox {
         ..style = PaintingStyle.stroke
         ..strokeWidth = 4.0;
 
-      canvas.drawRRect(borderTrackRRect, borderPaint);    
+      canvas.drawRRect(borderTrackRRect, borderPaint);
     }
 
     final double currentThumbExtension = CupertinoThumbPainter.extension * currentReactionValue;

--- a/packages/flutter/test/cupertino/switch_test.dart
+++ b/packages/flutter/test/cupertino/switch_test.dart
@@ -48,6 +48,39 @@ void main() {
     expect(value, isTrue);
   });
 
+  testWidgets('CupertinoSwitch can be toggled by keyboard shortcuts', (WidgetTester tester) async {
+    bool value = true;
+    Widget buildApp({bool enabled = true}) {
+      return CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: Center(
+            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
+              return CupertinoSwitch(
+                value: value,
+                onChanged: enabled ? (bool newValue) {
+                  setState(() {
+                    value = newValue;
+                  });
+                } : null,
+              );
+            }),
+          ),
+        ),
+      );
+    }
+    await tester.pumpWidget(buildApp());
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+    await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+    await tester.pumpAndSettle();
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(value, isFalse);
+    await tester.sendKeyEvent(LogicalKeyboardKey.space);
+    await tester.pumpAndSettle();
+    expect(value, isTrue);
+  });
+
   testWidgets('Switch emits light haptic vibration on tap', (WidgetTester tester) async {
     final Key switchKey = UniqueKey();
     bool value = false;


### PR DESCRIPTION
Addresses #101023

This PR: 

- Adds a border around the switch when focused on by the keyboard
- By default the border will be a more transparent version of the active color, but will be overwritten if provided with a `focusColor`
- Responds to keyboard input to flip the switch

Here is what it looks like in action. The top switch is not provided a focus color, the bottom one is:

https://user-images.githubusercontent.com/58190796/212970052-e4b36226-2a60-49fb-993d-40f316dc838e.mov



In comparison, this is what a native switch in the setting looks like with keyboard enabled:

https://user-images.githubusercontent.com/58190796/211917075-fb9d4d57-1649-49d6-a0c8-689f0b0e871a.mov

Issues that will need more direction on:

- Does not animate in and out like native seems to
- Is always enabled. Does not disable if keyboard navigation is off in macOS settings

I don't know if these issues should be addressed in this PR or a future one.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
