### PR TITLE
Use first Dart VM Service found with mDNS if there are duplicates

### DIFF
--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -10,6 +10,7 @@ import 'base/context.dart';
 import 'base/io.dart';
 import 'base/logger.dart';
 import 'build_info.dart';
+import 'convert.dart';
 import 'device.dart';
 import 'reporting/reporting.dart';
 
@@ -201,8 +202,16 @@ class MDnsVmServiceDiscovery {
 
       final List<MDnsVmServiceDiscoveryResult> results =
           <MDnsVmServiceDiscoveryResult>[];
+
+      // uniqueDomainNames is used to track all domain names of Dart VM services
+      // It is later used in this function to determine whether or not to throw an error.
+      // We do not want to throw the error if it was unable to find any domain
+      // names because that indicates it may be a problem with mDNS, which has
+      // a separate error message in _checkForIPv4LinkLocal.
       final Set<String> uniqueDomainNames = <String>{};
-      final Set<String> uniqueResultsByDomainName = <String>{};
+      // uniqueDomainNamesInResults is used to filter out duplicates with exactly
+      // the same domain name from the results.
+      final Set<String> uniqueDomainNamesInResults = <String>{};
 
       // Listen for mDNS connections until timeout.
       final Stream<PtrResourceRecord> ptrResourceStream = client.lookup<PtrResourceRecord>(
@@ -222,6 +231,11 @@ class MDnsVmServiceDiscovery {
           }
         } else {
           domainName = ptr.domainName;
+        }
+
+        // Result with same domain name was already found, skip it.
+        if (uniqueDomainNamesInResults.contains(domainName)) {
+          continue;
         }
 
         _logger.printTrace('Checking for available port on $domainName');
@@ -244,10 +258,6 @@ class MDnsVmServiceDiscovery {
 
         // If deviceVmservicePort is set, only use records that match it
         if (deviceVmservicePort != null && srvRecord.port != deviceVmservicePort) {
-          continue;
-        }
-
-        if (uniqueResultsByDomainName.contains(domainName)) {
           continue;
         }
 
@@ -295,7 +305,7 @@ class MDnsVmServiceDiscovery {
           authCode,
           ipAddress: ipAddress
         ));
-        uniqueResultsByDomainName.add(domainName);
+        uniqueDomainNamesInResults.add(domainName);
         if (quitOnFind) {
           return results;
         }
@@ -322,17 +332,12 @@ class MDnsVmServiceDiscovery {
 
   String _getAuthCode(String txtRecord) {
     const String authCodePrefix = 'authCode=';
-    String? raw;
-    for (final String record in txtRecord.split('\n')) {
-      if (record.startsWith(authCodePrefix)) {
-        raw = record;
-        break;
-      }
-    }
-    if (raw == null) {
+    final Iterable<String> matchingRecords =
+        LineSplitter.split(txtRecord).where((String record) => record.startsWith(authCodePrefix));
+    if (matchingRecords.isEmpty) {
       return '';
     }
-    String authCode = raw.substring(authCodePrefix.length);
+    String authCode = matchingRecords.first.substring(authCodePrefix.length);
     // The Dart VM Service currently expects a trailing '/' as part of the
     // URI, otherwise an invalid authentication code response is given.
     if (!authCode.endsWith('/')) {

--- a/packages/flutter_tools/lib/src/mdns_discovery.dart
+++ b/packages/flutter_tools/lib/src/mdns_discovery.dart
@@ -202,6 +202,7 @@ class MDnsVmServiceDiscovery {
       final List<MDnsVmServiceDiscoveryResult> results =
           <MDnsVmServiceDiscoveryResult>[];
       final Set<String> uniqueDomainNames = <String>{};
+      final Set<String> uniqueResultsByDomainName = <String>{};
 
       // Listen for mDNS connections until timeout.
       final Stream<PtrResourceRecord> ptrResourceStream = client.lookup<PtrResourceRecord>(
@@ -308,12 +309,17 @@ class MDnsVmServiceDiscovery {
           authCode += '/';
         }
 
+        if (uniqueResultsByDomainName.contains(domainName)) {
+          continue;
+        }
+
         results.add(MDnsVmServiceDiscoveryResult(
           domainName,
           srvRecord.port,
           authCode,
           ipAddress: ipAddress
         ));
+        uniqueResultsByDomainName.add(domainName);
         if (quitOnFind) {
           return results;
         }

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -136,6 +136,32 @@ void main() {
         expect(result, isNotNull);
       });
 
+      testWithoutContext('Find similar named in preliminary client', () async {
+        final MDnsClient client = FakeMDnsClient(
+          <PtrResourceRecord>[
+            PtrResourceRecord('foo', future, domainName: 'bar'),
+            PtrResourceRecord('foo', future, domainName: 'bar (2)'),
+          ],
+          <String, List<SrvResourceRecord>>{
+            'bar': <SrvResourceRecord>[
+              SrvResourceRecord('bar', future, port: 123, weight: 1, priority: 1, target: 'appId'),
+            ],
+            'bar (2)': <SrvResourceRecord>[
+              SrvResourceRecord('bar', future, port: 123, weight: 1, priority: 1, target: 'appId'),
+            ],
+          },
+        );
+
+        final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
+          mdnsClient: emptyClient,
+          preliminaryMDnsClient: client,
+          logger: BufferLogger.test(),
+          flutterUsage: TestUsage(),
+        );
+
+        expect(portDiscovery.queryForAttach, throwsToolExit());
+      });
+
       testWithoutContext('No ports available', () async {
         final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
           mdnsClient: emptyClient,

--- a/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
+++ b/packages/flutter_tools/test/general.shard/mdns_discovery_test.dart
@@ -112,6 +112,30 @@ void main() {
         expect(portDiscovery.queryForAttach, throwsToolExit());
       });
 
+      testWithoutContext('Find duplicates in preliminary client', () async {
+        final MDnsClient client = FakeMDnsClient(
+          <PtrResourceRecord>[
+            PtrResourceRecord('foo', future, domainName: 'bar'),
+            PtrResourceRecord('foo', future, domainName: 'bar'),
+          ],
+          <String, List<SrvResourceRecord>>{
+            'bar': <SrvResourceRecord>[
+              SrvResourceRecord('bar', future, port: 123, weight: 1, priority: 1, target: 'appId'),
+            ],
+          },
+        );
+
+        final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
+          mdnsClient: emptyClient,
+          preliminaryMDnsClient: client,
+          logger: BufferLogger.test(),
+          flutterUsage: TestUsage(),
+        );
+
+        final MDnsVmServiceDiscoveryResult? result = await portDiscovery.queryForAttach();
+        expect(result, isNotNull);
+      });
+
       testWithoutContext('No ports available', () async {
         final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
           mdnsClient: emptyClient,
@@ -679,6 +703,112 @@ void main() {
       );
       expect(result?.domainName, 'srv-bar');
       expect(result?.port, 222);
+    });
+    testWithoutContext('find with no txt record', () async {
+      final MDnsClient client = FakeMDnsClient(
+        <PtrResourceRecord>[
+          PtrResourceRecord('foo', future, domainName: 'srv-foo'),
+        ],
+        <String, List<SrvResourceRecord>>{
+          'srv-foo': <SrvResourceRecord>[
+            SrvResourceRecord('srv-foo', future, port: 111, weight: 1, priority: 1, target: 'target-foo'),
+          ],
+        },
+        ipResponse: <String, List<IPAddressResourceRecord>>{
+          'target-foo': <IPAddressResourceRecord>[
+            IPAddressResourceRecord('target-foo', 0, address: InternetAddress.tryParse('111.111.111.111')!),
+          ],
+        },
+      );
+
+      final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
+        mdnsClient: client,
+        logger: BufferLogger.test(),
+        flutterUsage: TestUsage(),
+      );
+      final MDnsVmServiceDiscoveryResult? result = await portDiscovery.firstMatchingVmService(
+        client,
+        applicationId: 'srv-foo',
+        isNetworkDevice: true,
+      );
+      expect(result?.domainName, 'srv-foo');
+      expect(result?.port, 111);
+      expect(result?.authCode, '');
+      expect(result?.ipAddress?.address, '111.111.111.111');
+    });
+    testWithoutContext('find with empty txt record', () async {
+      final MDnsClient client = FakeMDnsClient(
+        <PtrResourceRecord>[
+          PtrResourceRecord('foo', future, domainName: 'srv-foo'),
+        ],
+        <String, List<SrvResourceRecord>>{
+          'srv-foo': <SrvResourceRecord>[
+            SrvResourceRecord('srv-foo', future, port: 111, weight: 1, priority: 1, target: 'target-foo'),
+          ],
+        },
+        txtResponse: <String, List<TxtResourceRecord>>{
+          'srv-foo': <TxtResourceRecord>[
+            TxtResourceRecord('srv-foo', future, text: ''),
+          ],
+        },
+        ipResponse: <String, List<IPAddressResourceRecord>>{
+          'target-foo': <IPAddressResourceRecord>[
+            IPAddressResourceRecord('target-foo', 0, address: InternetAddress.tryParse('111.111.111.111')!),
+          ],
+        },
+      );
+
+      final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
+        mdnsClient: client,
+        logger: BufferLogger.test(),
+        flutterUsage: TestUsage(),
+      );
+      final MDnsVmServiceDiscoveryResult? result = await portDiscovery.firstMatchingVmService(
+        client,
+        applicationId: 'srv-foo',
+        isNetworkDevice: true,
+      );
+      expect(result?.domainName, 'srv-foo');
+      expect(result?.port, 111);
+      expect(result?.authCode, '');
+      expect(result?.ipAddress?.address, '111.111.111.111');
+    });
+    testWithoutContext('find with valid txt record', () async {
+      final MDnsClient client = FakeMDnsClient(
+        <PtrResourceRecord>[
+          PtrResourceRecord('foo', future, domainName: 'srv-foo'),
+        ],
+        <String, List<SrvResourceRecord>>{
+          'srv-foo': <SrvResourceRecord>[
+            SrvResourceRecord('srv-foo', future, port: 111, weight: 1, priority: 1, target: 'target-foo'),
+          ],
+        },
+        txtResponse: <String, List<TxtResourceRecord>>{
+          'srv-foo': <TxtResourceRecord>[
+            TxtResourceRecord('srv-foo', future, text: 'authCode=xyz\n'),
+          ],
+        },
+        ipResponse: <String, List<IPAddressResourceRecord>>{
+          'target-foo': <IPAddressResourceRecord>[
+            IPAddressResourceRecord('target-foo', 0, address: InternetAddress.tryParse('111.111.111.111')!),
+          ],
+        },
+      );
+
+      final MDnsVmServiceDiscovery portDiscovery = MDnsVmServiceDiscovery(
+        mdnsClient: client,
+        logger: BufferLogger.test(),
+        flutterUsage: TestUsage(),
+      );
+      final MDnsVmServiceDiscoveryResult? result = await portDiscovery.firstMatchingVmService(
+        client,
+        applicationId: 'srv-foo',
+        isNetworkDevice: true,
+      );
+      expect(result?.domainName, 'srv-foo');
+      expect(result?.port, 111);
+      expect(result?.authCode, 'xyz/');
+      expect(result?.ipAddress?.address, '111.111.111.111');
     });
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/119535.

Also, fixes issue where device IP would not be included in mDNS results if auth code was not found, although hypothetically this should never occur.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
