### PR TITLE
Only run Mac devicelab recipe tests on x64

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2432,6 +2432,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2446,6 +2447,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"}
@@ -2458,6 +2460,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2571,6 +2574,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2585,6 +2589,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2599,6 +2604,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2622,6 +2628,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2641,6 +2648,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2655,6 +2663,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2669,6 +2678,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2702,6 +2712,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"}
@@ -2793,6 +2804,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2811,6 +2823,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"}
@@ -2824,6 +2837,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2837,6 +2851,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2855,6 +2870,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2873,6 +2889,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2925,6 +2942,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"}
@@ -2937,6 +2955,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2957,6 +2976,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -2991,6 +3011,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -3028,6 +3049,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -3991,6 +4013,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -4009,6 +4032,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -4027,6 +4051,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -4060,6 +4085,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cpu: x86
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -4866,6 +4892,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
+      cpu: x86
       tags: >
         ["devicelab", "hostonly", "mac"]
       task_name: flutter_tool_startup__macos


### PR DESCRIPTION
Addresses the part of https://github.com/flutter/flutter/issues/119780 caused by https://github.com/flutter/flutter/pull/119762

Mac devicelab/devicelab_drone bots should not run on the arm machines.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
