### PR TITLE
Add mac_benchmark ci.yaml property

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2454,12 +2454,16 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       task_name: animated_complex_opacity_perf_macos__e2e_summary
 
   - name: Mac_benchmark basic_material_app_macos__compile
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2574,18 +2578,24 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
 
   - name: Mac_benchmark complex_layout_macos__compile
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       task_name: complex_layout_macos__compile
 
   - name: Mac_benchmark complex_layout_macos__start_up
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       task_name: complex_layout_macos__start_up
 
   - name: Mac_benchmark complex_layout_scroll_perf_macos__timeline_summary
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2634,12 +2644,16 @@ targets:
       task_name: flavors_test_macos
 
   - name: Mac_benchmark flutter_gallery_macos__compile
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       task_name: flutter_gallery_macos__compile
 
   - name: Mac_benchmark flutter_gallery_macos__start_up
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2666,6 +2680,8 @@ targets:
       cpu: "arm64"
 
   - name: Mac_benchmark flutter_view_macos__start_up
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2768,6 +2784,8 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark hello_world_macos__compile
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2875,6 +2893,8 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark platform_view_macos__start_up
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -4804,6 +4824,8 @@ targets:
       task_name: flutter_tool_startup__linux
 
   - name: Mac_benchmark flutter_tool_startup__macos
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2454,14 +2454,12 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       task_name: animated_complex_opacity_perf_macos__e2e_summary
 
   - name: Mac_benchmark basic_material_app_macos__compile
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2576,7 +2574,6 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
 
   - name: Mac_benchmark complex_layout_macos__compile
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2584,14 +2581,12 @@ targets:
 
   - name: Mac_benchmark complex_layout_macos__start_up
     recipe: devicelab/devicelab_drone
-    presubmit: false
     timeout: 60
     properties:
       task_name: complex_layout_macos__start_up
 
   - name: Mac_benchmark complex_layout_scroll_perf_macos__timeline_summary
     recipe: devicelab/devicelab_drone
-    presubmit: false
     timeout: 60
     properties:
       task_name: complex_layout_scroll_perf_macos__timeline_summary
@@ -2639,14 +2634,12 @@ targets:
       task_name: flavors_test_macos
 
   - name: Mac_benchmark flutter_gallery_macos__compile
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
       task_name: flutter_gallery_macos__compile
 
   - name: Mac_benchmark flutter_gallery_macos__start_up
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2673,7 +2666,6 @@ targets:
       cpu: "arm64"
 
   - name: Mac_benchmark flutter_view_macos__start_up
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2776,7 +2768,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark hello_world_macos__compile
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -2884,7 +2875,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark platform_view_macos__start_up
-    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
@@ -4815,7 +4805,6 @@ targets:
 
   - name: Mac_benchmark flutter_tool_startup__macos
     recipe: devicelab/devicelab_drone
-    presubmit: false
     timeout: 60
     properties:
       task_name: flutter_tool_startup__macos

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2450,16 +2450,12 @@ targets:
       - bin/
       - .ci.yaml
 
-  - name: Mac animated_complex_opacity_perf_macos__e2e_summary
+  - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
+    bringup: true # https://github.com/flutter/flutter/pull/119871
+    presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      device_type: none
-      mac_model: "Macmini8,1"
-      os: Mac-12
-      tags: >
-        ["devicelab", "hostonly", "mac"]
-      xcode: 14a5294e
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2452,12 +2452,17 @@ targets:
       - bin/
       - .ci.yaml
 
-  - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
-    bringup: true # https://github.com/flutter/flutter/pull/119871
-    presubmit: false
+  - name: Mac animated_complex_opacity_perf_macos__e2e_summary
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      device_type: none
+      drone_dimensions: >
+        ["mac_model=Macmini8,1"]
+      os: Mac-12
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      xcode: 14a5294e
       dependencies: >-
         [
           {"dependency": "gems", "version": "v3.3.14"}

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -96,7 +96,7 @@ platform_properties:
         [
           {"dependency": "apple_signing", "version": "version:2022_to_2023"},
           {"dependency": "gems", "version": "v3.3.14"},
-          {"dependency": "xcode", "version": "14a5294e"},
+          {"dependency": "xcode", "version": "14a5294e"}
         ]
       device_type: none
       drone_dimensions: >

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -98,8 +98,7 @@ platform_properties:
           {"dependency": "xcode", "version": "14a5294e"}
         ]
       device_type: none
-      drone_dimensions: >
-        ["mac_model=Macmini8,1"]
+      mac_model: "Macmini8,1"
       os: Mac-12
       tags: >
         ["devicelab", "hostonly", "mac"]
@@ -2457,8 +2456,7 @@ targets:
     timeout: 60
     properties:
       device_type: none
-      drone_dimensions: >
-        ["mac_model=Macmini8,1"]
+      mac_model: "Macmini8,1"
       os: Mac-12
       tags: >
         ["devicelab", "hostonly", "mac"]

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -92,6 +92,10 @@ platform_properties:
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_benchmark:
     properties:
+      dependencies: >-
+        [
+          {"dependency": "apple_signing", "version": "version:2022_to_2023"}
+        ]
       device_type: none
       mac_model: "Macmini8,1"
       os: Mac-12

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -95,7 +95,6 @@ platform_properties:
       dependencies: >-
         [
           {"dependency": "apple_signing", "version": "version:2022_to_2023"},
-          {"dependency": "gems", "version": "v3.3.14"},
           {"dependency": "xcode", "version": "14a5294e"}
         ]
       device_type: none
@@ -2459,6 +2458,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       task_name: animated_complex_opacity_perf_macos__e2e_summary
 
   - name: Mac_benchmark basic_material_app_macos__compile
@@ -2583,6 +2586,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       task_name: complex_layout_macos__compile
 
   - name: Mac_benchmark complex_layout_macos__start_up
@@ -2591,6 +2598,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       task_name: complex_layout_macos__start_up
 
   - name: Mac_benchmark complex_layout_scroll_perf_macos__timeline_summary
@@ -2599,6 +2610,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       task_name: complex_layout_scroll_perf_macos__timeline_summary
 
   - name: Mac customer_testing
@@ -2649,6 +2664,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       task_name: flutter_gallery_macos__compile
 
   - name: Mac_benchmark flutter_gallery_macos__start_up
@@ -2657,6 +2676,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "gems", "version": "v3.3.14"}
+        ]
       task_name: flutter_gallery_macos__start_up
 
   - name: Mac flutter_packaging_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -92,11 +92,6 @@ platform_properties:
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_benchmark:
     properties:
-      dependencies: >-
-        [
-          {"dependency": "apple_signing", "version": "version:2022_to_2023"},
-          {"dependency": "xcode", "version": "14a5294e"}
-        ]
       device_type: none
       mac_model: "Macmini8,1"
       os: Mac-12
@@ -2463,6 +2458,7 @@ targets:
       xcode: 14a5294e
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: animated_complex_opacity_perf_macos__e2e_summary
@@ -2473,6 +2469,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
       task_name: basic_material_app_macos__compile
 
   - name: Mac build_ios_framework_module_test
@@ -2591,6 +2591,7 @@ targets:
     properties:
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: complex_layout_macos__compile
@@ -2603,6 +2604,7 @@ targets:
     properties:
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: complex_layout_macos__start_up
@@ -2615,6 +2617,7 @@ targets:
     properties:
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: complex_layout_scroll_perf_macos__timeline_summary
@@ -2669,6 +2672,7 @@ targets:
     properties:
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: flutter_gallery_macos__compile
@@ -2681,6 +2685,7 @@ targets:
     properties:
       dependencies: >-
         [
+          {"dependency": "xcode", "version": "14a5294e"},
           {"dependency": "gems", "version": "v3.3.14"}
         ]
       task_name: flutter_gallery_macos__start_up
@@ -2711,6 +2716,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
       task_name: flutter_view_macos__start_up
 
   - name: Mac framework_tests_libraries
@@ -2815,6 +2824,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
       task_name: hello_world_macos__compile
 
   - name: Mac integration_ui_test_test_macos
@@ -2924,6 +2937,10 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
       task_name: platform_view_macos__start_up
 
   - name: Mac plugin_dependencies_test

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -90,6 +90,21 @@ platform_properties:
       device_type: none
       cpu: arm64
       xcode: 14a5294e # xcode 14.0 beta 5
+  mac_benchmark:
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "apple_signing", "version": "version:2022_to_2023"},
+          {"dependency": "gems", "version": "v3.3.14"},
+          {"dependency": "xcode", "version": "14a5294e"},
+        ]
+      device_type: none
+      drone_dimensions: >
+        ["mac_model=Macmini8,1"]
+      os: Mac-12
+      tags: >
+        ["devicelab", "hostonly", "mac"]
+      xcode: 14a5294e # xcode 14.0 beta 5
   mac_x64:
     properties:
       dependencies: >-
@@ -2438,31 +2453,18 @@ targets:
       - bin/
       - .ci.yaml
 
-  - name: Mac animated_complex_opacity_perf_macos__e2e_summary
+  - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: animated_complex_opacity_perf_macos__e2e_summary
 
-  - name: Mac basic_material_app_macos__compile
+  - name: Mac_benchmark basic_material_app_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: basic_material_app_macos__compile
 
   - name: Mac build_ios_framework_module_test
@@ -2573,46 +2575,25 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "mac"]
 
-  - name: Mac complex_layout_macos__compile
+  - name: Mac_benchmark complex_layout_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: complex_layout_macos__compile
 
-  - name: Mac complex_layout_macos__start_up
+  - name: Mac_benchmark complex_layout_macos__start_up
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: complex_layout_macos__start_up
 
-  - name: Mac complex_layout_scroll_perf_macos__timeline_summary
+  - name: Mac_benchmark complex_layout_scroll_perf_macos__timeline_summary
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: complex_layout_scroll_perf_macos__timeline_summary
 
   - name: Mac customer_testing
@@ -2657,32 +2638,18 @@ targets:
         ["devicelab", "hostonly", "mac"]
       task_name: flavors_test_macos
 
-  - name: Mac flutter_gallery_macos__compile
+  - name: Mac_benchmark flutter_gallery_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: flutter_gallery_macos__compile
 
-  - name: Mac flutter_gallery_macos__start_up
+  - name: Mac_benchmark flutter_gallery_macos__start_up
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"},
-          {"dependency": "gems", "version": "v3.3.14"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: flutter_gallery_macos__start_up
 
   - name: Mac flutter_packaging_test
@@ -2693,7 +2660,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-
 
   - name: Mac_arm64 flutter_packaging_test
     recipe: packaging_v2/packaging_v2
@@ -2706,17 +2672,11 @@ targets:
     dimensions:
       cpu: "arm64"
 
-  - name: Mac flutter_view_macos__start_up
+  - name: Mac_benchmark flutter_view_macos__start_up
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: flutter_view_macos__start_up
 
   - name: Mac framework_tests_libraries
@@ -2815,17 +2775,11 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac hello_world_macos__compile
+  - name: Mac_benchmark hello_world_macos__compile
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: hello_world_macos__compile
 
   - name: Mac integration_ui_test_test_macos
@@ -2929,17 +2883,11 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac platform_view_macos__start_up
+  - name: Mac_benchmark platform_view_macos__start_up
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      dependencies: >-
-        [
-          {"dependency": "xcode", "version": "14a5294e"}
-        ]
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: platform_view_macos__start_up
 
   - name: Mac plugin_dependencies_test
@@ -4865,13 +4813,11 @@ targets:
         ["devicelab", "hostonly", "linux"]
       task_name: flutter_tool_startup__linux
 
-  - name: Mac flutter_tool_startup__macos
+  - name: Mac_benchmark flutter_tool_startup__macos
     recipe: devicelab/devicelab_drone
     presubmit: false
     timeout: 60
     properties:
-      tags: >
-        ["devicelab", "hostonly", "mac"]
       task_name: flutter_tool_startup__macos
 
   - name: Linux flutter_packaging


### PR DESCRIPTION
Create a new `mac_benchmark` that runs on consistent a Mac mini model.  They are currently all running on `Macmini8,1` so enforce that (currently 30 bots in the pool) so that they don't run on the new arm Macs.

![Screenshot 2023-02-02 at 6 02 25 PM](https://user-images.githubusercontent.com/682784/216494563-3df09ea1-5872-48d6-a841-98c2336e516a.png)

Example: https://ci.chromium.org/p/flutter/builders/try/Mac%20animated_complex_opacity_perf_macos__e2e_summary/6?

Fixes https://github.com/flutter/flutter/issues/119780
