### PR TITLE
[macOS] bringup new e2e_summary devicelab test

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2442,6 +2442,20 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: animated_complex_opacity_perf_impeller_macos__e2e_summary
 
+  - name: Mac animated_complex_opacity_perf_macos__e2e_summary
+    bringup: true
+    presubmit: false
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      task_name: animated_complex_opacity_perf_macos__e2e_summary
+
   - name: Mac basic_material_app_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2428,6 +2428,20 @@ targets:
       - bin/
       - .ci.yaml
 
+  - name: Mac animated_complex_opacity_perf_impeller_macos__e2e_summary
+    bringup: true
+    presubmit: false
+    recipe: devicelab/devicelab_drone
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      task_name: animated_complex_opacity_perf_impeller_macos__e2e_summary
+
   - name: Mac basic_material_app_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -206,6 +206,7 @@
 /dev/devicelab/bin/tasks/tiles_scroll_perf_ios__timeline_summary.dart @zanderso @flutter/engine
 
 ## Host only DeviceLab tests
+/dev/devicelab/bin/tasks/animated_complex_opacity_perf_impeller_macos__e2e_summary.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/basic_material_app_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/build_aar_module_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/build_ios_framework_module_test.dart @jmagman @flutter/tool

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -207,6 +207,7 @@
 
 ## Host only DeviceLab tests
 /dev/devicelab/bin/tasks/animated_complex_opacity_perf_impeller_macos__e2e_summary.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/animated_complex_opacity_perf_macos__e2e_summary.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/basic_material_app_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/build_aar_module_test.dart @zanderso @flutter/tool
 /dev/devicelab/bin/tasks/build_ios_framework_module_test.dart @jmagman @flutter/tool

--- a/dev/devicelab/bin/tasks/animated_complex_opacity_perf_impeller_macos__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/animated_complex_opacity_perf_impeller_macos__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createAnimatedComplexOpacityPerfE2ETest(enableImpeller: true));
+}

--- a/dev/devicelab/bin/tasks/animated_complex_opacity_perf_macos__e2e_summary.dart
+++ b/dev/devicelab/bin/tasks/animated_complex_opacity_perf_macos__e2e_summary.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createAnimatedComplexOpacityPerfE2ETest());
+}


### PR DESCRIPTION
Bringing up a new e2e_summary devicelab test as a part of the Flutter Desktop Q1 OKRs.


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
