### PR TITLE
Document BrowserContextMenu API in editable text; add sample

### DIFF
--- a/examples/api/lib/material/context_menu/editable_text_toolbar_builder.3.dart
+++ b/examples/api/lib/material/context_menu/editable_text_toolbar_builder.3.dart
@@ -1,0 +1,73 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This example demonstrates disabling the browser's context menu
+// and displaying the context menu of a TextField widget instead.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show BrowserContextMenu;
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatefulWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final TextEditingController _controller = TextEditingController(
+    text: 'Select a word and right click to see the context menu.',
+  );
+
+  void disableBrowserContextMenu() {
+    if (kIsWeb && BrowserContextMenu.enabled) {
+      unawaited(BrowserContextMenu.disableContextMenu());
+    }
+  }
+
+  void enableBrowserContextMenu() {
+    if (kIsWeb && !BrowserContextMenu.enabled) {
+      unawaited(BrowserContextMenu.enableContextMenu());
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    disableBrowserContextMenu();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Context Menu on the Web'),
+        ),
+        body: Center(
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              controller: _controller,
+              // By default a TextField widget
+              // already has its own context menu builder.
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    enableBrowserContextMenu();
+    _controller.dispose();
+    super.dispose();
+  }
+}

--- a/examples/api/test/material/context_menu/editable_text_toolbar_builder.3_test.dart
+++ b/examples/api/test/material/context_menu/editable_text_toolbar_builder.3_test.dart
@@ -1,0 +1,69 @@
+// Copyright 2023 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/material/context_menu/editable_text_toolbar_builder.3.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+      'the TextField context menu is shown after disabling the browser context menu',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.MyApp(),
+    );
+
+    await tester.tap(find.byType(EditableText));
+    await tester.pump();
+
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+
+    // The selectWordsInRange with SelectionChangedCause.tap seems to be needed to show the toolbar.
+    final EditableTextState state =
+        tester.state<EditableTextState>(find.byType(EditableText));
+    state.renderEditable.selectWordsInRange(
+        from: Offset.zero, cause: SelectionChangedCause.tap);
+
+    expect(state.showToolbar(), true);
+
+    // This is needed for the AnimatedOpacity to turn from 0 to 1 so the toolbar is visible.
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+
+    // The buttons use the default buttons.
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        expect(find.byType(CupertinoTextSelectionToolbarButton),
+            findsAtLeastNWidgets(1));
+        break;
+      case TargetPlatform.android:
+      case TargetPlatform.fuchsia:
+        expect(find.byType(TextSelectionToolbarTextButton),
+            findsAtLeastNWidgets(1));
+        break;
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        expect(find.byType(DesktopTextSelectionToolbarButton),
+            findsAtLeastNWidgets(1));
+        break;
+      case TargetPlatform.macOS:
+        expect(find.byType(CupertinoDesktopTextSelectionToolbarButton),
+            findsAtLeastNWidgets(1));
+        break;
+    }
+
+    // Tap to dismiss.
+    await tester.tapAt(tester.getTopLeft(find.byType(EditableText)));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsNothing);
+    expect(find.byType(CupertinoTextSelectionToolbarButton), findsNothing);
+    expect(find.byType(TextSelectionToolbarTextButton), findsNothing);
+    expect(find.byType(DesktopTextSelectionToolbarButton), findsNothing);
+    expect(find.byType(CupertinoDesktopTextSelectionToolbarButton), findsNothing);
+  }, skip: !kIsWeb); // [intended] This test targets the browser context menu.
+}

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1776,6 +1776,24 @@ class EditableText extends StatefulWidget {
   /// {@endtemplate}
   ///
   /// If not provided, no context menu will be shown.
+  /// 
+  /// When running on the web, if [BrowserContextMenu.enabled] is true,
+  /// which is the default, the browser's context menu is shown.
+  /// If [BrowserContextMenu.enabled] is false,
+  /// then this builder is used to build the context menu.
+  /// 
+  /// {@tool dartpad}
+  /// 
+  /// This example shows how to disable the browser's context menu on the web,
+  /// so that a custom context menu can be shown.
+  /// 
+  /// ** See code in examples/api/lib/material/context_menu/editable_text_toolbar_builder.3.dart **
+  /// 
+  /// {@end tool}
+  /// 
+  /// See also:
+  ///   * [BrowserContextMenu.enableContextMenu], to enable the browser's context menu.
+  ///   * [BrowserContextMenu.disableContextMenu], to disable the browser's context menu.
   final EditableTextContextMenuBuilder? contextMenuBuilder;
 
   /// {@template flutter.widgets.EditableText.spellCheckConfiguration}


### PR DESCRIPTION
This PR adds a documentation reference for the new `BrowserContextMenu` API's that were recently added to EditableText. It also adds a code sample that demonstrates using said API for a `TextField`.

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes #119184

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
N/A

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
