### PR TITLE
Revert "Update the Linux Android defines test to use dimensions when selecting a build bot"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1379,26 +1379,12 @@ targets:
 
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone
-    presubmit: true
-    bringup: true
+    presubmit: false
     timeout: 60
-    dimensions: {
-      kvm: "1",
-      cores: "8",
-      machine_type: "n1-standard-8"
-    }
     properties:
-      device_type: "none"
       tags: >
         ["devicelab" ,"android", "linux"]
       task_name: android_defines_test
-      dependencies: >-
-        [
-          {"dependency": "android_virtual_device", "version": "31"},
-          {"dependency": "android_sdk", "version": "version:33v6"},
-          {"dependency": "open_jdk", "version": "version:11"}
-        ]
-      use_emulator: "true"
 
   - name: Linux_android android_obfuscate_test
     recipe: devicelab/devicelab_drone


### PR DESCRIPTION
Reverts flutter/flutter#118930

While this does run it cannot run under Linux_android because it is affecting the checks made in the test chain. It has to run as Linux or I need to make an adjustment on how we display the test icon in the dashboard.