### PR TITLE
Remove unnecessary null checks in `flutter/test`

### DIFF
--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -1830,7 +1830,6 @@ void main() {
             child: const Text('Home'),
             onPressed: () {
               navigator = Navigator.of(context);
-              assert(navigator != null);
               navigator.push<void>(r);
             },
           );

--- a/packages/flutter/test/gestures/locking_test.dart
+++ b/packages/flutter/test/gestures/locking_test.dart
@@ -29,7 +29,6 @@ class TestGestureFlutterBinding extends BindingBase with GestureBinding {
   );
 
   Future<void> test(VoidCallback callback) {
-    assert(callback != null);
     return _binding.lockEvents(() async {
       GestureBinding.instance.platformDispatcher.onPointerDataPacket?.call(packet);
       callback();
@@ -41,7 +40,6 @@ late TestGestureFlutterBinding _binding;
 
 void main() {
   _binding = TestGestureFlutterBinding();
-  assert(GestureBinding.instance != null);
 
   test('Pointer events are locked during reassemble', () async {
     final List<PointerEvent> events = <PointerEvent>[];

--- a/packages/flutter/test/gestures/velocity_tracker_test.dart
+++ b/packages/flutter/test/gestures/velocity_tracker_test.dart
@@ -13,8 +13,7 @@ bool _withinTolerance(double actual, double expected) {
 }
 
 bool _checkVelocity(Velocity actual, Offset expected) {
-  return (actual != null)
-      && _withinTolerance(actual.pixelsPerSecond.dx, expected.dx)
+  return _withinTolerance(actual.pixelsPerSecond.dx, expected.dx)
       && _withinTolerance(actual.pixelsPerSecond.dy, expected.dy);
 }
 

--- a/packages/flutter/test/material/bottom_navigation_bar_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_test.dart
@@ -2491,7 +2491,6 @@ void main() {
 }
 
 Widget boilerplate({ Widget? bottomNavigationBar, required TextDirection textDirection }) {
-  assert(textDirection != null);
   return MaterialApp(
     home: Localizations(
       locale: const Locale('en', 'US'),

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -1506,7 +1506,7 @@ void main() {
               StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
                 return RawChip(
                   avatar: avatar,
-                  onSelected: selectable != null
+                  onSelected: selectable
                     ? (bool value) {
                         setState(() {
                           selected = value;
@@ -1585,7 +1585,7 @@ void main() {
             children: <Widget>[
               StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
                 return RawChip(
-                  onSelected: selectable != null
+                  onSelected: selectable
                     ? (bool value) {
                         setState(() {
                           selected = value;
@@ -1659,7 +1659,7 @@ void main() {
               StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
                 return RawChip(
                   avatar: avatar,
-                  onSelected: selectable != null
+                  onSelected: selectable
                     ? (bool value) {
                         setState(() {
                           selected = value;

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -717,7 +717,6 @@ void main() {
       expect(itemBoxes.length, equals(2));
       for (final RenderBox itemBox in itemBoxes) {
         assert(itemBox.attached);
-        assert(textDirection != null);
         switch (textDirection) {
           case TextDirection.rtl:
             expect(
@@ -1145,13 +1144,11 @@ void main() {
       tester.element(find.byType(ListView)).visitAncestorElements((Element element) {
         if (element.toString().startsWith('_DropdownMenu')) {
           final RenderBox box = element.findRenderObject()! as RenderBox;
-          assert(box != null);
           menuRect = box.localToGlobal(Offset.zero) & box.size;
           return false;
         }
         return true;
       });
-      assert(menuRect != null);
       return menuRect;
     }
 
@@ -1859,9 +1856,7 @@ void main() {
     double getMenuScroll() {
       double scrollPosition;
       final ScrollController scrollController = PrimaryScrollController.of(tester.element(find.byType(ListView)));
-      assert(scrollController != null);
       scrollPosition = scrollController.position.pixels;
-      assert(scrollPosition != null);
       return scrollPosition;
     }
 
@@ -1895,9 +1890,7 @@ void main() {
     double getMenuScroll() {
       double scrollPosition;
       final ScrollController scrollController = PrimaryScrollController.of(tester.element(find.byType(ListView)));
-      assert(scrollController != null);
       scrollPosition = scrollController.position.pixels;
-      assert(scrollPosition != null);
       return scrollPosition;
     }
 
@@ -1932,9 +1925,7 @@ void main() {
     double getMenuScroll() {
       double scrollPosition;
       final ScrollController scrollController = PrimaryScrollController.of(tester.element(find.byType(ListView)));
-      assert(scrollController != null);
       scrollPosition = scrollController.position.pixels;
-      assert(scrollPosition != null);
       return scrollPosition;
     }
 
@@ -1969,9 +1960,7 @@ void main() {
     double getMenuScroll() {
       double scrollPosition;
       final ScrollController scrollController = PrimaryScrollController.of(tester.element(find.byType(ListView)));
-      assert(scrollController != null);
       scrollPosition = scrollController.position.pixels;
-      assert(scrollPosition != null);
       return scrollPosition;
     }
 

--- a/packages/flutter/test/material/floating_action_button_location_test.dart
+++ b/packages/flutter/test/material/floating_action_button_location_test.dart
@@ -132,8 +132,7 @@ void main() {
           );
           final Iterable<double> currentRotations = rotationTransitions.map((RotationTransition t) => t.turns.value);
 
-          if (previousRotations != null && previousRotations!.isNotEmpty
-              && currentRotations != null && currentRotations.isNotEmpty
+          if (previousRotations != null && previousRotations!.isNotEmpty && currentRotations.isNotEmpty
               && previousRect != null && currentRect != null) {
             final List<double> deltas = <double>[];
             for (final double currentRotation in currentRotations) {
@@ -1739,7 +1738,6 @@ class _StartTopFloatingActionButtonLocation extends FloatingActionButtonLocation
   @override
   Offset getOffset(ScaffoldPrelayoutGeometry scaffoldGeometry) {
     double fabX;
-    assert(scaffoldGeometry.textDirection != null);
     switch (scaffoldGeometry.textDirection) {
       case TextDirection.rtl:
         final double startPadding = kFloatingActionButtonMargin + scaffoldGeometry.minInsets.right;

--- a/packages/flutter/test/material/scaffold_test.dart
+++ b/packages/flutter/test/material/scaffold_test.dart
@@ -2774,7 +2774,7 @@ class _CustomPageRoute<T> extends PageRoute<T> {
     RouteSettings super.settings = const RouteSettings(),
     this.maintainState = true,
     super.fullscreenDialog,
-  }) : assert(builder != null);
+  });
 
   final WidgetBuilder builder;
 

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -1340,9 +1340,7 @@ void main() {
     const Duration waitDuration = Duration(seconds: 1);
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     addTearDown(() async {
-      if (gesture != null) {
-        return gesture.removePointer();
-      }
+      return gesture.removePointer();
     });
     await gesture.addPointer();
     await gesture.moveTo(const Offset(1.0, 1.0));

--- a/packages/flutter/test/material/tooltip_visibility_test.dart
+++ b/packages/flutter/test/material/tooltip_visibility_test.dart
@@ -14,9 +14,7 @@ void main() {
   testWidgets('Tooltip does not build MouseRegion when mouse is detected and in TooltipVisibility with visibility = false', (WidgetTester tester) async {
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     addTearDown(() async {
-      if (gesture != null) {
-        return gesture.removePointer();
-      }
+      return gesture.removePointer();
     });
     await gesture.addPointer();
     await gesture.moveTo(const Offset(1.0, 1.0));
@@ -45,9 +43,7 @@ void main() {
     const Duration waitDuration = Duration.zero;
     final TestGesture gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
     addTearDown(() async {
-      if (gesture != null) {
-        return gesture.removePointer();
-      }
+      return gesture.removePointer();
     });
     await gesture.addPointer();
     await gesture.moveTo(const Offset(1.0, 1.0));

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -240,7 +240,6 @@ void main() {
   test('BoxDecoration backgroundImage clip', () async {
     final ui.Image image = await createTestImage(width: 100, height: 100);
     void testDecoration({ BoxShape shape = BoxShape.rectangle, BorderRadius? borderRadius, required bool expectClip }) {
-      assert(shape != null);
       FakeAsync().run((FakeAsync async) async {
         final DelayedImageProvider imageProvider = DelayedImageProvider(image);
         final DecorationImage backgroundImage = DecorationImage(image: imageProvider);

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -42,8 +42,7 @@ class TestImageInfo extends ImageInfo {
 }
 
 class TestImageProvider extends ImageProvider<int> {
-  const TestImageProvider(this.key, this.imageValue, { required this.image })
-      : assert(image != null);
+  const TestImageProvider(this.key, this.imageValue, { required this.image });
 
   final int key;
   final int imageValue;

--- a/packages/flutter/test/rendering/mock_canvas.dart
+++ b/packages/flutter/test/rendering/mock_canvas.dart
@@ -498,7 +498,7 @@ class _PathMatcher extends Matcher {
 }
 
 class _MismatchedCall {
-  const _MismatchedCall(this.message, this.callIntroduction, this.call) : assert(call != null);
+  const _MismatchedCall(this.message, this.callIntroduction, this.call);
   final String message;
   final String callIntroduction;
   final RecordedInvocation call;

--- a/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_cursor_test.dart
@@ -448,8 +448,7 @@ ui.PointerData _pointerData(
 }
 
 class _CursorUpdateDetails extends MethodCall {
-  const _CursorUpdateDetails(super.method, Map<String, dynamic> super.arguments)
-    : assert(arguments != null);
+  const _CursorUpdateDetails(super.method, Map<String, dynamic> super.arguments);
 
   _CursorUpdateDetails.wrap(MethodCall call)
     : super(call.method, Map<String, dynamic>.from(call.arguments as Map<dynamic, dynamic>));

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -43,19 +43,13 @@ void main() {
   }) {
     final TestAnnotationTarget oneAnnotation = TestAnnotationTarget(
       onEnter: (PointerEnterEvent event) {
-        if (logEvents != null) {
-          logEvents.add(event);
-        }
+        logEvents.add(event);
       },
       onHover: (PointerHoverEvent event) {
-        if (logEvents != null) {
-          logEvents.add(event);
-        }
+        logEvents.add(event);
       },
       onExit: (PointerExitEvent event) {
-        if (logEvents != null) {
-          logEvents.add(event);
-        }
+        logEvents.add(event);
       },
     );
     setUpMouseAnnotationFinder(
@@ -608,8 +602,7 @@ ui.PointerData _pointerData(
 }
 
 class BaseEventMatcher extends Matcher {
-  BaseEventMatcher(this.expected)
-    : assert(expected != null);
+  BaseEventMatcher(this.expected);
 
   final PointerEvent expected;
 

--- a/packages/flutter/test/rendering/recording_canvas.dart
+++ b/packages/flutter/test/rendering/recording_canvas.dart
@@ -28,7 +28,6 @@ class RecordedInvocation {
 
   /// Converts [stack] to a string using the [FlutterError.defaultStackFilter] logic.
   String stackToString({ String indent = '' }) {
-    assert(indent != null);
     return indent + FlutterError.defaultStackFilter(
       stack.toString().trimRight().split('\n'),
     ).join('\n$indent');
@@ -124,7 +123,6 @@ class TestRecordingPaintingContext extends ClipContext implements PaintingContex
     Clip clipBehavior = Clip.antiAlias,
     ClipRRectLayer? oldLayer,
   }) {
-    assert(clipBehavior != null);
     clipRRectAndPaint(clipRRect.shift(offset), clipBehavior, bounds.shift(offset), () => painter(this, offset));
     return null;
   }

--- a/packages/flutter/test/rendering/rendering_tester.dart
+++ b/packages/flutter/test/rendering/rendering_tester.dart
@@ -197,13 +197,12 @@ class TestRenderingFlutterBinding extends BindingBase with SchedulerBinding, Ser
 ///
 /// If `onErrors` is not null, it is set as [TestRenderingFlutterBinding.onError].
 void layout(
-  RenderBox box, {
+  RenderBox box, { // If you want to just repump the last box, call pumpFrame().
   BoxConstraints? constraints,
   Alignment alignment = Alignment.center,
   EnginePhase phase = EnginePhase.layout,
   VoidCallback? onErrors,
 }) {
-  assert(box != null); // If you want to just repump the last box, call pumpFrame().
   assert(box.parent == null); // We stick the box in another, so you can't reuse it easily, sorry.
 
   TestRenderingFlutterBinding.instance.renderView.child = null;
@@ -225,8 +224,6 @@ void layout(
 ///
 /// If `onErrors` is not null, it is set as [TestRenderingFlutterBinding.onError].
 void pumpFrame({ EnginePhase phase = EnginePhase.layout, VoidCallback? onErrors }) {
-  assert(TestRenderingFlutterBinding.instance != null);
-  assert(TestRenderingFlutterBinding.instance.renderView != null);
   assert(TestRenderingFlutterBinding.instance.renderView.child != null); // call layout() first!
 
   if (onErrors != null) {

--- a/packages/flutter/test/services/text_input_utils.dart
+++ b/packages/flutter/test/services/text_input_utils.dart
@@ -8,7 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class FakeTextChannel implements MethodChannel {
-  FakeTextChannel(this.outgoing) : assert(outgoing != null);
+  FakeTextChannel(this.outgoing);
 
   Future<dynamic> Function(MethodCall) outgoing;
   Future<void> Function(MethodCall)? incoming;

--- a/packages/flutter/test/widgets/actions_test.dart
+++ b/packages/flutter/test/widgets/actions_test.dart
@@ -1869,8 +1869,7 @@ class ThirdTestIntent extends SecondTestIntent {
 class TestAction extends CallbackAction<TestIntent> {
   TestAction({
     required OnInvokeCallback onInvoke,
-  })  : assert(onInvoke != null),
-        super(onInvoke: onInvoke);
+  })  : super(onInvoke: onInvoke);
 
   @override
   bool isEnabled(TestIntent intent) => enabled;

--- a/packages/flutter/test/widgets/autocomplete_test.dart
+++ b/packages/flutter/test/widgets/autocomplete_test.dart
@@ -507,7 +507,7 @@ void main() {
         home: Scaffold(
           body: RawAutocomplete<String>(
             optionsBuilder: (TextEditingValue textEditingValue) {
-              if (textEditingValue.text == null || textEditingValue.text == '') {
+              if (textEditingValue.text == '') {
                 return const Iterable<String>.empty();
               }
               return kOptions.where((String option) {

--- a/packages/flutter/test/widgets/baseline_test.dart
+++ b/packages/flutter/test/widgets/baseline_test.dart
@@ -151,9 +151,7 @@ class RenderBaselineDetector extends RenderBox {
 
   @override
   double computeDistanceToActualBaseline(TextBaseline baseline) {
-    if (callback != null) {
-      callback();
-    }
+    callback();
     return 20.0;
   }
 

--- a/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
+++ b/packages/flutter/test/widgets/custom_multi_child_layout_test.dart
@@ -153,7 +153,7 @@ class LayoutWithMissingId extends ParentDataWidget<MultiChildLayoutParentData> {
   const LayoutWithMissingId({
     super.key,
     required super.child,
-  }) : assert(child != null);
+  });
 
   @override
   void applyParentData(RenderObject renderObject) {}

--- a/packages/flutter/test/widgets/dismissible_test.dart
+++ b/packages/flutter/test/widgets/dismissible_test.dart
@@ -174,7 +174,6 @@ Future<void> dismissItem(
   required AxisDirection gestureDirection,
   DismissMethod mechanism = dismissElement,
 }) async {
-  assert(gestureDirection != null);
   final Finder itemFinder = find.text(item.toString());
   expect(itemFinder, findsOneWidget);
 
@@ -188,7 +187,6 @@ Future<void> dragItem(
       required AxisDirection gestureDirection,
       required double amount,
     }) async {
-  assert(gestureDirection != null);
   final Finder itemFinder = find.text(item.toString());
   expect(itemFinder, findsOneWidget);
 
@@ -202,7 +200,6 @@ Future<void> checkFlingItemBeforeMovementEnd(
   required AxisDirection gestureDirection,
   DismissMethod mechanism = rollbackElement,
 }) async {
-  assert(gestureDirection != null);
   final Finder itemFinder = find.text(item.toString());
   expect(itemFinder, findsOneWidget);
 
@@ -218,7 +215,6 @@ Future<void> checkFlingItemAfterMovement(
   required AxisDirection gestureDirection,
   DismissMethod mechanism = rollbackElement,
 }) async {
-  assert(gestureDirection != null);
   final Finder itemFinder = find.text(item.toString());
   expect(itemFinder, findsOneWidget);
 

--- a/packages/flutter/test/widgets/fade_in_image_test.dart
+++ b/packages/flutter/test/widgets/fade_in_image_test.dart
@@ -15,9 +15,7 @@ import '../painting/image_test_utils.dart';
 const Duration animationDuration = Duration(milliseconds: 50);
 
 class FadeInImageParts {
-  const FadeInImageParts(this.fadeInImageElement, this.placeholder, this.target)
-      : assert(fadeInImageElement != null),
-        assert(target != null);
+  const FadeInImageParts(this.fadeInImageElement, this.placeholder, this.target);
 
   final ComponentElement fadeInImageElement;
   final FadeInImageElements? placeholder;

--- a/packages/flutter/test/widgets/framework_test.dart
+++ b/packages/flutter/test/widgets/framework_test.dart
@@ -1810,9 +1810,7 @@ class Decorate extends StatefulWidget {
     super.key,
     required this.didChangeDependencies,
     required this.build,
-  }) :
-    assert(didChangeDependencies != null),
-    assert(build != null);
+  });
 
   final void Function(bool isInBuild) didChangeDependencies;
   final void Function(bool isInBuild) build;
@@ -1974,7 +1972,7 @@ class StatelessWidgetSpy extends StatelessWidget {
   const StatelessWidgetSpy({
     super.key,
     required this.onBuild,
-  })  : assert(onBuild != null);
+  });
 
   final void Function(BuildContext) onBuild;
 

--- a/packages/flutter/test/widgets/gesture_detector_semantics_test.dart
+++ b/packages/flutter/test/widgets/gesture_detector_semantics_test.dart
@@ -725,9 +725,7 @@ class _RenderTestLayoutPerformer extends RenderBox {
   @override
   void performLayout() {
     size = const Size(1, 1);
-    if (_performLayout != null) {
-      _performLayout();
-    }
+    _performLayout();
   }
 }
 

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -205,7 +205,6 @@ class FakeWindowPadding implements WindowPadding {
 
 Future<void> main() async {
   final ui.Image testImage = await createTestImage();
-  assert(testImage != null);
 
   setUp(() {
     transitionFromUserGestures = false;

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -89,7 +89,6 @@ class TestAssetImage extends AssetImage {
     late ImageInfo imageInfo;
     key.bundle.load(key.name).then<void>((ByteData data) {
       final ui.Image image = images[scaleOf(data)]!;
-      assert(image != null, 'Expected ${scaleOf(data)} to have a key in $images');
       imageInfo = ImageInfo(image: image, scale: key.scale);
     });
     return FakeImageStreamCompleter(

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -2031,9 +2031,7 @@ void main() {
 
 @immutable
 class _ConfigurationAwareKey {
-  const _ConfigurationAwareKey(this.provider, this.configuration)
-    : assert(provider != null),
-      assert(configuration != null);
+  const _ConfigurationAwareKey(this.provider, this.configuration);
 
   final ImageProvider provider;
   final ImageConfiguration configuration;
@@ -2184,11 +2182,7 @@ class _FailingImageProvider extends ImageProvider<int> {
     this.failOnLoad = false,
     required this.throws,
     required this.image,
-  }) : assert(failOnLoad != null),
-       assert(failOnObtainKey != null),
-       assert(failOnLoad == true || failOnObtainKey == true),
-       assert(throws != null),
-       assert(image != null);
+  }) : assert(failOnLoad == true || failOnObtainKey == true);
 
   final bool failOnObtainKey;
   final bool failOnLoad;

--- a/packages/flutter/test/widgets/inherited_model_test.dart
+++ b/packages/flutter/test/widgets/inherited_model_test.dart
@@ -31,7 +31,7 @@ class ABCModel extends InheritedModel<String> {
 
   @override
   bool isSupportedAspect(Object aspect) {
-    return aspect == null || aspects == null || aspects!.contains(aspect);
+    return aspects == null || aspects!.contains(aspect);
   }
 
   @override

--- a/packages/flutter/test/widgets/layout_builder_mutations_test.dart
+++ b/packages/flutter/test/widgets/layout_builder_mutations_test.dart
@@ -16,7 +16,7 @@ class Wrapper extends StatelessWidget {
   const Wrapper({
     super.key,
     required this.child,
-  }) : assert(child != null);
+  });
 
   final Widget child;
 

--- a/packages/flutter/test/widgets/linked_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/linked_scroll_view_test.dart
@@ -111,7 +111,7 @@ class LinkedScrollPosition extends ScrollPositionWithSingleContext {
     required super.context,
     required double super.initialPixels,
     super.oldPosition,
-  }) : assert(owner != null);
+  });
 
   final LinkedScrollController owner;
 

--- a/packages/flutter/test/widgets/list_view_test.dart
+++ b/packages/flutter/test/widgets/list_view_test.dart
@@ -662,7 +662,6 @@ void main() {
     final ScrollController controller = ScrollController();
 
     Widget buildListView({ required Axis scrollDirection }) {
-      assert(scrollDirection != null);
       return Directionality(
         textDirection: TextDirection.ltr,
         child: Center(

--- a/packages/flutter/test/widgets/mouse_region_test.dart
+++ b/packages/flutter/test/widgets/mouse_region_test.dart
@@ -1930,7 +1930,7 @@ class _HoverClientWithClosuresState extends State<_HoverClientWithClosures> {
 class _ColumnContainer extends StatelessWidget {
   const _ColumnContainer({
     required this.children,
-  }) : assert(children != null);
+  });
 
   final List<Widget> children;
 

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -390,7 +390,7 @@ List<PlatformMenuItem> createTestMenus({
 }
 
 class FakeMenuChannel implements MethodChannel {
-  FakeMenuChannel(this.outgoing) : assert(outgoing != null);
+  FakeMenuChannel(this.outgoing);
 
   Future<dynamic> Function(MethodCall) outgoing;
   Future<void> Function(MethodCall)? incoming;

--- a/packages/flutter/test/widgets/render_object_element_test.dart
+++ b/packages/flutter/test/widgets/render_object_element_test.dart
@@ -113,7 +113,6 @@ class SwapperElementWithProperOverrides extends SwapperElement {
   @override
   void insertRenderObjectChild(RenderBox child, Object? slot) {
     insertSlots.add(slot);
-    assert(child != null);
     if (slot == 'stable') {
       renderObject.stable = child;
     } else {

--- a/packages/flutter/test/widgets/router_test.dart
+++ b/packages/flutter/test/widgets/router_test.dart
@@ -778,7 +778,7 @@ testWidgets('ChildBackButtonDispatcher take priority recursively', (WidgetTester
     final SimpleRouterDelegate delegate = SimpleRouterDelegate(
       builder: (BuildContext context, RouteInformation? information) {
         final List<Widget> children = <Widget>[];
-        if (information!.location! != null) {
+        if (information!.location != null) {
           children.add(Text(information.location!));
         }
         if (information.state != null) {

--- a/packages/flutter/test/widgets/semantics_6_test.dart
+++ b/packages/flutter/test/widgets/semantics_6_test.dart
@@ -48,7 +48,6 @@ void main() {
 }
 
 Widget buildWidget({ required String blockedText, bool blocking = true }) {
-  assert(blockedText != null);
   return Directionality(
     textDirection: TextDirection.ltr,
     child: Stack(

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -53,12 +53,6 @@ class TestSemantics {
     Iterable<SemanticsTag>? tags,
   }) : assert(flags is int || flags is List<SemanticsFlag>),
        assert(actions is int || actions is List<SemanticsAction>),
-       assert(label != null),
-       assert(value != null),
-       assert(increasedValue != null),
-       assert(decreasedValue != null),
-       assert(hint != null),
-       assert(children != null),
        tags = tags?.toSet() ?? <SemanticsTag>{};
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
@@ -82,15 +76,9 @@ class TestSemantics {
   }) : id = 0,
        assert(flags is int || flags is List<SemanticsFlag>),
        assert(actions is int || actions is List<SemanticsAction>),
-       assert(label != null),
-       assert(increasedValue != null),
-       assert(decreasedValue != null),
-       assert(value != null),
-       assert(hint != null),
        rect = TestSemantics.rootRect,
        elevation = 0.0,
        thickness = 0.0,
-       assert(children != null),
        tags = tags?.toSet() ?? <SemanticsTag>{};
 
   /// Creates an object with some test semantics data, with the [id] and [rect]
@@ -125,13 +113,7 @@ class TestSemantics {
     Iterable<SemanticsTag>? tags,
   }) : assert(flags is int || flags is List<SemanticsFlag>),
        assert(actions is int || actions is List<SemanticsAction>),
-       assert(label != null),
-       assert(value != null),
-       assert(increasedValue != null),
-       assert(decreasedValue != null),
-       assert(hint != null),
        transform = _applyRootChildScale(transform),
-       assert(children != null),
        tags = tags?.toSet() ?? <SemanticsTag>{};
 
   /// The unique identifier for this node.
@@ -381,22 +363,22 @@ class TestSemantics {
     if (actions is int && actions != 0 || actions is List<SemanticsAction> && (actions as List<SemanticsAction>).isNotEmpty) {
       buf.writeln('$indent  actions: ${SemanticsTester._actionsToSemanticsActionExpression(actions)},');
     }
-    if (label != null && label != '') {
+    if (label != '') {
       buf.writeln("$indent  label: '$label',");
     }
-    if (value != null && value != '') {
+    if (value != '') {
       buf.writeln("$indent  value: '$value',");
     }
-    if (increasedValue != null && increasedValue != '') {
+    if (increasedValue != '') {
       buf.writeln("$indent  increasedValue: '$increasedValue',");
     }
-    if (decreasedValue != null && decreasedValue != '') {
+    if (decreasedValue != '') {
       buf.writeln("$indent  decreasedValue: '$decreasedValue',");
     }
-    if (hint != null && hint != '') {
+    if (hint != '') {
       buf.writeln("$indent  hint: '$hint',");
     }
-    if (tooltip != null && tooltip != '') {
+    if (tooltip != '') {
       buf.writeln("$indent  tooltip: '$tooltip',");
     }
     if (textDirection != null) {
@@ -690,21 +672,21 @@ class SemanticsTester {
     if (nodeData.actions != 0) {
       buf.writeln('  actions: ${_actionsToSemanticsActionExpression(nodeData.actions)},');
     }
-    if (node.label != null && node.label.isNotEmpty) {
+    if (node.label.isNotEmpty) {
       // Escape newlines and text directionality control characters.
       final String escapedLabel = node.label.replaceAll('\n', r'\n').replaceAll('\u202a', r'\u202a').replaceAll('\u202c', r'\u202c');
       buf.writeln("  label: '$escapedLabel',");
     }
-    if (node.value != null && node.value.isNotEmpty) {
+    if (node.value.isNotEmpty) {
       buf.writeln("  value: '${node.value}',");
     }
-    if (node.increasedValue != null && node.increasedValue.isNotEmpty) {
+    if (node.increasedValue.isNotEmpty) {
       buf.writeln("  increasedValue: '${node.increasedValue}',");
     }
-    if (node.decreasedValue != null && node.decreasedValue.isNotEmpty) {
+    if (node.decreasedValue.isNotEmpty) {
       buf.writeln("  decreasedValue: '${node.decreasedValue}',");
     }
-    if (node.hint != null && node.hint.isNotEmpty) {
+    if (node.hint.isNotEmpty) {
       buf.writeln("  hint: '${node.hint}',");
     }
     if (node.textDirection != null) {
@@ -732,11 +714,7 @@ class _HasSemantics extends Matcher {
     required this.ignoreTransform,
     required this.ignoreId,
     required this.childOrder,
-  }) : assert(_semantics != null),
-       assert(ignoreRect != null),
-       assert(ignoreId != null),
-       assert(ignoreTransform != null),
-       assert(childOrder != null);
+  });
 
   final TestSemantics _semantics;
   final bool ignoreRect;

--- a/packages/flutter/test/widgets/shortcuts_test.dart
+++ b/packages/flutter/test/widgets/shortcuts_test.dart
@@ -1908,7 +1908,7 @@ class _TestCallbackRegistrationState extends State<TestCallbackRegistration> {
 class TestAction extends CallbackAction<Intent> {
   TestAction({
     required super.onInvoke,
-  })  : assert(onInvoke != null);
+  });
 
   static const LocalKey key = ValueKey<Type>(TestAction);
 }

--- a/packages/flutter/test/widgets/test_border.dart
+++ b/packages/flutter/test/widgets/test_border.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 typedef Logger = void Function(String caller);
 
 class TestBorder extends ShapeBorder {
-  const TestBorder(this.onLog) : assert(onLog != null);
+  const TestBorder(this.onLog);
 
   final Logger onLog;
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

Dart 3 drops support for non-null safe code, so we can finally turn on the unnecessary_null_comparison lint and remove the unnecessary checks it flags.