### PR TITLE
Fix CupertinoNavigationBar should create a backward compatible Annota…

### DIFF
--- a/packages/flutter/lib/src/cupertino/nav_bar.dart
+++ b/packages/flutter/lib/src/cupertino/nav_bar.dart
@@ -149,8 +149,20 @@ Widget _wrapWithBackground({
         overlayStyle = SystemUiOverlayStyle.dark;
         break;
     }
+    // [SystemUiOverlayStyle.light] and [SystemUiOverlayStyle.dark] set some system
+    // navigation bar properties,
+    // Before https://github.com/flutter/flutter/pull/104827 those properties
+    // had no effect, now they are used if there is no AnnotatedRegion on the
+    // bottom of the screen.
+    // For backward compatibility, create a `SystemUiOverlayStyle` without the
+    // system navigation bar properties.
     result = AnnotatedRegion<SystemUiOverlayStyle>(
-      value: overlayStyle,
+      value: SystemUiOverlayStyle(
+        statusBarColor: overlayStyle.statusBarColor,
+        statusBarBrightness: overlayStyle.statusBarBrightness,
+        statusBarIconBrightness: overlayStyle.statusBarIconBrightness,
+        systemStatusBarContrastEnforced: overlayStyle.systemStatusBarContrastEnforced,
+      ),
       child: result,
     );
   }

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -188,7 +188,7 @@ void main() {
   }
 
   // Regression test for https://github.com/flutter/flutter/issues/119270
-  testWidgets('System navigation bar properties are not overriden', (WidgetTester tester) async { 
+  testWidgets('System navigation bar properties are not overriden', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
         home: CupertinoNavigationBar(

--- a/packages/flutter/test/cupertino/nav_bar_test.dart
+++ b/packages/flutter/test/cupertino/nav_bar_test.dart
@@ -173,6 +173,32 @@ void main() {
     expect(tester.getCenter(find.text('Title')).dx, 400.0);
   });
 
+  // Assert that two SystemUiOverlayStyle instances have the same values for
+  // status bar properties and that the first instance has no system navigation
+  // bar properties set.
+  void expectSameStatusBarStyle(SystemUiOverlayStyle style, SystemUiOverlayStyle expectedStyle) {
+    expect(style.statusBarColor, expectedStyle.statusBarColor);
+    expect(style.statusBarBrightness, expectedStyle.statusBarBrightness);
+    expect(style.statusBarIconBrightness, expectedStyle.statusBarIconBrightness);
+    expect(style.systemStatusBarContrastEnforced, expectedStyle.systemStatusBarContrastEnforced);
+    expect(style.systemNavigationBarColor, isNull);
+    expect(style.systemNavigationBarContrastEnforced, isNull);
+    expect(style.systemNavigationBarDividerColor, isNull);
+    expect(style.systemNavigationBarIconBrightness, isNull);
+  }
+
+  // Regression test for https://github.com/flutter/flutter/issues/119270
+  testWidgets('System navigation bar properties are not overriden', (WidgetTester tester) async { 
+    await tester.pumpWidget(
+      const CupertinoApp(
+        home: CupertinoNavigationBar(
+          backgroundColor: Color(0xF0F9F9F9),
+        ),
+      ),
+    );
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
+  });
+
   testWidgets('Can specify custom brightness', (WidgetTester tester) async {
     await tester.pumpWidget(
       const CupertinoApp(
@@ -182,11 +208,7 @@ void main() {
         ),
       ),
     );
-
-    final AnnotatedRegion<SystemUiOverlayStyle> region1 = tester.allWidgets
-        .whereType<AnnotatedRegion<SystemUiOverlayStyle>>()
-        .single;
-    expect(region1.value, SystemUiOverlayStyle.light);
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.light);
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -196,11 +218,7 @@ void main() {
         ),
       ),
     );
-
-    final AnnotatedRegion<SystemUiOverlayStyle> region2 = tester.allWidgets
-        .whereType<AnnotatedRegion<SystemUiOverlayStyle>>()
-        .single;
-    expect(region2.value, SystemUiOverlayStyle.dark);
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -215,11 +233,7 @@ void main() {
         ),
       ),
     );
-
-    final AnnotatedRegion<SystemUiOverlayStyle> region3 = tester.allWidgets
-        .whereType<AnnotatedRegion<SystemUiOverlayStyle>>()
-        .single;
-    expect(region3.value, SystemUiOverlayStyle.light);
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.light);
 
     await tester.pumpWidget(
       const CupertinoApp(
@@ -234,11 +248,7 @@ void main() {
         ),
       ),
     );
-
-    final AnnotatedRegion<SystemUiOverlayStyle> region4 = tester.allWidgets
-        .whereType<AnnotatedRegion<SystemUiOverlayStyle>>()
-        .single;
-    expect(region4.value, SystemUiOverlayStyle.dark);
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
   });
 
   testWidgets('Padding works in RTL', (WidgetTester tester) async {
@@ -1021,7 +1031,7 @@ void main() {
         },
       ),
     );
-    expect(SystemChrome.latestStyle, SystemUiOverlayStyle.light);
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.light);
   });
 
   testWidgets('NavBar draws a dark system bar for a light background', (WidgetTester tester) async {
@@ -1041,7 +1051,7 @@ void main() {
         },
       ),
     );
-    expect(SystemChrome.latestStyle, SystemUiOverlayStyle.dark);
+    expectSameStatusBarStyle(SystemChrome.latestStyle!, SystemUiOverlayStyle.dark);
   });
 
   testWidgets('CupertinoNavigationBarBackButton shows an error when manually added outside a route', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR updates `CupertinoNavigationBar` to create an `AnnotatedRegion` which does not set system navigation bar properties.

`CupertinoNavigationBar` relies on `SystemUiOverlayStyle.light` and `SystemUiOverlayStyle.dark` which set some system navigation bar properties,
Before https://github.com/flutter/flutter/pull/104827 those properties had no effect, now they are used if there is no `AnnotatedRegion` on the bottom of the screen.

In order to restore the previous behavior (CupertinoNavigationBar having no impact on system navigation bar appearance) this PR updates `CupertinoNavigationBar` to rely on a `SystemUiOverlayStyle` instance which do not set the system navigation bar properties.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/119270

## Tests

Adds 1 tests, updates several existing tests.
