### PR TITLE
Removed "if" on resolving text color at "SnackBarAction"

### DIFF
--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -140,6 +140,20 @@ class _SnackBarActionState extends State<SnackBarAction> {
     final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
 
     MaterialStateColor resolveForegroundColor() {
+      if (widget.textColor != null) {
+        if (widget.textColor is MaterialStateColor) {
+          return widget.textColor! as MaterialStateColor;
+        }
+      } else if (snackBarTheme.actionTextColor != null) {
+        if (snackBarTheme.actionTextColor is MaterialStateColor) {
+          return snackBarTheme.actionTextColor! as MaterialStateColor;
+        }
+      } else if (defaults.actionTextColor != null) {
+        if (defaults.actionTextColor is MaterialStateColor) {
+          return defaults.actionTextColor! as MaterialStateColor;
+        }
+      }
+
       return MaterialStateColor.resolveWith((Set<MaterialState> states) {
         if (states.contains(MaterialState.disabled)) {
           return widget.disabledTextColor ??
@@ -233,10 +247,10 @@ class SnackBar extends StatefulWidget {
     this.dismissDirection = DismissDirection.down,
     this.clipBehavior = Clip.hardEdge,
   }) : assert(elevation == null || elevation >= 0.0),
-       assert(
-         width == null || margin == null,
-         'Width and margin can not be used together',
-       );
+        assert(
+        width == null || margin == null,
+        'Width and margin can not be used together',
+        );
 
   /// The primary content of the snack bar.
   ///
@@ -491,22 +505,22 @@ class _SnackBarState extends State<SnackBar> {
     final ThemeData effectiveTheme = theme.useMaterial3
         ? theme
         : theme.copyWith(
-            colorScheme: ColorScheme(
-              primary: colorScheme.onPrimary,
-              primaryVariant: colorScheme.onPrimary,
-              secondary: buttonColor,
-              secondaryVariant: colorScheme.onSecondary,
-              surface: colorScheme.onSurface,
-              background: defaults.backgroundColor!,
-              error: colorScheme.onError,
-              onPrimary: colorScheme.primary,
-              onSecondary: colorScheme.secondary,
-              onSurface: colorScheme.surface,
-              onBackground: colorScheme.background,
-              onError: colorScheme.error,
-              brightness: brightness,
-            ),
-          );
+      colorScheme: ColorScheme(
+        primary: colorScheme.onPrimary,
+        primaryVariant: colorScheme.onPrimary,
+        secondary: buttonColor,
+        secondaryVariant: colorScheme.onSecondary,
+        surface: colorScheme.onSurface,
+        background: defaults.backgroundColor!,
+        error: colorScheme.onError,
+        onPrimary: colorScheme.primary,
+        onSecondary: colorScheme.secondary,
+        onSurface: colorScheme.surface,
+        onBackground: colorScheme.background,
+        onError: colorScheme.error,
+        brightness: brightness,
+      ),
+    );
 
     final TextStyle? contentTextStyle = snackBarTheme.contentTextStyle ?? defaults.contentTextStyle;
     final SnackBarBehavior snackBarBehavior = widget.behavior ?? snackBarTheme.behavior ?? defaults.behavior!;
@@ -564,11 +578,11 @@ class _SnackBarState extends State<SnackBar> {
 
     final IconButton? iconButton = showCloseIcon
         ? IconButton(
-            icon: const Icon(Icons.close),
-            iconSize: 24.0,
-            color: widget.closeIconColor ?? snackBarTheme.closeIconColor ?? defaults.closeIconColor,
-            onPressed: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
-          )
+      icon: const Icon(Icons.close),
+      iconSize: 24.0,
+      color: widget.closeIconColor ?? snackBarTheme.closeIconColor ?? defaults.closeIconColor,
+      onPressed: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
+    )
         : null;
 
     // Calculate combined width of Action, Icon, and their padding, if they are present.
@@ -615,32 +629,32 @@ class _SnackBarState extends State<SnackBar> {
 
     Widget snackBar = Padding(
       padding: padding,
-        child: Wrap(
-          children: <Widget>[
-            Row(
-              children: <Widget>[
-                Expanded(
-                  child: Container(
-                    padding: widget.padding == null
-                        ? const EdgeInsets.symmetric(
-                            vertical: _singleLineVerticalPadding)
-                        : null,
-                    child: DefaultTextStyle(
-                      style: contentTextStyle!,
-                      child: widget.content,
-                    ),
+      child: Wrap(
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Container(
+                  padding: widget.padding == null
+                      ? const EdgeInsets.symmetric(
+                      vertical: _singleLineVerticalPadding)
+                      : null,
+                  child: DefaultTextStyle(
+                    style: contentTextStyle!,
+                    child: widget.content,
                   ),
                 ),
-                if(!actionLineOverflow) ...maybeActionAndIcon,
-                if(actionLineOverflow) SizedBox(width: snackBarWidth*0.4),
-              ],
-            ),
-            if(actionLineOverflow) Padding(
-              padding: const EdgeInsets.only(bottom: _singleLineVerticalPadding),
-              child: Row(mainAxisAlignment: MainAxisAlignment.end,
-              children: maybeActionAndIcon),
-            ),
-          ],
+              ),
+              if(!actionLineOverflow) ...maybeActionAndIcon,
+              if(actionLineOverflow) SizedBox(width: snackBarWidth*0.4),
+            ],
+          ),
+          if(actionLineOverflow) Padding(
+            padding: const EdgeInsets.only(bottom: _singleLineVerticalPadding),
+            child: Row(mainAxisAlignment: MainAxisAlignment.end,
+                children: maybeActionAndIcon),
+          ),
+        ],
 
       ),
     );
@@ -665,9 +679,9 @@ class _SnackBarState extends State<SnackBar> {
         child: accessibleNavigation || theme.useMaterial3
             ? snackBar
             : FadeTransition(
-                opacity: fadeOutAnimation,
-                child: snackBar,
-              ),
+          opacity: fadeOutAnimation,
+          child: snackBar,
+        ),
       ),
     );
 
@@ -717,7 +731,7 @@ class _SnackBarState extends State<SnackBar> {
         opacity: fadeInAnimation,
         child: snackBar,
       );
-     // Is Material 3 Floating Snack Bar.
+      // Is Material 3 Floating Snack Bar.
     } else if (isFloatingSnackBar && theme.useMaterial3) {
       snackBarTransition = FadeTransition(
         opacity: fadeInM3Animation,
@@ -775,9 +789,9 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 
   @override
   TextStyle? get contentTextStyle => ThemeData(
-          brightness: _theme.brightness == Brightness.light
-              ? Brightness.dark
-              : Brightness.light)
+      brightness: _theme.brightness == Brightness.light
+          ? Brightness.dark
+          : Brightness.light)
       .textTheme
       .titleMedium;
 
@@ -793,10 +807,10 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 
   @override
   ShapeBorder get shape => const RoundedRectangleBorder(
-        borderRadius: BorderRadius.all(
-          Radius.circular(4.0),
-        ),
-      );
+    borderRadius: BorderRadius.all(
+      Radius.circular(4.0),
+    ),
+  );
 
   @override
   EdgeInsets get insetPadding => const EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 10.0);
@@ -818,7 +832,7 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 // Token database version: v0_152
 
 class _SnackbarDefaultsM3 extends SnackBarThemeData {
-    _SnackbarDefaultsM3(this.context);
+  _SnackbarDefaultsM3(this.context);
 
   final BuildContext context;
   late final ThemeData _theme = Theme.of(context);
@@ -847,14 +861,14 @@ class _SnackbarDefaultsM3 extends SnackBarThemeData {
 
   @override
   Color get disabledActionTextColor =>
-    _colors.inversePrimary;
+      _colors.inversePrimary;
 
 
   @override
   TextStyle get contentTextStyle =>
-    Theme.of(context).textTheme.bodyMedium!.copyWith
-      (color:  _colors.onInverseSurface,
-    );
+      Theme.of(context).textTheme.bodyMedium!.copyWith
+        (color:  _colors.onInverseSurface,
+      );
 
   @override
   double get elevation => 6.0;

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -140,15 +140,6 @@ class _SnackBarActionState extends State<SnackBarAction> {
     final SnackBarThemeData snackBarTheme = Theme.of(context).snackBarTheme;
 
     MaterialStateColor resolveForegroundColor() {
-      if (widget.textColor is MaterialStateColor) {
-        return widget.textColor! as MaterialStateColor;
-      }
-      if (snackBarTheme.actionTextColor is MaterialStateColor) {
-        return snackBarTheme.actionTextColor! as MaterialStateColor;
-      }
-      if (defaults.actionTextColor is MaterialStateColor) {
-        return defaults.actionTextColor! as MaterialStateColor;
-      }
       return MaterialStateColor.resolveWith((Set<MaterialState> states) {
         if (states.contains(MaterialState.disabled)) {
           return widget.disabledTextColor ??

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -247,10 +247,10 @@ class SnackBar extends StatefulWidget {
     this.dismissDirection = DismissDirection.down,
     this.clipBehavior = Clip.hardEdge,
   }) : assert(elevation == null || elevation >= 0.0),
-        assert(
-        width == null || margin == null,
-        'Width and margin can not be used together',
-        );
+       assert(
+         width == null || margin == null,
+         'Width and margin can not be used together',
+       );
 
   /// The primary content of the snack bar.
   ///
@@ -505,22 +505,22 @@ class _SnackBarState extends State<SnackBar> {
     final ThemeData effectiveTheme = theme.useMaterial3
         ? theme
         : theme.copyWith(
-      colorScheme: ColorScheme(
-        primary: colorScheme.onPrimary,
-        primaryVariant: colorScheme.onPrimary,
-        secondary: buttonColor,
-        secondaryVariant: colorScheme.onSecondary,
-        surface: colorScheme.onSurface,
-        background: defaults.backgroundColor!,
-        error: colorScheme.onError,
-        onPrimary: colorScheme.primary,
-        onSecondary: colorScheme.secondary,
-        onSurface: colorScheme.surface,
-        onBackground: colorScheme.background,
-        onError: colorScheme.error,
-        brightness: brightness,
-      ),
-    );
+            colorScheme: ColorScheme(
+              primary: colorScheme.onPrimary,
+              primaryVariant: colorScheme.onPrimary,
+              secondary: buttonColor,
+              secondaryVariant: colorScheme.onSecondary,
+              surface: colorScheme.onSurface,
+              background: defaults.backgroundColor!,
+              error: colorScheme.onError,
+              onPrimary: colorScheme.primary,
+              onSecondary: colorScheme.secondary,
+              onSurface: colorScheme.surface,
+              onBackground: colorScheme.background,
+              onError: colorScheme.error,
+              brightness: brightness,
+            ),
+          );
 
     final TextStyle? contentTextStyle = snackBarTheme.contentTextStyle ?? defaults.contentTextStyle;
     final SnackBarBehavior snackBarBehavior = widget.behavior ?? snackBarTheme.behavior ?? defaults.behavior!;
@@ -578,11 +578,11 @@ class _SnackBarState extends State<SnackBar> {
 
     final IconButton? iconButton = showCloseIcon
         ? IconButton(
-      icon: const Icon(Icons.close),
-      iconSize: 24.0,
-      color: widget.closeIconColor ?? snackBarTheme.closeIconColor ?? defaults.closeIconColor,
-      onPressed: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
-    )
+            icon: const Icon(Icons.close),
+            iconSize: 24.0,
+            color: widget.closeIconColor ?? snackBarTheme.closeIconColor ?? defaults.closeIconColor,
+            onPressed: () => ScaffoldMessenger.of(context).hideCurrentSnackBar(reason: SnackBarClosedReason.dismiss),
+          )
         : null;
 
     // Calculate combined width of Action, Icon, and their padding, if they are present.
@@ -629,32 +629,32 @@ class _SnackBarState extends State<SnackBar> {
 
     Widget snackBar = Padding(
       padding: padding,
-      child: Wrap(
-        children: <Widget>[
-          Row(
-            children: <Widget>[
-              Expanded(
-                child: Container(
-                  padding: widget.padding == null
-                      ? const EdgeInsets.symmetric(
-                      vertical: _singleLineVerticalPadding)
-                      : null,
-                  child: DefaultTextStyle(
-                    style: contentTextStyle!,
-                    child: widget.content,
+        child: Wrap(
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Container(
+                    padding: widget.padding == null
+                        ? const EdgeInsets.symmetric(
+                            vertical: _singleLineVerticalPadding)
+                        : null,
+                    child: DefaultTextStyle(
+                      style: contentTextStyle!,
+                      child: widget.content,
+                    ),
                   ),
                 ),
-              ),
-              if(!actionLineOverflow) ...maybeActionAndIcon,
-              if(actionLineOverflow) SizedBox(width: snackBarWidth*0.4),
-            ],
-          ),
-          if(actionLineOverflow) Padding(
-            padding: const EdgeInsets.only(bottom: _singleLineVerticalPadding),
-            child: Row(mainAxisAlignment: MainAxisAlignment.end,
-                children: maybeActionAndIcon),
-          ),
-        ],
+                if(!actionLineOverflow) ...maybeActionAndIcon,
+                if(actionLineOverflow) SizedBox(width: snackBarWidth*0.4),
+              ],
+            ),
+            if(actionLineOverflow) Padding(
+              padding: const EdgeInsets.only(bottom: _singleLineVerticalPadding),
+              child: Row(mainAxisAlignment: MainAxisAlignment.end,
+              children: maybeActionAndIcon),
+            ),
+          ],
 
       ),
     );
@@ -679,9 +679,9 @@ class _SnackBarState extends State<SnackBar> {
         child: accessibleNavigation || theme.useMaterial3
             ? snackBar
             : FadeTransition(
-          opacity: fadeOutAnimation,
-          child: snackBar,
-        ),
+                opacity: fadeOutAnimation,
+                child: snackBar,
+              ),
       ),
     );
 
@@ -731,7 +731,7 @@ class _SnackBarState extends State<SnackBar> {
         opacity: fadeInAnimation,
         child: snackBar,
       );
-      // Is Material 3 Floating Snack Bar.
+     // Is Material 3 Floating Snack Bar.
     } else if (isFloatingSnackBar && theme.useMaterial3) {
       snackBarTransition = FadeTransition(
         opacity: fadeInM3Animation,
@@ -789,9 +789,9 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 
   @override
   TextStyle? get contentTextStyle => ThemeData(
-      brightness: _theme.brightness == Brightness.light
-          ? Brightness.dark
-          : Brightness.light)
+          brightness: _theme.brightness == Brightness.light
+              ? Brightness.dark
+              : Brightness.light)
       .textTheme
       .titleMedium;
 
@@ -807,10 +807,10 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 
   @override
   ShapeBorder get shape => const RoundedRectangleBorder(
-    borderRadius: BorderRadius.all(
-      Radius.circular(4.0),
-    ),
-  );
+        borderRadius: BorderRadius.all(
+          Radius.circular(4.0),
+        ),
+      );
 
   @override
   EdgeInsets get insetPadding => const EdgeInsets.fromLTRB(15.0, 5.0, 15.0, 10.0);
@@ -832,7 +832,7 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 // Token database version: v0_152
 
 class _SnackbarDefaultsM3 extends SnackBarThemeData {
-  _SnackbarDefaultsM3(this.context);
+    _SnackbarDefaultsM3(this.context);
 
   final BuildContext context;
   late final ThemeData _theme = Theme.of(context);
@@ -861,14 +861,14 @@ class _SnackbarDefaultsM3 extends SnackBarThemeData {
 
   @override
   Color get disabledActionTextColor =>
-      _colors.inversePrimary;
+    _colors.inversePrimary;
 
 
   @override
   TextStyle get contentTextStyle =>
-      Theme.of(context).textTheme.bodyMedium!.copyWith
-        (color:  _colors.onInverseSurface,
-      );
+    Theme.of(context).textTheme.bodyMedium!.copyWith
+      (color:  _colors.onInverseSurface,
+    );
 
   @override
   double get elevation => 6.0;

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -812,7 +812,7 @@ void main() {
     expect(snackBarBottomRight.dx, (800 + widgetWidth) / 2); // Device width is 800.
   });
 
-  testWidgets('Snackbar labels can be colored (M2 / MaterialColor)', (WidgetTester tester) async {
+  testWidgets('Snackbar labels can be colored as MaterialColor (Material 2)', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -856,7 +856,7 @@ void main() {
     }
   });
 
-  testWidgets('Snackbar labels can be colored (M3 / MaterialColor)',
+  testWidgets('Snackbar labels can be colored as MaterialColor (Material 3)',
       (WidgetTester tester) async {
     const MaterialColor usedColor = Colors.teal;
 
@@ -908,7 +908,7 @@ void main() {
     }
   });
 
-  testWidgets('Snackbar labels can be colored (M3 / MaterialStateColor)',
+  testWidgets('Snackbar labels can be colored as MaterialStateColor (Material 3)',
       (WidgetTester tester) async {
     const _TestMaterialStateColor usedColor = _TestMaterialStateColor();
 

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -812,7 +812,7 @@ void main() {
     expect(snackBarBottomRight.dx, (800 + widgetWidth) / 2); // Device width is 800.
   });
 
-  testWidgets('Snackbar labels can be colored', (WidgetTester tester) async {
+  testWidgets('Snackbar labels can be colored (M2 / MaterialColor)', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(
         home: Scaffold(
@@ -851,6 +851,110 @@ void main() {
     if (textWidget is Text) {
       final TextStyle effectiveStyle = defaultTextStyle.style.merge(textWidget.style);
       expect(effectiveStyle.color, Colors.lightBlue);
+    } else {
+      expect(false, true);
+    }
+  });
+
+  testWidgets('Snackbar labels can be colored (M3 / MaterialColor)',
+      (WidgetTester tester) async {
+    const MaterialColor usedColor = Colors.teal;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return GestureDetector(
+                onTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: const Text('I am a snack bar.'),
+                      duration: const Duration(seconds: 2),
+                      action: SnackBarAction(
+                        textColor: usedColor,
+                        label: 'ACTION',
+                        onPressed: () {},
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final Element actionTextButton =
+        tester.element(find.widgetWithText(TextButton, 'ACTION'));
+    final Widget textButton = actionTextButton.widget;
+    if (textButton is TextButton) {
+      final ButtonStyle buttonStyle = textButton.style!;
+      if (buttonStyle.foregroundColor is MaterialStateColor) {
+        // Same color when resolved
+        expect(buttonStyle.foregroundColor!.resolve(<MaterialState>{}), usedColor);
+      } else {
+        expect(false, true);
+      }
+    } else {
+      expect(false, true);
+    }
+  });
+
+  testWidgets('Snackbar labels can be colored (M3 / MaterialStateColor)',
+      (WidgetTester tester) async {
+    const _TestMaterialStateColor usedColor = _TestMaterialStateColor();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData(useMaterial3: true),
+        home: Scaffold(
+          body: Builder(
+            builder: (BuildContext context) {
+              return GestureDetector(
+                onTap: () {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: const Text('I am a snack bar.'),
+                      duration: const Duration(seconds: 2),
+                      action: SnackBarAction(
+                        textColor: usedColor,
+                        label: 'ACTION',
+                        onPressed: () {},
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('X'),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('X'));
+    await tester.pump(); // start animation
+    await tester.pump(const Duration(milliseconds: 750));
+
+    final Element actionTextButton =
+        tester.element(find.widgetWithText(TextButton, 'ACTION'));
+    final Widget textButton = actionTextButton.widget;
+    if (textButton is TextButton) {
+      final ButtonStyle buttonStyle = textButton.style!;
+      if (buttonStyle.foregroundColor is MaterialStateColor) {
+        // Exactly the same object
+        expect(buttonStyle.foregroundColor, usedColor);
+      } else {
+        expect(false, true);
+      }
     } else {
       expect(false, true);
     }
@@ -2587,4 +2691,20 @@ Map<DismissDirection, List<Offset>> _getDragGesturesOfDismissDirections(double s
   }
 
   return dragGestures;
+}
+
+class _TestMaterialStateColor extends MaterialStateColor {
+  const _TestMaterialStateColor() : super(_colorRed);
+
+  static const int _colorRed = 0xFFF44336;
+  static const int _colorBlue = 0xFF2196F3;
+
+  @override
+  Color resolve(Set<MaterialState> states) {
+    if (states.contains(MaterialState.pressed)) {
+      return const Color(_colorBlue);
+    }
+
+    return const Color(_colorRed);
+  }
 }


### PR DESCRIPTION
Removed multiple "if" for "resolveForegroundColor" method at "SnackBarAction". At least one of the multiple "if" ("defaults.actionTextColor is MaterialStateColor") led to not applying a custom set color (e.g. MaterialColor "Colors.red") for the action text when using Material 3.

The second "if" ("snackBarTheme.actionTextColor is MaterialStateColor") also makes no sense then as the set color of the Theme would lead to the same blocking behaviour of manual color assignment.

The last remaining "if" ("widget.textColor is MaterialStateColor") will be unnecessary if the other "if" will be removed, as it will be resolved in the code right afterwards.

The three "if" also seems to block the usage of the custom text color or the color at all if the widget is in the "MaterialState.disabled" state.

This PR resolves following issue:
* Fixes https://github.com/flutter/flutter/issues/120047