### PR TITLE
[flutter_tools] Skip over "Resolving dependencies..." text in integration tests

### DIFF
--- a/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/flutter_adapter_test.dart
@@ -67,7 +67,7 @@ void main() {
         'Application finished.',
         '',
         startsWith('Exited'),
-      ], allowExtras: true);
+      ]);
     });
 
     testWithoutContext('logs to client when sendLogsToClient=true', () async {
@@ -131,7 +131,7 @@ void main() {
         'Application finished.',
         '',
         startsWith('Exited'),
-      ], allowExtras: true);
+      ]);
 
       // If we're running with an out-of-process debug adapter, ensure that its
       // own process shuts down after we terminated.

--- a/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
+++ b/packages/flutter_tools/test/integration.shard/debug_adapter/test_client.dart
@@ -354,12 +354,18 @@ extension DapTestClientExtension on DapTestClient {
 
     final List<OutputEventBody> output = await outputEventsFuture;
 
-    // TODO(dantup): Integration tests currently trigger "flutter pub get" at
-    //   the start due to some timestamp manipulation writing the pubspec.
-    //   It may be possible to remove this if
-    //   https://github.com/flutter/flutter/pull/91300 lands.
+    // Integration tests may trigger "flutter pub get" at the start based of
+    // `pubspec/yaml` and `.dart_tool/package_config.json`.
+    // See
+    //  https://github.com/flutter/flutter/pull/91300
+    //  https://github.com/flutter/flutter/issues/120015
     return skipInitialPubGetOutput
-        ? output.skipWhile((OutputEventBody output) => output.output.startsWith('Running "flutter pub get"')).toList()
+        ? output
+            .skipWhile((OutputEventBody output) =>
+                output.output.startsWith('Running "flutter pub get"') ||
+                output.output.startsWith('Resolving dependencies') ||
+                output.output.startsWith('Got dependencies'))
+            .toList()
         : output;
   }
 


### PR DESCRIPTION
Sometimes when the integration tests run Flutter apps they get this output (perhaps based on timing of file modification times). Some of the tests want to verify strict output but not fail just based on these lines before the app starts, so this change skips over that output (and reverts the change from #120016 to make the tests a little more strict).

See https://github.com/flutter/flutter/issues/120015 / https://github.com/flutter/flutter/pull/120016.



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
