### PR TITLE
Fix widget inspector null check

### DIFF
--- a/packages/flutter/lib/src/widgets/widget_inspector.dart
+++ b/packages/flutter/lib/src/widgets/widget_inspector.dart
@@ -2455,7 +2455,10 @@ class _ElementLocationStatsTracker {
       return;
     }
     final _HasCreationLocation creationLocationSource = widget;
-    final _Location location = creationLocationSource._location;
+    final _Location? location = creationLocationSource._location;
+    if (location == null) {
+      return;
+    }
     final int id = _toLocationId(location);
 
     _LocationCount entry;
@@ -3279,7 +3282,7 @@ const TextStyle _messageStyle = TextStyle(
 /// {@macro flutter.widgets.WidgetInspectorService.getChildrenSummaryTree}
 // ignore: unused_element
 abstract class _HasCreationLocation {
-  _Location get _location;
+  _Location? get _location;
 }
 
 /// A tuple with file, line, and column number, for displaying human-readable

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -251,10 +251,12 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     tearDown(() async {
       service.resetAllState();
 
-      await service.testBoolExtension(
-        WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
-        <String, String>{'enabled': 'false'},
-      );
+      if (WidgetInspectorService.instance.isWidgetCreationTracked()) {
+        await service.testBoolExtension(
+          WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
+          <String, String>{'enabled': 'false'},
+        );
+      }
     });
 
     testWidgets('WidgetInspector smoke test', (WidgetTester tester) async {

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -10,7 +10,7 @@
 // reduced-test-set:
 //   This file is run as part of a reduced test set in CI on Mac and Windows
 //   machines.
-@Tags(<String>['reduced-test-set', 'no-shuffle'])
+@Tags(<String>['reduced-test-set'])
 @TestOn('!chrome')
 library;
 

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -248,8 +248,13 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     final TestWidgetInspectorService service = TestWidgetInspectorService();
     WidgetInspectorService.instance = service;
 
-    tearDown(() {
+    tearDown(() async {
       service.resetAllState();
+
+      await service.testBoolExtension(
+        WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
+        <String, String>{'enabled': 'false'},
+      );
     });
 
     testWidgets('WidgetInspector smoke test', (WidgetTester tester) async {
@@ -3603,23 +3608,15 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         ),
       );
 
-      try {
-        expect(
-          await service.testBoolExtension(
-            WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
-            <String, String>{'enabled': 'true'},
-          ),
-          equals('true'),
-        );
-
-        await tester.pumpWidget(widget);
-      } finally {
-        // If we don't disable this, later tests may fail
+      expect(
         await service.testBoolExtension(
           WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
-          <String, String>{'enabled': 'false'},
-        );
-      }
+          <String, String>{'enabled': 'true'},
+        ),
+        equals('true'),
+      );
+
+      await tester.pumpWidget(widget);
     },
       skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
     );

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -3603,15 +3603,23 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
         ),
       );
 
-      expect(
+      try {
+        expect(
+          await service.testBoolExtension(
+            WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
+            <String, String>{'enabled': 'true'},
+          ),
+          equals('true'),
+        );
+
+        await tester.pumpWidget(widget);
+      } finally {
+        // If we don't disable this, later tests may fail
         await service.testBoolExtension(
           WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
-          <String, String>{'enabled': 'true'},
-        ),
-        equals('true'),
-      );
-
-      await tester.pumpWidget(widget);
+          <String, String>{'enabled': 'false'},
+        );
+      }
     },
       skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
     );

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -220,6 +220,14 @@ class RepaintBoundaryWithDebugPaint extends RepaintBoundary {
   }
 }
 
+Widget _applyConstructor(Widget Function() constructor) => constructor();
+
+class _TrivialWidget extends StatelessWidget {
+  const _TrivialWidget() : super(key: const Key('singleton'));
+  @override
+  Widget build(BuildContext context) => const Text('Hello, world!');
+}
+
 int getChildLayerCount(OffsetLayer layer) {
   Layer? child = layer.firstChild;
   int count = 0;
@@ -356,6 +364,7 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       // ignore: avoid_dynamic_calls
       expect(paragraphText(getInspectorState().selection.current as RenderParagraph), equals('BOTTOM'));
     });
+
 
     testWidgets('WidgetInspector non-invertible transform regression test', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -3585,6 +3594,29 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     },
       skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
     );
+
+    testWidgets('ext.flutter.inspector.trackRebuildDirtyWidgets with tear-offs', (WidgetTester tester) async {
+      final Widget widget = Directionality(
+        textDirection: TextDirection.ltr,
+        child: WidgetInspector(
+          selectButtonBuilder: null,
+          child: _applyConstructor(_TrivialWidget.new),
+        ),
+      );
+
+      expect(
+        await service.testBoolExtension(
+          WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name,
+          <String, String>{'enabled': 'true'},
+        ),
+        equals('true'),
+      );
+
+      await tester.pumpWidget(widget);
+    },
+      skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
+    );
+
 
     testWidgets('ext.flutter.inspector.trackRebuildDirtyWidgets', (WidgetTester tester) async {
       service.rebuildCount = 0;

--- a/packages/flutter/test/widgets/widget_inspector_test.dart
+++ b/packages/flutter/test/widgets/widget_inspector_test.dart
@@ -365,7 +365,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
       expect(paragraphText(getInspectorState().selection.current as RenderParagraph), equals('BOTTOM'));
     });
 
-
     testWidgets('WidgetInspector non-invertible transform regression test', (WidgetTester tester) async {
       await tester.pumpWidget(
         Directionality(
@@ -3616,7 +3615,6 @@ class _TestWidgetInspectorService extends TestWidgetInspectorService {
     },
       skip: !WidgetInspectorService.instance.isWidgetCreationTracked(), // [intended] Test requires --track-widget-creation flag.
     );
-
 
     testWidgets('ext.flutter.inspector.trackRebuildDirtyWidgets', (WidgetTester tester) async {
       service.rebuildCount = 0;


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/115582
Fixes https://github.com/flutter/flutter/issues/118368

Makes `_HasCreationLocation._location` nullable, which it will be if created from a tear-off widget constructor.