### PR TITLE
Add trackOutlineColor for Switch and SwitchListTile

### DIFF
--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -353,7 +353,7 @@ class Switch extends StatelessWidget {
   /// Switch(
   ///   value: true,
   ///   onChanged: (_) => true,
-  ///   thumbOutlineColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+  ///   trackOutlineColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
   ///     if (states.contains(MaterialState.disabled)) {
   ///       return Colors.orange.withOpacity(.48);
   ///     }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -105,6 +105,7 @@ class Switch extends StatelessWidget {
     this.onInactiveThumbImageError,
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.thumbIcon,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -151,6 +152,7 @@ class Switch extends StatelessWidget {
     this.materialTapTargetSize,
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.thumbIcon,
     this.dragStartBehavior = DragStartBehavior.start,
     this.mouseCursor,
@@ -332,6 +334,40 @@ class Switch extends StatelessWidget {
   /// | Selected | [activeColor] with alpha `0x80` | [activeColor] with alpha `0x80` |
   /// | Disabled | `Colors.black12`                | `Colors.white10`                |
   final MaterialStateProperty<Color?>? trackColor;
+
+  /// {@template flutter.material.switch.trackOutlineColor}
+  /// The outline color of this [Switch]'s track.
+  ///
+  /// Resolved in the following states:
+  ///  * [MaterialState.selected].
+  ///  * [MaterialState.hovered].
+  ///  * [MaterialState.focused].
+  ///  * [MaterialState.disabled].
+  ///
+  /// {@tool snippet}
+  /// This example resolves the [trackOutlineColor] based on the current
+  /// [MaterialState] of the [Switch], providing a different [Color] when it is
+  /// [MaterialState.disabled].
+  ///
+  /// ```dart
+  /// Switch(
+  ///   value: true,
+  ///   onChanged: (_) => true,
+  ///   thumbOutlineColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+  ///     if (states.contains(MaterialState.disabled)) {
+  ///       return Colors.orange.withOpacity(.48);
+  ///     }
+  ///     return Colors.orange;
+  ///   }),
+  /// )
+  /// ```
+  /// {@end-tool}
+  /// {@endtemplate}
+  ///
+  /// In Material 3, the outline color defaults to transparent in the selected
+  /// state and [ColorScheme.outline] in the unselected state. In Material 2,
+  /// the [Switch] track has no outline by default.
+  final MaterialStateProperty<Color?>? trackOutlineColor;
 
   /// {@template flutter.material.switch.thumbIcon}
   /// The icon to use on the thumb of this switch
@@ -519,6 +555,7 @@ class Switch extends StatelessWidget {
       onInactiveThumbImageError: onInactiveThumbImageError,
       thumbColor: thumbColor,
       trackColor: trackColor,
+      trackOutlineColor: trackOutlineColor,
       thumbIcon: thumbIcon,
       materialTapTargetSize: materialTapTargetSize,
       dragStartBehavior: dragStartBehavior,
@@ -578,6 +615,7 @@ class _MaterialSwitch extends StatefulWidget {
     this.onInactiveThumbImageError,
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.thumbIcon,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -604,6 +642,7 @@ class _MaterialSwitch extends StatefulWidget {
   final ImageErrorListener? onInactiveThumbImageError;
   final MaterialStateProperty<Color?>? thumbColor;
   final MaterialStateProperty<Color?>? trackColor;
+  final MaterialStateProperty<Color?>? trackOutlineColor;
   final MaterialStateProperty<Icon?>? thumbIcon;
   final MaterialTapTargetSize? materialTapTargetSize;
   final DragStartBehavior dragStartBehavior;
@@ -765,11 +804,17 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
       ?? switchTheme.trackColor?.resolve(activeStates)
       ?? _widgetThumbColor.resolve(activeStates)?.withAlpha(0x80)
       ?? defaults.trackColor!.resolve(activeStates)!;
+    final Color effectiveActiveTrackOutlineColor = widget.trackOutlineColor?.resolve(activeStates)
+      ?? switchTheme.trackOutlineColor?.resolve(activeStates)
+      ?? Colors.transparent;
+
     final Color effectiveInactiveTrackColor = widget.trackColor?.resolve(inactiveStates)
       ?? _widgetTrackColor.resolve(inactiveStates)
       ?? switchTheme.trackColor?.resolve(inactiveStates)
       ?? defaults.trackColor!.resolve(inactiveStates)!;
-    final Color? effectiveInactiveTrackOutlineColor = switchConfig.trackOutlineColor?.resolve(inactiveStates);
+    final Color? effectiveInactiveTrackOutlineColor = widget.trackOutlineColor?.resolve(inactiveStates)
+      ?? switchTheme.trackOutlineColor?.resolve(inactiveStates)
+      ?? defaults.trackOutlineColor?.resolve(inactiveStates);
 
     final Icon? effectiveActiveIcon = widget.thumbIcon?.resolve(activeStates)
       ?? switchTheme.thumbIcon?.resolve(activeStates);
@@ -858,6 +903,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
             ..inactiveThumbImage = widget.inactiveThumbImage
             ..onInactiveThumbImageError = widget.onInactiveThumbImageError
             ..activeTrackColor = effectiveActiveTrackColor
+            ..activeTrackOutlineColor = effectiveActiveTrackOutlineColor
             ..inactiveTrackColor = effectiveInactiveTrackColor
             ..inactiveTrackOutlineColor = effectiveInactiveTrackOutlineColor
             ..configuration = createLocalImageConfiguration(context)
@@ -1089,6 +1135,16 @@ class _SwitchPainter extends ToggleablePainter {
     notifyListeners();
   }
 
+  Color? get activeTrackOutlineColor => _activeTrackOutlineColor;
+  Color? _activeTrackOutlineColor;
+  set activeTrackOutlineColor(Color? value) {
+    if (value == _activeTrackOutlineColor) {
+      return;
+    }
+    _activeTrackOutlineColor = value;
+    notifyListeners();
+  }
+
   Color? get inactiveTrackOutlineColor => _inactiveTrackOutlineColor;
   Color? _inactiveTrackOutlineColor;
   set inactiveTrackOutlineColor(Color? value) {
@@ -1297,7 +1353,7 @@ class _SwitchPainter extends ToggleablePainter {
     final double colorValue = CurvedAnimation(parent: positionController, curve: Curves.easeOut, reverseCurve: Curves.easeIn).value;
     final Color trackColor = Color.lerp(inactiveTrackColor, activeTrackColor, colorValue)!;
     final Color? trackOutlineColor = inactiveTrackOutlineColor == null ? null
-        : Color.lerp(inactiveTrackOutlineColor, Colors.transparent, colorValue);
+        : Color.lerp(inactiveTrackOutlineColor, activeTrackOutlineColor, colorValue);
     Color lerpedThumbColor;
     if (!reaction.isDismissed) {
       lerpedThumbColor = Color.lerp(inactivePressedColor, activePressedColor, colorValue)!;
@@ -1493,7 +1549,6 @@ mixin _SwitchConfig {
   double get pressedThumbRadius;
   double get thumbRadiusWithIcon;
   List<BoxShadow>? get thumbShadow;
-  MaterialStateProperty<Color?>? get trackOutlineColor;
   MaterialStateProperty<Color> get iconColor;
   double? get thumbOffset;
   Size get transitionalThumbSize;
@@ -1533,9 +1588,6 @@ class _SwitchConfigM2 with _SwitchConfig {
 
   @override
   double get trackHeight => 14.0;
-
-  @override
-  MaterialStateProperty<Color?>? get trackOutlineColor => null;
 
   @override
   double get trackWidth => 33.0;
@@ -1589,6 +1641,9 @@ class _SwitchDefaultsM2 extends SwitchThemeData {
       return isDark ? Colors.white30 : black32;
     });
   }
+
+  @override
+  MaterialStateProperty<Color?>? get trackOutlineColor => null;
 
   @override
   MaterialTapTargetSize get materialTapTargetSize => _theme.materialTapTargetSize;
@@ -1701,6 +1756,19 @@ class _SwitchDefaultsM3 extends SwitchThemeData {
   }
 
   @override
+  MaterialStateProperty<Color?> get trackOutlineColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return Colors.transparent;
+      }
+      if (states.contains(MaterialState.disabled)) {
+        return _colors.onSurface.withOpacity(0.12);
+      }
+      return _colors.outline;
+    });
+  }
+
+  @override
   MaterialStateProperty<Color?> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.selected)) {
@@ -1801,19 +1869,6 @@ class _SwitchConfigM3 with _SwitchConfig {
 
   @override
   double get trackHeight => 32.0;
-
-  @override
-  MaterialStateProperty<Color?> get trackOutlineColor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return null;
-      }
-      if (states.contains(MaterialState.disabled)) {
-        return _colors.onSurface.withOpacity(0.12);
-      }
-      return _colors.outline;
-    });
-  }
 
   @override
   double get trackWidth => 52.0;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -357,7 +357,7 @@ class Switch extends StatelessWidget {
   ///     if (states.contains(MaterialState.disabled)) {
   ///       return Colors.orange.withOpacity(.48);
   ///     }
-  ///     return Colors.orange;
+  ///     return null; // Use the default color.
   ///   }),
   /// )
   /// ```

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -353,7 +353,7 @@ class Switch extends StatelessWidget {
   /// Switch(
   ///   value: true,
   ///   onChanged: (_) => true,
-  ///   trackOutlineColor: MaterialStateProperty.resolveWith<Color>((Set<MaterialState> states) {
+  ///   trackOutlineColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
   ///     if (states.contains(MaterialState.disabled)) {
   ///       return Colors.orange.withOpacity(.48);
   ///     }

--- a/packages/flutter/lib/src/material/switch_list_tile.dart
+++ b/packages/flutter/lib/src/material/switch_list_tile.dart
@@ -186,6 +186,7 @@ class SwitchListTile extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.hoverColor,
+    this.trackOutlineColor,
   }) : _switchListTileType = _SwitchListTileType.material,
        assert(!isThreeLine || subtitle != null);
 
@@ -228,6 +229,7 @@ class SwitchListTile extends StatelessWidget {
     this.onFocusChange,
     this.enableFeedback,
     this.hoverColor,
+    this.trackOutlineColor,
   }) : _switchListTileType = _SwitchListTileType.adaptive,
        assert(!isThreeLine || subtitle != null);
 
@@ -382,6 +384,16 @@ class SwitchListTile extends StatelessWidget {
   /// The color for the tile's [Material] when a pointer is hovering over it.
   final Color? hoverColor;
 
+  /// {@macro flutter.material.switch.trackOutlineColor}
+  ///
+  /// The [ListTile] will be focused when this [SwitchListTile] requests focus,
+  /// so the focused outline color of the switch will be ignored.
+  ///
+  /// In Material 3, the outline color defaults to transparent in the selected
+  /// state and [ColorScheme.outline] in the unselected state. In Material 2,
+  /// the [Switch] track has no outline.
+  final MaterialStateProperty<Color?>? trackOutlineColor;
+
   @override
   Widget build(BuildContext context) {
     final Widget control;
@@ -399,6 +411,7 @@ class SwitchListTile extends StatelessWidget {
           inactiveThumbColor: inactiveThumbColor,
           autofocus: autofocus,
           onFocusChange: onFocusChange,
+          trackOutlineColor: trackOutlineColor,
         );
         break;
 
@@ -415,6 +428,7 @@ class SwitchListTile extends StatelessWidget {
           inactiveThumbColor: inactiveThumbColor,
           autofocus: autofocus,
           onFocusChange: onFocusChange,
+          trackOutlineColor: trackOutlineColor,
         );
     }
 

--- a/packages/flutter/lib/src/material/switch_theme.dart
+++ b/packages/flutter/lib/src/material/switch_theme.dart
@@ -39,6 +39,7 @@ class SwitchThemeData with Diagnosticable {
   const SwitchThemeData({
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.materialTapTargetSize,
     this.mouseCursor,
     this.overlayColor,
@@ -55,6 +56,11 @@ class SwitchThemeData with Diagnosticable {
   ///
   /// If specified, overrides the default value of [Switch.trackColor].
   final MaterialStateProperty<Color?>? trackColor;
+
+  /// {@macro flutter.material.switch.trackOutlineColor}
+  ///
+  /// If specified, overrides the default value of [Switch.trackOutlineColor].
+  final MaterialStateProperty<Color?>? trackOutlineColor;
 
   /// {@macro flutter.material.switch.materialTapTargetSize}
   ///
@@ -87,6 +93,7 @@ class SwitchThemeData with Diagnosticable {
   SwitchThemeData copyWith({
     MaterialStateProperty<Color?>? thumbColor,
     MaterialStateProperty<Color?>? trackColor,
+    MaterialStateProperty<Color?>? trackOutlineColor,
     MaterialTapTargetSize? materialTapTargetSize,
     MaterialStateProperty<MouseCursor?>? mouseCursor,
     MaterialStateProperty<Color?>? overlayColor,
@@ -96,6 +103,7 @@ class SwitchThemeData with Diagnosticable {
     return SwitchThemeData(
       thumbColor: thumbColor ?? this.thumbColor,
       trackColor: trackColor ?? this.trackColor,
+      trackOutlineColor: trackOutlineColor ?? this.trackOutlineColor,
       materialTapTargetSize: materialTapTargetSize ?? this.materialTapTargetSize,
       mouseCursor: mouseCursor ?? this.mouseCursor,
       overlayColor: overlayColor ?? this.overlayColor,
@@ -111,6 +119,7 @@ class SwitchThemeData with Diagnosticable {
     return SwitchThemeData(
       thumbColor: MaterialStateProperty.lerp<Color?>(a?.thumbColor, b?.thumbColor, t, Color.lerp),
       trackColor: MaterialStateProperty.lerp<Color?>(a?.trackColor, b?.trackColor, t, Color.lerp),
+      trackOutlineColor: MaterialStateProperty.lerp<Color?>(a?.trackOutlineColor, b?.trackOutlineColor, t, Color.lerp),
       materialTapTargetSize: t < 0.5 ? a?.materialTapTargetSize : b?.materialTapTargetSize,
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
       overlayColor: MaterialStateProperty.lerp<Color?>(a?.overlayColor, b?.overlayColor, t, Color.lerp),
@@ -123,6 +132,7 @@ class SwitchThemeData with Diagnosticable {
   int get hashCode => Object.hash(
     thumbColor,
     trackColor,
+    trackOutlineColor,
     materialTapTargetSize,
     mouseCursor,
     overlayColor,
@@ -141,6 +151,7 @@ class SwitchThemeData with Diagnosticable {
     return other is SwitchThemeData
       && other.thumbColor == thumbColor
       && other.trackColor == trackColor
+      && other.trackOutlineColor == trackOutlineColor
       && other.materialTapTargetSize == materialTapTargetSize
       && other.mouseCursor == mouseCursor
       && other.overlayColor == overlayColor
@@ -153,6 +164,7 @@ class SwitchThemeData with Diagnosticable {
     super.debugFillProperties(properties);
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('thumbColor', thumbColor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('trackColor', trackColor, defaultValue: null));
+    properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('trackOutlineColor', trackOutlineColor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialTapTargetSize>('materialTapTargetSize', materialTapTargetSize, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<MouseCursor?>>('mouseCursor', mouseCursor, defaultValue: null));
     properties.add(DiagnosticsProperty<MaterialStateProperty<Color?>>('overlayColor', overlayColor, defaultValue: null));

--- a/packages/flutter/test/material/switch_test.dart
+++ b/packages/flutter/test/material/switch_test.dart
@@ -405,20 +405,16 @@ void main() {
 
   testWidgets('Switch has default colors when disabled', (WidgetTester tester) async {
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return const Material(
-              child: Center(
-                child: Switch(
-                  value: false,
-                  onChanged: null,
-                ),
-              ),
-            );
-          },
-        ),
+        child: Material(
+          child: Center(
+            child: Switch(
+              value: false,
+              onChanged: null,
+            ),
+          ),
+        )
       ),
     );
 
@@ -437,19 +433,15 @@ void main() {
     );
 
     await tester.pumpWidget(
-      Directionality(
+      const Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return const Material(
-              child: Center(
-                child: Switch(
-                  value: true,
-                  onChanged: null,
-                ),
-              ),
-            );
-          },
+        child: Material(
+          child: Center(
+            child: Switch(
+              value: true,
+              onChanged: null,
+            ),
+          ),
         ),
       ),
     );
@@ -891,15 +883,13 @@ void main() {
         theme: theme,
         home: Material(
           child: Center(
-            child: StatefulBuilder(builder: (BuildContext context, StateSetter setState) {
-              return Switch(
-                value: true,
-                onChanged: (bool newValue) {},
-                focusColor: Colors.orange[500],
-                autofocus: true,
-                splashRadius: splashRadius,
-              );
-            }),
+            child: Switch(
+              value: true,
+              onChanged: (bool newValue) {},
+              focusColor: Colors.orange[500],
+              autofocus: true,
+              splashRadius: splashRadius,
+            ),
           ),
         ),
       );
@@ -1204,18 +1194,14 @@ void main() {
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Material(
-              child: Center(
-                child: Switch(
-                  thumbColor: thumbColor,
-                  value: active,
-                  onChanged: enabled ? (_) { } : null,
-                ),
-              ),
-            );
-          },
+        child: Material(
+          child: Center(
+            child: Switch(
+              thumbColor: thumbColor,
+              value: active,
+              onChanged: enabled ? (_) { } : null,
+            ),
+          ),
         ),
       );
     }
@@ -1310,20 +1296,16 @@ void main() {
     Widget buildSwitch() {
       return Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Material(
-              child: Center(
-                child: Switch(
-                  focusNode: focusNode,
-                  autofocus: true,
-                  value: true,
-                  thumbColor: thumbColor,
-                  onChanged: (_) { },
-                ),
-              ),
-            );
-          },
+        child: Material(
+          child: Center(
+            child: Switch(
+              focusNode: focusNode,
+              autofocus: true,
+              value: true,
+              thumbColor: thumbColor,
+              onChanged: (_) { },
+            ),
+          ),
         ),
       );
     }
@@ -1393,18 +1375,14 @@ void main() {
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Material(
-              child: Center(
-                child: Switch(
-                  trackColor: trackColor,
-                  value: active,
-                  onChanged: enabled ? (_) { } : null,
-                ),
-              ),
-            );
-          },
+        child: Material(
+          child: Center(
+            child: Switch(
+              trackColor: trackColor,
+              value: active,
+              onChanged: enabled ? (_) { } : null,
+            ),
+          ),
         ),
       );
     }
@@ -1483,20 +1461,16 @@ void main() {
     Widget buildSwitch() {
       return Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Material(
-              child: Center(
-                child: Switch(
-                  focusNode: focusNode,
-                  autofocus: true,
-                  value: true,
-                  trackColor: trackColor,
-                  onChanged: (_) { },
-                ),
-              ),
-            );
-          },
+        child: Material(
+          child: Center(
+            child: Switch(
+              focusNode: focusNode,
+              autofocus: true,
+              value: true,
+              trackColor: trackColor,
+              onChanged: (_) { },
+            ),
+          ),
         ),
       );
     }
@@ -1548,21 +1522,17 @@ void main() {
     Widget buildSwitch({required bool enabled, required bool active}) {
       return Directionality(
         textDirection: TextDirection.rtl,
-        child: StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return Theme(
-              data: theme,
-              child: Material(
-                child: Center(
-                  child: Switch(
-                    thumbColor: thumbColor,
-                    value: active,
-                    onChanged: enabled ? (_) { } : null,
-                  ),
-                ),
+        child: Theme(
+          data: theme,
+          child: Material(
+            child: Center(
+              child: Switch(
+                thumbColor: thumbColor,
+                value: active,
+                onChanged: enabled ? (_) { } : null,
               ),
-            );
-          },
+            ),
+          ),
         ),
       );
     }
@@ -2140,19 +2110,15 @@ void main() {
 
       await tester.pumpWidget(MaterialApp(
         theme: themeData,
-        home: Directionality(
+        home: const Directionality(
           textDirection: TextDirection.rtl,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return const Material(
-                child: Center(
-                  child: Switch(
-                    value: false,
-                    onChanged: null,
-                  ),
-                ),
-              );
-            },
+          child: Material(
+            child: Center(
+              child: Switch(
+                value: false,
+                onChanged: null,
+              ),
+            ),
           ),
         ),
       ));
@@ -2183,19 +2149,15 @@ void main() {
       final ColorScheme colors = themeData.colorScheme;
       await tester.pumpWidget(MaterialApp(
         theme: themeData,
-        home: Directionality(
+        home: const Directionality(
           textDirection: TextDirection.rtl,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return const Material(
-                child: Center(
-                  child: Switch(
-                    value: true,
-                    onChanged: null,
-                  ),
-                ),
-              );
-            },
+          child: Material(
+            child: Center(
+              child: Switch(
+                value: true,
+                onChanged: null,
+              ),
+            ),
           ),
         ),
       ));
@@ -2550,18 +2512,14 @@ void main() {
           data: themeData,
           child: Directionality(
             textDirection: TextDirection.rtl,
-            child: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return Material(
-                  child: Center(
-                    child: Switch(
-                      thumbColor: thumbColor,
-                      value: active,
-                      onChanged: enabled ? (_) { } : null,
-                    ),
-                  ),
-                );
-              },
+            child: Material(
+              child: Center(
+                child: Switch(
+                  thumbColor: thumbColor,
+                  value: active,
+                  onChanged: enabled ? (_) { } : null,
+                ),
+              ),
             ),
           ),
         );
@@ -2660,20 +2618,16 @@ void main() {
           theme: themeData,
           home: Directionality(
             textDirection: TextDirection.rtl,
-            child: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return Material(
-                  child: Center(
-                    child: Switch(
-                      focusNode: focusNode,
-                      autofocus: true,
-                      value: true,
-                      thumbColor: thumbColor,
-                      onChanged: (_) { },
-                    ),
-                  ),
-                );
-              },
+            child: Material(
+              child: Center(
+                child: Switch(
+                  focusNode: focusNode,
+                  autofocus: true,
+                  value: true,
+                  thumbColor: thumbColor,
+                  onChanged: (_) { },
+                ),
+              ),
             ),
           ),
         );
@@ -2743,18 +2697,14 @@ void main() {
           data: themeData,
           child: Directionality(
             textDirection: TextDirection.rtl,
-            child: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return Material(
-                  child: Center(
-                    child: Switch(
-                      trackColor: trackColor,
-                      value: active,
-                      onChanged: enabled ? (_) { } : null,
-                    ),
-                  ),
-                );
-              },
+            child: Material(
+              child: Center(
+                child: Switch(
+                  trackColor: trackColor,
+                  value: active,
+                  onChanged: enabled ? (_) { } : null,
+                ),
+              ),
             ),
           ),
         );
@@ -2837,20 +2787,16 @@ void main() {
           data: themeData,
           child: Directionality(
             textDirection: TextDirection.rtl,
-            child: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return Material(
-                  child: Center(
-                    child: Switch(
-                      focusNode: focusNode,
-                      autofocus: true,
-                      value: true,
-                      trackColor: trackColor,
-                      onChanged: (_) { },
-                    ),
-                  ),
-                );
-              },
+            child: Material(
+              child: Center(
+                child: Switch(
+                  focusNode: focusNode,
+                  autofocus: true,
+                  value: true,
+                  trackColor: trackColor,
+                  onChanged: (_) { },
+                ),
+              ),
             ),
           ),
         );
@@ -2910,18 +2856,14 @@ void main() {
       Widget buildSwitch({required bool enabled, required bool active}) {
         return Directionality(
           textDirection: TextDirection.rtl,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Material(
-                child: Center(
-                  child: Switch(
-                    trackOutlineColor: trackOutlineColor,
-                    value: active,
-                    onChanged: enabled ? (_) { } : null,
-                  ),
-                ),
-              );
-            },
+          child: Material(
+            child: Center(
+              child: Switch(
+                trackOutlineColor: trackOutlineColor,
+                value: active,
+                onChanged: enabled ? (_) { } : null,
+              ),
+            ),
           ),
         );
       }
@@ -2987,20 +2929,16 @@ void main() {
       Widget buildSwitch() {
         return Directionality(
           textDirection: TextDirection.rtl,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Material(
-                child: Center(
-                  child: Switch(
-                    focusNode: focusNode,
-                    autofocus: true,
-                    value: true,
-                    trackOutlineColor: trackOutlineColor,
-                    onChanged: (_) { },
-                  ),
-                ),
-              );
-            },
+          child: Material(
+            child: Center(
+              child: Switch(
+                focusNode: focusNode,
+                autofocus: true,
+                value: true,
+                trackOutlineColor: trackOutlineColor,
+                onChanged: (_) { },
+              ),
+            ),
           ),
         );
       }
@@ -3047,21 +2985,17 @@ void main() {
       Widget buildSwitch({required bool enabled, required bool active}) {
         return Directionality(
           textDirection: TextDirection.rtl,
-          child: StatefulBuilder(
-            builder: (BuildContext context, StateSetter setState) {
-              return Theme(
-                data: theme,
-                child: Material(
-                  child: Center(
-                    child: Switch(
-                      thumbColor: thumbColor,
-                      value: active,
-                      onChanged: enabled ? (_) { } : null,
-                    ),
-                  ),
+          child: Theme(
+            data: theme,
+            child: Material(
+              child: Center(
+                child: Switch(
+                  thumbColor: thumbColor,
+                  value: active,
+                  onChanged: enabled ? (_) { } : null,
                 ),
-              );
-            },
+              ),
+            ),
           ),
         );
       }
@@ -3102,18 +3036,14 @@ void main() {
           data: themeData,
           child: Directionality(
             textDirection: TextDirection.ltr,
-            child: StatefulBuilder(
-              builder: (BuildContext context, StateSetter setState) {
-                return Material(
-                  child: Center(
-                    child: Switch(
-                      thumbIcon: thumbIcon(activeIcon, inactiveIcon),
-                      value: active,
-                      onChanged: enabled ? (_) {} : null,
-                    ),
-                  ),
-                );
-              },
+            child: Material(
+              child: Center(
+                child: Switch(
+                  thumbIcon: thumbIcon(activeIcon, inactiveIcon),
+                  value: active,
+                  onChanged: enabled ? (_) {} : null,
+                ),
+              ),
             ),
           ),
         );

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -19,6 +19,7 @@ void main() {
     const SwitchThemeData themeData = SwitchThemeData();
     expect(themeData.thumbColor, null);
     expect(themeData.trackColor, null);
+    expect(themeData.trackOutlineColor, null);
     expect(themeData.mouseCursor, null);
     expect(themeData.materialTapTargetSize, null);
     expect(themeData.overlayColor, null);
@@ -28,6 +29,7 @@ void main() {
     const SwitchTheme theme = SwitchTheme(data: SwitchThemeData(), child: SizedBox());
     expect(theme.data.thumbColor, null);
     expect(theme.data.trackColor, null);
+    expect(theme.data.trackOutlineColor, null);
     expect(theme.data.mouseCursor, null);
     expect(theme.data.materialTapTargetSize, null);
     expect(theme.data.overlayColor, null);
@@ -52,6 +54,7 @@ void main() {
     const SwitchThemeData(
       thumbColor: MaterialStatePropertyAll<Color>(Color(0xfffffff0)),
       trackColor: MaterialStatePropertyAll<Color>(Color(0xfffffff1)),
+      trackOutlineColor: MaterialStatePropertyAll<Color>(Color(0xfffffff3)),
       mouseCursor: MaterialStatePropertyAll<MouseCursor>(SystemMouseCursors.click),
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       overlayColor: MaterialStatePropertyAll<Color>(Color(0xfffffff2)),
@@ -66,11 +69,12 @@ void main() {
 
     expect(description[0], 'thumbColor: MaterialStatePropertyAll(Color(0xfffffff0))');
     expect(description[1], 'trackColor: MaterialStatePropertyAll(Color(0xfffffff1))');
-    expect(description[2], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
-    expect(description[3], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
-    expect(description[4], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff2))');
-    expect(description[5], 'splashRadius: 1.0');
-    expect(description[6], 'thumbIcon: MaterialStatePropertyAll(Icon(IconData(U+0007B)))');
+    expect(description[2], 'trackOutlineColor: MaterialStatePropertyAll(Color(0xfffffff3))');
+    expect(description[3], 'materialTapTargetSize: MaterialTapTargetSize.shrinkWrap');
+    expect(description[4], 'mouseCursor: MaterialStatePropertyAll(SystemMouseCursor(click))');
+    expect(description[5], 'overlayColor: MaterialStatePropertyAll(Color(0xfffffff2))');
+    expect(description[6], 'splashRadius: 1.0');
+    expect(description[7], 'thumbIcon: MaterialStatePropertyAll(Icon(IconData(U+0007B)))');
   });
 
   testWidgets('Switch is themeable', (WidgetTester tester) async {
@@ -80,6 +84,8 @@ void main() {
     const Color selectedThumbColor = Color(0xfffffff1);
     const Color defaultTrackColor = Color(0xfffffff2);
     const Color selectedTrackColor = Color(0xfffffff3);
+    const Color defaultTrackOutlineColor = Color(0xfffffff4);
+    const Color selectedTrackOutlineColor = Color(0xfffffff5);
     const MouseCursor mouseCursor = SystemMouseCursors.text;
     const MaterialTapTargetSize materialTapTargetSize = MaterialTapTargetSize.shrinkWrap;
     const Color focusOverlayColor = Color(0xfffffff4);
@@ -102,6 +108,12 @@ void main() {
             return selectedTrackColor;
           }
           return defaultTrackColor;
+        }),
+        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return selectedTrackOutlineColor;
+          }
+          return defaultTrackOutlineColor;
         }),
         mouseCursor: const MaterialStatePropertyAll<MouseCursor>(mouseCursor),
         materialTapTargetSize: materialTapTargetSize,
@@ -146,13 +158,13 @@ void main() {
       material3
       ? (paints
         ..rrect(color: defaultTrackColor)
-        ..rrect(color: themeData.colorScheme.outline)
+        ..rrect(color: defaultTrackOutlineColor)
         ..rrect(color: defaultThumbColor)
         ..paragraph()
       )
       : (paints
         ..rrect(color: defaultTrackColor)
-        ..rrect()
+        ..rrect(color: defaultTrackOutlineColor)
         ..rrect()
         ..rrect()
         ..rrect(color: defaultThumbColor)
@@ -168,11 +180,12 @@ void main() {
       _getSwitchMaterial(tester),
       material3
       ? (paints
-        ..rrect(color: selectedTrackColor)..rrect()
+        ..rrect(color: selectedTrackColor)
+        ..rrect(color: selectedTrackOutlineColor)
         ..rrect(color: selectedThumbColor)..paragraph())
       : (paints
         ..rrect(color: selectedTrackColor)
-        ..rrect()
+        ..rrect(color: selectedTrackOutlineColor)
         ..rrect()
         ..rrect()
         ..rrect(color: selectedThumbColor))
@@ -198,6 +211,8 @@ void main() {
     const Color themeSelectedThumbColor = Color(0xfffffff1);
     const Color themeDefaultTrackColor = Color(0xfffffff2);
     const Color themeSelectedTrackColor = Color(0xfffffff3);
+    const Color themeDefaultOutlineColor = Color(0xfffffff6);
+    const Color themeSelectedOutlineColor = Color(0xfffffff7);
     const MouseCursor themeMouseCursor = SystemMouseCursors.click;
     const MaterialTapTargetSize themeMaterialTapTargetSize = MaterialTapTargetSize.padded;
     const Color themeFocusOverlayColor = Color(0xfffffff4);
@@ -208,6 +223,8 @@ void main() {
     const Color selectedThumbColor = Color(0xffffff1f);
     const Color defaultTrackColor = Color(0xffffff2f);
     const Color selectedTrackColor = Color(0xffffff3f);
+    const Color defaultOutlineColor = Color(0xffffff6f);
+    const Color selectedOutlineColor = Color(0xffffff7f);
     const MouseCursor mouseCursor = SystemMouseCursors.text;
     const MaterialTapTargetSize materialTapTargetSize = MaterialTapTargetSize.shrinkWrap;
     const Color focusColor = Color(0xffffff4f);
@@ -227,6 +244,12 @@ void main() {
             return themeSelectedTrackColor;
           }
           return themeDefaultTrackColor;
+        }),
+        trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+          if (states.contains(MaterialState.selected)) {
+            return themeSelectedOutlineColor;
+          }
+          return themeDefaultOutlineColor;
         }),
         mouseCursor: const MaterialStatePropertyAll<MouseCursor>(themeMouseCursor),
         materialTapTargetSize: themeMaterialTapTargetSize,
@@ -270,6 +293,12 @@ void main() {
               }
               return defaultTrackColor;
             }),
+            trackOutlineColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+              if (states.contains(MaterialState.selected)) {
+                return selectedOutlineColor;
+              }
+              return defaultOutlineColor;
+            }),
             mouseCursor: mouseCursor,
             materialTapTargetSize: materialTapTargetSize,
             focusColor: focusColor,
@@ -294,10 +323,11 @@ void main() {
       material3
       ? (paints
         ..rrect(color: defaultTrackColor)
-        ..rrect(color: themeData.colorScheme.outline)
+        ..rrect(color: defaultOutlineColor)
         ..rrect(color: defaultThumbColor)..paragraph(offset: const Offset(12, 16)))
       : (paints
         ..rrect(color: defaultTrackColor)
+        ..rrect(color: defaultOutlineColor)
         ..rrect()
         ..rrect()
         ..rrect()
@@ -313,10 +343,11 @@ void main() {
       _getSwitchMaterial(tester),
       material3
       ? (paints
-        ..rrect(color: selectedTrackColor)
+        ..rrect(color: selectedTrackColor)..rrect(color: selectedOutlineColor)
         ..rrect(color: selectedThumbColor))
       : (paints
         ..rrect(color: selectedTrackColor)
+        ..rrect(color: selectedOutlineColor)
         ..rrect()
         ..rrect()
         ..rrect()
@@ -496,13 +527,16 @@ void main() {
   testWidgets('Local SwitchTheme can override global SwitchTheme', (WidgetTester tester) async {
     const Color globalThemeThumbColor = Color(0xfffffff1);
     const Color globalThemeTrackColor = Color(0xfffffff2);
+    const Color globalThemeOutlineColor = Color(0xfffffff3);
     const Color localThemeThumbColor = Color(0xffff0000);
     const Color localThemeTrackColor = Color(0xffff0000);
+    const Color localThemeOutlineColor = Color(0xffff0000);
 
     final ThemeData themeData = ThemeData(
       switchTheme: const SwitchThemeData(
         thumbColor: MaterialStatePropertyAll<Color>(globalThemeThumbColor),
         trackColor: MaterialStatePropertyAll<Color>(globalThemeTrackColor),
+        trackOutlineColor: MaterialStatePropertyAll<Color>(globalThemeOutlineColor),
       ),
     );
     final bool material3 = themeData.useMaterial3;
@@ -514,6 +548,7 @@ void main() {
             data: const SwitchThemeData(
               thumbColor: MaterialStatePropertyAll<Color>(localThemeThumbColor),
               trackColor: MaterialStatePropertyAll<Color>(localThemeTrackColor),
+              trackOutlineColor: MaterialStatePropertyAll<Color>(localThemeOutlineColor),
             ),
             child: Switch(
               value: selected,
@@ -532,9 +567,11 @@ void main() {
       material3
       ? (paints
         ..rrect(color: localThemeTrackColor)
+        ..rrect(color: localThemeOutlineColor)
         ..rrect(color: localThemeThumbColor))
       : (paints
         ..rrect(color: localThemeTrackColor)
+        ..rrect(color: localThemeOutlineColor)
         ..rrect()
         ..rrect()
         ..rrect()

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -95,7 +95,6 @@ void main() {
     const Icon icon2 = Icon(Icons.close);
 
     final ThemeData themeData = ThemeData(
-      useMaterial3: true,
       switchTheme: SwitchThemeData(
         thumbColor: MaterialStateProperty.resolveWith((Set<MaterialState> states) {
           if (states.contains(MaterialState.selected)) {
@@ -167,6 +166,7 @@ void main() {
         ..rrect(color: defaultTrackOutlineColor)
         ..rrect()
         ..rrect()
+        ..rrect()
         ..rrect(color: defaultThumbColor)
       )
     );
@@ -186,6 +186,7 @@ void main() {
       : (paints
         ..rrect(color: selectedTrackColor)
         ..rrect(color: selectedTrackOutlineColor)
+        ..rrect()
         ..rrect()
         ..rrect()
         ..rrect(color: selectedThumbColor))


### PR DESCRIPTION
Fixes #119334

This PR is to add `trackOutlineColor` for `Switch` and `SwitchListTile`.

<img width="204" alt="Screenshot 2023-02-06 at 4 14 17 PM" src="https://user-images.githubusercontent.com/36861262/217115856-ced58dec-8dc9-4465-b675-c2f757dfbc7f.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
