### PR TITLE
Update the Linux Android defines test to use dimensions when selecting a build bot

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1379,12 +1379,25 @@ targets:
 
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    presubmit: true
+    bringup: true
     timeout: 60
+    dimensions: 
+      cores: "8"
+      kvm: "1"
+      machine_type: "n1-standard-8"
     properties:
+      device_type: "none"
       tags: >
         ["devicelab" ,"android", "linux"]
       task_name: android_defines_test
+      dependencies: >-
+        [
+          {"dependency": "android_virtual_device", "version": "31"},
+          {"dependency": "android_sdk", "version": "version:33v6"},
+          {"dependency": "open_jdk", "version": "version:11"}
+        ]
+      use_emulator: "true"
 
   - name: Linux_android android_obfuscate_test
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1384,7 +1384,7 @@ targets:
     timeout: 60
     dimensions: {
       "cores": "8",
-      "kvm": "1"
+      "kvm": "1",
       "machine_type": "n1-standard-8"
     }
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1382,10 +1382,11 @@ targets:
     presubmit: true
     bringup: true
     timeout: 60
-    dimensions: 
-      cores: "8"
-      kvm: "1"
-      machine_type: "n1-standard-8"
+    dimensions: {
+      "cores": "8",
+      "kvm": "1"
+      "machine_type": "n1-standard-8"
+    }
     properties:
       device_type: "none"
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1382,8 +1382,10 @@ targets:
     presubmit: true
     bringup: true
     timeout: 60
-    swarming_dimensions: {
-      "kvm": "8"
+    dimensions: {
+      kvm: "1",
+      cores: "8",
+      machine_type: "n1-standard-8"
     }
     properties:
       device_type: "none"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1384,9 +1384,9 @@ targets:
     timeout: 60
     dimensions: >-
       [
-        {"cores": "8"},
-        {"kvm": "1"},
-        {"machine_type": "n1-standard-8"}
+        {"key":"cores", "value","8"},
+        {"key":"kvm", "value":"1"},
+        {"key":"machine_type", "value":"n1-standard-8"}
       ]
     properties:
       device_type: "none"

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1382,12 +1382,8 @@ targets:
     presubmit: true
     bringup: true
     timeout: 60
-    dimensions: >-
-      [
-        {"key":"cores", "value","8"},
-        {"key":"kvm", "value":"1"},
-        {"key":"machine_type", "value":"n1-standard-8"}
-      ]
+    dimensions:
+      kvm: "1"
     properties:
       device_type: "none"
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1382,11 +1382,12 @@ targets:
     presubmit: true
     bringup: true
     timeout: 60
-    dimensions: {
-      "cores": "8",
-      "kvm": "1",
-      "machine_type": "n1-standard-8"
-    }
+    dimensions: >-
+      [
+        {"cores": "8"},
+        {"kvm": "1"},
+        {"machine_type": "n1-standard-8"}
+      ]
     properties:
       device_type: "none"
       tags: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1382,8 +1382,9 @@ targets:
     presubmit: true
     bringup: true
     timeout: 60
-    dimensions:
-      kvm: "1"
+    swarming_dimensions: {
+      "kvm": "8"
+    }
     properties:
       device_type: "none"
       tags: >


### PR DESCRIPTION
Updating the Linux Android defines test to use dimensions to specify a kvm supported bot to run emulator tests on. Also moves this target to presubmit instead of post submit.

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
