### PR TITLE
Fix path for require.js

### DIFF
--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -187,14 +187,31 @@ class FlutterWebPlatform extends PlatformPlugin {
   ));
 
   /// The require js binary.
-  File get _requireJs => _fileSystem.file(_fileSystem.path.join(
-    _artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
-    'lib',
-    'dev_compiler',
-    'kernel',
-    'amd',
-    'require.js',
-  ));
+  File get _requireJs {
+    // TODO(nshahan): Remove the initializing function once the file location
+    //                change in the Dart SDK has landed and rolled to the engine
+    //                and flutter repos. There is no long-term need for the
+    //                fallback logic.
+    //                See https://github.com/flutter/flutter/issues/118119
+    final File oldFile = _fileSystem.file(_fileSystem.path.join(
+      _artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
+      'lib',
+      'dev_compiler',
+      'kernel',
+      'amd',
+      'require.js',
+    ));
+
+    return oldFile.existsSync()
+        ? oldFile
+        : _fileSystem.file(_fileSystem.path.join(
+            _artifacts!.getArtifactPath(Artifact.engineDartSdkPath, platform: TargetPlatform.web_javascript),
+            'lib',
+            'dev_compiler',
+            'amd',
+            'require.js',
+          ));
+  }
 
   /// The ddc to dart stack trace mapper.
   File get _stackTraceMapper => _fileSystem.file(_fileSystem.path.join(


### PR DESCRIPTION
Matches new location in the Dart SDK.
https://dart-review.googlesource.com/c/sdk/+/275482

Includes fall back logic so the old file location will continue to be used until the new location change lands. Then we can remove the logic and only use the new location in a future change.

Issue: #118119