### PR TITLE
Fix BottomAppBar & BottomSheet M3 shadow

### DIFF
--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 
 import 'bottom_app_bar_theme.dart';
+import 'colors.dart';
 import 'elevation_overlay.dart';
 import 'material.dart';
 import 'scaffold.dart';
@@ -177,6 +178,7 @@ class _BottomAppBarState extends State<BottomAppBar> {
     final Color color = widget.color ?? babTheme.color ?? defaults.color!;
     final Color surfaceTintColor = widget.surfaceTintColor ?? babTheme.surfaceTintColor ?? defaults.surfaceTintColor!;
     final Color effectiveColor = isMaterial3 ? color : ElevationOverlay.applyOverlay(context, color, elevation);
+    final Color? shadowColor = isMaterial3 ? Colors.transparent : null;
 
     final Widget child = Padding(
       padding: widget.padding ?? babTheme.padding ?? (isMaterial3 ? const EdgeInsets.symmetric(vertical: 12.0, horizontal: 16.0) : EdgeInsets.zero),
@@ -190,12 +192,14 @@ class _BottomAppBarState extends State<BottomAppBar> {
         elevation: elevation,
         color: effectiveColor,
         clipBehavior: widget.clipBehavior,
+        elevation: isMaterial3 ? 0 : elevation,
         child: Material(
           key: materialKey,
           type: isMaterial3 ? MaterialType.canvas : MaterialType.transparency,
           elevation: elevation,
           color: isMaterial3 ? effectiveColor : null,
           surfaceTintColor: surfaceTintColor,
+          shadowColor: shadowColor,
           child: SafeArea(child: child),
         ),
       ),

--- a/packages/flutter/lib/src/material/bottom_app_bar.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar.dart
@@ -189,7 +189,6 @@ class _BottomAppBarState extends State<BottomAppBar> {
       height: height,
       child: PhysicalShape(
         clipper: clipper,
-        elevation: elevation,
         color: effectiveColor,
         clipBehavior: widget.clipBehavior,
         elevation: isMaterial3 ? 0 : elevation,

--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -270,14 +270,16 @@ class _BottomSheetState extends State<BottomSheet> {
 
   @override
   Widget build(BuildContext context) {
+    final bool useMaterial3 = Theme.of(context).useMaterial3;
     final BottomSheetThemeData bottomSheetTheme = Theme.of(context).bottomSheetTheme;
-    final BottomSheetThemeData defaults = Theme.of(context).useMaterial3 ? _BottomSheetDefaultsM3(context) : const BottomSheetThemeData();
+    final BottomSheetThemeData defaults = useMaterial3 ? _BottomSheetDefaultsM3(context) : const BottomSheetThemeData();
     final BoxConstraints? constraints = widget.constraints ?? bottomSheetTheme.constraints;
     final Color? color = widget.backgroundColor ?? bottomSheetTheme.backgroundColor ?? defaults.backgroundColor;
     final Color? surfaceTintColor = bottomSheetTheme.surfaceTintColor ?? defaults.surfaceTintColor;
     final double elevation = widget.elevation ?? bottomSheetTheme.elevation ?? defaults.elevation ?? 0;
     final ShapeBorder? shape = widget.shape ?? bottomSheetTheme.shape ?? defaults.shape;
     final Clip clipBehavior = widget.clipBehavior ?? bottomSheetTheme.clipBehavior ?? Clip.none;
+    final Color? shadowColor = useMaterial3 ? Colors.transparent : null;
 
     Widget bottomSheet = Material(
       key: _childKey,
@@ -286,6 +288,7 @@ class _BottomSheetState extends State<BottomSheet> {
       surfaceTintColor: surfaceTintColor,
       shape: shape,
       clipBehavior: clipBehavior,
+      shadowColor: shadowColor,
       child: NotificationListener<DraggableScrollableNotification>(
         onNotification: extentChanged,
         child: widget.builder(context),

--- a/packages/flutter/test/material/bottom_app_bar_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_test.dart
@@ -233,6 +233,27 @@ void main() {
     expect(material.color, const Color(0xff0000ff));
   });
 
+  testWidgets('Shadow color is transparent in Material 3', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true,
+        ),
+        home: const Scaffold(
+          floatingActionButton: FloatingActionButton(
+            onPressed: null,
+          ),
+          bottomNavigationBar: BottomAppBar(
+            color: Color(0xff0000ff),
+          ),
+        ),
+      )
+    );
+
+    final Material material = tester.widget(find.byType(Material).at(1));
+
+    expect(material.shadowColor, Colors.transparent); /* no value in Material 2. */
+  });
+
   testWidgets('dark theme applies an elevation overlay color', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -173,10 +173,10 @@ void main() {
         home: const Scaffold(body: BottomAppBar()),
       ));
 
-      final PhysicalShape widget = _getBabRenderObject(tester);
+      final Material material = tester.widget(find.byType(Material).at(1));
 
-      expect(widget.color, theme.colorScheme.surface);
-      expect(widget.elevation, equals(3.0));
+      expect(material.color, theme.colorScheme.surface);
+      expect(material.elevation, equals(3.0));
     });
 
     testWidgets('BAB theme overrides surfaceTintColor - M3', (WidgetTester tester) async {

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -841,7 +841,7 @@ void main() {
     expect(modalBarrier.color, barrierColor);
   });
 
-  testWidgets('BottomSheet uses fallback values in maretial3',
+  testWidgets('BottomSheet uses fallback values in material 3',
       (WidgetTester tester) async {
     const Color surfaceColor = Colors.pink;
     const Color surfaceTintColor = Colors.blue;
@@ -878,6 +878,30 @@ void main() {
     expect(material.surfaceTintColor, surfaceTintColor);
     expect(material.elevation, 1.0);
     expect(material.shape, defaultShape);
+  });
+
+  testWidgets('BottomSheet has transparent shadow in material3', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+      ),
+      home: Scaffold(
+        body: BottomSheet(
+          onClosing: () {},
+          builder: (BuildContext context) {
+            return Container();
+          },
+        ),
+      ),
+    ));
+
+    final Material material = tester.widget<Material>(
+      find.descendant(
+        of: find.byType(BottomSheet),
+        matching: find.byType(Material),
+      ),
+    );
+    expect(material.shadowColor, Colors.transparent);
   });
 
   testWidgets('modal BottomSheet with scrollController has semantics', (WidgetTester tester) async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/118150 and fixes https://github.com/flutter/flutter/issues/118244. 

I considered making `shadowColor` a property of each widget's theme, but as it doesn't already exist in M2/M3 for the widgets, and is only noticable when the widget is taken out of its usual context (i.e not anchored to the bottom of screen), I made it a hard-coded M3 property.

Per the code samples in the issues, I've verified they're now looking as expected:

| BottomSheet Before | BottomSheet After  |
|------|---------|
|![image](https://user-images.githubusercontent.com/39990307/211555973-6805c349-c40b-49a1-b8d4-5adae6a4f4b1.png)|![Screenshot 2023-02-02 12 45 25 PM](https://user-images.githubusercontent.com/15033982/216330455-707b9c34-536c-4a7e-b510-e86ada4ba9e0.png)

| BottomAppBar Before | BottomAppBar After  |
|------|---------|
|![Screenshot 2023-01-08 at 2 28 20](https://user-images.githubusercontent.com/39990307/211175222-34f3d973-4d47-4c09-b05c-a00ba766b597.png)|![Screenshot 2023-02-02 12 52 17 PM](https://user-images.githubusercontent.com/15033982/216331157-4d77a1ba-22e6-49fe-a088-ae2e74c165a7.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

