### PR TITLE
Fix Unable to Confirm Windows Version in flutter doctor

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,3 +101,4 @@ Junhua Lin <1075209054@qq.com>
 Tomasz Gucio <tgucio@gmail.com>
 Jason C.H <ctrysbita@outlook.com>
 Hubert Jóźwiak <hjozwiakdx@gmail.com>
+Stenio Oliveira <steniooliv@gmail.com>

--- a/packages/flutter_tools/lib/src/windows/windows_version_validator.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_version_validator.dart
@@ -16,8 +16,7 @@ const List<String> kUnsupportedVersions = <String>[
 
 /// Regex pattern for identifying line from systeminfo stdout with windows version
 /// (ie. 10.5.4123)
-const String kWindowsOSVersionSemVerPattern =
-    r'^(OS )([^:]*:\s*)([0-9]+\.[0-9]+\.[0-9]+)(.*)$';
+const String kWindowsOSVersionSemVerPattern = r'([0-9]+\.[0-9]+\.[0-9]+)(.*)$';
 
 /// Validator for supported Windows host machine operating system version.
 class WindowsVersionValidator extends DoctorValidator {
@@ -52,7 +51,7 @@ class WindowsVersionValidator extends DoctorValidator {
     final String statusInfo;
     if (matches.length == 1 &&
         !kUnsupportedVersions
-            .contains(matches.elementAt(0).group(3)?.split('.').elementAt(0))) {
+            .contains(matches.elementAt(0).group(2)?.split('.').elementAt(0))) {
       windowsVersionStatus = ValidationType.success;
       statusInfo = 'Installed version of Windows is version 10 or higher';
     } else {

--- a/packages/flutter_tools/lib/src/windows/windows_version_validator.dart
+++ b/packages/flutter_tools/lib/src/windows/windows_version_validator.dart
@@ -51,7 +51,7 @@ class WindowsVersionValidator extends DoctorValidator {
     final String statusInfo;
     if (matches.length == 1 &&
         !kUnsupportedVersions
-            .contains(matches.elementAt(0).group(2)?.split('.').elementAt(0))) {
+            .contains(matches.elementAt(0).group(1)?.split('.').elementAt(0))) {
       windowsVersionStatus = ValidationType.success;
       statusInfo = 'Installed version of Windows is version 10 or higher';
     } else {

--- a/packages/flutter_tools/test/general.shard/windows_version_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows_version_validator_test.dart
@@ -52,6 +52,47 @@ Hotfix(s):                 7 Hotfix(s) Installed.
 Hyper-V Requirements:      A hypervisor has been detected. Features required for Hyper-V will not be displayed.
 ''';
 
+/// Example output from `systeminfo` from a Windows 10 host
+const String validWindows11PtStdOut = r'''
+Nome do host:                              XXXXXXXXXXXX
+Nome do sistema operacional:               Microsoft Windows 11 Home Single Language
+Versão do sistema operacional:             10.0.22621 N/A compilação 22621
+Fabricante do sistema operacional:         Microsoft Corporation
+Configuração do SO:                        Estação de trabalho autônoma
+Tipo de compilação do sistema operacional: Multiprocessor Free
+Proprietário registrado:                   N/A
+Organização registrada:                    N/A
+Identificação do produto:                  00327-31015-87755-AAOEM
+Data da instalação original:               19/12/2022, 15:54:47
+Tempo de Inicialização do Sistema:         26/01/2023, 09:05:50
+Fabricante do sistema:                     XXXXXXXXXXXX
+Modelo do sistema:                         XXXXXXXXXXXX
+Tipo de sistema:                           x64-based PC
+Processador(es):                           1 processador(es) instalado(s).
+                                           [01]: Intel64 Family 6 Model 142 Stepping 12 GenuineIntel ~1609 Mhz
+Versão do BIOS:                            XXXXXXXXXXXX, 17/11/2022
+Pasta do Windows:                          C:\Windows
+Pasta do sistema:                          C:\Windows\system32
+Inicializar dispositivo:                   \Device\HarddiskVolume1
+Localidade do sistema:                     pt-br;Português (Brasil)
+Localidade de entrada:                     pt-br;Português (Brasil)
+Fuso horário:                              (UTC-03:00) Brasília
+Memória física total:                      20.314 MB
+Memória física disponível:                 1.353 MB
+Memória Virtual: Tamanho Máximo:           33.626 MB
+Memória Virtual: Disponível:               6.177 MB
+Memória Virtual: Em Uso:                   27.449 MB
+Local(is) de arquivo de paginação:         C:\pagefile.sys
+Domínio:                                   WORKGROUP
+Servidor de Logon:                         \\XXXXXXXXXXXX
+Hotfix(es):                                4 hotfix(es) instalado(s).
+                                           [01]: KB5020880
+                                           [02]: KB5012170
+                                           [03]: KB5022303
+                                           [04]: KB5020487
+Requisitos do Hyper-V:                     Hipervisor detectado. Recursos necessários para o Hyper-V não serão exibidos.
+''';
+
 const String validWindows11CnStdOut = r'''
 主机名:           XXXXXXXXXXXX
 OS 名称:          Microsoft Windows 11 专业版
@@ -189,6 +230,36 @@ void main() {
     expect(result.statusInfo, validWindows10ValidationResult.statusInfo,
         reason: 'The ValidationResult statusInfo messages should be the same');
   });
+
+  testWithoutContext(
+    'Successfully running windows version check on windows 11 PT',
+    () async {
+      final WindowsVersionValidator windowsVersionValidator =
+          WindowsVersionValidator(
+        processManager: FakeProcessManager.list(
+          <FakeCommand>[
+            const FakeCommand(
+              command: <String>['systeminfo'],
+              stdout: validWindows11PtStdOut,
+            ),
+          ],
+        ),
+      );
+
+      final ValidationResult result = await windowsVersionValidator.validate();
+
+      expect(
+        result.type,
+        validWindows10ValidationResult.type,
+        reason: 'The ValidationResult type should be the same (installed)',
+      );
+      expect(
+        result.statusInfo,
+        validWindows10ValidationResult.statusInfo,
+        reason: 'The ValidationResult statusInfo messages should be the same',
+      );
+    },
+  );
 
   testWithoutContext(
     'Successfully running windows version check on windows 11 CN',

--- a/packages/flutter_tools/test/general.shard/windows_version_validator_test.dart
+++ b/packages/flutter_tools/test/general.shard/windows_version_validator_test.dart
@@ -355,14 +355,15 @@ void main() {
 
   testWithoutContext('Unit testing on a regex pattern validator', () async {
     const String testStr = r'''
-OS Version:                10.0.19044 N/A Build 19044
-OSz Version:                10.0.19044 N/A Build 19044
-OxS Version:                10.0.19044 N/A Build 19044
-OS Version:                10.19044 N/A Build 19044
-OS Version:                10.x.19044 N/A Build 19044
-OS Version:                10.0.19044 N/A Build 19044
-OS Version:                .0.19044 N/A Build 19044
-OS 版本:          10.0.22621 暂缺 Build 22621
+OS Version:                     10.0.19044 N/A Build 19044
+OSz Version:                    10.0.19044 N/A Build 19044
+OxS Version:                    10.0.19044 N/A Build 19044
+OS Version:                     10.19044 N/A Build 19044
+OS Version:                     10.x.19044 N/A Build 19044
+OS Version:                     10.0.19044 N/A Build 19044
+OS Version:                     .0.19044 N/A Build 19044
+OS 版本:                         10.0.22621 暂缺 Build 22621
+Versão do sistema operacional:  10.0.22621 N/A compilação 22621
 ''';
 
     final RegExp regex = RegExp(
@@ -373,8 +374,8 @@ OS 版本:          10.0.22621 暂缺 Build 22621
 
     expect(
       matches.length,
-      3,
-      reason: 'There should be only two matches for the pattern provided',
+      6,
+      reason: 'There should be six matches for the pattern provided',
     );
   });
 }


### PR DESCRIPTION
Fix Windows Version validation in `flutter doctor`, depending on the language, the text (OS Version in English) generated in `systeminfo`, the regular expression does not validate the version.

- Example in English
```
Host Name:                 XXXXXXXXXXXX
OS Name:                   Microsoft Windows 10 Enterprise
OS Version:                10.0.19044 N/A Build 19044
OS Manufacturer:           Microsoft Corporation
OS Configuration:          Member Workstation
OS Build Type:             Multiprocessor Free
Registered Owner:          N/A
Registered Organization:   N/A
```
- Example in Portuguese
```
Nome do host:                              XXXXXXXXXXXX
Nome do sistema operacional:               Microsoft Windows 11 Home Single Language
Versão do sistema operacional:             10.0.22621 N/A compilação 22621
Fabricante do sistema operacional:         Microsoft Corporation
Configuração do SO:                        Estação de trabalho autônoma
Tipo de compilação do sistema operacional: Multiprocessor Free
Proprietário registrado:                   N/A
Organização registrada:                    N/A
```
- Example in Chinese
```
主机名:           XXXXXXXXXXXX
OS 名称:          Microsoft Windows 11 专业版
OS 版本:          10.0.22621 暂缺 Build 22621
OS 制造商:        Microsoft Corporation
OS 配置:          独立工作站
OS 构建类型:      Multiprocessor Free
注册的所有人:     暂缺
注册的组织:       暂缺
```


I made a change to the regular expression so that only the operating system version is recognized, excluding the previous text.
Based on version number only, any language can be validated

This fixes #117890



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.