### PR TITLE
Enable `unnecessary_null_comparison` check

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,8 +23,6 @@ analyzer:
     # allow self-reference to deprecated members (we do this because otherwise we have
     # to annotate every member in every test, assert, etc, when we deprecate something)
     deprecated_member_use_from_same_package: ignore
-    # Turned off until null-safe rollout is complete.
-    unnecessary_null_comparison: ignore
   exclude:
     - "bin/cache/**"
       # Ignore protoc generated files

--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -3,11 +3,6 @@
 
 include: ../analysis_options.yaml
 
-analyzer:
-  errors:
-    # Turned off until null-safe rollout is complete.
-    unnecessary_null_comparison: ignore
-
 linter:
   rules:
     - public_member_api_docs # see https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#documentation-dartdocs-javadocs-etc

--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -3,6 +3,11 @@
 
 include: ../analysis_options.yaml
 
+analyzer:
+  errors:
+    # Turned off until null-safe rollout is complete.
+    unnecessary_null_comparison: ignore
+
 linter:
   rules:
     - public_member_api_docs # see https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#documentation-dartdocs-javadocs-etc

--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -987,7 +987,6 @@ class _IntrinsicDimensionsCacheEntry {
 /// AxisDirection get axis => _axis;
 /// AxisDirection _axis = AxisDirection.down; // or initialized in constructor
 /// set axis(AxisDirection value) {
-///   assert(value != null); // same checks as in the constructor
 ///   if (value == _axis) {
 ///     return;
 ///   }


### PR DESCRIPTION
**Blocked on https://github.com/flutter/engine/pull/39071 rolling into the framework.**

Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint. Everything ~outside of `packages`~ has already been cleaned up. ~`packages` will follow.~