### PR TITLE
Fix gets removedItem instead of its index

### DIFF
--- a/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
+++ b/examples/api/lib/widgets/animated_list/sliver_animated_list.0.dart
@@ -135,8 +135,8 @@ class _SliverAnimatedListSampleState extends State<SliverAnimatedListSample> {
   }
 }
 
-typedef RemovedItemBuilder = Widget Function(
-    int item, BuildContext context, Animation<double> animation);
+typedef RemovedItemBuilder<E> = Widget Function(
+    E item, BuildContext context, Animation<double> animation);
 
 // Keeps a Dart [List] in sync with an [AnimatedList].
 //
@@ -155,7 +155,7 @@ class ListModel<E> {
   }) : _items = List<E>.from(initialItems ?? <E>[]);
 
   final GlobalKey<SliverAnimatedListState> listKey;
-  final RemovedItemBuilder removedItemBuilder;
+  final RemovedItemBuilder<E> removedItemBuilder;
   final List<E> _items;
 
   SliverAnimatedListState get _animatedList => listKey.currentState!;
@@ -171,7 +171,7 @@ class ListModel<E> {
       _animatedList.removeItem(
         index,
         (BuildContext context, Animation<double> animation) =>
-            removedItemBuilder(index, context, animation),
+            removedItemBuilder(removedItem, context, animation),
       );
     }
     return removedItem;
@@ -197,7 +197,7 @@ class CardItem extends StatelessWidget {
     this.selected = false,
     required this.animation,
     required this.item,
-  })  : assert(item >= 0);
+  }) : assert(item >= 0);
 
   final Animation<double> animation;
   final VoidCallback? onTap;

--- a/examples/api/test/widgets/animated_list/sliver_animated_list.0.dart
+++ b/examples/api/test/widgets/animated_list/sliver_animated_list.0.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/animated_list/sliver_animated_list.0.dart'
+    as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'Items can be selected, added, and removed fromSliverAnimatedList',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(const example.SliverAnimatedListSample());
+
+      expect(find.text('Item 0'), findsOneWidget);
+      expect(find.text('Item 1'), findsOneWidget);
+      expect(find.text('Item 2'), findsOneWidget);
+
+      //add item at the end of the list
+      await tester.tap(find.byIcon(Icons.add_circle));
+      await tester.pumpAndSettle();
+      expect(find.text('Item 3'), findsOneWidget);
+
+      //select Item 1
+      await tester.tap(find.text('Item 1'));
+      await tester.pumpAndSettle();
+      //add item at the top of the list
+      await tester.tap(find.byIcon(Icons.add_circle));
+      await tester.pumpAndSettle();
+      expect(find.text('Item 4'), findsOneWidget);
+
+      //remove Item 1 that was selected before
+      await tester.tap(find.byIcon(Icons.remove_circle));
+      //one frame ahead the Item 1 is still animating on the screen
+      await tester.pump();
+      expect(find.text('Item 1'), findsOneWidget);
+
+      //when the animation complete, the Item 1 disappear
+      await tester.pumpAndSettle();
+      expect(find.text('Item 1'), findsNothing);
+    },
+  );
+}

--- a/examples/api/test/widgets/animated_list/sliver_animated_list.0_test.dart
+++ b/examples/api/test/widgets/animated_list/sliver_animated_list.0_test.dart
@@ -9,7 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   testWidgets(
-    'Items can be selected, added, and removed fromSliverAnimatedList',
+    'Items can be selected, added, and removed from SliverAnimatedList',
     (WidgetTester tester) async {
       await tester.pumpWidget(const example.SliverAnimatedListSample());
 
@@ -17,26 +17,28 @@ void main() {
       expect(find.text('Item 1'), findsOneWidget);
       expect(find.text('Item 2'), findsOneWidget);
 
-      //add item at the end of the list
+      // Add an item at the end of the list
       await tester.tap(find.byIcon(Icons.add_circle));
       await tester.pumpAndSettle();
       expect(find.text('Item 3'), findsOneWidget);
 
-      //select Item 1
+      // Select Item 1.
       await tester.tap(find.text('Item 1'));
       await tester.pumpAndSettle();
-      //add item at the top of the list
+
+      // Add item at the top of the list
       await tester.tap(find.byIcon(Icons.add_circle));
       await tester.pumpAndSettle();
       expect(find.text('Item 4'), findsOneWidget);
 
-      //remove Item 1 that was selected before
+      // Remove selected item.
       await tester.tap(find.byIcon(Icons.remove_circle));
-      //one frame ahead the Item 1 is still animating on the screen
+
+      // Item animation is not completed.
       await tester.pump();
       expect(find.text('Item 1'), findsOneWidget);
 
-      //when the animation complete, the Item 1 disappear
+      // When the animation completes, Item 1 disappears.
       await tester.pumpAndSettle();
       expect(find.text('Item 1'), findsNothing);
     },

--- a/examples/api/test/widgets/animated_list/sliver_animated_list.0_test.dart
+++ b/examples/api/test/widgets/animated_list/sliver_animated_list.0_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_api_samples/widgets/animated_list/sliver_animated_list.0.dart'
     as example;

--- a/examples/api/test/widgets/animated_list/sliver_animated_list.0_test.dart
+++ b/examples/api/test/widgets/animated_list/sliver_animated_list.0_test.dart
@@ -3,8 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter_api_samples/widgets/animated_list/sliver_animated_list.0.dart'
-    as example;
+import 'package:flutter_api_samples/widgets/animated_list/sliver_animated_list.0.dart' as example;
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/105251

Fix gets removedItem instead of its index
Add sliver_animated_list.0_test.dart

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
