### PR TITLE
Remove unnecessary null checks in `flutter_web_plugins`

### DIFF
--- a/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
+++ b/packages/flutter_web_plugins/lib/src/plugin_event_channel.dart
@@ -43,8 +43,7 @@ class PluginEventChannel<T> {
     this.name, [
     this.codec = const StandardMethodCodec(),
     this.binaryMessenger,
-  ]) : assert(name != null),
-       assert(codec != null);
+  ]);
 
   /// The logical channel on which communication happens.
   ///
@@ -108,7 +107,7 @@ class _EventChannelHandler<T> {
     this.codec,
     this.controller,
     this.messenger,
-  ) : assert(messenger != null);
+  );
 
   final String name;
   final MethodCodec codec;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.