### PR TITLE
Remove unnecessary null checks in `dev/*_tests`

### DIFF
--- a/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
+++ b/dev/integration_tests/android_semantics_testing/test_driver/main_test.dart
@@ -20,7 +20,7 @@ const List<AndroidSemanticsAction> ignoredAccessibilityFocusActions = <AndroidSe
 ];
 
 String adbPath() {
-  final String androidHome = io.Platform.environment['ANDROID_HOME'] ?? io.Platform.environment['ANDROID_SDK_ROOT']!;
+  final String? androidHome = io.Platform.environment['ANDROID_HOME'] ?? io.Platform.environment['ANDROID_SDK_ROOT'];
   if (androidHome == null) {
     return 'adb';
   } else {

--- a/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
+++ b/dev/integration_tests/hybrid_android_views/lib/android_platform_view.dart
@@ -19,7 +19,7 @@ class AndroidPlatformView extends StatelessWidget {
     this.onPlatformViewCreated,
     this.useHybridComposition = false,
     required this.viewType,
-  })  : assert(viewType != null);
+  });
 
   /// The unique identifier for the view type to be embedded by this widget.
   ///

--- a/dev/integration_tests/web_e2e_tests/test_driver/url_strategy_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/url_strategy_integration.dart
@@ -99,7 +99,7 @@ class TestUrlStrategy extends UrlStrategy {
   @override
   void replaceState(dynamic state, String title, String url) {
     assert(withinAppHistory);
-    if (url == null || url == '') {
+    if (url == '') {
       url = currentEntry.url;
     }
     currentEntry = TestHistoryEntry(state, title, url);

--- a/dev/manual_tests/lib/actions.dart
+++ b/dev/manual_tests/lib/actions.dart
@@ -48,8 +48,6 @@ class Memento extends Object with Diagnosticable {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(StringProperty('name', name));
-    properties.add(FlagProperty('undo', value: undo != null, ifTrue: 'undo'));
-    properties.add(FlagProperty('redo', value: redo != null, ifTrue: 'redo'));
   }
 }
 
@@ -63,8 +61,7 @@ class UndoableActionDispatcher extends ActionDispatcher implements Listenable {
   /// The [maxUndoLevels] argument must not be null.
   UndoableActionDispatcher({
     int maxUndoLevels = _defaultMaxUndoLevels,
-  })  : assert(maxUndoLevels != null),
-        _maxUndoLevels = maxUndoLevels;
+  })  : _maxUndoLevels = maxUndoLevels;
 
   // A stack of actions that have been performed. The most recent action
   // performed is at the end of the list.

--- a/dev/manual_tests/lib/density.dart
+++ b/dev/manual_tests/lib/density.dart
@@ -365,9 +365,7 @@ class _OptionsState extends State<Options> {
 }
 
 class _ControlTile extends StatelessWidget {
-  const _ControlTile({required this.label, required this.child})
-      : assert(label != null),
-        assert(child != null);
+  const _ControlTile({required this.label, required this.child});
 
   final String label;
   final Widget child;

--- a/dev/manual_tests/lib/raw_keyboard.dart
+++ b/dev/manual_tests/lib/raw_keyboard.dart
@@ -43,7 +43,7 @@ class _HardwareKeyDemoState extends State<RawKeyboardDemo> {
     return KeyEventResult.ignored;
   }
 
-  String _asHex(int value) => value != null ? '0x${value.toRadixString(16)}' : 'null';
+  String _asHex(int value) => '0x${value.toRadixString(16)}';
 
   String _getEnumName(dynamic enumItem) {
     final String name = '$enumItem';


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.