### PR TITLE
Fix cut button creation in 'buttonItemsForToolbarOptions'

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2430,9 +2430,9 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       if (toolbarOptions.cut && cutEnabled)
         ContextMenuButtonItem(
           onPressed: () {
-            selectAll(SelectionChangedCause.toolbar);
+            cutSelection(SelectionChangedCause.toolbar);
           },
-          type: ContextMenuButtonType.selectAll,
+          type: ContextMenuButtonType.cut,
         ),
       if (toolbarOptions.copy && copyEnabled)
         ContextMenuButtonItem(

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2197,7 +2197,7 @@ void main() {
       final EditableTextState state = tester.state<EditableTextState>(
         find.byType(EditableText),
       );
-            
+
       expect(state.cutEnabled, isFalse);
       expect(state.buttonItemsForToolbarOptions(), isEmpty);
     });
@@ -2225,7 +2225,7 @@ void main() {
 
       // Selecting all
       controller.selection = TextSelection(
-        baseOffset: 0, 
+        baseOffset: 0,
         extentOffset: controller.text.length,
       );
       expect(state.cutEnabled, isTrue);
@@ -2270,7 +2270,7 @@ void main() {
       final EditableTextState state = tester.state<EditableTextState>(
         find.byType(EditableText),
       );
-            
+
       expect(state.copyEnabled, isFalse);
       expect(state.buttonItemsForToolbarOptions(), isEmpty);
     });
@@ -2298,7 +2298,7 @@ void main() {
 
       // Selecting all
       controller.selection = TextSelection(
-        baseOffset: 0, 
+        baseOffset: 0,
         extentOffset: controller.text.length,
       );
       expect(state.copyEnabled, isTrue);
@@ -2343,7 +2343,7 @@ void main() {
       final EditableTextState state = tester.state<EditableTextState>(
         find.byType(EditableText),
       );
-            
+
       expect(state.pasteEnabled, isFalse);
       expect(state.buttonItemsForToolbarOptions(), isEmpty);
     });
@@ -2414,7 +2414,7 @@ void main() {
       final EditableTextState state = tester.state<EditableTextState>(
         find.byType(EditableText),
       );
-            
+
       expect(state.selectAllEnabled, isFalse);
       expect(state.buttonItemsForToolbarOptions(), isEmpty);
     });

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2223,7 +2223,7 @@ void main() {
         find.byType(EditableText),
       );
 
-      // Selecting all
+      // Selecting all.
       controller.selection = TextSelection(
         baseOffset: 0,
         extentOffset: controller.text.length,
@@ -2232,15 +2232,10 @@ void main() {
 
       final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
 
-      if (items == null) {
-        fail('Cut button was not returned');
-      }
+      expect(items, isNotNull);
+      expect(items, hasLength(1));
 
-      if (items.length > 1) {
-        fail('Not only the cut button was returned');
-      }
-
-      final ContextMenuButtonItem cutButton = items.first;
+      final ContextMenuButtonItem cutButton = items!.first;
       expect(cutButton.type, ContextMenuButtonType.cut);
 
       cutButton.onPressed();
@@ -2296,7 +2291,7 @@ void main() {
         find.byType(EditableText),
       );
 
-      // Selecting all
+      // Selecting all.
       controller.selection = TextSelection(
         baseOffset: 0,
         extentOffset: controller.text.length,
@@ -2305,15 +2300,10 @@ void main() {
 
       final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
 
-      if (items == null) {
-        fail('Copy button was not returned');
-      }
+      expect(items, isNotNull);
+      expect(items, hasLength(1));
 
-      if (items.length > 1) {
-        fail('Not only the copy button was returned');
-      }
-
-      final ContextMenuButtonItem copyButton = items.first;
+      final ContextMenuButtonItem copyButton = items!.first;
       expect(copyButton.type, ContextMenuButtonType.copy);
 
       copyButton.onPressed();
@@ -2369,24 +2359,19 @@ void main() {
         find.byType(EditableText),
       );
 
-      // Moving caret to the end
+      // Moving caret to the end.
       controller.selection = TextSelection.collapsed(offset: controller.text.length);
       expect(state.pasteEnabled, isTrue);
 
       final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
 
-      if (items == null) {
-        fail('Paste button was not returned');
-      }
+      expect(items, isNotNull);
+      expect(items, hasLength(1));
 
-      if (items.length > 1) {
-        fail('Not only the paste button was returned');
-      }
-
-      final ContextMenuButtonItem pasteButton = items.first;
+      final ContextMenuButtonItem pasteButton = items!.first;
       expect(pasteButton.type, ContextMenuButtonType.paste);
 
-      // Setting data which will be pasted into the clipboard
+      // Setting data which will be pasted into the clipboard.
       await Clipboard.setData(const ClipboardData(text: text));
 
       pasteButton.onPressed();
@@ -2442,15 +2427,10 @@ void main() {
 
       final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
 
-      if (items == null) {
-        fail('Select all button was not returned');
-      }
+      expect(items, isNotNull);
+      expect(items, hasLength(1));
 
-      if (items.length > 1) {
-        fail('Not only the select all button was returned');
-      }
-
-      final ContextMenuButtonItem selectAllButton = items.first;
+      final ContextMenuButtonItem selectAllButton = items!.first;
       expect(selectAllButton.type, ContextMenuButtonType.selectAll);
 
       selectAllButton.onPressed();

--- a/packages/flutter/test/widgets/editable_text_test.dart
+++ b/packages/flutter/test/widgets/editable_text_test.dart
@@ -2157,6 +2157,310 @@ void main() {
     expect(state.textEditingValue.selection.isCollapsed, isTrue);
   });
 
+  group('buttonItemsForToolbarOptions', () {
+    testWidgets('returns null when toolbarOptions are empty', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: TextEditingController(text: 'TEXT'),
+            toolbarOptions: ToolbarOptions.empty,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+
+      expect(state.buttonItemsForToolbarOptions(), isNull);
+    });
+
+    testWidgets('returns empty array when only cut is selected in toolbarOptions but cut is not enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: TextEditingController(text: 'TEXT'),
+            toolbarOptions: const ToolbarOptions(cut: true),
+            readOnly: true,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+            
+      expect(state.cutEnabled, isFalse);
+      expect(state.buttonItemsForToolbarOptions(), isEmpty);
+    });
+
+    testWidgets('returns only cut button when only cut is selected in toolbarOptions and cut is enabled', (WidgetTester tester) async {
+      const String text = 'TEXT';
+      final TextEditingController controller = TextEditingController(text: text);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: controller,
+            toolbarOptions: const ToolbarOptions(cut: true),
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+
+      // Selecting all
+      controller.selection = TextSelection(
+        baseOffset: 0, 
+        extentOffset: controller.text.length,
+      );
+      expect(state.cutEnabled, isTrue);
+
+      final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
+
+      if (items == null) {
+        fail('Cut button was not returned');
+      }
+
+      if (items.length > 1) {
+        fail('Not only the cut button was returned');
+      }
+
+      final ContextMenuButtonItem cutButton = items.first;
+      expect(cutButton.type, ContextMenuButtonType.cut);
+
+      cutButton.onPressed();
+      await tester.pump();
+
+      expect(controller.text, isEmpty);
+      final ClipboardData? data = await Clipboard.getData('text/plain');
+      expect(data, isNotNull);
+      expect(data!.text, equals(text));
+    });
+
+    testWidgets('returns empty array when only copy is selected in toolbarOptions but copy is not enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: TextEditingController(text: 'TEXT'),
+            toolbarOptions: const ToolbarOptions(copy: true),
+            obscureText: true,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+            
+      expect(state.copyEnabled, isFalse);
+      expect(state.buttonItemsForToolbarOptions(), isEmpty);
+    });
+
+    testWidgets('returns only copy button when only copy is selected in toolbarOptions and copy is enabled', (WidgetTester tester) async {
+      const String text = 'TEXT';
+      final TextEditingController controller = TextEditingController(text: text);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: controller,
+            toolbarOptions: const ToolbarOptions(copy: true),
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+
+      // Selecting all
+      controller.selection = TextSelection(
+        baseOffset: 0, 
+        extentOffset: controller.text.length,
+      );
+      expect(state.copyEnabled, isTrue);
+
+      final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
+
+      if (items == null) {
+        fail('Copy button was not returned');
+      }
+
+      if (items.length > 1) {
+        fail('Not only the copy button was returned');
+      }
+
+      final ContextMenuButtonItem copyButton = items.first;
+      expect(copyButton.type, ContextMenuButtonType.copy);
+
+      copyButton.onPressed();
+      await tester.pump();
+
+      expect(controller.text, equals(text));
+      final ClipboardData? data = await Clipboard.getData('text/plain');
+      expect(data, isNotNull);
+      expect(data!.text, equals(text));
+    });
+
+    testWidgets('returns empty array when only paste is selected in toolbarOptions but paste is not enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: TextEditingController(text: 'TEXT'),
+            toolbarOptions: const ToolbarOptions(paste: true),
+            readOnly: true,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+            
+      expect(state.pasteEnabled, isFalse);
+      expect(state.buttonItemsForToolbarOptions(), isEmpty);
+    });
+
+    testWidgets('returns only paste button when only paste is selected in toolbarOptions and paste is enabled', (WidgetTester tester) async {
+      const String text = 'TEXT';
+      final TextEditingController controller = TextEditingController(text: text);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: controller,
+            toolbarOptions: const ToolbarOptions(paste: true),
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+
+      // Moving caret to the end
+      controller.selection = TextSelection.collapsed(offset: controller.text.length);
+      expect(state.pasteEnabled, isTrue);
+
+      final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
+
+      if (items == null) {
+        fail('Paste button was not returned');
+      }
+
+      if (items.length > 1) {
+        fail('Not only the paste button was returned');
+      }
+
+      final ContextMenuButtonItem pasteButton = items.first;
+      expect(pasteButton.type, ContextMenuButtonType.paste);
+
+      // Setting data which will be pasted into the clipboard
+      await Clipboard.setData(const ClipboardData(text: text));
+
+      pasteButton.onPressed();
+      await tester.pump();
+
+      expect(controller.text, equals(text + text));
+    });
+
+    testWidgets('returns empty array when only selectAll is selected in toolbarOptions but selectAll is not enabled', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: TextEditingController(text: 'TEXT'),
+            toolbarOptions: const ToolbarOptions(selectAll: true),
+            readOnly: true,
+            obscureText: true,
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+            
+      expect(state.selectAllEnabled, isFalse);
+      expect(state.buttonItemsForToolbarOptions(), isEmpty);
+    });
+
+    testWidgets('returns only selectAll button when only selectAll is selected in toolbarOptions and selectAll is enabled', (WidgetTester tester) async {
+      const String text = 'TEXT';
+      final TextEditingController controller = TextEditingController(text: text);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EditableText(
+            controller: controller,
+            toolbarOptions: const ToolbarOptions(selectAll: true),
+            focusNode: focusNode,
+            style: textStyle,
+            cursorColor: cursorColor,
+            backgroundCursorColor: Colors.grey,
+          ),
+        ),
+      );
+
+      final EditableTextState state = tester.state<EditableTextState>(
+        find.byType(EditableText),
+      );
+
+      final List<ContextMenuButtonItem>? items = state.buttonItemsForToolbarOptions();
+
+      if (items == null) {
+        fail('Select all button was not returned');
+      }
+
+      if (items.length > 1) {
+        fail('Not only the select all button was returned');
+      }
+
+      final ContextMenuButtonItem selectAllButton = items.first;
+      expect(selectAllButton.type, ContextMenuButtonType.selectAll);
+
+      selectAllButton.onPressed();
+      await tester.pump();
+
+      expect(controller.text, equals(text));
+      expect(state.textEditingValue.selection.textInside(text), equals(text));
+    });
+  });
+
   testWidgets('Handles the read-only flag correctly', (WidgetTester tester) async {
     final TextEditingController controller =
         TextEditingController(text: 'Lorem ipsum dolor sit amet');


### PR DESCRIPTION
This PR fixes the bug in `buttonItemsForToolbarOptions` method of `EditableTextState`. 
Because of this bug, the cut button in the text field's context menu is not created when a user passes only `toolbarOptions` without the `contextMenuBuilder`.

Fixes #119820 

#### Before
https://user-images.githubusercontent.com/30288967/216338640-b1f9ae21-98bd-461f-a6d4-fc17654c4b49.mov

#### After
https://user-images.githubusercontent.com/30288967/216338647-762f42c0-5039-4f68-99ff-541074bcfa44.mov



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
