### PR TITLE
CP: Copying/applying font fallback with package

### DIFF
--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -895,7 +895,7 @@ class TextStyle with Diagnosticable {
       decorationThickness: decorationThickness ?? this.decorationThickness,
       debugLabel: newDebugLabel,
       fontFamily: fontFamily ?? _fontFamily,
-      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
+      fontFamilyFallback: fontFamilyFallback ?? _fontFamilyFallback,
       package: package ?? _package,
       overflow: overflow ?? this.overflow,
     );
@@ -989,7 +989,7 @@ class TextStyle with Diagnosticable {
       color: foreground == null ? color ?? this.color : null,
       backgroundColor: background == null ? backgroundColor ?? this.backgroundColor : null,
       fontFamily: fontFamily ?? _fontFamily,
-      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
+      fontFamilyFallback: fontFamilyFallback ?? _fontFamilyFallback,
       fontSize: fontSize == null ? null : fontSize! * fontSizeFactor + fontSizeDelta,
       fontWeight: fontWeight == null ? null : FontWeight.values[(fontWeight!.index + fontWeightDelta).clamp(0, FontWeight.values.length - 1)], // ignore_clamp_double_lint
       fontStyle: fontStyle ?? this.fontStyle,

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -302,6 +302,20 @@ void main() {
 
     const TextStyle s10 = TextStyle(fontFamilyFallback: <String>[], package: 'p');
     expect(s10.fontFamilyFallback, <String>[]);
+
+    // Ensure that package prefix is not duplicated after copying.
+    final TextStyle s11 = s8.copyWith();
+    expect(s11.fontFamilyFallback![0], 'packages/p/test');
+    expect(s11.fontFamilyFallback![1], 'packages/p/test2');
+    expect(s11.fontFamilyFallback!.length, 2);
+    expect(s8, s11);
+
+    // Ensure that package prefix is not duplicated after applying.
+    final TextStyle s12 = s8.apply();
+    expect(s12.fontFamilyFallback![0], 'packages/p/test');
+    expect(s12.fontFamilyFallback![1], 'packages/p/test2');
+    expect(s12.fontFamilyFallback!.length, 2);
+    expect(s8, s12);
   });
 
   test('TextStyle package font merge', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118392 for the upcoming beta/stable release.