### PR TITLE
[web] Fix paths fetched by flutter.js

### DIFF
--- a/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
+++ b/packages/flutter_tools/lib/src/web/file_generators/flutter_js.dart
@@ -20,6 +20,21 @@ _flutter.loader = null;
 
 (function () {
   "use strict";
+
+  const baseUri = ensureTrailingSlash(getBaseURI());
+
+  function getBaseURI() {
+    const base = document.querySelector("base");
+    return (base && base.getAttribute("href")) || "";
+  }
+
+  function ensureTrailingSlash(uri) {
+    if (uri == "") {
+      return uri;
+    }
+    return uri.endsWith("/") ? uri : `${uri}/`;
+  }
+
   /**
    * Wraps `promise` in a timeout of the given `duration` in ms.
    *
@@ -120,8 +135,7 @@ _flutter.loader = null;
       }
       const {
         serviceWorkerVersion,
-        serviceWorkerUrl = "flutter_service_worker.js?v=" +
-          serviceWorkerVersion,
+        serviceWorkerUrl = `${baseUri}flutter_service_worker.js?v=${serviceWorkerVersion}`,
         timeoutMillis = 4000,
       } = settings;
 
@@ -239,7 +253,7 @@ _flutter.loader = null;
      * Returns undefined when an `onEntrypointLoaded` callback is supplied in `options`.
      */
     async loadEntrypoint(options) {
-      const { entrypointUrl = "main.dart.js", onEntrypointLoaded } =
+      const { entrypointUrl = `${baseUri}main.dart.js`, onEntrypointLoaded } =
         options || {};
 
       return this._loadEntrypoint(entrypointUrl, onEntrypointLoaded);

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -852,6 +852,18 @@ void main() {
       contains('"main.dart.js"'));
   }));
 
+  test('flutter.js sanity checks', () {
+    final String flutterJsContents = flutter_js.generateFlutterJsFile();
+    expect(flutterJsContents, contains('"use strict";'));
+    expect(flutterJsContents, contains('main.dart.js'));
+    expect(flutterJsContents, contains('flutter_service_worker.js?v='));
+    expect(flutterJsContents, contains('document.createElement("script")'));
+    expect(flutterJsContents, contains('"application/javascript"'));
+    expect(flutterJsContents, contains('const baseUri = '));
+    expect(flutterJsContents, contains('document.querySelector("base")'));
+    expect(flutterJsContents, contains('.getAttribute("href")'));
+  });
+
   test('flutter.js is not dynamically generated', () => testbed.run(() async {
     globals.fs.file('bin/cache/flutter_web_sdk/canvaskit/foo')
       ..createSync(recursive: true)


### PR DESCRIPTION
### This fix may be cherry-picked into 3.7.X

This PR is in the process of being cherry-picked for the current `stable` channel (3.7.?). Click the link to [follow the progress of the cherry-pick](https://github.com/flutter/flutter/issues/120197).

### Workaround

In the meantime, you can also configure the main.dart.js and flutter_service_worker.js URLs as described in this comment to something that matches your app:

* https://github.com/flutter/flutter/issues/116360#issuecomment-1364181861

TL;DR:

```js
      _flutter.loader.loadEntrypoint({
        entrypointUrl: "/YOUR_APP_BASE/main.dart.js",
        serviceWorker: {
          serviceWorkerVersion: serviceWorkerVersion,
          serviceWorkerUrl: "/YOUR_APP_BASE/flutter_service_worker.js?v=",
        },
   ...
```

That way the files will be requested from their "absolute" URL, rather than URLs relative to the ones specified by the PathStrategy.

(If your base URL is "/", you just need: `/main.dart.js` and `/flutter_service_worker.js?v=`)



----

`flutter.js` fetches `main.dart.js` and `flutter_service_worker.js` using relative paths. That works in the default case of most flutter web apps, but when an app uses `<base href="/foo/">` or use the `PathUrlStrategy`, things break.

This PR adjusts all requests made by `flutter.js` to take `<base href="...">` into account.

Fixes https://github.com/flutter/flutter/issues/116360