### PR TITLE
Run integration_ui_test_test_macos in prod pool

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2840,7 +2840,6 @@ targets:
       task_name: hello_world_macos__compile
 
   - name: Mac integration_ui_test_test_macos
-    bringup: true
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60


### PR DESCRIPTION
Introduced in #112297, has been passing from the beginning.