### PR TITLE
Test `Utf8FromUtf16` from Windows app template's `utils.h`

### DIFF
--- a/dev/integration_tests/windows_startup_test/lib/main.dart
+++ b/dev/integration_tests/windows_startup_test/lib/main.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:typed_data';
 import 'dart:ui' as ui;
 
 import 'package:flutter_driver/driver_extension.dart';
@@ -44,6 +45,18 @@ void main() async {
       return (app == system)
         ? 'success'
         : 'error: app dark mode ($app) does not match system dark mode ($system)';
+    } else if (message == 'verifyStringConversion') {
+      // Use a test string that contains code points that fit in both 8 and 16 bits.
+      // The code points are passed a list of integers through the method channel,
+      // which will use the UTF16 to UTF8 utility function to convert them to a
+      // std::string, which should equate to the original expected string.
+      // TODO(schectman): Remove trailing null from returned string
+      const String expected = 'ABCℵ\x00';
+      final Int32List codePoints = Int32List.fromList(expected.codeUnits);
+      final String converted = await testStringConversion(codePoints);
+      return (converted == expected)
+        ? 'success'
+        : 'error: conversion of UTF16 string to UTF8 failed, expected "${expected.codeUnits}" but got "${converted.codeUnits}"';
     }
 
     throw 'Unrecognized message: $message';

--- a/dev/integration_tests/windows_startup_test/lib/windows.dart
+++ b/dev/integration_tests/windows_startup_test/lib/windows.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:typed_data';
+
 import 'package:flutter/services.dart';
 
 const MethodChannel _kMethodChannel =
@@ -35,4 +37,14 @@ Future<bool> isSystemDarkModeEnabled() async {
   }
 
   return enabled;
+}
+
+/// Test conversion of a UTF16 string to UTF8 using the app template utils.
+Future<String> testStringConversion(Int32List twoByteCodes) async {
+  final String? converted = await _kMethodChannel.invokeMethod<String?>('convertString', twoByteCodes);
+  if (converted == null) {
+    throw 'Method channel unavailable.';
+  }
+
+  return converted;
 }

--- a/dev/integration_tests/windows_startup_test/test_driver/main_test.dart
+++ b/dev/integration_tests/windows_startup_test/test_driver/main_test.dart
@@ -23,4 +23,13 @@ void main() {
 
     await driver.close();
   }, timeout: Timeout.none);
+
+  test('Windows app template can convert string from UTF16 to UTF8', () async {
+    final FlutterDriver driver = await FlutterDriver.connect(printCommunication: true);
+    final String result = await driver.requestData('verifyStringConversion');
+
+    expect(result, equals('success'));
+
+    await driver.close();
+  }, timeout: Timeout.none);
 }

--- a/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
+++ b/dev/integration_tests/windows_startup_test/windows/runner/flutter_window.cpp
@@ -12,6 +12,7 @@
 #include <flutter/standard_method_codec.h>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "utils.h"
 
 /// Window attribute that enables dark mode window decorations.
 ///
@@ -106,6 +107,15 @@ bool FlutterWindow::OnCreate() {
         } else {
           result->Error("error", "Received status " + status);
         }
+      } else if (method == "convertString") {
+        const flutter::EncodableValue* argument = call.arguments();
+        const std::vector<int32_t> code_points = std::get<std::vector<int32_t>>(*argument);
+        std::vector<wchar_t> wide_str;
+        for (int32_t code_point : code_points) {
+          wide_str.push_back((wchar_t)(code_point));
+        }
+        const std::string string = Utf8FromUtf16(wide_str.data());
+        result->Success(string);
       } else {
         result->NotImplemented();
       }


### PR DESCRIPTION
Dispatch a platform channel message in the `windows_startup_test` that triggers a test of `Utf8FromUtf16`, ensuring that the codepoints of the input and output equate.

Part of https://github.com/flutter/flutter/issues/118644

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
