### PR TITLE
Remove unnecessary null checks in `dev/tools`

### DIFF
--- a/dev/tools/dartdoc.dart
+++ b/dev/tools/dartdoc.dart
@@ -581,8 +581,6 @@ Iterable<String> libraryRefs() sync* {
 }
 
 void printStream(Stream<List<int>> stream, { String prefix = '', List<Pattern> filter = const <Pattern>[] }) {
-  assert(prefix != null);
-  assert(filter != null);
   stream
     .transform<String>(utf8.decoder)
     .transform<String>(const LineSplitter())

--- a/dev/tools/gen_keycodes/lib/android_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/android_code_gen.dart
@@ -31,10 +31,8 @@ class AndroidCodeGenerator extends PlatformCodeGenerator {
   String get _androidScanCodeMap {
     final StringBuffer androidScanCodeMap = StringBuffer();
     for (final PhysicalKeyEntry entry in keyData.entries) {
-      if (entry.androidScanCodes != null) {
-        for (final int code in entry.androidScanCodes.cast<int>()) {
-          androidScanCodeMap.writeln('          put(${toHex(code, digits: 10)}L, ${toHex(entry.usbHidCode, digits: 10)}L); // ${entry.constantName}');
-        }
+      for (final int code in entry.androidScanCodes.cast<int>()) {
+        androidScanCodeMap.writeln('          put(${toHex(code, digits: 10)}L, ${toHex(entry.usbHidCode, digits: 10)}L); // ${entry.constantName}');
       }
     }
     return androidScanCodeMap.toString().trimRight();

--- a/dev/tools/gen_keycodes/lib/keyboard_maps_code_gen.dart
+++ b/dev/tools/gen_keycodes/lib/keyboard_maps_code_gen.dart
@@ -144,10 +144,8 @@ class KeyboardMapsCodeGenerator extends BaseCodeGenerator {
   String get _androidScanCodeMap {
     final OutputLines<int> lines = OutputLines<int>('Android scancode map');
     for (final PhysicalKeyEntry entry in keyData.entries) {
-      if (entry.androidScanCodes != null) {
-        for (final int code in entry.androidScanCodes) {
-          lines.add(code, '  $code: PhysicalKeyboardKey.${entry.constantName},');
-        }
+      for (final int code in entry.androidScanCodes) {
+        lines.add(code, '  $code: PhysicalKeyboardKey.${entry.constantName},');
       }
     }
     return lines.sortedJoin().trimRight();
@@ -296,9 +294,7 @@ class KeyboardMapsCodeGenerator extends BaseCodeGenerator {
   String get _fuchsiaHidCodeMap {
     final StringBuffer fuchsiaScanCodeMap = StringBuffer();
     for (final PhysicalKeyEntry entry in keyData.entries) {
-      if (entry.usbHidCode != null) {
-        fuchsiaScanCodeMap.writeln('  ${toHex(entry.usbHidCode)}: PhysicalKeyboardKey.${entry.constantName},');
-      }
+      fuchsiaScanCodeMap.writeln('  ${toHex(entry.usbHidCode)}: PhysicalKeyboardKey.${entry.constantName},');
     }
     return fuchsiaScanCodeMap.toString().trimRight();
   }
@@ -328,9 +324,7 @@ class KeyboardMapsCodeGenerator extends BaseCodeGenerator {
   String get _webNumpadMap {
     final OutputLines<String> lines = OutputLines<String>('Web numpad map');
     for (final LogicalKeyEntry entry in _numpadLogicalKeyData) {
-      if (entry.name != null) {
-        lines.add(entry.name, "  '${entry.name}': LogicalKeyboardKey.${entry.constantName},");
-      }
+      lines.add(entry.name, "  '${entry.name}': LogicalKeyboardKey.${entry.constantName},");
     }
     return lines.sortedJoin().trimRight();
   }

--- a/dev/tools/gen_keycodes/lib/utils.dart
+++ b/dev/tools/gen_keycodes/lib/utils.dart
@@ -153,9 +153,6 @@ String wrapString(String input, {required String prefix}) {
 ///
 /// An null list is considered a list with length 0.
 void zipStrict<T1, T2>(Iterable<T1> list1, Iterable<T2> list2, void Function(T1, T2) fn) {
-  if (list1 == null && list2 == null) {
-    return;
-  }
   assert(list1.length == list2.length);
   final Iterator<T1> it1 = list1.iterator;
   final Iterator<T2> it2 = list2.iterator;

--- a/dev/tools/localization/bin/gen_localizations.dart
+++ b/dev/tools/localization/bin/gen_localizations.dart
@@ -71,12 +71,8 @@ String generateArbBasedLocalizationSubclasses({
   required String supportedLanguagesConstant,
   required String supportedLanguagesDocMacro,
 }) {
-  assert(localeToResources != null);
-  assert(localeToResourceAttributes != null);
   assert(generatedClassPrefix.isNotEmpty);
   assert(baseClass.isNotEmpty);
-  assert(generateHeader != null);
-  assert(generateConstructor != null);
   assert(factoryName.isNotEmpty);
   assert(factoryDeclaration.isNotEmpty);
   assert(factoryArguments.isNotEmpty);

--- a/dev/tools/localization/localizations_utils.dart
+++ b/dev/tools/localization/localizations_utils.dart
@@ -51,7 +51,7 @@ class LocaleInfo implements Comparable<LocaleInfo> {
       scriptCode = codes[1].length > codes[2].length ? codes[1] : codes[2];
       countryCode = codes[1].length < codes[2].length ? codes[1] : codes[2];
     }
-    assert(codes[0] != null && codes[0].isNotEmpty);
+    assert(codes[0].isNotEmpty);
     assert(countryCode == null || countryCode.isNotEmpty);
     assert(scriptCode == null || scriptCode.isNotEmpty);
 
@@ -151,10 +151,6 @@ void loadMatchingArbsIntoBundleMaps({
   required Map<LocaleInfo, Map<String, String>> localeToResources,
   required Map<LocaleInfo, Map<String, dynamic>> localeToResourceAttributes,
 }) {
-  assert(directory != null);
-  assert(filenamePattern != null);
-  assert(localeToResources != null);
-  assert(localeToResourceAttributes != null);
 
   /// Set that holds the locales that were assumed from the existing locales.
   ///
@@ -214,7 +210,6 @@ void loadMatchingArbsIntoBundleMaps({
 }
 
 void exitWithError(String errorMessage) {
-  assert(errorMessage != null);
   stderr.writeln('fatal: $errorMessage');
   exit(1);
 }

--- a/dev/tools/vitool/test/vitool_test.dart
+++ b/dev/tools/vitool/test/vitool_test.dart
@@ -614,7 +614,7 @@ class PathMatcher extends Matcher {
 
   @override
   bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
-    if (item == null || actual == null) {
+    if (item == null) {
       return item == actual;
     }
 
@@ -666,7 +666,7 @@ class PathAnimationMatcher extends Matcher {
 
   @override
   bool matches(dynamic item, Map<dynamic, dynamic> matchState) {
-    if (item == null || expected == null) {
+    if (item == null) {
       return item == expected;
     }
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.