### PR TITLE
Add `@pragma('vm:entry-point')` to `RestorableRouteBuilder` arguments

### DIFF
--- a/examples/api/lib/cupertino/route/show_cupertino_dialog.0.dart
+++ b/examples/api/lib/cupertino/route/show_cupertino_dialog.0.dart
@@ -41,6 +41,7 @@ class CupertinoDialogExample extends StatelessWidget {
     );
   }
 
+  @pragma('vm:entry-point')
   static Route<Object?> _dialogBuilder(
       BuildContext context, Object? arguments) {
     return CupertinoDialogRoute<void>(

--- a/examples/api/lib/cupertino/route/show_cupertino_modal_popup.0.dart
+++ b/examples/api/lib/cupertino/route/show_cupertino_modal_popup.0.dart
@@ -41,6 +41,7 @@ class ModalPopupExample extends StatelessWidget {
     );
   }
 
+  @pragma('vm:entry-point')
   static Route<void> _modalBuilder(BuildContext context, Object? arguments) {
     return CupertinoModalPopupRoute<void>(
       builder: (BuildContext context) {

--- a/examples/api/lib/material/date_picker/show_date_picker.0.dart
+++ b/examples/api/lib/material/date_picker/show_date_picker.0.dart
@@ -53,6 +53,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget>
     },
   );
 
+  @pragma('vm:entry-point')
   static Route<DateTime> _datePickerRoute(
     BuildContext context,
     Object? arguments,

--- a/examples/api/lib/material/date_picker/show_date_range_picker.0.dart
+++ b/examples/api/lib/material/date_picker/show_date_range_picker.0.dart
@@ -74,6 +74,7 @@ class _MyStatefulWidgetState extends State<MyStatefulWidget>
         _restorableDateRangePickerRouteFuture, 'date_picker_route_future');
   }
 
+  @pragma('vm:entry-point')
   static Route<DateTimeRange?> _dateRangePickerRoute(
     BuildContext context,
     Object? arguments,

--- a/examples/api/lib/material/dialog/show_dialog.2.dart
+++ b/examples/api/lib/material/dialog/show_dialog.2.dart
@@ -38,6 +38,7 @@ class DialogExample extends StatelessWidget {
     );
   }
 
+  @pragma('vm:entry-point')
   static Route<Object?> _dialogBuilder(
       BuildContext context, Object? arguments) {
     return DialogRoute<void>(

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push.0.dart
@@ -30,6 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
       builder: (BuildContext context) => const MyStatefulWidget(),

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_and_remove_until.0.dart
@@ -30,6 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
       builder: (BuildContext context) => const MyStatefulWidget(),

--- a/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator.restorable_push_replacement.0.dart
@@ -30,6 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
       builder: (BuildContext context) => const MyStatefulWidget(),

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push.0.dart
@@ -30,6 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
       builder: (BuildContext context) => const MyStatefulWidget(),

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push_and_remove_until.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push_and_remove_until.0.dart
@@ -30,6 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
       builder: (BuildContext context) => const MyStatefulWidget(),

--- a/examples/api/lib/widgets/navigator/navigator_state.restorable_push_replacement.0.dart
+++ b/examples/api/lib/widgets/navigator/navigator_state.restorable_push_replacement.0.dart
@@ -30,6 +30,7 @@ class MyStatefulWidget extends StatefulWidget {
 }
 
 class _MyStatefulWidgetState extends State<MyStatefulWidget> {
+  @pragma('vm:entry-point')
   static Route<void> _myRouteBuilder(BuildContext context, Object? arguments) {
     return MaterialPageRoute<void>(
       builder: (BuildContext context) => const MyStatefulWidget(),

--- a/examples/api/lib/widgets/navigator/restorable_route_future.0.dart
+++ b/examples/api/lib/widgets/navigator/restorable_route_future.0.dart
@@ -73,6 +73,7 @@ class _MyHomeState extends State<MyHome> with RestorationMixin {
 
   // A static `RestorableRouteBuilder` that can re-create the route during
   // state restoration.
+  @pragma('vm:entry-point')
   static Route<int> _counterRouteBuilder(
       BuildContext context, Object? arguments) {
     return MaterialPageRoute<int>(

--- a/examples/api/lib/widgets/routes/show_general_dialog.0.dart
+++ b/examples/api/lib/widgets/routes/show_general_dialog.0.dart
@@ -38,6 +38,7 @@ class GeneralDialogExample extends StatelessWidget {
     );
   }
 
+  @pragma('vm:entry-point')
   static Route<Object?> _dialogBuilder(
       BuildContext context, Object? arguments) {
     return RawDialogRoute<void>(

--- a/packages/flutter/lib/src/widgets/navigator.dart
+++ b/packages/flutter/lib/src/widgets/navigator.dart
@@ -55,8 +55,9 @@ typedef RouteListFactory = List<Route<dynamic>> Function(NavigatorState navigato
 ///
 /// Used by the restorable methods of the [Navigator] that add anonymous routes
 /// (e.g. [NavigatorState.restorablePush]). For this use case, the
-/// [RestorableRouteBuilder] must be static function as the [Navigator] will
-/// call it again during state restoration to re-create the route.
+/// [RestorableRouteBuilder] must be static function annotated with
+/// `@pragma('vm:entry-point')`. The [Navigator] will call it again during
+/// state restoration to re-create the route.
 typedef RestorableRouteBuilder<T> = Route<T> Function(BuildContext context, Object? arguments);
 
 /// Signature for the [Navigator.popUntil] predicate argument.
@@ -2108,9 +2109,10 @@ class Navigator extends StatefulWidget {
   /// {@macro flutter.widgets.navigator.push}
   ///
   /// {@template flutter.widgets.Navigator.restorablePush}
-  /// The method takes a _static_ [RestorableRouteBuilder] as argument, which
-  /// must instantiate and return a new [Route] object that will be added to
-  /// the navigator. The provided `arguments` object is passed to the
+  /// The method takes a [RestorableRouteBuilder] as argument, which must be a
+  /// _static_ function annotated with `@pragma('vm:entry-point')`. It must
+  /// instantiate and return a new [Route] object that will be added to the
+  /// navigator. The provided `arguments` object is passed to the
   /// `routeBuilder`. The navigator calls the static `routeBuilder` function
   /// again during state restoration to re-create the route object.
   ///

--- a/packages/flutter/test/cupertino/dialog_test.dart
+++ b/packages/flutter/test/cupertino/dialog_test.dart
@@ -1566,6 +1566,7 @@ Widget createAppWithCenteredButton(Widget child) {
 class _RestorableDialogTestWidget extends StatelessWidget {
   const _RestorableDialogTestWidget();
 
+  @pragma('vm:entry-point')
   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
     return CupertinoDialogRoute<void>(
       context: context,

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -2314,6 +2314,7 @@ class _TestPostRouteCancelState extends State<_TestPostRouteCancel> {
 class _RestorableModalTestWidget extends StatelessWidget {
   const _RestorableModalTestWidget();
 
+  @pragma('vm:entry-point')
   static Route<void> _modalBuilder(BuildContext context, Object? arguments) {
     return CupertinoModalPopupRoute<void>(
       builder: (BuildContext context) {

--- a/packages/flutter/test/material/date_picker_test.dart
+++ b/packages/flutter/test/material/date_picker_test.dart
@@ -1412,6 +1412,7 @@ class _RestorableDatePickerDialogTestWidgetState extends State<_RestorableDatePi
     }
   }
 
+  @pragma('vm:entry-point')
   static Route<DateTime> _datePickerRoute(
     BuildContext context,
     Object? arguments,

--- a/packages/flutter/test/material/date_range_picker_test.dart
+++ b/packages/flutter/test/material/date_range_picker_test.dart
@@ -1150,6 +1150,7 @@ class _RestorableDateRangePickerDialogTestWidgetState extends State<_RestorableD
     }
   }
 
+  @pragma('vm:entry-point')
   static Route<DateTimeRange?> _dateRangePickerRoute(
     BuildContext context,
     Object? arguments,

--- a/packages/flutter/test/material/dialog_test.dart
+++ b/packages/flutter/test/material/dialog_test.dart
@@ -2710,6 +2710,7 @@ void main() {
 class _RestorableDialogTestWidget extends StatelessWidget {
   const _RestorableDialogTestWidget();
 
+  @pragma('vm:entry-point')
   static Route<Object?> _materialDialogBuilder(BuildContext context, Object? arguments) {
     return DialogRoute<void>(
       context: context,

--- a/packages/flutter/test/material/time_picker_test.dart
+++ b/packages/flutter/test/material/time_picker_test.dart
@@ -1628,6 +1628,7 @@ class _TimePickerLauncherState extends State<_TimePickerLauncher> with Restorati
     },
   );
 
+  @pragma('vm:entry-point')
   static Route<TimeOfDay> _timePickerRoute(
     BuildContext context,
     Object? arguments,

--- a/packages/flutter/test/widgets/navigator_restoration_test.dart
+++ b/packages/flutter/test/widgets/navigator_restoration_test.dart
@@ -1015,6 +1015,7 @@ void main() {
   });
 }
 
+@pragma('vm:entry-point')
 Route<void> _routeBuilder(BuildContext context, Object? arguments) {
   return MaterialPageRoute<void>(
     builder: (BuildContext context) {
@@ -1025,6 +1026,7 @@ Route<void> _routeBuilder(BuildContext context, Object? arguments) {
   );
 }
 
+@pragma('vm:entry-point')
 Route<void> _routeFutureBuilder(BuildContext context, Object? arguments) {
   return MaterialPageRoute<void>(
     builder: (BuildContext context) {

--- a/packages/flutter/test/widgets/routes_test.dart
+++ b/packages/flutter/test/widgets/routes_test.dart
@@ -2153,6 +2153,7 @@ class WidgetWithNoLocalHistoryState extends State<WidgetWithNoLocalHistory> {
 class _RestorableDialogTestWidget extends StatelessWidget {
   const _RestorableDialogTestWidget();
 
+  @pragma('vm:entry-point')
   static Route<Object?> _dialogBuilder(BuildContext context, Object? arguments) {
     return RawDialogRoute<void>(
       pageBuilder: (


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118565.

Behind the scenes, the restoration API for routes uses `PluginUtilities.getCallbackHandle`. For that to work correctly, the callback passed into these restoration methods must be marked with `@pragma('vm:entry-point')` as @mraleph explains in https://github.com/flutter/flutter/issues/118608. Ideally, we find a better solution for this in the future that doesn't leak this ugly implementation detail to consumers of the restoration API for routes. Until then, this ensures the feature works as advertised.