### PR TITLE
Remove unnecessary null checks in `flutter_test`

### DIFF
--- a/packages/flutter_test/lib/src/accessibility.dart
+++ b/packages/flutter_test/lib/src/accessibility.dart
@@ -229,7 +229,7 @@ class LabeledTapTargetGuideline extends AccessibilityGuideline {
           !data.hasAction(ui.SemanticsAction.tap)) {
         return result;
       }
-      if ((data.label == null || data.label.isEmpty) && (data.tooltip == null || data.tooltip.isEmpty)) {
+      if ((data.label.isEmpty) && (data.tooltip.isEmpty)) {
         result += Evaluation.fail(
           '$node: expected tappable node to have semantic label, '
           'but none was found.\n',

--- a/packages/flutter_test/lib/src/all_elements.dart
+++ b/packages/flutter_test/lib/src/all_elements.dart
@@ -73,7 +73,6 @@ class _DepthFirstChildIterator implements Iterator<Element> {
   }
 
   void _fillChildren(Element element) {
-    assert(element != null);
     // If we did not have to follow LTR order and could instead use RTL,
     // we could avoid reversing this and the operation would be measurably
     // faster. Unfortunately, a lot of tests depend on LTR order.

--- a/packages/flutter_test/lib/src/animation_sheet.dart
+++ b/packages/flutter_test/lib/src/animation_sheet.dart
@@ -89,8 +89,7 @@ class AnimationSheetBuilder {
   AnimationSheetBuilder({
     required this.frameSize,
     this.allLayers = false,
-  }) : assert(!kIsWeb), // Does not support Web. See [AnimationSheetBuilder].
-       assert(frameSize != null);
+  }) : assert(!kIsWeb);
 
   /// The size of the child to be recorded.
   ///
@@ -150,7 +149,6 @@ class AnimationSheetBuilder {
     Key? key,
     bool recording = true,
   }) {
-    assert(child != null);
     return _AnimationSheetRecorder(
       key: key,
       size: frameSize,
@@ -454,8 +452,7 @@ class _CellSheet extends StatelessWidget {
     super.key,
     required this.cellSize,
     required this.children,
-  }) : assert(cellSize != null),
-       assert(children != null && children.isNotEmpty);
+  }) : assert(children.isNotEmpty);
 
   final Size cellSize;
   final List<Widget> children;

--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -772,7 +772,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     VoidCallback invariantTester,
     String description,
   ) {
-    assert(description != null);
     assert(inTest);
 
     // Set the handler only if there is currently none.
@@ -1194,7 +1193,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     Future<T> Function() callback, {
     Duration additionalTime = const Duration(milliseconds: 1000),
   }) {
-    assert(additionalTime != null);
     assert(() {
       if (_pendingAsyncTasks == null) {
         return true;
@@ -1335,7 +1333,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
       debugBuildingDirtyElements = true;
       buildOwner!.buildScope(renderViewElement!);
       if (_phase != EnginePhase.build) {
-        assert(renderView != null);
         pipelineOwner.flushLayout();
         if (_phase != EnginePhase.layout) {
           pipelineOwner.flushCompositingBits();
@@ -1383,7 +1380,6 @@ class AutomatedTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     )
     Duration? timeout,
   }) {
-    assert(description != null);
     assert(!inTest);
     assert(_currentFakeAsync == null);
     assert(_clock == null);
@@ -1885,7 +1881,6 @@ class LiveTestWidgetsFlutterBinding extends TestWidgetsFlutterBinding {
     )
     Duration? timeout,
   }) {
-    assert(description != null);
     assert(!inTest);
     _inTest = true;
     _liveTestRenderView._setDescription(description);
@@ -2038,7 +2033,6 @@ class _LiveTestRenderView extends RenderView {
     fontSize: 10.0,
   );
   void _setDescription(String value) {
-    assert(value != null);
     if (value.isEmpty) {
       _label = null;
       return;
@@ -2081,7 +2075,7 @@ class _LiveTestRenderView extends RenderView {
         .where((int pointer) => _pointers[pointer]!.decay == 0)
         .toList()
         .forEach(_pointers.remove);
-      if (dirty && onNeedPaint != null) {
+      if (dirty) {
         scheduleMicrotask(onNeedPaint);
       }
     }

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -890,7 +890,6 @@ abstract class WidgetController {
     assert(kDragSlopDefault > kTouchSlop);
     return TestAsyncUtils.guard<void>(() async {
       final TestGesture gesture = await startGesture(startLocation, pointer: pointer, buttons: buttons, kind: kind);
-      assert(gesture != null);
 
       final double xSign = offset.dx.sign;
       final double ySign = offset.dy.sign;
@@ -1120,7 +1119,6 @@ abstract class WidgetController {
     PointerDeviceKind kind = PointerDeviceKind.touch,
     int buttons = kPrimaryButton,
   }) async {
-    assert(downLocation != null);
     final TestGesture result = await createGesture(
       pointer: pointer,
       kind: kind,
@@ -1268,9 +1266,7 @@ abstract class WidgetController {
       }
       if (!found) {
         bool outOfBounds = false;
-        if (binding.renderView != null && binding.renderView.size != null) {
-          outOfBounds = !(Offset.zero & binding.renderView.size).contains(location);
-        }
+        outOfBounds = !(Offset.zero & binding.renderView.size).contains(location);
         if (hitTestWarningShouldBeFatal) {
           throw FlutterError.fromParts(<DiagnosticsNode>[
             ErrorSummary('Finder specifies a widget that would not receive pointer events.'),
@@ -1349,7 +1345,6 @@ abstract class WidgetController {
     String? character,
     PhysicalKeyboardKey? physicalKey
   }) async {
-    assert(platform != null);
     final bool handled = await simulateKeyDownEvent(key, platform: platform, character: character, physicalKey: physicalKey);
     // Internally wrapped in async guard.
     await simulateKeyUpEvent(key, platform: platform, physicalKey: physicalKey);
@@ -1393,7 +1388,6 @@ abstract class WidgetController {
     String? character,
     PhysicalKeyboardKey? physicalKey
   }) async {
-    assert(platform != null);
     // Internally wrapped in async guard.
     return simulateKeyDownEvent(key, platform: platform, character: character, physicalKey: physicalKey);
   }
@@ -1427,7 +1421,6 @@ abstract class WidgetController {
         String platform = _defaultPlatform,
         PhysicalKeyboardKey? physicalKey
       }) async {
-    assert(platform != null);
     // Internally wrapped in async guard.
     return simulateKeyUpEvent(key, platform: platform, physicalKey: physicalKey);
   }
@@ -1469,7 +1462,6 @@ abstract class WidgetController {
         String? character,
         PhysicalKeyboardKey? physicalKey
       }) async {
-    assert(platform != null);
     // Internally wrapped in async guard.
     return simulateKeyRepeatEvent(key, platform: platform, character: character, physicalKey: physicalKey);
   }
@@ -1627,7 +1619,6 @@ class LiveWidgetController extends WidgetController {
   Future<int> pumpAndSettle([
     Duration duration = const Duration(milliseconds: 100),
   ]) {
-    assert(duration != null);
     assert(duration > Duration.zero);
     return TestAsyncUtils.guard<int>(() async {
       int count = 0;
@@ -1641,7 +1632,6 @@ class LiveWidgetController extends WidgetController {
 
   @override
   Future<List<Duration>> handlePointerEventRecord(List<PointerEventRecord> records) {
-    assert(records != null);
     assert(records.isNotEmpty);
     return TestAsyncUtils.guard<List<Duration>>(() async {
       final List<Duration> handleTimeStampDiff = <Duration>[];

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -567,7 +567,7 @@ abstract class Finder {
 /// Applies additional filtering against a [parent] [Finder].
 abstract class ChainedFinder extends Finder {
   /// Create a Finder chained against the candidates of another [Finder].
-  ChainedFinder(this.parent) : assert(parent != null);
+  ChainedFinder(this.parent);
 
   /// Another [Finder] that will run first.
   final Finder parent;

--- a/packages/flutter_test/lib/src/frame_timing_summarizer.dart
+++ b/packages/flutter_test/lib/src/frame_timing_summarizer.dart
@@ -22,7 +22,6 @@ class FrameTimingSummarizer {
     int? newGenGCCount,
     int? oldGenGCCount,
   }) {
-    assert(data != null);
     assert(data.isNotEmpty);
     final List<Duration> frameBuildTime = List<Duration>.unmodifiable(
       data.map<Duration>((FrameTiming datum) => datum.buildDuration),

--- a/packages/flutter_test/lib/src/image.dart
+++ b/packages/flutter_test/lib/src/image.dart
@@ -29,9 +29,8 @@ Future<ui.Image> createTestImage({
   int height = 1,
   bool cache = true,
 }) => TestAsyncUtils.guard(() async {
-  assert(width != null && width > 0);
-  assert(height != null && height > 0);
-  assert(cache != null);
+  assert(width > 0);
+  assert(height > 0);
 
   final int cacheKey = Object.hash(width, height);
   if (cache && _cache.containsKey(cacheKey)) {

--- a/packages/flutter_test/lib/src/matchers.dart
+++ b/packages/flutter_test/lib/src/matchers.dart
@@ -1981,7 +1981,7 @@ class _CoversSameAreaAs extends Matcher {
 class _ColorMatcher extends Matcher {
   const _ColorMatcher({
     required this.targetColor,
-  }) : assert(targetColor != null);
+  });
 
   final Color targetColor;
 

--- a/packages/flutter_test/lib/src/stack_manipulation.dart
+++ b/packages/flutter_test/lib/src/stack_manipulation.dart
@@ -26,7 +26,6 @@ int reportExpectCall(StackTrace stack, List<DiagnosticsNode> information) {
       line2.firstMatch(stackLines[2]) != null &&
       line3.firstMatch(stackLines[3]) != null) {
     final Match expectMatch = line4.firstMatch(stackLines[4])!;
-    assert(expectMatch != null);
     assert(expectMatch.groupCount == 2);
     information.add(DiagnosticsStackTrace.singleFrame(
       'This was caught by the test expectation on the following line',

--- a/packages/flutter_test/lib/src/test_async_utils.dart
+++ b/packages/flutter_test/lib/src/test_async_utils.dart
@@ -187,10 +187,7 @@ class TestAsyncUtils {
         return;
       }
       candidateScope = _scopeStack[_scopeStack.length - skipCount - 1];
-      assert(candidateScope != null);
-      assert(candidateScope.zone != null);
     } while (candidateScope.zone != zone);
-    assert(scope != null);
     final List<DiagnosticsNode> information = <DiagnosticsNode>[
       ErrorSummary('Guarded function conflict.'),
       ErrorHint('You must use "await" with all Future-returning test APIs.'),

--- a/packages/flutter_test/lib/src/test_default_binary_messenger.dart
+++ b/packages/flutter_test/lib/src/test_default_binary_messenger.dart
@@ -46,7 +46,7 @@ class TestDefaultBinaryMessenger extends BinaryMessenger {
   /// Creates a [TestDefaultBinaryMessenger] instance.
   ///
   /// The [delegate] instance must not be null.
-  TestDefaultBinaryMessenger(this.delegate): assert(delegate != null);
+  TestDefaultBinaryMessenger(this.delegate);
 
   /// The delegate [BinaryMessenger].
   final BinaryMessenger delegate;

--- a/packages/flutter_test/lib/src/test_exception_reporter.dart
+++ b/packages/flutter_test/lib/src/test_exception_reporter.dart
@@ -24,7 +24,6 @@ typedef TestExceptionReporter = void Function(FlutterErrorDetails details, Strin
 TestExceptionReporter get reportTestException => _reportTestException;
 TestExceptionReporter _reportTestException = _defaultTestExceptionReporter;
 set reportTestException(TestExceptionReporter handler) {
-  assert(handler != null);
   _reportTestException = handler;
 }
 

--- a/packages/flutter_test/lib/src/widget_tester.dart
+++ b/packages/flutter_test/lib/src/widget_tester.dart
@@ -138,7 +138,6 @@ void testWidgets(
   TestVariant<Object?> variant = const DefaultTestVariant(),
   dynamic tags,
 }) {
-  assert(variant != null);
   assert(variant.values.isNotEmpty, 'There must be at least one value to test in the testing variant.');
   final TestWidgetsFlutterBinding binding = TestWidgetsFlutterBinding.ensureInitialized();
   final WidgetTester tester = WidgetTester._(binding);
@@ -573,7 +572,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
   @override
   Future<List<Duration>> handlePointerEventRecord(Iterable<PointerEventRecord> records) {
-    assert(records != null);
     assert(records.isNotEmpty);
     return TestAsyncUtils.guard<List<Duration>>(() async {
       final List<Duration> handleTimeStampDiff = <Duration>[];
@@ -664,9 +662,7 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     EnginePhase phase = EnginePhase.sendSemanticsUpdate,
     Duration timeout = const Duration(minutes: 10),
   ]) {
-    assert(duration != null);
     assert(duration > Duration.zero);
-    assert(timeout != null);
     assert(timeout > Duration.zero);
     assert(() {
       final WidgetsBinding binding = this.binding;
@@ -705,7 +701,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
     Duration maxDuration, [
     Duration interval = const Duration(milliseconds: 16, microseconds: 683),
   ]) {
-    assert(maxDuration != null);
     // The interval following the last frame doesn't have to be within the fullDuration.
     Duration elapsed = Duration.zero;
     return TestAsyncUtils.guard<void>(() async {
@@ -822,7 +817,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
 
   @override
   HitTestResult hitTestOnBinding(Offset location) {
-    assert(location != null);
     location = binding.localToGlobal(location);
     return super.hitTestOnBinding(location);
   }
@@ -1003,7 +997,6 @@ class WidgetTester extends WidgetController implements HitTestDispatcher, Ticker
   /// error message. It should be an adverbial phrase describing the current
   /// situation, such as "at the end of the test".
   void verifyTickersWereDisposed([ String when = 'when none should have been' ]) {
-    assert(when != null);
     if (_tickers != null) {
       for (final Ticker ticker in _tickers!) {
         if (ticker.isActive) {


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.