### PR TITLE
Remove references to dart:ui's window singleton

### DIFF
--- a/packages/flutter/test/gestures/gesture_binding_test.dart
+++ b/packages/flutter/test/gestures/gesture_binding_test.dart
@@ -350,7 +350,7 @@ void main() {
     final List<PointerEvent> events = <PointerEvent>[];
     binding.callback = events.add;
 
-    ui.window.onPointerDataPacket?.call(packet);
+    binding.platformDispatcher.onPointerDataPacket?.call(packet);
     expect(events.length, 3);
     expect(events[0], isA<PointerPanZoomStartEvent>());
     expect(events[1], isA<PointerPanZoomUpdateEvent>());

--- a/packages/flutter/test/rendering/mouse_tracker_test.dart
+++ b/packages/flutter/test/rendering/mouse_tracker_test.dart
@@ -134,7 +134,7 @@ void main() {
   test('should not crash if the first event is a Removed event', () {
     final List<PointerEvent> events = <PointerEvent>[];
     setUpWithOneAnnotation(logEvents: events);
-    ui.window.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
+    binding.platformDispatcher.onPointerDataPacket!(ui.PointerDataPacket(data: <ui.PointerData>[
       _pointerData(PointerChange.remove, Offset.zero),
     ]));
     events.clear();

--- a/packages/flutter/test/widgets/independent_widget_layout_test.dart
+++ b/packages/flutter/test/widgets/independent_widget_layout_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui;
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -11,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 const Size _kTestViewSize = Size(800.0, 600.0);
 
 class ScheduledFrameTrackingWindow extends TestWindow {
-  ScheduledFrameTrackingWindow() : super(window: ui.window);
+  ScheduledFrameTrackingWindow({ required super.window });
 
   int _scheduledFrameCount = 0;
   int get scheduledFrameCount => _scheduledFrameCount;
@@ -28,7 +26,7 @@ class ScheduledFrameTrackingWindow extends TestWindow {
 }
 
 class ScheduledFrameTrackingBindings extends AutomatedTestWidgetsFlutterBinding {
-  final ScheduledFrameTrackingWindow _window = ScheduledFrameTrackingWindow();
+  late final ScheduledFrameTrackingWindow _window = ScheduledFrameTrackingWindow(window: super.window);
 
   @override
   ScheduledFrameTrackingWindow get window => _window;


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/116929.

The global `window` property exposed by `dart:ui` is about to be deprecated. This change removes references to it from the framework's tests.