### PR TITLE
Remove unnecessary null checks in `dev/devicelab`

### DIFF
--- a/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
+++ b/dev/devicelab/bin/tasks/module_custom_host_app_name_test.dart
@@ -275,7 +275,7 @@ Future<void> main() async {
 
       String modes = readonlyDebugAssetFile.statSync().modeString();
       print('\nread-only.txt file access modes = $modes');
-      if (modes != null && modes.compareTo(fileReadWriteMode) != 0) {
+      if (modes.compareTo(fileReadWriteMode) != 0) {
         return TaskResult.failure('Failed to make assets user-readable and writable');
       }
 
@@ -347,7 +347,7 @@ Future<void> main() async {
 
       modes = readonlyReleaseAssetFile.statSync().modeString();
       print('\nread-only.txt file access modes = $modes');
-      if (modes != null && modes.compareTo(fileReadWriteMode) != 0) {
+      if (modes.compareTo(fileReadWriteMode) != 0) {
         return TaskResult.failure('Failed to make assets user-readable and writable');
       }
 

--- a/dev/devicelab/bin/tasks/module_test.dart
+++ b/dev/devicelab/bin/tasks/module_test.dart
@@ -278,7 +278,7 @@ Future<void> main() async {
 
       String modes = readonlyDebugAssetFile.statSync().modeString();
       print('\nread-only.txt file access modes = $modes');
-      if (modes != null && modes.compareTo(fileReadWriteMode) != 0) {
+      if (modes.compareTo(fileReadWriteMode) != 0) {
         return TaskResult.failure('Failed to make assets user-readable and writable');
       }
 
@@ -326,7 +326,7 @@ Future<void> main() async {
         // Shouldn't be missing since we already checked it exists above.
         final ArchiveFile? noticesFile = apk.findFile('assets/flutter_assets/NOTICES.Z');
 
-        final Uint8List licenseData = noticesFile?.content as Uint8List;
+        final Uint8List? licenseData = noticesFile?.content as Uint8List?;
         if (licenseData == null) {
           return TaskResult.failure('Invalid license file.');
         }
@@ -368,7 +368,7 @@ Future<void> main() async {
 
       modes = readonlyReleaseAssetFile.statSync().modeString();
       print('\nread-only.txt file access modes = $modes');
-      if (modes != null && modes.compareTo(fileReadWriteMode) != 0) {
+      if (modes.compareTo(fileReadWriteMode) != 0) {
         return TaskResult.failure('Failed to make assets user-readable and writable');
       }
 

--- a/dev/devicelab/lib/framework/browser.dart
+++ b/dev/devicelab/lib/framework/browser.dart
@@ -304,12 +304,6 @@ class BlinkTraceSummary {
         orElse: () => throw noMeasuredFramesFound(),
       );
 
-      if (firstMeasuredFrameEvent == null) {
-        // This happens in benchmarks that do not measure frames, such as some
-        // of the text layout benchmarks.
-        return null;
-      }
-
       final int tabPid = firstMeasuredFrameEvent.pid!;
 
       // Filter out data from unrelated processes

--- a/dev/devicelab/lib/framework/cocoon.dart
+++ b/dev/devicelab/lib/framework/cocoon.dart
@@ -246,7 +246,7 @@ class AuthenticatedCocoonClient extends BaseClient {
 }
 
 class CocoonException implements Exception {
-  CocoonException(this.message) : assert(message != null);
+  CocoonException(this.message);
 
   /// The message to show to the issuer to explain the error.
   final String message;

--- a/dev/devicelab/lib/framework/devices.dart
+++ b/dev/devicelab/lib/framework/devices.dart
@@ -19,7 +19,7 @@ class DeviceException implements Exception {
   final String message;
 
   @override
-  String toString() => message == null ? '$DeviceException' : '$DeviceException: $message';
+  String toString() => '$DeviceException: $message';
 }
 
 /// Gets the artifact path relative to the current directory.

--- a/dev/devicelab/lib/framework/running_processes.dart
+++ b/dev/devicelab/lib/framework/running_processes.dart
@@ -9,9 +9,7 @@ import 'package:process/process.dart';
 
 @immutable
 class RunningProcessInfo {
-  const RunningProcessInfo(this.pid, this.commandLine, this.creationDate)
-      : assert(pid != null),
-        assert(commandLine != null);
+  const RunningProcessInfo(this.pid, this.commandLine, this.creationDate);
 
   final int pid;
   final String commandLine;
@@ -94,10 +92,6 @@ Future<Set<RunningProcessInfo>> windowsRunningProcesses(
 ///      2904 3/11/2019 11:01:54 AM "C:\Program Files\Android\Android Studio\jre\bin\java.exe" -Xmx1536M -Dfile.encoding=windows-1252 -Duser.country=US -Duser.language=en -Duser.variant -cp C:\Users\win1\.gradle\wrapper\dists\gradle-4.10.2-all\9fahxiiecdb76a5g3aw9oi8rv\gradle-4.10.2\lib\gradle-launcher-4.10.2.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 4.10.2
 @visibleForTesting
 Iterable<RunningProcessInfo> processPowershellOutput(String output) sync* {
-  if (output == null) {
-    return;
-  }
-
   const int processIdHeaderSize = 'ProcessId'.length;
   const int creationDateHeaderStart = processIdHeaderSize + 1;
   late int creationDateHeaderEnd;
@@ -187,9 +181,6 @@ Iterable<RunningProcessInfo> processPsOutput(
   String output,
   String? processName,
 ) sync* {
-  if (output == null) {
-    return;
-  }
   bool inTableBody = false;
   for (String line in output.split('\n')) {
     if (line.trim().startsWith('STARTED')) {

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -139,7 +139,7 @@ void recursiveCopy(Directory source, Directory target) {
       dest.writeAsBytesSync(entity.readAsBytesSync());
       // Preserve executable bit
       final String modes = entity.statSync().modeString();
-      if (modes != null && modes.contains('x')) {
+      if (modes.contains('x')) {
         makeExecutable(dest);
       }
     }
@@ -276,7 +276,6 @@ Future<Process> startProcess(
   bool isBot = true, // set to false to pretend not to be on a bot (e.g. to test user-facing outputs)
   String? workingDirectory,
 }) async {
-  assert(isBot != null);
   final String command = '$executable ${arguments?.join(" ") ?? ""}';
   final String finalWorkingDirectory = workingDirectory ?? cwd;
   final Map<String, String> newEnvironment = Map<String, String>.from(environment ?? <String, String>{});
@@ -504,7 +503,6 @@ Future<Process> startFlutter(String command, {
   Map<String, String> environment = const <String, String>{},
   bool isBot = true, // set to false to pretend not to be on a bot (e.g. to test user-facing outputs)
 }) {
-  assert(isBot != null);
   final List<String> args = flutterCommandArgs(command, options);
   return startProcess(
     path.join(flutterDirectory.path, 'bin', 'flutter'),
@@ -633,48 +631,6 @@ Future<void> getNewGallery(String revision, Directory galleryDir) async {
   await inDirectory<void>(galleryDir, () async {
     await exec('git', <String>['checkout', revision]);
   });
-}
-
-void checkNotNull(Object o1,
-    [Object o2 = 1,
-    Object o3 = 1,
-    Object o4 = 1,
-    Object o5 = 1,
-    Object o6 = 1,
-    Object o7 = 1,
-    Object o8 = 1,
-    Object o9 = 1,
-    Object o10 = 1]) {
-  if (o1 == null) {
-    throw 'o1 is null';
-  }
-  if (o2 == null) {
-    throw 'o2 is null';
-  }
-  if (o3 == null) {
-    throw 'o3 is null';
-  }
-  if (o4 == null) {
-    throw 'o4 is null';
-  }
-  if (o5 == null) {
-    throw 'o5 is null';
-  }
-  if (o6 == null) {
-    throw 'o6 is null';
-  }
-  if (o7 == null) {
-    throw 'o7 is null';
-  }
-  if (o8 == null) {
-    throw 'o8 is null';
-  }
-  if (o9 == null) {
-    throw 'o9 is null';
-  }
-  if (o10 == null) {
-    throw 'o10 is null';
-  }
 }
 
 /// Splits [from] into lines and selects those that contain [pattern].

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -2042,10 +2042,7 @@ class _UnzipListEntry {
     required this.uncompressedSize,
     required this.compressedSize,
     required this.path,
-  }) : assert(uncompressedSize != null),
-       assert(compressedSize != null),
-       assert(compressedSize <= uncompressedSize),
-       assert(path != null);
+  }) : assert(compressedSize <= uncompressedSize);
 
   final int uncompressedSize;
   final int compressedSize;

--- a/dev/devicelab/lib/tasks/web_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/web_benchmarks.dart
@@ -161,11 +161,11 @@ Future<TaskResult> runWebBenchmark({ required bool useCanvasKit }) async {
 
         final String namespace = '$benchmarkName.$backend';
         final List<String> scoreKeys = List<String>.from(profile['scoreKeys'] as List<dynamic>);
-        if (scoreKeys == null || scoreKeys.isEmpty) {
+        if (scoreKeys.isEmpty) {
           throw 'No score keys in benchmark "$benchmarkName"';
         }
         for (final String scoreKey in scoreKeys) {
-          if (scoreKey == null || scoreKey.isEmpty) {
+          if (scoreKey.isEmpty) {
             throw 'Score key is empty in benchmark "$benchmarkName". '
                 'Received [${scoreKeys.join(', ')}]';
           }


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.