### PR TITLE
Remove unnecessary null checks in `dev/bots`

### DIFF
--- a/dev/bots/analyze.dart
+++ b/dev/bots/analyze.dart
@@ -597,7 +597,6 @@ Future<void> verifyDeprecations(String workingDirectory, { int minimumMatches = 
 }
 
 String _generateLicense(String prefix) {
-  assert(prefix != null);
   return '${prefix}Copyright 2014 The Flutter Authors. All rights reserved.\n'
          '${prefix}Use of this source code is governed by a BSD-style license that can be\n'
          '${prefix}found in the LICENSE file.';
@@ -1576,8 +1575,6 @@ Future<void> verifyNoBinaries(String workingDirectory, { Set<Hash256>? legacyBin
 // UTILITY FUNCTIONS
 
 bool _listEquals<T>(List<T> a, List<T> b) {
-  assert(a != null);
-  assert(b != null);
   if (a.length != b.length) {
     return false;
   }

--- a/dev/bots/analyze_snippet_code.dart
+++ b/dev/bots/analyze_snippet_code.dart
@@ -924,7 +924,7 @@ class _SnippetChecker {
         continue;
       }
 
-      final _SnippetFile snippet = snippets[file.path]!;
+      final _SnippetFile? snippet = snippets[file.path];
       if (snippet == null) {
         errors.add(_SnippetCheckerException(
           "Unknown section for ${file.path}. Maybe the temporary directory wasn't empty?",

--- a/dev/bots/prepare_package.dart
+++ b/dev/bots/prepare_package.dart
@@ -41,9 +41,7 @@ class PreparePackageException implements Exception {
   @override
   String toString() {
     String output = runtimeType.toString();
-    if (message != null) {
-      output += ': $message';
-    }
+    output += ': $message';
     final String stderr = result?.stderr as String? ?? '';
     if (stderr.isNotEmpty) {
       output += ':\n$stderr';

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1018,7 +1018,7 @@ Future<void> _runFrameworkTests() async {
       printOutput: false,
       outputChecker: (CommandResult result) {
         final Iterable<Match> matches = httpClientWarning.allMatches(result.flattenedStdout!);
-        if (matches == null || matches.isEmpty || matches.length > 1) {
+        if (matches.isEmpty || matches.length > 1) {
           return 'Failed to print warning about HttpClientUsage, or printed it too many times.\n\n'
                  'stdout:\n${result.flattenedStdout}\n\n'
                  'stderr:\n${result.flattenedStderr}';

--- a/dev/bots/unpublish_package.dart
+++ b/dev/bots/unpublish_package.dart
@@ -37,9 +37,7 @@ class UnpublishException implements Exception {
   @override
   String toString() {
     String output = runtimeType.toString();
-    if (message != null) {
-      output += ': $message';
-    }
+    output += ': $message';
     final String stderr = result?.stderr as String? ?? '';
     if (stderr.isNotEmpty) {
       output += ':\n$stderr';
@@ -113,9 +111,7 @@ class ProcessRunner {
     this.subprocessOutput = true,
     this.defaultWorkingDirectory,
     this.platform = const LocalPlatform(),
-  }) : assert(subprocessOutput != null),
-       assert(processManager != null),
-       assert(platform != null) {
+  }) {
     environment = Map<String, String>.from(platform.environment);
   }
 
@@ -255,9 +251,6 @@ class ArchiveUnpublisher {
         continue;
       }
       final Map<String, String> replacementRelease = releases.firstWhere((Map<String, String> value) => value['channel'] == getChannelName(channel));
-      if (replacementRelease == null) {
-        throw UnpublishException('Unable to find previous release for channel ${getChannelName(channel)}.');
-      }
       (jsonData['current_release'] as Map<String, dynamic>)[getChannelName(channel)] = replacementRelease['hash'];
       print(
         '${confirmed ? 'Reverting' : 'Would revert'} current ${getChannelName(channel)} '
@@ -468,7 +461,7 @@ Future<void> main(List<String> rawArguments) async {
   final String tempDirArg = parsedArguments['temp_dir'] as String;
   Directory tempDir;
   bool removeTempDir = false;
-  if (tempDirArg == null || tempDirArg.isEmpty) {
+  if (tempDirArg.isEmpty) {
     tempDir = Directory.systemTemp.createTempSync('flutter_package.');
     removeTempDir = true;
   } else {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.