### PR TITLE
Run `verify_binaries_codesigned` task on release branches

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3220,6 +3220,8 @@ targets:
       - .ci.yaml
 
   - name: Mac_x64 verify_binaries_codesigned
+    enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
     timeout: 60
     properties:
@@ -3233,6 +3235,8 @@ targets:
       validation_name: Verify x64 binaries codesigned
 
   - name: Mac_arm64 verify_binaries_codesigned
+    enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
     timeout: 60
     properties:

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3220,9 +3220,6 @@ targets:
       - .ci.yaml
 
   - name: Mac_x64 verify_binaries_codesigned
-    bringup: true
-    enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
     timeout: 60
     properties:
@@ -3236,9 +3233,6 @@ targets:
       validation_name: Verify x64 binaries codesigned
 
   - name: Mac_arm64 verify_binaries_codesigned
-    bringup: true
-    enabled_branches:
-      - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
     timeout: 60
     properties:


### PR DESCRIPTION
Follow up to https://github.com/flutter/flutter/pull/119971 to prevent https://github.com/flutter/flutter/issues/111764 in the future: run `verify_binaries_codesigned` in the prod pool so it will fail if either arm64 or x64 releases are not codesigned.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
