### PR TITLE
Add proper disabled values for input chips

### DIFF
--- a/dev/tools/gen_defaults/lib/input_chip_template.dart
+++ b/dev/tools/gen_defaults/lib/input_chip_template.dart
@@ -13,7 +13,7 @@ class InputChipTemplate extends TokenTemplate {
   @override
   String generate() => '''
 class _${blockName}DefaultsM3 extends ChipThemeData {
-  const _${blockName}DefaultsM3(this.context, this.isEnabled)
+  const _${blockName}DefaultsM3(this.context, this.isEnabled, this.isSelected)
     : super(
         elevation: ${elevation("$tokenGroup$variant.container")},
         shape: ${shape("$tokenGroup.container")},
@@ -22,6 +22,7 @@ class _${blockName}DefaultsM3 extends ChipThemeData {
 
   final BuildContext context;
   final bool isEnabled;
+  final bool isSelected;
 
   @override
   TextStyle? get labelStyle => ${textStyle("$tokenGroup.label-text")};
@@ -36,7 +37,9 @@ class _${blockName}DefaultsM3 extends ChipThemeData {
   Color? get surfaceTintColor => ${colorOrTransparent("$tokenGroup.container.surface-tint-layer.color")};
 
   @override
-  Color? get selectedColor => ${componentColor("$tokenGroup$variant.selected.container")};
+  Color? get selectedColor => isEnabled
+    ? ${componentColor("$tokenGroup$variant.selected.container")}
+    : ${componentColor("$tokenGroup$variant.disabled.selected.container")};
 
   @override
   Color? get checkmarkColor => ${color("$tokenGroup.with-icon.selected.icon.color")};
@@ -48,9 +51,11 @@ class _${blockName}DefaultsM3 extends ChipThemeData {
   Color? get deleteIconColor => ${color("$tokenGroup.with-trailing-icon.selected.trailing-icon.color")};
 
   @override
-  BorderSide? get side => isEnabled
-    ? ${border('$tokenGroup$variant.unselected.outline')}
-    : ${border('$tokenGroup$variant.disabled.unselected.outline')};
+  BorderSide? get side => !isSelected
+    ? isEnabled
+      ? ${border('$tokenGroup$variant.unselected.outline')}
+      : ${border('$tokenGroup$variant.disabled.unselected.outline')}
+    : const BorderSide(color: Colors.transparent);
 
   @override
   IconThemeData? get iconTheme => IconThemeData(

--- a/packages/flutter/lib/src/material/input_chip.dart
+++ b/packages/flutter/lib/src/material/input_chip.dart
@@ -194,7 +194,7 @@ class InputChip extends StatelessWidget
   Widget build(BuildContext context) {
     assert(debugCheckHasMaterial(context));
     final ChipThemeData? defaults = Theme.of(context).useMaterial3
-      ? _InputChipDefaultsM3(context, isEnabled)
+      ? _InputChipDefaultsM3(context, isEnabled, selected)
       : null;
     final Widget? resolvedDeleteIcon = deleteIcon
       ?? (Theme.of(context).useMaterial3 ? const Icon(Icons.clear, size: 18) : null);
@@ -247,7 +247,7 @@ class InputChip extends StatelessWidget
 // Token database version: v0_152
 
 class _InputChipDefaultsM3 extends ChipThemeData {
-  const _InputChipDefaultsM3(this.context, this.isEnabled)
+  const _InputChipDefaultsM3(this.context, this.isEnabled, this.isSelected)
     : super(
         elevation: 0.0,
         shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8.0))),
@@ -256,6 +256,7 @@ class _InputChipDefaultsM3 extends ChipThemeData {
 
   final BuildContext context;
   final bool isEnabled;
+  final bool isSelected;
 
   @override
   TextStyle? get labelStyle => Theme.of(context).textTheme.labelLarge;
@@ -270,7 +271,9 @@ class _InputChipDefaultsM3 extends ChipThemeData {
   Color? get surfaceTintColor => Colors.transparent;
 
   @override
-  Color? get selectedColor => Theme.of(context).colorScheme.secondaryContainer;
+  Color? get selectedColor => isEnabled
+    ? Theme.of(context).colorScheme.secondaryContainer
+    : Theme.of(context).colorScheme.onSurface.withOpacity(0.12);
 
   @override
   Color? get checkmarkColor => null;
@@ -282,9 +285,11 @@ class _InputChipDefaultsM3 extends ChipThemeData {
   Color? get deleteIconColor => Theme.of(context).colorScheme.onSecondaryContainer;
 
   @override
-  BorderSide? get side => isEnabled
-    ? BorderSide(color: Theme.of(context).colorScheme.outline)
-    : BorderSide(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12));
+  BorderSide? get side => !isSelected
+    ? isEnabled
+      ? BorderSide(color: Theme.of(context).colorScheme.outline)
+      : BorderSide(color: Theme.of(context).colorScheme.onSurface.withOpacity(0.12))
+    : const BorderSide(color: Colors.transparent);
 
   @override
   IconThemeData? get iconTheme => IconThemeData(


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/115826 - all chips now use the correct M3 spec for disabled values.

The issue was specific only to `InputChips`, so we can use the same `isSelected` solution from the `ChoiceChips` to implement the solution.

Verification - 

**Before**
![Screenshot 2023-02-07 3 03 43 PM](https://user-images.githubusercontent.com/15033982/217281978-c272dc6f-2e47-47c3-9e96-db936dc081c3.png)

**After**
![Screenshot 2023-02-07 2 31 42 PM](https://user-images.githubusercontent.com/15033982/217277404-3ed3bb8e-eb4c-49a6-b7ed-bca0e9d5591f.png)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
