### PR TITLE
Fix `pub get --unknown-flag`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/packages.dart
+++ b/packages/flutter_tools/lib/src/commands/packages.dart
@@ -213,6 +213,7 @@ class PackagesGetCommand extends FlutterCommand {
     argParser.addOption('git-ref');
     argParser.addOption('git-path');
     argParser.addFlag('dev');
+    argParser.addFlag('verbose', abbr: 'v');
     return argParser;
   }
 
@@ -238,7 +239,11 @@ class PackagesGetCommand extends FlutterCommand {
     FlutterProject? rootProject;
 
     if (!isHelp) {
-      if (directoryOption == null && rest.length == 1 &&
+      if (directoryOption == null &&
+          rest.length == 1 &&
+          // Anything that looks like an argument should not be interpreted as
+          // a directory.
+          !rest.single.startsWith('-') &&
           ((rest.single.contains('/') || rest.single.contains(r'\')) ||
             name == 'get')) {
         // For historical reasons, if there is one argument to the command and it contains

--- a/packages/flutter_tools/test/commands.shard/hermetic/pub_get_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/pub_get_test.dart
@@ -93,6 +93,32 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
     FileSystem: () => fileSystem,
   });
+  
+  testUsingContext("pub get doesn't treat unknown flag as directory", () async {
+    fileSystem.currentDirectory.childDirectory('target').createSync();
+    fileSystem.currentDirectory.childFile('pubspec.yaml').createSync();
+    final PackagesGetCommand command = PackagesGetCommand('get', '', PubContext.pubGet);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    pub.expectedArguments = <String>['get', '--unknown-flag', '--example', '--directory', '.'];
+    await commandRunner.run(<String>['get', '--unknown-flag']);
+  }, overrides: <Type, Generator>{
+    Pub: () => pub,
+    ProcessManager: () => FakeProcessManager.any(),
+    FileSystem: () => fileSystem,
+  });
+
+    testUsingContext("pub get doesn't treat -v as directory", () async {
+    fileSystem.currentDirectory.childDirectory('target').createSync();
+    fileSystem.currentDirectory.childFile('pubspec.yaml').createSync();
+    final PackagesGetCommand command = PackagesGetCommand('get', '', PubContext.pubGet);
+    final CommandRunner<void> commandRunner = createTestCommandRunner(command);
+    pub.expectedArguments = <String>['get', '-v', '--example', '--directory', '.'];
+    await commandRunner.run(<String>['get', '-v']);
+  }, overrides: <Type, Generator>{
+    Pub: () => pub,
+    ProcessManager: () => FakeProcessManager.any(),
+    FileSystem: () => fileSystem,
+  });
 
   testUsingContext("pub get skips example directory if it doesn't contain a pubspec.yaml", () async {
     fileSystem.currentDirectory.childFile('pubspec.yaml').createSync();
@@ -181,6 +207,7 @@ class FakePub extends Fake implements Pub {
   FakePub(this.fileSystem);
 
   final FileSystem fileSystem;
+  List<String>? expectedArguments;
 
   @override
   Future<void> interactively(
@@ -192,6 +219,9 @@ class FakePub extends Fake implements Pub {
     bool generateSyntheticPackage = false,
     PubOutputMode outputMode = PubOutputMode.all,
   }) async {
+    if (expectedArguments != null) {
+      expect(arguments, expectedArguments);
+    }
     if (project != null) {
       fileSystem.directory(project.directory)
         .childDirectory('.dart_tool')

--- a/packages/flutter_tools/test/commands.shard/hermetic/pub_get_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/pub_get_test.dart
@@ -93,7 +93,7 @@ void main() {
     ProcessManager: () => FakeProcessManager.any(),
     FileSystem: () => fileSystem,
   });
-  
+
   testUsingContext("pub get doesn't treat unknown flag as directory", () async {
     fileSystem.currentDirectory.childDirectory('target').createSync();
     fileSystem.currentDirectory.childFile('pubspec.yaml').createSync();


### PR DESCRIPTION
Fixes argument handling in `flutter pub get` when a single flag is passed.

https://github.com/flutter/flutter/issues/119614

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
