### PR TITLE
Make MultiChildRenderObjectWidget const

### DIFF
--- a/dev/benchmarks/platform_views_layout/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout/lib/main.dart
@@ -55,8 +55,8 @@ class PlatformViewLayout extends StatelessWidget {
             child: Material(
               elevation: (index % 5 + 1).toDouble(),
               color: Colors.white,
-              child: Stack(
-                children: const <Widget> [
+              child: const Stack(
+                children: <Widget> [
                   DummyPlatformView(),
                   RotationContainer(),
                 ],

--- a/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
+++ b/dev/benchmarks/platform_views_layout_hybrid_composition/lib/main.dart
@@ -59,8 +59,8 @@ class PlatformViewLayout extends StatelessWidget {
             child: Material(
               elevation: (index % 5 + 1).toDouble(),
               color: Colors.white,
-              child: Stack(
-                children: const <Widget> [
+              child: const Stack(
+                children: <Widget> [
                   DummyPlatformView(),
                   RotationContainer(),
                 ],

--- a/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
+++ b/dev/integration_tests/android_semantics_testing/lib/src/tests/popup_page.dart
@@ -77,9 +77,9 @@ class _PopupControlsPageState extends State<PopupControlsPage> {
                       return AlertDialog(
                         key: const ValueKey<String>(alertKeyValue),
                         title: const Text('Title text', key: ValueKey<String>('$alertKeyValue.Title')),
-                        content: SingleChildScrollView(
+                        content: const SingleChildScrollView(
                           child: ListBody(
-                            children: const <Widget>[
+                            children: <Widget>[
                               Text('Body text line 1.', key: ValueKey<String>('$alertKeyValue.Body1')),
                               Text('Body text line 2.', key: ValueKey<String>('$alertKeyValue.Body2')),
                             ],

--- a/packages/flutter/lib/src/cupertino/dialog.dart
+++ b/packages/flutter/lib/src/cupertino/dialog.dart
@@ -1763,7 +1763,7 @@ class CupertinoDialogAction extends StatelessWidget {
 //
 // See [_RenderCupertinoDialogActions] for specific layout policy details.
 class _CupertinoDialogActionsRenderWidget extends MultiChildRenderObjectWidget {
-  _CupertinoDialogActionsRenderWidget({
+  const _CupertinoDialogActionsRenderWidget({
     required List<Widget> actionButtons,
     double dividerThickness = 0.0,
     bool hasCancelButton = false,

--- a/packages/flutter/lib/src/cupertino/segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/segmented_control.dart
@@ -405,7 +405,7 @@ class _SegmentedControlState<T extends Object> extends State<CupertinoSegmentedC
 }
 
 class _SegmentedControlRenderWidget<T> extends MultiChildRenderObjectWidget {
-  _SegmentedControlRenderWidget({
+  const _SegmentedControlRenderWidget({
     super.key,
     super.children,
     required this.selectedIndex,

--- a/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
+++ b/packages/flutter/lib/src/cupertino/sliding_segmented_control.dart
@@ -711,7 +711,7 @@ class _SegmentedControlState<T> extends State<CupertinoSlidingSegmentedControl<T
 }
 
 class _SegmentedControlRenderWidget<T> extends MultiChildRenderObjectWidget {
-  _SegmentedControlRenderWidget({
+  const _SegmentedControlRenderWidget({
     super.key,
     super.children,
     required this.highlightedIndex,

--- a/packages/flutter/lib/src/material/button_bar.dart
+++ b/packages/flutter/lib/src/material/button_bar.dart
@@ -233,7 +233,7 @@ class ButtonBar extends StatelessWidget {
 class _ButtonBarRow extends Flex {
   /// Creates a button bar that attempts to display in a row, but displays in
   /// a column if there is insufficient horizontal space.
-  _ButtonBarRow({
+  const _ButtonBarRow({
     required super.children,
     super.mainAxisSize,
     super.mainAxisAlignment,

--- a/packages/flutter/lib/src/material/dialog.dart
+++ b/packages/flutter/lib/src/material/dialog.dart
@@ -302,9 +302,9 @@ class Dialog extends StatelessWidget {
 ///     builder: (BuildContext context) {
 ///       return AlertDialog(
 ///         title: const Text('AlertDialog Title'),
-///         content: SingleChildScrollView(
+///         content: const SingleChildScrollView(
 ///           child: ListBody(
-///             children: const <Widget>[
+///             children: <Widget>[
 ///               Text('This is a demo alert dialog.'),
 ///               Text('Would you like to approve of this message?'),
 ///             ],

--- a/packages/flutter/lib/src/material/dropdown_menu.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu.dart
@@ -605,7 +605,7 @@ class _ArrowDownIntent extends Intent {
 }
 
 class _DropdownMenuBody extends MultiChildRenderObjectWidget {
-  _DropdownMenuBody({
+  const _DropdownMenuBody({
     super.key,
     super.children,
     this.width,

--- a/packages/flutter/lib/src/material/mergeable_material.dart
+++ b/packages/flutter/lib/src/material/mergeable_material.dart
@@ -655,7 +655,7 @@ class _MergeableMaterialSliceKey extends GlobalKey {
 }
 
 class _MergeableMaterialListBody extends ListBody {
-  _MergeableMaterialListBody({
+  const _MergeableMaterialListBody({
     required super.children,
     super.mainAxis,
     required this.items,

--- a/packages/flutter/lib/src/material/segmented_button.dart
+++ b/packages/flutter/lib/src/material/segmented_button.dart
@@ -372,7 +372,7 @@ class SegmentedButton<T> extends StatelessWidget {
   }
 }
 class _SegmentedButtonRenderWidget<T> extends MultiChildRenderObjectWidget {
-  _SegmentedButtonRenderWidget({
+  const _SegmentedButtonRenderWidget({
     super.key,
     required this.segments,
     required this.enabledBorder,

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -275,7 +275,7 @@ class _TabLabelBarRenderer extends RenderFlex {
 // upon layout. The tab widths are only used at paint time (see _IndicatorPainter)
 // or in response to input.
 class _TabLabelBar extends Flex {
-  _TabLabelBar({
+  const _TabLabelBar({
     super.children,
     required this.onPerformLayout,
   }) : super(

--- a/packages/flutter/lib/src/material/text_selection_toolbar.dart
+++ b/packages/flutter/lib/src/material/text_selection_toolbar.dart
@@ -373,7 +373,7 @@ class _TextSelectionToolbarTrailingEdgeAlignRenderBox extends RenderProxyBox {
 // Renders the menu items in the correct positions in the menu and its overflow
 // submenu based on calculating which item would first overflow.
 class _TextSelectionToolbarItemsLayout extends MultiChildRenderObjectWidget {
-  _TextSelectionToolbarItemsLayout({
+  const _TextSelectionToolbarItemsLayout({
     required this.isAbove,
     required this.overflowOpen,
     required super.children,

--- a/packages/flutter/lib/src/widgets/basic.dart
+++ b/packages/flutter/lib/src/widgets/basic.dart
@@ -2304,7 +2304,7 @@ class CustomMultiChildLayout extends MultiChildRenderObjectWidget {
   /// Creates a custom multi-child layout.
   ///
   /// The [delegate] argument must not be null.
-  CustomMultiChildLayout({
+  const CustomMultiChildLayout({
     super.key,
     required this.delegate,
     super.children,
@@ -3666,7 +3666,7 @@ class ListBody extends MultiChildRenderObjectWidget {
   /// given axis.
   ///
   /// By default, the [mainAxis] is [Axis.vertical].
-  ListBody({
+  const ListBody({
     super.key,
     this.mainAxis = Axis.vertical,
     this.reverse = false,
@@ -3825,7 +3825,7 @@ class Stack extends MultiChildRenderObjectWidget {
   ///
   /// By default, the non-positioned children of the stack are aligned by their
   /// top left corners.
-  Stack({
+  const Stack({
     super.key,
     this.alignment = AlignmentDirectional.topStart,
     this.textDirection,
@@ -3941,7 +3941,7 @@ class IndexedStack extends Stack {
   /// Creates a [Stack] widget that paints a single child.
   ///
   /// The [index] argument must not be null.
-  IndexedStack({
+  const IndexedStack({
     super.key,
     super.alignment,
     super.textDirection,
@@ -4445,7 +4445,7 @@ class Flex extends MultiChildRenderObjectWidget {
   /// to be necessary to decide which direction to lay the children in or to
   /// disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
-  Flex({
+  const Flex({
     super.key,
     required this.direction,
     this.mainAxisAlignment = MainAxisAlignment.start,
@@ -4812,7 +4812,7 @@ class Row extends Flex {
   /// unless the row has no children or only one child) or to disambiguate
   /// `start` or `end` values for the [mainAxisAlignment], the [textDirection]
   /// must not be null.
-  Row({
+  const Row({
     super.key,
     super.mainAxisAlignment,
     super.mainAxisSize,
@@ -5005,7 +5005,7 @@ class Column extends Flex {
   /// any. If there is no ambient directionality, and a text direction is going
   /// to be necessary to disambiguate `start` or `end` values for the
   /// [crossAxisAlignment], the [textDirection] must not be null.
-  Column({
+  const Column({
     super.key,
     super.mainAxisAlignment,
     super.mainAxisSize,
@@ -5212,7 +5212,7 @@ class Wrap extends MultiChildRenderObjectWidget {
   /// to be necessary to decide which direction to lay the children in or to
   /// disambiguate `start` or `end` values for the main or cross axis
   /// directions, the [textDirection] must not be null.
-  Wrap({
+  const Wrap({
     super.key,
     this.direction = Axis.horizontal,
     this.alignment = WrapAlignment.start,
@@ -5474,7 +5474,7 @@ class Flow extends MultiChildRenderObjectWidget {
   /// a repaint boundary.
   ///
   /// The [delegate] argument must not be null.
-  Flow.unwrapped({
+  const Flow.unwrapped({
     super.key,
     required this.delegate,
     super.children,

--- a/packages/flutter/lib/src/widgets/framework.dart
+++ b/packages/flutter/lib/src/widgets/framework.dart
@@ -1855,9 +1855,7 @@ abstract class MultiChildRenderObjectWidget extends RenderObjectWidget {
   ///
   /// The [children] argument must not be null and must not contain any null
   /// objects.
-  // TODO(goderbauer): Make this const and fix fallout, https://github.com/flutter/flutter/issues/108248
-  // ignore: prefer_const_constructors_in_immutables
-  MultiChildRenderObjectWidget({ super.key, this.children = const <Widget>[] });
+  const MultiChildRenderObjectWidget({ super.key, this.children = const <Widget>[] });
 
   /// The widgets below this widget in the tree.
   ///

--- a/packages/flutter/lib/src/widgets/overflow_bar.dart
+++ b/packages/flutter/lib/src/widgets/overflow_bar.dart
@@ -59,7 +59,7 @@ class OverflowBar extends MultiChildRenderObjectWidget {
   /// [overflowDirection], and [clipBehavior] parameters must not be
   /// null. The [children] argument must not be null and must not contain
   /// any null objects.
-  OverflowBar({
+  const OverflowBar({
     super.key,
     this.spacing = 0.0,
     this.alignment,

--- a/packages/flutter/lib/src/widgets/overlay.dart
+++ b/packages/flutter/lib/src/widgets/overlay.dart
@@ -637,7 +637,7 @@ class OverlayState extends State<Overlay> with TickerProviderStateMixin {
 ///
 /// The first [skipCount] children are considered "offstage".
 class _Theatre extends MultiChildRenderObjectWidget {
-  _Theatre({
+  const _Theatre({
     this.skipCount = 0,
     this.clipBehavior = Clip.hardEdge,
     super.children,

--- a/packages/flutter/lib/src/widgets/viewport.dart
+++ b/packages/flutter/lib/src/widgets/viewport.dart
@@ -324,7 +324,7 @@ class ShrinkWrappingViewport extends MultiChildRenderObjectWidget {
   /// rebuild this widget when the [offset] changes.
   ///
   /// The [offset] argument must not be null.
-  ShrinkWrappingViewport({
+  const ShrinkWrappingViewport({
     super.key,
     this.axisDirection = AxisDirection.down,
     this.crossAxisDirection,

--- a/packages/flutter/test/cupertino/scaffold_test.dart
+++ b/packages/flutter/test/cupertino/scaffold_test.dart
@@ -227,7 +227,7 @@ void main() {
                   ),
                   child: page1Center,
                 )
-                : Stack();
+                : const Stack();
           },
         ),
       ),
@@ -270,7 +270,7 @@ void main() {
                       ],
                     ),
                   )
-                  : Stack();
+                  : const Stack();
             },
           ),
         ),

--- a/packages/flutter/test/material/button_bar_test.dart
+++ b/packages/flutter/test/material/button_bar_test.dart
@@ -341,9 +341,9 @@ void main() {
 
     testWidgets('ButtonBar has a min height of 52 when using ButtonBarLayoutBehavior.constrained', (WidgetTester tester) async {
       await tester.pumpWidget(
-        SingleChildScrollView(
+        const SingleChildScrollView(
           child: ListBody(
-            children: const <Widget>[
+            children: <Widget>[
               Directionality(
                 textDirection: TextDirection.ltr,
                 child: ButtonBar(
@@ -364,9 +364,9 @@ void main() {
 
     testWidgets('ButtonBar has padding applied when using ButtonBarLayoutBehavior.padded', (WidgetTester tester) async {
       await tester.pumpWidget(
-        SingleChildScrollView(
+        const SingleChildScrollView(
           child: ListBody(
-            children: const <Widget>[
+            children: <Widget>[
               Directionality(
                 textDirection: TextDirection.ltr,
                 child: ButtonBar(

--- a/packages/flutter/test/material/icons_test.dart
+++ b/packages/flutter/test/material/icons_test.dart
@@ -63,11 +63,11 @@ void main() {
   testWidgets('A sample of icons look as expected', (WidgetTester tester) async {
     await _loadIconFont();
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(const MaterialApp(
       home: IconTheme(
-        data: const IconThemeData(size: 200),
+        data: IconThemeData(size: 200),
         child: Wrap(
-          children: const <Icon>[
+          children: <Icon>[
             Icon(Icons.ten_k),
             Icon(Icons.ac_unit),
             Icon(Icons.local_taxi),
@@ -87,11 +87,11 @@ void main() {
   testWidgets('Another sample of icons look as expected', (WidgetTester tester) async {
     await _loadIconFont();
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(const MaterialApp(
       home: IconTheme(
-        data: const IconThemeData(size: 200),
+        data: IconThemeData(size: 200),
         child: Wrap(
-          children: const <Icon>[
+          children: <Icon>[
             Icon(Icons.water_drop),
             Icon(Icons.water_drop_outlined),
             Icon(Icons.water_drop_rounded),
@@ -107,11 +107,11 @@ void main() {
   testWidgets('Another sample of icons look as expected', (WidgetTester tester) async {
     await _loadIconFont();
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(const MaterialApp(
       home: IconTheme(
-        data: const IconThemeData(size: 200),
+        data: IconThemeData(size: 200),
         child: Wrap(
-          children: const <Icon>[
+          children: <Icon>[
             Icon(Icons.electric_bolt),
             Icon(Icons.electric_bolt_outlined),
             Icon(Icons.electric_bolt_rounded),
@@ -128,11 +128,11 @@ void main() {
   testWidgets('Another sample of icons look as expected', (WidgetTester tester) async {
     await _loadIconFont();
 
-    await tester.pumpWidget(MaterialApp(
+    await tester.pumpWidget(const MaterialApp(
       home: IconTheme(
-        data: const IconThemeData(size: 200),
+        data: IconThemeData(size: 200),
         child: Wrap(
-          children: const <Icon>[
+          children: <Icon>[
             Icon(Icons.repeat_on),
             Icon(Icons.repeat_on_outlined),
             Icon(Icons.repeat_on_rounded),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -5903,14 +5903,14 @@ void main() {
     };
     try {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Center(
             child: Directionality(
               textDirection: TextDirection.ltr,
               child: InputDecorator(
-                decoration: const InputDecoration(),
+                decoration: InputDecoration(),
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     SizedBox(height: 0),
                     Positioned(
                       bottom: 5,

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -2652,10 +2652,10 @@ void main() {
       navigationRail: NavigationRail(
         labelType: NavigationRailLabelType.none,
         selectedIndex: 0,
-        destinations:  <NavigationRailDestination>[
+        destinations:  const <NavigationRailDestination>[
           NavigationRailDestination(
             icon: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Icon(Icons.umbrella),
                 Positioned(
                   top: 0,
@@ -2667,13 +2667,13 @@ void main() {
                 ),
               ],
             ),
-            label: const Text('Abc'),
+            label: Text('Abc'),
           ),
-          const NavigationRailDestination(
+          NavigationRailDestination(
             icon: Icon(Icons.umbrella),
             label: Text('Def'),
           ),
-          const NavigationRailDestination(
+          NavigationRailDestination(
             icon: Icon(Icons.bookmark_border),
             label: Text('Ghi'),
           ),
@@ -4867,10 +4867,10 @@ void main() {
         navigationRail: NavigationRail(
           labelType: NavigationRailLabelType.none,
           selectedIndex: 0,
-          destinations:  <NavigationRailDestination>[
+          destinations:  const <NavigationRailDestination>[
             NavigationRailDestination(
               icon: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Icon(Icons.umbrella),
                   Positioned(
                     top: 0,
@@ -4882,13 +4882,13 @@ void main() {
                   ),
                 ],
               ),
-              label: const Text('Abc'),
+              label: Text('Abc'),
             ),
-            const NavigationRailDestination(
+            NavigationRailDestination(
               icon: Icon(Icons.umbrella),
               label: Text('Def'),
             ),
-            const NavigationRailDestination(
+            NavigationRailDestination(
               icon: Icon(Icons.bookmark_border),
               label: Text('Ghi'),
             ),

--- a/packages/flutter/test/widgets/automatic_keep_alive_test.dart
+++ b/packages/flutter/test/widgets/automatic_keep_alive_test.dart
@@ -230,23 +230,23 @@ void main() {
           addRepaintBoundaries: false,
           addSemanticIndexes: false,
           cacheExtent: 0.0,
-          children: <Widget>[
+          children: const <Widget>[
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(0), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
                 ]),
               ),
             ),
-            const AutomaticKeepAlive(
+            AutomaticKeepAlive(
               child: SizedBox(
                 key: GlobalObjectKey<_LeafState>(2),
                 height: 400.0,
               ),
             ),
-            const AutomaticKeepAlive(
+            AutomaticKeepAlive(
               child: SizedBox(
                 key: GlobalObjectKey<_LeafState>(3),
                 height: 400.0,
@@ -314,11 +314,11 @@ void main() {
           addRepaintBoundaries: false,
           addSemanticIndexes: false,
           cacheExtent: 0.0,
-          children: <Widget>[
+          children: const <Widget>[
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(0), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
                 ]),
@@ -327,7 +327,7 @@ void main() {
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(2), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(3), child: Placeholder()),
                 ]),
@@ -336,7 +336,7 @@ void main() {
             AutomaticKeepAlive(
               child: SizedBox(
                 height: 400.0,
-                child: Stack(children: const <Widget>[
+                child: Stack(children: <Widget>[
                   Leaf(key: GlobalObjectKey<_LeafState>(4), child: Placeholder()),
                   Leaf(key: GlobalObjectKey<_LeafState>(5), child: Placeholder()),
                 ]),
@@ -370,11 +370,11 @@ void main() {
         addRepaintBoundaries: false,
         addSemanticIndexes: false,
         cacheExtent: 0.0,
-        children: <Widget>[
+        children: const <Widget>[
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
               ]),
             ),
@@ -382,7 +382,7 @@ void main() {
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(2), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(3), child: Placeholder()),
               ]),
@@ -391,7 +391,7 @@ void main() {
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(4), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(5), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(0), child: Placeholder()),
@@ -434,11 +434,11 @@ void main() {
         addRepaintBoundaries: false,
         addSemanticIndexes: false,
         cacheExtent: 0.0,
-        children: <Widget>[
+        children: const <Widget>[
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(1), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(2), child: Placeholder()),
               ]),
@@ -453,7 +453,7 @@ void main() {
           AutomaticKeepAlive(
             child: SizedBox(
               height: 400.0,
-              child: Stack(children: const <Widget>[
+              child: Stack(children: <Widget>[
                 Leaf(key: GlobalObjectKey<_LeafState>(3), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(4), child: Placeholder()),
                 Leaf(key: GlobalObjectKey<_LeafState>(5), child: Placeholder()),

--- a/packages/flutter/test/widgets/basic_test.dart
+++ b/packages/flutter/test/widgets/basic_test.dart
@@ -911,12 +911,12 @@ void main() {
 
   testWidgets('Wrap implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
-    Wrap(
+    const Wrap(
       spacing: 8.0, // gap between adjacent Text widget
       runSpacing: 4.0, // gap between lines
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         Text('Hamilton'),
         Text('Lafayette'),
         Text('Mulligan'),

--- a/packages/flutter/test/widgets/global_keys_duplicated_test.dart
+++ b/packages/flutter/test/widgets/global_keys_duplicated_test.dart
@@ -12,7 +12,7 @@ void main() {
   testWidgets('GlobalKey children of one node', (WidgetTester tester) async {
     // This is actually a test of the regular duplicate key logic, which
     // happens before the duplicate GlobalKey logic.
-    await tester.pumpWidget(Stack(children: const <Widget>[
+    await tester.pumpWidget(const Stack(children: <Widget>[
       DummyWidget(key: GlobalObjectKey(0)),
       DummyWidget(key: GlobalObjectKey(0)),
     ]));
@@ -24,9 +24,9 @@ void main() {
   });
 
   testWidgets('GlobalKey children of two nodes - A', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         DummyWidget(child: DummyWidget(key: GlobalObjectKey(0))),
         DummyWidget(
           child: DummyWidget(key: GlobalObjectKey(0),
@@ -44,9 +44,9 @@ void main() {
   });
 
   testWidgets('GlobalKey children of two different nodes - B', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         DummyWidget(child: DummyWidget(key: GlobalObjectKey(0))),
         DummyWidget(key: Key('x'), child: DummyWidget(key:  GlobalObjectKey(0))),
       ],

--- a/packages/flutter/test/widgets/list_body_test.dart
+++ b/packages/flutter/test/widgets/list_body_test.dart
@@ -31,7 +31,7 @@ void main() {
   testWidgets('ListBody down', (WidgetTester tester) async {
     await tester.pumpWidget(Flex(
       direction: Axis.vertical,
-      children: <Widget>[ ListBody(children: children) ],
+      children: const <Widget>[ ListBody(children: children) ],
     ));
 
     expectRects(
@@ -48,7 +48,7 @@ void main() {
   testWidgets('ListBody up', (WidgetTester tester) async {
     await tester.pumpWidget(Flex(
       direction: Axis.vertical,
-      children: <Widget>[ ListBody(reverse: true, children: children) ],
+      children: const <Widget>[ ListBody(reverse: true, children: children) ],
     ));
 
     expectRects(
@@ -66,7 +66,7 @@ void main() {
     await tester.pumpWidget(Flex(
       textDirection: TextDirection.ltr,
       direction: Axis.horizontal,
-      children: <Widget>[
+      children: const <Widget>[
         Directionality(
           textDirection: TextDirection.ltr,
           child: ListBody(mainAxis: Axis.horizontal, children: children),
@@ -89,7 +89,7 @@ void main() {
     await tester.pumpWidget(Flex(
       textDirection: TextDirection.ltr,
       direction: Axis.horizontal,
-      children: <Widget>[
+      children: const <Widget>[
         Directionality(
           textDirection: TextDirection.rtl,
           child: ListBody(mainAxis: Axis.horizontal, children: children),
@@ -114,7 +114,7 @@ void main() {
     FlutterError.onError = (FlutterErrorDetails error) => errors.add(error);
     try {
       await tester.pumpWidget(
-        SizedBox(
+        const SizedBox(
           width: 100,
           height: 100,
           child: Directionality(
@@ -159,7 +159,7 @@ void main() {
                   Flex(
                     textDirection: TextDirection.ltr,
                     direction: Axis.vertical,
-                    children: <Widget>[
+                    children: const <Widget>[
                       Directionality(
                         textDirection: TextDirection.ltr,
                         child: ListBody(

--- a/packages/flutter/test/widgets/modal_barrier_test.dart
+++ b/packages/flutter/test/widgets/modal_barrier_test.dart
@@ -910,9 +910,9 @@ void main() {
   });
 
   testWidgets('uses default mouse cursor', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         MouseRegion(cursor: SystemMouseCursors.click),
         ModalBarrier(dismissible: false),
       ],

--- a/packages/flutter/test/widgets/multichild_test.dart
+++ b/packages/flutter/test/widgets/multichild_test.dart
@@ -35,9 +35,9 @@ void main() {
   testWidgets('MultiChildRenderObjectElement control test', (WidgetTester tester) async {
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
@@ -48,9 +48,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationC),
         ],
@@ -60,9 +60,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(key: Key('b'), decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
@@ -73,9 +73,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(key: Key('b'), decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
           DecoratedBox(key: Key('a'), decoration: kBoxDecorationA),
@@ -86,9 +86,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC, kBoxDecorationA]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(key: Key('a'), decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationC),
           DecoratedBox(key: Key('b'), decoration: kBoxDecorationB),
@@ -99,9 +99,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationC, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationC),
         ],
       ),
@@ -110,7 +110,7 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <BoxDecoration>[]);
@@ -120,9 +120,9 @@ void main() {
   testWidgets('MultiChildRenderObjectElement with stateless widgets', (WidgetTester tester) async {
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationB),
           DecoratedBox(decoration: kBoxDecorationC),
@@ -133,9 +133,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DummyWidget(
             child: DecoratedBox(decoration: kBoxDecorationB),
@@ -148,9 +148,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DummyWidget(
             child: DummyWidget(
@@ -165,9 +165,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             child: DummyWidget(
               child: DecoratedBox(decoration: kBoxDecorationB),
@@ -184,9 +184,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             child: DecoratedBox(decoration: kBoxDecorationB),
           ),
@@ -201,9 +201,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             key: Key('b'),
             child: DecoratedBox(decoration: kBoxDecorationB),
@@ -219,9 +219,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationA]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DummyWidget(
             key: Key('a'),
             child: DecoratedBox(decoration: kBoxDecorationA),
@@ -237,7 +237,7 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <BoxDecoration>[]);
@@ -245,9 +245,9 @@ void main() {
 
   testWidgets('MultiChildRenderObjectElement with stateful widgets', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           DecoratedBox(decoration: kBoxDecorationB),
         ],
@@ -257,9 +257,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             left: DecoratedBox(decoration: kBoxDecorationA),
             right: DecoratedBox(decoration: kBoxDecorationB),
@@ -277,9 +277,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationB, kBoxDecorationC]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             left: DecoratedBox(decoration: kBoxDecorationA),
             right: DecoratedBox(decoration: kBoxDecorationB),
@@ -296,9 +296,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationA]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             key: Key('flip'),
             left: DecoratedBox(decoration: kBoxDecorationA),
@@ -309,9 +309,9 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(key: Key('c'), decoration: kBoxDecorationC),
           FlipWidget(
             key: Key('flip'),
@@ -330,9 +330,9 @@ void main() {
     checkTree(tester, <BoxDecoration>[kBoxDecorationC, kBoxDecorationB]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           FlipWidget(
             key: Key('flip'),
             left: DecoratedBox(decoration: kBoxDecorationA),

--- a/packages/flutter/test/widgets/overflow_bar_test.dart
+++ b/packages/flutter/test/widgets/overflow_bar_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets('OverflowBar documented defaults', (WidgetTester tester) async {
-    final OverflowBar bar = OverflowBar();
+    const OverflowBar bar = OverflowBar();
     expect(bar.spacing, 0);
     expect(bar.alignment, null);
     expect(bar.overflowSpacing, 0);
@@ -26,7 +26,7 @@ void main() {
         child: Center(
           child: ConstrainedBox(
             constraints: BoxConstraints.tight(size),
-            child: OverflowBar(),
+            child: const OverflowBar(),
           ),
         ),
       ),
@@ -35,7 +35,7 @@ void main() {
     expect(tester.getSize(find.byType(OverflowBar)), size);
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: OverflowBar(),
@@ -182,11 +182,11 @@ void main() {
           child: Container(
             width: width,
             alignment: Alignment.topLeft,
-            child: IntrinsicWidth(
+            child: const IntrinsicWidth(
               child: OverflowBar(
                 spacing: 4,
                 overflowSpacing: 8,
-                children: const <Widget>[
+                children: <Widget>[
                   SizedBox(width: 48, height: 50),
                   SizedBox(width: 64, height: 25),
                   SizedBox(width: 32, height: 75),
@@ -213,11 +213,11 @@ void main() {
           child: Container(
             width: maxWidth,
             alignment: Alignment.topLeft,
-            child: IntrinsicHeight(
+            child: const IntrinsicHeight(
               child: OverflowBar(
                 spacing: 4,
                 overflowSpacing: 8,
-                children: const <Widget>[
+                children: <Widget>[
                   SizedBox(width: 48, height: 50),
                   SizedBox(width: 64, height: 25),
                   SizedBox(width: 32, height: 75),

--- a/packages/flutter/test/widgets/parent_data_test.dart
+++ b/packages/flutter/test/widgets/parent_data_test.dart
@@ -51,9 +51,9 @@ final TestParentData kNonPositioned = TestParentData();
 void main() {
   testWidgets('ParentDataWidget control test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           DecoratedBox(decoration: kBoxDecorationA),
           Positioned(
             top: 10.0,
@@ -72,9 +72,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             bottom: 5.0,
             right: 7.0,
@@ -101,9 +101,9 @@ void main() {
     const DecoratedBox kDecoratedBoxC = DecoratedBox(decoration: kBoxDecorationC);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             bottom: 5.0,
             right: 7.0,
@@ -126,9 +126,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             bottom: 6.0,
             right: 8.0,
@@ -197,9 +197,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             right: 10.0,
             child: FlipWidget(left: kDecoratedBoxA, right: kDecoratedBoxB),
@@ -220,9 +220,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             top: 7.0,
             child: FlipWidget(left: kDecoratedBoxA, right: kDecoratedBoxB),
@@ -243,7 +243,7 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <TestParentData>[]);
@@ -251,11 +251,11 @@ void main() {
 
   testWidgets('ParentDataWidget conflicting data', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             Positioned(
               top: 5.0,
               bottom: 8.0,
@@ -287,7 +287,7 @@ void main() {
       ),
     );
 
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr));
 
     checkTree(tester, <TestParentData>[]);
 
@@ -325,7 +325,7 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Stack(textDirection: TextDirection.ltr),
+      const Stack(textDirection: TextDirection.ltr),
     );
 
     checkTree(tester, <TestParentData>[]);

--- a/packages/flutter/test/widgets/placeholder_test.dart
+++ b/packages/flutter/test/widgets/placeholder_test.dart
@@ -13,11 +13,11 @@ void main() {
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(800.0, 600.0));
     await tester.pumpWidget(const Center(child: Placeholder()));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(800.0, 600.0));
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, children: const <Widget>[Positioned(top: 0.0, bottom: 0.0, child: Placeholder())]));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, children: <Widget>[Positioned(top: 0.0, bottom: 0.0, child: Placeholder())]));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(400.0, 600.0));
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, children: const <Widget>[Positioned(left: 0.0, right: 0.0, child: Placeholder())]));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, children: <Widget>[Positioned(left: 0.0, right: 0.0, child: Placeholder())]));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(800.0, 400.0));
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr, children: const <Widget>[Positioned(top: 0.0, child: Placeholder(fallbackWidth: 200.0, fallbackHeight: 300.0))]));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr, children: <Widget>[Positioned(top: 0.0, child: Placeholder(fallbackWidth: 200.0, fallbackHeight: 300.0))]));
     expect(tester.renderObject<RenderBox>(find.byType(Placeholder)).size, const Size(200.0, 300.0));
   });
 

--- a/packages/flutter/test/widgets/stack_test.dart
+++ b/packages/flutter/test/widgets/stack_test.dart
@@ -20,7 +20,7 @@ class TestPaintingContext implements PaintingContext {
 void main() {
   testWidgets('Can construct an empty Stack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(),
       ),
@@ -29,7 +29,7 @@ void main() {
 
   testWidgets('Can construct an empty Centered Stack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(child: Stack()),
       ),
@@ -40,9 +40,9 @@ void main() {
     const Key key = Key('container');
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.topLeft,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             left: 10.0,
             child: SizedBox(
@@ -68,9 +68,9 @@ void main() {
     expect(parentData.height, isNull);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.topLeft,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             right: 10.0,
             child: SizedBox(
@@ -98,9 +98,9 @@ void main() {
     const SizedBox sizedBox = SizedBox(key: key, width: 10.0, height: 10.0);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[ Positioned(left: 10.0, child: sizedBox) ],
+        children: <Widget>[ Positioned(left: 10.0, child: sizedBox) ],
       ),
     );
     Element containerElement = tester.element(find.byKey(key));
@@ -115,9 +115,9 @@ void main() {
     expect(parentData.height, isNull);
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[ sizedBox ],
+        children: <Widget>[ sizedBox ],
       ),
     );
     containerElement = tester.element(find.byKey(key));
@@ -136,12 +136,12 @@ void main() {
     const Key child1Key = Key('child1');
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             alignment: Alignment.center,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -159,12 +159,12 @@ void main() {
     expect(child1RenderObjectParentData.offset, equals(const Offset(5.0, 5.0)));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             alignment: AlignmentDirectional.bottomEnd,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -182,12 +182,12 @@ void main() {
     const Key child1Key = Key('child1');
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
         child: Center(
           child: Stack(
             alignment: Alignment.center,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -205,12 +205,12 @@ void main() {
     expect(child1RenderObjectParentData.offset, equals(const Offset(5.0, 5.0)));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
         child: Center(
           child: Stack(
             alignment: AlignmentDirectional.bottomEnd,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(key: child0Key, width: 20.0, height: 20.0),
               SizedBox(key: child1Key, width: 10.0, height: 10.0),
             ],
@@ -225,7 +225,7 @@ void main() {
 
   testWidgets('Can construct an empty IndexedStack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: IndexedStack(),
       ),
@@ -234,7 +234,7 @@ void main() {
 
   testWidgets('Can construct an empty Centered IndexedStack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(child: IndexedStack()),
       ),
@@ -316,9 +316,9 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             left: 10.0,
             width: 11.0,
@@ -348,9 +348,9 @@ void main() {
     expect(renderBox.size.height, equals(12.0));
 
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           Positioned(
             right: 10.0,
             width: 11.0,
@@ -377,18 +377,18 @@ void main() {
   });
 
   testWidgets('Can set and update clipBehavior', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr));
     final RenderStack renderObject = tester.allRenderObjects.whereType<RenderStack>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
-    await tester.pumpWidget(Stack(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Stack(textDirection: TextDirection.ltr));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
   });
 
   testWidgets('Clip.none is respected by describeApproximateClip', (WidgetTester tester) async {
-    await tester.pumpWidget(Stack(
+    await tester.pumpWidget(const Stack(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[Positioned(left: 1000, right: 2000, child: SizedBox(width: 2000, height: 2000))],
+      children: <Widget>[Positioned(left: 1000, right: 2000, child: SizedBox(width: 2000, height: 2000))],
     ));
     final RenderStack renderObject = tester.allRenderObjects.whereType<RenderStack>().first;
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
@@ -440,11 +440,11 @@ void main() {
 
   testWidgets('Stack clip test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(
                 width: 100.0,
                 height: 100.0,
@@ -469,12 +469,12 @@ void main() {
     expect(context.invocations.first.memberName, equals(#pushClipRect));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Center(
           child: Stack(
             clipBehavior: Clip.none,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(
                 width: 100.0,
                 height: 100.0,
@@ -645,17 +645,17 @@ void main() {
 
   testWidgets('Can change the text direction of a Stack', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.center,
       ),
     );
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         textDirection: TextDirection.rtl,
       ),
     );
     await tester.pumpWidget(
-      Stack(
+      const Stack(
         alignment: Alignment.center,
       ),
     );
@@ -663,11 +663,11 @@ void main() {
 
   testWidgets('Alignment with partially-positioned children', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
         child: Stack(
           alignment: Alignment.center,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -692,11 +692,11 @@ void main() {
     expect(tester.getRect(find.byType(SizedBox).at(8)), const Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           alignment: Alignment.center,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -721,11 +721,11 @@ void main() {
     expect(tester.getRect(find.byType(SizedBox).at(8)), const Rect.fromLTWH(350.0, 500.0, 100.0, 100.0));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           alignment: Alignment.bottomRight,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -750,11 +750,11 @@ void main() {
     expect(tester.getRect(find.byType(SizedBox).at(8)), const Rect.fromLTWH(700.0, 500.0, 100.0, 100.0));
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.ltr,
         child: Stack(
           alignment: Alignment.topLeft,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 100.0),
             Positioned(left: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
             Positioned(right: 0.0, child: SizedBox(width: 100.0, height: 100.0)),
@@ -781,7 +781,7 @@ void main() {
 
   testWidgets('Stack error messages', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Stack(),
+      const Stack(),
     );
     final String exception = tester.takeException().toString();
 
@@ -808,14 +808,14 @@ void main() {
 
   testWidgets('Can update clipBehavior of IndexedStack',
       (WidgetTester tester) async {
-    await tester.pumpWidget(IndexedStack(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const IndexedStack(textDirection: TextDirection.ltr));
     final RenderIndexedStack renderObject =
       tester.renderObject<RenderIndexedStack>(find.byType(IndexedStack));
     expect(renderObject.clipBehavior, equals(Clip.hardEdge));
 
     // Update clipBehavior to Clip.antiAlias
 
-    await tester.pumpWidget(IndexedStack(
+    await tester.pumpWidget(const IndexedStack(
       textDirection: TextDirection.ltr,
       clipBehavior: Clip.antiAlias,
     ));

--- a/packages/flutter/test/widgets/tap_region_test.dart
+++ b/packages/flutter/test/widgets/tap_region_test.dart
@@ -210,7 +210,7 @@ void main() {
                       onTapInside: (PointerEvent event) {
                         tappedInside.add(noGroupKey.value);
                       },
-                      child: Stack(key: noGroupKey),
+                      child: const Stack(key: noGroupKey),
                     ),
                   ),
                   ConstrainedBox(
@@ -221,7 +221,7 @@ void main() {
                       onTapInside: (PointerEvent event) {
                         tappedInside.add(group1AKey.value);
                       },
-                      child: Stack(key: group1AKey),
+                      child: const Stack(key: group1AKey),
                     ),
                   ),
                   ConstrainedBox(
@@ -232,7 +232,7 @@ void main() {
                       onTapInside: (PointerEvent event) {
                         tappedInside.add(group1BKey.value);
                       },
-                      child: Stack(key: group1BKey),
+                      child: const Stack(key: group1BKey),
                     ),
                   ),
                 ],

--- a/packages/flutter/test/widgets/text_test.dart
+++ b/packages/flutter/test/widgets/text_test.dart
@@ -1332,21 +1332,21 @@ void main() {
             height: 100,
             child: IntrinsicWidth(
               child: RichText(
-                text: TextSpan(
-                  style: const TextStyle(fontSize: 16, height: 1),
+                text: const TextSpan(
+                  style: TextStyle(fontSize: 16, height: 1),
                   children: <InlineSpan>[
-                    const TextSpan(text: 'S '),
+                    TextSpan(text: 'S '),
                     WidgetSpan(
                       alignment: PlaceholderAlignment.top,
                       child: Wrap(
                         direction: Axis.vertical,
-                        children: const <Widget>[
+                        children: <Widget>[
                           SizedBox(width: 200, height: 100),
                           SizedBox(width: 200, height: 30),
                         ],
                       ),
                     ),
-                    const TextSpan(text: ' E'),
+                    TextSpan(text: ' E'),
                   ],
                 ),
               ),

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -247,10 +247,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     testWidgets('WidgetInspector smoke test', (WidgetTester tester) async {
       // This is a smoke test to verify that adding the inspector doesn't crash.
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -260,12 +260,12 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       );
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: WidgetInspector(
             selectButtonBuilder: null,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a', textDirection: TextDirection.ltr),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -365,8 +365,8 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
             selectButtonBuilder: null,
             child: Transform(
               transform: Matrix4.identity()..scale(0.0),
-              child: Stack(
-                children: const <Widget>[
+              child: const Stack(
+                children: <Widget>[
                   Text('a', textDirection: TextDirection.ltr),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -729,10 +729,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService maybeSetSelection', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -776,10 +776,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService defunct selection regression test', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
             ],
           ),
@@ -831,10 +831,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -902,10 +902,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -929,10 +929,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('WidgetInspectorService creationLocation', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -977,10 +977,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
   testWidgets('WidgetInspectorService setSelection notifiers for an Element',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1023,10 +1023,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       'WidgetInspectorService setSelection notifiers for a RenderObject',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          Directionality(
+          const Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -1118,10 +1118,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     testWidgets('test transformDebugCreator will re-order if after stack trace', (WidgetTester tester) async {
       final bool widgetTracked = WidgetInspectorService.instance.isWidgetCreationTracked();
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1182,10 +1182,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     testWidgets('test transformDebugCreator will not re-order if before stack trace', (WidgetTester tester) async {
       final bool widgetTracked = WidgetInspectorService.instance.isWidgetCreationTracked();
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1249,10 +1249,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       setupDefaultPubRootDirectory(service);
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1283,10 +1283,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       setupDefaultPubRootDirectory(service);
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1315,10 +1315,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       setupDefaultPubRootDirectory(service);
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -1454,10 +1454,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'does not have createdByLocalProject when there are no pubRootDirectories',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1484,10 +1484,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'has createdByLocalProject when the element is part of the pubRootDirectory',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1510,10 +1510,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'does not have createdByLocalProject when widget package directory is a suffix of a pubRootDirectory',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1535,10 +1535,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1560,10 +1560,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'does not have createdByLocalProject when thePubRootDirecty has a different suffix',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1585,10 +1585,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'has createdByLocalProject even if another pubRootDirectory does not match',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1613,10 +1613,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           testWidgets(
             'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
             (WidgetTester tester) async {
-              final Widget widget = Directionality(
+              const Widget widget = Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -1690,10 +1690,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'reacts to add and removing pubRootDirectories',
           (WidgetTester tester) async {
-            final Widget widget = Directionality(
+            const Widget widget = Directionality(
               textDirection: TextDirection.ltr,
               child: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Text('a'),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -1728,10 +1728,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'does not match when the package directory does not match',
           (WidgetTester tester) async {
-            final Widget widget = Directionality(
+            const Widget widget = Directionality(
               textDirection: TextDirection.ltr,
               child: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Text('a'),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -1756,10 +1756,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
           (WidgetTester tester) async {
-            final Widget widget = Directionality(
+            const Widget widget = Directionality(
               textDirection: TextDirection.ltr,
               child: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Text('a'),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -1781,10 +1781,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'can handle consecutive calls to add',
           (WidgetTester tester) async {
-            final Widget widget = Directionality(
+            const Widget widget = Directionality(
               textDirection: TextDirection.ltr,
               child: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Text('a'),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -1810,10 +1810,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'can handle removing an unrelated pubRootDirectory',
           (WidgetTester tester) async {
-            final Widget widget = Directionality(
+            const Widget widget = Directionality(
               textDirection: TextDirection.ltr,
               child: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Text('a'),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -1846,10 +1846,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         testWidgets(
           'can handle parent widget being part of a separate package',
           (WidgetTester tester) async {
-            final Widget widget = Directionality(
+            const Widget widget = Directionality(
               textDirection: TextDirection.ltr,
               child: Stack(
-                children: const <Widget>[
+                children: <Widget>[
                   Text('a'),
                   Text('b', textDirection: TextDirection.ltr),
                   Text('c', textDirection: TextDirection.ltr),
@@ -1970,10 +1970,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('ext.flutter.inspector.setSelection', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2022,10 +2022,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2097,10 +2097,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2128,10 +2128,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2167,10 +2167,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2260,10 +2260,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2369,10 +2369,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2460,10 +2460,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       const String group = 'test-group';
 
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a', textDirection: TextDirection.ltr),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2529,10 +2529,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
 
     testWidgets('ext.flutter.inspector creationLocation', (WidgetTester tester) async {
       await tester.pumpWidget(
-        Directionality(
+        const Directionality(
           textDirection: TextDirection.ltr,
           child: Stack(
-            children: const <Widget>[
+            children: <Widget>[
               Text('a'),
               Text('b', textDirection: TextDirection.ltr),
               Text('c', textDirection: TextDirection.ltr),
@@ -2593,10 +2593,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'has createdByLocalProject when the widget is in the pubRootDirectory',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2626,10 +2626,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2659,10 +2659,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2692,10 +2692,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2725,10 +2725,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'has createdByLocalProject if at least one of the pubRootDirectories matches',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2762,10 +2762,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'widget is part of core framework and is the child of a widget in the package pubRootDirectories',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2873,10 +2873,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'has createdByLocalProject when the widget is in the pubRootDirectory',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                       Text('c', textDirection: TextDirection.ltr),
@@ -2905,10 +2905,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'does not have createdByLocalProject if the prefix of the pubRootDirectory is different',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2940,10 +2940,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'has createdByLocalProject if the pubRootDirectory is prefixed with file://',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -2972,10 +2972,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'does not have createdByLocalProject if the pubRootDirectory has a different suffix',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -3007,10 +3007,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
           'has createdByLocalProject if at least one of the pubRootDirectories matches',
           (WidgetTester tester) async {
             await tester.pumpWidget(
-              Directionality(
+              const Directionality(
                 textDirection: TextDirection.ltr,
                 child: Stack(
-                  children: const <Widget>[
+                  children: <Widget>[
                     Text('a'),
                     Text('b', textDirection: TextDirection.ltr),
                     Text('c', textDirection: TextDirection.ltr),
@@ -3064,10 +3064,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'reacts to add and removing pubRootDirectories',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3114,10 +3114,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'does not match when the package directory does not match',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3148,10 +3148,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3179,10 +3179,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'can handle consecutive calls to add',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3213,10 +3213,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'can handle removing an unrelated pubRootDirectory',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3259,10 +3259,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'can handle parent widget being part of a separate package',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3370,10 +3370,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'reacts to add and removing pubRootDirectories',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3422,10 +3422,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'does not match when the package directory does not match',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3456,10 +3456,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'has createdByLocalProject when the pubRootDirectory is prefixed with file://',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3490,10 +3490,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'can handle consecutive calls to add',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),
@@ -3530,10 +3530,10 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       testWidgets(
         'can handle removing an unrelated pubRootDirectory',
         (WidgetTester tester) async {
-          final Widget widget = Directionality(
+          const Widget widget = Directionality(
             textDirection: TextDirection.ltr,
             child: Stack(
-              children: const <Widget>[
+              children: <Widget>[
                 Text('a'),
                 Text('b', textDirection: TextDirection.ltr),
                 Text('c', textDirection: TextDirection.ltr),

--- a/packages/flutter/test/widgets/wrap_test.dart
+++ b/packages/flutter/test/widgets/wrap_test.dart
@@ -18,9 +18,9 @@ void verify(WidgetTester tester, List<Offset> answerKey) {
 void main() {
   testWidgets('Basic Wrap test (LTR)', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -36,10 +36,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.center,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -55,10 +55,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.end,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -74,9 +74,9 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -92,10 +92,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         crossAxisAlignment: WrapCrossAlignment.center,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -111,10 +111,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         crossAxisAlignment: WrapCrossAlignment.end,
         textDirection: TextDirection.ltr,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -133,9 +133,9 @@ void main() {
 
   testWidgets('Basic Wrap test (RTL)', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         textDirection: TextDirection.rtl,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -151,10 +151,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.center,
         textDirection: TextDirection.rtl,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -170,10 +170,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         alignment: WrapAlignment.end,
         textDirection: TextDirection.rtl,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -189,10 +189,10 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -208,11 +208,11 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         crossAxisAlignment: WrapCrossAlignment.center,
         textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -228,11 +228,11 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Wrap(
+      const Wrap(
         crossAxisAlignment: WrapCrossAlignment.end,
         textDirection: TextDirection.ltr,
         verticalDirection: VerticalDirection.up,
-        children: const <Widget>[
+        children: <Widget>[
           SizedBox(width: 300.0, height: 50.0),
           SizedBox(width: 300.0, height: 100.0),
           SizedBox(width: 300.0, height: 100.0),
@@ -250,16 +250,16 @@ void main() {
   });
 
   testWidgets('Empty wrap', (WidgetTester tester) async {
-    await tester.pumpWidget(Center(child: Wrap(alignment: WrapAlignment.center)));
+    await tester.pumpWidget(const Center(child: Wrap(alignment: WrapAlignment.center)));
     expect(tester.renderObject<RenderBox>(find.byType(Wrap)).size, equals(Size.zero));
   });
 
   testWidgets('Wrap alignment (LTR)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.center,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -272,11 +272,11 @@ void main() {
       const Offset(405.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceBetween,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -289,11 +289,11 @@ void main() {
       const Offset(500.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceAround,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -306,11 +306,11 @@ void main() {
       const Offset(460.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceEvenly,
       spacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -325,11 +325,11 @@ void main() {
   });
 
   testWidgets('Wrap alignment (RTL)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.center,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -342,11 +342,11 @@ void main() {
       const Offset(95.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceBetween,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -359,11 +359,11 @@ void main() {
       Offset.zero,
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceAround,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -376,11 +376,11 @@ void main() {
       const Offset(30.0, 0.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       alignment: WrapAlignment.spaceEvenly,
       spacing: 5.0,
       textDirection: TextDirection.rtl,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 310.0, height: 30.0),
@@ -395,11 +395,11 @@ void main() {
   });
 
   testWidgets('Wrap runAlignment (DOWN)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.center,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -416,11 +416,11 @@ void main() {
       const Offset(0.0, 310.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceBetween,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -437,11 +437,11 @@ void main() {
       const Offset(0.0, 540.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceAround,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -458,11 +458,11 @@ void main() {
       const Offset(0.0, 455.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceEvenly,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -482,12 +482,12 @@ void main() {
   });
 
   testWidgets('Wrap runAlignment (UP)', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.center,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -504,12 +504,12 @@ void main() {
       const Offset(0.0, 230.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceBetween,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -526,12 +526,12 @@ void main() {
       Offset.zero,
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceAround,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -548,12 +548,12 @@ void main() {
       const Offset(0.0, 75.0),
     ]);
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       runAlignment: WrapAlignment.spaceEvenly,
       runSpacing: 5.0,
       textDirection: TextDirection.ltr,
       verticalDirection: VerticalDirection.up,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 100.0, height: 10.0),
         SizedBox(width: 200.0, height: 20.0),
         SizedBox(width: 300.0, height: 30.0),
@@ -574,13 +574,13 @@ void main() {
 
   testWidgets('Shrink-wrapping Wrap test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           alignment: WrapAlignment.end,
           crossAxisAlignment: WrapCrossAlignment.end,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 100.0, height: 10.0),
             SizedBox(width: 200.0, height: 20.0),
             SizedBox(width: 300.0, height: 30.0),
@@ -598,13 +598,13 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           alignment: WrapAlignment.end,
           crossAxisAlignment: WrapCrossAlignment.end,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 400.0, height: 40.0),
             SizedBox(width: 300.0, height: 30.0),
             SizedBox(width: 200.0, height: 20.0),
@@ -624,12 +624,12 @@ void main() {
 
   testWidgets('Wrap spacing test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           runSpacing: 10.0,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 500.0, height: 10.0),
             SizedBox(width: 500.0, height: 20.0),
             SizedBox(width: 500.0, height: 30.0),
@@ -649,14 +649,14 @@ void main() {
 
   testWidgets('Vertical Wrap test with spacing', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           direction: Axis.vertical,
           spacing: 10.0,
           runSpacing: 15.0,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 10.0, height: 250.0),
             SizedBox(width: 20.0, height: 250.0),
             SizedBox(width: 30.0, height: 250.0),
@@ -678,13 +678,13 @@ void main() {
     ]);
 
     await tester.pumpWidget(
-      Align(
+      const Align(
         alignment: Alignment.topLeft,
         child: Wrap(
           spacing: 12.0,
           runSpacing: 8.0,
           textDirection: TextDirection.ltr,
-          children: const <Widget>[
+          children: <Widget>[
             SizedBox(width: 10.0, height: 250.0),
             SizedBox(width: 20.0, height: 250.0),
             SizedBox(width: 30.0, height: 250.0),
@@ -707,19 +707,19 @@ void main() {
   });
 
   testWidgets('Visual overflow generates a clip', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 500.0, height: 500.0),
       ],
     ));
 
     expect(tester.renderObject<RenderBox>(find.byType(Wrap)), isNot(paints..clipRect()));
 
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       textDirection: TextDirection.ltr,
       clipBehavior: Clip.hardEdge,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 500.0, height: 500.0),
         SizedBox(width: 500.0, height: 500.0),
       ],
@@ -765,18 +765,18 @@ void main() {
   });
 
   testWidgets('RenderWrap toStringShallow control test', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(alignment: WrapAlignment.center));
+    await tester.pumpWidget(const Wrap(alignment: WrapAlignment.center));
 
     final RenderBox wrap = tester.renderObject(find.byType(Wrap));
     expect(wrap.toStringShallow(), hasOneLineDescription);
   });
 
   testWidgets('RenderWrap toString control test', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       direction: Axis.vertical,
       runSpacing: 7.0,
       textDirection: TextDirection.ltr,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 500.0, height: 400.0),
         SizedBox(width: 500.0, height: 400.0),
         SizedBox(width: 500.0, height: 400.0),
@@ -791,18 +791,18 @@ void main() {
 
   testWidgets('Wrap baseline control test', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Center(
+      const Center(
         child: Baseline(
           baseline: 180.0,
           baselineType: TextBaseline.alphabetic,
           child: DefaultTextStyle(
-            style: const TextStyle(
+            style: TextStyle(
               fontFamily: 'Ahem',
               fontSize: 100.0,
             ),
             child: Wrap(
               textDirection: TextDirection.ltr,
-              children: const <Widget>[
+              children: <Widget>[
                 Text('X', textDirection: TextDirection.ltr),
               ],
             ),
@@ -818,11 +818,11 @@ void main() {
   });
 
   testWidgets('Spacing with slight overflow', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(
+    await tester.pumpWidget(const Wrap(
       textDirection: TextDirection.ltr,
       spacing: 10.0,
       runSpacing: 10.0,
-      children: const <Widget>[
+      children: <Widget>[
         SizedBox(width: 200.0, height: 10.0),
         SizedBox(width: 200.0, height: 10.0),
         SizedBox(width: 200.0, height: 10.0),
@@ -842,12 +842,12 @@ void main() {
   testWidgets('Object exactly matches container width', (WidgetTester tester) async {
     await tester.pumpWidget(
       Column(
-        children: <Widget>[
+        children: const <Widget>[
           Wrap(
             textDirection: TextDirection.ltr,
             spacing: 10.0,
             runSpacing: 10.0,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(width: 800.0, height: 10.0),
             ],
           ),
@@ -860,12 +860,12 @@ void main() {
 
     await tester.pumpWidget(
       Column(
-        children: <Widget>[
+        children: const <Widget>[
           Wrap(
             textDirection: TextDirection.ltr,
             spacing: 10.0,
             runSpacing: 10.0,
-            children: const <Widget>[
+            children: <Widget>[
               SizedBox(width: 800.0, height: 10.0),
               SizedBox(width: 800.0, height: 10.0),
             ],
@@ -882,11 +882,11 @@ void main() {
   });
 
   testWidgets('Wrap can set and update clipBehavior', (WidgetTester tester) async {
-    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr));
+    await tester.pumpWidget(const Wrap(textDirection: TextDirection.ltr));
     final RenderWrap renderObject = tester.allRenderObjects.whereType<RenderWrap>().first;
     expect(renderObject.clipBehavior, equals(Clip.none));
 
-    await tester.pumpWidget(Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.antiAlias));
+    await tester.pumpWidget(const Wrap(textDirection: TextDirection.ltr, clipBehavior: Clip.antiAlias));
     expect(renderObject.clipBehavior, equals(Clip.antiAlias));
   });
 


### PR DESCRIPTION
~**Submission is blocked on https://github.com/flutter/plugins/pull/7030 rolling into `flutter/flutter` to make the `Linux flutter_plugins` check green.**~

Fixes https://github.com/flutter/flutter/issues/108248.
Part of https://github.com/flutter/flutter/issues/118837.

This change fixes this TODO:

https://github.com/flutter/flutter/blob/a45727d81360b278cc51c5a9ae429529038cf069/packages/flutter/lib/src/widgets/framework.dart#L1858-L1860

Everything else is fallout from that tiny fix generated by `dart fix --apply`.