### PR TITLE
DraggableScrollableSheet - multiple scrollables

### DIFF
--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -827,12 +827,9 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
 
 class _SheetBallisticScrollActivity extends BallisticScrollActivity {
   _SheetBallisticScrollActivity(
-      _DraggableScrollableSheetScrollPosition scrollPosition,
-      Simulation simulation,
-      {required this.isScrolling})
-      : super(scrollPosition, simulation, scrollPosition.context.vsync, false);
-  @override
-  final bool isScrolling;
+    _DraggableScrollableSheetScrollPosition scrollPosition,
+    Simulation simulation,
+  ) : super(scrollPosition, simulation, scrollPosition.context.vsync, false);
 
   @override
   _DraggableScrollableSheetScrollPosition get delegate =>
@@ -980,35 +977,28 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
       return;
     }
 
+    final Simulation simulation;
     if (extent.snap) {
       // Snap is enabled, simulate snapping instead of clamping scroll.
-      final Simulation simulation = _SnappingSimulation(
+      simulation = _SnappingSimulation(
         position: extent.currentPixels,
         initialVelocity: velocity,
         pixelSnapSize: extent.pixelSnapSizes,
         snapAnimationDuration: extent.snapAnimationDuration,
         tolerance: physics.toleranceFor(this),
       );
-      beginActivity(_SheetBallisticScrollActivity(
-        this,
-        simulation,
-        isScrolling: velocity != 0,
-      ));
     } else {
       // The iOS bouncing simulation just isn't right here - once we delegate
       // the ballistic back to the ScrollView, it will use the right simulation.
-      final Simulation simulation = ClampingScrollSimulation(
+      simulation = ClampingScrollSimulation(
         // Run the simulation in terms of pixels, not extent.
         position: extent.currentPixels,
         velocity: velocity,
         tolerance: physics.toleranceFor(this),
       );
-      beginActivity(_SheetBallisticScrollActivity(
-        this,
-        simulation,
-        isScrolling: true,
-      ));
     }
+
+    beginActivity(_SheetBallisticScrollActivity(this, simulation));
   }
 }
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -918,8 +918,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
   _DraggableSheetExtent get extent => controller.extent;
 
   bool shouldScrollList(double direction) =>
-      pixels > 0.0 &&
-      (pixels < maxScrollExtent || direction < 0) ||
+      pixels > 0.0 && (pixels < maxScrollExtent || direction < 0) ||
       extent.isAtMin && direction < 0 ||
       extent.isAtMax && direction > 0;
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -680,25 +680,30 @@ class _DraggableScrollableSheetState extends State<DraggableScrollableSheet> {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<double>(
+    final Widget child = ValueListenableBuilder<double>(
       valueListenable: _extent._currentSize,
-      builder: (BuildContext context, double currentSize, Widget? child) => LayoutBuilder(
-        builder: (BuildContext context, BoxConstraints constraints) {
-          _extent.availablePixels = widget.maxChildSize * constraints.biggest.height;
-
-          for (final _DraggableScrollableSheetScrollPosition position in _scrollController.positions) {
-            position.applyNewOuterDimensions(isLayout: true);
-          }
-
-          final Widget sheet = FractionallySizedBox(
-            heightFactor: currentSize,
-            alignment: Alignment.bottomCenter,
-            child: child,
-          );
-          return widget.expand ? SizedBox.expand(child: sheet) : sheet;
-        },
-      ),
+      builder: (BuildContext context, double currentSize, Widget? child) =>
+        FractionallySizedBox(
+          heightFactor: currentSize,
+          alignment: Alignment.bottomCenter,
+          child: child,
+        ),
       child: widget.builder(context, _scrollController),
+    );
+
+    final Widget wrappedChild = widget.expand ?
+      SizedBox.expand(child: child) : child;
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        _extent.availablePixels = widget.maxChildSize * constraints.biggest.height;
+
+        for (final _DraggableScrollableSheetScrollPosition position in _scrollController.positions) {
+          position.applyNewOuterDimensions(isLayout: true);
+        }
+
+        return wrappedChild;
+      },
     );
   }
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -835,6 +835,13 @@ class _SheetBallisticScrollActivity extends BallisticScrollActivity {
   _DraggableScrollableSheetScrollPosition get delegate =>
       super.delegate as _DraggableScrollableSheetScrollPosition;
 
+  /// The relative velocity of the inner content during the ballistic scrolling
+  /// of the outer sheet is always effectively 0. This allows the scroll physics
+  /// to maintain the inner extent within its bounds while the sheet size
+  /// changes.
+  @override
+  double get velocity => 0.0;
+
   @override
   void applyNewDimensions() {
     // This is expected to happen continuously while scrolling the outer sheet.
@@ -846,6 +853,7 @@ class _SheetBallisticScrollActivity extends BallisticScrollActivity {
     extent.updateSize(
         extent.pixelsToSize(value), delegate.context.notificationContext!);
 
+    final double velocity = super.velocity;
     if ((velocity < 0.0 && extent.isAtMin) ||
         (velocity > 0.0 && extent.isAtMax)) {
       // Make sure we pass along enough velocity to keep scrolling - otherwise

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -933,6 +933,7 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
     // extent.activePositionCount as if the activity were ours.
     if (other.activity!.isScrolling) {
       ++extent.activePositionCount;
+      _isActive = true;
       // The symmetric -- case is handled in dispose.
     }
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -844,10 +843,6 @@ class _SheetBallisticScrollActivity extends BallisticScrollActivity {
     Simulation simulation,
   ) : super(scrollPosition, simulation, scrollPosition.context.vsync, false);
 
-  @override
-  _DraggableScrollableSheetScrollPosition get delegate =>
-      super.delegate as _DraggableScrollableSheetScrollPosition;
-
   /// The relative velocity of the inner content during the ballistic scrolling
   /// of the outer sheet is always effectively 0. This allows the scroll physics
   /// to maintain the inner extent within its bounds while the sheet size
@@ -861,13 +856,7 @@ class _SheetBallisticScrollActivity extends BallisticScrollActivity {
 
   @override
   void resetActivity() {
-    // This actually happens before the delegate is updated, so we have to
-    // do our reset in a microtask.
-    //
-    // This may have been a regression introduced long ago.
-    scheduleMicrotask(() {
-      super.delegate.goBallistic(outerVelocity);
-    });
+    super.delegate.goBallistic(outerVelocity);
   }
 
   @override
@@ -882,6 +871,7 @@ class _SheetBallisticScrollActivity extends BallisticScrollActivity {
 
   @override
   bool applyMoveTo(double value){
+    final _DraggableScrollableSheetScrollPosition delegate = this.delegate as _DraggableScrollableSheetScrollPosition;
     final _DraggableSheetExtent extent = delegate.extent;
     extent.updateSize(
         extent.pixelsToSize(value), delegate.context.notificationContext!);

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -1001,7 +1001,13 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
       );
     }
 
-    beginActivity(_SheetBallisticScrollActivity(this, simulation));
+    final ScrollActivity outerActivity = _SheetBallisticScrollActivity(this, simulation);
+    extent.startActivity(onCanceled: () {
+      if (activity == outerActivity) {
+        goIdle();
+      }
+    });
+    beginActivity(outerActivity);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
+++ b/packages/flutter/lib/src/widgets/draggable_scrollable_sheet.dart
@@ -485,7 +485,6 @@ class _DraggableSheetExtent {
     ValueNotifier<double>? currentSize,
     bool? hasDragged,
     bool? hasChanged,
-    this.activePositionCount = 0,
   })  : assert(minSize >= 0),
         assert(maxSize <= 1),
         assert(minSize <= initialSize),
@@ -519,8 +518,6 @@ class _DraggableSheetExtent {
   //      sheet has not changed, either by drag or programmatic control. See
   //      docs for `initialChildSize`.
   bool hasChanged;
-
-  int activePositionCount;
 
   bool get isAtMin => minSize >= _currentSize.value;
   bool get isAtMax => maxSize <= _currentSize.value;
@@ -614,7 +611,6 @@ class _DraggableSheetExtent {
           : initialSize),
       hasDragged: hasDragged,
       hasChanged: hasChanged,
-      activePositionCount: activePositionCount,
     );
   }
 }
@@ -795,7 +791,7 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
       physics: const AlwaysScrollableScrollPhysics().applyTo(physics),
       context: context,
       oldPosition: oldPosition,
-      getExtent: () => extent,
+      controller: this,
     );
   }
 
@@ -835,6 +831,9 @@ class _DraggableScrollableSheetScrollController extends ScrollController {
     onPositionDetached?.call();
     super.detach(position);
   }
+
+  bool get isIdle => positions.every(
+    (_DraggableScrollableSheetScrollPosition position) => position.isIdle);
 }
 
 class _SheetBallisticScrollActivity extends BallisticScrollActivity {
@@ -906,38 +905,17 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
     required super.physics,
     required super.context,
     super.oldPosition,
-    required this.getExtent,
+    required this.controller,
   });
 
-  final _DraggableSheetExtent Function() getExtent;
+  final _DraggableScrollableSheetScrollController controller;
 
-  bool _isActive = false;
+  /// Whether this scroll position is idle. This differs from
+  /// [isScrollingNotifier] in that it considers [HoldScrollActivity] to be
+  /// active for the purposes of preventing snaps.
+  bool get isIdle => activity is IdleScrollActivity;
 
-  _DraggableSheetExtent get extent => getExtent();
-
-  @override
-  void absorb(ScrollPosition other) {
-    // super.absorb will adopt other.activity, but may also immediately reset it
-    // (if other was of a different runtimeType) or goIdle (if other was not a
-    // ScrollPositionWithSingleContext). We need to prepare for this by updating
-    // extent.activePositionCount as if the activity were ours.
-    if (other.activity!.isScrolling) {
-      ++extent.activePositionCount;
-      _isActive = true;
-      // The symmetric -- case is handled in dispose.
-    }
-
-    super.absorb(other);
-  }
-
-  @override
-  void dispose() {
-    if (_isActive) {
-      --extent.activePositionCount;
-      assert(extent.activePositionCount >= 0);
-    }
-    super.dispose();
-  }
+  _DraggableSheetExtent get extent => controller.extent;
 
   bool shouldScrollList(double direction) =>
       pixels > 0.0 &&
@@ -966,42 +944,8 @@ class _DraggableScrollableSheetScrollPosition extends ScrollPositionWithSingleCo
       extent.hasDragged &&
       !_isAtSnapSize &&
       // Only allow `goBallistic(0)` to snap if there are no active positions on
-      // the extent or if this position itself is active.
-      (extent.activePositionCount == 0 || _isActive);
-
-  @override
-  void beginActivity(ScrollActivity? newActivity) {
-    super.beginActivity(newActivity);
-    if (newActivity == null) {
-      return;
-    }
-
-    // It's debatable whether HoldScrollActivity should be considered active. In
-    // principle, hold should probably prevent snapping. However, this comes at
-    // the expense of instead gating on `is IdleScrollActivity` or introducing a
-    // separate notion of activity, and in practice there are additional
-    // complexities since we allow ongoing scrolling activities to trigger snaps
-    // in order to transfer velocity.
-    //
-    // TODO(AsturaPhoenix): There are several related outstanding edge cases:
-    // * Hold arrests a snap but then snaps to the nearest snap position when
-    //   drag begins.
-    // * More conflicts between ballistic activities (not just snaps) between
-    //   multiple controllers.
-    if (newActivity.isScrolling != _isActive) {
-      // Store this in a field rather than using a getter derived from the
-      // activity to handle the absorb + dispose case, where the only
-      // notification we get that we've been absorbed is the dispose call, by
-      // which point our activity is null.
-      _isActive = newActivity.isScrolling;
-      if (_isActive) {
-        ++extent.activePositionCount;
-      } else {
-        --extent.activePositionCount;
-        assert(extent.activePositionCount >= 0);
-      }
-    }
-  }
+      // the controller or if this position itself is active.
+      (controller.isIdle || !isIdle);
 
   /// Re-evaluates scroll physics for updated max dimensions or snap positions.
   ///

--- a/packages/flutter/lib/src/widgets/nested_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/nested_scroll_view.dart
@@ -1206,8 +1206,8 @@ class _NestedScrollPosition extends ScrollPosition implements ScrollActivityDele
 
   @override
   void absorb(ScrollPosition other) {
+    other.activity!.updateDelegate(this);
     super.absorb(other);
-    activity!.updateDelegate(this);
   }
 
   @override

--- a/packages/flutter/lib/src/widgets/scroll_activity.dart
+++ b/packages/flutter/lib/src/widgets/scroll_activity.dart
@@ -72,11 +72,10 @@ abstract class ScrollActivity {
     _delegate = value;
   }
 
-  /// Called by the [ScrollActivityDelegate] when it has changed type (for
-  /// example, when changing from an Android-style scroll position to an
-  /// iOS-style scroll position). If this activity can differ between the two
-  /// modes, then it should tell the position to restart that activity
-  /// appropriately.
+  /// Called by the [ScrollPosition] when it has changed type (for example, when
+  /// changing from an Android-style scroll position to an iOS-style scroll
+  /// position). If this activity can differ between the two modes, then it
+  /// should tell the position to restart that activity appropriately.
   ///
   /// For example, [BallisticScrollActivity]'s implementation calls
   /// [ScrollActivityDelegate.goBallistic].

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -205,8 +205,8 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   /// Overrides of this method must call `super.absorb` after setting any
   /// metrics-related or activity-related state, since this method may restart
   /// the activity and scroll activities tend to use those metrics when being
-  /// restarted. This includes updating the delegates of absorbed scroll
-  /// activities if they use themselves as a [ScrollActivityDelegate].
+  /// restarted. This includes updating the delegate of an absorbed scroll
+  /// activity if they use themselves as a [ScrollActivityDelegate].
   ///
   /// Overrides of this method might need to start an [IdleScrollActivity] if
   /// they are unable to absorb the activity from the other [ScrollPosition].

--- a/packages/flutter/lib/src/widgets/scroll_position.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position.dart
@@ -205,14 +205,11 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
   /// Overrides of this method must call `super.absorb` after setting any
   /// metrics-related or activity-related state, since this method may restart
   /// the activity and scroll activities tend to use those metrics when being
-  /// restarted.
+  /// restarted. This includes updating the delegates of absorbed scroll
+  /// activities if they use themselves as a [ScrollActivityDelegate].
   ///
   /// Overrides of this method might need to start an [IdleScrollActivity] if
   /// they are unable to absorb the activity from the other [ScrollPosition].
-  ///
-  /// Overrides of this method might also need to update the delegates of
-  /// absorbed scroll activities if they use themselves as a
-  /// [ScrollActivityDelegate].
   @protected
   @mustCallSuper
   void absorb(ScrollPosition other) {
@@ -234,6 +231,11 @@ abstract class ScrollPosition extends ViewportOffset with ScrollMetrics {
     _activity = other.activity;
     other._activity = null;
     if (other.runtimeType != runtimeType) {
+      // The common case of other is ScrollPositionWithSingleContext implements
+      // ScrollActivityDelegate.
+      // ignore: unrelated_type_equality_checks
+      assert(activity!.delegate != other, 'Activity absorbed with stale '
+        'delegate. Call other.activity!.updateDelegate before super.absorb.');
       activity!.resetActivity();
     }
     context.setIgnorePointer(activity!.shouldIgnorePointer);

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -80,12 +80,12 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
 
   @override
   void absorb(ScrollPosition other) {
+    other.activity!.updateDelegate(this);
     super.absorb(other);
     if (other is! ScrollPositionWithSingleContext) {
       goIdle();
       return;
     }
-    activity!.updateDelegate(this);
     _userScrollDirection = other._userScrollDirection;
     assert(_currentDrag == null);
     if (other._currentDrag != null) {

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1198,27 +1198,35 @@ void main() {
 
     await tester.drag(find.text('Item 1'), Offset(0, .1 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.4, precisionErrorTolerance)]);
     loggedSizes.clear();
 
     await tester.timedDrag(find.text('Item 1'), Offset(0, -.1 * screenHeight), const Duration(seconds: 1), frequency: 2);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.45, .5].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[
+      closeTo(.45, precisionErrorTolerance),
+      closeTo(.5, precisionErrorTolerance),
+    ]);
     loggedSizes.clear();
 
     controller.jumpTo(.6);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.6].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.6, precisionErrorTolerance)]);
     loggedSizes.clear();
 
     controller.animateTo(1, duration: const Duration(milliseconds: 400), curve: Curves.linear);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.7, .8, .9, 1].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[
+      closeTo(.7, precisionErrorTolerance),
+      closeTo(.8, precisionErrorTolerance),
+      closeTo(.9, precisionErrorTolerance),
+      closeTo(1.0, precisionErrorTolerance),
+    ]);
     loggedSizes.clear();
 
     DraggableScrollableActuator.reset(tester.element(find.byKey(containerKey)));
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.5].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.5, precisionErrorTolerance)]);
     loggedSizes.clear();
   });
 
@@ -1242,7 +1250,7 @@ void main() {
 
     await tester.drag(find.text('Item 1'), Offset(0, .1 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.4, precisionErrorTolerance)]);
     loggedSizes.clear();
 
     // Update a parameter without forcing a change in the current size.
@@ -1256,7 +1264,7 @@ void main() {
 
     await tester.drag(find.text('Item 1'), Offset(0, .1 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.3].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.3, precisionErrorTolerance)]);
     loggedSizes.clear();
   });
 
@@ -1286,13 +1294,13 @@ void main() {
       stackKey: stackKey,
       containerKey: containerKey,
     ));
-    expect(loggedSizes, const <double>[.6].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.6, precisionErrorTolerance)]);
     loggedSizes.clear();
 
     // Move away from initial child size.
     await tester.drag(find.text('Item 1'), Offset(0, .3 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, const <double>[.3].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.3, precisionErrorTolerance)]);
     loggedSizes.clear();
 
     // Set a `minChildSize` greater than the current size.
@@ -1302,7 +1310,7 @@ void main() {
       stackKey: stackKey,
       containerKey: containerKey,
     ));
-    expect(loggedSizes, const <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, <Matcher>[closeTo(.4, precisionErrorTolerance)]);
     loggedSizes.clear();
   });
 

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -7,7 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  Widget boilerplateWidget(VoidCallback? onButtonPressed, {
+  Widget boilerplateWidget({
+    VoidCallback? onButtonPressed,
     DraggableScrollableController? controller,
     int itemCount = 100,
     double initialChildSize = .5,
@@ -116,7 +117,6 @@ void main() {
   testWidgets('Scrolls correct amount when maxChildSize < 1.0', (WidgetTester tester) async {
     const Key key = ValueKey<String>('container');
     await tester.pumpWidget(boilerplateWidget(
-      null,
       maxChildSize: .6,
       initialChildSize: .25,
       itemExtent: 25.0,
@@ -132,7 +132,6 @@ void main() {
   testWidgets('Scrolls correct amount when maxChildSize == 1.0', (WidgetTester tester) async {
     const Key key = ValueKey<String>('container');
     await tester.pumpWidget(boilerplateWidget(
-      null,
       initialChildSize: .25,
       itemExtent: 25.0,
       containerKey: key,
@@ -146,29 +145,22 @@ void main() {
 
   testWidgets('Invalid snap targets throw assertion errors.', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplateWidget(
-      null,
       maxChildSize: .8,
-      snapSizes: <double>[.9],
+      snapSizes: const <double>[.9],
     ));
     expect(tester.takeException(), isAssertionError);
 
-    await tester.pumpWidget(boilerplateWidget(
-      null,
-      snapSizes: <double>[.1],
-    ));
+    await tester.pumpWidget(boilerplateWidget(snapSizes: const <double>[.1]));
     expect(tester.takeException(), isAssertionError);
 
-    await tester.pumpWidget(boilerplateWidget(
-      null,
-      snapSizes: <double>[.6, .6, .9],
-    ));
+    await tester.pumpWidget(boilerplateWidget(snapSizes: const <double>[.6, .6, .9]));
     expect(tester.takeException(), isAssertionError);
   });
 
   group('Scroll Physics', () {
     testWidgets('Can be dragged up without covering its container', (WidgetTester tester) async {
       int taps = 0;
-      await tester.pumpWidget(boilerplateWidget(() => taps++));
+      await tester.pumpWidget(boilerplateWidget(onButtonPressed: () => taps++));
 
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'));
@@ -188,7 +180,7 @@ void main() {
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('Can be dragged down when not full height', (WidgetTester tester) async {
-      await tester.pumpWidget(boilerplateWidget(null));
+      await tester.pumpWidget(boilerplateWidget());
       expect(find.text('Item 1'), findsOneWidget);
       expect(find.text('Item 21'), findsOneWidget);
       expect(find.text('Item 36'), findsNothing);
@@ -201,7 +193,7 @@ void main() {
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('Can be dragged down when list is shorter than full height', (WidgetTester tester) async {
-      await tester.pumpWidget(boilerplateWidget(null, itemCount: 30, initialChildSize: .25));
+      await tester.pumpWidget(boilerplateWidget(itemCount: 30, initialChildSize: .25));
 
       expect(find.text('Item 1').hitTestable(), findsOneWidget);
       expect(find.text('Item 29').hitTestable(), findsNothing);
@@ -219,7 +211,7 @@ void main() {
 
     testWidgets('Can be dragged up and cover its container and scroll in single motion, and then dragged back down', (WidgetTester tester) async {
       int taps = 0;
-      await tester.pumpWidget(boilerplateWidget(() => taps++));
+      await tester.pumpWidget(boilerplateWidget(onButtonPressed: () => taps++));
 
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'));
@@ -248,7 +240,7 @@ void main() {
 
     testWidgets('Can be flung up gently', (WidgetTester tester) async {
       int taps = 0;
-      await tester.pumpWidget(boilerplateWidget(() => taps++));
+      await tester.pumpWidget(boilerplateWidget(onButtonPressed: () => taps++));
 
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'));
@@ -271,7 +263,7 @@ void main() {
 
     testWidgets('Can be flung up', (WidgetTester tester) async {
       int taps = 0;
-      await tester.pumpWidget(boilerplateWidget(() => taps++));
+      await tester.pumpWidget(boilerplateWidget(onButtonPressed: () => taps++));
 
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'));
@@ -296,7 +288,7 @@ void main() {
     }, variant: TargetPlatformVariant.all());
 
     testWidgets('Can be flung down when not full height', (WidgetTester tester) async {
-      await tester.pumpWidget(boilerplateWidget(null));
+      await tester.pumpWidget(boilerplateWidget());
       expect(find.text('Item 1'), findsOneWidget);
       expect(find.text('Item 21'), findsOneWidget);
       expect(find.text('Item 36'), findsNothing);
@@ -310,7 +302,7 @@ void main() {
 
     testWidgets('Can be flung up and then back down', (WidgetTester tester) async {
       int taps = 0;
-      await tester.pumpWidget(boilerplateWidget(() => taps++));
+      await tester.pumpWidget(boilerplateWidget(onButtonPressed: () => taps++));
 
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'));
@@ -354,7 +346,7 @@ void main() {
 
     testWidgets('Ballistic animation on fling can be interrupted', (WidgetTester tester) async {
       int taps = 0;
-      await tester.pumpWidget(boilerplateWidget(() => taps++));
+      await tester.pumpWidget(boilerplateWidget(onButtonPressed: () => taps++));
 
       expect(find.text('TapHere'), findsOneWidget);
       await tester.tap(find.text('TapHere'));
@@ -444,7 +436,7 @@ void main() {
   testWidgets('Does not snap away from initial child on build', (WidgetTester tester) async {
     const Key containerKey = ValueKey<String>('container');
     const Key stackKey = ValueKey<String>('stack');
-    await tester.pumpWidget(boilerplateWidget(null,
+    await tester.pumpWidget(boilerplateWidget(
       snap: true,
       initialChildSize: .7,
       containerKey: containerKey,
@@ -460,13 +452,12 @@ void main() {
     ));
   }, variant: TargetPlatformVariant.all());
 
-  for (final bool useActuator in <bool>[false, true]) {
+  for (final bool useActuator in const <bool>[false, true]) {
     testWidgets('Does not snap away from initial child on ${useActuator ? 'actuator' : 'controller'}.reset()', (WidgetTester tester) async {
       const Key containerKey = ValueKey<String>('container');
       const Key stackKey = ValueKey<String>('stack');
       final DraggableScrollableController controller = DraggableScrollableController();
       await tester.pumpWidget(boilerplateWidget(
-        null,
         controller: controller,
         snap: true,
         containerKey: containerKey,
@@ -504,11 +495,11 @@ void main() {
       (WidgetTester tester) async {
       const Key stackKey = ValueKey<String>('stack');
       const Key containerKey = ValueKey<String>('container');
-      await tester.pumpWidget(boilerplateWidget(null,
+      await tester.pumpWidget(boilerplateWidget(
         snap: true,
         stackKey: stackKey,
         containerKey: containerKey,
-        snapSizes: <double>[.25, .5, .75, 1.0],
+        snapSizes: const <double>[.25, .5, .75, 1.0],
         snapAnimationDuration: snapAnimationDuration
       ));
       await tester.pumpAndSettle();
@@ -556,11 +547,11 @@ void main() {
     }, variant: TargetPlatformVariant.all());
   }
 
-  for (final List<double>? snapSizes in <List<double>?>[null, <double>[]]) {
+  for (final List<double>? snapSizes in const <List<double>?>[null, <double>[]]) {
     testWidgets('Setting snapSizes to $snapSizes resolves to min and max', (WidgetTester tester) async {
       const Key stackKey = ValueKey<String>('stack');
       const Key containerKey = ValueKey<String>('container');
-      await tester.pumpWidget(boilerplateWidget(null,
+      await tester.pumpWidget(boilerplateWidget(
         snap: true,
         stackKey: stackKey,
         containerKey: containerKey,
@@ -588,11 +579,11 @@ void main() {
   testWidgets('Min and max are implicitly added to snapSizes', (WidgetTester tester) async {
     const Key stackKey = ValueKey<String>('stack');
     const Key containerKey = ValueKey<String>('container');
-    await tester.pumpWidget(boilerplateWidget(null,
+    await tester.pumpWidget(boilerplateWidget(
       snap: true,
       stackKey: stackKey,
       containerKey: containerKey,
-      snapSizes: <double>[.5],
+      snapSizes: const <double>[.5],
     ));
     await tester.pumpAndSettle();
     final double screenHeight = tester.getSize(find.byKey(stackKey)).height;
@@ -616,7 +607,6 @@ void main() {
     const Key stackKey = ValueKey<String>('stack');
     const Key containerKey = ValueKey<String>('container');
     await tester.pumpWidget(boilerplateWidget(
-      null,
       stackKey: stackKey,
       containerKey: containerKey,
     ));
@@ -629,7 +619,6 @@ void main() {
 
     // Pump the same widget but with a new initial child size.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       stackKey: stackKey,
       containerKey: containerKey,
       initialChildSize: .6,
@@ -644,7 +633,6 @@ void main() {
 
     // Pump the same widget but with a new max child size.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       stackKey: stackKey,
       containerKey: containerKey,
       initialChildSize: .6,
@@ -666,7 +654,6 @@ void main() {
 
     // Pump the same widget but with a new max child size and initial size.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       stackKey: stackKey,
       containerKey: containerKey,
       maxChildSize: .8,
@@ -686,12 +673,11 @@ void main() {
 
     // Pump the same widget but with snapping enabled.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       snap: true,
       stackKey: stackKey,
       containerKey: containerKey,
       maxChildSize: .8,
-      snapSizes: <double>[.5],
+      snapSizes: const <double>[.5],
     ));
     await tester.pumpAndSettle();
 
@@ -701,16 +687,13 @@ void main() {
       closeTo(.5, precisionErrorTolerance),
     );
 
-    final List<double> snapSizes = <double>[.6];
-
     // Change the snap sizes.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       snap: true,
       stackKey: stackKey,
       containerKey: containerKey,
       maxChildSize: .8,
-      snapSizes: snapSizes,
+      snapSizes: const <double>[.6],
     ));
     await tester.pumpAndSettle();
 
@@ -723,11 +706,11 @@ void main() {
   testWidgets('Fling snaps in direction of momentum', (WidgetTester tester) async {
     const Key stackKey = ValueKey<String>('stack');
     const Key containerKey = ValueKey<String>('container');
-    await tester.pumpWidget(boilerplateWidget(null,
+    await tester.pumpWidget(boilerplateWidget(
       snap: true,
       stackKey: stackKey,
       containerKey: containerKey,
-      snapSizes: <double>[.5, .75],
+      snapSizes: const <double>[.5, .75],
     ));
     await tester.pumpAndSettle();
     final double screenHeight = tester.getSize(find.byKey(stackKey)).height;
@@ -750,16 +733,12 @@ void main() {
 
   testWidgets("Changing parameters with an un-listened controller doesn't throw", (WidgetTester tester) async {
     await tester.pumpWidget(boilerplateWidget(
-      null,
       snap: true,
       // Will prevent the sheet's child from listening to the controller.
       ignoreController: true,
     ));
     await tester.pumpAndSettle();
-    await tester.pumpWidget(boilerplateWidget(
-      null,
-      snap: true,
-    ));
+    await tester.pumpWidget(boilerplateWidget(snap: true));
     await tester.pumpAndSettle();
   }, variant: TargetPlatformVariant.all());
 
@@ -823,7 +802,6 @@ void main() {
   testWidgets('ScrollNotification correctly dispatched when flung without covering its container', (WidgetTester tester) async {
     final List<Type> notificationTypes = <Type>[];
     await tester.pumpWidget(boilerplateWidget(
-      null,
       onScrollNotification: (ScrollNotification notification) {
         notificationTypes.add(notification.runtimeType);
         return false;
@@ -844,7 +822,6 @@ void main() {
   testWidgets('ScrollNotification correctly dispatched when flung with contents scroll', (WidgetTester tester) async {
     final List<Type> notificationTypes = <Type>[];
     await tester.pumpWidget(boilerplateWidget(
-      null,
       onScrollNotification: (ScrollNotification notification) {
         notificationTypes.add(notification.runtimeType);
         return false;
@@ -867,28 +844,21 @@ void main() {
   testWidgets('Do not crash when remove the tree during animation.', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/89214
     await tester.pumpWidget(boilerplateWidget(
-      null,
-      onScrollNotification: (ScrollNotification notification) {
-        return false;
-      },
-    ));
-
+      onScrollNotification: (ScrollNotification notification) => false));
     await tester.flingFrom(const Offset(0, 325), const Offset(0, 325), 200);
 
     // The animation is running.
 
     await tester.pumpWidget(const SizedBox.shrink());
-
     expect(tester.takeException(), isNull);
   });
 
-  for (final bool shouldAnimate in <bool>[true, false]) {
+  for (final bool shouldAnimate in const <bool>[true, false]) {
     testWidgets('Can ${shouldAnimate ? 'animate' : 'jump'} to arbitrary positions', (WidgetTester tester) async {
       const Key stackKey = ValueKey<String>('stack');
       const Key containerKey = ValueKey<String>('container');
       final DraggableScrollableController controller = DraggableScrollableController();
       await tester.pumpWidget(boilerplateWidget(
-        null,
         controller: controller,
         stackKey: stackKey,
         containerKey: containerKey,
@@ -963,7 +933,6 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1010,7 +979,6 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();
     await tester.pumpWidget(boilerplateWidget(
-      null,
       initialChildSize: 0.25,
       controller: controller,
       stackKey: stackKey,
@@ -1033,7 +1001,6 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1042,7 +1009,6 @@ void main() {
 
     // Pump a new sheet with the same controller. This will dispose of the old sheet first.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1065,7 +1031,6 @@ void main() {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: boilerplateWidget(
-        null,
         controller: controller,
         stackKey: stackKey,
         containerKey: containerKey,
@@ -1101,7 +1066,6 @@ void main() {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: boilerplateWidget(
-        null,
         controller: controller,
         stackKey: stackKey,
         containerKey: containerKey,
@@ -1134,7 +1098,6 @@ void main() {
     await tester.pumpWidget(Directionality(
       textDirection: TextDirection.ltr,
       child: boilerplateWidget(
-        null,
         controller: controller,
         stackKey: stackKey,
         containerKey: containerKey,
@@ -1174,7 +1137,6 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1205,14 +1167,8 @@ void main() {
       textDirection: TextDirection.ltr,
       child: Stack(
         children: <Widget>[
-          boilerplateWidget(
-            null,
-            controller: controller,
-          ),
-          boilerplateWidget(
-            null,
-            controller: controller,
-          ),
+          boilerplateWidget(controller: controller),
+          boilerplateWidget(controller: controller),
         ],
       ),
     ), null, EnginePhase.build);
@@ -1228,7 +1184,6 @@ void main() {
       loggedSizes.add(controller.size);
     });
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1243,27 +1198,27 @@ void main() {
 
     await tester.drag(find.text('Item 1'), Offset(0, .1 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     await tester.timedDrag(find.text('Item 1'), Offset(0, -.1 * screenHeight), const Duration(seconds: 1), frequency: 2);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.45, .5].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.45, .5].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     controller.jumpTo(.6);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.6].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.6].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     controller.animateTo(1, duration: const Duration(milliseconds: 400), curve: Curves.linear);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.7, .8, .9, 1].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.7, .8, .9, 1].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     DraggableScrollableActuator.reset(tester.element(find.byKey(containerKey)));
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.5].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.5].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
   });
 
@@ -1272,11 +1227,8 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final List<double> loggedSizes = <double>[];
     final DraggableScrollableController controller = DraggableScrollableController();
-    controller.addListener(() {
-      loggedSizes.add(controller.size);
-    });
+    controller.addListener(() => loggedSizes.add(controller.size));
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1290,12 +1242,11 @@ void main() {
 
     await tester.drag(find.text('Item 1'), Offset(0, .1 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     // Update a parameter without forcing a change in the current size.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       minChildSize: .1,
       controller: controller,
       stackKey: stackKey,
@@ -1305,7 +1256,7 @@ void main() {
 
     await tester.drag(find.text('Item 1'), Offset(0, .1 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.3].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.3].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
   });
 
@@ -1314,11 +1265,8 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final List<double> loggedSizes = <double>[];
     final DraggableScrollableController controller = DraggableScrollableController();
-    controller.addListener(() {
-      loggedSizes.add(controller.size);
-    });
+    controller.addListener(() => loggedSizes.add(controller.size));
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1333,30 +1281,28 @@ void main() {
     // Set a new `initialChildSize` which will trigger a size change because we
     // haven't moved away initial size yet.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       initialChildSize: .6,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
     ));
-    expect(loggedSizes, <double>[.6].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.6].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     // Move away from initial child size.
     await tester.drag(find.text('Item 1'), Offset(0, .3 * screenHeight), touchSlopY: 0);
     await tester.pumpAndSettle();
-    expect(loggedSizes, <double>[.3].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.3].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
 
     // Set a `minChildSize` greater than the current size.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       minChildSize: .4,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
     ));
-    expect(loggedSizes, <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
+    expect(loggedSizes, const <double>[.4].map((double v) => closeTo(v, precisionErrorTolerance)));
     loggedSizes.clear();
   });
 
@@ -1370,11 +1316,7 @@ void main() {
     expect(() => controller.pixelsToSize(0), throwsAssertionError);
     expect(() => controller.sizeToPixels(0), throwsAssertionError);
 
-    await tester.pumpWidget(boilerplateWidget(
-      null,
-      controller: controller,
-    ));
-
+    await tester.pumpWidget(boilerplateWidget(controller: controller));
 
     // Can't jump or animate to invalid sizes.
     expect(() => controller.jumpTo(-1), throwsAssertionError);
@@ -1397,29 +1339,28 @@ void main() {
     expect(controller.isAttached, false);
     expect(()=>controller.size, throwsAssertionError);
     final Widget boilerplate = boilerplateWidget(
-        null,
-        minChildSize: 0.4,
-        controller: controller,
-      );
+      minChildSize: 0.4,
+      controller: controller,
+    );
     await tester.pumpWidget(boilerplate);
     expect(controller.isAttached, true);
     expect(controller.size, isNotNull);
-    });
+  });
 
-    testWidgets('DraggableScrollableController.animateTo should not leak Ticker', (WidgetTester tester) async {
-      // Regression test for https://github.com/flutter/flutter/issues/102483
-      final DraggableScrollableController controller = DraggableScrollableController();
-      await tester.pumpWidget(boilerplateWidget(() {}, controller: controller));
+  testWidgets('DraggableScrollableController.animateTo should not leak Ticker', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/102483
+    final DraggableScrollableController controller = DraggableScrollableController();
+    await tester.pumpWidget(boilerplateWidget(controller: controller));
 
-      controller.animateTo(0.0, curve: Curves.linear, duration: const Duration(milliseconds: 200));
-      await tester.pump();
+    controller.animateTo(0.0, curve: Curves.linear, duration: const Duration(milliseconds: 200));
+    await tester.pump();
 
-      // Dispose the DraggableScrollableSheet
-      await tester.pumpWidget(const SizedBox.shrink());
-      // Controller should be detached and no exception should be thrown
-      expect(controller.isAttached, false);
-      expect(tester.takeException(), isNull);
-    });
+    // Dispose the DraggableScrollableSheet
+    await tester.pumpWidget(const SizedBox.shrink());
+    // Controller should be detached and no exception should be thrown
+    expect(controller.isAttached, false);
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets('DraggableScrollableSheet should not reset programmatic drag on rebuild', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/101114
@@ -1427,7 +1368,6 @@ void main() {
     const Key containerKey = ValueKey<String>('container');
     final DraggableScrollableController controller = DraggableScrollableController();
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1444,7 +1384,6 @@ void main() {
 
     // Force an arbitrary rebuild by pushing a new widget.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,
@@ -1475,7 +1414,6 @@ void main() {
 
     // Force an arbitrary rebuild by pushing a new widget.
     await tester.pumpWidget(boilerplateWidget(
-      null,
       controller: controller,
       stackKey: stackKey,
       containerKey: containerKey,

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -435,8 +435,12 @@ void main() {
     });
 
     group('While content is scrolled and sheet is snapped somewhere other than min/max', () {
-      Widget buildWidget([ScrollController? innerControllerOverride]) =>
+      Widget buildWidget({
+        DraggableScrollableController? controller,
+        ScrollController? innerControllerOverride,
+      }) =>
         boilerplateWidget(
+          controller: controller,
           snap: true,
           snapSizes: const <double>[0.5],
           innerControllerOverride: innerControllerOverride,
@@ -445,7 +449,7 @@ void main() {
       testWidgets('Can be flung up', (WidgetTester tester) async {
         // Set the initial scroll position.
         await tester.pumpWidget(buildWidget(
-          ScrollController(initialScrollOffset: 500.0)));
+          innerControllerOverride: ScrollController(initialScrollOffset: 500.0)));
         // Rebuild with the DraggableScrollableSheet scroll controller to
         // connect the scrollables.
         await tester.pumpWidget(buildWidget());
@@ -459,7 +463,7 @@ void main() {
       testWidgets('Can be flung down', (WidgetTester tester) async {
         // Set the initial scroll position.
         await tester.pumpWidget(buildWidget(
-          ScrollController(initialScrollOffset: 500.0)));
+          innerControllerOverride: ScrollController(initialScrollOffset: 500.0)));
         // Rebuild with the DraggableScrollableSheet scroll controller to
         // connect the scrollables.
         await tester.pumpWidget(buildWidget());
@@ -468,6 +472,25 @@ void main() {
         final double oldOffset = innerController.offset;
         await tester.pumpAndSettle();
         expect(innerController.offset, lessThan(oldOffset));
+      }, variant: TargetPlatformVariant.all());
+
+      testWidgets('While content is scrolled to end can be flung up', (WidgetTester tester) async {
+        final DraggableScrollableController outerController = DraggableScrollableController();
+        await tester.pumpWidget(buildWidget(
+          controller: outerController,
+          innerControllerOverride: ScrollController(),
+        ));
+        innerController.jumpTo(innerController.position.maxScrollExtent);
+        // Rebuild with the DraggableScrollableSheet scroll controller to
+        // connect the scrollables.
+        await tester.pumpWidget(buildWidget(controller: outerController));
+
+        await tester.fling(find.byType(ListView), const Offset(0, -100), 1000);
+        // TODO(AsturaPhoenix): This should really be in exclusive range
+        // (0.5, 1.0) and will be fixed in a later commit.
+        expect(outerController.size, 0.5);
+        await tester.pumpAndSettle();
+        expect(outerController.size, 1.0);
       }, variant: TargetPlatformVariant.all());
     });
   });

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -429,7 +429,6 @@ void main() {
       await tester.pumpWidget(const SizedBox.shrink());
 
       // When a Ticker leaks an exception is thrown
-      expect(tester.takeException(), isNull);
     });
   });
 
@@ -843,14 +842,12 @@ void main() {
 
   testWidgets('Do not crash when remove the tree during animation.', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/89214
-    await tester.pumpWidget(boilerplateWidget(
-      onScrollNotification: (ScrollNotification notification) => false));
-    await tester.flingFrom(const Offset(0, 325), const Offset(0, 325), 200);
+    await tester.pumpWidget(boilerplateWidget());
+    await tester.fling(find.text('Item 1'), const Offset(0, -100), 1000);
 
     // The animation is running.
 
-    await tester.pumpWidget(const SizedBox.shrink());
-    expect(tester.takeException(), isNull);
+    await tester.pumpWidget(const SizedBox());
   });
 
   for (final bool shouldAnimate in const <bool>[true, false]) {
@@ -1367,7 +1364,6 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
     // Controller should be detached and no exception should be thrown
     expect(controller.isAttached, false);
-    expect(tester.takeException(), isNull);
   });
 
   testWidgets('DraggableScrollableSheet should not reset programmatic drag on rebuild', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1989,20 +1989,6 @@ void main() {
     ));
 
     await tester.pumpAndSettle();
-
-    // TODO(AsturaPhoenix): Since dispose happens in a microtask after absorb
-    // right now, the interrupted animation may not snap to a snap point. Update
-    // layout dimensions to make sure we're not stuck.
-    //
-    // A user interaction would also unstick us, but that could happen even if
-    // we're holding onto a stale extent lock since we allow scrolling scroll
-    // activities to trigger snaps regardless.
-    //
-    // Ideally, the snap should complete without any changes.
-    tester.binding.window.physicalSizeTestValue = tester.binding.window.physicalSize + const Offset(0, 1);
-    addTearDown(tester.binding.window.clearPhysicalSizeTestValue);
-    await tester.pumpAndSettle();
-
     expect(outerController.size, 1.0);
   });
 }

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -486,9 +486,7 @@ void main() {
         await tester.pumpWidget(buildWidget(controller: outerController));
 
         await tester.fling(find.byType(ListView), const Offset(0, -100), 1000);
-        // TODO(AsturaPhoenix): This should really be in exclusive range
-        // (0.5, 1.0) and will be fixed in a later commit.
-        expect(outerController.size, 0.5);
+        expect(outerController.size, inExclusiveRange(0.5, 1.0));
         await tester.pumpAndSettle();
         expect(outerController.size, 1.0);
       }, variant: TargetPlatformVariant.all());

--- a/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
+++ b/packages/flutter/test/widgets/draggable_scrollable_sheet_test.dart
@@ -1833,4 +1833,49 @@ void main() {
       }
     }, variant: TargetPlatformVariant.all());
   });
+
+  testWidgets('Scrollable can be wrapped in a DraggableScrollableSheet while animating', (WidgetTester tester) async {
+    final Key innerKey = GlobalKey();
+
+    Widget buildScrollable({ScrollController? controller}) {
+      return SingleChildScrollView(
+        key: innerKey,
+        controller: controller,
+        child: const SizedBox(height: 100000),
+      );
+    }
+
+    final ScrollController animator = ScrollController();
+    await tester.pumpWidget(buildScrollable(controller: animator));
+    animator.animateTo(50000, duration: const Duration(seconds: 1), curve: Curves.easeInOut);
+
+    await tester.pumpWidget(DraggableScrollableSheet(
+      builder: (BuildContext context, ScrollController controller) {
+        return buildScrollable(controller: controller);
+      },
+    ));
+
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('Scrollable can be unwrapped from a DraggableScrollableSheet while the sheet is ballistic', (WidgetTester tester) async {
+    final Key innerKey = GlobalKey();
+
+    Widget buildScrollable({ScrollController? controller}) {
+      return SingleChildScrollView(
+        key: innerKey,
+        controller: controller,
+        child: const SizedBox(height: 100000),
+      );
+    }
+
+    await tester.pumpWidget(DraggableScrollableSheet(
+      builder: (BuildContext context, ScrollController controller) {
+        return buildScrollable(controller: controller);
+      },
+    ));
+    await tester.fling(find.byKey(innerKey), const Offset(0, -200), 2000);
+    await tester.pumpWidget(buildScrollable());
+    await tester.pumpAndSettle();
+  });
 }


### PR DESCRIPTION
Allow multiple scroll positions for DraggableScrollableSheet. These were not explicitly disallowed, but their snap animations would conflict with one another.

* Only allow a scroll position to start a snap if it was actively scrolling or if none of the other scroll positions is actively scrolling.
  - If it was actively scrolling: snap at the end of a drag/hold.
  - If none of the other scroll positions is actively scrolling: snap when dimensions changed or snap changed.
  - Otherwise: do not start a conflicting snap.
* Make snap an actual scrolling activity (actuated by the DraggableScrollableSheet extent rather than the default scroll context).
  - Snap counts as an active scroll to prevent conflicting snaps.
  - Cancelled snaps properly update internal state (e.g. cancelling holds).
  - Somewhat deduplicates code, though there are subtle changes in behavior.

This allows DraggableScrollableSheet to be used with multiple scrollable children without needing NestedScrollView, though as with NestedScrollView, children wishing to render a scroll bar need to wrap their scroll positions in a dedicated ScrollController.

**Issues:**
Fixes #119966

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
