### PR TITLE
Remove unnecessary null checks in `dev/benchmarks`

### DIFF
--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_bad_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_bad_test.dart
@@ -18,9 +18,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null) {
-        driver.close();
-      }
+      driver.close();
     });
 
     Future<void> testScrollPerf(String listKey, String summaryName) async {

--- a/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/scroll_perf_test.dart
@@ -18,9 +18,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null) {
-        driver.close();
-      }
+      driver.close();
     });
 
     Future<void> testScrollPerf(String listKey, String summaryName) async {

--- a/dev/benchmarks/complex_layout/test_driver/semantics_perf_test.dart
+++ b/dev/benchmarks/complex_layout/test_driver/semantics_perf_test.dart
@@ -34,9 +34,7 @@ void main() {
     });
 
     tearDownAll(() async {
-      if (driver != null) {
-        driver.close();
-      }
+      driver.close();
     });
 
     test('initial tree creation', () async {

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_grid_hover.dart
@@ -159,9 +159,7 @@ class _Tester {
     final Stopwatch stopwatch = Stopwatch()..start();
     await gesture.moveTo(location, timeStamp: currentTime);
     stopwatch.stop();
-    if (onDataPoint != null) {
-      onDataPoint(stopwatch.elapsed);
-    }
+    onDataPoint(stopwatch.elapsed);
     await _UntilNextFrame.wait();
   }
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_mixed_grid_hover.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_mouse_region_mixed_grid_hover.dart
@@ -181,9 +181,7 @@ class _Tester {
     final Stopwatch stopwatch = Stopwatch()..start();
     await gesture.moveTo(location, timeStamp: currentTime);
     stopwatch.stop();
-    if (onDataPoint != null) {
-      onDataPoint(stopwatch.elapsed);
-    }
+    onDataPoint(stopwatch.elapsed);
     await _UntilNextFrame.wait();
   }
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_layout.dart
@@ -340,9 +340,7 @@ class ColorItem extends StatelessWidget {
     required this.index,
     required this.color,
     this.prefix = '',
-  })  : assert(index != null),
-        assert(color != null),
-        assert(prefix != null);
+  });
 
   final int index;
   final Color color;

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -841,8 +841,7 @@ class Profile {
   /// If [useCustomWarmUp] is true the benchmark will continue running until
   /// [stopBenchmark] is called. Otherwise, the benchmark collects the
   /// [kDefaultTotalSampleCount] samples and stops automatically.
-  Profile({required this.name, this.useCustomWarmUp = false})
-      : assert(name != null);
+  Profile({required this.name, this.useCustomWarmUp = false});
 
   /// The name of the benchmark that produced this profile.
   final String name;
@@ -1296,13 +1295,6 @@ final Map<String, EngineBenchmarkValueListener> _engineBenchmarkListeners = <Str
 ///
 /// If another listener is already registered, overrides it.
 void registerEngineBenchmarkValueListener(String name, EngineBenchmarkValueListener listener) {
-  if (listener == null) {
-    throw ArgumentError(
-      'Listener must not be null. To stop listening to engine benchmark values '
-      'under label "$name", call stopListeningToEngineBenchmarkValues(\'$name\').',
-    );
-  }
-
   if (_engineBenchmarkListeners.containsKey(name)) {
     throw StateError(
       'A listener for "$name" is already registered.\n'

--- a/dev/benchmarks/microbenchmarks/lib/language/sync_star_semantics_bench.dart
+++ b/dev/benchmarks/microbenchmarks/lib/language/sync_star_semantics_bench.dart
@@ -83,11 +83,9 @@ Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoSyncStar(List<Inlin
   String? workingLabel;
   for (final InlineSpanSemanticsInformation info in inputs) {
     if (info.requiresOwnNode) {
-      if (workingText != null) {
-        yield InlineSpanSemanticsInformation(workingText, semanticsLabel: workingLabel ?? workingText);
-        workingText = '';
-        workingLabel = null;
-      }
+      yield InlineSpanSemanticsInformation(workingText, semanticsLabel: workingLabel ?? workingText);
+      workingText = '';
+      workingLabel = null;
       yield info;
     } else {
       workingText += info.text;
@@ -100,11 +98,7 @@ Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoSyncStar(List<Inlin
       }
     }
   }
-  if (workingText != null) {
-    yield InlineSpanSemanticsInformation(workingText, semanticsLabel: workingLabel);
-  } else {
-    assert(workingLabel != null);
-  }
+  assert(workingLabel != null);
 }
 
 Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoList(List<InlineSpanSemanticsInformation> inputs) {
@@ -113,11 +107,9 @@ Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoList(List<InlineSpa
   final List<InlineSpanSemanticsInformation> result = <InlineSpanSemanticsInformation>[];
   for (final InlineSpanSemanticsInformation info in inputs) {
     if (info.requiresOwnNode) {
-      if (workingText != null) {
-        result.add(InlineSpanSemanticsInformation(workingText, semanticsLabel: workingLabel ?? workingText));
-        workingText = '';
-        workingLabel = null;
-      }
+      result.add(InlineSpanSemanticsInformation(workingText, semanticsLabel: workingLabel ?? workingText));
+      workingText = '';
+      workingLabel = null;
       result.add(info);
     } else {
       workingText += info.text;
@@ -130,10 +122,6 @@ Iterable<InlineSpanSemanticsInformation> combineSemanticsInfoList(List<InlineSpa
       }
     }
   }
-  if (workingText != null) {
-    result.add(InlineSpanSemanticsInformation(workingText, semanticsLabel: workingLabel));
-  } else {
-    assert(workingLabel != null);
-  }
+  assert(workingLabel != null);
   return result;
 }

--- a/dev/benchmarks/test_apps/stocks/lib/stock_data.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_data.dart
@@ -78,11 +78,6 @@ class StockData extends ChangeNotifier {
   void _fetchNextChunk() {
     _httpClient!.get(_urlToFetch(_nextChunk++)).then<void>((http.Response response) {
       final String json = response.body;
-      if (json == null) {
-        debugPrint('Failed to load stock data chunk ${_nextChunk - 1}');
-        _end();
-        return;
-      }
       const JsonDecoder decoder = JsonDecoder();
       add(decoder.convert(json) as List<dynamic>);
       if (_nextChunk < _chunkCount) {

--- a/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_home.dart
@@ -85,9 +85,7 @@ class StockHomeState extends State<StockHome> {
   }
 
   void _handleStockModeChange(StockMode? value) {
-    if (widget.updater != null) {
-      widget.updater(widget.configuration.copyWith(stockMode: value));
-    }
+    widget.updater(widget.configuration.copyWith(stockMode: value));
   }
 
   void _handleStockMenu(BuildContext context, _StockMenuItem value) {

--- a/dev/benchmarks/test_apps/stocks/lib/stock_settings.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_settings.dart
@@ -93,9 +93,7 @@ class StockSettingsState extends State<StockSettings> {
   }
 
   void sendUpdates(StockConfiguration value) {
-    if (widget.updater != null) {
-      widget.updater(value);
-    }
+    widget.updater(value);
   }
 
   AppBar buildAppBar(BuildContext context) {

--- a/dev/benchmarks/test_apps/stocks/lib/stock_symbol_viewer.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_symbol_viewer.dart
@@ -18,7 +18,6 @@ class _StockSymbolView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(stock != null);
     final String lastSale = '\$${stock.lastSale.toStringAsFixed(2)}';
     String changeInPrice = '${stock.percentChange.toStringAsFixed(2)}%';
     if (stock.percentChange > 0) {

--- a/dev/benchmarks/test_apps/stocks/lib/stock_types.dart
+++ b/dev/benchmarks/test_apps/stocks/lib/stock_types.dart
@@ -17,16 +17,7 @@ class StockConfiguration {
     required this.debugShowRainbow,
     required this.showPerformanceOverlay,
     required this.showSemanticsDebugger,
-  }) : assert(stockMode != null),
-       assert(backupMode != null),
-       assert(debugShowGrid != null),
-       assert(debugShowSizes != null),
-       assert(debugShowBaselines != null),
-       assert(debugShowLayers != null),
-       assert(debugShowPointers != null),
-       assert(debugShowRainbow != null),
-       assert(showPerformanceOverlay != null),
-       assert(showSemanticsDebugger != null);
+  });
 
   final StockMode stockMode;
   final BackupMode backupMode;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the `unnecessary_null_comparison` lint and remove the unnecessary checks it flags.