### PR TITLE
Run macOS benchmarks in prod pool to upload metrics

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2451,7 +2451,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark animated_complex_opacity_perf_macos__e2e_summary
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2464,7 +2463,6 @@ targets:
       task_name: animated_complex_opacity_perf_macos__e2e_summary
 
   - name: Mac_benchmark basic_material_app_macos__compile
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2584,7 +2582,6 @@ targets:
         ["framework", "hostonly", "shard", "mac"]
 
   - name: Mac_benchmark complex_layout_macos__compile
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2597,7 +2594,6 @@ targets:
       task_name: complex_layout_macos__compile
 
   - name: Mac_benchmark complex_layout_macos__start_up
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2610,7 +2606,6 @@ targets:
       task_name: complex_layout_macos__start_up
 
   - name: Mac_benchmark complex_layout_scroll_perf_macos__timeline_summary
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2665,7 +2660,6 @@ targets:
       task_name: flavors_test_macos
 
   - name: Mac_benchmark flutter_gallery_macos__compile
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2678,7 +2672,6 @@ targets:
       task_name: flutter_gallery_macos__compile
 
   - name: Mac_benchmark flutter_gallery_macos__start_up
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2711,7 +2704,6 @@ targets:
       cpu: "arm64"
 
   - name: Mac_benchmark flutter_view_macos__start_up
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2819,7 +2811,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark hello_world_macos__compile
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -2932,7 +2923,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_benchmark platform_view_macos__start_up
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60
@@ -4867,7 +4857,6 @@ targets:
       task_name: flutter_tool_startup__linux
 
   - name: Mac_benchmark flutter_tool_startup__macos
-    bringup: true # https://github.com/flutter/flutter/pull/119871
     presubmit: false
     recipe: devicelab/devicelab_drone
     timeout: 60


### PR DESCRIPTION
Remove `bringup` from the `mac_benchmark` tasks renamed in https://github.com/flutter/flutter/pull/119871 to run them in the prod pool.

`mac_model` dimension is being passed in:
![Screenshot 2023-02-03 at 2 16 01 PM](https://user-images.githubusercontent.com/682784/216721249-2a504c9d-ece7-4f03-9394-852e366bb757.png)

Runs:
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20platform_view_macos__start_up/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20hello_world_macos__compile/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20flutter_view_macos__start_up/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20flutter_tool_startup__macos/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20flutter_gallery_macos__start_up/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20flutter_gallery_macos__compile/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20complex_layout_scroll_perf_macos__timeline_summary/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20complex_layout_macos__start_up/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20complex_layout_macos__compile/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20basic_material_app_macos__compile/1
https://ci.chromium.org/p/flutter/builders/staging/Mac_benchmark%20animated_complex_opacity_perf_macos__e2e_summary/1

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
