### PR TITLE
Revert "Run Mac hostonly tests on any available arch"

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -78,6 +78,7 @@ platform_properties:
         ]
       os: Mac-12
       device_type: none
+      cpu: x86 # TODO(jmagman): https://github.com/flutter/flutter/issues/112130
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_arm64:
     properties:
@@ -2696,6 +2697,8 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+    dimensions:
+      cpu: "arm64"
 
   - name: Mac flutter_view_macos__start_up
     presubmit: false
@@ -3009,7 +3012,6 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -3065,6 +3067,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: arm64
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -4911,6 +4914,8 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
+    dimensions:
+      cpu: "arm64"
 
   - name: Windows flutter_packaging
     recipe: packaging_v2/packaging_v2


### PR DESCRIPTION
Reverts flutter/flutter#119762

This caused https://github.com/flutter/flutter/issues/119780 and seems to be causing some framework_tests_libraries failures?

```
══╡ EXCEPTION CAUGHT BY FLUTTER TEST FRAMEWORK ╞════════════════════════════════════════════════════
The following SkiaException was thrown while running async test code:
Skia Gold received an unapproved image in post-submit
testing. Golden file images in flutter/flutter are triaged
in pre-submit during code review for the given PR.
```

https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8790307749641290785/+/u/run_test.dart_for_framework_tests_shard_and_subshard_libraries/test_stdout