### PR TITLE
[macOS] Add timeline summary benchmarks

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2609,6 +2609,20 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: complex_layout_macos__start_up
 
+  - name: Mac complex_layout_scroll_perf_impeller_macos__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      task_name: complex_layout_scroll_perf_impeller_macos__timeline_summary
+
   - name: Mac customer_testing
     recipe: flutter/flutter
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2610,6 +2610,7 @@ targets:
       task_name: complex_layout_macos__start_up
 
   - name: Mac complex_layout_scroll_perf_impeller_macos__timeline_summary
+    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
@@ -2624,6 +2625,7 @@ targets:
       task_name: complex_layout_scroll_perf_impeller_macos__timeline_summary
 
   - name: Mac complex_layout_scroll_perf_macos__timeline_summary
+    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2623,6 +2623,20 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: complex_layout_scroll_perf_impeller_macos__timeline_summary
 
+  - name: Mac complex_layout_scroll_perf_macos__timeline_summary
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      task_name: complex_layout_scroll_perf_macos__timeline_summary
+
   - name: Mac customer_testing
     recipe: flutter/flutter
     timeout: 60

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -215,6 +215,7 @@
 /dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller_macos__timeline_summary.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/complex_layout_scroll_perf_macos__timeline_summary.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_win_desktop__compile.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_win_desktop__start_up.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/dart_plugin_registry_test.dart @stuartmorgan @flutter/plugin

--- a/TESTOWNERS
+++ b/TESTOWNERS
@@ -214,6 +214,7 @@
 /dev/devicelab/bin/tasks/channels_integration_test_macos.dart @gaaclarke @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__compile.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_macos__start_up.dart @a-wallen @flutter/desktop
+/dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller_macos__timeline_summary.dart @a-wallen @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_win_desktop__compile.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/complex_layout_win_desktop__start_up.dart @yaakovschectman @flutter/desktop
 /dev/devicelab/bin/tasks/dart_plugin_registry_test.dart @stuartmorgan @flutter/plugin

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller_macos__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf_impeller_macos__timeline_summary.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createComplexLayoutScrollPerfTest(enableImpeller: true));
+}

--- a/dev/devicelab/bin/tasks/complex_layout_scroll_perf_macos__timeline_summary.dart
+++ b/dev/devicelab/bin/tasks/complex_layout_scroll_perf_macos__timeline_summary.dart
@@ -1,0 +1,12 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_devicelab/framework/devices.dart';
+import 'package:flutter_devicelab/framework/framework.dart';
+import 'package:flutter_devicelab/tasks/perf_tests.dart';
+
+Future<void> main() async {
+  deviceOperatingSystem = DeviceOperatingSystem.macos;
+  await task(createComplexLayoutScrollPerfTest());
+}


### PR DESCRIPTION
Bringing up a new timeline_summary devicelab test as a part of the Flutter Desktop Q1 OKRs.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
