### PR TITLE
Add debug diagnostics to channels integration test

### DIFF
--- a/dev/integration_tests/channels/lib/main.dart
+++ b/dev/integration_tests/channels/lib/main.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:io' show Platform;
 import 'dart:typed_data';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
 
@@ -16,6 +17,8 @@ import 'src/test_step.dart';
 
 void main() {
   enableFlutterDriverExtension();
+  // TODO(goderbauer): Remove this once https://github.com/flutter/flutter/issues/116663 is diagnosed.
+  debugPrintHitTestResults = true;
   runApp(const TestApp());
 }
 

--- a/packages/flutter/lib/src/gestures/binding.dart
+++ b/packages/flutter/lib/src/gestures/binding.dart
@@ -357,7 +357,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
   void _handlePointerEventImmediately(PointerEvent event) {
     HitTestResult? hitTestResult;
     if (event is PointerDownEvent || event is PointerSignalEvent || event is PointerHoverEvent || event is PointerPanZoomStartEvent) {
-      assert(!_hitTests.containsKey(event.pointer), 'Pointer of $event unexpectedly has a HitTestResult associated with it.');
+      assert(!_hitTests.containsKey(event.pointer), 'Pointer of ${event.toString(minLevel: DiagnosticLevel.debug)} unexpectedly has a HitTestResult associated with it.');
       hitTestResult = HitTestResult();
       hitTest(hitTestResult, event.position);
       if (event is PointerDownEvent || event is PointerPanZoomStartEvent) {
@@ -365,7 +365,7 @@ mixin GestureBinding on BindingBase implements HitTestable, HitTestDispatcher, H
       }
       assert(() {
         if (debugPrintHitTestResults) {
-          debugPrint('$event: $hitTestResult');
+          debugPrint('${event.toString(minLevel: DiagnosticLevel.debug)}: $hitTestResult');
         }
         return true;
       }());


### PR DESCRIPTION
Adds some more fine-grained logging to hopefully get more information on why the test is flaky (https://github.com/flutter/flutter/issues/116663). Unfortunately, it flakes so rarely that I cannot get it to flake locally. Will have to wait for another flake on CI to know more.