### PR TITLE
Use yaml alias and anchors in ci.yaml to share properties

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2614,7 +2614,7 @@ targets:
     presubmit: false
     timeout: 60
     properties:
-      *MAC_BENCHMARK_PROPERTIES_TEMPLATE
+      * MAC_BENCHMARK_PROPERTIES_TEMPLATE
       task_name: complex_layout_scroll_perf_macos__timeline_summary
 
   - name: Mac customer_testing

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -145,21 +145,20 @@ platform_properties:
       cpu: arm64
       device_os: iOS-16
       xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
-  mac_benchmark: &MAC_BENCHMARK_TEMPLATE
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "apple_signing", "version": "version:2022_to_2023"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "xcode", "version": "14a5294e"},
-        ]
-      device_type: none
-      drone_dimensions: >
-        ["mac_model=Macmini8,1"]
-      os: Mac-12
-      tags: >
-        ["devicelab", "hostonly", "mac"]
-      xcode: 14a5294e # xcode 14.0 beta 5
+  mac_benchmark_properties: &MAC_BENCHMARK_PROPERTIES_TEMPLATE
+    dependencies: >-
+      [
+        {"dependency": "apple_signing", "version": "version:2022_to_2023"},
+        {"dependency": "gems", "version": "v3.3.14"},
+        {"dependency": "xcode", "version": "14a5294e"},
+      ]
+    device_type: none
+    drone_dimensions: >
+      ["mac_model=Macmini8,1"]
+    os: Mac-12
+    tags: >
+      ["devicelab", "hostonly", "mac"]
+    xcode: 14a5294e # xcode 14.0 beta 5
   windows:
     properties:
       dependencies: >-
@@ -2611,11 +2610,11 @@ targets:
       task_name: complex_layout_macos__start_up
 
   - name: Mac complex_layout_scroll_perf_macos__timeline_summary
-    << : *MAC_BENCHMARK_TEMPLATE
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
+      *MAC_BENCHMARK_PROPERTIES_TEMPLATE
       task_name: complex_layout_scroll_perf_macos__timeline_summary
 
   - name: Mac customer_testing

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -9,6 +9,35 @@ enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
 
+mac_ios_template: &MAC_IOS_TEMPLATE
+  properties:
+    dependencies: >-
+      [
+        {"dependency": "xcode", "version": "14c18"},
+        {"dependency": "gems", "version": "v3.3.14"},
+        {"dependency": "apple_signing", "version": "version:2022_to_2023"}
+      ]
+    os: Mac-12
+    device_os: iOS-16
+    xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+
+mac_x64_ios_template: &MAC_X64_IOS_TEMPLATE
+  properties:
+    cpu: x86
+
+mac_arm64_ios_template: &MAC_ARM64_IOS_TEMPLATE
+  properties:
+    cpu: arm64
+
+ios_benchmark_template: &IOS_BENCHMARK_TEMPLATE
+  << : *MAC_X64_IOS_TEMPLATE
+  recipe: devicelab/devicelab_drone
+  presubmit: false
+  timeout: 60
+  properties:
+    tags: >
+      ["devicelab", "ios", "mac"]
+
 platform_properties:
   staging_build_linux:
     properties:
@@ -122,29 +151,9 @@ platform_properties:
       cpu: arm64
       device_type: "msm8952"
   mac_ios:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14c18"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "apple_signing", "version": "version:2022_to_2023"}
-        ]
-      os: Mac-12
-      cpu: x86
-      device_os: iOS-16
-      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+    << : *MAC_X64_IOS_TEMPLATE
   mac_arm64_ios:
-    properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14c18"},
-          {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "apple_signing", "version": "none"}
-        ]
-      os: Mac-12
-      cpu: arm64
-      device_os: iOS-16
-      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+    << : *MAC_ARM64_IOS_TEMPLATE
   windows:
     properties:
       dependencies: >-
@@ -3380,12 +3389,8 @@ targets:
       task_name: run_release_test
 
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
-    recipe: devicelab/devicelab_drone
-    presubmit: false
-    timeout: 60
+    << : *IOS_BENCHMARK_TEMPLATE
     properties:
-      tags: >
-        ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
 
   - name: Mac_ios backdrop_filter_perf_ios__timeline_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -146,7 +146,6 @@ platform_properties:
       device_os: iOS-16
       xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
   ios_benchmark: &IOS_BENCHMARK_TEMPLATE
-    recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
@@ -3398,6 +3397,7 @@ targets:
 
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
     << : *IOS_BENCHMARK_TEMPLATE
+    recipe: devicelab/devicelab_drone
     properties:
       task_name: animation_with_microtasks_perf_ios__timeline_summary
 

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -9,35 +9,6 @@ enabled_branches:
   - master
   - flutter-\d+\.\d+-candidate\.\d+
 
-mac_ios_template: &MAC_IOS_TEMPLATE
-  properties:
-    dependencies: >-
-      [
-        {"dependency": "xcode", "version": "14c18"},
-        {"dependency": "gems", "version": "v3.3.14"},
-        {"dependency": "apple_signing", "version": "version:2022_to_2023"}
-      ]
-    os: Mac-12
-    device_os: iOS-16
-    xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
-
-mac_x64_ios_template: &MAC_X64_IOS_TEMPLATE
-  properties:
-    cpu: x86
-
-mac_arm64_ios_template: &MAC_ARM64_IOS_TEMPLATE
-  properties:
-    cpu: arm64
-
-ios_benchmark_template: &IOS_BENCHMARK_TEMPLATE
-  << : *MAC_X64_IOS_TEMPLATE
-  recipe: devicelab/devicelab_drone
-  presubmit: false
-  timeout: 60
-  properties:
-    tags: >
-      ["devicelab", "ios", "mac"]
-
 platform_properties:
   staging_build_linux:
     properties:
@@ -151,9 +122,46 @@ platform_properties:
       cpu: arm64
       device_type: "msm8952"
   mac_ios:
-    << : *MAC_X64_IOS_TEMPLATE
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14c18"},
+          {"dependency": "gems", "version": "v3.3.14"},
+          {"dependency": "apple_signing", "version": "version:2022_to_2023"}
+        ]
+      os: Mac-12
+      cpu: x86
+      device_os: iOS-16
+      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
   mac_arm64_ios:
-    << : *MAC_ARM64_IOS_TEMPLATE
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14c18"},
+          {"dependency": "gems", "version": "v3.3.14"},
+          {"dependency": "apple_signing", "version": "none"}
+        ]
+      os: Mac-12
+      cpu: arm64
+      device_os: iOS-16
+      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+  ios_benchmark: &IOS_BENCHMARK_TEMPLATE
+    recipe: devicelab/devicelab_drone
+    presubmit: false
+    timeout: 60
+    properties:
+      cpu: x86
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14c18"},
+          {"dependency": "gems", "version": "v3.3.14"},
+          {"dependency": "apple_signing", "version": "version:2022_to_2023"}
+        ]
+      os: Mac-12
+      device_os: iOS-16
+      tags: >
+        ["devicelab", "ios", "mac"]
+      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
   windows:
     properties:
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -145,21 +145,21 @@ platform_properties:
       cpu: arm64
       device_os: iOS-16
       xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
-  ios_benchmark: &IOS_BENCHMARK_TEMPLATE
-    timeout: 60
+  mac_benchmark: &MAC_BENCHMARK_TEMPLATE
     properties:
-      cpu: x86
       dependencies: >-
         [
-          {"dependency": "xcode", "version": "14c18"},
+          {"dependency": "apple_signing", "version": "version:2022_to_2023"},
           {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "apple_signing", "version": "version:2022_to_2023"}
+          {"dependency": "xcode", "version": "14a5294e"},
         ]
+      device_type: none
+      drone_dimensions: >
+        ["mac_model=Macmini8,1"]
       os: Mac-12
-      device_os: iOS-16
       tags: >
-        ["devicelab", "ios", "mac"]
-      xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
+        ["devicelab", "hostonly", "mac"]
+      xcode: 14a5294e # xcode 14.0 beta 5
   windows:
     properties:
       dependencies: >-
@@ -2611,17 +2611,11 @@ targets:
       task_name: complex_layout_macos__start_up
 
   - name: Mac complex_layout_scroll_perf_macos__timeline_summary
+    << : *MAC_BENCHMARK_TEMPLATE
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: complex_layout_scroll_perf_macos__timeline_summary
 
   - name: Mac customer_testing
@@ -3395,10 +3389,12 @@ targets:
       task_name: run_release_test
 
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
-    << : *IOS_BENCHMARK_TEMPLATE
     recipe: devicelab/devicelab_drone
     presubmit: false
+    timeout: 60
     properties:
+      tags: >
+        ["devicelab", "ios", "mac"]
       task_name: animation_with_microtasks_perf_ios__timeline_summary
 
   - name: Mac_ios backdrop_filter_perf_ios__timeline_summary

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -146,7 +146,6 @@ platform_properties:
       device_os: iOS-16
       xcode: 14c18 # Xcode 14.2 to support iOS 16.2 in devicelab.
   ios_benchmark: &IOS_BENCHMARK_TEMPLATE
-    presubmit: false
     timeout: 60
     properties:
       cpu: x86
@@ -3398,6 +3397,7 @@ targets:
   - name: Mac_ios animation_with_microtasks_perf_ios__timeline_summary
     << : *IOS_BENCHMARK_TEMPLATE
     recipe: devicelab/devicelab_drone
+    presubmit: false
     properties:
       task_name: animation_with_microtasks_perf_ios__timeline_summary
 


### PR DESCRIPTION
Use yaml node anchors to share properties between tasks.  This will allow us to define just once the properties for a macOS/iOS/Android, etc benchmark should vs macOS/Linux/Windows host-only non-benchmark properties, without changing the task name, which is used for benchmarks and should stay stable.