### PR TITLE
Remove unreachable_from_main linter rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -222,7 +222,6 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
-    - unreachable_from_main
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -222,8 +222,7 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
-    # Do not enable this rule until it is un-marked as "experimental" and carefully re-evaulated.
-    # - unreachable_from_main
+    # - unreachable_from_main # Do not enable this rule until it is un-marked as "experimental" and carefully re-evaulated.
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -222,6 +222,8 @@ linter:
     - unnecessary_string_interpolations
     - unnecessary_this
     - unnecessary_to_list_in_spreads
+    # Do not enable this rule until it is un-marked as "experimental" and carefully re-evaulated.
+    # - unreachable_from_main
     - unrelated_type_equality_checks
     - unsafe_html
     - use_build_context_synchronously


### PR DESCRIPTION
Flutter repo is using an experimental lint rule, `unreachable_from_main`. It should not. This rule is unstable, and the diagnostics it reports can change. Using this rule in the flutter repository prevents us from iterating on the rule. It is not complete yet.

Fixes https://github.com/flutter/flutter/issues/120109

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
