### PR TITLE
Remove unnecessary null checks in `flutter_tool`

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -150,7 +150,7 @@ class AndroidDevices extends PollingDeviceDiscovery {
         String rest = match[3]!;
 
         final Map<String, String> info = <String, String>{};
-        if (rest != null && rest.isNotEmpty) {
+        if (rest.isNotEmpty) {
           rest = rest.trim();
           for (final String data in rest.split(' ')) {
             if (data.contains(':')) {

--- a/packages/flutter_tools/lib/src/android/android_device_discovery.dart
+++ b/packages/flutter_tools/lib/src/android/android_device_discovery.dart
@@ -147,10 +147,10 @@ class AndroidDevices extends PollingDeviceDiscovery {
 
         final String deviceID = match[1]!;
         final String deviceState = match[2]!;
-        String rest = match[3]!;
+        String? rest = match[3];
 
         final Map<String, String> info = <String, String>{};
-        if (rest.isNotEmpty) {
+        if (rest != null && rest.isNotEmpty) {
           rest = rest.trim();
           for (final String data in rest.split(' ')) {
             if (data.contains(':')) {

--- a/packages/flutter_tools/lib/src/android/android_emulator.dart
+++ b/packages/flutter_tools/lib/src/android/android_emulator.dart
@@ -62,9 +62,7 @@ class AndroidEmulators extends EmulatorDiscovery {
       <String>[emulatorPath, '-list-avds'])).stdout.trim();
 
     final List<AndroidEmulator> emulators = <AndroidEmulator>[];
-    if (listAvdsOutput != null) {
-      _extractEmulatorAvdInfo(listAvdsOutput, emulators);
-    }
+    _extractEmulatorAvdInfo(listAvdsOutput, emulators);
     return emulators;
   }
 

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -435,11 +435,9 @@ class AndroidSdk {
           throwOnError: true,
           hideStdout: true,
         ).stdout.trim();
-        if (javaHomeOutput != null) {
-          if ((javaHomeOutput != null) && (javaHomeOutput.isNotEmpty)) {
-            final String javaHome = javaHomeOutput.split('\n').last.trim();
-            return fileSystem.path.join(javaHome, 'bin', 'java');
-          }
+        if ((javaHomeOutput != null) && (javaHomeOutput.isNotEmpty)) {
+          final String javaHome = javaHomeOutput.split('\n').last.trim();
+          return fileSystem.path.join(javaHome, 'bin', 'java');
         }
       } on Exception { /* ignore */ }
     }
@@ -500,10 +498,7 @@ class AndroidSdkVersion implements Comparable<AndroidSdkVersion> {
     required this.platformName,
     required this.buildToolsVersion,
     required FileSystem fileSystem,
-  }) : assert(sdkLevel != null),
-       assert(platformName != null),
-       assert(buildToolsVersion != null),
-       _fileSystem = fileSystem;
+  }) : _fileSystem = fileSystem;
 
   final AndroidSdk sdk;
   final int sdkLevel;

--- a/packages/flutter_tools/lib/src/android/android_sdk.dart
+++ b/packages/flutter_tools/lib/src/android/android_sdk.dart
@@ -435,7 +435,7 @@ class AndroidSdk {
           throwOnError: true,
           hideStdout: true,
         ).stdout.trim();
-        if ((javaHomeOutput != null) && (javaHomeOutput.isNotEmpty)) {
+        if (javaHomeOutput.isNotEmpty) {
           final String javaHome = javaHomeOutput.split('\n').last.trim();
           return fileSystem.path.join(javaHome, 'bin', 'java');
         }

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -425,9 +425,6 @@ class AndroidStudio implements Comparable<AndroidStudio> {
   }
 
   static String? extractStudioPlistValueWithMatcher(String plistValue, RegExp keyMatcher) {
-    if (keyMatcher == null) {
-      return null;
-    }
     return keyMatcher.stringMatch(plistValue)?.split('=').last.trim().replaceAll('"', '');
   }
 

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -110,7 +110,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     // and <base dir>/system/.home for Android Studio < 4.1
     String dotHomeFilePath;
 
-    if (major != null && major >= 4 && minor != null && minor >= 1) {
+    if (major >= 4 && minor >= 1) {
       dotHomeFilePath = globals.fs.path.join(homeDotDir.path, '.home');
     } else {
       dotHomeFilePath =
@@ -161,7 +161,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
     }
     if (globals.platform.isMacOS) {
       /// plugin path of Android Studio has been changed after version 4.1.
-      if (major != null && major >= 4 && minor != null && minor >= 1) {
+      if (major >= 4 && minor >= 1) {
         return globals.fs.path.join(
           homeDirPath,
           'Library',
@@ -185,7 +185,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
         return toolboxPluginsPath;
       }
 
-      if (major != null && major >= 4 && minor != null && minor >= 1 &&
+      if (major >= 4 && minor >= 1 &&
           globals.platform.isLinux) {
         return globals.fs.path.join(
           homeDirPath,
@@ -394,7 +394,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
                 version: Version.parse(version),
                 studioAppName: title,
               );
-              if (studio != null && !hasStudioAt(studio.directory, newerThan: studio.version)) {
+              if (!hasStudioAt(studio.directory, newerThan: studio.version)) {
                 studios.removeWhere((AndroidStudio other) => other.directory == studio.directory);
                 studios.add(studio);
               }
@@ -425,7 +425,7 @@ class AndroidStudio implements Comparable<AndroidStudio> {
   }
 
   static String? extractStudioPlistValueWithMatcher(String plistValue, RegExp keyMatcher) {
-    if (plistValue == null || keyMatcher == null) {
+    if (keyMatcher == null) {
       return null;
     }
     return keyMatcher.stringMatch(plistValue)?.split('=').last.trim().replaceAll('"', '');

--- a/packages/flutter_tools/lib/src/android/application_package.dart
+++ b/packages/flutter_tools/lib/src/android/application_package.dart
@@ -27,8 +27,7 @@ class AndroidApk extends ApplicationPackage implements PrebuiltApplicationPackag
     required this.applicationPackage,
     required this.versionCode,
     required this.launchActivity,
-  }) : assert(applicationPackage != null),
-       assert(launchActivity != null);
+  });
 
   /// Creates a new AndroidApk from an existing APK.
   ///
@@ -294,7 +293,7 @@ class ApkManifestData {
   }
 
   static ApkManifestData? parseFromXmlDump(String data, Logger logger) {
-    if (data == null || data.trim().isEmpty) {
+    if (data.trim().isEmpty) {
       return null;
     }
 

--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -187,7 +187,7 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
     loadingUnitComparisonResults = <String, Object>{};
     final Set<LoadingUnit> unmatchedLoadingUnits = <LoadingUnit>{};
     final List<LoadingUnit> newLoadingUnits = <LoadingUnit>[];
-    if (generatedLoadingUnits == null || cachedLoadingUnits == null) {
+    if (cachedLoadingUnits == null) {
       loadingUnitComparisonResults!['new'] = newLoadingUnits;
       loadingUnitComparisonResults!['missing'] = unmatchedLoadingUnits;
       loadingUnitComparisonResults!['match'] = false;
@@ -335,7 +335,7 @@ loading-units:
         continue;
       }
       buffer.write('  - id: ${unit.id}\n');
-      if (unit.libraries != null && unit.libraries.isNotEmpty) {
+      if (unit.libraries.isNotEmpty) {
         buffer.write('    libraries:\n');
         for (final String lib in unit.libraries) {
           buffer.write('      - $lib\n');

--- a/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_gen_snapshot_validator.dart
@@ -187,12 +187,6 @@ class DeferredComponentsGenSnapshotValidator extends DeferredComponentsValidator
     loadingUnitComparisonResults = <String, Object>{};
     final Set<LoadingUnit> unmatchedLoadingUnits = <LoadingUnit>{};
     final List<LoadingUnit> newLoadingUnits = <LoadingUnit>[];
-    if (cachedLoadingUnits == null) {
-      loadingUnitComparisonResults!['new'] = newLoadingUnits;
-      loadingUnitComparisonResults!['missing'] = unmatchedLoadingUnits;
-      loadingUnitComparisonResults!['match'] = false;
-      return false;
-    }
     unmatchedLoadingUnits.addAll(cachedLoadingUnits);
     final Set<int> addedNewIds = <int>{};
     for (final LoadingUnit genUnit in generatedLoadingUnits) {

--- a/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_prebuild_validator.dart
@@ -51,7 +51,7 @@ class DeferredComponentsPrebuildValidator extends DeferredComponentsValidator {
   /// valid, as there are many ways that they can be validly configured.
   Future<bool> checkAndroidDynamicFeature(List<DeferredComponent> components) async {
     inputs.add(projectDir.childFile('pubspec.yaml'));
-    if (components == null || components.isEmpty) {
+    if (components.isEmpty) {
       return false;
     }
     bool changesMade = false;
@@ -124,7 +124,7 @@ class DeferredComponentsPrebuildValidator extends DeferredComponentsValidator {
       .childDirectory('values')
       .childFile('strings.xml');
     ErrorHandlingFileSystem.deleteIfExists(stringResOutput);
-    if (components == null || components.isEmpty) {
+    if (components.isEmpty) {
       return true;
     }
     final Map<String, String> requiredEntriesMap  = <String, String>{};
@@ -148,7 +148,7 @@ class DeferredComponentsPrebuildValidator extends DeferredComponentsValidator {
         for (final XmlElement element in resources.findElements('string')) {
           final String? name = element.getAttribute('name');
           if (requiredEntriesMap.containsKey(name)) {
-            if (element.text != null && element.text != requiredEntriesMap[name]) {
+            if (element.text != requiredEntriesMap[name]) {
               element.innerText = requiredEntriesMap[name]!;
               modified = true;
             }

--- a/packages/flutter_tools/lib/src/android/deferred_components_validator.dart
+++ b/packages/flutter_tools/lib/src/android/deferred_components_validator.dart
@@ -122,7 +122,7 @@ abstract class DeferredComponentsValidator {
         }
       }
       // Log diff file contents, with color highlighting
-      if (diffLines != null && diffLines.isNotEmpty) {
+      if (diffLines.isNotEmpty) {
         logger.printStatus('Diff between `android` and expected files:', emphasis: true);
         logger.printStatus('');
         for (final String line in diffLines) {
@@ -163,7 +163,7 @@ abstract class DeferredComponentsValidator {
 The above files have been placed into `build/$kDeferredComponentsTempDirectory`,
 a temporary directory. The files should be reviewed and moved into the project's
 `android` directory.''');
-        if (diffLines != null && diffLines.isNotEmpty && !platform.isWindows) {
+        if (diffLines.isNotEmpty && !platform.isWindows) {
           logger.printStatus(r'''
 
 The recommended changes can be quickly applied by running:

--- a/packages/flutter_tools/lib/src/android/gradle.dart
+++ b/packages/flutter_tools/lib/src/android/gradle.dart
@@ -229,11 +229,6 @@ class AndroidGradleBuilder implements AndroidBuilder {
     int retry = 0,
     @visibleForTesting int? maxRetries,
   }) async {
-    assert(project != null);
-    assert(androidBuildInfo != null);
-    assert(target != null);
-    assert(isBuildingBundle != null);
-    assert(localGradleErrors != null);
 
     if (!project.android.isSupportedVersion) {
       _exitWithUnsupportedProjectMessage(_usage, _logger.terminal);
@@ -299,9 +294,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
           .map(getPlatformNameForAndroidArch).join(',');
       command.add('-Ptarget-platform=$targetPlatforms');
     }
-    if (target != null) {
-      command.add('-Ptarget=$target');
-    }
+    command.add('-Ptarget=$target');
     // Only attempt adding multidex support if all the flutter generated files exist.
     // If the files do not exist and it was unintentional, the app will fail to build
     // and prompt the developer if they wish Flutter to add the files again via gradle_error.dart.
@@ -342,7 +335,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
       }
     }
     command.addAll(androidBuildInfo.buildInfo.toGradleConfig());
-    if (buildInfo.fileSystemRoots != null && buildInfo.fileSystemRoots.isNotEmpty) {
+    if (buildInfo.fileSystemRoots.isNotEmpty) {
       command.add('-Pfilesystem-roots=${buildInfo.fileSystemRoots.join('|')}');
     }
     if (buildInfo.fileSystemScheme != null) {
@@ -557,10 +550,6 @@ class AndroidGradleBuilder implements AndroidBuilder {
     required Directory outputDirectory,
     required String buildNumber,
   }) async {
-    assert(project != null);
-    assert(target != null);
-    assert(androidBuildInfo != null);
-    assert(outputDirectory != null);
 
     final FlutterManifest manifest = project.manifest;
     if (!manifest.isModule && !manifest.isPlugin) {
@@ -600,7 +589,7 @@ class AndroidGradleBuilder implements AndroidBuilder {
       command.add('--no-daemon');
     }
 
-    if (target != null && target.isNotEmpty) {
+    if (target.isNotEmpty) {
       command.add('-Ptarget=$target');
     }
     command.addAll(androidBuildInfo.buildInfo.toGradleConfig());
@@ -699,8 +688,7 @@ void printHowToConsumeAar({
   required FileSystem fileSystem,
   String? buildNumber,
 }) {
-  assert(buildModes != null && buildModes.isNotEmpty);
-  assert(repoDirectory != null);
+  assert(buildModes.isNotEmpty);
   buildNumber ??= '1.0';
 
   logger.printStatus('\nConsuming the Module', emphasis: true);
@@ -913,8 +901,6 @@ Never _exitWithExpectedFileNotFound({
   required Logger logger,
   required Usage usage,
 }) {
-  assert(project != null);
-  assert(fileExtension != null);
 
   final String androidGradlePluginVersion =
   getGradleVersionForAndroidPlugin(project.android.hostAppGradleRoot, logger);
@@ -984,8 +970,6 @@ Directory _getLocalEngineRepo({
   required AndroidBuildInfo androidBuildInfo,
   required FileSystem fileSystem,
 }) {
-  assert(engineOutPath != null);
-  assert(androidBuildInfo != null);
 
   final String abi = _getAbiByLocalEnginePath(engineOutPath);
   final Directory localEngineRepo = fileSystem.systemTempDirectory

--- a/packages/flutter_tools/lib/src/android/gradle_errors.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_errors.dart
@@ -337,7 +337,6 @@ final GradleHandledError licenseNotAcceptedHandler = GradleHandledError(
       r'You have not accepted the license agreements of the following SDK components:\s*\[(.+)\]';
 
     final RegExp licenseFailure = RegExp(licenseNotAcceptedMatcher, multiLine: true);
-    assert(licenseFailure != null);
     final Match? licenseMatch = licenseFailure.firstMatch(line);
     globals.printBox(
       '${globals.logger.terminal.warningMark} Unable to download needed Android SDK components, as the '

--- a/packages/flutter_tools/lib/src/android/gradle_utils.dart
+++ b/packages/flutter_tools/lib/src/android/gradle_utils.dart
@@ -151,8 +151,6 @@ bool _isWithinVersionRange(
   required String min,
   required String max,
 }) {
-  assert(min != null);
-  assert(max != null);
   final Version? parsedTargetVersion = Version.parse(targetVersion);
   final Version? minVersion = Version.parse(min);
   final Version? maxVersion = Version.parse(max);

--- a/packages/flutter_tools/lib/src/application_package.dart
+++ b/packages/flutter_tools/lib/src/application_package.dart
@@ -18,8 +18,7 @@ abstract class ApplicationPackageFactory {
 }
 
 abstract class ApplicationPackage {
-  ApplicationPackage({ required this.id })
-    : assert(id != null);
+  ApplicationPackage({ required this.id });
 
   /// Package ID from the Android Manifest or equivalent.
   final String id;

--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -625,7 +625,6 @@ class CachedArtifacts implements Artifacts {
   }
 
   String _getHostArtifactPath(Artifact artifact, TargetPlatform platform, BuildMode? mode) {
-    assert(platform != null);
     switch (artifact) {
       case Artifact.genSnapshot:
         // For script snapshots any gen_snapshot binary will do. Returning gen_snapshot for
@@ -1227,7 +1226,7 @@ class OverrideArtifacts implements Artifacts {
     this.engineDartBinary,
     this.platformKernelDill,
     this.flutterPatchedSdk,
-  }) : assert(parent != null);
+  });
 
   final Artifacts parent;
   final File? frontendServer;

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -200,9 +200,6 @@ class ManifestAssetBundle implements AssetBundle {
       }
       for (final File file in directory.listSync().whereType<File>()) {
         final DateTime dateTime = file.statSync().modified;
-        if (dateTime == null) {
-          continue;
-        }
         if (dateTime.isAfter(lastBuildTimestamp)) {
           return true;
         }

--- a/packages/flutter_tools/lib/src/asset.dart
+++ b/packages/flutter_tools/lib/src/asset.dart
@@ -301,7 +301,7 @@ class ManifestAssetBundle implements AssetBundle {
     final Map<String, List<File>> additionalLicenseFiles = <String, List<File>>{};
     for (final Package package in packageConfig.packages) {
       final Uri packageUri = package.packageUriRoot;
-      if (packageUri != null && packageUri.scheme == 'file') {
+      if (packageUri.scheme == 'file') {
         final String packageManifestPath = _fileSystem.path.fromUri(packageUri.resolve('../pubspec.yaml'));
         inputFiles.add(_fileSystem.file(packageManifestPath));
         final FlutterManifest? packageFlutterManifest = FlutterManifest.createFromPath(
@@ -390,34 +390,32 @@ class ManifestAssetBundle implements AssetBundle {
     }
     // Save the contents of each deferred component image, image variant, and font
     // asset in deferredComponentsEntries.
-    if (deferredComponentsAssetVariants != null) {
-      for (final String componentName in deferredComponentsAssetVariants.keys) {
-        deferredComponentsEntries[componentName] = <String, DevFSContent>{};
-        final Map<_Asset, List<_Asset>> assetsMap = deferredComponentsAssetVariants[componentName]!;
-        for (final _Asset asset in assetsMap.keys) {
-          final File assetFile = asset.lookupAssetFile(_fileSystem);
-          if (!assetFile.existsSync() && assetsMap[asset]!.isEmpty) {
-            _logger.printStatus('Error detected in pubspec.yaml:', emphasis: true);
-            _logger.printError('No file or variants found for $asset.\n');
-            if (asset.package != null) {
-              _logger.printError('This asset was included from package ${asset.package?.name}.');
-            }
-            return 1;
+    for (final String componentName in deferredComponentsAssetVariants.keys) {
+      deferredComponentsEntries[componentName] = <String, DevFSContent>{};
+      final Map<_Asset, List<_Asset>> assetsMap = deferredComponentsAssetVariants[componentName]!;
+      for (final _Asset asset in assetsMap.keys) {
+        final File assetFile = asset.lookupAssetFile(_fileSystem);
+        if (!assetFile.existsSync() && assetsMap[asset]!.isEmpty) {
+          _logger.printStatus('Error detected in pubspec.yaml:', emphasis: true);
+          _logger.printError('No file or variants found for $asset.\n');
+          if (asset.package != null) {
+            _logger.printError('This asset was included from package ${asset.package?.name}.');
           }
-          // The file name for an asset's "main" entry is whatever appears in
-          // the pubspec.yaml file. The main entry's file must always exist for
-          // font assets. It need not exist for an image if resolution-specific
-          // variant files exist. An image's main entry is treated the same as a
-          // "1x" resolution variant and if both exist then the explicit 1x
-          // variant is preferred.
-          if (assetFile.existsSync() && !assetsMap[asset]!.contains(asset)) {
-            assetsMap[asset]!.insert(0, asset);
-          }
-          for (final _Asset variant in assetsMap[asset]!) {
-            final File variantFile = variant.lookupAssetFile(_fileSystem);
-            assert(variantFile.existsSync());
-            deferredComponentsEntries[componentName]![variant.entryUri.path] ??= DevFSFileContent(variantFile);
-          }
+          return 1;
+        }
+        // The file name for an asset's "main" entry is whatever appears in
+        // the pubspec.yaml file. The main entry's file must always exist for
+        // font assets. It need not exist for an image if resolution-specific
+        // variant files exist. An image's main entry is treated the same as a
+        // "1x" resolution variant and if both exist then the explicit 1x
+        // variant is preferred.
+        if (assetFile.existsSync() && !assetsMap[asset]!.contains(asset)) {
+          assetsMap[asset]!.insert(0, asset);
+        }
+        for (final _Asset variant in assetsMap[asset]!) {
+          final File variantFile = variant.lookupAssetFile(_fileSystem);
+          assert(variantFile.existsSync());
+          deferredComponentsEntries[componentName]![variant.entryUri.path] ??= DevFSFileContent(variantFile);
         }
       }
     }
@@ -665,15 +663,13 @@ class ManifestAssetBundle implements AssetBundle {
           variant.entryUri.path,
       ];
     });
-    if (deferredComponentsAssetVariants != null) {
-      for (final Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values) {
-        componentAssets.forEach((_Asset main, List<_Asset> variants) {
-          entries[main] = <String>[
-            for (final _Asset variant in variants)
-              variant.entryUri.path,
-          ];
-        });
-      }
+    for (final Map<_Asset, List<_Asset>> componentAssets in deferredComponentsAssetVariants.values) {
+      componentAssets.forEach((_Asset main, List<_Asset> variants) {
+        entries[main] = <String>[
+          for (final _Asset variant in variants)
+            variant.entryUri.path,
+        ];
+      });
     }
     final List<_Asset> sortedKeys = entries.keys.toList()
         ..sort((_Asset left, _Asset right) => left.entryUri.path.compareTo(right.entryUri.path));

--- a/packages/flutter_tools/lib/src/base/analyze_size.dart
+++ b/packages/flutter_tools/lib/src/base/analyze_size.dart
@@ -430,9 +430,7 @@ class _SymbolNode {
   _SymbolNode(
     this.name, {
     this.byteSize = 0,
-  })  : assert(name != null),
-        assert(byteSize != null),
-        _children = <String, _SymbolNode>{};
+  })  : _children = <String, _SymbolNode>{};
 
   /// The human friendly identifier for this node.
   String name;

--- a/packages/flutter_tools/lib/src/base/build.dart
+++ b/packages/flutter_tools/lib/src/base/build.dart
@@ -14,8 +14,7 @@ import 'process.dart';
 
 /// A snapshot build configuration.
 class SnapshotType {
-  SnapshotType(this.platform, this.mode)
-    : assert(mode != null);
+  SnapshotType(this.platform, this.mode);
 
   final TargetPlatform? platform;
   final BuildMode mode;
@@ -145,7 +144,7 @@ class AOTSnapshotter {
     // We strip snapshot by default, but allow to suppress this behavior
     // by supplying --no-strip in extraGenSnapshotOptions.
     bool shouldStrip = true;
-    if (extraGenSnapshotOptions != null && extraGenSnapshotOptions.isNotEmpty) {
+    if (extraGenSnapshotOptions.isNotEmpty) {
       _logger.printTrace('Extra gen_snapshot options: $extraGenSnapshotOptions');
       for (final String option in extraGenSnapshotOptions) {
         if (option == '--no-strip') {

--- a/packages/flutter_tools/lib/src/base/command_help.dart
+++ b/packages/flutter_tools/lib/src/base/command_help.dart
@@ -220,7 +220,7 @@ class CommandHelpOption {
   /// Text shown in parenthesis to give the context.
   final String inParenthesis;
 
-  bool get _hasTextInParenthesis => inParenthesis != null && inParenthesis.isNotEmpty;
+  bool get _hasTextInParenthesis => inParenthesis.isNotEmpty;
 
   int get _rawMessageLength => key.length + description.length;
 

--- a/packages/flutter_tools/lib/src/base/deferred_component.dart
+++ b/packages/flutter_tools/lib/src/base/deferred_component.dart
@@ -71,9 +71,6 @@ class DeferredComponent {
   void assignLoadingUnits(List<LoadingUnit> allLoadingUnits) {
     _assigned = true;
     _loadingUnits = <LoadingUnit>{};
-    if (allLoadingUnits == null) {
-      return;
-    }
     for (final String lib in libraries) {
       for (final LoadingUnit loadingUnit in allLoadingUnits) {
         if (loadingUnit.libraries.contains(lib)) {

--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -40,8 +40,6 @@ class ErrorHandlingFileSystem extends ForwardingFileSystem {
     required FileSystem delegate,
     required Platform platform,
   }) :
-      assert(delegate != null),
-      assert(platform != null),
       _platform = platform,
       super(delegate);
 
@@ -164,9 +162,6 @@ class ErrorHandlingFile
     required this.fileSystem,
     required this.delegate,
   }) :
-    assert(platform != null),
-    assert(fileSystem != null),
-    assert(delegate != null),
     _platform = platform;
 
   @override
@@ -379,9 +374,6 @@ class ErrorHandlingDirectory
     required this.fileSystem,
     required this.delegate,
   }) :
-    assert(platform != null),
-    assert(fileSystem != null),
-    assert(delegate != null),
     _platform = platform;
 
   @override
@@ -518,9 +510,6 @@ class ErrorHandlingLink
     required this.fileSystem,
     required this.delegate,
   }) :
-    assert(platform != null),
-    assert(fileSystem != null),
-    assert(delegate != null),
     _platform = platform;
 
   @override
@@ -563,7 +552,6 @@ Future<T> _run<T>(Future<T> Function() op, {
   String? failureMessage,
   String? posixPermissionSuggestion,
 }) async {
-  assert(platform != null);
   try {
     return await op();
   } on ProcessPackageExecutableNotFoundException catch (e) {
@@ -595,7 +583,6 @@ T _runSync<T>(T Function() op, {
   String? failureMessage,
   String? posixPermissionSuggestion,
 }) {
-  assert(platform != null);
   try {
     return op();
   } on ProcessPackageExecutableNotFoundException catch (e) {

--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -22,8 +22,7 @@ class Fingerprinter {
     required FileSystem fileSystem,
     required Logger logger,
   }) : _paths = paths.toList(),
-       assert(fingerprintPath != null),
-       assert(paths != null && paths.every((String path) => path != null)),
+       assert(paths.every((String path) => path != null)),
        _logger = logger,
        _fileSystem = fileSystem;
 

--- a/packages/flutter_tools/lib/src/base/fingerprint.dart
+++ b/packages/flutter_tools/lib/src/base/fingerprint.dart
@@ -22,7 +22,6 @@ class Fingerprinter {
     required FileSystem fileSystem,
     required Logger logger,
   }) : _paths = paths.toList(),
-       assert(paths.every((String path) => path != null)),
        _logger = logger,
        _fileSystem = fileSystem;
 

--- a/packages/flutter_tools/lib/src/base/io.dart
+++ b/packages/flutter_tools/lib/src/base/io.dart
@@ -399,7 +399,6 @@ class _DefaultProcessInfo implements ProcessInfo {
 
   @override
   File writePidFile(String pidFile) {
-    assert(pidFile != null);
     return _fileSystem.file(pidFile)
       ..writeAsStringSync(io.pid.toString());
   }
@@ -419,7 +418,6 @@ class _TestProcessInfo implements ProcessInfo {
 
   @override
   File writePidFile(String pidFile) {
-    assert(pidFile != null);
     return _fileSystem.file(pidFile)
       ..writeAsStringSync('12345');
   }

--- a/packages/flutter_tools/lib/src/base/logger.dart
+++ b/packages/flutter_tools/lib/src/base/logger.dart
@@ -877,7 +877,6 @@ class BufferLogger extends Logger {
     String? progressId,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
-    assert(progressIndicatorPadding != null);
     printStatus(message);
     return SilentStatus(
       stopwatch: _stopwatchFactory.createStopwatch(),
@@ -1020,7 +1019,6 @@ class VerboseLogger extends DelegatingLogger {
     String? progressId,
     int progressIndicatorPadding = kDefaultStatusPadding,
   }) {
-    assert(progressIndicatorPadding != null);
     printStatus(message);
     final Stopwatch timer = _stopwatchFactory.createStopwatch()..start();
     return SilentStatus(
@@ -1356,7 +1354,6 @@ class AnonymousSpinnerStatus extends Status {
 
   void _callback(Timer timer) {
     assert(this.timer == timer);
-    assert(timer != null);
     assert(timer.isActive);
     _writeToStdOut(_backspaceChar * _lastAnimationFrameLength);
     ticks += 1;

--- a/packages/flutter_tools/lib/src/base/multi_root_file_system.dart
+++ b/packages/flutter_tools/lib/src/base/multi_root_file_system.dart
@@ -44,8 +44,7 @@ class MultiRootFileSystem extends ForwardingFileSystem {
     required FileSystem delegate,
     required String scheme,
     required List<String> roots,
-  })   : assert(delegate != null),
-        assert(roots.isNotEmpty),
+  })   : assert(roots.isNotEmpty),
         _scheme = scheme,
         _roots = roots.map((String root) => delegate.path.normalize(root)).toList(),
         super(delegate);

--- a/packages/flutter_tools/lib/src/base/net.dart
+++ b/packages/flutter_tools/lib/src/base/net.dart
@@ -133,7 +133,6 @@ class Net {
       _logger.printTrace('Download error: $error');
       return false;
     }
-    assert(response != null);
 
     // If we're making a HEAD request, we're only checking to see if the URL is
     // valid.

--- a/packages/flutter_tools/lib/src/base/os.dart
+++ b/packages/flutter_tools/lib/src/base/os.dart
@@ -90,7 +90,7 @@ abstract class OperatingSystemUtils {
   /// if `which` was not able to locate the binary.
   File? which(String execName) {
     final List<File> result = _which(execName);
-    if (result == null || result.isEmpty) {
+    if (result.isEmpty) {
       return null;
     }
     return result.first;

--- a/packages/flutter_tools/lib/src/base/process.dart
+++ b/packages/flutter_tools/lib/src/base/process.dart
@@ -98,8 +98,7 @@ class ProcessExit implements Exception {
 
 class RunResult {
   RunResult(this.processResult, this._command)
-    : assert(_command != null),
-      assert(_command.isNotEmpty);
+    : assert(_command.isNotEmpty);
 
   final ProcessResult processResult;
 
@@ -256,7 +255,7 @@ class _DefaultProcessUtils implements ProcessUtils {
     Duration? timeout,
     int timeoutRetries = 0,
   }) async {
-    if (cmd == null || cmd.isEmpty) {
+    if (cmd.isEmpty) {
       throw ArgumentError('cmd must be a non-empty list');
     }
     if (timeoutRetries < 0) {

--- a/packages/flutter_tools/lib/src/base/terminal.dart
+++ b/packages/flutter_tools/lib/src/base/terminal.dart
@@ -226,7 +226,6 @@ class AnsiTerminal implements Terminal {
 
   @override
   String bolden(String message) {
-    assert(message != null);
     if (!supportsColor || message.isEmpty) {
       return message;
     }
@@ -247,8 +246,7 @@ class AnsiTerminal implements Terminal {
 
   @override
   String color(String message, TerminalColor color) {
-    assert(message != null);
-    if (!supportsColor || color == null || message.isEmpty) {
+    if (!supportsColor || message.isEmpty) {
       return message;
     }
     final StringBuffer buffer = StringBuffer();

--- a/packages/flutter_tools/lib/src/base/utils.dart
+++ b/packages/flutter_tools/lib/src/base/utils.dart
@@ -207,7 +207,7 @@ String wrapText(String text, {
   int? indent,
 }) {
   assert(columnWidth >= 0);
-  if (text == null || text.isEmpty) {
+  if (text.isEmpty) {
     return '';
   }
   indent ??= 0;
@@ -295,7 +295,7 @@ List<String> _wrapTextAsLines(String text, {
   required int columnWidth,
   required bool shouldWrap,
 }) {
-  if (text == null || text.isEmpty) {
+  if (text.isEmpty) {
     return <String>[''];
   }
   assert(start >= 0);

--- a/packages/flutter_tools/lib/src/build_info.dart
+++ b/packages/flutter_tools/lib/src/build_info.dart
@@ -6,7 +6,6 @@ import 'package:package_config/package_config_types.dart';
 
 import 'artifacts.dart';
 import 'base/config.dart';
-import 'base/context.dart';
 import 'base/file_system.dart';
 import 'base/logger.dart';
 import 'base/os.dart';
@@ -237,18 +236,15 @@ class BuildInfo {
       kBuildMode: getNameForBuildMode(mode),
       if (dartDefines.isNotEmpty)
         kDartDefines: encodeDartDefines(dartDefines),
-      if (dartObfuscation != null)
-        kDartObfuscation: dartObfuscation.toString(),
+      kDartObfuscation: dartObfuscation.toString(),
       if (extraFrontEndOptions.isNotEmpty)
         kExtraFrontEndOptions: extraFrontEndOptions.join(','),
       if (extraGenSnapshotOptions.isNotEmpty)
         kExtraGenSnapshotOptions: extraGenSnapshotOptions.join(','),
       if (splitDebugInfoPath != null)
         kSplitDebugInfo: splitDebugInfoPath!,
-      if (trackWidgetCreation != null)
-        kTrackWidgetCreation: trackWidgetCreation.toString(),
-      if (treeShakeIcons != null)
-        kIconTreeShakerFlag: treeShakeIcons.toString(),
+      kTrackWidgetCreation: trackWidgetCreation.toString(),
+      kIconTreeShakerFlag: treeShakeIcons.toString(),
       if (bundleSkSLPath != null)
         kBundleSkSLPath: bundleSkSLPath!,
       if (codeSizeDirectory != null)
@@ -277,24 +273,20 @@ class BuildInfo {
     final Map<String, String> environmentMap = <String, String>{
       if (dartDefines.isNotEmpty)
         'DART_DEFINES': encodeDartDefines(dartDefines),
-      if (dartObfuscation != null)
-        'DART_OBFUSCATION': dartObfuscation.toString(),
+      'DART_OBFUSCATION': dartObfuscation.toString(),
       if (extraFrontEndOptions.isNotEmpty)
         'EXTRA_FRONT_END_OPTIONS': extraFrontEndOptions.join(','),
       if (extraGenSnapshotOptions.isNotEmpty)
         'EXTRA_GEN_SNAPSHOT_OPTIONS': extraGenSnapshotOptions.join(','),
       if (splitDebugInfoPath != null)
         'SPLIT_DEBUG_INFO': splitDebugInfoPath!,
-      if (trackWidgetCreation != null)
-        'TRACK_WIDGET_CREATION': trackWidgetCreation.toString(),
-      if (treeShakeIcons != null)
-        'TREE_SHAKE_ICONS': treeShakeIcons.toString(),
+      'TRACK_WIDGET_CREATION': trackWidgetCreation.toString(),
+      'TREE_SHAKE_ICONS': treeShakeIcons.toString(),
       if (performanceMeasurementFile != null)
         'PERFORMANCE_MEASUREMENT_FILE': performanceMeasurementFile!,
       if (bundleSkSLPath != null)
         'BUNDLE_SKSL_PATH': bundleSkSLPath!,
-      if (packagesPath != null)
-        'PACKAGE_CONFIG': packagesPath,
+      'PACKAGE_CONFIG': packagesPath,
       if (codeSizeDirectory != null)
         'CODE_SIZE_DIRECTORY': codeSizeDirectory!,
     };
@@ -317,18 +309,15 @@ class BuildInfo {
     final List<String> result = <String>[
       if (dartDefines.isNotEmpty)
         '-Pdart-defines=${encodeDartDefines(dartDefines)}',
-      if (dartObfuscation != null)
-        '-Pdart-obfuscation=$dartObfuscation',
+      '-Pdart-obfuscation=$dartObfuscation',
       if (extraFrontEndOptions.isNotEmpty)
         '-Pextra-front-end-options=${extraFrontEndOptions.join(',')}',
       if (extraGenSnapshotOptions.isNotEmpty)
         '-Pextra-gen-snapshot-options=${extraGenSnapshotOptions.join(',')}',
       if (splitDebugInfoPath != null)
         '-Psplit-debug-info=$splitDebugInfoPath',
-      if (trackWidgetCreation != null)
-        '-Ptrack-widget-creation=$trackWidgetCreation',
-      if (treeShakeIcons != null)
-        '-Ptree-shake-icons=$treeShakeIcons',
+      '-Ptrack-widget-creation=$trackWidgetCreation',
+      '-Ptree-shake-icons=$treeShakeIcons',
       if (performanceMeasurementFile != null)
         '-Pperformance-measurement-file=$performanceMeasurementFile',
       if (bundleSkSLPath != null)
@@ -870,14 +859,8 @@ FileSystemEntity getWebPlatformBinariesDirectory(Artifacts artifacts, WebRendere
 String getBuildDirectory([Config? config, FileSystem? fileSystem]) {
   // TODO(johnmccutchan): Stop calling this function as part of setting
   // up command line argument processing.
-  if (context == null) {
-    return 'build';
-  }
   final Config localConfig = config ?? globals.config;
   final FileSystem localFilesystem = fileSystem ?? globals.fs;
-  if (localConfig == null) {
-    return 'build';
-  }
 
   final String buildDir = localConfig.getValue('build-dir') as String? ?? 'build';
   if (localFilesystem.path.isAbsolute(buildDir)) {

--- a/packages/flutter_tools/lib/src/build_system/build_system.dart
+++ b/packages/flutter_tools/lib/src/build_system/build_system.dart
@@ -985,7 +985,7 @@ class Node {
     }
     final String content = stamp.readAsStringSync();
     // Something went wrong writing the stamp file.
-    if (content == null || content.isEmpty) {
+    if (content.isEmpty) {
       stamp.deleteSync();
       // Malformed stamp file, not safe to skip.
       _dirty = true;

--- a/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
+++ b/packages/flutter_tools/lib/src/build_system/targets/icon_tree_shaker.dart
@@ -42,12 +42,7 @@ class IconTreeShaker {
     required Logger logger,
     required FileSystem fileSystem,
     required Artifacts artifacts,
-  }) : assert(_environment != null),
-       assert(processManager != null),
-       assert(logger != null),
-       assert(fileSystem != null),
-       assert(artifacts != null),
-       _processManager = processManager,
+  }) : _processManager = processManager,
        _logger = logger,
        _fs = fileSystem,
        _artifacts = artifacts,
@@ -366,9 +361,7 @@ class _IconTreeShakerData {
     required this.family,
     required this.relativePath,
     required this.codePoints,
-  }) : assert(family != null),
-       assert(relativePath != null),
-       assert(codePoints != null);
+  });
 
   /// The font family name, e.g. "MaterialIcons".
   final String family;

--- a/packages/flutter_tools/lib/src/bundle_builder.dart
+++ b/packages/flutter_tools/lib/src/bundle_builder.dart
@@ -85,18 +85,16 @@ class BundleBuilder {
       }
       throwToolExit('Failed to build bundle.');
     }
-    if (depfilePath != null) {
-      final Depfile depfile = Depfile(result.inputFiles, result.outputFiles);
-      final File outputDepfile = globals.fs.file(depfilePath);
-      if (!outputDepfile.parent.existsSync()) {
-        outputDepfile.parent.createSync(recursive: true);
-      }
-      final DepfileService depfileService = DepfileService(
-        fileSystem: globals.fs,
-        logger: globals.logger,
-      );
-      depfileService.writeToFile(depfile, outputDepfile);
+    final Depfile depfile = Depfile(result.inputFiles, result.outputFiles);
+    final File outputDepfile = globals.fs.file(depfilePath);
+    if (!outputDepfile.parent.existsSync()) {
+      outputDepfile.parent.createSync(recursive: true);
     }
+    final DepfileService depfileService = DepfileService(
+      fileSystem: globals.fs,
+      logger: globals.logger,
+    );
+    depfileService.writeToFile(depfile, outputDepfile);
 
     // Work around for flutter_tester placing kernel artifacts in odd places.
     if (applicationKernelFilePath != null) {

--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -575,7 +575,7 @@ class Cache {
     final List<String> paths = <String>[];
     for (final ArtifactSet artifact in _artifacts) {
       final Map<String, String> env = artifact.environment;
-      if (env == null || !env.containsKey('DYLD_LIBRARY_PATH')) {
+      if (!env.containsKey('DYLD_LIBRARY_PATH')) {
         continue;
       }
       final String path = env['DYLD_LIBRARY_PATH']!;
@@ -721,7 +721,7 @@ class Cache {
 
 /// Representation of a set of artifacts used by the tool.
 abstract class ArtifactSet {
-  ArtifactSet(this.developmentArtifact) : assert(developmentArtifact != null);
+  ArtifactSet(this.developmentArtifact);
 
   /// The development artifact.
   final DevelopmentArtifact developmentArtifact;

--- a/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
+++ b/packages/flutter_tools/lib/src/commands/analyze_continuously.dart
@@ -113,9 +113,7 @@ class AnalyzeContinuously extends AnalyzeBase {
 
       for (final AnalysisError error in sortedErrors) {
         logger.printStatus(error.toString());
-        if (error.code != null) {
-          logger.printTrace('error code: ${error.code}');
-        }
+        logger.printTrace('error code: ${error.code}');
       }
 
       dumpErrors(sortedErrors.map<String>((AnalysisError error) => error.toLegacyString()));

--- a/packages/flutter_tools/lib/src/commands/assemble.dart
+++ b/packages/flutter_tools/lib/src/commands/assemble.dart
@@ -138,9 +138,6 @@ class AssembleCommand extends FlutterCommand {
   @override
   Future<CustomDimensions> get usageValues async {
     final FlutterProject flutterProject = FlutterProject.current();
-    if (flutterProject == null) {
-      return const CustomDimensions();
-    }
     try {
       return CustomDimensions(
         commandBuildBundleTargetPlatform: environment.defines[kTargetPlatform],

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -287,7 +287,7 @@ known, it can be explicitly provided to attach via the command-line, e.g.
 
     if ((debugPort == null && debugUri == null) || isNetworkDevice) {
       if (device is FuchsiaDevice) {
-        final String module = stringArgDeprecated('module')!;
+        final String? module = stringArgDeprecated('module');
         if (module == null) {
           throwToolExit("'--module' is required for attaching to a Fuchsia device");
         }

--- a/packages/flutter_tools/lib/src/commands/attach.dart
+++ b/packages/flutter_tools/lib/src/commands/attach.dart
@@ -439,7 +439,6 @@ known, it can be explicitly provided to attach via the command-line, e.g.
           throwToolExit(error.toString());
         }
         result = await app.runner!.waitForAppToFinish();
-        assert(result != null);
         return;
       }
       while (true) {
@@ -498,10 +497,6 @@ known, it can be explicitly provided to attach via the command-line, e.g.
     required FlutterProject flutterProject,
     required bool usesIpv6,
   }) async {
-    assert(observatoryUris != null);
-    assert(device != null);
-    assert(flutterProject != null);
-    assert(usesIpv6 != null);
     final BuildInfo buildInfo = await getBuildInfo();
 
     final FlutterDevice flutterDevice = await FlutterDevice.create(

--- a/packages/flutter_tools/lib/src/commands/build_aar.dart
+++ b/packages/flutter_tools/lib/src/commands/build_aar.dart
@@ -79,9 +79,6 @@ class BuildAarCommand extends BuildSubCommand {
   @override
   Future<CustomDimensions> get usageValues async {
     final FlutterProject flutterProject = _getProject();
-    if (flutterProject == null) {
-      return const CustomDimensions();
-    }
 
     String projectType;
     if (flutterProject.manifest.isModule) {

--- a/packages/flutter_tools/lib/src/commands/build_bundle.dart
+++ b/packages/flutter_tools/lib/src/commands/build_bundle.dart
@@ -77,9 +77,6 @@ class BuildBundleCommand extends BuildSubCommand {
   Future<CustomDimensions> get usageValues async {
     final String projectDir = globals.fs.file(targetFile).parent.parent.path;
     final FlutterProject flutterProject = FlutterProject.fromDirectory(globals.fs.directory(projectDir));
-    if (flutterProject == null) {
-      return const CustomDimensions();
-    }
     return CustomDimensions(
       commandBuildBundleTargetPlatform: stringArgDeprecated('target-platform'),
       commandBuildBundleIsModule: flutterProject.isModule,
@@ -98,9 +95,6 @@ class BuildBundleCommand extends BuildSubCommand {
   Future<FlutterCommandResult> runCommand() async {
     final String targetPlatform = stringArgDeprecated('target-platform')!;
     final TargetPlatform platform = getTargetPlatformForName(targetPlatform);
-    if (platform == null) {
-      throwToolExit('Unknown platform: $targetPlatform');
-    }
     // Check for target platforms that are only allowed via feature flags.
     switch (platform) {
       case TargetPlatform.darwin:

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -232,7 +232,7 @@ class CreateCommand extends CreateBase {
         'The "--platforms" argument is not supported in $template template.',
         exitCode: 2
       );
-    } else if (platforms == null || platforms.isEmpty) {
+    } else if (platforms.isEmpty) {
       throwToolExit('Must specify at least one platform using --platforms',
         exitCode: 2);
     } else if (generateFfiPlugin && argResults!.wasParsed('platforms') && platforms.contains('web')) {
@@ -731,7 +731,7 @@ Your plugin code is in $relativePluginMain.
 Your example app code is in $relativeExampleMain.
 
 ''');
-  if (platformsString != null && platformsString.isNotEmpty) {
+  if (platformsString.isNotEmpty) {
     globals.printStatus('''
 Host platform code is in the $platformsString directories under $pluginPath.
 To edit platform code in an IDE see https://flutter.dev/developing-packages/#edit-plugin-package.

--- a/packages/flutter_tools/lib/src/commands/create_base.dart
+++ b/packages/flutter_tools/lib/src/commands/create_base.dart
@@ -333,7 +333,6 @@ abstract class CreateBase extends FlutterCommand {
         throwToolExit(error);
       }
     }
-    assert(projectName != null);
     return projectName;
   }
 
@@ -688,7 +687,7 @@ abstract class CreateBase extends FlutterCommand {
       onFileCopied: (File sourceFile, File destinationFile) {
         filesCreated++;
         final String modes = sourceFile.statSync().modeString();
-        if (modes != null && modes.contains('x')) {
+        if (modes.contains('x')) {
           globals.os.makeExecutable(destinationFile);
         }
       },

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -434,13 +434,13 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
         // find a random port we can forward
         final int port = await _operatingSystemUtils.findFreePort();
 
-        final ForwardedPort forwardedPort = await (portForwarder.tryForward(port, port) as FutureOr<ForwardedPort>);
+        final ForwardedPort? forwardedPort = await portForwarder.tryForward(port, port);
         if (forwardedPort == null) {
           _printConfigCheckingError("Couldn't forward test port $port from device.",);
           result = false;
         }
 
-        await portForwarder.unforward(forwardedPort);
+        await portForwarder.unforward(forwardedPort!);
       } on Exception catch (e) {
         _printConfigCheckingError(
           'While forwarding/unforwarding device port: $e',

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -88,16 +88,7 @@ class CustomDevicesCommand extends FlutterCommand {
     required Logger logger,
     required FeatureFlags featureFlags,
     PrintFn usagePrintFn = print,
-  }) : assert(customDevicesConfig != null),
-       assert(operatingSystemUtils != null),
-       assert(terminal != null),
-       assert(platform != null),
-       assert(processManager != null),
-       assert(fileSystem != null),
-       assert(logger != null),
-       assert(featureFlags != null),
-       assert(usagePrintFn != null),
-       _customDevicesConfig = customDevicesConfig,
+  }) : _customDevicesConfig = customDevicesConfig,
        _featureFlags = featureFlags,
        _usagePrintFn = usagePrintFn
   {

--- a/packages/flutter_tools/lib/src/commands/custom_devices.dart
+++ b/packages/flutter_tools/lib/src/commands/custom_devices.dart
@@ -438,9 +438,9 @@ class CustomDevicesAddCommand extends CustomDevicesCommandBase {
         if (forwardedPort == null) {
           _printConfigCheckingError("Couldn't forward test port $port from device.",);
           result = false;
+        } else {
+          await portForwarder.unforward(forwardedPort);
         }
-
-        await portForwarder.unforward(forwardedPort!);
       } on Exception catch (e) {
         _printConfigCheckingError(
           'While forwarding/unforwarding device port: $e',

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -210,7 +210,6 @@ class Daemon {
 
     try {
       final String method = request.data['method']! as String;
-      assert(method != null);
       if (!method.contains('.')) {
         throw DaemonException('method not understood: $method');
       }

--- a/packages/flutter_tools/lib/src/commands/daemon.dart
+++ b/packages/flutter_tools/lib/src/commands/daemon.dart
@@ -1528,7 +1528,7 @@ class AppRunLogger extends DelegatingLogger {
         'id': eventId,
         'progressId': eventType,
         if (message != null) 'message': message,
-        if (finished != null) 'finished': finished,
+        'finished': finished,
       };
 
       domain!._sendAppEvent(app, 'progress', event);

--- a/packages/flutter_tools/lib/src/commands/drive.dart
+++ b/packages/flutter_tools/lib/src/commands/drive.dart
@@ -240,7 +240,7 @@ class DriveCommand extends RunCommandBase {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
-    final String testFile = _getTestFile()!;
+    final String? testFile = _getTestFile();
     if (testFile == null) {
       throwToolExit(null);
     }

--- a/packages/flutter_tools/lib/src/commands/emulators.dart
+++ b/packages/flutter_tools/lib/src/commands/emulators.dart
@@ -53,7 +53,7 @@ class EmulatorsCommand extends FlutterCommand {
       await _createEmulator(name: stringArgDeprecated('name'));
     } else {
       final String? searchText =
-          argumentResults.rest != null && argumentResults.rest.isNotEmpty
+          argumentResults.rest.isNotEmpty
               ? argumentResults.rest.first
               : null;
       await _listEmulators(searchText);

--- a/packages/flutter_tools/lib/src/commands/install.dart
+++ b/packages/flutter_tools/lib/src/commands/install.dart
@@ -104,10 +104,6 @@ Future<bool> installApp(
   String? userIdentifier,
   bool uninstall = true
 }) async {
-  if (package == null) {
-    return false;
-  }
-
   try {
     if (uninstall && await device.isAppInstalled(package, userIdentifier: userIdentifier)) {
       globals.printStatus('Uninstalling old version...');

--- a/packages/flutter_tools/lib/src/commands/run.dart
+++ b/packages/flutter_tools/lib/src/commands/run.dart
@@ -437,14 +437,14 @@ class RunCommand extends RunCommandBase {
     final List<String> hostLanguage = <String>[];
     if (anyAndroidDevices) {
       final AndroidProject androidProject = FlutterProject.current().android;
-      if (androidProject != null && androidProject.existsSync()) {
+      if (androidProject.existsSync()) {
         hostLanguage.add(androidProject.isKotlin ? 'kotlin' : 'java');
         androidEmbeddingVersion = androidProject.getEmbeddingVersion().toString().split('.').last;
       }
     }
     if (anyIOSDevices) {
       final IosProject iosProject = FlutterProject.current().ios;
-      if (iosProject != null && iosProject.exists) {
+      if (iosProject.exists) {
         final Iterable<File> swiftFiles = iosProject.hostAppRoot
             .listSync(recursive: true, followLinks: false)
             .whereType<File>()

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -64,7 +64,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
     this.testWrapper = const TestWrapper(),
     this.testRunner = const FlutterTestRunner(),
     this.verbose = false,
-  }) : assert(testWrapper != null) {
+  }) {
     requiresPubspecYaml();
     usesPubOption();
     addNullSafetyModeOptions(hide: !verboseHelp);

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -603,9 +603,7 @@ class UpdatePackagesCommand extends FlutterCommand {
       while (path != null) {
         buf.write(path.to);
         path = path.from!;
-        if (path != null) {
-          buf.write(' <- ');
-        }
+        buf.write(' <- ');
       }
       globals.printStatus(buf.toString(), wrap: false);
     }
@@ -878,7 +876,6 @@ class PubspecYaml {
   /// that depend on the Flutter or Dart SDK directly and are thus automatically
   /// pinned).
   void apply(PubDependencyTree versions, Set<String> specialDependencies) {
-    assert(versions != null);
     final List<String> output = <String>[]; // the string data to output to the file, line by line
     final Set<String> directDependencies = <String>{}; // packages this pubspec directly depends on (i.e. not transitive)
     final Set<String> devDependencies = <String>{};
@@ -1311,7 +1308,6 @@ class PubspecDependency extends PubspecLine {
   /// We return true if we parsed it and stored the line in lockLine.
   /// We return false if we parsed it and it's a git dependency that needs the next few lines.
   bool parseLock(String line, String pubspecPath, { required bool lockIsOverride }) {
-    assert(lockIsOverride != null);
     assert(kind == DependencyKind.unknown);
     if (line.startsWith(_pathPrefix)) {
       // We're a path dependency; remember the (absolute) path.
@@ -1545,8 +1541,6 @@ class PubDependencyTree {
     required Set<String> exclude,
     List<String>? result,
   }) {
-    assert(seen != null);
-    assert(exclude != null);
     result ??= <String>[];
     final Set<String>? dependencies = _dependencyTree[package];
     if (dependencies == null) {

--- a/packages/flutter_tools/lib/src/commands/update_packages.dart
+++ b/packages/flutter_tools/lib/src/commands/update_packages.dart
@@ -598,12 +598,14 @@ class UpdatePackagesCommand extends FlutterCommand {
       }
     }
 
-    for (_DependencyLink path in paths) {
+    for (_DependencyLink? path in paths) {
       final StringBuffer buf = StringBuffer();
       while (path != null) {
         buf.write(path.to);
-        path = path.from!;
-        buf.write(' <- ');
+        path = path.from;
+        if (path != null) {
+          buf.write(' <- ');
+        }
       }
       globals.printStatus(buf.toString(), wrap: false);
     }
@@ -1574,9 +1576,6 @@ String _computeChecksum(Iterable<String> names, String Function(String name) get
   final List<String> sortedNames = names.toList()..sort();
   for (final String name in sortedNames) {
     final String version = getVersion(name);
-    if (version == null) {
-      continue;
-    }
     final String value = '$name: $version';
     // Each code unit is 16 bits.
     for (final int codeUnit in value.codeUnits) {

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -775,11 +775,10 @@ class DefaultResidentCompiler implements ResidentCompiler {
       ],
       ...buildModeOptions(buildMode, dartDefines),
       if (trackWidgetCreation) '--track-widget-creation',
-      if (fileSystemRoots != null)
-        for (final String root in fileSystemRoots) ...<String>[
-          '--filesystem-root',
-          root,
-        ],
+      for (final String root in fileSystemRoots) ...<String>[
+        '--filesystem-root',
+        root,
+      ],
       if (fileSystemScheme != null) ...<String>[
         '--filesystem-scheme',
         fileSystemScheme!,

--- a/packages/flutter_tools/lib/src/compile.dart
+++ b/packages/flutter_tools/lib/src/compile.dart
@@ -590,8 +590,7 @@ class DefaultResidentCompiler implements ResidentCompiler {
     List<String>? dartDefines,
     this.librariesSpec,
     @visibleForTesting StdoutHandler? stdoutHandler,
-  }) : assert(sdkRoot != null),
-       _logger = logger,
+  }) : _logger = logger,
        _processManager = processManager,
        _artifacts = artifacts,
        _stdoutHandler = stdoutHandler ?? StdoutHandler(logger: logger, fileSystem: fileSystem),
@@ -654,7 +653,6 @@ class DefaultResidentCompiler implements ResidentCompiler {
     String? projectRootPath,
     FileSystem? fs,
   }) async {
-    assert(outputPath != null);
     if (!_controller.hasListener) {
       _controller.stream.listen(_handleCompilationRequest);
     }

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -14,8 +14,6 @@ Future<void> generateLocalizationsSyntheticPackage({
   required Environment environment,
   required BuildSystem buildSystem,
 }) async {
-  assert(environment != null);
-  assert(buildSystem != null);
 
   final FileSystem fileSystem = environment.fileSystem;
   final File l10nYamlFile = fileSystem.file(

--- a/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
+++ b/packages/flutter_tools/lib/src/dart/generate_synthetic_packages.dart
@@ -58,9 +58,6 @@ Future<void> generateLocalizationsSyntheticPackage({
     environment,
   );
 
-  if (result == null) {
-    throwToolExit('Generating synthetic localizations package failed: result is null.');
-  }
   if (result.hasException) {
     throwToolExit(
       'Generating synthetic localizations package failed with ${result.exceptions.length} ${pluralize('error', result.exceptions.length)}:'

--- a/packages/flutter_tools/lib/src/devfs.dart
+++ b/packages/flutter_tools/lib/src/devfs.dart
@@ -124,8 +124,7 @@ class DevFSFileContent extends DevFSContent {
     if (oldFileStat == null && newFileStat == null) {
       return false;
     }
-    return time == null
-        || oldFileStat == null
+    return oldFileStat == null
         || newFileStat == null
         || newFileStat.modified.isAfter(time);
   }
@@ -173,7 +172,7 @@ class DevFSByteContent extends DevFSContent {
 
   @override
   bool isModifiedAfter(DateTime time) {
-    return time == null || _modificationTime.isAfter(time);
+    return _modificationTime.isAfter(time);
   }
 
   @override
@@ -246,7 +245,7 @@ class DevFSStringCompressingBytesContent extends DevFSContent {
 
   @override
   bool isModifiedAfter(DateTime time) {
-    return time == null || _modificationTime.isAfter(time);
+    return _modificationTime.isAfter(time);
   }
 
   @override
@@ -594,8 +593,6 @@ class DevFS {
     String? projectRootPath,
     File? dartPluginRegistrant,
   }) async {
-    assert(trackWidgetCreation != null);
-    assert(generator != null);
     final DateTime candidateCompileTime = DateTime.now();
     didUpdateFontManifest = false;
     lastPackageConfig = packageConfig;
@@ -670,7 +667,7 @@ class DevFS {
               }
               dirtyEntries[deviceUri] = content;
               syncedBytes += content.size;
-              if (archivePath != null && !bundleFirstUpload) {
+              if (!bundleFirstUpload) {
                 shaderPathsToEvict.add(archivePath);
               }
             });
@@ -688,7 +685,7 @@ class DevFS {
               }
               dirtyEntries[deviceUri] = content;
               syncedBytes += content.size;
-              if (archivePath != null && !bundleFirstUpload) {
+              if (!bundleFirstUpload) {
                 scenePathsToEvict.add(archivePath);
               }
             });
@@ -698,7 +695,7 @@ class DevFS {
           case null:
             dirtyEntries[deviceUri] = content;
             syncedBytes += content.size;
-            if (archivePath != null && !bundleFirstUpload) {
+            if (!bundleFirstUpload) {
               assetPathsToEvict.add(archivePath);
             }
         }

--- a/packages/flutter_tools/lib/src/doctor_validator.dart
+++ b/packages/flutter_tools/lib/src/doctor_validator.dart
@@ -165,7 +165,6 @@ class ValidationResult {
   final List<ValidationMessage> messages;
 
   String get leadingBox {
-    assert(type != null);
     switch (type) {
       case ValidationType.crash:
         return '[☠]';
@@ -180,7 +179,6 @@ class ValidationResult {
   }
 
   String get coloredLeadingBox {
-    assert(type != null);
     switch (type) {
       case ValidationType.crash:
         return globals.terminal.color(leadingBox, TerminalColor.red);
@@ -196,7 +194,6 @@ class ValidationResult {
 
   /// The string representation of the type.
   String get typeStr {
-    assert(type != null);
     switch (type) {
       case ValidationType.crash:
         return 'crash';

--- a/packages/flutter_tools/lib/src/drive/drive_service.dart
+++ b/packages/flutter_tools/lib/src/drive/drive_service.dart
@@ -184,7 +184,7 @@ class FlutterDriverService extends DriverService {
         userIdentifier: userIdentifier,
         prebuiltApplication: prebuiltApplication,
       );
-      if (result != null && result.started) {
+      if (result.started) {
         break;
       }
       // On attempts past 1, assume the application is built correctly and re-use it.

--- a/packages/flutter_tools/lib/src/flutter_cache.dart
+++ b/packages/flutter_tools/lib/src/flutter_cache.dart
@@ -100,7 +100,7 @@ class PubDependencies extends ArtifactSet {
       logger: _logger,
       throwOnError: false,
     );
-    if (packageConfig == null || packageConfig == PackageConfig.empty) {
+    if (packageConfig == PackageConfig.empty) {
       return false;
     }
     for (final Package package in packageConfig.packages) {

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -42,7 +42,7 @@ class FlutterManifest {
   /// Returns null on missing or invalid manifest.
   @visibleForTesting
   static FlutterManifest? createFromString(String manifest, { required Logger logger }) {
-    return _createFromYaml(manifest != null ? loadYaml(manifest) : null, logger);
+    return _createFromYaml(loadYaml(manifest), logger);
   }
 
   static FlutterManifest? _createFromYaml(Object? yamlDocument, Logger logger) {
@@ -663,9 +663,6 @@ void _validateDeferredComponents(MapEntry<Object?, Object?> kvp, List<String> er
 }
 
 void _validateFonts(YamlList fonts, List<String> errors) {
-  if (fonts == null) {
-    return;
-  }
   const Set<int> fontWeights = <int>{
     100, 200, 300, 400, 500, 600, 700, 800, 900,
   };

--- a/packages/flutter_tools/lib/src/flutter_manifest.dart
+++ b/packages/flutter_tools/lib/src/flutter_manifest.dart
@@ -32,7 +32,7 @@ class FlutterManifest {
     required FileSystem fileSystem,
     required Logger logger,
   }) {
-    if (path == null || !fileSystem.isFileSync(path)) {
+    if (!fileSystem.isFileSync(path)) {
       return _createFromYaml(null, logger);
     }
     final String manifest = fileSystem.file(path).readAsStringSync();
@@ -237,7 +237,7 @@ class FlutterManifest {
         assetsUri = const <Uri>[];
       } else {
         for (final Object? asset in assets) {
-          if (asset is! String || asset == null || asset == '') {
+          if (asset is! String || asset == '') {
             _logger.printError('Deferred component asset manifest contains a null or empty uri.');
             continue;
           }
@@ -319,7 +319,7 @@ class FlutterManifest {
     }
     final List<Uri> results = <Uri>[];
     for (final Object? asset in assets) {
-      if (asset is! String || asset == null || asset == '') {
+      if (asset is! String || asset == '') {
         _logger.printError('Asset manifest contains a null or empty uri.');
         continue;
       }
@@ -387,7 +387,7 @@ class FlutterManifest {
     }
     final List<Uri> results = <Uri>[];
     for (final Object? item in items) {
-      if (item is! String || item == null || item == '') {
+      if (item is! String || item == '') {
         _logger.printError('$singularName manifest contains a null or empty uri.');
         continue;
       }
@@ -422,9 +422,7 @@ class FlutterManifest {
 
 class Font {
   Font(this.familyName, this.fontAssets)
-    : assert(familyName != null),
-      assert(fontAssets != null),
-      assert(fontAssets.isNotEmpty);
+    : assert(fontAssets.isNotEmpty);
 
   final String familyName;
   final List<FontAsset> fontAssets;
@@ -441,8 +439,7 @@ class Font {
 }
 
 class FontAsset {
-  FontAsset(this.assetUri, {this.weight, this.style})
-    : assert(assetUri != null);
+  FontAsset(this.assetUri, {this.weight, this.style});
 
   final Uri assetUri;
   final int? weight;
@@ -510,7 +507,7 @@ bool _validate(Object? manifest, Logger logger) {
 }
 
 void _validateFlutter(YamlMap? yaml, List<String> errors) {
-  if (yaml == null || yaml.entries == null) {
+  if (yaml == null) {
     return;
   }
   for (final MapEntry<Object?, Object?> kvp in yaml.entries) {
@@ -602,7 +599,7 @@ void _validateFlutter(YamlMap? yaml, List<String> errors) {
         }
         break;
       case 'plugin':
-        if (yamlValue is! YamlMap || yamlValue == null) {
+        if (yamlValue is! YamlMap) {
           errors.add('Expected "$yamlKey" to be an object, but got $yamlValue (${yamlValue.runtimeType}).');
           break;
         }

--- a/packages/flutter_tools/lib/src/flutter_plugins.dart
+++ b/packages/flutter_tools/lib/src/flutter_plugins.dart
@@ -361,7 +361,6 @@ List<Map<String, Object?>> _extractPlatformMaps(List<Plugin> plugins, String typ
 /// Returns the version of the Android embedding that the current
 /// [project] is using.
 AndroidEmbeddingVersion _getAndroidEmbeddingVersion(FlutterProject project) {
-  assert(project.android != null);
   return project.android.getEmbeddingVersion();
 }
 
@@ -912,9 +911,8 @@ List<Plugin> _filterPluginsByVariant(List<Plugin> plugins, String platformKey, P
     if (platformPlugin == null) {
       return false;
     }
-    assert(variant == null || platformPlugin is VariantPlatformPlugin);
-    return variant == null ||
-        (platformPlugin as VariantPlatformPlugin).supportedVariants.contains(variant);
+    assert(platformPlugin is VariantPlatformPlugin);
+    return (platformPlugin as VariantPlatformPlugin).supportedVariants.contains(variant);
   }).toList();
 }
 

--- a/packages/flutter_tools/lib/src/flutter_project_metadata.dart
+++ b/packages/flutter_tools/lib/src/flutter_project_metadata.dart
@@ -146,11 +146,6 @@ class FlutterProjectMetadata {
   /// needs to be able to write the .migrate_config file into legacy apps.
   void writeFile({File? outputFile}) {
     outputFile = outputFile ?? file;
-    if (outputFile == null) {
-      // In-memory FlutterProjectMetadata instances requires an output file to
-      // be passed or specified in the constructor.
-      throw const FileSystemException('No outputFile specified to write .metadata to. Initialize with a file or provide one when writing.');
-    }
     outputFile
       ..createSync(recursive: true)
       ..writeAsStringSync(toString(), flush: true);

--- a/packages/flutter_tools/lib/src/ios/mac.dart
+++ b/packages/flutter_tools/lib/src/ios/mac.dart
@@ -298,13 +298,11 @@ Future<XcodeBuildResult> buildXcodeProject({
 
   if (activeArch != null) {
     final String activeArchName = getNameForDarwinArch(activeArch);
-    if (activeArchName != null) {
-      buildCommands.add('ONLY_ACTIVE_ARCH=YES');
-      // Setting ARCHS to $activeArchName will break the build if a watchOS companion app exists,
-      // as it cannot be build for the architecture of the Flutter app.
-      if (!hasWatchCompanion) {
-        buildCommands.add('ARCHS=$activeArchName');
-      }
+    buildCommands.add('ONLY_ACTIVE_ARCH=YES');
+    // Setting ARCHS to $activeArchName will break the build if a watchOS companion app exists,
+    // as it cannot be build for the architecture of the Flutter app.
+    if (!hasWatchCompanion) {
+      buildCommands.add('ARCHS=$activeArchName');
     }
   }
 
@@ -550,7 +548,6 @@ Future<RunResult?> _runBuildWithRetries(List<String> buildCommands, BuildableIOS
 
 bool _isXcodeConcurrentBuildFailure(RunResult result) {
 return result.exitCode != 0 &&
-    result.stdout != null &&
     result.stdout.contains('database is locked') &&
     result.stdout.contains('there are two concurrent builds running');
 }

--- a/packages/flutter_tools/lib/src/ios/plist_parser.dart
+++ b/packages/flutter_tools/lib/src/ios/plist_parser.dart
@@ -66,7 +66,6 @@ class PlistParser {
   ///
   /// The [plistFilePath] argument must not be null.
   Map<String, Object> parseFile(String plistFilePath) {
-    assert(plistFilePath != null);
     if (!_fileSystem.isFileSync(plistFilePath)) {
       return const <String, Object>{};
     }

--- a/packages/flutter_tools/lib/src/ios/simulators.dart
+++ b/packages/flutter_tools/lib/src/ios/simulators.dart
@@ -865,9 +865,6 @@ class _IOSSimulatorLogReader extends DeviceLogReader {
     }
 
     final String filteredLine = _filterSystemLog(line);
-    if (filteredLine == null) {
-      return;
-    }
 
     _linesController.add(filteredLine);
   }

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -105,7 +105,7 @@ class WebExpressionCompiler implements ExpressionCompiler {
         await _generator.compileExpressionToJs(libraryUri, line, column,
             jsModules, jsFrameValues, moduleName, expression);
 
-    if (compilerOutput != null && compilerOutput.outputFilename != null) {
+    if (compilerOutput != null) {
       final String content = utf8.decode(
           _fileSystem.file(compilerOutput.outputFilename).readAsBytesSync());
       return ExpressionCompilationResult(
@@ -827,8 +827,6 @@ class WebDevFS implements DevFS {
     String? projectRootPath,
     File? dartPluginRegistrant,
   }) async {
-    assert(trackWidgetCreation != null);
-    assert(generator != null);
     lastPackageConfig = packageConfig;
     final File mainFile = globals.fs.file(mainUri);
     final String outputDirectoryPath = mainFile.parent.path;
@@ -1031,8 +1029,7 @@ class ReleaseAssetServer {
     } else {
       for (final Uri uri in _searchPaths()) {
         final Uri potential = uri.resolve(requestPath);
-        if (potential == null ||
-            !_fileSystem.isFileSync(
+        if (!_fileSystem.isFileSync(
                 potential.toFilePath(windows: _platform.isWindows))) {
           continue;
         }

--- a/packages/flutter_tools/lib/src/license_collector.dart
+++ b/packages/flutter_tools/lib/src/license_collector.dart
@@ -47,7 +47,7 @@ class LicenseCollector {
 
     for (final Package package in packageConfig.packages) {
       final Uri packageUri = package.packageUriRoot;
-      if (packageUri == null || packageUri.scheme != 'file') {
+      if (packageUri.scheme != 'file') {
         continue;
       }
       // First check for NOTICES, then fallback to LICENSE

--- a/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
+++ b/packages/flutter_tools/lib/src/localizations/gen_l10n_types.dart
@@ -185,7 +185,7 @@ class L10nMissingPlaceholderException extends L10nParserException {
 //   }
 // }
 class OptionalParameter {
-  const OptionalParameter(this.name, this.value) : assert(name != null), assert(value != null);
+  const OptionalParameter(this.name, this.value);
 
   final String name;
   final Object value;
@@ -226,9 +226,7 @@ class OptionalParameter {
 //
 class Placeholder {
   Placeholder(this.resourceId, this.name, Map<String, Object?> attributes)
-    : assert(resourceId != null),
-      assert(name != null),
-      example = _stringAttribute(resourceId, name, attributes, 'example'),
+    : example = _stringAttribute(resourceId, name, attributes, 'example'),
       type = _stringAttribute(resourceId, name, attributes, 'type'),
       format = _stringAttribute(resourceId, name, attributes, 'format'),
       optionalParameters = _optionalParameters(resourceId, name, attributes),
@@ -338,9 +336,7 @@ class Message {
       this.useEscaping = false,
       this.logger,
     }
-  ) : assert(templateBundle != null),
-      assert(allBundles != null),
-      assert(resourceId != null && resourceId.isNotEmpty),
+  ) : assert(resourceId.isNotEmpty),
       value = _value(templateBundle.resources, resourceId),
       description = _description(templateBundle.resources, resourceId, isResourceAttributeRequired),
       placeholders = _placeholders(templateBundle.resources, resourceId, isResourceAttributeRequired),
@@ -529,7 +525,6 @@ class Message {
 // Represents the contents of one ARB file.
 class AppResourceBundle {
   factory AppResourceBundle(File file) {
-    assert(file != null);
     // Assuming that the caller has verified that the file exists and is readable.
     Map<String, Object?> resources;
     try {
@@ -548,7 +543,7 @@ class AppResourceBundle {
 
     for (int index = 0; index < fileName.length; index += 1) {
       // If an underscore was found, check if locale string follows.
-      if (fileName[index] == '_' && fileName[index + 1] != null) {
+      if (fileName[index] == '_') {
         // If Locale.tryParse fails, it returns null.
         final Locale? parserResult = Locale.tryParse(fileName.substring(index + 1));
         // If the parserResult is not an actual locale identifier, end the loop.
@@ -613,7 +608,6 @@ class AppResourceBundle {
 // Represents all of the ARB files in [directory] as [AppResourceBundle]s.
 class AppResourceBundleCollection {
   factory AppResourceBundleCollection(Directory directory) {
-    assert(directory != null);
     // Assuming that the caller has verified that the directory is readable.
 
     final RegExp filenameRE = RegExp(r'(\w+)\.arb$');

--- a/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
+++ b/packages/flutter_tools/lib/src/localizations/localizations_utils.dart
@@ -51,7 +51,7 @@ class LocaleInfo implements Comparable<LocaleInfo> {
       scriptCode = codes[1].length > codes[2].length ? codes[1] : codes[2];
       countryCode = codes[1].length < codes[2].length ? codes[1] : codes[2];
     }
-    assert(codes[0] != null && codes[0].isNotEmpty);
+    assert(codes[0].isNotEmpty);
     assert(countryCode == null || countryCode.isNotEmpty);
     assert(scriptCode == null || scriptCode.isNotEmpty);
 
@@ -340,7 +340,7 @@ class LocalizationOptions {
     this.format = false,
     this.useEscaping = false,
     this.suppressWarnings = false,
-  }) : assert(useSyntheticPackage != null);
+  });
 
   /// The `--arb-dir` argument.
   ///

--- a/packages/flutter_tools/lib/src/macos/xcode.dart
+++ b/packages/flutter_tools/lib/src/macos/xcode.dart
@@ -113,9 +113,9 @@ class Xcode {
         final RunResult result = _processUtils.runSync(
           <String>[...xcrunCommand(), 'clang'],
         );
-        if (result.stdout != null && result.stdout.contains('license')) {
+        if (result.stdout.contains('license')) {
           _eulaSigned = false;
-        } else if (result.stderr != null && result.stderr.contains('license')) {
+        } else if (result.stderr.contains('license')) {
           _eulaSigned = false;
         } else {
           _eulaSigned = true;
@@ -181,7 +181,6 @@ class Xcode {
   }
 
   Future<String> sdkLocation(EnvironmentType environmentType) async {
-    assert(environmentType != null);
     final RunResult runResult = await _processUtils.run(
       <String>[...xcrunCommand(), '--sdk', getSDKNameForIOSEnvironmentType(environmentType), '--show-sdk-path'],
     );
@@ -202,7 +201,6 @@ class Xcode {
 }
 
 EnvironmentType? environmentTypeFromSdkroot(String sdkroot, FileSystem fileSystem) {
-  assert(sdkroot != null);
   // iPhoneSimulator.sdk or iPhoneOS.sdk
   final String sdkName = fileSystem.path.basename(sdkroot).toLowerCase();
   if (sdkName.contains('iphone')) {

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -279,7 +279,7 @@ class MDnsVmServiceDiscovery {
               ResourceRecordQuery.text(domainName),
           )
           .toList();
-        if (txt == null || txt.isEmpty) {
+        if (txt.isEmpty) {
           results.add(MDnsVmServiceDiscoveryResult(domainName, srvRecord.port, ''));
           if (quitOnFind) {
             return results;

--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -110,9 +110,6 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
   bool hasDart() => dartPluginClass != null;
 
   static bool validate(YamlMap yaml) {
-    if (yaml == null) {
-      return false;
-    }
     return (yaml['package'] is String && yaml[kPluginClass] is String) ||
         yaml[kDartPluginClass] is String ||
         yaml[kFfiPlugin] == true ||
@@ -261,9 +258,6 @@ class IOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPlug
   }
 
   static bool validate(YamlMap yaml) {
-    if (yaml == null) {
-      return false;
-    }
     return yaml[kPluginClass] is String ||
         yaml[kDartPluginClass] is String ||
         yaml[kFfiPlugin] == true ||
@@ -345,9 +339,6 @@ class MacOSPlugin extends PluginPlatform implements NativeOrDartPlugin, DarwinPl
   }
 
   static bool validate(YamlMap yaml) {
-    if (yaml == null) {
-      return false;
-    }
     return yaml[kPluginClass] is String ||
         yaml[kDartPluginClass] is String ||
         yaml[kFfiPlugin] == true ||
@@ -442,10 +433,6 @@ class WindowsPlugin extends PluginPlatform
   }
 
   static bool validate(YamlMap yaml) {
-    if (yaml == null) {
-      return false;
-    }
-
     return yaml[kPluginClass] is String ||
         yaml[kDartPluginClass] is String ||
         yaml[kFfiPlugin] == true ||
@@ -517,9 +504,6 @@ class LinuxPlugin extends PluginPlatform implements NativeOrDartPlugin {
   }
 
   static bool validate(YamlMap yaml) {
-    if (yaml == null) {
-      return false;
-    }
     return yaml[kPluginClass] is String ||
         yaml[kDartPluginClass] is String ||
         yaml[kFfiPlugin] == true ||

--- a/packages/flutter_tools/lib/src/platform_plugins.dart
+++ b/packages/flutter_tools/lib/src/platform_plugins.dart
@@ -161,7 +161,6 @@ class AndroidPlugin extends PluginPlatform implements NativeOrDartPlugin {
   late final Set<String> _supportedEmbeddings = _getSupportedEmbeddings();
 
   Set<String> _getSupportedEmbeddings() {
-    assert(pluginPath != null);
     final Set<String> supportedEmbeddings = <String>{};
     final String baseMainPath = _fileSystem.path.join(
       pluginPath,

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -20,13 +20,7 @@ class Plugin {
     required this.dependencies,
     required this.isDirectDependency,
     this.implementsPackage,
-  }) : assert(name != null),
-       assert(path != null),
-       assert(platforms != null),
-       assert(defaultPackagePlatforms != null),
-       assert(pluginDartClassPlatforms != null),
-       assert(dependencies != null),
-       assert(isDirectDependency != null);
+  });
 
   /// Parses [Plugin] specification from the provided pluginYaml.
   ///
@@ -194,26 +188,22 @@ class Plugin {
   ) {
     final Map<String, PluginPlatform> platforms = <String, PluginPlatform>{};
     final String pluginClass = (pluginYaml as Map<dynamic, dynamic>)['pluginClass'] as String;
-    if (pluginYaml != null && pluginClass != null) {
-      final String androidPackage = pluginYaml['androidPackage'] as String;
-      if (androidPackage != null) {
-        platforms[AndroidPlugin.kConfigKey] = AndroidPlugin(
-          name: name,
-          package: pluginYaml['androidPackage'] as String,
-          pluginClass: pluginClass,
-          pluginPath: path,
-          fileSystem: fileSystem,
-        );
-      }
+    final String androidPackage = pluginYaml['androidPackage'] as String;
+    platforms[AndroidPlugin.kConfigKey] = AndroidPlugin(
+      name: name,
+      package: pluginYaml['androidPackage'] as String,
+      pluginClass: pluginClass,
+      pluginPath: path,
+      fileSystem: fileSystem,
+    );
 
-      final String iosPrefix = pluginYaml['iosPrefix'] as String? ?? '';
-      platforms[IOSPlugin.kConfigKey] =
-          IOSPlugin(
-            name: name,
-            classPrefix: iosPrefix,
-            pluginClass: pluginClass,
-          );
-    }
+    final String iosPrefix = pluginYaml['iosPrefix'] as String? ?? '';
+    platforms[IOSPlugin.kConfigKey] =
+        IOSPlugin(
+          name: name,
+          classPrefix: iosPrefix,
+          pluginClass: pluginClass,
+        );
     return Plugin(
       name: name,
       path: path,
@@ -410,8 +400,7 @@ class PluginInterfaceResolution {
   PluginInterfaceResolution({
     required this.plugin,
     required this.platform,
-  }) : assert(plugin != null),
-       assert(platform != null);
+  });
 
   /// The plugin.
   final Plugin plugin;

--- a/packages/flutter_tools/lib/src/plugins.dart
+++ b/packages/flutter_tools/lib/src/plugins.dart
@@ -187,23 +187,27 @@ class Plugin {
     bool isDirectDependency,
   ) {
     final Map<String, PluginPlatform> platforms = <String, PluginPlatform>{};
-    final String pluginClass = (pluginYaml as Map<dynamic, dynamic>)['pluginClass'] as String;
-    final String androidPackage = pluginYaml['androidPackage'] as String;
-    platforms[AndroidPlugin.kConfigKey] = AndroidPlugin(
-      name: name,
-      package: pluginYaml['androidPackage'] as String,
-      pluginClass: pluginClass,
-      pluginPath: path,
-      fileSystem: fileSystem,
-    );
-
-    final String iosPrefix = pluginYaml['iosPrefix'] as String? ?? '';
-    platforms[IOSPlugin.kConfigKey] =
-        IOSPlugin(
+    final String? pluginClass = (pluginYaml as Map<dynamic, dynamic>)['pluginClass'] as String?;
+    if (pluginClass != null) {
+      final String? androidPackage = pluginYaml['androidPackage'] as String?;
+      if (androidPackage != null) {
+        platforms[AndroidPlugin.kConfigKey] = AndroidPlugin(
           name: name,
-          classPrefix: iosPrefix,
+          package: pluginYaml['androidPackage'] as String,
           pluginClass: pluginClass,
+          pluginPath: path,
+          fileSystem: fileSystem,
         );
+      }
+
+      final String iosPrefix = pluginYaml['iosPrefix'] as String? ?? '';
+      platforms[IOSPlugin.kConfigKey] =
+          IOSPlugin(
+            name: name,
+            classPrefix: iosPrefix,
+            pluginClass: pluginClass,
+          );
+    }
     return Plugin(
       name: name,
       path: path,

--- a/packages/flutter_tools/lib/src/project.dart
+++ b/packages/flutter_tools/lib/src/project.dart
@@ -56,7 +56,6 @@ class FlutterProjectFactory {
   /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
   /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
   FlutterProject fromDirectory(Directory directory) {
-    assert(directory != null);
     return projects.putIfAbsent(directory.path, () {
       final FlutterManifest manifest = FlutterProject._readManifest(
         directory.childFile(bundle.defaultManifestPath).path,
@@ -86,10 +85,7 @@ class FlutterProjectFactory {
 /// cached.
 class FlutterProject {
   @visibleForTesting
-  FlutterProject(this.directory, this.manifest, this._exampleManifest)
-    : assert(directory != null),
-      assert(manifest != null),
-      assert(_exampleManifest != null);
+  FlutterProject(this.directory, this.manifest, this._exampleManifest);
 
   /// Returns a [FlutterProject] view of the given directory or a ToolExit error,
   /// if `pubspec.yaml` or `example/pubspec.yaml` is invalid.
@@ -176,7 +172,7 @@ class FlutterProject {
   }
 
   String? _organizationNameFromPackageName(String packageName) {
-    if (packageName != null && 0 <= packageName.lastIndexOf('.')) {
+    if (0 <= packageName.lastIndexOf('.')) {
       return packageName.substring(0, packageName.lastIndexOf('.'));
     }
     return null;
@@ -645,7 +641,7 @@ The detected reason was:
       // the v1 embedding, we should check for this once removal is further along.
       return AndroidEmbeddingVersionResult(AndroidEmbeddingVersion.v2, 'Is plugin');
     }
-    if (appManifestFile == null || !appManifestFile.existsSync()) {
+    if (!appManifestFile.existsSync()) {
       return AndroidEmbeddingVersionResult(AndroidEmbeddingVersion.v1, 'No `${appManifestFile.absolute.path}` file');
     }
     XmlDocument document;

--- a/packages/flutter_tools/lib/src/protocol_discovery.dart
+++ b/packages/flutter_tools/lib/src/protocol_discovery.dart
@@ -22,8 +22,7 @@ class ProtocolDiscovery {
     this.devicePort,
     required this.ipv6,
     required Logger logger,
-  }) : _logger = logger,
-       assert(logReader != null) {
+  }) : _logger = logger {
     _deviceLogSubscription = logReader.logLines.listen(
       _handleLine,
       onDone: _stopScrapingLogs,
@@ -217,7 +216,6 @@ class _BufferedStreamController<T> {
 StreamTransformer<S, S> _throttle<S>({
   required Duration waitDuration,
 }) {
-  assert(waitDuration != null);
 
   S latestLine;
   int? lastExecution;

--- a/packages/flutter_tools/lib/src/reporting/events.dart
+++ b/packages/flutter_tools/lib/src/reporting/events.dart
@@ -191,9 +191,7 @@ class BuildEvent extends UsageEvent {
 /// An event that reports the result of a top-level command.
 class CommandResultEvent extends UsageEvent {
   CommandResultEvent(super.commandPath, super.result)
-      : assert(commandPath != null),
-        assert(result != null),
-        super(flutterUsage: globals.flutterUsage);
+      : super(flutterUsage: globals.flutterUsage);
 
   @override
   void send() {

--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -125,7 +125,7 @@ ${_projectMetadataInformation()}
     }
     try {
       final FlutterManifest manifest = project.manifest;
-      if (project == null || manifest == null || manifest.isEmpty) {
+      if (manifest.isEmpty) {
         return 'No pubspec in working directory.';
       }
       final FlutterProjectMetadata metadata = FlutterProjectMetadata(project.metadataFile, _logger);

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -395,10 +395,6 @@ class FlutterDevice {
       return;
     }
     final Stream<String> logStream = (await device!.getLogReader(app: package)).logLines;
-    if (logStream == null) {
-      globals.printError('Failed to read device log stream');
-      return;
-    }
     _loggingSubscription = logStream.listen((String line) {
       if (!line.contains(globals.kVMServiceMessageRegExp)) {
         globals.printStatus(line, wrap: false);
@@ -513,18 +509,10 @@ class FlutterDevice {
 
     final String modeName = coldRunner.debuggingOptions.buildInfo.friendlyModeName;
     final bool prebuiltMode = coldRunner.applicationBinary != null;
-    if (coldRunner.mainPath == null) {
-      assert(prebuiltMode);
-      globals.printStatus(
-        'Launching ${applicationPackage.displayName} '
-        'on ${device!.name} in $modeName mode...',
-      );
-    } else {
-      globals.printStatus(
-        'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
-        'on ${device!.name} in $modeName mode...',
-      );
-    }
+    globals.printStatus(
+      'Launching ${getDisplayPath(coldRunner.mainPath, globals.fs)} '
+      'on ${device!.name} in $modeName mode...',
+    );
 
     final Map<String, dynamic> platformArgs = <String, dynamic>{};
     platformArgs['trace-startup'] = coldRunner.traceStartup;
@@ -1907,9 +1895,6 @@ class DevToolsServerAddress {
   final int port;
 
   Uri? get uri {
-    if (port == null) {
-      return null;
-    }
     return Uri(scheme: 'http', host: host, port: port);
   }
 }

--- a/packages/flutter_tools/lib/src/resident_runner.dart
+++ b/packages/flutter_tools/lib/src/resident_runner.dart
@@ -53,8 +53,7 @@ class FlutterDevice {
     this.userIdentifier,
     required this.developmentShaderCompiler,
     this.developmentSceneImporter,
-  }) : assert(buildInfo.trackWidgetCreation != null),
-       generator = generator ?? ResidentCompiler(
+  }) : generator = generator ?? ResidentCompiler(
          globals.artifacts!.getArtifactPath(
            Artifact.flutterPatchedSdkPath,
            platform: targetPlatform,
@@ -528,9 +527,7 @@ class FlutterDevice {
     }
 
     final Map<String, dynamic> platformArgs = <String, dynamic>{};
-    if (coldRunner.traceStartup != null) {
-      platformArgs['trace-startup'] = coldRunner.traceStartup;
-    }
+    platformArgs['trace-startup'] = coldRunner.traceStartup;
     platformArgs['multidex'] = coldRunner.multidexEnabled;
 
     await startEchoingDeviceLog();
@@ -1433,7 +1430,6 @@ abstract class ResidentRunner extends ResidentHandlers {
 
   Future<int> waitForAppToFinish() async {
     final int exitCode = await _finished.future;
-    assert(exitCode != null);
     await cleanupAtFinish();
     return exitCode;
   }
@@ -1911,7 +1907,7 @@ class DevToolsServerAddress {
   final int port;
 
   Uri? get uri {
-    if (host == null || port == null) {
+    if (port == null) {
       return null;
     }
     return Uri(scheme: 'http', host: host, port: port);

--- a/packages/flutter_tools/lib/src/run_hot.dart
+++ b/packages/flutter_tools/lib/src/run_hot.dart
@@ -1380,7 +1380,6 @@ String _describePausedIsolates(int pausedIsolatesFound, String serviceEventKind)
     message.write('$pausedIsolatesFound isolates are ');
     plural = true;
   }
-  assert(serviceEventKind != null);
   switch (serviceEventKind) {
     case vm_service.EventKind.kPauseStart:
       message.write('paused (probably due to --start-paused)');
@@ -1453,8 +1452,6 @@ class ProjectFileInvalidator {
     required PackageConfig packageConfig,
     bool asyncScanning = false,
   }) async {
-    assert(urisToMonitor != null);
-    assert(packagesPath != null);
 
     if (lastCompiled == null) {
       // Initial load.
@@ -1484,7 +1481,7 @@ class ProjectFileInvalidator {
             :  _fileSystem.stat(uri.toFilePath(windows: _platform.isWindows)))
             .then((FileStat stat) {
               final DateTime updatedAt = stat.modified;
-              if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
+              if (updatedAt.isAfter(lastCompiled)) {
                 invalidatedFiles.add(uri);
               }
             })
@@ -1498,7 +1495,7 @@ class ProjectFileInvalidator {
         final DateTime updatedAt = uri.hasScheme && uri.scheme != 'file'
           ? _fileSystem.file(uri).statSync().modified
           : _fileSystem.statSync(uri.toFilePath(windows: _platform.isWindows)).modified;
-        if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
+        if (updatedAt.isAfter(lastCompiled)) {
           invalidatedFiles.add(uri);
         }
       }
@@ -1507,7 +1504,7 @@ class ProjectFileInvalidator {
     final File packageFile = _fileSystem.file(packagesPath);
     final Uri packageUri = packageFile.uri;
     final DateTime updatedAt = packageFile.statSync().modified;
-    if (updatedAt != null && updatedAt.isAfter(lastCompiled)) {
+    if (updatedAt.isAfter(lastCompiled)) {
       invalidatedFiles.add(packageUri);
       packageConfig = await _createPackageConfig(packagesPath);
       // The frontend_server might be monitoring the package_config.json file,

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1344,16 +1344,12 @@ abstract class FlutterCommand extends Command<void> {
     DateTime startTime,
     DateTime endTime,
   ) {
-    if (commandPath == null) {
-      return;
-    }
     // Send command result.
     CommandResultEvent(commandPath, commandResult.toString()).send();
 
     // Send timing.
     final List<String?> labels = <String?>[
-      if (commandResult.exitStatus != null)
-        getEnumName(commandResult.exitStatus),
+      getEnumName(commandResult.exitStatus),
       if (commandResult.timingLabelParts?.isNotEmpty ?? false)
         ...?commandResult.timingLabelParts,
     ];

--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1347,7 +1347,6 @@ abstract class FlutterCommand extends Command<void> {
     if (commandPath == null) {
       return;
     }
-    assert(commandResult != null);
     // Send command result.
     CommandResultEvent(commandPath, commandResult.toString()).send();
 
@@ -1752,4 +1751,4 @@ DevelopmentArtifact? artifactFromTargetPlatform(TargetPlatform targetPlatform) {
 }
 
 /// Returns true if s is either null, empty or is solely made of whitespace characters (as defined by String.trim).
-bool _isBlank(String s) => s == null || s.trim().isEmpty;
+bool _isBlank(String s) => s.trim().isEmpty;

--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -274,9 +274,7 @@ class FlutterCommandRunner extends CommandRunner<void> {
           String status;
           if (machineFlag) {
             final Map<String, Object> jsonOut = globals.flutterVersion.toJson();
-            if (jsonOut != null) {
-              jsonOut['flutterRoot'] = Cache.flutterRoot!;
-            }
+            jsonOut['flutterRoot'] = Cache.flutterRoot!;
             status = const JsonEncoder.withIndent('  ').convert(jsonOut);
           } else {
             status = globals.flutterVersion.toString();

--- a/packages/flutter_tools/lib/src/runner/local_engine.dart
+++ b/packages/flutter_tools/lib/src/runner/local_engine.dart
@@ -142,7 +142,7 @@ class LocalEngineLocator {
         .parent
         .parent
         .path;
-      if (engineSourcePath != null && (engineSourcePath == _fileSystem.path.dirname(engineSourcePath) || engineSourcePath.isEmpty)) {
+      if (engineSourcePath == _fileSystem.path.dirname(engineSourcePath) || engineSourcePath.isEmpty) {
         engineSourcePath = null;
         throwToolExit(
           _userMessages.runnerNoEngineSrcDir(

--- a/packages/flutter_tools/lib/src/template.dart
+++ b/packages/flutter_tools/lib/src/template.dart
@@ -228,7 +228,7 @@ class Template {
         .replaceAll(testTemplateExtension, '')
         .replaceAll(templateExtension, '');
 
-      if (android != null && android && androidIdentifier != null) {
+      if (android && androidIdentifier != null) {
         finalDestinationPath = finalDestinationPath
             .replaceAll('androidIdentifier', androidIdentifier.replaceAll('.', pathSeparator));
       }

--- a/packages/flutter_tools/lib/src/test/coverage_collector.dart
+++ b/packages/flutter_tools/lib/src/test/coverage_collector.dart
@@ -104,9 +104,6 @@ class CoverageCollector extends TestWatcher {
     _logMessage('collecting coverage data from $observatoryUri...');
     final Map<String, dynamic> data = await collect(
         observatoryUri, libraryNames, branchCoverage: branchCoverage);
-    if (data == null) {
-      throw Exception('Failed to collect coverage.');
-    }
 
     _logMessage('($observatoryUri): collected coverage data; merging...');
     _addHitmap(await coverage.HitMap.parseJson(
@@ -146,9 +143,6 @@ class CoverageCollector extends TestWatcher {
             observatoryUri!, libraryNames, serviceOverride: serviceOverride,
             branchCoverage: branchCoverage)
           .then<void>((Map<String, dynamic> result) {
-            if (result == null) {
-              throw Exception('Failed to collect coverage.');
-            }
             _logMessage('Collected coverage data.');
             data = result;
           });

--- a/packages/flutter_tools/lib/src/test/flutter_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_platform.dart
@@ -68,7 +68,6 @@ FlutterPlatform installHook({
   TestTimeRecorder? testTimeRecorder,
   UriConverter? uriConverter,
 }) {
-  assert(testWrapper != null);
   assert(enableObservatory || (!debuggingOptions.startPaused && debuggingOptions.hostVmServicePort == null));
 
   // registerPlatformPlugin can be injected for testing since it's not very mock-friendly.
@@ -134,9 +133,6 @@ String generateTestBootstrap({
   bool flutterTestDep = true,
   bool integrationTest = false,
 }) {
-  assert(testUrl != null);
-  assert(host != null);
-  assert(updateGoldens != null);
 
   final String websocketUrl = host.type == InternetAddressType.IPv4
       ? 'ws://${host.address}'
@@ -294,7 +290,7 @@ class FlutterPlatform extends PlatformPlugin {
     this.integrationTestUserIdentifier,
     this.testTimeRecorder,
     this.uriConverter,
-  }) : assert(shellPath != null);
+  });
 
   final String shellPath;
   final DebuggingOptions debuggingOptions;

--- a/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_tester_device.dart
@@ -44,8 +44,7 @@ class FlutterTesterTestDevice extends TestDevice {
     required this.compileExpression,
     required this.fontConfigManager,
     required this.uriConverter,
-  })  : assert(shellPath != null), // Please provide the path to the shell in the SKY_SHELL environment variable.
-        assert(!debuggingOptions.startPaused || enableObservatory),
+  })  : assert(!debuggingOptions.startPaused || enableObservatory),
         _gotProcessObservatoryUri = enableObservatory
             ? Completer<Uri?>() : (Completer<Uri?>()..complete());
 
@@ -200,7 +199,6 @@ class FlutterTesterTestDevice extends TestDevice {
 
   @override
   Future<Uri?> get observatoryUri {
-    assert(_gotProcessObservatoryUri != null);
     return _gotProcessObservatoryUri.future;
   }
 
@@ -303,15 +301,14 @@ class FlutterTesterTestDevice extends TestDevice {
           if (match != null) {
             try {
               final Uri uri = Uri.parse(match[1]!);
-              if (reportObservatoryUri != null) {
-                await reportObservatoryUri(uri);
-              }
+              await reportObservatoryUri(uri);
             } on Exception catch (error) {
               logger.printError('Could not parse shell observatory port message: $error');
             }
-          } else if (line != null) {
+          } else {
             logger.printStatus('Shell: $line');
           }
+
         },
         onError: (dynamic error) {
           logger.printError('shell console stream for process pid ${process.pid} experienced an unexpected error: $error');

--- a/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_goldens.dart
@@ -108,12 +108,7 @@ class TestGoldenComparator {
     process.sendCommand(imageFile, goldenKey, updateGoldens);
 
     final Map<String, dynamic> result = await process.getResponse();
-
-    if (result == null) {
-      return 'unknown error';
-    } else {
-      return (result['success'] as bool) ? null : ((result['message'] as String?) ?? 'does not match');
-    }
+    return (result['success'] as bool) ? null : ((result['message'] as String?) ?? 'does not match');
   }
 }
 

--- a/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
+++ b/packages/flutter_tools/lib/src/test/flutter_web_platform.dart
@@ -396,10 +396,6 @@ class FlutterWebPlatform extends PlatformPlugin {
         return shelf.Response.ok('Caught exception: $ex');
       }
 
-      if (bytes == null) {
-        return shelf.Response.ok('Unknown error, bytes is null');
-      }
-
       final String? errorMessage = await _testGoldenComparator.compareGoldens(testUri, bytes, goldenKey, updateGoldens);
       return shelf.Response.ok(errorMessage ?? 'true');
     } else {

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../artifacts.dart';
-import '../base/common.dart';
 import '../base/file_system.dart';
 import '../base/io.dart';
 import '../device.dart';
@@ -144,9 +143,6 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         testFiles: testFiles,
         buildInfo: debuggingOptions.buildInfo,
       );
-      if (result == null) {
-        throwToolExit('Failed to compile tests');
-      }
       testArgs
         ..add('--platform=chrome')
         ..add('--')

--- a/packages/flutter_tools/lib/src/vmservice.dart
+++ b/packages/flutter_tools/lib/src/vmservice.dart
@@ -1009,7 +1009,6 @@ class FlutterVmService {
 
   /// Set the VM timeline flags.
   Future<void> setTimelineFlags(List<String> recordedStreams) async {
-    assert(recordedStreams != null);
     await _checkedCallServiceExtension(
       'setVMTimelineFlags',
       args: <String, Object?>{

--- a/packages/flutter_tools/lib/src/web/chrome.dart
+++ b/packages/flutter_tools/lib/src/web/chrome.dart
@@ -73,9 +73,6 @@ String findChromeExecutable(Platform platform, FileSystem fileSystem) {
         platform.environment['PROGRAMFILES(X86)']!,
     ];
     final String windowsPrefix = kWindowsPrefixes.firstWhere((String prefix) {
-      if (prefix == null) {
-        return false;
-      }
       final String path = fileSystem.path.join(prefix, kWindowsExecutable);
       return fileSystem.file(path).existsSync();
     }, orElse: () => '.');
@@ -102,9 +99,6 @@ String findEdgeExecutable(Platform platform, FileSystem fileSystem) {
         platform.environment['PROGRAMFILES(X86)']!,
     ];
     final String windowsPrefix = kWindowsPrefixes.firstWhere((String prefix) {
-      if (prefix == null) {
-        return false;
-      }
       final String path = fileSystem.path.join(prefix, kWindowsEdgeExecutable);
       return fileSystem.file(path).existsSync();
     }, orElse: () => '.');

--- a/packages/flutter_tools/lib/src/web/compile.dart
+++ b/packages/flutter_tools/lib/src/web/compile.dart
@@ -67,10 +67,9 @@ Future<void> buildWeb(
             kBaseHref : baseHref,
           kSourceMapsEnabled: sourceMaps.toString(),
           kNativeNullAssertions: nativeNullAssertions.toString(),
-          if (serviceWorkerStrategy != null)
           kServiceWorkerStrategy: serviceWorkerStrategy,
           if (dart2jsOptimization != null)
-          kDart2jsOptimization: dart2jsOptimization,
+            kDart2jsOptimization: dart2jsOptimization,
           kDart2jsDumpInfo: dumpInfo.toString(),
           kDart2jsNoFrequencyBasedMinification: noFrequencyBasedMinification.toString(),
           ...buildInfo.toBuildSystemEnvironment(),

--- a/packages/flutter_tools/lib/src/web/memory_fs.dart
+++ b/packages/flutter_tools/lib/src/web/memory_fs.dart
@@ -37,9 +37,6 @@ class WebMemoryFS {
     final Map<String, dynamic> manifest =
         castStringKeyedMap(json.decode(manifestFile.readAsStringSync()))!;
     for (final String filePath in manifest.keys) {
-      if (filePath == null) {
-        continue;
-      }
       final Map<String, dynamic> offsets =
           castStringKeyedMap(manifest[filePath])!;
       final List<int> codeOffsets =

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -153,7 +153,7 @@ abstract class ChromiumDevice extends Device {
       );
     }
     _logger.sendEvent('app.webLaunchUrl', <String, Object>{'url': url, 'launched': launchChrome});
-    return LaunchResult.succeeded(observatoryUri: url != null ? Uri.parse(url): null);
+    return LaunchResult.succeeded(observatoryUri: Uri.parse(url));
   }
 
   @override

--- a/packages/flutter_tools/lib/src/xcode_project.dart
+++ b/packages/flutter_tools/lib/src/xcode_project.dart
@@ -329,7 +329,7 @@ class IosProject extends XcodeBasedProject {
       xcodeProject.path,
       buildContext: buildContext,
     );
-    if (buildSettings != null && buildSettings.isNotEmpty) {
+    if (buildSettings.isNotEmpty) {
       // No timeouts, flakes, or errors.
       return buildSettings;
     }

--- a/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/custom_devices_test.dart
@@ -257,10 +257,7 @@ class FakeCommandRunner extends FlutterCommandRunner {
   }) : _platform = platform,
        _fileSystem = fileSystem,
        _logger = logger,
-       _userMessages = userMessages ?? UserMessages(),
-       assert(platform != null),
-       assert(fileSystem != null),
-       assert(logger != null);
+       _userMessages = userMessages ?? UserMessages();
 
   final Platform _platform;
   final FileSystem _fileSystem;

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -86,9 +86,7 @@ void main() {
     });
 
     tearDown(() async {
-      if (daemon != null) {
-        return daemon.shutdown();
-      }
+      return daemon.shutdown();
       notifyingLogger.dispose();
       await daemonConnection.dispose();
     });

--- a/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/daemon_test.dart
@@ -86,7 +86,7 @@ void main() {
     });
 
     tearDown(() async {
-      return daemon.shutdown();
+      await daemon.shutdown();
       notifyingLogger.dispose();
       await daemonConnection.dispose();
     });

--- a/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/icon_tree_shaker_test.dart
@@ -64,7 +64,6 @@ void main() {
     String stderr = '',
     required CompleterIOSink stdinSink,
   }) {
-    assert(stdinSink != null);
     stdinSink.clear();
     processManager.addCommand(FakeCommand(
       command: fontSubsetArgs,

--- a/packages/flutter_tools/test/general.shard/cold_test.dart
+++ b/packages/flutter_tools/test/general.shard/cold_test.dart
@@ -202,8 +202,7 @@ class TestFlutterDevice extends FlutterDevice {
     required Device device,
     required this.exception,
     required ResidentCompiler generator,
-  })  : assert(exception != null),
-        super(device, buildInfo: BuildInfo.debug, generator: generator, developmentShaderCompiler: const FakeShaderCompiler());
+  })  : super(device, buildInfo: BuildInfo.debug, generator: generator, developmentShaderCompiler: const FakeShaderCompiler());
 
   /// The exception to throw when the connect method is called.
   final Exception exception;

--- a/packages/flutter_tools/test/general.shard/convert_test.dart
+++ b/packages/flutter_tools/test/general.shard/convert_test.dart
@@ -19,13 +19,11 @@ void main() {
   });
 
   testWithoutContext('Decode a normal string', () async {
-    assert(passedString != null);
 
     expect(decoder.convert(passedString.codeUnits), passedString);
   });
 
   testWithoutContext('Decode a malformed string', () async {
-    assert(nonpassString != null);
 
     expect(
       () => decoder.convert(nonpassString.codeUnits),

--- a/packages/flutter_tools/test/general.shard/desktop_device_test.dart
+++ b/packages/flutter_tools/test/general.shard/desktop_device_test.dart
@@ -371,7 +371,7 @@ class FakeDesktopDevice extends DesktopDevice {
     if (nullExecutablePathForDevice) {
       return null;
     }
-    return buildMode == null ? 'null' : getNameForBuildMode(buildMode);
+    return getNameForBuildMode(buildMode);
   }
 }
 

--- a/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
+++ b/packages/flutter_tools/test/general.shard/drive/drive_service_test.dart
@@ -448,7 +448,6 @@ FlutterDriverService setUpDriverService({
       Device? device,
       required Logger logger,
     }) async {
-      assert(logger != null);
       if (httpUri.scheme != 'http') {
         fail('Expected an HTTP scheme, found $httpUri');
       }

--- a/packages/flutter_tools/test/general.shard/hot_test.dart
+++ b/packages/flutter_tools/test/general.shard/hot_test.dart
@@ -667,8 +667,7 @@ class TestFlutterDevice extends FlutterDevice {
     required Device device,
     required this.exception,
     required ResidentCompiler generator,
-  })  : assert(exception != null),
-        super(device, buildInfo: BuildInfo.debug, generator: generator, developmentShaderCompiler: const FakeShaderCompiler());
+  })  : super(device, buildInfo: BuildInfo.debug, generator: generator, developmentShaderCompiler: const FakeShaderCompiler());
 
   /// The exception to throw when the connect method is called.
   final Exception exception;

--- a/packages/flutter_tools/test/general.shard/plugins_test.dart
+++ b/packages/flutter_tools/test/general.shard/plugins_test.dart
@@ -379,8 +379,6 @@ flutter:
       required String name,
       required List<String> dependencies,
     }) {
-      assert(name != null);
-      assert(dependencies != null);
 
       final Directory pluginDirectory = fs.systemTempDirectory.createTempSync('flutter_plugin.');
       pluginDirectory
@@ -412,8 +410,6 @@ dependencies:
       required Map<String, _PluginPlatformInfo> platforms,
       List<String> dependencies = const <String>[],
     }) {
-      assert(name != null);
-      assert(dependencies != null);
 
       final Iterable<String> platformSections = platforms.entries.map((MapEntry<String, _PluginPlatformInfo> entry) => '''
       ${entry.key}:

--- a/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
+++ b/packages/flutter_tools/test/integration.shard/analyze_once_test.dart
@@ -389,10 +389,8 @@ analyzer:
 }
 
 void assertContains(String text, List<String> patterns) {
-  if (patterns != null) {
-    for (final String pattern in patterns) {
-      expect(text, contains(pattern));
-    }
+  for (final String pattern in patterns) {
+    expect(text, contains(pattern));
   }
 }
 

--- a/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
+++ b/packages/flutter_tools/test/integration.shard/flutter_run_with_error_test.dart
@@ -56,13 +56,11 @@ void main() {
         final RegExp exp = RegExp(r'http://127.0.0.1:(\d+)/');
         final RegExpMatch match = exp.firstMatch(line)!;
         final String port = match.group(1)!;
-        if (port != null) {
-          final VmService vmService =
-              await vmServiceConnectUri('ws://localhost:$port/ws');
-          final VM vm = await vmService.getVM();
-          for (final IsolateRef isolate in vm.isolates!) {
-            await vmService.resume(isolate.id!);
-          }
+        final VmService vmService =
+            await vmServiceConnectUri('ws://localhost:$port/ws');
+        final VM vm = await vmService.getVM();
+        for (final IsolateRef isolate in vm.isolates!) {
+          await vmService.resume(isolate.id!);
         }
       }
 

--- a/packages/flutter_tools/test/integration.shard/test_data/deferred_components_config.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/deferred_components_config.dart
@@ -25,56 +25,26 @@ abstract class DeferredComponentsConfig {
   List<DeferredComponentModule> get deferredComponents;
 
   void setUpIn(Directory dir) {
-    if (deferredLibrary != null) {
-      writeFile(fileSystem.path.join(dir.path, 'lib', 'deferred_library.dart'), deferredLibrary);
-    }
+    writeFile(fileSystem.path.join(dir.path, 'lib', 'deferred_library.dart'), deferredLibrary);
     final String? golden = deferredComponentsGolden;
     if (golden != null) {
       writeFile(fileSystem.path.join(dir.path, 'deferred_components_loading_units.yaml'), golden);
     }
-    if (androidSettings != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'settings.gradle'), androidSettings);
-    }
-    if (androidBuild != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'build.gradle'), androidBuild);
-    }
-    if (androidLocalProperties != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'local.properties'), androidLocalProperties);
-    }
-    if (androidGradleProperties != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'gradle.properties'), androidGradleProperties);
-    }
-    if (androidKeyProperties != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'key.properties'), androidKeyProperties);
-    }
-    if (androidKey != null) {
-      writeBytesFile(fileSystem.path.join(dir.path, 'android', 'app', 'key.jks'), androidKey);
-    }
-    if (appBuild != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'build.gradle'), appBuild);
-    }
-    if (appManifest != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), appManifest);
-    }
-    if (appStrings != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'strings.xml'), appStrings);
-    }
-    if (appStyles != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'styles.xml'), appStyles);
-    }
-    if (appLaunchBackground != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'drawable', 'launch_background.xml'), appLaunchBackground);
-    }
-    if (asset1 != null) {
-      writeFile(fileSystem.path.join(dir.path, 'test_assets/asset1.txt'), asset1);
-    }
-    if (asset2 != null) {
-      writeFile(fileSystem.path.join(dir.path, 'test_assets/asset2.txt'), asset2);
-    }
-    if (deferredComponents != null) {
-      for (final DeferredComponentModule component in deferredComponents) {
-        component.setUpIn(dir);
-      }
+    writeFile(fileSystem.path.join(dir.path, 'android', 'settings.gradle'), androidSettings);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'build.gradle'), androidBuild);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'local.properties'), androidLocalProperties);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'gradle.properties'), androidGradleProperties);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'key.properties'), androidKeyProperties);
+    writeBytesFile(fileSystem.path.join(dir.path, 'android', 'app', 'key.jks'), androidKey);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'build.gradle'), appBuild);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), appManifest);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'strings.xml'), appStrings);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'styles.xml'), appStyles);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'drawable', 'launch_background.xml'), appLaunchBackground);
+    writeFile(fileSystem.path.join(dir.path, 'test_assets/asset1.txt'), asset1);
+    writeFile(fileSystem.path.join(dir.path, 'test_assets/asset2.txt'), asset2);
+    for (final DeferredComponentModule component in deferredComponents) {
+      component.setUpIn(dir);
     }
   }
 }
@@ -85,70 +55,68 @@ class DeferredComponentModule {
   String name;
 
   void setUpIn(Directory dir) {
-    if (name != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', name, 'build.gradle'), r'''
-      def localProperties = new Properties()
-      def localPropertiesFile = rootProject.file('local.properties')
-      if (localPropertiesFile.exists()) {
-          localPropertiesFile.withReader('UTF-8') { reader ->
-              localProperties.load(reader)
-          }
-      }
-
-      def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
-      if (flutterVersionCode == null) {
-          flutterVersionCode = '1'
-      }
-
-      def flutterVersionName = localProperties.getProperty('flutter.versionName')
-      if (flutterVersionName == null) {
-          flutterVersionName = '1.0'
-      }
-
-      apply plugin: "com.android.dynamic-feature"
-
-      android {
-          compileSdkVersion 31
-
-          sourceSets {
-              applicationVariants.all { variant ->
-                  main.assets.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_assets"
-                  main.jniLibs.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_libs"
-              }
-          }
-
-          defaultConfig {
-              minSdkVersion 16
-              targetSdkVersion 31
-              versionCode flutterVersionCode.toInteger()
-              versionName flutterVersionName
-          }
-          compileOptions {
-              sourceCompatibility 1.8
-              targetCompatibility 1.8
-          }
-      }
-
-      dependencies {
-          implementation project(":app")
-      }
-      ''');
-
-      writeFile(fileSystem.path.join(dir.path, 'android', name, 'src', 'main', 'AndroidManifest.xml'), '''
-      <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:dist="http://schemas.android.com/apk/distribution"
-          package="com.example.$name">
-
-          <dist:module
-              dist:instant="false"
-              dist:title="@string/component1Name">
-              <dist:delivery>
-                  <dist:on-demand />
-              </dist:delivery>
-              <dist:fusing dist:include="true" />
-          </dist:module>
-      </manifest>
-      ''');
+    writeFile(fileSystem.path.join(dir.path, 'android', name, 'build.gradle'), r'''
+    def localProperties = new Properties()
+    def localPropertiesFile = rootProject.file('local.properties')
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.withReader('UTF-8') { reader ->
+            localProperties.load(reader)
+        }
     }
+
+    def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
+    if (flutterVersionCode == null) {
+        flutterVersionCode = '1'
+    }
+
+    def flutterVersionName = localProperties.getProperty('flutter.versionName')
+    if (flutterVersionName == null) {
+        flutterVersionName = '1.0'
+    }
+
+    apply plugin: "com.android.dynamic-feature"
+
+    android {
+        compileSdkVersion 31
+
+        sourceSets {
+            applicationVariants.all { variant ->
+                main.assets.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_assets"
+                main.jniLibs.srcDirs += "${project.buildDir}/intermediates/flutter/${variant.name}/deferred_libs"
+            }
+        }
+
+        defaultConfig {
+            minSdkVersion 16
+            targetSdkVersion 31
+            versionCode flutterVersionCode.toInteger()
+            versionName flutterVersionName
+        }
+        compileOptions {
+            sourceCompatibility 1.8
+            targetCompatibility 1.8
+        }
+    }
+
+    dependencies {
+        implementation project(":app")
+    }
+    ''');
+
+    writeFile(fileSystem.path.join(dir.path, 'android', name, 'src', 'main', 'AndroidManifest.xml'), '''
+    <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:dist="http://schemas.android.com/apk/distribution"
+        package="com.example.$name">
+
+        <dist:module
+            dist:instant="false"
+            dist:title="@string/component1Name">
+            <dist:delivery>
+                <dist:on-demand />
+            </dist:delivery>
+            <dist:fusing dist:include="true" />
+        </dist:module>
+    </manifest>
+    ''');
   }
 }

--- a/packages/flutter_tools/test/integration.shard/test_data/migrate_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/migrate_project.dart
@@ -22,9 +22,7 @@ class MigrateProject extends Project {
   }) async {
     this.dir = dir;
     _appPath = dir.path;
-    if (androidLocalProperties != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'local.properties'), androidLocalProperties);
-    }
+    writeFile(fileSystem.path.join(dir.path, 'android', 'local.properties'), androidLocalProperties);
     final Directory tempDir = createResolvedTempDirectorySync('cipd_dest.');
     final Directory depotToolsDir = createResolvedTempDirectorySync('depot_tools.');
 

--- a/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
+++ b/packages/flutter_tools/test/integration.shard/test_data/multidex_project.dart
@@ -17,34 +17,16 @@ class MultidexProject extends Project {
     bool useSyntheticPackage = false,
   }) {
     this.dir = dir;
-    if (androidSettings != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'settings.gradle'), androidSettings);
-    }
-    if (androidBuild != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'build.gradle'), androidBuild);
-    }
-    if (androidLocalProperties != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'local.properties'), androidLocalProperties);
-    }
-    if (androidGradleProperties != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'gradle.properties'), androidGradleProperties);
-    }
-    if (appBuild != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'build.gradle'), appBuild);
-    }
-    if (appManifest != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), appManifest);
-    }
-    if (appStrings != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'strings.xml'), appStrings);
-    }
-    if (appStyles != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'styles.xml'), appStyles);
-    }
-    if (appLaunchBackground != null) {
-      writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'drawable', 'launch_background.xml'), appLaunchBackground);
-    }
-    if (includeFlutterMultiDexApplication && appMultidexApplication != null) {
+    writeFile(fileSystem.path.join(dir.path, 'android', 'settings.gradle'), androidSettings);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'build.gradle'), androidBuild);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'local.properties'), androidLocalProperties);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'gradle.properties'), androidGradleProperties);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'build.gradle'), appBuild);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'AndroidManifest.xml'), appManifest);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'strings.xml'), appStrings);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'values', 'styles.xml'), appStyles);
+    writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'res', 'drawable', 'launch_background.xml'), appLaunchBackground);
+    if (includeFlutterMultiDexApplication) {
       writeFile(fileSystem.path.join(dir.path, 'android', 'app', 'src', 'main', 'java', fileSystem.path.join('io', 'flutter', 'app', 'FlutterMultiDexApplication.java')), appMultidexApplication);
     }
     return super.setUpIn(dir);

--- a/packages/flutter_tools/test/integration.shard/test_driver.dart
+++ b/packages/flutter_tools/test/integration.shard/test_driver.dart
@@ -334,7 +334,6 @@ abstract class FlutterTestDriver {
   }
 
   Future<Isolate?> _resume(String? step, bool waitForNextPause) async {
-    assert(waitForNextPause != null);
     final String isolateId = await _getFlutterIsolateId();
 
     final Future<Event> resume = subscribeToResumeEvent(isolateId);
@@ -400,7 +399,6 @@ abstract class FlutterTestDriver {
     Duration timeout = defaultTimeout,
     bool ignoreAppStopEvent = false,
   }) async {
-    assert(timeout != null);
     assert(event != null || id != null);
     assert(event == null || id == null);
     final String interestingOccurrence = event != null ? '$event event' : 'response to request $id';
@@ -447,8 +445,6 @@ abstract class FlutterTestDriver {
     required String task,
     Duration timeout = defaultTimeout,
   }) {
-    assert(task != null);
-    assert(timeout != null);
 
     if (_printDebugOutputToStdOut) {
       _debugPrint('$task...');
@@ -820,7 +816,6 @@ class FlutterTestTestDriver extends FlutterTestDriver {
   Future<Map<String, Object?>?> _waitForJson({
     Duration timeout = defaultTimeout,
   }) async {
-    assert(timeout != null);
     return _timeoutWithMessages<Map<String, Object?>?>(
       () => _stdout.stream.map<Map<String, Object?>?>(_parseJsonResponse)
           .firstWhere((Map<String, Object?>? output) => output != null),

--- a/packages/flutter_tools/test/src/android_common.dart
+++ b/packages/flutter_tools/test/src/android_common.dart
@@ -40,7 +40,6 @@ class FakeAndroidBuilder implements AndroidBuilder {
 /// within [directoryOverride].
 class FakeFlutterProjectFactory extends FlutterProjectFactory {
   FakeFlutterProjectFactory(this.directoryOverride) :
-    assert(directoryOverride != null),
     super(
       fileSystem: globals.fs,
       logger: globals.logger,

--- a/packages/flutter_tools/test/src/fake_process_manager.dart
+++ b/packages/flutter_tools/test/src/fake_process_manager.dart
@@ -33,9 +33,7 @@ class FakeCommand {
     this.stdin,
     this.exception,
     this.outputFollowsExit = false,
-  }) : assert(command != null),
-       assert(duration != null),
-       assert(exitCode != null);
+  });
 
   /// The exact commands that must be matched for this [FakeCommand] to be
   /// considered correct.

--- a/packages/flutter_tools/test/src/fakes.dart
+++ b/packages/flutter_tools/test/src/fakes.dart
@@ -185,7 +185,6 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
   @override
   bool get hasTerminal => _hasTerminal;
   set hasTerminal(bool value) {
-    assert(value != null);
     _hasTerminal = value;
   }
   bool _hasTerminal = true;
@@ -196,7 +195,6 @@ class MemoryStdout extends MemoryIOSink implements io.Stdout {
   @override
   bool get supportsAnsiEscapes => _supportsAnsiEscapes;
   set supportsAnsiEscapes(bool value) {
-    assert(value != null);
     _supportsAnsiEscapes = value;
   }
   bool _supportsAnsiEscapes = true;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.

The first commit contains fixes automatically applied by running `dart fix --apply`. The second commit contains some manual fixes on top of that.  