### PR TITLE
Rename DeviceGestureSettings.fromWindow to DeviceGestureSettings.fromView

### DIFF
--- a/packages/flutter/lib/src/gestures/gesture_settings.dart
+++ b/packages/flutter/lib/src/gestures/gesture_settings.dart
@@ -24,11 +24,11 @@ class DeviceGestureSettings {
     this.touchSlop,
   });
 
-  /// Create a new [DeviceGestureSettings] from the provided [window].
-  factory DeviceGestureSettings.fromWindow(ui.FlutterView window) {
-    final double? physicalTouchSlop = window.viewConfiguration.gestureSettings.physicalTouchSlop;
+  /// Create a new [DeviceGestureSettings] from the provided [view].
+  factory DeviceGestureSettings.fromView(ui.FlutterView view) {
+    final double? physicalTouchSlop = view.viewConfiguration.gestureSettings.physicalTouchSlop;
     return DeviceGestureSettings(
-      touchSlop: physicalTouchSlop == null ? null : physicalTouchSlop / window.devicePixelRatio
+      touchSlop: physicalTouchSlop == null ? null : physicalTouchSlop / view.devicePixelRatio
     );
   }
 

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -219,7 +219,7 @@ class MediaQueryData {
       highContrast = platformData?.highContrast ?? view.platformDispatcher.accessibilityFeatures.highContrast,
       alwaysUse24HourFormat = platformData?.alwaysUse24HourFormat ?? view.platformDispatcher.alwaysUse24HourFormat,
       navigationMode = platformData?.navigationMode ?? NavigationMode.traditional,
-      gestureSettings = DeviceGestureSettings.fromWindow(view),
+      gestureSettings = DeviceGestureSettings.fromView(view),
       displayFeatures = view.displayFeatures;
 
   /// The size of the media in logical pixels (e.g, the size of the screen).

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -200,7 +200,7 @@ void main() {
     expect(data.highContrast, platformData.highContrast);
     expect(data.alwaysUse24HourFormat, platformData.alwaysUse24HourFormat);
     expect(data.navigationMode, platformData.navigationMode);
-    expect(data.gestureSettings, DeviceGestureSettings.fromWindow(view));
+    expect(data.gestureSettings, DeviceGestureSettings.fromView(view));
     expect(data.displayFeatures, view.displayFeatures);
   });
 
@@ -240,7 +240,7 @@ void main() {
     expect(data.highContrast, platformDispatcher.accessibilityFeatures.highContrast);
     expect(data.alwaysUse24HourFormat, platformDispatcher.alwaysUse24HourFormat);
     expect(data.navigationMode, NavigationMode.traditional);
-    expect(data.gestureSettings, DeviceGestureSettings.fromWindow(view));
+    expect(data.gestureSettings, DeviceGestureSettings.fromView(view));
     expect(data.displayFeatures, view.displayFeatures);
   });
 
@@ -296,7 +296,7 @@ void main() {
     expect(data.highContrast, platformData.highContrast);
     expect(data.alwaysUse24HourFormat, platformData.alwaysUse24HourFormat);
     expect(data.navigationMode, platformData.navigationMode);
-    expect(data.gestureSettings, DeviceGestureSettings.fromWindow(view));
+    expect(data.gestureSettings, DeviceGestureSettings.fromView(view));
     expect(data.displayFeatures, view.displayFeatures);
   });
 
@@ -354,7 +354,7 @@ void main() {
     expect(data.highContrast, platformDispatcher.accessibilityFeatures.highContrast);
     expect(data.alwaysUse24HourFormat, platformDispatcher.alwaysUse24HourFormat);
     expect(data.navigationMode, NavigationMode.traditional);
-    expect(data.gestureSettings, DeviceGestureSettings.fromWindow(view));
+    expect(data.gestureSettings, DeviceGestureSettings.fromView(view));
     expect(data.displayFeatures, view.displayFeatures);
   });
 


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/116929.

More accurately describes what this is actually doing and avoids confusion in a multi window world. We will do the same for MediaQuery.fromWindow.

Decided to go for a straight rename since the API has no known usages outside of the framework (therefore the change is not considered breaking under our policy). Also, the API is fairly new and rather low-level.