### PR TITLE
[macOS] New e2e_summary benchmark fails without Cocoapods.

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2436,7 +2436,8 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
         ["devicelab", "hostonly", "mac"]
@@ -2450,7 +2451,8 @@ targets:
     properties:
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14a5294e"}
+          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "gems", "version": "v3.3.14"}
         ]
       tags: >
         ["devicelab", "hostonly", "mac"]

--- a/dev/benchmarks/macrobenchmarks/macos/Runner/DebugProfile.entitlements
+++ b/dev/benchmarks/macrobenchmarks/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
 </dict>
 </plist>

--- a/dev/benchmarks/macrobenchmarks/macos/Runner/Release.entitlements
+++ b/dev/benchmarks/macrobenchmarks/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+  <key>com.apple.security.network.client</key>
+  <true/>
 </dict>
 </plist>


### PR DESCRIPTION
`animated_complex_opacity_perf_impeller_macos__e2e_summary` and `animated_complex_opacity_perf_macos__e2e_summary` fail without Cocoapods and without entitlements in the xcconfigs.

```
[animated_complex_opacity_perf_impeller_macos__e2e_summary] [STDOUT] stdout: [  +13 ms] "flutter drive" took 2,564ms.
[animated_complex_opacity_perf_impeller_macos__e2e_summary] [STDOUT] stderr: [   +2 ms] CocoaPods not installed or not in valid state.
```

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
