### PR TITLE
Add more flexible image API

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/animated_placeholder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/animated_placeholder.dart
@@ -58,7 +58,7 @@ class DelayedBase64Image extends ImageProvider<int> {
   }
 
   @override
-  ImageStreamCompleter loadBuffer(int key, DecoderBufferCallback decode) {
+  ImageStreamCompleter loadImage(int key, ImageDecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
       codec: Future<ui.Codec>.delayed(
         delay,

--- a/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
@@ -9,15 +9,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-// This class allows loadBuffer, a protected method, to be called with a custom
-// DecoderBufferCallback function.
+// This class allows loadImage, a protected method, to be called with a custom
+// ImageDecoderCallback function.
 class LoadTestImageProvider extends ImageProvider<Object> {
   LoadTestImageProvider(this.provider);
 
   final ImageProvider provider;
 
-  ImageStreamCompleter testLoad(Object key, DecoderBufferCallback decode) {
-    return provider.loadBuffer(key, decode);
+  ImageStreamCompleter testLoad(Object key, ImageDecoderCallback decode) {
+    return provider.loadImage(key, decode);
   }
 
   @override
@@ -26,7 +26,7 @@ class LoadTestImageProvider extends ImageProvider<Object> {
   }
 
   @override
-  ImageStreamCompleter loadBuffer(Object key, DecoderBufferCallback decode) {
+  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) {
     throw UnimplementedError();
   }
 }
@@ -47,12 +47,14 @@ void main() {
 
     bool called = false;
 
-    Future<ui.Codec> decode(ui.ImmutableBuffer buffer, {int? cacheWidth, int? cacheHeight, bool allowUpscaling = false}) {
-      expect(cacheHeight, expectedCacheHeight);
-      expect(cacheWidth, expectedCacheWidth);
-      expect(allowUpscaling, false);
-      called = true;
-      return PaintingBinding.instance.instantiateImageCodecFromBuffer(buffer, cacheWidth: cacheWidth, cacheHeight: cacheHeight, allowUpscaling: allowUpscaling);
+    Future<ui.Codec> decode(ui.ImmutableBuffer buffer, {ui.TargetImageSizeCallback? getTargetSize}) {
+      return PaintingBinding.instance.instantiateImageCodecWithSize(buffer, getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
+        ui.TargetImageSize targetSize = getTargetSize(intrinsicWidth, intrinsicHeight);
+        expect(targetSize.width, expectedCacheWidth);
+        expect(targetSize.height, expectedCacheHeight);
+        called = true;
+        return targetSize;
+      });
     }
 
     final ImageProvider resizeImage = image.image;

--- a/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
+++ b/dev/integration_tests/web_e2e_tests/test_driver/cache_width_cache_height_integration.dart
@@ -49,7 +49,8 @@ void main() {
 
     Future<ui.Codec> decode(ui.ImmutableBuffer buffer, {ui.TargetImageSizeCallback? getTargetSize}) {
       return PaintingBinding.instance.instantiateImageCodecWithSize(buffer, getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
-        ui.TargetImageSize targetSize = getTargetSize(intrinsicWidth, intrinsicHeight);
+        expect(getTargetSize, isNotNull);
+        final ui.TargetImageSize targetSize = getTargetSize!(intrinsicWidth, intrinsicHeight);
         expect(targetSize.width, expectedCacheWidth);
         expect(targetSize.height, expectedCacheHeight);
         called = true;

--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -43,7 +43,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
 
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key as NetworkImage, chunkEvents, null, null, decode),
+      codec: _loadAsync(key as NetworkImage, chunkEvents, decodeDeprecated: decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       debugLabel: key.url,
@@ -62,7 +62,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
 
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key as NetworkImage, chunkEvents, null, decode, null),
+      codec: _loadAsync(key as NetworkImage, chunkEvents, decodeBufferDeprecated: decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       debugLabel: key.url,
@@ -81,7 +81,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
 
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key as NetworkImage, chunkEvents, decode, null, null),
+      codec: _loadAsync(key as NetworkImage, chunkEvents, decode: decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       debugLabel: key.url,
@@ -111,11 +111,11 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
 
   Future<ui.Codec> _loadAsync(
     NetworkImage key,
-    StreamController<ImageChunkEvent> chunkEvents,
+    StreamController<ImageChunkEvent> chunkEvents, {
     image_provider.ImageDecoderCallback? decode,
     image_provider.DecoderBufferCallback? decodeBufferDeprecated,
     image_provider.DecoderCallback? decodeDeprecated,
-  ) async {
+  }) async {
     try {
       assert(key == this);
 

--- a/packages/flutter/lib/src/painting/_network_image_io.dart
+++ b/packages/flutter/lib/src/painting/_network_image_io.dart
@@ -43,7 +43,7 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
 
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key as NetworkImage, chunkEvents, null, decode),
+      codec: _loadAsync(key as NetworkImage, chunkEvents, null, null, decode),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       debugLabel: key.url,
@@ -62,7 +62,26 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
     final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
 
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key as NetworkImage, chunkEvents, decode, null),
+      codec: _loadAsync(key as NetworkImage, chunkEvents, null, decode, null),
+      chunkEvents: chunkEvents.stream,
+      scale: key.scale,
+      debugLabel: key.url,
+      informationCollector: () => <DiagnosticsNode>[
+        DiagnosticsProperty<image_provider.ImageProvider>('Image provider', this),
+        DiagnosticsProperty<image_provider.NetworkImage>('Image key', key),
+      ],
+    );
+  }
+
+  @override
+  ImageStreamCompleter loadImage(image_provider.NetworkImage key, image_provider.ImageDecoderCallback decode) {
+    // Ownership of this controller is handed off to [_loadAsync]; it is that
+    // method's responsibility to close the controller's stream when the image
+    // has been loaded or an error is thrown.
+    final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
+
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key as NetworkImage, chunkEvents, decode, null, null),
       chunkEvents: chunkEvents.stream,
       scale: key.scale,
       debugLabel: key.url,
@@ -93,8 +112,9 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
   Future<ui.Codec> _loadAsync(
     NetworkImage key,
     StreamController<ImageChunkEvent> chunkEvents,
-    image_provider.DecoderBufferCallback? decode,
-    image_provider.DecoderCallback? decodeDepreacted,
+    image_provider.ImageDecoderCallback? decode,
+    image_provider.DecoderBufferCallback? decodeBufferDeprecated,
+    image_provider.DecoderCallback? decodeDeprecated,
   ) async {
     try {
       assert(key == this);
@@ -131,9 +151,12 @@ class NetworkImage extends image_provider.ImageProvider<image_provider.NetworkIm
       if (decode != null) {
         final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
         return decode(buffer);
+      } else if (decodeBufferDeprecated != null) {
+        final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+        return decodeBufferDeprecated(buffer);
       } else {
-        assert(decodeDepreacted != null);
-        return decodeDepreacted!(bytes);
+        assert(decodeDeprecated != null);
+        return decodeDeprecated!(bytes);
       }
     } catch (e) {
       // Depending on where the exception was thrown, the image cache may not

--- a/packages/flutter/lib/src/painting/_network_image_web.dart
+++ b/packages/flutter/lib/src/painting/_network_image_web.dart
@@ -65,7 +65,7 @@ class NetworkImage
 
     return MultiFrameImageStreamCompleter(
       chunkEvents: chunkEvents.stream,
-      codec: _loadAsync(key as NetworkImage, null, decode, chunkEvents),
+      codec: _loadAsync(key as NetworkImage, null, null, decode, chunkEvents),
       scale: key.scale,
       debugLabel: key.url,
       informationCollector: _imageStreamInformationCollector(key),
@@ -82,7 +82,23 @@ class NetworkImage
 
     return MultiFrameImageStreamCompleter(
       chunkEvents: chunkEvents.stream,
-      codec: _loadAsync(key as NetworkImage, decode, null, chunkEvents),
+      codec: _loadAsync(key as NetworkImage, null, decode, null, chunkEvents),
+      scale: key.scale,
+      debugLabel: key.url,
+      informationCollector: _imageStreamInformationCollector(key),
+    );
+  }
+
+  @override
+  ImageStreamCompleter loadImage(image_provider.NetworkImage key, image_provider.ImageDecoderCallback decode) {
+    // Ownership of this controller is handed off to [_loadAsync]; it is that
+    // method's responsibility to close the controller's stream when the image
+    // has been loaded or an error is thrown.
+    final StreamController<ImageChunkEvent> chunkEvents = StreamController<ImageChunkEvent>();
+
+    return MultiFrameImageStreamCompleter(
+      chunkEvents: chunkEvents.stream,
+      codec: _loadAsync(key as NetworkImage, decode, null, null, chunkEvents),
       scale: key.scale,
       debugLabel: key.url,
       informationCollector: _imageStreamInformationCollector(key),
@@ -106,8 +122,9 @@ class NetworkImage
   // directly in place of the typical `instantiateImageCodec` method.
   Future<ui.Codec> _loadAsync(
     NetworkImage key,
-    image_provider.DecoderBufferCallback? decode,
-    image_provider.DecoderCallback? decodeDepreacted,
+    image_provider.ImageDecoderCallback? decode,
+    image_provider.DecoderBufferCallback? decodeBufferDeprecated,
+    image_provider.DecoderCallback? decodeDeprecated,
     StreamController<ImageChunkEvent> chunkEvents,
   ) async {
     assert(key == this);
@@ -165,9 +182,12 @@ class NetworkImage
       if (decode != null) {
         final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
         return decode(buffer);
+      } else if (decodeBufferDeprecated != null) {
+        final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+        return decodeBufferDeprecated(buffer);
       } else {
-        assert(decodeDepreacted != null);
-        return decodeDepreacted!(bytes);
+        assert(decodeDeprecated != null);
+        return decodeDeprecated!(bytes);
       }
     } else {
       // This API only exists in the web engine implementation and is not

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -142,7 +142,7 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// drawn into.
   @Deprecated(
     'Use instantiateImageCodecWithSize instead. '
-    'This feature was deprecated after v3.7.0.',
+    'This feature was deprecated after v3.7.0-1.4.pre.',
   )
   Future<ui.Codec> instantiateImageCodecFromBuffer(
     ui.ImmutableBuffer buffer, {

--- a/packages/flutter/lib/src/painting/binding.dart
+++ b/packages/flutter/lib/src/painting/binding.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show Codec, ImmutableBuffer, instantiateImageCodec, instantiateImageCodecFromBuffer;
+import 'dart:ui' as ui;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show ServicesBinding;
 
@@ -100,7 +100,7 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// above its native resolution should prefer scaling the canvas the image is
   /// drawn into.
   @Deprecated(
-    'Use instantiateImageCodecFromBuffer with an ImmutableBuffer instance instead. '
+    'Use instantiateImageCodecWithSize with an ImmutableBuffer instance instead. '
     'This feature was deprecated after v2.13.0-1.0.pre.',
   )
   Future<ui.Codec> instantiateImageCodec(
@@ -140,6 +140,10 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
   /// unnecessary memory usage for images. Callers that wish to display an image
   /// above its native resolution should prefer scaling the canvas the image is
   /// drawn into.
+  @Deprecated(
+    'Use instantiateImageCodecWithSize instead. '
+    'This feature was deprecated after v3.7.0.',
+  )
   Future<ui.Codec> instantiateImageCodecFromBuffer(
     ui.ImmutableBuffer buffer, {
     int? cacheWidth,
@@ -154,6 +158,28 @@ mixin PaintingBinding on BindingBase, ServicesBinding {
       targetHeight: cacheHeight,
       allowUpscaling: allowUpscaling,
     );
+  }
+
+  /// Calls through to [dart:ui.instantiateImageCodecWithSize] from [ImageCache].
+  ///
+  /// The [buffer] parameter should be an [ui.ImmutableBuffer] instance which can
+  /// be acquired from [ui.ImmutableBuffer.fromUint8List] or
+  /// [ui.ImmutableBuffer.fromAsset].
+  ///
+  /// The [getTargetSize] parameter, when specified, will be invoked and passed
+  /// the image's intrinsic size to determine the size to decode the image to.
+  /// The width and the height of the size it returns must be positive values
+  /// greater than or equal to 1, or null. It is valid to return a [TargetImageSize]
+  /// that specifies only one of `width` and `height` with the other remaining
+  /// null, in which case the omitted dimension will be scaled to maintain the
+  /// aspect ratio of the original dimensions. When both are null or omitted,
+  /// the image will be decoded at its native resolution (as will be the case if
+  /// the [getTargetSize] parameter is omitted).
+  Future<ui.Codec> instantiateImageCodecWithSize(
+    ui.ImmutableBuffer buffer, {
+    ui.TargetImageSizeCallback? getTargetSize,
+  }) {
+    return ui.instantiateImageCodecWithSize(buffer, getTargetSize: getTargetSize);
   }
 
   @override

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -1416,7 +1416,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
 }
 
 // A completer used when resolving an image fails sync.
-class _ErrorImageCompleter extends ImageStreamCompleter {}
+class _ErrorImageCompleter extends ImageStreamCompleter { }
 
 /// The exception thrown when the HTTP request to load a network image fails.
 class NetworkImageLoadException implements Exception {

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -803,7 +803,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
     DecoderCallback? decodeDeprecated,
   ) async {
     if (decode != null) {
-      ui.ImmutableBuffer? buffer;
+      ui.ImmutableBuffer buffer;
       // Hot reload/restart could change whether an asset bundle or key in a
       // bundle are available, or if it is a network backed bundle.
       try {
@@ -815,18 +815,14 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       return decode(buffer);
     }
     if (decodeBufferDeprecated != null) {
-      ui.ImmutableBuffer? buffer;
-      // Hot reload/restart could chnage whether an asset bundle or key in a
+      ui.ImmutableBuffer buffer;
+      // Hot reload/restart could change whether an asset bundle or key in a
       // bundle are available, or if it is a network backed bundle.
       try {
         buffer = await key.bundle.loadBuffer(key.name);
       } on FlutterError {
         PaintingBinding.instance.imageCache.evict(key);
         rethrow;
-      }
-      if (buffer == null) {
-        PaintingBinding.instance.imageCache.evict(key);
-        throw StateError('Unable to read data');
       }
       return decodeBufferDeprecated(buffer);
     }

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -667,7 +667,7 @@ abstract class ImageProvider<T extends Object> {
   /// See also:
   ///
   ///  * [ResizeImage], for modifying the key to account for cache dimensions.
-  // TODO(tvolkert): make abstract nethod once backwards compatibility shim isn't needed.
+  // TODO(tvolkert): make abstract (https://github.com/flutter/flutter/issues/119209)
   @protected
   ImageStreamCompleter loadImage(T key, ImageDecoderCallback decode) {
     return _AbstractImageStreamCompleter();
@@ -746,7 +746,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       return true;
     }());
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode, null, null),
+      codec: _loadAsync(key, decode: decode),
       scale: key.scale,
       debugLabel: key.name,
       informationCollector: collector,
@@ -766,7 +766,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       return true;
     }());
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, decode, null),
+      codec: _loadAsync(key, decodeBufferDeprecated: decode),
       scale: key.scale,
       debugLabel: key.name,
       informationCollector: collector,
@@ -784,7 +784,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       return true;
     }());
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, null, decode),
+      codec: _loadAsync(key, decodeDeprecated: decode),
       scale: key.scale,
       debugLabel: key.name,
       informationCollector: collector,
@@ -797,11 +797,11 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
   /// This function is used by [load].
   @protected
   Future<ui.Codec> _loadAsync(
-    AssetBundleImageKey key,
+    AssetBundleImageKey key, {
     ImageDecoderCallback? decode,
     DecoderBufferCallback? decodeBufferDeprecated,
     DecoderCallback? decodeDeprecated,
-  ) async {
+  }) async {
     if (decode != null) {
       ui.ImmutableBuffer buffer;
       // Hot reload/restart could change whether an asset bundle or key in a
@@ -1082,7 +1082,7 @@ class FileImage extends ImageProvider<FileImage> {
   @override
   ImageStreamCompleter load(FileImage key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, null, decode),
+      codec: _loadAsync(key, decodeDeprecated: decode),
       scale: key.scale,
       debugLabel: key.file.path,
       informationCollector: () => <DiagnosticsNode>[
@@ -1094,7 +1094,7 @@ class FileImage extends ImageProvider<FileImage> {
   @override
   ImageStreamCompleter loadBuffer(FileImage key, DecoderBufferCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, decode, null),
+      codec: _loadAsync(key, decodeBufferDeprecated: decode),
       scale: key.scale,
       debugLabel: key.file.path,
       informationCollector: () => <DiagnosticsNode>[
@@ -1107,7 +1107,7 @@ class FileImage extends ImageProvider<FileImage> {
   @protected
   ImageStreamCompleter loadImage(FileImage key, ImageDecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode, null, null),
+      codec: _loadAsync(key, decode: decode),
       scale: key.scale,
       debugLabel: key.file.path,
       informationCollector: () => <DiagnosticsNode>[
@@ -1117,11 +1117,11 @@ class FileImage extends ImageProvider<FileImage> {
   }
 
   Future<ui.Codec> _loadAsync(
-    FileImage key,
+    FileImage key, {
     ImageDecoderCallback? decode,
     DecoderBufferCallback? decodeBufferDeprecated,
     DecoderCallback? decodeDeprecated,
-  ) async {
+  }) async {
     assert(key == this);
 
     // TODO(jonahwilliams): making this sync caused test failures that seem to
@@ -1211,7 +1211,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   @override
   ImageStreamCompleter load(MemoryImage key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, null, decode),
+      codec: _loadAsync(key, decodeDeprecated: decode),
       scale: key.scale,
       debugLabel: 'MemoryImage(${describeIdentity(key.bytes)})',
     );
@@ -1220,7 +1220,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   @override
   ImageStreamCompleter loadBuffer(MemoryImage key, DecoderBufferCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, decode, null),
+      codec: _loadAsync(key, decodeBufferDeprecated: decode),
       scale: key.scale,
       debugLabel: 'MemoryImage(${describeIdentity(key.bytes)})',
     );
@@ -1229,18 +1229,18 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   @override
   ImageStreamCompleter loadImage(MemoryImage key, ImageDecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode, null, null),
+      codec: _loadAsync(key, decode: decode),
       scale: key.scale,
       debugLabel: 'MemoryImage(${describeIdentity(key.bytes)})',
     );
   }
 
   Future<ui.Codec> _loadAsync(
-    MemoryImage key,
+    MemoryImage key, {
     ImageDecoderCallback? decode,
     DecoderBufferCallback? decodeBufferDeprecated,
     DecoderCallback? decodeDeprecated,
-  ) async {
+  }) async {
     assert(key == this);
     if (decode != null) {
       final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -192,7 +192,7 @@ typedef DecoderCallback = Future<ui.Codec> Function(Uint8List buffer, {int? cach
 ///    `cacheHeight`, and `allowUpscaling` parameters.
 @Deprecated(
   'Use ImageDecoderCallback with ImageProvider.loadImage instead. '
-  'This feature was deprecated after v3.0.0.',
+  'This feature was deprecated after v3.7.0-1.4.pre.',
 )
 typedef DecoderBufferCallback = Future<ui.Codec> Function(ui.ImmutableBuffer buffer, {int? cacheWidth, int? cacheHeight, bool allowUpscaling});
 
@@ -647,7 +647,7 @@ abstract class ImageProvider<T extends Object> {
   @protected
   @Deprecated(
     'Implement loadImage for image loading. '
-    'This feature was deprecated after v3.7.0',
+    'This feature was deprecated after v3.7.0-1.4.pre.',
   )
   ImageStreamCompleter loadBuffer(T key, DecoderBufferCallback decode) {
     return _AbstractImageStreamCompleter();

--- a/packages/flutter/lib/src/painting/image_provider.dart
+++ b/packages/flutter/lib/src/painting/image_provider.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui' as ui show Codec, ImmutableBuffer;
+import 'dart:ui' as ui;
 import 'dart:ui' show Locale, Size, TextDirection;
 
 import 'package:flutter/foundation.dart';
@@ -175,11 +175,10 @@ class ImageConfiguration {
 ///  * [ResizeImage], which uses this to override the `cacheWidth`,
 ///    `cacheHeight`, and `allowUpscaling` parameters.
 @Deprecated(
-  'Use DecoderBufferCallback with ImageProvider.loadBuffer instead. '
+  'Use ImageDecoderCallback with ImageProvider.loadImage instead. '
   'This feature was deprecated after v2.13.0-1.0.pre.',
 )
 typedef DecoderCallback = Future<ui.Codec> Function(Uint8List buffer, {int? cacheWidth, int? cacheHeight, bool allowUpscaling});
-
 
 /// Performs the decode process for use in [ImageProvider.loadBuffer].
 ///
@@ -191,7 +190,24 @@ typedef DecoderCallback = Future<ui.Codec> Function(Uint8List buffer, {int? cach
 ///
 ///  * [ResizeImage], which uses this to override the `cacheWidth`,
 ///    `cacheHeight`, and `allowUpscaling` parameters.
+@Deprecated(
+  'Use ImageDecoderCallback with ImageProvider.loadImage instead. '
+  'This feature was deprecated after v3.0.0.',
+)
 typedef DecoderBufferCallback = Future<ui.Codec> Function(ui.ImmutableBuffer buffer, {int? cacheWidth, int? cacheHeight, bool allowUpscaling});
+
+/// Performs the decode process for use in [ImageProvider.loadImage].
+///
+/// This callback allows decoupling of the `getTargetSize` parameter from
+/// implementations of [ImageProvider] that do not expose it.
+///
+/// See also:
+///
+///  * [ResizeImage], which uses this to load images at specific sizes.
+typedef ImageDecoderCallback = Future<ui.Codec> Function(
+  ui.ImmutableBuffer buffer, {
+  ui.TargetImageSizeCallback? getTargetSize,
+});
 
 /// Identifies an image without committing to the precise final asset. This
 /// allows a set of images to be identified and for the precise image to later
@@ -453,9 +469,9 @@ abstract class ImageProvider<T extends Object> {
         return;
       }
       if (!didError) {
+        didError = true;
         errorCallback(obtainedKey, exception, stack);
       }
-      didError = true;
     }
 
     Future<T> key;
@@ -508,7 +524,22 @@ abstract class ImageProvider<T extends Object> {
     }
     final ImageStreamCompleter? completer = PaintingBinding.instance.imageCache.putIfAbsent(
       key,
-      () => loadBuffer(key, PaintingBinding.instance.instantiateImageCodecFromBuffer),
+      () {
+        ImageStreamCompleter result = loadImage(key, PaintingBinding.instance.instantiateImageCodecWithSize);
+        // This check exists as a fallback for backwards compatibility until the
+        // deprecated `loadBuffer()` method is removed. Until then, ImageProvider
+        // subclasses may have only overridden `loadBuffer()`, in which case the
+        // base implementation of `loadWithSize()` will return a sentinel value
+        // of type `_AbstractImageStreamCompleter`.
+        if (result is _AbstractImageStreamCompleter) {
+          result = loadBuffer(key, PaintingBinding.instance.instantiateImageCodecFromBuffer);
+          if (result is _AbstractImageStreamCompleter) {
+            // Same fallback as above but for the deprecated `load()` method.
+            result = load(key, PaintingBinding.instance.instantiateImageCodec);
+          }
+        }
+        return result;
+      },
       onError: handleError,
     );
     if (completer != null) {
@@ -592,7 +623,7 @@ abstract class ImageProvider<T extends Object> {
   ///  * [ResizeImage], for modifying the key to account for cache dimensions.
   @protected
   @Deprecated(
-    'Implement loadBuffer for faster image loading. '
+    'Implement loadImage for faster image loading. '
     'This feature was deprecated after v2.13.0-1.0.pre.',
   )
   ImageStreamCompleter load(T key, DecoderCallback decode) {
@@ -602,9 +633,10 @@ abstract class ImageProvider<T extends Object> {
   /// Converts a key into an [ImageStreamCompleter], and begins fetching the
   /// image.
   ///
-  /// For backwards-compatibility the default implementation of this method calls
-  /// through to [ImageProvider.load]. However, implementors of this interface should
-  /// only override this method and not [ImageProvider.load], which is deprecated.
+  /// For backwards-compatibility the default implementation of this method returns
+  /// an object that will cause [resolveStreamForKey] to consult [load]. However,
+  /// implementors of this interface should only override this method and not
+  /// [load], which is deprecated.
   ///
   /// The [decode] callback provides the logic to obtain the codec for the
   /// image.
@@ -613,13 +645,41 @@ abstract class ImageProvider<T extends Object> {
   ///
   ///  * [ResizeImage], for modifying the key to account for cache dimensions.
   @protected
+  @Deprecated(
+    'Implement loadImage for image loading. '
+    'This feature was deprecated after v3.7.0',
+  )
   ImageStreamCompleter loadBuffer(T key, DecoderBufferCallback decode) {
-    return load(key, PaintingBinding.instance.instantiateImageCodec);
+    return _AbstractImageStreamCompleter();
+  }
+
+  /// Converts a key into an [ImageStreamCompleter], and begins fetching the
+  /// image.
+  ///
+  /// For backwards-compatibility the default implementation of this method returns
+  /// an object that will cause [resolveStreamForKey] to consult [loadBuffer].
+  /// However, implementors of this interface should only override this method
+  /// and not [loadBuffer], which is deprecated.
+  ///
+  /// The [decode] callback provides the logic to obtain the codec for the
+  /// image.
+  ///
+  /// See also:
+  ///
+  ///  * [ResizeImage], for modifying the key to account for cache dimensions.
+  // TODO(tvolkert): make abstract nethod once backwards compatibility shim isn't needed.
+  @protected
+  ImageStreamCompleter loadImage(T key, ImageDecoderCallback decode) {
+    return _AbstractImageStreamCompleter();
   }
 
   @override
   String toString() => '${objectRuntimeType(this, 'ImageConfiguration')}()';
 }
+
+/// A class that exists to facilitate backwards compatibility in the transition
+/// from [ImageProvider.load] to [ImageProvider.loadBuffer] to [ImageProvider.loadImage]
+class _AbstractImageStreamCompleter extends ImageStreamCompleter {}
 
 /// Key for the image obtained by an [AssetImage] or [ExactAssetImage].
 ///
@@ -675,6 +735,24 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
   /// const constructors so that they can be used in const expressions.
   const AssetBundleImageProvider();
 
+  @override
+  ImageStreamCompleter loadImage(AssetBundleImageKey key, ImageDecoderCallback decode) {
+    InformationCollector? collector;
+    assert(() {
+      collector = () => <DiagnosticsNode>[
+            DiagnosticsProperty<ImageProvider>('Image provider', this),
+            DiagnosticsProperty<AssetBundleImageKey>('Image key', key),
+          ];
+      return true;
+    }());
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, decode, null, null),
+      scale: key.scale,
+      debugLabel: key.name,
+      informationCollector: collector,
+    );
+  }
+
   /// Converts a key into an [ImageStreamCompleter], and begins fetching the
   /// image.
   @override
@@ -688,7 +766,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       return true;
     }());
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode, null),
+      codec: _loadAsync(key, null, decode, null),
       scale: key.scale,
       debugLabel: key.name,
       informationCollector: collector,
@@ -706,7 +784,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       return true;
     }());
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, decode),
+      codec: _loadAsync(key, null, null, decode),
       scale: key.scale,
       debugLabel: key.name,
       informationCollector: collector,
@@ -718,7 +796,12 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
   ///
   /// This function is used by [load].
   @protected
-  Future<ui.Codec> _loadAsync(AssetBundleImageKey key, DecoderBufferCallback? decode, DecoderCallback? decodeDepreacted) async {
+  Future<ui.Codec> _loadAsync(
+    AssetBundleImageKey key,
+    ImageDecoderCallback? decode,
+    DecoderBufferCallback? decodeBufferDeprecated,
+    DecoderCallback? decodeDeprecated,
+  ) async {
     if (decode != null) {
       ui.ImmutableBuffer? buffer;
       // Hot reload/restart could change whether an asset bundle or key in a
@@ -731,6 +814,22 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       }
       return decode(buffer);
     }
+    if (decodeBufferDeprecated != null) {
+      ui.ImmutableBuffer? buffer;
+      // Hot reload/restart could chnage whether an asset bundle or key in a
+      // bundle are available, or if it is a network backed bundle.
+      try {
+        buffer = await key.bundle.loadBuffer(key.name);
+      } on FlutterError {
+        PaintingBinding.instance.imageCache.evict(key);
+        rethrow;
+      }
+      if (buffer == null) {
+        PaintingBinding.instance.imageCache.evict(key);
+        throw StateError('Unable to read data');
+      }
+      return decodeBufferDeprecated(buffer);
+    }
     ByteData data;
     // Hot reload/restart could change whether an asset bundle or key in a
     // bundle are available, or if it is a network backed bundle.
@@ -740,7 +839,7 @@ abstract class AssetBundleImageProvider extends ImageProvider<AssetBundleImageKe
       PaintingBinding.instance.imageCache.evict(key);
       rethrow;
     }
-    return decodeDepreacted!(data.buffer.asUint8List());
+    return decodeDeprecated!(data.buffer.asUint8List());
   }
 }
 
@@ -850,7 +949,38 @@ class ResizeImage extends ImageProvider<ResizeImageKey> {
       );
       return decode(buffer, cacheWidth: width, cacheHeight: height, allowUpscaling: this.allowUpscaling);
     }
+
     final ImageStreamCompleter completer = imageProvider.loadBuffer(key._providerCacheKey, decodeResize);
+    if (!kReleaseMode) {
+      completer.debugLabel = '${completer.debugLabel} - Resized(${key._width}×${key._height})';
+    }
+    return completer;
+  }
+
+  @override
+  ImageStreamCompleter loadImage(ResizeImageKey key, ImageDecoderCallback decode) {
+    Future<ui.Codec> decodeResize(ui.ImmutableBuffer buffer, {ui.TargetImageSizeCallback? getTargetSize}) {
+      assert(
+        getTargetSize == null,
+        'ResizeImage cannot be composed with another ImageProvider that applies '
+        'getTargetSize.',
+      );
+      return decode(buffer, getTargetSize: (int intrinsicWidth, int intrinsicHeight) {
+        int? targetWidth = width;
+        int? targetHeight = height;
+        if (!allowUpscaling) {
+          if (targetWidth != null && targetWidth > intrinsicWidth) {
+            targetWidth = intrinsicWidth;
+          }
+          if (targetHeight != null && targetHeight > intrinsicHeight) {
+            targetHeight = intrinsicHeight;
+          }
+        }
+        return ui.TargetImageSize(width: targetWidth, height: targetHeight);
+      });
+    }
+
+    final ImageStreamCompleter completer = imageProvider.loadImage(key._providerCacheKey, decodeResize);
     if (!kReleaseMode) {
       completer.debugLabel = '${completer.debugLabel} - Resized(${key._width}×${key._height})';
     }
@@ -921,6 +1051,9 @@ abstract class NetworkImage extends ImageProvider<NetworkImage> {
 
   @override
   ImageStreamCompleter loadBuffer(NetworkImage key, DecoderBufferCallback decode);
+
+  @override
+  ImageStreamCompleter loadImage(NetworkImage key, ImageDecoderCallback decode);
 }
 
 /// Decodes the given [File] object as an image, associating it with the given
@@ -953,7 +1086,7 @@ class FileImage extends ImageProvider<FileImage> {
   @override
   ImageStreamCompleter load(FileImage key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, decode),
+      codec: _loadAsync(key, null, null, decode),
       scale: key.scale,
       debugLabel: key.file.path,
       informationCollector: () => <DiagnosticsNode>[
@@ -965,7 +1098,7 @@ class FileImage extends ImageProvider<FileImage> {
   @override
   ImageStreamCompleter loadBuffer(FileImage key, DecoderBufferCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode, null),
+      codec: _loadAsync(key, null, decode, null),
       scale: key.scale,
       debugLabel: key.file.path,
       informationCollector: () => <DiagnosticsNode>[
@@ -974,7 +1107,25 @@ class FileImage extends ImageProvider<FileImage> {
     );
   }
 
-  Future<ui.Codec> _loadAsync(FileImage key, DecoderBufferCallback? decode, DecoderCallback? decodeDeprecated) async {
+  @override
+  @protected
+  ImageStreamCompleter loadImage(FileImage key, ImageDecoderCallback decode) {
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, decode, null, null),
+      scale: key.scale,
+      debugLabel: key.file.path,
+      informationCollector: () => <DiagnosticsNode>[
+        ErrorDescription('Path: ${file.path}'),
+      ],
+    );
+  }
+
+  Future<ui.Codec> _loadAsync(
+    FileImage key,
+    ImageDecoderCallback? decode,
+    DecoderBufferCallback? decodeBufferDeprecated,
+    DecoderCallback? decodeDeprecated,
+  ) async {
     assert(key == this);
 
     // TODO(jonahwilliams): making this sync caused test failures that seem to
@@ -992,6 +1143,12 @@ class FileImage extends ImageProvider<FileImage> {
         return decode(await ui.ImmutableBuffer.fromFilePath(file.path));
       }
       return decode(await ui.ImmutableBuffer.fromUint8List(await file.readAsBytes()));
+    }
+    if (decodeBufferDeprecated != null) {
+      if (file.runtimeType == File) {
+        return decodeBufferDeprecated(await ui.ImmutableBuffer.fromFilePath(file.path));
+      }
+      return decodeBufferDeprecated(await ui.ImmutableBuffer.fromUint8List(await file.readAsBytes()));
     }
     return decodeDeprecated!(await file.readAsBytes());
   }
@@ -1058,7 +1215,7 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   @override
   ImageStreamCompleter load(MemoryImage key, DecoderCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, null, decode),
+      codec: _loadAsync(key, null, null, decode),
       scale: key.scale,
       debugLabel: 'MemoryImage(${describeIdentity(key.bytes)})',
     );
@@ -1067,19 +1224,37 @@ class MemoryImage extends ImageProvider<MemoryImage> {
   @override
   ImageStreamCompleter loadBuffer(MemoryImage key, DecoderBufferCallback decode) {
     return MultiFrameImageStreamCompleter(
-      codec: _loadAsync(key, decode, null),
+      codec: _loadAsync(key, null, decode, null),
       scale: key.scale,
       debugLabel: 'MemoryImage(${describeIdentity(key.bytes)})',
     );
   }
 
-  Future<ui.Codec> _loadAsync(MemoryImage key, DecoderBufferCallback? decode, DecoderCallback? decodeDepreacted) async {
+  @override
+  ImageStreamCompleter loadImage(MemoryImage key, ImageDecoderCallback decode) {
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, decode, null, null),
+      scale: key.scale,
+      debugLabel: 'MemoryImage(${describeIdentity(key.bytes)})',
+    );
+  }
+
+  Future<ui.Codec> _loadAsync(
+    MemoryImage key,
+    ImageDecoderCallback? decode,
+    DecoderBufferCallback? decodeBufferDeprecated,
+    DecoderCallback? decodeDeprecated,
+  ) async {
     assert(key == this);
     if (decode != null) {
       final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
       return decode(buffer);
     }
-    return decodeDepreacted!(bytes);
+    if (decodeBufferDeprecated != null) {
+      final ui.ImmutableBuffer buffer = await ui.ImmutableBuffer.fromUint8List(bytes);
+      return decodeBufferDeprecated(buffer);
+    }
+    return decodeDeprecated!(bytes);
   }
 
   @override
@@ -1241,7 +1416,7 @@ class ExactAssetImage extends AssetBundleImageProvider {
 }
 
 // A completer used when resolving an image fails sync.
-class _ErrorImageCompleter extends ImageStreamCompleter { }
+class _ErrorImageCompleter extends ImageStreamCompleter {}
 
 /// The exception thrown when the HTTP request to load a network image fails.
 class NetworkImageLoadException implements Exception {

--- a/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
+++ b/packages/flutter/lib/src/widgets/scroll_aware_image_provider.dart
@@ -112,5 +112,8 @@ class ScrollAwareImageProvider<T extends Object> extends ImageProvider<T> {
   ImageStreamCompleter loadBuffer(T key, DecoderBufferCallback decode) => imageProvider.loadBuffer(key, decode);
 
   @override
+  ImageStreamCompleter loadImage(T key, ImageDecoderCallback decode) => imageProvider.loadImage(key, decode);
+
+  @override
   Future<T> obtainKey(ImageConfiguration configuration) => imageProvider.obtainKey(configuration);
 }

--- a/packages/flutter/test/painting/image_test_utils.dart
+++ b/packages/flutter/test/painting/image_test_utils.dart
@@ -30,11 +30,16 @@ class TestImageProvider extends ImageProvider<TestImageProvider> {
 
   @override
   ImageStreamCompleter load(TestImageProvider key, DecoderCallback decode) {
-    throw UnsupportedError('Use ImageProvider.loadBuffer instead.');
+    throw UnsupportedError('Use ImageProvider.loadImage instead.');
   }
 
   @override
   ImageStreamCompleter loadBuffer(TestImageProvider key, DecoderBufferCallback decode) {
+    throw UnsupportedError('Use ImageProvider.loadImage instead.');
+  }
+
+  @override
+  ImageStreamCompleter loadImage(TestImageProvider key, ImageDecoderCallback decode) {
     loadCallCount += 1;
     return OneFrameImageStreamCompleter(_completer.future);
   }

--- a/packages/flutter/test/painting/mocks_for_image_cache.dart
+++ b/packages/flutter/test/painting/mocks_for_image_cache.dart
@@ -86,6 +86,11 @@ Future<ImageInfo> extractOneFrame(ImageStream stream) {
 
 class ErrorImageProvider extends ImageProvider<ErrorImageProvider> {
   @override
+  ImageStreamCompleter loadImage(ErrorImageProvider key, ImageDecoderCallback decode) {
+    throw Error();
+  }
+
+  @override
   ImageStreamCompleter loadBuffer(ErrorImageProvider key, DecoderBufferCallback decode) {
     throw Error();
   }
@@ -103,8 +108,13 @@ class ErrorImageProvider extends ImageProvider<ErrorImageProvider> {
 
 class ObtainKeyErrorImageProvider extends ImageProvider<ObtainKeyErrorImageProvider> {
   @override
-  ImageStreamCompleter loadBuffer(ObtainKeyErrorImageProvider key, DecoderBufferCallback decode) {
+  ImageStreamCompleter loadImage(ObtainKeyErrorImageProvider key, ImageDecoderCallback decode) {
     throw Error();
+  }
+
+  @override
+  ImageStreamCompleter loadBuffer(ObtainKeyErrorImageProvider key, DecoderBufferCallback decode) {
+    throw UnimplementedError();
   }
 
   @override
@@ -120,8 +130,13 @@ class ObtainKeyErrorImageProvider extends ImageProvider<ObtainKeyErrorImageProvi
 
 class LoadErrorImageProvider extends ImageProvider<LoadErrorImageProvider> {
   @override
-  ImageStreamCompleter loadBuffer(LoadErrorImageProvider key, DecoderBufferCallback decode) {
+  ImageStreamCompleter loadImage(LoadErrorImageProvider key, ImageDecoderCallback decode) {
     throw Error();
+  }
+
+  @override
+  ImageStreamCompleter loadBuffer(LoadErrorImageProvider key, DecoderBufferCallback decode) {
+    throw UnimplementedError();
   }
 
   @override

--- a/packages/flutter/test/widgets/image_resolution_test.dart
+++ b/packages/flutter/test/widgets/image_resolution_test.dart
@@ -85,7 +85,7 @@ class TestAssetImage extends AssetImage {
   final Map<double, ui.Image> images;
 
   @override
-  ImageStreamCompleter loadBuffer(AssetBundleImageKey key, DecoderBufferCallback decode) {
+  ImageStreamCompleter loadImage(AssetBundleImageKey key, ImageDecoderCallback decode) {
     late ImageInfo imageInfo;
     key.bundle.load(key.name).then<void>((ByteData data) {
       final ui.Image image = images[scaleOf(data)]!;

--- a/packages/flutter/test/widgets/image_test.dart
+++ b/packages/flutter/test/widgets/image_test.dart
@@ -2173,7 +2173,7 @@ class _DebouncingImageProvider extends ImageProvider<Object> {
   Future<Object> obtainKey(ImageConfiguration configuration) => imageProvider.obtainKey(configuration);
 
   @override
-  ImageStreamCompleter loadBuffer(Object key, DecoderBufferCallback decode) => imageProvider.loadBuffer(key, decode);
+  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) => imageProvider.loadImage(key, decode);
 }
 
 class _FailingImageProvider extends ImageProvider<int> {

--- a/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
+++ b/packages/flutter/test/widgets/scroll_aware_image_provider_test.dart
@@ -322,7 +322,7 @@ void main() {
     // If we miss the early return, we will fail.
     testImageProvider.complete();
 
-    imageCache.putIfAbsent(testImageProvider, () => testImageProvider.loadBuffer(testImageProvider, PaintingBinding.instance.instantiateImageCodecFromBuffer));
+    imageCache.putIfAbsent(testImageProvider, () => testImageProvider.loadImage(testImageProvider, PaintingBinding.instance.instantiateImageCodecWithSize));
     // We've stopped scrolling fast.
     physics.recommendDeferredLoadingValue = false;
     await tester.idle();
@@ -377,7 +377,7 @@ void main() {
 
     // Complete the original image while we're still scrolling fast.
     testImageProvider.complete();
-    stream.setCompleter(testImageProvider.loadBuffer(testImageProvider, PaintingBinding.instance.instantiateImageCodecFromBuffer));
+    stream.setCompleter(testImageProvider.loadImage(testImageProvider, PaintingBinding.instance.instantiateImageCodecWithSize));
 
     // Verify that this hasn't changed the cache state yet
     expect(imageCache.containsKey(testImageProvider), false);


### PR DESCRIPTION
This updates the framework to provide higher level wrappers around `ui.instantiateImageCodecWithSize()`.  Functionally, this doesn't change anything (other than deprecating the older `loadBuffer()` method in favor of `loadImage()`), but it sets the stage for a simpler change that will allow us to provide a more flexible way to load sized images.

https://github.com/flutter/flutter/issues/118543

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
