### PR TITLE
Remove unnecessary null checks in `examples/`

### DIFF
--- a/examples/layers/rendering/src/sector_layout.dart
+++ b/examples/layers/rendering/src/sector_layout.dart
@@ -110,10 +110,7 @@ abstract class RenderSector extends RenderObject {
 
   @override
   void debugAssertDoesMeetConstraints() {
-    assert(constraints != null);
-    assert(deltaRadius != null);
     assert(deltaRadius < double.infinity);
-    assert(deltaTheta != null);
     assert(deltaTheta < double.infinity);
     assert(constraints.minDeltaRadius <= deltaRadius);
     assert(deltaRadius <= math.max(constraints.minDeltaRadius, constraints.maxDeltaRadius));
@@ -174,8 +171,6 @@ abstract class RenderDecoratedSector extends RenderSector {
   // offset must point to the center of the circle
   @override
   void paint(PaintingContext context, Offset offset) {
-    assert(deltaRadius != null);
-    assert(deltaTheta != null);
     assert(parentData is SectorParentData);
 
     if (_decoration == null) {
@@ -242,7 +237,6 @@ class RenderSectorRing extends RenderSectorWithChildren {
   double _desiredDeltaRadius;
   double get desiredDeltaRadius => _desiredDeltaRadius;
   set desiredDeltaRadius(double value) {
-    assert(value != null);
     assert(value >= 0);
     if (_desiredDeltaRadius != value) {
       _desiredDeltaRadius = value;
@@ -254,7 +248,6 @@ class RenderSectorRing extends RenderSectorWithChildren {
   double get padding => _padding;
   set padding(double value) {
     // TODO(ianh): avoid code duplication
-    assert(value != null);
     if (_padding != value) {
       _padding = value;
       markNeedsLayout();
@@ -360,7 +353,6 @@ class RenderSectorSlice extends RenderSectorWithChildren {
   double _desiredDeltaTheta;
   double get desiredDeltaTheta => _desiredDeltaTheta;
   set desiredDeltaTheta(double value) {
-    assert(value != null);
     if (_desiredDeltaTheta != value) {
       _desiredDeltaTheta = value;
       markNeedsLayout();
@@ -371,7 +363,6 @@ class RenderSectorSlice extends RenderSectorWithChildren {
   double get padding => _padding;
   set padding(double value) {
     // TODO(ianh): avoid code duplication
-    assert(value != null);
     if (_padding != value) {
       _padding = value;
       markNeedsLayout();
@@ -519,8 +510,6 @@ class RenderBoxToRenderSectorAdapter extends RenderBox with RenderObjectWithChil
   }) {
     assert(child is RenderSector);
     assert(child!.parentData is SectorParentData);
-    assert(width != null);
-    assert(height != null);
     if (!width.isFinite && !height.isFinite) {
       return Size.zero;
     }
@@ -649,9 +638,7 @@ class SectorHitTestEntry extends HitTestEntry {
   /// Creates a box hit test entry.
   ///
   /// The [radius] and [theta] argument must not be null.
-  SectorHitTestEntry(RenderSector super.target, { required this.radius,  required this.theta })
-      : assert(radius != null),
-        assert(theta != null);
+  SectorHitTestEntry(RenderSector super.target, { required this.radius,  required this.theta });
 
   @override
   RenderSector get target => super.target as RenderSector;

--- a/examples/layers/services/isolate.dart
+++ b/examples/layers/services/isolate.dart
@@ -17,11 +17,7 @@ typedef OnResultListener = void Function(String result);
 // in real-world applications.
 class Calculator {
   Calculator({ required this.onProgressListener, required this.onResultListener, String? data })
-    : assert(onProgressListener != null),
-      assert(onResultListener != null),
-      // In order to keep the example files smaller, we "cheat" a little and
-      // replicate our small json string into a 10,000-element array.
-      _data = _replicateJson(data, 10000);
+    : _data = _replicateJson(data, 10000);
 
   final OnProgressListener onProgressListener;
   final OnResultListener onResultListener;
@@ -87,9 +83,7 @@ class CalculationMessage {
 // progress of the background computation.
 class CalculationManager {
   CalculationManager({ required this.onProgressListener, required this.onResultListener })
-    : assert(onProgressListener != null),
-      assert(onResultListener != null),
-      _receivePort = ReceivePort() {
+    : _receivePort = ReceivePort() {
     _receivePort.listen(_handleMessage);
   }
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.