### PR TITLE
Cupertino navbar ellipsis fix

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1770,7 +1770,8 @@ class _NavigationBarTransition extends StatelessWidget {
     // The actual outer box is big enough to contain both the bottom and top
     // navigation bars. It's not a direct Rect lerp because some components
     // can actually be outside the linearly lerp'ed Rect in the middle of
-    // the animation, such as the topLargeTitle.
+    // the animation, such as the topLargeTitle. The textScaleFactor is kept
+    // at 1 to avoid odd transitions between pages.
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
       child: SizedBox(

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1730,7 +1730,6 @@ class _NavigationBarTransition extends StatelessWidget {
       bottomNavBar: bottomNavBar,
       topNavBar: topNavBar,
       directionality: Directionality.of(context),
-      context: context,
     );
 
     final List<Widget> children = <Widget>[
@@ -1772,11 +1771,14 @@ class _NavigationBarTransition extends StatelessWidget {
     // navigation bars. It's not a direct Rect lerp because some components
     // can actually be outside the linearly lerp'ed Rect in the middle of
     // the animation, such as the topLargeTitle.
-    return SizedBox(
-      height: math.max(heightTween.begin!, heightTween.end!) + MediaQuery.paddingOf(context).top,
-      width: double.infinity,
-      child: Stack(
-        children: children,
+    return MediaQuery(
+      data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
+      child: SizedBox(
+        height: math.max(heightTween.begin!, heightTween.end!) + MediaQuery.paddingOf(context).top,
+        width: double.infinity,
+        child: Stack(
+          children: children,
+        ),
       ),
     );
   }
@@ -1810,7 +1812,6 @@ class _NavigationBarComponentsTransition {
     required _TransitionableNavigationBar bottomNavBar,
     required _TransitionableNavigationBar topNavBar,
     required TextDirection directionality,
-    required BuildContext context,
   }) : bottomComponents = bottomNavBar.componentsKeys,
        topComponents = topNavBar.componentsKeys,
        bottomNavBarBox = bottomNavBar.renderBox,
@@ -2100,9 +2101,7 @@ class _NavigationBarComponentsTransition {
 
     if (bottomLargeTitle != null && topBackLabel != null) {
       // Move from current position to the top page's back label position.
-      return MediaQuery(
-      data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
-      child: slideFromLeadingEdge(
+      return slideFromLeadingEdge(
         fromKey: bottomComponents.largeTitleKey,
         fromNavBarBox: bottomNavBarBox,
         toKey: topComponents.backLabelKey,
@@ -2123,8 +2122,8 @@ class _NavigationBarComponentsTransition {
               child: bottomLargeTitle.child,
             ),
           ),
-        ),
-      ));
+        )
+      );
     }
 
     if (bottomLargeTitle != null && topLeading != null) {

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -2122,7 +2122,7 @@ class _NavigationBarComponentsTransition {
               child: bottomLargeTitle.child,
             ),
           ),
-        )
+        ),
       );
     }
 

--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -1730,6 +1730,7 @@ class _NavigationBarTransition extends StatelessWidget {
       bottomNavBar: bottomNavBar,
       topNavBar: topNavBar,
       directionality: Directionality.of(context),
+      context: context,
     );
 
     final List<Widget> children = <Widget>[
@@ -1809,6 +1810,7 @@ class _NavigationBarComponentsTransition {
     required _TransitionableNavigationBar bottomNavBar,
     required _TransitionableNavigationBar topNavBar,
     required TextDirection directionality,
+    required BuildContext context,
   }) : bottomComponents = bottomNavBar.componentsKeys,
        topComponents = topNavBar.componentsKeys,
        bottomNavBarBox = bottomNavBar.renderBox,
@@ -2098,7 +2100,9 @@ class _NavigationBarComponentsTransition {
 
     if (bottomLargeTitle != null && topBackLabel != null) {
       // Move from current position to the top page's back label position.
-      return slideFromLeadingEdge(
+      return MediaQuery(
+      data: MediaQuery.of(context).copyWith(textScaleFactor: 1),
+      child: slideFromLeadingEdge(
         fromKey: bottomComponents.largeTitleKey,
         fromNavBarBox: bottomNavBarBox,
         toKey: topComponents.backLabelKey,
@@ -2120,7 +2124,7 @@ class _NavigationBarComponentsTransition {
             ),
           ),
         ),
-      );
+      ));
     }
 
     if (bottomLargeTitle != null && topLeading != null) {

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -25,17 +25,21 @@ Future<void> startTransitionBetween(
   String? toTitle,
   TextDirection textDirection = TextDirection.ltr,
   CupertinoThemeData? theme,
+  double textScale = 1.0,
 }) async {
   await tester.pumpWidget(
     CupertinoApp(
       theme: theme,
       builder: (BuildContext context, Widget? navigator) {
-        return Directionality(
-          textDirection: textDirection,
-          child: navigator!,
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(textScaleFactor: textScale),
+          child: Directionality(
+            textDirection: textDirection,
+            child: navigator!,
+          )
         );
       },
-      home: const Placeholder(),
+      home: Placeholder(),
     ),
   );
 
@@ -1223,6 +1227,14 @@ void main() {
     expect(() => flying(tester, find.text('Page 2')), throwsAssertionError);
     // Just the bottom route's middle now.
     expect(find.text('Page 1'), findsOneWidget);
+  });
+
+  testWidgets('textScaleFactor is set to 1.0 on transition', (WidgetTester tester) async {
+    await startTransitionBetween(tester, fromTitle: 'Page 1', textScale: 99);
+
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(tester.firstWidget<RichText>(flying(tester, find.byType(RichText))).textScaleFactor, 1);
   });
 
   testWidgets('Back swipe gesture cancels properly with transition', (WidgetTester tester) async {

--- a/packages/flutter/test/cupertino/nav_bar_transition_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_transition_test.dart
@@ -39,7 +39,7 @@ Future<void> startTransitionBetween(
           )
         );
       },
-      home: Placeholder(),
+      home: const Placeholder(),
     ),
   );
 


### PR DESCRIPTION
Addresses #117709.

The issue came from the fact that the NavBar ignores the preferred text size by default, which is noted in the documentation. However, the transitional widget on a route transition did not. This PR fixes that.

The old behavior (watch the "Landmarks" title at the top):

https://user-images.githubusercontent.com/58190796/213581816-d95d3230-61ef-44ce-8f04-64a1acc106b2.mov

The new:

https://user-images.githubusercontent.com/58190796/213581860-70713d1b-24b2-463d-9186-4715f4ac6209.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
