### PR TITLE
Allow disabling background dim on CupertinoPageRoute

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -331,6 +331,7 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
     this.title,
     super.settings,
     this.maintainState = true,
+    this.useBarrierColor = true,
     super.fullscreenDialog,
     super.allowSnapshotting = true,
   }) {
@@ -340,6 +341,10 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
   /// Builds the primary contents of the route.
   final WidgetBuilder builder;
 
+  /// Sets whether or not the content is dimmed without setting the route as a
+  /// fullscreen dialog.
+  final bool useBarrierColor;
+
   @override
   Widget buildContent(BuildContext context) => builder(context);
 
@@ -348,6 +353,9 @@ class CupertinoPageRoute<T> extends PageRoute<T> with CupertinoRouteTransitionMi
 
   @override
   final bool maintainState;
+
+  @override
+  Color? get barrierColor => fullscreenDialog || !useBarrierColor ? null : _kCupertinoPageTransitionBarrierColor;
 
   @override
   String get debugLabel => '${super.debugLabel}(${settings.name})';

--- a/packages/flutter/lib/src/cupertino/tab_view.dart
+++ b/packages/flutter/lib/src/cupertino/tab_view.dart
@@ -188,6 +188,7 @@ class _CupertinoTabViewState extends State<CupertinoTabView> {
         builder: routeBuilder,
         title: title,
         settings: settings,
+        useBarrierColor: false,
       );
     }
     if (widget.onGenerateRoute != null) {

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -943,7 +943,7 @@ void main() {
   });
 
   group('Cupertino page transitions', () {
-    CupertinoPageRoute<void> buildRoute({required bool fullscreenDialog, useBarrierColor = true}) {
+    CupertinoPageRoute<void> buildRoute({required bool fullscreenDialog, bool useBarrierColor = true}) {
       return CupertinoPageRoute<void>(
         fullscreenDialog: fullscreenDialog,
         useBarrierColor: useBarrierColor,

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -943,9 +943,10 @@ void main() {
   });
 
   group('Cupertino page transitions', () {
-    CupertinoPageRoute<void> buildRoute({required bool fullscreenDialog}) {
+    CupertinoPageRoute<void> buildRoute({required bool fullscreenDialog, useBarrierColor = true}) {
       return CupertinoPageRoute<void>(
         fullscreenDialog: fullscreenDialog,
+        useBarrierColor: useBarrierColor,
         builder: (_) => const SizedBox(),
       );
     }
@@ -974,6 +975,21 @@ void main() {
 
       tester.state<NavigatorState>(find.byType(Navigator)).push(
         buildRoute(fullscreenDialog: true),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.widget<ModalBarrier>(find.byType(ModalBarrier).last).color, isNull);
+    });
+
+    testWidgets('when route has useBarrierColor set to false, it has no barrierColor', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: SizedBox.expand(),
+        ),
+      );
+
+      tester.state<NavigatorState>(find.byType(Navigator)).push(
+        buildRoute(fullscreenDialog: false, useBarrierColor: false),
       );
       await tester.pumpAndSettle();
 


### PR DESCRIPTION
Addresses issue #117654. The source of the problem was that the CupertinoTabView leverages CupertinoPageRoute, which assumes the widget either needs a modal dimming, or is a full screen dialog that doesn't dim, but has different built in route transitions. As CupertinoTabView is neither, this PR adds in the ability to just disable the color dimming from the barrier color.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
