### PR TITLE
Re-land "Fix unable to find bundled Java version"

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,3 +101,4 @@ Junhua Lin <1075209054@qq.com>
 Tomasz Gucio <tgucio@gmail.com>
 Jason C.H <ctrysbita@outlook.com>
 Hubert Jóźwiak <hjozwiakdx@gmail.com>
+Eli Albert <crasowas@gmail.com>

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -441,11 +441,22 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       return;
     }
 
-    final String javaPath = globals.platform.isMacOS ?
-        version != null && version.major < 2020 ?
-        globals.fs.path.join(directory, 'jre', 'jdk', 'Contents', 'Home') :
-        globals.fs.path.join(directory, 'jre', 'Contents', 'Home') :
-        globals.fs.path.join(directory, 'jre');
+    final String javaPath;
+    if (globals.platform.isMacOS) {
+      if (version != null && version.major < 2020) {
+        javaPath = globals.fs.path.join(directory, 'jre', 'jdk', 'Contents', 'Home');
+      } else if (version != null && version.major == 2022) {
+        javaPath = globals.fs.path.join(directory, 'jbr', 'Contents', 'Home');
+      } else {
+        javaPath = globals.fs.path.join(directory, 'jre', 'Contents', 'Home');
+      }
+    } else {
+      if (version != null && version.major == 2022) {
+        javaPath = globals.fs.path.join(directory, 'jbr');
+      } else {
+        javaPath = globals.fs.path.join(directory, 'jre');
+      }
+    }
     final String javaExecutable = globals.fs.path.join(javaPath, 'bin', 'java');
     if (!globals.processManager.canRun(javaExecutable)) {
       _validationMessages.add('Unable to find bundled Java version.');


### PR DESCRIPTION
Reverts flutter/flutter#119981

Re-land of https://github.com/flutter/flutter/pull/119244

Fixes https://github.com/flutter/flutter/issues/106674

This was reverted because of a flake in Mac web_tool_tests, however, even after the revert this flake persists: https://ci.chromium.org/p/flutter/builders/prod/Mac%20web_tool_tests/10455