### PR TITLE
Remove unnecessary null checks in `dev/conductor`

### DIFF
--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -126,8 +126,13 @@ List<String> getValuesFromEnvOrArgs(
   if (env[envName] != null && env[envName] != '') {
     return env[envName]!.split(',');
   }
-  final List<String> argValues = argResults[name] as List<String>;
-  return argValues;
+  final List<String>? argValues = argResults[name] as List<String>?;
+  if (argValues != null) {
+    return argValues;
+  }
+
+  throw ConductorException('Expected either the CLI arg --$name or the environment variable $envName '
+      'to be provided!');
 }
 
 /// Translate CLI arg names to env variable names.

--- a/dev/conductor/core/lib/src/globals.dart
+++ b/dev/conductor/core/lib/src/globals.dart
@@ -127,12 +127,7 @@ List<String> getValuesFromEnvOrArgs(
     return env[envName]!.split(',');
   }
   final List<String> argValues = argResults[name] as List<String>;
-  if (argValues != null) {
-    return argValues;
-  }
-
-  throw ConductorException('Expected either the CLI arg --$name or the environment variable $envName '
-      'to be provided!');
+  return argValues;
 }
 
 /// Translate CLI arg names to env variable names.

--- a/dev/conductor/core/lib/src/repository.dart
+++ b/dev/conductor/core/lib/src/repository.dart
@@ -28,7 +28,6 @@ class Remote {
     required RemoteName name,
     required this.url,
   })  : _name = name,
-        assert(url != null),
         assert(url != '');
 
   factory Remote.mirror(String url) {
@@ -241,7 +240,6 @@ abstract class Repository {
 
   /// The URL of the remote named [remoteName].
   Future<String> remoteUrl(String remoteName) async {
-    assert(remoteName != null);
     return git.getOutput(
       <String>['remote', 'get-url', remoteName],
       'verify the URL of the $remoteName remote',

--- a/dev/conductor/core/lib/src/state.dart
+++ b/dev/conductor/core/lib/src/state.dart
@@ -86,8 +86,7 @@ String presentState(pb.ConductorState state) {
   } else {
     buffer.writeln('0 Engine cherrypicks.');
   }
-  if (state.engine.dartRevision != null &&
-      state.engine.dartRevision.isNotEmpty) {
+  if (state.engine.dartRevision.isNotEmpty) {
     buffer.writeln('New Dart SDK revision: ${state.engine.dartRevision}');
   }
   buffer.writeln('Framework Repo');
@@ -271,7 +270,6 @@ String githubAccount(String remoteUrl) {
 /// Will throw a [ConductorException] if [ReleasePhase.RELEASE_COMPLETED] is
 /// passed as an argument, as there is no next phase.
 ReleasePhase getNextPhase(ReleasePhase currentPhase) {
-  assert(currentPhase != null);
   final ReleasePhase? nextPhase = ReleasePhase.valueOf(currentPhase.value + 1);
   if (nextPhase == null) {
     throw globals.ConductorException('There is no next ReleasePhase!');

--- a/dev/conductor/core/lib/src/version.dart
+++ b/dev/conductor/core/lib/src/version.dart
@@ -77,7 +77,6 @@ class Version {
   /// `flutter --version` and match one of `stablePattern`, `developmentPattern`
   /// and `latestPattern`.
   factory Version.fromString(String versionString) {
-    assert(versionString != null);
 
     versionString = versionString.trim();
     // stable tag


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.