### PR TITLE
Run Mac hostonly tests on any available arch

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2720,6 +2720,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}
@@ -2745,6 +2746,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"},
@@ -2774,6 +2776,7 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
+      cpu: x86 # https://github.com/flutter/flutter/issues/119880
       dependencies: >-
         [
           {"dependency": "goldctl", "version": "git_revision:3a77d0b12c697a840ca0c7705208e8622dc94603"}

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -78,7 +78,6 @@ platform_properties:
         ]
       os: Mac-12
       device_type: none
-      cpu: x86 # TODO(jmagman): https://github.com/flutter/flutter/issues/112130
       xcode: 14a5294e # xcode 14.0 beta 5
   mac_arm64:
     properties:
@@ -2703,8 +2702,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-    dimensions:
-      cpu: "arm64"
 
   - name: Mac flutter_view_macos__start_up
     presubmit: false
@@ -3018,6 +3015,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -3073,7 +3071,6 @@ targets:
     recipe: flutter/flutter_drone
     timeout: 60
     properties:
-      cpu: arm64
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},
@@ -4915,8 +4912,6 @@ targets:
       task_name: flutter_packaging
       tags: >
         ["framework", "hostonly", "shard", "mac"]
-    dimensions:
-      cpu: "arm64"
 
   - name: Windows flutter_packaging
     recipe: packaging_v2/packaging_v2


### PR DESCRIPTION
M1 capacity has now been added. Another attempt at https://github.com/flutter/flutter/pull/109889 and https://github.com/flutter/flutter/pull/119762

Allow Mac hostonly (not benchmark or iOS devicelab) tests to run on any available architecture, not just x64 Intel machines.

Continue to run framework tests on Intel to avoid SkiaGold diffs: https://github.com/flutter/flutter/issues/119880

Web tests should now pass on either arch: https://github.com/flutter/flutter/pull/119773
