### PR TITLE
Getter to fetch line metrics from RenderEditable

### DIFF
--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -806,6 +806,10 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
   /// In order to get the styled text as an [InlineSpan] tree, use [text].
   String get plainText => _textPainter.plainText;
 
+  /// Returns the line metrics for the text in [TextPainter].
+  /// See [TextPainter.computeLineMetrics].
+  List<ui.LineMetrics> get lineMetrics => _textPainter.computeLineMetrics()
+
   /// The text to paint in the form of a tree of [InlineSpan]s.
   ///
   /// In order to get the plain text representation, use [plainText].

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -808,7 +808,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin, 
 
   /// Returns the line metrics for the text in [TextPainter].
   /// See [TextPainter.computeLineMetrics].
-  List<ui.LineMetrics> get lineMetrics => _textPainter.computeLineMetrics()
+  List<ui.LineMetrics> get lineMetrics => _textPainter.computeLineMetrics();
 
   /// The text to paint in the form of a tree of [InlineSpan]s.
   ///

--- a/packages/flutter/test/rendering/editable_test.dart
+++ b/packages/flutter/test/rendering/editable_test.dart
@@ -394,6 +394,38 @@ void main() {
     expect(editable.plainText, 'abcdef');
   });
 
+  test('Can read line metrics', () {
+    final RenderEditable editable = RenderEditable(
+      maxLines: null,
+      textDirection: TextDirection.ltr,
+      offset: ViewportOffset.zero(),
+      textSelectionDelegate: _FakeEditableTextState(),
+      startHandleLayerLink: LayerLink(),
+      endHandleLayerLink: LayerLink(),
+    );
+
+    const text = '''
+Some longer text that will require being laid out in several lines.
+    This line follows after a hard break.
+    ''';
+    const style = TextStyle(fontSize: 12, fontFamily: 'Ahem');
+    editable.text = const TextSpan(text: text, style: style);
+
+    editable.layout(const BoxConstraints.tightFor(width: 400));
+
+    final actualLineWidths = editable.lineMetrics.map((lm) => lm.width)
+        .toList();
+    final List<double> expectedLineWidths = [
+      312.0,
+      396.0,
+      72.0,
+      348.0,
+      132.0,
+      0.0,
+    ];
+    expect(actualLineWidths, expectedLineWidths);
+  });
+
   test('Cursor with ideographic script', () {
     final TextSelectionDelegate delegate = _FakeEditableTextState();
     final ValueNotifier<bool> showCursor = ValueNotifier<bool>(true);


### PR DESCRIPTION
I have a TextField for which I want to render line numbers. The TextField is wrapping long lines automatically, thus I cannot just count the newline characters and call it a day. I have access to the RenderEditable of the TextField where I want to extract the Paragraphs line metrics. Unfortunately there is currently no way to access that information from RenderEditable. This PR is adding a Getter to fetch the line metrics.

This would allow me to fix a line numbering bug in the `code_text_field` package: https://github.com/BertrandBev/code_field/issues/6

I am not sure whether this change needs any tests.
