### PR TITLE
Add URL shortener to shorten long Github Issue URL in flutter tool crash

### DIFF
--- a/packages/flutter_tools/lib/src/reporting/github_template.dart
+++ b/packages/flutter_tools/lib/src/reporting/github_template.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:file/file.dart';
 import 'package:intl/intl.dart';
+import 'package:http/http.dart' as http;
 
 import '../base/file_system.dart';
 import '../base/io.dart';
@@ -25,9 +26,9 @@ class GitHubTemplateCreator {
     required FileSystem fileSystem,
     required Logger logger,
     required FlutterProjectFactory flutterProjectFactory,
-  }) : _fileSystem = fileSystem,
-      _logger = logger,
-      _flutterProjectFactory = flutterProjectFactory;
+  })  : _fileSystem = fileSystem,
+        _logger = logger,
+        _flutterProjectFactory = flutterProjectFactory;
 
   final FileSystem _fileSystem;
   final Logger _logger;
@@ -51,15 +52,15 @@ class GitHubTemplateCreator {
     } else if (error is DevFSException) {
       // Suppress underlying error.
       return 'DevFSException: ${error.message}';
-    } else if (error is NoSuchMethodError
-      || error is ArgumentError
-      || error is VersionCheckError
-      || error is MissingDefineException
-      || error is UnsupportedError
-      || error is UnimplementedError
-      || error is StateError
-      || error is ProcessExit
-      || error is OSError) {
+    } else if (error is NoSuchMethodError ||
+        error is ArgumentError ||
+        error is VersionCheckError ||
+        error is MissingDefineException ||
+        error is UnsupportedError ||
+        error is UnimplementedError ||
+        error is StateError ||
+        error is ProcessExit ||
+        error is OSError) {
       // These exception objects only reference tool internals, print the whole error.
       return '${error.runtimeType}: $error';
     } else if (error is Error) {
@@ -75,12 +76,8 @@ class GitHubTemplateCreator {
   /// GitHub URL to present to the user containing encoded suggested template.
   ///
   /// Shorten the URL, if possible.
-  Future<String> toolCrashIssueTemplateGitHubURL(
-      String command,
-      Object error,
-      StackTrace stackTrace,
-      String doctorText
-    ) async {
+  Future<String> toolCrashIssueTemplateGitHubURL(String command, Object error,
+      StackTrace stackTrace, String doctorText) async {
     final String errorString = sanitizedCrashException(error);
     final String title = '[tool_crash] $errorString';
     final String body = '''
@@ -107,18 +104,21 @@ $doctorText
 ${_projectMetadataInformation()}
 ''';
 
-    return 'https://github.com/flutter/flutter/issues'
-      '/new' // We split this here to appease our lint that looks for bad "new bug" links.
-      '?title=${Uri.encodeQueryComponent(title)}'
-      '&body=${Uri.encodeQueryComponent(body)}'
-      '&labels=${Uri.encodeQueryComponent('tool,severe: crash')}';
+    final String fullURL = 'https://github.com/flutter/flutter/issues'
+        '/new' // We split this here to appease our lint that looks for bad "new bug" links.
+        '?title=${Uri.encodeQueryComponent(title)}'
+        '&body=${Uri.encodeQueryComponent(body)}'
+        '&labels=${Uri.encodeQueryComponent('tool,severe: crash')}';
+
+    return _shortURL(fullURL);
   }
 
   /// Provide information about the Flutter project in the working directory, if present.
   String _projectMetadataInformation() {
     FlutterProject project;
     try {
-      project = _flutterProjectFactory.fromDirectory(_fileSystem.currentDirectory);
+      project =
+          _flutterProjectFactory.fromDirectory(_fileSystem.currentDirectory);
     } on Exception catch (exception) {
       // pubspec may be malformed.
       return exception.toString();
@@ -128,10 +128,12 @@ ${_projectMetadataInformation()}
       if (manifest.isEmpty) {
         return 'No pubspec in working directory.';
       }
-      final FlutterProjectMetadata metadata = FlutterProjectMetadata(project.metadataFile, _logger);
+      final FlutterProjectMetadata metadata =
+          FlutterProjectMetadata(project.metadataFile, _logger);
       final FlutterProjectType? projectType = metadata.projectType;
       final StringBuffer description = StringBuffer()
-        ..writeln('**Type**: ${projectType == null ? 'malformed' : flutterProjectTypeToString(projectType)}')
+        ..writeln(
+            '**Type**: ${projectType == null ? 'malformed' : flutterProjectTypeToString(projectType)}')
         ..writeln('**Version**: ${manifest.appVersion}')
         ..writeln('**Material**: ${manifest.usesMaterialDesign}')
         ..writeln('**Android X**: ${manifest.usesAndroidX}')
@@ -140,14 +142,16 @@ ${_projectMetadataInformation()}
         ..writeln('**Android package**: ${manifest.androidPackage}')
         ..writeln('**iOS bundle identifier**: ${manifest.iosBundleIdentifier}')
         ..writeln('**Creation channel**: ${metadata.versionChannel}')
-        ..writeln('**Creation framework version**: ${metadata.versionRevision}');
+        ..writeln(
+            '**Creation framework version**: ${metadata.versionRevision}');
 
       final File file = project.flutterPluginsFile;
       if (file.existsSync()) {
         description.writeln('### Plugins');
         // Format is:
         // camera=/path/to/.pub-cache/hosted/pub.dartlang.org/camera-0.5.7+2/
-        for (final String plugin in project.flutterPluginsFile.readAsLinesSync()) {
+        for (final String plugin
+            in project.flutterPluginsFile.readAsLinesSync()) {
           final List<String> pluginParts = plugin.split('=');
           if (pluginParts.length != 2) {
             continue;
@@ -155,7 +159,8 @@ ${_projectMetadataInformation()}
           // Write the last part of the path, which includes the plugin name and version.
           // Example: camera-0.5.7+2
           final List<String> pathParts = _fileSystem.path.split(pluginParts[1]);
-          description.writeln(pathParts.isEmpty ? pluginParts.first : pathParts.last);
+          description
+              .writeln(pathParts.isEmpty ? pluginParts.first : pathParts.last);
         }
       }
 
@@ -164,4 +169,21 @@ ${_projectMetadataInformation()}
       return exception.toString();
     }
   }
+}
+
+// Shorten Github URL with HTTP request to lstu API
+//
+// See: https://www.lifestylebysusa.com/api
+
+Future<String> _shortURL(String fullURL) async {
+  String? url;
+  final request = await http.post(
+      Uri.parse('https://www.lifestylebysusa.com/a'),
+      headers: <String, String>{
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: "lsturl=$fullURL&format=json");
+  var jsonBlock = jsonDecode(request.body);
+  url = jsonBlock['short'];
+  return url ?? fullURL;
 }


### PR DESCRIPTION
Uses the lstu API to shorten the github issue link. 

*List which issues are fixed by this PR. You must list at least one issue.*

Fixes #99572

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
