### PR TITLE
Remove deprecated SystemNavigator.routeUpdated method

### DIFF
--- a/packages/flutter/lib/src/services/system_navigator.dart
+++ b/packages/flutter/lib/src/services/system_navigator.dart
@@ -98,28 +98,4 @@ class SystemNavigator {
       },
     );
   }
-
-  /// Notifies the platform of a route change, and selects single-entry history
-  /// mode.
-  ///
-  /// This is equivalent to calling [selectSingleEntryHistory] and
-  /// [routeInformationUpdated] together.
-  ///
-  /// The `previousRouteName` argument is ignored.
-  @Deprecated(
-    'Use routeInformationUpdated instead. '
-    'This feature was deprecated after v2.3.0-1.0.pre.'
-  )
-  static Future<void> routeUpdated({
-    String? routeName,
-    String? previousRouteName,
-  }) {
-    return SystemChannels.navigation.invokeMethod<void>(
-      'routeUpdated',
-      <String, dynamic>{
-        'previousRouteName': previousRouteName,
-        'routeName': routeName,
-      },
-    );
-  }
 }

--- a/packages/flutter/test/services/system_navigator_test.dart
+++ b/packages/flutter/test/services/system_navigator_test.dart
@@ -56,10 +56,6 @@ void main() {
       isMethodCall('routeInformationUpdated', arguments: <String, dynamic>{ 'location': 'a', 'state': true, 'replace': true }),
     ]);
 
-    await verify(() => SystemNavigator.routeUpdated(routeName: 'a', previousRouteName: 'b'), <Object>[
-      isMethodCall('routeUpdated', arguments: <String, dynamic>{ 'routeName': 'a', 'previousRouteName': 'b' }),
-    ]);
-
     TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger.setMockMethodCallHandler(SystemChannels.navigation, null);
   });
 }


### PR DESCRIPTION
The deprecation period has elapsed. The method was made obsolete in https://github.com/flutter/flutter/pull/82594.