### PR TITLE
Expose callback that allows focus traversal customization

### DIFF
--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -178,10 +178,12 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     Curve? curve,
   }) {
     node.requestFocus();
-    Scrollable.ensureVisible(node.context!, alignment: alignment ?? 1.0,
-        alignmentPolicy: alignmentPolicy ?? ScrollPositionAlignmentPolicy.explicit,
-        duration: duration ?? Duration.zero,
-        curve: curve ?? Curves.ease);
+    Scrollable.ensureVisible(
+      node.context!, alignment: alignment ?? 1.0,
+      alignmentPolicy: alignmentPolicy ?? ScrollPositionAlignmentPolicy.explicit,
+      duration: duration ?? Duration.zero,
+      curve: curve ?? Curves.ease,
+    );
   }
 
   /// Returns the node that should receive focus if focus is traversing

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -154,7 +154,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// const constructors so that they can be used in const expressions.
   ///
   /// {@template flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
-  /// The `requestFocusCallback` can be used to override the default behaviour
+  /// The `requestFocusCallback` can be used to override the default behavior
   /// of the focus requests. If `requestFocusCallback`
   /// is null, it defaults to [defaultTraversalRequestFocusCallback].
   /// {@endtemplate}

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -163,6 +163,12 @@ enum TraversalEdgeBehavior {
 abstract class FocusTraversalPolicy with Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
+  ///
+  /// {@template flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
+  /// The `requestFocusCallback` can be used to overwrite the default behaviour
+  /// of the focus requests. If `requestFocusCallback`
+  /// is null, defaults to [defaultTraversalRequestFocusCallback].
+  /// {@endtemplate}
   const FocusTraversalPolicy({
     TraversalRequestFocusCallback? requestFocusCallback
   }) : requestFocusCallback = requestFocusCallback ?? defaultTraversalRequestFocusCallback;
@@ -997,6 +1003,8 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
 class WidgetOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalFocusTraversalPolicyMixin {
   /// Constructs a traversal policy that orders widgets for keyboard traversal
   /// based on the widget hierarchy order.
+  ///
+  /// {@macro flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
   WidgetOrderTraversalPolicy({super.requestFocusCallback});
   @override
   Iterable<FocusNode> sortDescendants(Iterable<FocusNode> descendants, FocusNode currentNode) => descendants;
@@ -1166,6 +1174,8 @@ class _ReadingOrderDirectionalGroupData with Diagnosticable {
 ///    explicitly using [FocusTraversalOrder] widgets.
 class ReadingOrderTraversalPolicy extends FocusTraversalPolicy with DirectionalFocusTraversalPolicyMixin {
   /// Constructs a traversal policy that orders the widgets in "reading order".
+  ///
+  /// {@macro flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
   ReadingOrderTraversalPolicy({super.requestFocusCallback});
 
   // Collects the given candidates into groups by directionality. The candidates

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -1812,8 +1812,16 @@ class _FocusTraversalGroupState extends State<FocusTraversalGroup> {
 class RequestFocusIntent extends Intent {
   /// Creates an intent used with [RequestFocusAction].
   ///
-  /// The argument must not be null.
-  const RequestFocusIntent(this.focusNode);
+  /// The [focusNode] argument must not be null.
+  /// {@macro flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
+  const RequestFocusIntent(this.focusNode, {
+    TraversalRequestFocusCallback? requestFocusCallback
+  }) : requestFocusCallback = requestFocusCallback ?? FocusTraversalPolicy.defaultTraversalRequestFocusCallback;
+
+  /// The callback used to move the focus to the node [focusNode].
+  /// By default it requests focus on the node and ensures the node is visible
+  /// if it's in a scrollable.
+  final TraversalRequestFocusCallback requestFocusCallback;
 
   /// The [FocusNode] that is to be focused.
   final FocusNode focusNode;
@@ -1844,9 +1852,10 @@ class RequestFocusIntent extends Intent {
 ///
 /// See [FocusTraversalPolicy] for more information about focus traversal.
 class RequestFocusAction extends Action<RequestFocusIntent> {
+
   @override
   void invoke(RequestFocusIntent intent) {
-    FocusTraversalPolicy.defaultTraversalRequestFocusCallback(intent.focusNode);
+    intent.requestFocusCallback(intent.focusNode);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -48,7 +48,7 @@ void _focusAndEnsureVisible(
 
 /// Signature for the callback that's called when a traversal policy is
 /// requesting focus.
-typedef RequestFocusCallback = void Function(
+typedef TraversalRequestFocusCallback = void Function(
     FocusNode node, {
     ScrollPositionAlignmentPolicy alignmentPolicy,
     double alignment,
@@ -164,12 +164,26 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// Abstract const constructor. This constructor enables subclasses to provide
   /// const constructors so that they can be used in const expressions.
   const FocusTraversalPolicy({
-    RequestFocusCallback? requestFocusCallback
-  }) : requestFocusCallback = requestFocusCallback ?? _focusAndEnsureVisible;
+    TraversalRequestFocusCallback? requestFocusCallback
+  }) : requestFocusCallback = requestFocusCallback ?? defaultTraversalRequestFocusCallback;
 
   /// The callback used to move the focus from one focus node to another when
   /// traversing them using a keyboard.
-  final RequestFocusCallback requestFocusCallback;
+  final TraversalRequestFocusCallback requestFocusCallback;
+
+  /// The default value for [requestFocusCallback].
+  /// Requests focus from `node` and ensures the node is visible
+  /// by calling [Scrollable.ensureVisible].
+  static void defaultTraversalRequestFocusCallback(
+      FocusNode node, {
+        ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
+        double alignment = 1.0,
+        Duration duration = Duration.zero,
+        Curve curve = Curves.ease,
+      }) {
+    node.requestFocus();
+    Scrollable.ensureVisible(node.context!, alignment: alignment, alignmentPolicy: alignmentPolicy, duration: duration, curve: curve);
+  }
 
   /// Returns the node that should receive focus if focus is traversing
   /// forwards, and there is no current focus.

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -35,8 +35,8 @@ BuildContext? _getAncestor(BuildContext context, {int count = 1}) {
   return target;
 }
 
-/// Signature for the callback that's called when a traversal policy is
-/// requesting focus.
+/// Signature for the callback that's called when a traversal policy
+/// requests focus.
 typedef TraversalRequestFocusCallback = void Function(
     FocusNode node, {
     ScrollPositionAlignmentPolicy? alignmentPolicy,

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -165,7 +165,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// const constructors so that they can be used in const expressions.
   const FocusTraversalPolicy({
     RequestFocusCallback? requestFocusCallback
-  }) : requestFocusCallback = requestFocusCallback ?? _focusAndEnsureVisible as RequestFocusCallback;
+  }) : requestFocusCallback = requestFocusCallback ?? _focusAndEnsureVisible;
 
   /// The callback used to move the focus from one focus node to another when
   /// traversing them using a keyboard.

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -442,7 +442,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     if (focusedChild == null) {
       final FocusNode? firstFocus = forward ? findFirstFocus(currentNode) : findLastFocus(currentNode);
       if (firstFocus != null) {
-        _focusAndEnsureVisible(
+        requestFocusCallback(
           firstFocus,
           alignmentPolicy: forward ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
         );
@@ -461,7 +461,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
           focusedChild!.unfocus();
           return false;
         case TraversalEdgeBehavior.closedLoop:
-          _focusAndEnsureVisible(sortedNodes.first, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd);
+          requestFocusCallback(sortedNodes.first, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd);
           return true;
       }
     }
@@ -471,7 +471,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
           focusedChild!.unfocus();
           return false;
         case TraversalEdgeBehavior.closedLoop:
-          _focusAndEnsureVisible(sortedNodes.last, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart);
+          requestFocusCallback(sortedNodes.last, alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart);
           return true;
       }
     }
@@ -480,7 +480,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
     FocusNode? previousNode;
     for (final FocusNode node in maybeFlipped) {
       if (previousNode == focusedChild) {
-        _focusAndEnsureVisible(
+        requestFocusCallback(
           node,
           alignmentPolicy: forward ? ScrollPositionAlignmentPolicy.keepVisibleAtEnd : ScrollPositionAlignmentPolicy.keepVisibleAtStart,
         );
@@ -790,7 +790,7 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
           case TraversalDirection.down:
             alignmentPolicy = ScrollPositionAlignmentPolicy.keepVisibleAtEnd;
         }
-        _focusAndEnsureVisible(
+        requestFocusCallback(
           lastNode,
           alignmentPolicy: alignmentPolicy,
         );
@@ -869,13 +869,13 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
       switch (direction) {
         case TraversalDirection.up:
         case TraversalDirection.left:
-          _focusAndEnsureVisible(
+          requestFocusCallback(
             firstFocus,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
           );
         case TraversalDirection.right:
         case TraversalDirection.down:
-          _focusAndEnsureVisible(
+          requestFocusCallback(
             firstFocus,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
           );
@@ -946,13 +946,13 @@ mixin DirectionalFocusTraversalPolicyMixin on FocusTraversalPolicy {
       switch (direction) {
         case TraversalDirection.up:
         case TraversalDirection.left:
-          _focusAndEnsureVisible(
+          requestFocusCallback(
             found,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtStart,
           );
         case TraversalDirection.down:
         case TraversalDirection.right:
-          _focusAndEnsureVisible(
+          requestFocusCallback(
             found,
             alignmentPolicy: ScrollPositionAlignmentPolicy.keepVisibleAtEnd,
           );

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -154,16 +154,17 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// const constructors so that they can be used in const expressions.
   ///
   /// {@template flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
-  /// The `requestFocusCallback` can be used to overwrite the default behaviour
+  /// The `requestFocusCallback` can be used to override the default behaviour
   /// of the focus requests. If `requestFocusCallback`
-  /// is null, defaults to [defaultTraversalRequestFocusCallback].
+  /// is null, it defaults to [defaultTraversalRequestFocusCallback].
   /// {@endtemplate}
   const FocusTraversalPolicy({
     TraversalRequestFocusCallback? requestFocusCallback
   }) : requestFocusCallback = requestFocusCallback ?? defaultTraversalRequestFocusCallback;
 
   /// The callback used to move the focus from one focus node to another when
-  /// traversing them using a keyboard.
+  /// traversing them using a keyboard. By default it requests focus on the next
+  /// node and ensures the node is visible if it's in a scrollable.
   final TraversalRequestFocusCallback requestFocusCallback;
 
   /// The default value for [requestFocusCallback].

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -156,7 +156,7 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// {@template flutter.widgets.FocusTraversalPolicy.requestFocusCallback}
   /// The `requestFocusCallback` can be used to override the default behavior
   /// of the focus requests. If `requestFocusCallback`
-  /// is null, it defaults to [defaultTraversalRequestFocusCallback].
+  /// is null, it defaults to [FocusTraversalPolicy.defaultTraversalRequestFocusCallback].
   /// {@endtemplate}
   const FocusTraversalPolicy({
     TraversalRequestFocusCallback? requestFocusCallback

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -50,10 +50,10 @@ void _focusAndEnsureVisible(
 /// requesting focus.
 typedef TraversalRequestFocusCallback = void Function(
     FocusNode node, {
-    ScrollPositionAlignmentPolicy alignmentPolicy,
-    double alignment,
-    Duration duration,
-    Curve curve,
+    ScrollPositionAlignmentPolicy? alignmentPolicy,
+    double? alignment,
+    Duration? duration,
+    Curve? curve,
 });
 
 // A class to temporarily hold information about FocusTraversalGroups when
@@ -182,13 +182,16 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// by calling [Scrollable.ensureVisible].
   static void defaultTraversalRequestFocusCallback(
       FocusNode node, {
-        ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
-        double alignment = 1.0,
-        Duration duration = Duration.zero,
-        Curve curve = Curves.ease,
+        ScrollPositionAlignmentPolicy? alignmentPolicy,
+        double? alignment,
+        Duration? duration,
+        Curve? curve,
       }) {
     node.requestFocus();
-    Scrollable.ensureVisible(node.context!, alignment: alignment, alignmentPolicy: alignmentPolicy, duration: duration, curve: curve);
+    Scrollable.ensureVisible(node.context!, alignment: alignment ?? 1.0,
+        alignmentPolicy: alignmentPolicy ?? ScrollPositionAlignmentPolicy.explicit,
+        duration: duration ?? Duration.zero,
+        curve: curve ?? Curves.ease);
   }
 
   /// Returns the node that should receive focus if focus is traversing

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -35,17 +35,6 @@ BuildContext? _getAncestor(BuildContext context, {int count = 1}) {
   return target;
 }
 
-void _focusAndEnsureVisible(
-  FocusNode node, {
-  ScrollPositionAlignmentPolicy alignmentPolicy = ScrollPositionAlignmentPolicy.explicit,
-  double alignment = 1.0,
-  Duration duration = Duration.zero,
-  Curve curve = Curves.ease,
-}) {
-  node.requestFocus();
-  Scrollable.ensureVisible(node.context!, alignment: alignment, alignmentPolicy: alignmentPolicy, duration: duration, curve: curve);
-}
-
 /// Signature for the callback that's called when a traversal policy is
 /// requesting focus.
 typedef TraversalRequestFocusCallback = void Function(
@@ -1856,7 +1845,7 @@ class RequestFocusIntent extends Intent {
 class RequestFocusAction extends Action<RequestFocusIntent> {
   @override
   void invoke(RequestFocusIntent intent) {
-    _focusAndEnsureVisible(intent.focusNode);
+    FocusTraversalPolicy.defaultTraversalRequestFocusCallback(intent.focusNode);
   }
 }
 

--- a/packages/flutter/lib/src/widgets/focus_traversal.dart
+++ b/packages/flutter/lib/src/widgets/focus_traversal.dart
@@ -171,12 +171,12 @@ abstract class FocusTraversalPolicy with Diagnosticable {
   /// Requests focus from `node` and ensures the node is visible
   /// by calling [Scrollable.ensureVisible].
   static void defaultTraversalRequestFocusCallback(
-      FocusNode node, {
-        ScrollPositionAlignmentPolicy? alignmentPolicy,
-        double? alignment,
-        Duration? duration,
-        Curve? curve,
-      }) {
+    FocusNode node, {
+    ScrollPositionAlignmentPolicy? alignmentPolicy,
+    double? alignment,
+    Duration? duration,
+    Curve? curve,
+  }) {
     node.requestFocus();
     Scrollable.ensureVisible(node.context!, alignment: alignment ?? 1.0,
         alignmentPolicy: alignmentPolicy ?? ScrollPositionAlignmentPolicy.explicit,

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -385,6 +385,49 @@ void main() {
       expect(firstFocusNode.hasFocus, isTrue);
       expect(scope.hasFocus, isTrue);
     });
+
+    testWidgets('Custom requestFocusCallback gets called on the next/previous focus.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final FocusNode testNode1 = FocusNode(debugLabel: 'Focus Node');
+      bool calledCallback = false;
+
+      await tester.pumpWidget(
+        FocusTraversalGroup(
+          policy: WidgetOrderTraversalPolicy(
+            requestFocusCallback: (FocusNode node, {double? alignment,
+              ScrollPositionAlignmentPolicy? alignmentPolicy,
+              Curve? curve,
+              Duration? duration}) {
+              calledCallback = true;
+            },
+          ),
+          child: FocusScope(
+            debugLabel: 'key1',
+            key: key1,
+            child: Focus(
+              focusNode: testNode1,
+              child: Container(),
+            ),
+          ),
+        ),
+      );
+
+      final Element element = tester.element(find.byKey(key1));
+      final FocusNode scope = Focus.of(element);
+      scope.nextFocus();
+
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+
+      calledCallback = false;
+
+      scope.previousFocus();
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+    });
+
   });
 
   group(ReadingOrderTraversalPolicy, () {
@@ -824,6 +867,51 @@ void main() {
       }
       expect(order, orderedEquals(<int>[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]));
     });
+
+    testWidgets('Custom requestFocusCallback gets called on the next/previous focus.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final FocusNode testNode1 = FocusNode(debugLabel: 'Focus Node');
+      bool calledCallback = false;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusTraversalGroup(
+            policy: ReadingOrderTraversalPolicy(
+              requestFocusCallback: (FocusNode node, {double? alignment,
+                ScrollPositionAlignmentPolicy? alignmentPolicy,
+                Curve? curve,
+                Duration? duration}) {
+                calledCallback = true;
+              },
+            ),
+            child: FocusScope(
+              debugLabel: 'key1',
+              key: key1,
+              child: Focus(
+                focusNode: testNode1,
+                child: Container(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Element element = tester.element(find.byKey(key1));
+      final FocusNode scope = Focus.of(element);
+      scope.nextFocus();
+
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+
+      calledCallback = false;
+
+      scope.previousFocus();
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+    });
   });
 
   group(OrderedTraversalPolicy, () {
@@ -1187,6 +1275,51 @@ void main() {
 
       expect(firstFocusNode.hasFocus, isTrue);
       expect(scope.hasFocus, isTrue);
+    });
+
+    testWidgets('Custom requestFocusCallback gets called on the next/previous focus.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final FocusNode testNode1 = FocusNode(debugLabel: 'Focus Node');
+      bool calledCallback = false;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: FocusTraversalGroup(
+            policy: OrderedTraversalPolicy(
+              requestFocusCallback: (FocusNode node, {double? alignment,
+                ScrollPositionAlignmentPolicy? alignmentPolicy,
+                Curve? curve,
+                Duration? duration}) {
+                calledCallback = true;
+              },
+            ),
+            child: FocusScope(
+              debugLabel: 'key1',
+              key: key1,
+              child: Focus(
+                focusNode: testNode1,
+                child: Container(),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      final Element element = tester.element(find.byKey(key1));
+      final FocusNode scope = Focus.of(element);
+      scope.nextFocus();
+
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+
+      calledCallback = false;
+
+      scope.previousFocus();
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
     });
   });
 
@@ -2324,6 +2457,60 @@ void main() {
 
       expect(events.length, 2);
     }, variant: KeySimulatorTransitModeVariant.all());
+
+    testWidgets('Custom requestFocusCallback gets called on focusInDirection up/down/left/right.', (WidgetTester tester) async {
+      final GlobalKey key1 = GlobalKey(debugLabel: '1');
+      final FocusNode testNode1 = FocusNode(debugLabel: 'Focus Node');
+      bool calledCallback = false;
+
+      await tester.pumpWidget(
+        FocusTraversalGroup(
+          policy: ReadingOrderTraversalPolicy(
+            requestFocusCallback: (FocusNode node, {double? alignment,
+              ScrollPositionAlignmentPolicy? alignmentPolicy,
+              Curve? curve,
+              Duration? duration}) {
+              calledCallback = true;
+            },
+          ),
+          child: FocusScope(
+            debugLabel: 'key1',
+            key: key1,
+            child: Focus(
+              focusNode: testNode1,
+              child: Container(),
+            ),
+          ),
+        ),
+      );
+
+      final Element element = tester.element(find.byKey(key1));
+      final FocusNode scope = Focus.of(element);
+      scope.focusInDirection(TraversalDirection.up);
+
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+
+      calledCallback = false;
+
+      scope.focusInDirection(TraversalDirection.down);
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+
+      calledCallback = false;
+
+      scope.focusInDirection(TraversalDirection.left);
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+
+      scope.focusInDirection(TraversalDirection.right);
+      await tester.pump();
+
+      expect(calledCallback, isTrue);
+    });
   });
 
   group(FocusTraversalGroup, () {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -3052,6 +3052,42 @@ void main() {
       KeyEventResult.skipRemainingHandlers,
     );
   });
+
+  testWidgets('RequestFocusAction calls the RequestFocusIntent.requestFocusCallback', (WidgetTester tester) async {
+    bool calledCallback = false;
+    final FocusNode nodeA = FocusNode();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SingleChildScrollView(
+          child: TextButton(
+            focusNode: nodeA,
+            child: const Text('A'),
+            onPressed: () {},
+          ),
+        )
+      )
+    );
+
+    RequestFocusAction().invoke(RequestFocusIntent(nodeA));
+    await tester.pump();
+    expect(nodeA.hasFocus, isTrue);
+
+    nodeA.unfocus();
+    await tester.pump();
+    expect(nodeA.hasFocus, isFalse);
+
+    final RequestFocusIntent focusIntentWithCallback = RequestFocusIntent(nodeA, requestFocusCallback: (FocusNode node, {
+      double? alignment,
+      ScrollPositionAlignmentPolicy? alignmentPolicy,
+      Curve? curve,
+      Duration? duration
+    }) => calledCallback = true);
+
+    RequestFocusAction().invoke(focusIntentWithCallback);
+    await tester.pump();
+    expect(calledCallback, isTrue);
+  });
 }
 
 class TestRoute extends PageRouteBuilder<void> {

--- a/packages/flutter/test/widgets/focus_traversal_test.dart
+++ b/packages/flutter/test/widgets/focus_traversal_test.dart
@@ -403,8 +403,8 @@ void main() {
           ),
           child: FocusScope(
             debugLabel: 'key1',
-            key: key1,
             child: Focus(
+              key: key1,
               focusNode: testNode1,
               child: Container(),
             ),
@@ -413,7 +413,7 @@ void main() {
       );
 
       final Element element = tester.element(find.byKey(key1));
-      final FocusNode scope = Focus.of(element);
+      final FocusNode scope = FocusScope.of(element);
       scope.nextFocus();
 
       await tester.pump();
@@ -887,8 +887,8 @@ void main() {
             ),
             child: FocusScope(
               debugLabel: 'key1',
-              key: key1,
               child: Focus(
+                key: key1,
                 focusNode: testNode1,
                 child: Container(),
               ),
@@ -898,7 +898,7 @@ void main() {
       );
 
       final Element element = tester.element(find.byKey(key1));
-      final FocusNode scope = Focus.of(element);
+      final FocusNode scope = FocusScope.of(element);
       scope.nextFocus();
 
       await tester.pump();
@@ -1296,8 +1296,8 @@ void main() {
             ),
             child: FocusScope(
               debugLabel: 'key1',
-              key: key1,
               child: Focus(
+                key: key1,
                 focusNode: testNode1,
                 child: Container(),
               ),
@@ -1307,7 +1307,7 @@ void main() {
       );
 
       final Element element = tester.element(find.byKey(key1));
-      final FocusNode scope = Focus.of(element);
+      final FocusNode scope = FocusScope.of(element);
       scope.nextFocus();
 
       await tester.pump();
@@ -2475,8 +2475,8 @@ void main() {
           ),
           child: FocusScope(
             debugLabel: 'key1',
-            key: key1,
             child: Focus(
+              key: key1,
               focusNode: testNode1,
               child: Container(),
             ),
@@ -2485,7 +2485,7 @@ void main() {
       );
 
       final Element element = tester.element(find.byKey(key1));
-      final FocusNode scope = Focus.of(element);
+      final FocusNode scope = FocusScope.of(element);
       scope.focusInDirection(TraversalDirection.up);
 
       await tester.pump();


### PR DESCRIPTION
This PR exposes a requestFocusCallback on `FocusTraversalPolicy` and it's inheritors.

Fixes #83175.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
