### PR TITLE
Remove deprecated AnimatedSize.vsync parameter

### DIFF
--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -23,6 +23,17 @@
 #     * ListWheelScrollView: fix_list_wheel_scroll_view.yaml
 version: 1
 transforms:
+  # Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
+  - title: "Remove 'vsync'"
+    date: 2022-01-39
+    element:
+      uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
+      constructor: ''
+      inClass: 'AnimatedSize'
+    changes:
+      - kind: 'removeParameter'
+        name: 'vsync'
+
   # Changes made in https://github.com/flutter/flutter/pull/114459
   - title: "Migrate to 'boldTextOf'"
     date: 2022-10-28

--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -25,7 +25,7 @@ version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
   - title: "Remove 'vsync'"
-    date: 2022-01-39
+    date: 2022-01-30
     element:
       uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
       constructor: ''

--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -25,7 +25,7 @@ version: 1
 transforms:
   # Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
   - title: "Remove 'vsync'"
-    date: 2022-01-30
+    date: 2023-01-30
     element:
       uris: ['widgets.dart', 'material.dart', 'cupertino.dart']
       constructor: ''

--- a/packages/flutter/lib/src/widgets/animated_size.dart
+++ b/packages/flutter/lib/src/widgets/animated_size.dart
@@ -32,11 +32,6 @@ class AnimatedSize extends StatefulWidget {
     this.curve = Curves.linear,
     required this.duration,
     this.reverseDuration,
-    @Deprecated(
-      'This field is now ignored. '
-      'This feature was deprecated after v2.2.0-10.1.pre.'
-    )
-    TickerProvider? vsync,
     this.clipBehavior = Clip.hardEdge,
   });
 

--- a/packages/flutter/test_fixes/widgets/widgets.dart
+++ b/packages/flutter/test_fixes/widgets/widgets.dart
@@ -10,6 +10,10 @@ void main() {
   RenderObjectWidget renderObjectWidget;
   RenderObject renderObject;
   Object object;
+  TickerProvider vsync;
+
+  // Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
+  AnimatedSize(vsync: vsync, duration: Duration.zero);
 
   // Changes made in https://github.com/flutter/flutter/pull/45941 and https://github.com/flutter/flutter/pull/83843
   final WidgetsBinding binding = WidgetsBinding.instance;

--- a/packages/flutter/test_fixes/widgets/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets/widgets.dart.expect
@@ -10,6 +10,10 @@ void main() {
   RenderObjectWidget renderObjectWidget;
   RenderObject renderObject;
   Object object;
+  TickerProvider vsync;
+
+  // Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
+  AnimatedSize(duration: Duration.zero);
 
   // Changes made in https://github.com/flutter/flutter/pull/45941 and https://github.com/flutter/flutter/pull/83843
   final WidgetsBinding binding = WidgetsBinding.instance;


### PR DESCRIPTION
The deprecation period has elapsed. The parameter was made obsolete in https://github.com/flutter/flutter/pull/81067.