### PR TITLE
[flutter_tools] Use base DAP detach and ensure correct output

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -354,7 +354,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
   @override
   Future<void> terminateImpl() async {
     if (isAttach) {
-      await preventBreakingAndResume();
+      await handleDetach();
     }
 
     // Send a request to stop/detach to give Flutter chance to do some cleanup.

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_base_adapter.dart
@@ -122,7 +122,7 @@ abstract class FlutterBaseDebugAdapter extends DartDebugAdapter<FlutterLaunchReq
   @override
   Future<void> disconnectImpl() async {
     if (isAttach) {
-      await preventBreakingAndResume();
+      await handleDetach();
     }
     terminatePids(ProcessSignal.sigkill);
   }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -564,7 +564,7 @@ void main() {
       // Detach and expected resume and correct output.
       await Future.wait(<Future<void>>[
         // We should print "Detached" instead of "Exited".
-        dap.client.outputEvents.firstWhere((OutputEventBody event) => event.output.startsWith('\nDetached.')),
+        dap.client.outputEvents.firstWhere((OutputEventBody event) => event.output.contains('\nDetached')),
         // We should still get terminatedEvent (this signals the DAP server terminating).
         dap.client.event('terminated'),
         // We should get additional output from the test process confirming the process resumed.

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -561,11 +561,18 @@ void main() {
         dap.client.setBreakpoint(breakpointFilePath, breakpointLine),
       ], eagerError: true);
 
-      // Detach.
-      await dap.client.terminate();
+      // Detach and expected resume and correct output.
+      await Future.wait(<Future<void>>[
+        // We should print "Detached" instead of "Exited".
+        dap.client.outputEvents.firstWhere((OutputEventBody event) => event.output.startsWith('\nDetached.')),
+        // We should still get terminatedEvent (this signals the DAP server terminating).
+        dap.client.event('terminated'),
+        // We should get additional output from the test process confirming the process resumed.
+        testProcess.output.first,
+        // Trigger the detach.
+        dap.client.terminate(),
+      ]);
 
-      // Ensure we get additional output (confirming the process resumed).
-      await testProcess.output.first;
     });
   });
 }

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -567,8 +567,8 @@ void main() {
         dap.client.outputEvents.firstWhere((OutputEventBody event) => event.output.contains('\nDetached')),
         // We should still get terminatedEvent (this signals the DAP server terminating).
         dap.client.event('terminated'),
-        // We should get additional output from the test process confirming the process resumed.
-        testProcess.output.first,
+        // We should get output showing the app resumed.
+        testProcess.output.firstWhere((String output) => output.contains('topLevelFunction')),
         // Trigger the detach.
         dap.client.terminate(),
       ]);


### PR DESCRIPTION
This is a minor tidy up to call a more specific method (which now exists in the base Dart debug adapter) when detaching, which ensures the final output (written by the base Dart debug adapter) reads "Detached" instead of "Exited".


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
