### PR TITLE
Fix test when a Skia RTL positioning bug is fixed

### DIFF
--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -842,7 +842,7 @@ void main() {
       // Add a little offset to cross the boundary between paragraph 2 and 3.
       await gesture.moveTo(textOffsetToPosition(paragraph3, 6) + const Offset(0, 1));
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 2, extentOffset: 12));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 8));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 9));
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
 
       await gesture.up();


### PR DESCRIPTION
See [this comment](https://github.com/flutter/flutter/issues/118566#issuecomment-1397795676) for where this came about.

There is an existing bug about the cursor going to the penultimate character in RTL text (https://github.com/flutter/flutter/issues/118566), which is being fixed in Skia.  Once that fix is rolled into Flutter, the test that's modified in this PR will fail, and this PR will be needed to make it pass again.

This must not be merged until Skia fix https://skia-review.googlesource.com/c/skia/+/619838/1 is rolled into Flutter.