### PR TITLE
Update a test expectation that depended on an SkParagraph fix

### DIFF
--- a/packages/flutter/test/widgets/selectable_region_test.dart
+++ b/packages/flutter/test/widgets/selectable_region_test.dart
@@ -842,8 +842,7 @@ void main() {
       // Add a little offset to cross the boundary between paragraph 2 and 3.
       await gesture.moveTo(textOffsetToPosition(paragraph3, 6) + const Offset(0, 1));
       expect(paragraph1.selections[0], const TextSelection(baseOffset: 2, extentOffset: 12));
-      // TODO(jsimmons): reenable this with updated expectations after https://skia-review.googlesource.com/c/skia/+/619838 lands
-      //expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 8));
+      expect(paragraph2.selections[0], const TextSelection(baseOffset: 0, extentOffset: 9));
       expect(paragraph3.selections[0], const TextSelection(baseOffset: 0, extentOffset: 6));
 
       await gesture.up();


### PR DESCRIPTION
This assertion had been disabled because a bug fix was pending in SkParagraph.  This PR updates it to match the new behavior.

See https://github.com/flutter/flutter/pull/119653
