### PR TITLE
Disable an inaccurate test assertion that will be fixed by an engine roll

### DIFF
--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -842,7 +842,8 @@ void main() {
       // Add a little offset to cross the boundary between paragraph 2 and 3.
       await gesture.moveTo(textOffsetToPosition(paragraph3, 6) + const Offset(0, 1));
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 2, extentOffset: 12));
-      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 8));
+      // TODO(jsimmons): reenable this with updated expectations after https://skia-review.googlesource.com/c/skia/+/619838 lands
+      //expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 8));
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
 
       await gesture.up();


### PR DESCRIPTION
https://skia-review.googlesource.com/c/skia/+/619838 fixes a bug in SkParagraph.  One of the selectable region tests relies on the old behavior.

After that Skia change rolls into the framework, the update to the test in https://github.com/flutter/flutter/pull/118902 should be landed.
