### PR TITLE
Verify Mac artifact codesigning on x64 and arm64

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3231,7 +3231,7 @@ targets:
       validation: verify_binaries_codesigned
       validation_name: Verify x64 binaries codesigned
 
-  - name: Mac_arm verify_binaries_codesigned
+  - name: Mac_arm64 verify_binaries_codesigned
     bringup: true
     enabled_branches:
       - flutter-\d+\.\d+-candidate\.\d+

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3215,7 +3215,8 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac verify_binaries_codesigned
+  - name: Mac_x64 verify_binaries_codesigned
+    bringup: true
     enabled_branches:
       - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
@@ -3228,7 +3229,23 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "mac"]
       validation: verify_binaries_codesigned
-      validation_name: Verify binaries codesigned
+      validation_name: Verify x64 binaries codesigned
+
+  - name: Mac_arm verify_binaries_codesigned
+    bringup: true
+    enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
+    recipe: flutter/flutter
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+      validation: verify_binaries_codesigned
+      validation_name: Verify arm64 binaries codesigned
 
   - name: Mac web_tool_tests
     recipe: flutter/flutter_drone


### PR DESCRIPTION
Intel x64 and ARM Mac artifacts are uploaded separately.  Run codesign verification on Macs of both architectures.

Would prevent arm packages from being shipped without codesigning, as happened in 3.3.4 and 3.7: https://github.com/flutter/flutter/issues/111764#issuecomment-1275539149
