### PR TITLE
[flutter_tools] No more implicit --no-sound-null-safety

### DIFF
--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -83,10 +83,8 @@ class FlutterDevice {
     required Platform platform,
     TargetModel targetModel = TargetModel.flutter,
     List<String>? experimentalFlags,
-    ResidentCompiler? generator,
     String? userIdentifier,
   }) async {
-    ResidentCompiler generator;
     final TargetPlatform targetPlatform = await device.targetPlatform;
     if (device.platformType == PlatformType.fuchsia) {
       targetModel = TargetModel.flutterRunner;
@@ -111,6 +109,8 @@ class FlutterDevice {
       fileSystem: globals.fs,
     );
 
+    final ResidentCompiler generator;
+
     // For both web and non-web platforms we initialize dill to/from
     // a shared location for faster bootstrapping. If the compiler fails
     // due to a kernel target or version mismatch, no error is reported
@@ -119,7 +119,7 @@ class FlutterDevice {
     // used to file a bug, but the compiler will still start up correctly.
     if (targetPlatform == TargetPlatform.web_javascript) {
       // TODO(zanderso): consistently provide these flags across platforms.
-      late String platformDillName;
+      final String platformDillName;
       final List<String> extraFrontEndOptions = List<String>.of(buildInfo.extraFrontEndOptions);
       if (buildInfo.nullSafetyMode == NullSafetyMode.unsound) {
         platformDillName = 'ddc_outline.dill';
@@ -132,12 +132,12 @@ class FlutterDevice {
           extraFrontEndOptions.add('--sound-null-safety');
         }
       } else {
-        assert(false);
+        throw StateError('Expected buildInfo.nullSafetyMode to be one of unsound or sound, got ${buildInfo.nullSafetyMode}');
       }
 
       final String platformDillPath = globals.fs.path.join(
         getWebPlatformBinariesDirectory(globals.artifacts!, buildInfo.webRenderer).path,
-        platformDillName
+        platformDillName,
       );
 
       generator = ResidentCompiler(

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1093,7 +1093,11 @@ abstract class FlutterCommand extends Command<void> {
             (languageVersion.major == nullSafeVersion.major && languageVersion.minor >= nullSafeVersion.minor)) {
           nullSafetyMode = NullSafetyMode.sound;
         } else {
-          nullSafetyMode = NullSafetyMode.unsound;
+          throwToolExit(
+            'This application does not support sound null-safety (its language version is $languageVersion).\n'
+            'To build this application, you must provide the CLI flag --no-sound-null-safety. Dart 3 will only '
+            'support sound null safety, see https://dart.dev/null-safety.',
+          );
         }
       } else if (!wasNullSafetyFlagParsed) {
         // This mode is only used for commands which do not build a single target like

--- a/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
+++ b/packages/flutter_tools/test/general.shard/runner/flutter_command_test.dart
@@ -554,6 +554,27 @@ void main() {
       ProcessManager: () => processManager,
     });
 
+    testUsingContext('tool exits on non-sound-null-safe code when explicit flag not passed', () async {
+      final DummyFlutterCommand flutterCommand = DummyFlutterCommand(packagesPath: 'foo');
+      flutterCommand.argParser
+          ..addFlag(FlutterOptions.kNullSafety, defaultsTo: true)
+          ..addOption('target');
+      final File targetFile = fileSystem.file('targetFile.dart')
+          ..writeAsStringSync('// @dart = 2.11');
+      expect(
+        () async => flutterCommand.getBuildInfo(
+          forcedBuildMode: BuildMode.debug,
+          forcedTargetFile: targetFile,
+        ),
+        throwsToolExit(
+          message: 'This application does not support sound null-safety (its language version is 2.11)',
+        ),
+      );
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fileSystem,
+      ProcessManager: () => processManager,
+    });
+
     testUsingContext('use packagesPath to generate BuildInfo', () async {
       final DummyFlutterCommand flutterCommand = DummyFlutterCommand(packagesPath: 'foo');
       final BuildInfo buildInfo = await flutterCommand.getBuildInfo(forcedBuildMode: BuildMode.debug);

--- a/packages/flutter_tools/test/integration.shard/test_data/stepping_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/stepping_project.dart
@@ -65,7 +65,7 @@ class WebSteppingProject extends Project {
   final String pubspec = '''
   name: test
   environment:
-    sdk: '>=2.10.0 <4.0.0'
+    sdk: '>=2.12.0 <4.0.0'
   dependencies:
     flutter:
       sdk: flutter


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118331

Before this change, when trying to build a Flutter app that is not soundly null-safe (specifically, if the language version of the Dart entrypoint is less than 2.12) and the explicit flag `--no-sound-null-safe` is *not* provided from the command line:

1. For web debug builds (which use DDC), compilation would succeed, because there are two dills for DDC, and the tool has special handling for detecting which dill should be used for compilation;
2. For all other builds (dart2js and VM builds), the tool would invoke the appropriate dart compiler, which would fail with an error message instructing to provide the flag and that this flag would be deprecated in Dart v3 for all platforms.

This change will cause the tool to ToolExit for all target platforms *before* any compilers get invoked with a message similar to that provided by the dart compiler.

Running a web target on this branch:

```
$ flutter run -d chrome                                                
This application does not support sound null-safety (its language version is 2.11).
To build this application, you must provide the CLI flag --no-sound-null-safety. Dart 3 will only support sound null safety, see https://dart.dev/null-safety.

$ flutter run -d chrome --no-sound-null-safety
Launching lib/main.dart on Chrome in debug mode...
Waiting for connection from debug service on Chrome...             22.0s
This app is linked to the debug service: ws://127.0.0.1:33389/iwRiGUncaNk=/ws
Debug service listening on ws://127.0.0.1:33389/iwRiGUncaNk=/ws

Running without sound null safety ⚠️
Dart 3 will only support sound null safety, see https://dart.dev/null-safety

🔥  To hot restart changes while running, press "r" or "R".
For a more detailed help message, press "h". To quit, press "q".

An Observatory debugger and profiler on Chrome is available at:
http://127.0.0.1:33389/iwRiGUncaNk=
The Flutter DevTools debugger and profiler on Chrome is available at:
http://127.0.0.1:9100?uri=http://127.0.0.1:33389/iwRiGUncaNk=
```

Running a desktop target on this branch:

```
$ flutter run -d linux
This application does not support sound null-safety (its language version is 2.11).
To build this application, you must provide the CLI flag --no-sound-null-safety. Dart 3 will only
support sound null safety, see https://dart.dev/null-safety.

$ flutter run -d linux --no-sound-null-safety
Launching lib/main.dart on Linux in debug mode...
fatal: not a git repository (or any of the parent directories): .git
Building Linux application...
Syncing files to device Linux...                                   386ms

Flutter run key commands.
r Hot reload. 🔥🔥🔥
R Hot restart.
h List all available interactive commands.
d Detach (terminate "flutter run" but leave application running).
c Clear the screen
q Quit (terminate the application on the device).

Running without sound null safety ⚠️
Dart 3 will only support sound null safety, see https://dart.dev/null-safety

An Observatory debugger and profiler on Linux is available at:
http://127.0.0.1:36037/7-kXLgw0gtY=/
The Flutter DevTools debugger and profiler on Linux is available at:
http://127.0.0.1:9100?uri=http://127.0.0.1:36037/7-kXLgw0gtY=/
```