### PR TITLE
Support logging 'flutter run' communication to DAP clients

### DIFF
--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -57,6 +57,11 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   late List<String> processArgs;
   late Map<String, String>? env;
 
+  /// Overrides base implementation of [sendLogsToClient] which requires valid
+  /// `args` to have been set which may not be the case for mocks.
+  @override
+  bool get sendLogsToClient => false;
+
   final StreamController<Map<String, Object?>> _dapToClientMessagesController = StreamController<Map<String, Object?>>.broadcast();
 
   /// A stream of all messages sent from the adapter back to the client.

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -153,6 +153,7 @@ class DapTestClient {
     bool? debugExternalPackageLibraries,
     bool? evaluateGettersInDebugViews,
     bool? evaluateToStringInDebugViews,
+    bool sendLogsToClient = false,
   }) {
     return sendRequest(
       FlutterLaunchRequestArguments(
@@ -167,9 +168,9 @@ class DapTestClient {
         evaluateGettersInDebugViews: evaluateGettersInDebugViews,
         evaluateToStringInDebugViews: evaluateToStringInDebugViews,
         // When running out of process, VM Service traffic won't be available
-        // to the client-side logger, so force logging on which sends VM Service
-        // traffic in a custom event.
-        sendLogsToClient: captureVmServiceTraffic,
+        // to the client-side logger, so force logging regardless of
+        // `sendLogsToClient` which sends VM Service traffic in a custom event.
+        sendLogsToClient: sendLogsToClient || captureVmServiceTraffic,
       ),
       // We can't automatically pick the command when using a custom type
       // (FlutterLaunchRequestArguments).


### PR DESCRIPTION
The debug adapters have a `sendLogsToClient` setting that allows a DAP client to ask the debug adapter to send log events back to it to aid debugging. This is set by the VS Code extension if you're running the **Dart: Capture Debugging Logs** command when you start your debug session.

It was already including VM Service traffic (via the base Dart debug adapter), but the traffic to/from the `flutter run`/`flutter attach` process was not included (it was in the legacy debug adapters, just not the new SDK one). This traffic is useful because Hot Reload/Hot Restart and some other things are done via the `flutter run` process `stdin`/stdout`.

Fixes https://github.com/Dart-Code/Dart-Code/issues/4266.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
