### PR TITLE
remove single-view assumption from `paintImage`

### DIFF
--- a/packages/flutter/lib/src/painting/decoration_image.dart
+++ b/packages/flutter/lib/src/painting/decoration_image.dart
@@ -567,7 +567,7 @@ void paintImage({
     // as an upper bound for the display size of the image.
     final double maxDevicePixelRatio = PaintingBinding.instance.platformDispatcher.views.fold(
       0.0,
-      (double previousValue, ui.FlutterView element) => math.max(previousValue, element.devicePixelRatio),
+      (double previousValue, ui.FlutterView view) => math.max(previousValue, view.devicePixelRatio),
     );
 
     final ImageSizeInfo sizeInfo = ImageSizeInfo(
@@ -586,7 +586,8 @@ void paintImage({
           exception: 'Image $debugImageLabel has a display size of '
             '$outputWidth×$outputHeight but a decode size of '
             '${image.width}×${image.height}, which uses an additional '
-            '${overheadInKilobytes}KB.\n\n'
+            '${overheadInKilobytes}KB (assuming a device pixel ratio of '
+            '$maxDevicePixelRatio).\n\n'
             'Consider resizing the asset ahead of time, supplying a cacheWidth '
             'parameter of $outputWidth, a cacheHeight parameter of '
             '$outputHeight, or using a ResizeImage.',

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -102,7 +102,7 @@ void main() {
 
     expect(
       messages.single,
-      'Image TestImage has a display size of 300×150 but a decode size of 300×300, which uses an additional 234KB (assuming a device pixel ratio of 3.0).\n\n'
+      'Image TestImage has a display size of 300×150 but a decode size of 300×300, which uses an additional 234KB (assuming a device pixel ratio of ${3.0}).\n\n'
       'Consider resizing the asset ahead of time, supplying a cacheWidth parameter of 300, a cacheHeight parameter of 150, or using a ResizeImage.',
     );
 

--- a/packages/flutter/test/painting/paint_image_test.dart
+++ b/packages/flutter/test/painting/paint_image_test.dart
@@ -102,7 +102,7 @@ void main() {
 
     expect(
       messages.single,
-      'Image TestImage has a display size of 300×150 but a decode size of 300×300, which uses an additional 234KB.\n\n'
+      'Image TestImage has a display size of 300×150 but a decode size of 300×300, which uses an additional 234KB (assuming a device pixel ratio of 3.0).\n\n'
       'Consider resizing the asset ahead of time, supplying a cacheWidth parameter of 300, a cacheHeight parameter of 150, or using a ResizeImage.',
     );
 


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/117477.
Part of https://github.com/flutter/flutter/issues/116929.
Supersedes https://github.com/flutter/flutter/pull/117495.