### PR TITLE
🥅 Produce warning instead of error for storage base url overrides

### DIFF
--- a/packages/flutter_tools/lib/src/cache.dart
+++ b/packages/flutter_tools/lib/src/cache.dart
@@ -520,7 +520,7 @@ class Cache {
     if (_hasWarnedAboutStorageOverride) {
       return;
     }
-    _logger.printError(
+    _logger.printWarning(
       'Flutter assets will be downloaded from $overrideUrl. Make sure you trust this source!',
       emphasis: true,
     );

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -6,7 +6,6 @@ import 'package:file/memory.dart';
 import 'package:flutter_tools/src/artifacts.dart';
 import 'package:flutter_tools/src/base/file_system.dart';
 import 'package:flutter_tools/src/base/logger.dart';
-import 'package:flutter_tools/src/base/platform.dart';
 import 'package:flutter_tools/src/cache.dart';
 import 'package:flutter_tools/src/commands/generate_localizations.dart';
 

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -267,6 +267,7 @@ format: true
     ProcessManager: () => FakeProcessManager.any(),
   });
 
+  // Regression test for https://github.com/flutter/flutter/issues/119593
   testUsingContext('overridden storage base url does not affect the command', () async {
     const String baseUrl = 'https://storage.com';
     final Cache cache = Cache.test(

--- a/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/generate_localizations_test.dart
@@ -266,43 +266,4 @@ format: true
     FileSystem: () => fileSystem,
     ProcessManager: () => FakeProcessManager.any(),
   });
-
-  // Regression test for https://github.com/flutter/flutter/issues/119593
-  testUsingContext('overridden storage base url does not affect the command', () async {
-    const String baseUrl = 'https://storage.com';
-    final Cache cache = Cache.test(
-      platform: FakePlatform(environment: <String, String>{
-        'FLUTTER_STORAGE_BASE_URL': baseUrl,
-      }),
-      processManager: processManager,
-      logger: logger,
-    );
-
-    expect(cache.storageBaseUrl, baseUrl);
-
-    final File arbFile = fileSystem.file(fileSystem.path.join('lib', 'l10n', 'app_en.arb'))
-      ..createSync(recursive: true);
-    arbFile.writeAsStringSync('''
-{
-  "helloWorld": "Hello, World!",
-  "@helloWorld": {
-    "description": "Sample description"
-  }
-}''');
-    final GenerateLocalizationsCommand command = GenerateLocalizationsCommand(
-      fileSystem: fileSystem,
-      logger: logger,
-      artifacts: artifacts,
-      processManager: processManager,
-    );
-    await createTestCommandRunner(command).run(<String>['gen-l10n']);
-
-    final Directory outputDirectory = fileSystem.directory(fileSystem.path.join('.dart_tool', 'flutter_gen', 'gen_l10n'));
-    expect(outputDirectory.existsSync(), true);
-    expect(outputDirectory.childFile('app_localizations_en.dart').existsSync(), true);
-    expect(outputDirectory.childFile('app_localizations.dart').existsSync(), true);
-  }, overrides: <Type, Generator>{
-    FileSystem: () => fileSystem,
-    ProcessManager: () => FakeProcessManager.any(),
-  });
 }

--- a/packages/flutter_tools/test/general.shard/cache_test.dart
+++ b/packages/flutter_tools/test/general.shard/cache_test.dart
@@ -319,7 +319,7 @@ void main() {
       expect(() => cache.storageBaseUrl, throwsToolExit());
     });
 
-    testWithoutContext('overridden storage base url prints warning to STDERR', () async {
+    testWithoutContext('overridden storage base url prints warning', () async {
       final BufferLogger logger = BufferLogger.test();
       const String baseUrl = 'https://storage.com';
       final Cache cache = Cache.test(
@@ -331,7 +331,7 @@ void main() {
       );
 
       expect(cache.storageBaseUrl, baseUrl);
-      expect(logger.errorText, contains('Flutter assets will be downloaded from $baseUrl'));
+      expect(logger.warningText, contains('Flutter assets will be downloaded from $baseUrl'));
       expect(logger.statusText, isEmpty);
     });
   });


### PR DESCRIPTION
~Fixes #119593.~

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
