### PR TITLE
Prepare for adding values to AppLifecycleState

### DIFF
--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -393,6 +393,11 @@ mixin SchedulerBinding on BindingBase {
       case AppLifecycleState.paused:
       case AppLifecycleState.detached:
         _setFramesEnabledState(false);
+      // ignore: no_default_cases
+      default:
+        // TODO(gspencergoog): Remove this and replace with real cases once
+        // engine change rolls into framework.
+        break;
     }
   }
 

--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -3245,6 +3245,12 @@ class ClipboardStatusNotifier extends ValueNotifier<ClipboardStatus> with Widget
       case AppLifecycleState.inactive:
       case AppLifecycleState.paused:
         // Nothing to do.
+        break;
+      // ignore: no_default_cases
+      default:
+        // TODO(gspencergoog): Remove this and replace with real cases once
+        // engine change rolls into framework.
+        break;
     }
   }
 


### PR DESCRIPTION
## Description

This adds necessary default cases to two switch statements that look at `AppLifecycleState`. The defaults need to be added temporarily so that a new state `hidden` can be added to the engine side without breaking the framework build. The `default:`s will be removed once those new states are available.

See this [design doc](https://docs.google.com/document/d/1FL5Fgk7EzMNOpJL0GZJt-lfWtGt2igHuC2ZznItS2l8/edit?usp=sharing&resourcekey=0-IZNfpSVPkMbigQLLXoJcfw) for more information.

## Related Issues
 - https://github.com/flutter/flutter/issues/30735

## Tests
 - Refactor with no semantic changes.