### PR TITLE
Add `build macos --config-only` option

### DIFF
--- a/packages/flutter_tools/lib/src/commands/build_macos.dart
+++ b/packages/flutter_tools/lib/src/commands/build_macos.dart
@@ -20,6 +20,13 @@ class BuildMacosCommand extends BuildSubCommand {
     required bool verboseHelp,
   }) : super(verboseHelp: verboseHelp) {
     addCommonDesktopBuildOptions(verboseHelp: verboseHelp);
+    usesFlavorOption();
+    argParser
+      .addFlag('config-only',
+        help: 'Update the project configuration without performing a build. '
+          'This can be used in CI/CD process that create an archive to avoid '
+          'performing duplicate work.'
+    );
   }
 
   @override
@@ -39,6 +46,8 @@ class BuildMacosCommand extends BuildSubCommand {
   @override
   bool get supported => globals.platform.isMacOS;
 
+  bool get configOnly => boolArgDeprecated('config-only');
+
   @override
   Future<FlutterCommandResult> runCommand() async {
     final BuildInfo buildInfo = await getBuildInfo();
@@ -55,6 +64,7 @@ class BuildMacosCommand extends BuildSubCommand {
       buildInfo: buildInfo,
       targetOverride: targetFile,
       verboseLogging: globals.logger.isVerbose,
+      configOnly: configOnly,
       sizeAnalyzer: SizeAnalyzer(
         fileSystem: globals.fs,
         logger: globals.logger,

--- a/packages/flutter_tools/lib/src/macos/build_macos.dart
+++ b/packages/flutter_tools/lib/src/macos/build_macos.dart
@@ -35,6 +35,7 @@ Future<void> buildMacOS({
   required BuildInfo buildInfo,
   String? targetOverride,
   required bool verboseLogging,
+  bool configOnly = false,
   SizeAnalyzer? sizeAnalyzer,
 }) async {
   final Directory? xcodeWorkspace = flutterProject.macos.xcodeWorkspace;
@@ -78,6 +79,9 @@ Future<void> buildMacOS({
   if (!flutterProject.macos.outputFileList.existsSync()) {
     flutterProject.macos.outputFileList.createSync(recursive: true);
   }
+  if (configOnly) {
+    return;
+  }
 
   final Directory xcodeProject = flutterProject.macos.xcodeProject;
 
@@ -97,7 +101,6 @@ Future<void> buildMacOS({
   if (configuration == null) {
     throwToolExit('Unable to find expected configuration in Xcode project.');
   }
-
   // Run the Xcode build.
   final Stopwatch sw = Stopwatch()..start();
   final Status status = globals.logger.startProgress(

--- a/packages/flutter_tools/test/integration.shard/build_macos_config_only_test.dart
+++ b/packages/flutter_tools/test/integration.shard/build_macos_config_only_test.dart
@@ -1,0 +1,82 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:file_testing/file_testing.dart';
+import 'package:flutter_tools/src/base/file_system.dart';
+import 'package:flutter_tools/src/base/io.dart';
+
+import '../src/common.dart';
+import 'test_utils.dart';
+
+void main() {
+  test('flutter build macOS --config only updates generated xcconfig file without performing build', () async {
+    final String workingDirectory = fileSystem.path.join(
+      getFlutterRoot(),
+      'dev',
+      'integration_tests',
+      'flutter_gallery',
+    );
+    final String flutterBin = fileSystem.path.join(getFlutterRoot(), 'bin', 'flutter');
+
+    await processManager.run(<String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'clean',
+    ], workingDirectory: workingDirectory);
+    final List<String> buildCommand = <String>[
+      flutterBin,
+      ...getLocalEngineArguments(),
+      'build',
+      'macos',
+      '--config-only',
+      '--release',
+      '--obfuscate',
+      '--split-debug-info=info',
+    ];
+    final ProcessResult firstRunResult = await processManager.run(buildCommand, workingDirectory: workingDirectory);
+
+    printOnFailure('Output of flutter build macOS:');
+    final String firstRunStdout = firstRunResult.stdout.toString();
+    printOnFailure('First run stdout: $firstRunStdout');
+    printOnFailure('First run stderr: ${firstRunResult.stderr}');
+
+    expect(firstRunResult.exitCode, 0);
+    expect(firstRunStdout, contains('Running pod install'));
+
+    final File generatedConfig = fileSystem.file(fileSystem.path.join(
+      workingDirectory,
+      'macos',
+      'Flutter',
+      'ephemeral',
+      'Flutter-Generated.xcconfig',
+    ));
+
+    // Config is updated if command succeeded.
+    expect(generatedConfig, exists);
+    expect(generatedConfig.readAsStringSync(), contains('DART_OBFUSCATION=true'));
+
+    // file that only exists if app was fully built.
+    final File frameworkPlist = fileSystem.file(fileSystem.path.join(
+      workingDirectory,
+      'build',
+      'macos',
+      'Build',
+      'Products',
+      'Release',
+      'App.framework',
+      'Resources',
+      'Info.plist'
+    ));
+
+    expect(frameworkPlist, isNot(exists));
+
+    // Run again with no changes.
+    final ProcessResult secondRunResult = await processManager.run(buildCommand, workingDirectory: workingDirectory);
+    final String secondRunStdout = secondRunResult.stdout.toString();
+    printOnFailure('Second run stdout: $secondRunStdout');
+    printOnFailure('Second run stderr: ${secondRunResult.stderr}');
+
+    expect(secondRunResult.exitCode, 0);
+  }, skip: !platform.isMacOS); // [intended] macOS builds only work on macos.
+}


### PR DESCRIPTION
New flutter apps aren't executable from Xcode unless `flutter build` generates files in `macos/Flutter/ephemeral`. `iOS` has `--config-only` to generate the `iOS` equivalents and abort before the full project is built. This PR adds `--config-only` for macOS.

Fixes https://github.com/flutter/flutter/issues/84018

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
