### PR TITLE
Make `_focusDebug` not interpolate in debug mode

### DIFF
--- a/examples/api/lib/widgets/focus_manager/focus_node.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.0.dart
@@ -7,10 +7,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-void main() {
-  debugFocusChanges = false;
-  runApp(const MyApp());
-}
+void main() => runApp(const MyApp());
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});

--- a/examples/api/lib/widgets/focus_manager/focus_node.0.dart
+++ b/examples/api/lib/widgets/focus_manager/focus_node.0.dart
@@ -7,7 +7,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-void main() => runApp(const MyApp());
+void main() {
+  debugFocusChanges = false;
+  runApp(const MyApp());
+}
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});

--- a/packages/flutter/lib/src/widgets/focus_manager.dart
+++ b/packages/flutter/lib/src/widgets/focus_manager.dart
@@ -27,12 +27,15 @@ bool debugFocusChanges = false;
 // assert(_focusDebug(() => 'Blah $foo'));
 //
 // It needs to be inside the assert in order to be removed in release mode, and
-// it needs to use a closure to generate the string in order to avoid the string
+// it needs to use a closure to generate the string in order to avoid string
 // interpolation when debugFocusChanges is false.
 //
 // It will throw a StateError if you try to call it when the app is in release
 // mode.
-bool _focusDebug(String Function() messageFunc, [Iterable<Object> Function()? detailsFunc]) {
+bool _focusDebug(
+  String Function() messageFunc, [
+  Iterable<Object> Function()? detailsFunc,
+]) {
   if (kReleaseMode) {
     throw StateError(
       '_focusDebug was called in Release mode. It should always be wrapped in '

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1700,4 +1700,54 @@ void main() {
     expect(messagesStr, contains('FOCUS: Notified 2 dirty nodes'));
     expect(messagesStr, contains(RegExp(r'FOCUS: Scheduling update, current focus is null, next focus will be FocusScopeNode#.*parent1')));
   });
+
+    testWidgets("doesn't call toStringDeep on a focus node when debugFocusChanges is false", (WidgetTester tester) async {
+    final bool oldDebugFocusChanges = debugFocusChanges;
+    final DebugPrintCallback oldDebugPrint = debugPrint;
+    final StringBuffer messages = StringBuffer();
+    debugPrint = (String? message, {int? wrapWidth}) {
+      messages.writeln(message ?? '');
+    };
+    Future<void> testDebugFocusChanges() async {
+      final BuildContext context = await setupWidget(tester);
+      final FocusScopeNode parent1 = FocusScopeNode(debugLabel: 'parent1');
+      final FocusAttachment parent1Attachment = parent1.attach(context);
+      final FocusNode child1 = debugFocusChanges ? FocusNode(debugLabel: 'child1') : _LoggingTestFocusNode(debugLabel: 'child1');
+      final FocusAttachment child1Attachment = child1.attach(context);
+      parent1Attachment.reparent(parent: tester.binding.focusManager.rootScope);
+      child1Attachment.reparent(parent: parent1);
+
+      child1.requestFocus();
+      await tester.pump();
+      child1.dispose();
+      parent1.dispose();
+      await tester.pump();
+    }
+    try {
+      debugFocusChanges = false;
+      await testDebugFocusChanges();
+      expect(messages, isEmpty);
+      expect(tester.takeException(), isNull);
+      debugFocusChanges = true;
+      await testDebugFocusChanges();
+      expect(messages.toString(), contains('FOCUS: Notified 3 dirty nodes:'));
+      expect(tester.takeException(), isNull);
+    } finally {
+      debugFocusChanges = oldDebugFocusChanges;
+      debugPrint = oldDebugPrint;
+    }
+  });
+}
+
+class _LoggingTestFocusNode extends FocusNode {
+  _LoggingTestFocusNode({super.debugLabel});
+
+  @override
+  String toStringDeep({
+    String prefixLineOne = '',
+    String? prefixOtherLines,
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    throw StateError("Shouldn't call toStringDeep here");
+  }
 }

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -229,7 +229,7 @@ void main() {
         'hasFocus: false',
         'hasPrimaryFocus: false',
       ]);
-    });
+    }, skip: true);
 
     testWidgets('onKeyEvent and onKey correctly cooperate', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode(debugLabel: 'Test Node 3');
@@ -1266,7 +1266,7 @@ void main() {
         ),
       );
     });
-  });
+  }, skip: true);
 
   group('Autofocus', () {
     testWidgets(
@@ -1699,9 +1699,9 @@ void main() {
     expect(messagesStr, contains(RegExp(r'   └─Child 1: FocusScopeNode#[a-f0-9]{5}\(parent1 \[PRIMARY FOCUS\]\)')));
     expect(messagesStr, contains('FOCUS: Notified 2 dirty nodes'));
     expect(messagesStr, contains(RegExp(r'FOCUS: Scheduling update, current focus is null, next focus will be FocusScopeNode#.*parent1')));
-  });
+  }, skip: true);
 
-    testWidgets("doesn't call toStringDeep on a focus node when debugFocusChanges is false", (WidgetTester tester) async {
+    testWidgets("doesn't call toString on a focus node when debugFocusChanges is false", (WidgetTester tester) async {
     final bool oldDebugFocusChanges = debugFocusChanges;
     final DebugPrintCallback oldDebugPrint = debugPrint;
     final StringBuffer messages = StringBuffer();
@@ -1728,10 +1728,10 @@ void main() {
       await testDebugFocusChanges();
       expect(messages, isEmpty);
       expect(tester.takeException(), isNull);
-      debugFocusChanges = true;
-      await testDebugFocusChanges();
-      expect(messages.toString(), contains('FOCUS: Notified 3 dirty nodes:'));
-      expect(tester.takeException(), isNull);
+      // debugFocusChanges = true;
+      // await testDebugFocusChanges();
+      // expect(messages.toString(), contains('FOCUS: Notified 3 dirty nodes:'));
+      // expect(tester.takeException(), isNull);
     } finally {
       debugFocusChanges = oldDebugFocusChanges;
       debugPrint = oldDebugPrint;
@@ -1741,6 +1741,13 @@ void main() {
 
 class _LoggingTestFocusNode extends FocusNode {
   _LoggingTestFocusNode({super.debugLabel});
+
+  @override
+  String toString({
+    DiagnosticLevel minLevel = DiagnosticLevel.debug,
+  }) {
+    throw StateError("Shouldn't call toString here");
+  }
 
   @override
   String toStringDeep({

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1728,10 +1728,10 @@ void main() {
       await testDebugFocusChanges();
       expect(messages, isEmpty);
       expect(tester.takeException(), isNull);
-      // debugFocusChanges = true;
-      // await testDebugFocusChanges();
-      // expect(messages.toString(), contains('FOCUS: Notified 3 dirty nodes:'));
-      // expect(tester.takeException(), isNull);
+      debugFocusChanges = true;
+      await testDebugFocusChanges();
+      expect(messages.toString(), contains('FOCUS: Notified 3 dirty nodes:'));
+      expect(tester.takeException(), isNull);
     } finally {
       debugFocusChanges = oldDebugFocusChanges;
       debugPrint = oldDebugPrint;

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -229,7 +229,7 @@ void main() {
         'hasFocus: false',
         'hasPrimaryFocus: false',
       ]);
-    }, skip: true);
+    });
 
     testWidgets('onKeyEvent and onKey correctly cooperate', (WidgetTester tester) async {
       final FocusNode focusNode = FocusNode(debugLabel: 'Test Node 3');
@@ -1266,7 +1266,7 @@ void main() {
         ),
       );
     });
-  }, skip: true);
+  });
 
   group('Autofocus', () {
     testWidgets(
@@ -1699,7 +1699,7 @@ void main() {
     expect(messagesStr, contains(RegExp(r'   └─Child 1: FocusScopeNode#[a-f0-9]{5}\(parent1 \[PRIMARY FOCUS\]\)')));
     expect(messagesStr, contains('FOCUS: Notified 2 dirty nodes'));
     expect(messagesStr, contains(RegExp(r'FOCUS: Scheduling update, current focus is null, next focus will be FocusScopeNode#.*parent1')));
-  }, skip: true);
+  });
 
     testWidgets("doesn't call toString on a focus node when debugFocusChanges is false", (WidgetTester tester) async {
     final bool oldDebugFocusChanges = debugFocusChanges;

--- a/packages/flutter/test/widgets/focus_manager_test.dart
+++ b/packages/flutter/test/widgets/focus_manager_test.dart
@@ -1701,7 +1701,7 @@ void main() {
     expect(messagesStr, contains(RegExp(r'FOCUS: Scheduling update, current focus is null, next focus will be FocusScopeNode#.*parent1')));
   });
 
-    testWidgets("doesn't call toString on a focus node when debugFocusChanges is false", (WidgetTester tester) async {
+  testWidgets("doesn't call toString on a focus node when debugFocusChanges is false", (WidgetTester tester) async {
     final bool oldDebugFocusChanges = debugFocusChanges;
     final DebugPrintCallback oldDebugPrint = debugPrint;
     final StringBuffer messages = StringBuffer();


### PR DESCRIPTION
## Description

Because it was calling `toString`/`toStringDeep` on objects being interpolated into the string even when `debugFocusChanges` was false, this changes the `_focusDebug` calls in focus_manager.dart so that instead of being called like so:

```dart
assert(_focusDebug('Blah $foo'));
```

They are now called like this, so that the string interpolation won't happen if `debugFocusChanges` is false:

```dart
assert(_focusDebug(() => 'Blah $foo'));
```

## Tests
 - Added a test that throws when `toString` or `toStringDeep` is called on a `FocusNode` when `debugFocusChanges == true`.