### PR TITLE
[release] use current branch as opposed to master

### DIFF
--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -69,7 +69,7 @@ String findCommit({
     'rev-parse',
     '--abbrev-ref',
     'HEAD'
-  ]);
+  ]).trim();
 
   return git(secondaryRepoDirectory, <String>[
     'log',

--- a/dev/tools/bin/find_commit.dart
+++ b/dev/tools/bin/find_commit.dart
@@ -65,12 +65,18 @@ String findCommit({
       anchor = trunkCommits[index - 1];
     }
   }
+  final String currentBranch = git(secondaryRepoDirectory, <String>[
+    'rev-parse',
+    '--abbrev-ref',
+    'HEAD'
+  ]);
+
   return git(secondaryRepoDirectory, <String>[
     'log',
     '--format=%H',
     '--until=${anchor.timestamp.toIso8601String()}',
     '--max-count=1',
-    secondaryBranch,
+    currentBranch,
     '--',
   ]);
 }


### PR DESCRIPTION
context: all the framework cherrypicks are blocked on customer testings this week. For example, https://github.com/flutter/flutter/pull/118963 , https://github.com/flutter/flutter/pull/119384 and Kate's PR as well.
The customer testings are failing with an exception of `bad revision of 'master'`, when the flutter tests repository https://github.com/flutter/tests is checked out. The command would have worked if main is checked out.

As pointed out by Godofredo, instead of hard coding a master or a main branch, we will use the current branch after the git repo is cloned. Therefore the revision will be always valid. 