### PR TITLE
Deprecate MediaQuery[Data].fromWindow

### DIFF
--- a/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
+++ b/packages/flutter/lib/fix_data/fix_widgets/fix_widgets.yaml
@@ -23,7 +23,18 @@
 #     * ListWheelScrollView: fix_list_wheel_scroll_view.yaml
 version: 1
 transforms:
-  # Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
+  # Changes made in https://github.com/flutter/flutter/pull/119647
+  - title: "Migrate to 'fromView'"
+    date: 2022-10-28
+    element:
+      uris: [ 'widgets.dart', 'material.dart', 'cupertino.dart' ]
+      constructor: 'fromWindow'
+      inClass: 'MediaQueryData'
+    changes:
+      - kind: 'rename'
+        newName: 'fromView'
+
+  # Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067
   - title: "Remove 'vsync'"
     date: 2023-01-30
     element:

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -13,6 +13,7 @@ import 'binding.dart';
 import 'debug.dart';
 import 'framework.dart';
 import 'inherited_model.dart';
+import 'view.dart';
 
 // Examples can assume:
 // late BuildContext context;
@@ -160,13 +161,16 @@ class MediaQueryData {
     this.displayFeatures = const <ui.DisplayFeature>[],
   });
 
-  /// Creates data for a media query based on the given window.
+  /// Deprecated. Use [MediaQueryData.fromView] instead.
   ///
-  /// If you use this, you should ensure that you also register for
-  /// notifications so that you can update your [MediaQueryData] when the
-  /// window's metrics change. For example, see
-  /// [WidgetsBindingObserver.didChangeMetrics] or
-  /// [dart:ui.PlatformDispatcher.onMetricsChanged].
+  /// This constructor was operating on a single window assumption. In
+  /// preparation for Flutter's upcoming multi-window support, it has been
+  /// deprecated.
+  @Deprecated(
+    'Use MediaQueryData.fromView instead. '
+    "This constructor was deprecated in preparation for Flutter's upcoming multi-window support. "
+    'This feature was deprecated after v3.7.0-32.0.pre.'
+  )
   factory MediaQueryData.fromWindow(ui.FlutterView window) => MediaQueryData.fromView(window);
 
   /// Creates data for a [MediaQuery] based on the given `view`.
@@ -918,14 +922,16 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
     );
   }
 
-  /// Provides a [MediaQuery] which is built and updated using the latest
-  /// [WidgetsBinding.window] values.
+  /// Deprecated. Use [MediaQuery.fromView] instead.
   ///
-  /// The [MediaQuery] is wrapped in a separate widget to ensure that only it
-  /// and its dependents are updated when `window` changes, instead of
-  /// rebuilding the whole widget tree.
-  ///
-  /// The [child] argument is required and must not be null.
+  /// This constructor was operating on a single window assumption. In
+  /// preparation for Flutter's upcoming multi-window support, it has been
+  /// deprecated.
+  @Deprecated(
+    'Use MediaQuery.fromView instead. '
+    "This constructor was deprecated in preparation for Flutter's upcoming multi-window support. "
+    'This feature was deprecated after v3.7.0-32.0.pre.'
+  )
   static Widget fromWindow({
     Key? key,
     required Widget child,
@@ -941,6 +947,9 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// Wraps the [child] in a [MediaQuery] which is built using data from the
   /// provided [view].
   ///
+  /// If no [view] is provided, the [FlutterView] obtained from the context
+  /// via [View.of] is used.
+  ///
   /// The [MediaQuery] is constructed using the platform-specific data of the
   /// surrounding [MediaQuery] and the view-specific data of the provided
   /// [view]. If no surrounding [MediaQuery] exists, the platform-specific data
@@ -953,10 +962,10 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// The injected [MediaQuery] automatically updates when any of the data used
   /// to construct it changes.
   ///
-  /// The [view] and [child] argument is required and must not be null.
+  /// The [child] argument is required and must not be null.
   static Widget fromView({
     Key? key,
-    required FlutterView view,
+    FlutterView? view,
     required Widget child,
   }) {
     return _MediaQueryFromView(
@@ -1464,12 +1473,12 @@ enum NavigationMode {
 class _MediaQueryFromView extends StatefulWidget {
   const _MediaQueryFromView({
     super.key,
-    required this.view,
+    this.view,
     this.ignoreParentData = false,
     required this.child,
   });
 
-  final FlutterView view;
+  final FlutterView? view;
   final bool ignoreParentData;
   final Widget child;
 
@@ -1513,7 +1522,8 @@ class _MediaQueryFromViewState extends State<_MediaQueryFromView> with WidgetsBi
   }
 
   void _updateData() {
-    final MediaQueryData newData = MediaQueryData.fromView(widget.view, platformData: _parentData);
+    final FlutterView view = widget.view ?? View.of(context);
+    final MediaQueryData newData = MediaQueryData.fromView(view, platformData: _parentData);
     if (newData != _data) {
       setState(() {
         _data = newData;

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -13,7 +13,6 @@ import 'binding.dart';
 import 'debug.dart';
 import 'framework.dart';
 import 'inherited_model.dart';
-import 'view.dart';
 
 // Examples can assume:
 // late BuildContext context;
@@ -168,7 +167,7 @@ class MediaQueryData {
   /// deprecated.
   @Deprecated(
     'Use MediaQueryData.fromView instead. '
-    "This constructor was deprecated in preparation for Flutter's upcoming multi-window support. "
+    'This constructor was deprecated in preparation for the upcoming multi-window support. '
     'This feature was deprecated after v3.7.0-32.0.pre.'
   )
   factory MediaQueryData.fromWindow(ui.FlutterView window) => MediaQueryData.fromView(window);
@@ -927,9 +926,14 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// This constructor was operating on a single window assumption. In
   /// preparation for Flutter's upcoming multi-window support, it has been
   /// deprecated.
+  ///
+  /// Replaced by [MediaQuery.fromView], which requires specifying the
+  /// [FlutterView] the [MediaQuery] is constructed for. The [FlutterView] can,
+  /// for example, be obtained from the context via [View.of] or from
+  /// [PlatformDispatcher.views].
   @Deprecated(
     'Use MediaQuery.fromView instead. '
-    "This constructor was deprecated in preparation for Flutter's upcoming multi-window support. "
+    'This constructor was deprecated in preparation for the upcoming multi-window support. '
     'This feature was deprecated after v3.7.0-32.0.pre.'
   )
   static Widget fromWindow({
@@ -947,9 +951,6 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// Wraps the [child] in a [MediaQuery] which is built using data from the
   /// provided [view].
   ///
-  /// If no [view] is provided, the [FlutterView] obtained from the context
-  /// via [View.of] is used.
-  ///
   /// The [MediaQuery] is constructed using the platform-specific data of the
   /// surrounding [MediaQuery] and the view-specific data of the provided
   /// [view]. If no surrounding [MediaQuery] exists, the platform-specific data
@@ -962,10 +963,10 @@ class MediaQuery extends InheritedModel<_MediaQueryAspect> {
   /// The injected [MediaQuery] automatically updates when any of the data used
   /// to construct it changes.
   ///
-  /// The [child] argument is required and must not be null.
+  /// The [view] and [child] arguments are required and must not be null.
   static Widget fromView({
     Key? key,
-    FlutterView? view,
+    required FlutterView view,
     required Widget child,
   }) {
     return _MediaQueryFromView(
@@ -1473,12 +1474,12 @@ enum NavigationMode {
 class _MediaQueryFromView extends StatefulWidget {
   const _MediaQueryFromView({
     super.key,
-    this.view,
+    required this.view,
     this.ignoreParentData = false,
     required this.child,
   });
 
-  final FlutterView? view;
+  final FlutterView view;
   final bool ignoreParentData;
   final Widget child;
 
@@ -1522,8 +1523,7 @@ class _MediaQueryFromViewState extends State<_MediaQueryFromView> with WidgetsBi
   }
 
   void _updateData() {
-    final FlutterView view = widget.view ?? View.of(context);
-    final MediaQueryData newData = MediaQueryData.fromView(view, platformData: _parentData);
+    final MediaQueryData newData = MediaQueryData.fromView(widget.view, platformData: _parentData);
     if (newData != _data) {
       setState(() {
         _data = newData;

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -2215,8 +2215,7 @@ Widget buildNavigator({
   GlobalKey<NavigatorState>? key,
   TransitionDelegate<dynamic>? transitionDelegate,
 }) {
-  return MediaQuery(
-    data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+  return MediaQuery.fromView(
     child: Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[

--- a/packages/flutter/test/cupertino/route_test.dart
+++ b/packages/flutter/test/cupertino/route_test.dart
@@ -2215,7 +2215,8 @@ Widget buildNavigator({
   GlobalKey<NavigatorState>? key,
   TransitionDelegate<dynamic>? transitionDelegate,
 }) {
-  return MediaQuery.fromView(
+  return MediaQuery(
+    data: MediaQueryData.fromView(WidgetsBinding.instance.window),
     child: Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[

--- a/packages/flutter/test/material/action_chip_test.dart
+++ b/packages/flutter/test/material/action_chip_test.dart
@@ -17,7 +17,7 @@ Widget wrapForChip({
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScaleFactor),
+        data: MediaQueryData(textScaleFactor: textScaleFactor),
         child: Material(child: child),
       ),
     ),

--- a/packages/flutter/test/material/chip_test.dart
+++ b/packages/flutter/test/material/chip_test.dart
@@ -80,7 +80,7 @@ Widget wrapForChip({
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScaleFactor),
+        data: MediaQueryData(textScaleFactor: textScaleFactor),
         child: Material(child: child),
       ),
     ),

--- a/packages/flutter/test/material/choice_chip_test.dart
+++ b/packages/flutter/test/material/choice_chip_test.dart
@@ -46,7 +46,7 @@ Widget wrapForChip({
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScaleFactor),
+        data: MediaQueryData(textScaleFactor: textScaleFactor),
         child: Material(child: child),
       ),
     ),

--- a/packages/flutter/test/material/dropdown_form_field_test.dart
+++ b/packages/flutter/test/material/dropdown_form_field_test.dart
@@ -90,7 +90,7 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: widget.mediaSize),
+        data: const MediaQueryData().copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -246,7 +246,7 @@ class _TestAppState extends State<TestApp> {
         DefaultMaterialLocalizations.delegate,
       ],
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(size: widget.mediaSize),
+        data: MediaQueryData.fromView(View.of(context)).copyWith(size: widget.mediaSize),
         child: Directionality(
           textDirection: widget.textDirection,
           child: Navigator(
@@ -400,8 +400,7 @@ void main() {
     Widget build() {
       return Directionality(
         textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+        child: MediaQuery.fromView(
           child: Navigator(
             initialRoute: '/',
             onGenerateRoute: (RouteSettings settings) {

--- a/packages/flutter/test/material/dropdown_test.dart
+++ b/packages/flutter/test/material/dropdown_test.dart
@@ -400,7 +400,8 @@ void main() {
     Widget build() {
       return Directionality(
         textDirection: TextDirection.ltr,
-        child: MediaQuery.fromView(
+        child: MediaQuery(
+          data: MediaQueryData.fromView(tester.binding.window),
           child: Navigator(
             initialRoute: '/',
             onGenerateRoute: (RouteSettings settings) {

--- a/packages/flutter/test/material/filter_chip_test.dart
+++ b/packages/flutter/test/material/filter_chip_test.dart
@@ -19,7 +19,7 @@ Widget wrapForChip({
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScaleFactor),
+        data: MediaQueryData(textScaleFactor: textScaleFactor),
         child: Material(child: child),
       ),
     ),

--- a/packages/flutter/test/material/input_chip_test.dart
+++ b/packages/flutter/test/material/input_chip_test.dart
@@ -19,7 +19,7 @@ Widget wrapForChip({
     home: Directionality(
       textDirection: textDirection,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScaleFactor),
+        data: MediaQueryData(textScaleFactor: textScaleFactor),
         child: Material(child: child),
       ),
     ),

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -35,7 +35,7 @@ void main() {
   }
 
   setUpAll(() {
-    final MediaQueryData mediaQueryData = MediaQueryData.fromWindow(TestWidgetsFlutterBinding.instance.window);
+    final MediaQueryData mediaQueryData = MediaQueryData.fromView(TestWidgetsFlutterBinding.instance.window);
     defaultSize = mediaQueryData.size;
   });
 
@@ -1205,7 +1205,7 @@ void main() {
 
     testWidgets('menus close on view size change', (WidgetTester tester) async {
       final ScrollController scrollController = ScrollController();
-      final MediaQueryData mediaQueryData = MediaQueryData.fromWindow(tester.binding.window);
+      final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.binding.window);
 
       Widget build(Size size) {
         return MaterialApp(

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -1218,8 +1218,7 @@ Widget buildNavigator({
   GlobalKey<NavigatorState>? key,
   TransitionDelegate<dynamic>? transitionDelegate,
 }) {
-  return MediaQuery(
-    data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+  return MediaQuery.fromView(
     child: Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[
@@ -1322,8 +1321,7 @@ class TestDependencies extends StatelessWidget {
   Widget build(BuildContext context) {
     return Directionality(
       textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      child: MediaQuery.fromView(
         child: child,
       ),
     );

--- a/packages/flutter/test/material/page_test.dart
+++ b/packages/flutter/test/material/page_test.dart
@@ -1218,7 +1218,8 @@ Widget buildNavigator({
   GlobalKey<NavigatorState>? key,
   TransitionDelegate<dynamic>? transitionDelegate,
 }) {
-  return MediaQuery.fromView(
+  return MediaQuery(
+    data: MediaQueryData.fromView(WidgetsBinding.instance.window),
     child: Localizations(
       locale: const Locale('en', 'US'),
       delegates: const <LocalizationsDelegate<dynamic>>[
@@ -1321,7 +1322,8 @@ class TestDependencies extends StatelessWidget {
   Widget build(BuildContext context) {
     return Directionality(
       textDirection: TextDirection.ltr,
-      child: MediaQuery.fromView(
+      child: MediaQuery(
+        data: MediaQueryData.fromView(View.of(context)),
         child: child,
       ),
     );

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3118,8 +3118,7 @@ class TestApp extends StatelessWidget {
         DefaultWidgetsLocalizations.delegate,
         DefaultMaterialLocalizations.delegate,
       ],
-      child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      child: MediaQuery.fromView(
         child: Directionality(
           textDirection: textDirection,
           child: Navigator(

--- a/packages/flutter/test/material/popup_menu_test.dart
+++ b/packages/flutter/test/material/popup_menu_test.dart
@@ -3118,7 +3118,8 @@ class TestApp extends StatelessWidget {
         DefaultWidgetsLocalizations.delegate,
         DefaultMaterialLocalizations.delegate,
       ],
-      child: MediaQuery.fromView(
+      child: MediaQuery(
+        data: MediaQueryData.fromView(View.of(context)),
         child: Directionality(
           textDirection: textDirection,
           child: Navigator(

--- a/packages/flutter/test/material/range_slider_test.dart
+++ b/packages/flutter/test/material/range_slider_test.dart
@@ -1658,7 +1658,7 @@ void main() {
           child: StatefulBuilder(
             builder: (BuildContext context, StateSetter setState) {
               return MediaQuery(
-                data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: 2.0),
+                data: const MediaQueryData(textScaleFactor: 2.0),
                 child: Material(
                   child: Center(
                     child: Theme(

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -900,7 +900,7 @@ void main() {
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: MediaQuery(
-              data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScale),
+              data: MediaQueryData(textScaleFactor: textScale),
               child: Material(
                 child: Row(
                   children: <Widget>[
@@ -1082,7 +1082,7 @@ void main() {
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: MediaQuery(
-              data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScale),
+              data: MediaQueryData(textScaleFactor: textScale),
               child: Material(
                 child: Row(
                   children: <Widget>[
@@ -1870,7 +1870,7 @@ void main() {
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: MediaQuery(
-              data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScale),
+              data: MediaQueryData(textScaleFactor: textScale),
               child: Material(
                 child: Row(
                   children: <Widget>[
@@ -2080,7 +2080,7 @@ void main() {
             home: Directionality(
               textDirection: TextDirection.ltr,
               child: MediaQuery(
-                data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: textScale),
+                data: MediaQueryData(textScaleFactor: textScale),
                 child: Material(
                   child: Row(
                     children: <Widget>[

--- a/packages/flutter/test/material/text_field_test.dart
+++ b/packages/flutter/test/material/text_field_test.dart
@@ -7845,7 +7845,7 @@ void main() {
       MaterialApp(
         home: Scaffold(
           body: MediaQuery(
-              data: MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(textScaleFactor: 4.0),
+              data: const MediaQueryData(textScaleFactor: 4.0),
               child: Center(
                 child: TextField(
                   decoration: const InputDecoration(labelText: 'Label', border: UnderlineInputBorder()),

--- a/packages/flutter/test/material/tooltip_test.dart
+++ b/packages/flutter/test/material/tooltip_test.dart
@@ -476,15 +476,13 @@ void main() {
           child: const Icon(Icons.add),
         ),
       );
-      return MediaQuery.fromWindow(
-        child: MediaQuery(
-          data: MediaQueryData(
-            viewInsets: EdgeInsets.only(bottom: viewInsetsHeight),
-          ),
-          child: MaterialApp(
-            useInheritedMediaQuery: true,
-            home: scaffold,
-          ),
+      return MediaQuery(
+        data: MediaQueryData(
+          viewInsets: EdgeInsets.only(bottom: viewInsetsHeight),
+        ),
+        child: MaterialApp(
+          useInheritedMediaQuery: true,
+          home: scaffold,
         ),
       );
     }

--- a/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
+++ b/packages/flutter/test/widgets/display_feature_sub_screen_test.dart
@@ -11,7 +11,7 @@ void main() {
   group('DisplayFeatureSubScreen', () {
     testWidgets('without Directionality or anchor', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             const DisplayFeature(
               bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -39,7 +39,7 @@ void main() {
 
     testWidgets('with anchorPoint', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             const DisplayFeature(
               bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -70,7 +70,7 @@ void main() {
 
     testWidgets('with infinity anchorpoint', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             const DisplayFeature(
               bounds: Rect.fromLTRB(390, 0, 410, 600),
@@ -101,7 +101,7 @@ void main() {
 
     testWidgets('with horizontal hinge and anchorPoint', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             const DisplayFeature(
               bounds: Rect.fromLTRB(0, 290, 800, 310),
@@ -131,7 +131,7 @@ void main() {
 
     testWidgets('with multiple display features and anchorPoint', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             const DisplayFeature(
               bounds: Rect.fromLTRB(0, 290, 800, 310),
@@ -166,7 +166,7 @@ void main() {
 
     testWidgets('with non-splitting display features and anchorPoint', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             // Top notch
             const DisplayFeature(
@@ -211,7 +211,7 @@ void main() {
 
     testWidgets('with size 0 display feature in half-opened posture and anchorPoint', (WidgetTester tester) async {
       const Key childKey = Key('childKey');
-      final MediaQueryData mediaQuery = MediaQueryData.fromWindow(WidgetsBinding.instance.window).copyWith(
+      final MediaQueryData mediaQuery = MediaQueryData.fromView(WidgetsBinding.instance.window).copyWith(
           displayFeatures: <DisplayFeature>[
             const DisplayFeature(
               bounds: Rect.fromLTRB(0, 300, 800, 300),

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3167,7 +3167,8 @@ class TestDependencies extends StatelessWidget {
   Widget build(BuildContext context) {
     return Directionality(
       textDirection: TextDirection.ltr,
-      child: MediaQuery.fromView(
+      child: MediaQuery(
+        data: MediaQueryData.fromView(View.of(context)),
         child: child,
       ),
     );

--- a/packages/flutter/test/widgets/heroes_test.dart
+++ b/packages/flutter/test/widgets/heroes_test.dart
@@ -3167,8 +3167,7 @@ class TestDependencies extends StatelessWidget {
   Widget build(BuildContext context) {
     return Directionality(
       textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      child: MediaQuery.fromView(
         child: child,
       ),
     );

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -145,11 +145,11 @@ void main() {
     expect(tested, isTrue);
   });
 
-  testWidgets('MediaQueryData.fromWindow is sane', (WidgetTester tester) async {
-    final MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance.window);
+  testWidgets('MediaQueryData.fromView is sane', (WidgetTester tester) async {
+    final MediaQueryData data = MediaQueryData.fromView(tester.binding.window);
     expect(data, hasOneLineDescription);
     expect(data.hashCode, equals(data.copyWith().hashCode));
-    expect(data.size, equals(WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio));
+    expect(data.size, equals(tester.binding.window.physicalSize / tester.binding.window.devicePixelRatio));
     expect(data.accessibleNavigation, false);
     expect(data.invertColors, false);
     expect(data.disableAnimations, false);
@@ -513,7 +513,7 @@ void main() {
   });
 
   testWidgets('MediaQueryData.copyWith defaults to source', (WidgetTester tester) async {
-    final MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance.window);
+    final MediaQueryData data = MediaQueryData.fromView(tester.binding.window);
     final MediaQueryData copied = data.copyWith();
     expect(copied.size, data.size);
     expect(copied.devicePixelRatio, data.devicePixelRatio);
@@ -552,7 +552,7 @@ void main() {
       ),
     ];
 
-    final MediaQueryData data = MediaQueryData.fromWindow(WidgetsBinding.instance.window);
+    final MediaQueryData data = MediaQueryData.fromView(tester.binding.window);
     final MediaQueryData copied = data.copyWith(
       size: customSize,
       devicePixelRatio: customDevicePixelRatio,
@@ -1110,7 +1110,7 @@ void main() {
     expect(insideBoldTextOverride, true);
   });
 
-  testWidgets('MediaQuery.fromWindow creates a MediaQuery', (WidgetTester tester) async {
+  testWidgets('MediaQuery.fromView creates a MediaQuery', (WidgetTester tester) async {
     MediaQuery? mediaQueryOutside;
     MediaQuery? mediaQueryInside;
 
@@ -1118,7 +1118,7 @@ void main() {
       Builder(
         builder: (BuildContext context) {
           mediaQueryOutside = context.findAncestorWidgetOfExactType<MediaQuery>();
-          return MediaQuery.fromWindow(
+          return MediaQuery.fromView(
             child: Builder(
               builder: (BuildContext context) {
                 mediaQueryInside = context.findAncestorWidgetOfExactType<MediaQuery>();
@@ -1134,12 +1134,12 @@ void main() {
     expect(mediaQueryOutside, isNot(mediaQueryInside));
   });
 
-  testWidgets('MediaQueryData.fromWindow is created using window values', (WidgetTester tester) async {
-    final MediaQueryData windowData = MediaQueryData.fromWindow(WidgetsBinding.instance.window);
+  testWidgets('MediaQuery.fromView is created using values from surrounding view', (WidgetTester tester) async {
+    final MediaQueryData windowData = MediaQueryData.fromView(tester.binding.window);
     late MediaQueryData fromWindowData;
 
     await tester.pumpWidget(
-      MediaQuery.fromWindow(
+      MediaQuery.fromView(
         child: Builder(
           builder: (BuildContext context) {
             fromWindowData = MediaQuery.of(context);
@@ -1329,7 +1329,7 @@ void main() {
       gestureSettings: GestureSettings(physicalDoubleTapSlop: 100, physicalTouchSlop: 100),
     );
 
-    expect(MediaQueryData.fromWindow(tester.binding.window).gestureSettings.touchSlop, closeTo(33.33, 0.1)); // Repeating, of course
+    expect(MediaQueryData.fromView(tester.binding.window).gestureSettings.touchSlop, closeTo(33.33, 0.1)); // Repeating, of course
     tester.binding.window.viewConfigurationTestValue = null;
   });
 

--- a/packages/flutter/test/widgets/media_query_test.dart
+++ b/packages/flutter/test/widgets/media_query_test.dart
@@ -1119,6 +1119,7 @@ void main() {
         builder: (BuildContext context) {
           mediaQueryOutside = context.findAncestorWidgetOfExactType<MediaQuery>();
           return MediaQuery.fromView(
+            view: View.of(context),
             child: Builder(
               builder: (BuildContext context) {
                 mediaQueryInside = context.findAncestorWidgetOfExactType<MediaQuery>();
@@ -1134,12 +1135,12 @@ void main() {
     expect(mediaQueryOutside, isNot(mediaQueryInside));
   });
 
-  testWidgets('MediaQuery.fromView is created using values from surrounding view', (WidgetTester tester) async {
-    final MediaQueryData windowData = MediaQueryData.fromView(tester.binding.window);
+  testWidgets('MediaQueryData.fromWindow is created using window values', (WidgetTester tester) async {
+    final MediaQueryData windowData = MediaQueryData.fromWindow(tester.binding.window);
     late MediaQueryData fromWindowData;
 
     await tester.pumpWidget(
-      MediaQuery.fromView(
+      MediaQuery.fromWindow(
         child: Builder(
           builder: (BuildContext context) {
             fromWindowData = MediaQuery.of(context);

--- a/packages/flutter/test/widgets/navigator_restoration_test.dart
+++ b/packages/flutter/test/widgets/navigator_restoration_test.dart
@@ -1046,7 +1046,8 @@ class PagedTestWidget extends StatelessWidget {
       restorationId: restorationId,
       child: Directionality(
         textDirection: TextDirection.ltr,
-        child: MediaQuery.fromView(
+        child: MediaQuery(
+          data: MediaQueryData.fromView(View.of(context)),
           child: const PagedTestNavigator(),
         ),
       ),
@@ -1171,7 +1172,8 @@ class TestWidget extends StatelessWidget {
       restorationId: restorationId,
       child: Directionality(
         textDirection: TextDirection.ltr,
-        child: MediaQuery.fromView(
+        child: MediaQuery(
+          data: MediaQueryData.fromView(View.of(context)),
           child: Navigator(
             initialRoute: 'home',
             restorationScopeId: 'app',

--- a/packages/flutter/test/widgets/navigator_restoration_test.dart
+++ b/packages/flutter/test/widgets/navigator_restoration_test.dart
@@ -1046,8 +1046,7 @@ class PagedTestWidget extends StatelessWidget {
       restorationId: restorationId,
       child: Directionality(
         textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+        child: MediaQuery.fromView(
           child: const PagedTestNavigator(),
         ),
       ),
@@ -1172,8 +1171,7 @@ class TestWidget extends StatelessWidget {
       restorationId: restorationId,
       child: Directionality(
         textDirection: TextDirection.ltr,
-        child: MediaQuery(
-          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+        child: MediaQuery.fromView(
           child: Navigator(
             initialRoute: 'home',
             restorationScopeId: 'app',

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -203,7 +203,8 @@ void main() {
   testWidgets('Navigator can set clip behavior', (WidgetTester tester) async {
     const MaterialPage<void> page = MaterialPage<void>(child: Text('page'));
     await tester.pumpWidget(
-      MediaQuery.fromView(
+      MediaQuery(
+        data: MediaQueryData.fromView(tester.binding.window),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Navigator(
@@ -217,7 +218,8 @@ void main() {
     expect(tester.widget<Overlay>(find.byType(Overlay)).clipBehavior, Clip.hardEdge);
 
     await tester.pumpWidget(
-      MediaQuery.fromView(
+      MediaQuery(
+        data: MediaQueryData.fromView(tester.binding.window),
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Navigator(
@@ -2681,7 +2683,8 @@ void main() {
       TransitionDelegate<dynamic>? transitionDelegate,
       List<NavigatorObserver> observers = const <NavigatorObserver>[],
     }) {
-      return MediaQuery.fromView(
+      return MediaQuery(
+        data: MediaQueryData.fromView(WidgetsBinding.instance.window),
         child: Localizations(
           locale: const Locale('en', 'US'),
           delegates: const <LocalizationsDelegate<dynamic>>[
@@ -2778,7 +2781,8 @@ void main() {
       ];
 
       await tester.pumpWidget(
-        MediaQuery.fromView(
+        MediaQuery(
+          data: MediaQueryData.fromView(tester.binding.window),
           child: Localizations(
             locale: const Locale('en', 'US'),
             delegates: const <LocalizationsDelegate<dynamic>>[
@@ -2816,7 +2820,8 @@ void main() {
         firstError ??= detail;
       };
       await tester.pumpWidget(
-        MediaQuery.fromView(
+        MediaQuery(
+          data: MediaQueryData.fromView(tester.binding.window),
           child: Localizations(
             locale: const Locale('en', 'US'),
             delegates: const <LocalizationsDelegate<dynamic>>[
@@ -4265,7 +4270,8 @@ class TestDependencies extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MediaQuery.fromView(
+    return MediaQuery(
+      data: MediaQueryData.fromView(View.of(context)),
       child: Directionality(
         textDirection: TextDirection.ltr,
         child: child,

--- a/packages/flutter/test/widgets/navigator_test.dart
+++ b/packages/flutter/test/widgets/navigator_test.dart
@@ -203,8 +203,7 @@ void main() {
   testWidgets('Navigator can set clip behavior', (WidgetTester tester) async {
     const MaterialPage<void> page = MaterialPage<void>(child: Text('page'));
     await tester.pumpWidget(
-      MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      MediaQuery.fromView(
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Navigator(
@@ -218,8 +217,7 @@ void main() {
     expect(tester.widget<Overlay>(find.byType(Overlay)).clipBehavior, Clip.hardEdge);
 
     await tester.pumpWidget(
-      MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      MediaQuery.fromView(
         child: Directionality(
           textDirection: TextDirection.ltr,
           child: Navigator(
@@ -2683,8 +2681,7 @@ void main() {
       TransitionDelegate<dynamic>? transitionDelegate,
       List<NavigatorObserver> observers = const <NavigatorObserver>[],
     }) {
-      return MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      return MediaQuery.fromView(
         child: Localizations(
           locale: const Locale('en', 'US'),
           delegates: const <LocalizationsDelegate<dynamic>>[
@@ -2781,8 +2778,7 @@ void main() {
       ];
 
       await tester.pumpWidget(
-        MediaQuery(
-          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+        MediaQuery.fromView(
           child: Localizations(
             locale: const Locale('en', 'US'),
             delegates: const <LocalizationsDelegate<dynamic>>[
@@ -2820,8 +2816,7 @@ void main() {
         firstError ??= detail;
       };
       await tester.pumpWidget(
-        MediaQuery(
-          data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+        MediaQuery.fromView(
           child: Localizations(
             locale: const Locale('en', 'US'),
             delegates: const <LocalizationsDelegate<dynamic>>[
@@ -4270,8 +4265,7 @@ class TestDependencies extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MediaQuery(
-      data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+    return MediaQuery.fromView(
       child: Directionality(
         textDirection: TextDirection.ltr,
         child: child,

--- a/packages/flutter/test/widgets/page_view_test.dart
+++ b/packages/flutter/test/widgets/page_view_test.dart
@@ -142,7 +142,7 @@ void main() {
 
     // Set the starting viewportDimension to 0.0
     await tester.binding.setSurfaceSize(Size.zero);
-    final MediaQueryData mediaQueryData = MediaQueryData.fromWindow(tester.binding.window);
+    final MediaQueryData mediaQueryData = MediaQueryData.fromView(tester.binding.window);
 
     Widget build(Size size) {
       return MediaQuery(

--- a/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
@@ -95,7 +95,8 @@ void main() {
     Widget layoutBuilderChild = keyedWidget;
     Widget deepChild = Container();
 
-    await tester.pumpWidget(MediaQuery.fromView(
+    await tester.pumpWidget(MediaQuery(
+      data: MediaQueryData.fromView(tester.binding.window),
       child: Column(
         children: <Widget>[
           StatefulBuilder(builder: (BuildContext context, StateSetter setState) {

--- a/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
+++ b/packages/flutter/test/widgets/reparent_state_with_layout_builder_test.dart
@@ -95,8 +95,7 @@ void main() {
     Widget layoutBuilderChild = keyedWidget;
     Widget deepChild = Container();
 
-    await tester.pumpWidget(MediaQuery(
-      data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+    await tester.pumpWidget(MediaQuery.fromView(
       child: Column(
         children: <Widget>[
           StatefulBuilder(builder: (BuildContext context, StateSetter setState) {

--- a/packages/flutter/test/widgets/scroll_position_test.dart
+++ b/packages/flutter/test/widgets/scroll_position_test.dart
@@ -33,7 +33,8 @@ Future<void> performTest(WidgetTester tester, bool maintainState) async {
   await tester.pumpWidget(
     Directionality(
       textDirection: TextDirection.ltr,
-      child: MediaQuery.fromView(
+      child: MediaQuery(
+        data: MediaQueryData.fromView(tester.binding.window),
         child: Navigator(
           key: navigatorKey,
           onGenerateRoute: (RouteSettings settings) {

--- a/packages/flutter/test/widgets/scroll_position_test.dart
+++ b/packages/flutter/test/widgets/scroll_position_test.dart
@@ -33,8 +33,7 @@ Future<void> performTest(WidgetTester tester, bool maintainState) async {
   await tester.pumpWidget(
     Directionality(
       textDirection: TextDirection.ltr,
-      child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+      child: MediaQuery.fromView(
         child: Navigator(
           key: navigatorKey,
           onGenerateRoute: (RouteSettings settings) {

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -300,7 +300,8 @@ void main() {
           child: SemanticsDebugger(
             child: Directionality(
               textDirection: TextDirection.ltr,
-              child: MediaQuery.fromView(
+              child: MediaQuery(
+                data: MediaQueryData.fromView(tester.binding.window),
                 child: Material(
                   child: Center(
                     child: Slider(

--- a/packages/flutter/test/widgets/semantics_debugger_test.dart
+++ b/packages/flutter/test/widgets/semantics_debugger_test.dart
@@ -300,8 +300,7 @@ void main() {
           child: SemanticsDebugger(
             child: Directionality(
               textDirection: TextDirection.ltr,
-              child: MediaQuery(
-                data: MediaQueryData.fromWindow(WidgetsBinding.instance.window),
+              child: MediaQuery.fromView(
                 child: Material(
                   child: Center(
                     child: Slider(

--- a/packages/flutter/test/widgets/snapshot_widget_test.dart
+++ b/packages/flutter/test/widgets/snapshot_widget_test.dart
@@ -371,8 +371,7 @@ class TestDependencies extends StatelessWidget {
     return Directionality(
       textDirection: TextDirection.ltr,
       child: MediaQuery(
-        data: MediaQueryData.fromWindow(WidgetsBinding.instance.window)
-          .copyWith(devicePixelRatio: devicePixelRatio),
+        data: const MediaQueryData().copyWith(devicePixelRatio: devicePixelRatio),
         child: child,
       ),
     );

--- a/packages/flutter/test_fixes/widgets/widgets.dart
+++ b/packages/flutter/test_fixes/widgets/widgets.dart
@@ -12,7 +12,10 @@ void main() {
   Object object;
   TickerProvider vsync;
 
-  // Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
+  // Changes made in https://github.com/flutter/flutter/pull/119647
+  MediaQueryData.fromWindow(View.of(context));
+
+  // Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067
   AnimatedSize(vsync: vsync, duration: Duration.zero);
 
   // Changes made in https://github.com/flutter/flutter/pull/45941 and https://github.com/flutter/flutter/pull/83843

--- a/packages/flutter/test_fixes/widgets/widgets.dart.expect
+++ b/packages/flutter/test_fixes/widgets/widgets.dart.expect
@@ -12,7 +12,10 @@ void main() {
   Object object;
   TickerProvider vsync;
 
-  // Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067.
+  // Changes made in https://github.com/flutter/flutter/pull/119647
+  MediaQueryData.fromView(View.of(context));
+
+  // Changes made in https://github.com/flutter/flutter/pull/119186 and https://github.com/flutter/flutter/pull/81067
   AnimatedSize(duration: Duration.zero);
 
   // Changes made in https://github.com/flutter/flutter/pull/45941 and https://github.com/flutter/flutter/pull/83843


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/116929.

These have been replaced by `MediaQuery[Data].fromView`.