### PR TITLE
[cp] Verify Mac artifact codesigning on x64 and arm64

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3098,7 +3098,7 @@ targets:
       - bin/**
       - .ci.yaml
 
-  - name: Mac verify_binaries_codesigned
+  - name: Mac_x64 verify_binaries_codesigned
     enabled_branches:
       - flutter-\d+\.\d+-candidate\.\d+
     recipe: flutter/flutter
@@ -3111,7 +3111,22 @@ targets:
       tags: >
         ["framework", "hostonly", "shard", "mac"]
       validation: verify_binaries_codesigned
-      validation_name: Verify binaries codesigned
+      validation_name: Verify x64 binaries codesigned
+
+  - name: Mac_arm64 verify_binaries_codesigned
+    enabled_branches:
+      - flutter-\d+\.\d+-candidate\.\d+
+    recipe: flutter/flutter
+    timeout: 60
+    properties:
+      dependencies: >-
+        [
+          {"dependency": "xcode", "version": "14a5294e"}
+        ]
+      tags: >
+        ["framework", "hostonly", "shard", "mac"]
+      validation: verify_binaries_codesigned
+      validation_name: Verify arm64 binaries codesigned
 
   - name: Mac web_tool_tests
     recipe: flutter/flutter_drone


### PR DESCRIPTION
Run `verify_binaries_codesigned` on x64 and arm64 Macs to validate https://github.com/flutter/flutter/issues/111764 doesn't happen again.  Cherry-pick https://github.com/flutter/flutter/pull/119971 and https://github.com/flutter/flutter/pull/120141.

Request at https://github.com/flutter/flutter/issues/120152

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
