### PR TITLE
Use String.codeUnitAt instead of String.codeUnits[] in ParagraphBoundary

### DIFF
--- a/packages/flutter/lib/src/services/text_boundary.dart
+++ b/packages/flutter/lib/src/services/text_boundary.dart
@@ -150,17 +150,16 @@ class ParagraphBoundary extends TextBoundary {
       return 0;
     }
 
-    final List<int> codeUnits = _text.codeUnits;
     int index = position;
 
-    if (index > 1 && codeUnits[index] == 0xA && codeUnits[index - 1] == 0xD) {
+    if (index > 1 && _text.codeUnitAt(index) == 0xA && _text.codeUnitAt(index - 1) == 0xD) {
       index -= 2;
-    } else if (TextLayoutMetrics.isLineTerminator(codeUnits[index])) {
+    } else if (TextLayoutMetrics.isLineTerminator(_text.codeUnitAt(index))) {
       index -= 1;
     }
 
     while (index > 0) {
-      if (TextLayoutMetrics.isLineTerminator(codeUnits[index])) {
+      if (TextLayoutMetrics.isLineTerminator(_text.codeUnitAt(index))) {
         return index + 1;
       }
       index -= 1;
@@ -183,19 +182,18 @@ class ParagraphBoundary extends TextBoundary {
       return 0;
     }
 
-    final List<int> codeUnits = _text.codeUnits;
     int index = position;
 
-    while (!TextLayoutMetrics.isLineTerminator(codeUnits[index])) {
+    while (!TextLayoutMetrics.isLineTerminator(_text.codeUnitAt(index))) {
       index += 1;
-      if (index == codeUnits.length) {
+      if (index == _text.length) {
         return index;
       }
     }
 
-    return index < codeUnits.length - 1
-                && codeUnits[index] == 0xD
-                && codeUnits[index + 1] == 0xA
+    return index < _text.length - 1
+                && _text.codeUnitAt(index) == 0xD
+                && _text.codeUnitAt(index + 1) == 0xA
                 ? index + 2
                 : index + 1;
   }

--- a/packages/flutter/lib/src/services/text_boundary.dart
+++ b/packages/flutter/lib/src/services/text_boundary.dart
@@ -152,7 +152,7 @@ class ParagraphBoundary extends TextBoundary {
 
     int index = position;
 
-    if (index > 1 && _text.codeUnitAt(index) == 0xA && _text.codeUnitAt(index - 1) == 0xD) {
+    if (index > 1 && _text.codeUnitAt(index) == 0x0A && _text.codeUnitAt(index - 1) == 0x0D) {
       index -= 2;
     } else if (TextLayoutMetrics.isLineTerminator(_text.codeUnitAt(index))) {
       index -= 1;
@@ -192,8 +192,8 @@ class ParagraphBoundary extends TextBoundary {
     }
 
     return index < _text.length - 1
-                && _text.codeUnitAt(index) == 0xD
-                && _text.codeUnitAt(index + 1) == 0xA
+                && _text.codeUnitAt(index) == 0x0D
+                && _text.codeUnitAt(index + 1) == 0x0A
                 ? index + 2
                 : index + 1;
   }

--- a/packages/flutter/lib/src/services/text_layout_metrics.dart
+++ b/packages/flutter/lib/src/services/text_layout_metrics.dart
@@ -60,10 +60,10 @@ abstract class TextLayoutMetrics {
   /// (https://www.unicode.org/standard/reports/tr13/tr13-5.html).
   static bool isLineTerminator(int codeUnit) {
     switch (codeUnit) {
-      case 0xA: // line feed
-      case 0xB: // vertical feed
-      case 0xC: // form feed
-      case 0xD: // carriage return
+      case 0x0A: // line feed
+      case 0x0B: // vertical feed
+      case 0x0C: // form feed
+      case 0x0D: // carriage return
       case 0x85: // new line
       case 0x2028: // line separator
       case 0x2029: // paragraph separator


### PR DESCRIPTION
This change changes `ParagraphBoundary` uses of `String.codeUnits[index]` to `String.codeUnitAt(index)` to avoid creating a new list when using the `.codeUnits` getter.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.