### PR TITLE
Cherry-pick changes to support the use_emulator flag that made it into candidate branch

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1331,12 +1331,23 @@ targets:
 
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone
-    presubmit: false
+    presubmit: true
     timeout: 60
+    dimensions: {
+      kvm: "1",
+      cores: "8",
+      machine_type: "n1-standard-8"
+    }
     properties:
+      device_type: "none"
       tags: >
-        ["devicelab" ,"android", "linux"]
+        ["devicelab", "linux"]
       task_name: android_defines_test
+      dependencies: >-
+        [
+          {"dependency": "android_virtual_device", "version": "31"}
+        ]
+      use_emulator: "true"
 
   - name: Linux_android android_obfuscate_test
     recipe: devicelab/devicelab_drone

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1331,7 +1331,7 @@ targets:
 
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone
-    bringup: true
+    # bringup: true
     presubmit: true
     timeout: 60
     dimensions: {

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -1331,6 +1331,7 @@ targets:
 
   - name: Linux_android android_defines_test
     recipe: devicelab/devicelab_drone
+    bringup: true
     presubmit: true
     timeout: 60
     dimensions: {

--- a/dev/devicelab/bin/run.dart
+++ b/dev/devicelab/bin/run.dart
@@ -62,6 +62,9 @@ Future<void> main(List<String> rawArgs) async {
   /// Path to write test results to.
   final String? resultsPath = args['results-file'] as String?;
 
+  /// Use an emulator for this test if it is an android test.
+  final bool useEmulator = (args['use-emulator'] as bool?) ?? false;
+
   if (args.wasParsed('list')) {
     for (int i = 0; i < taskNames.length; i++) {
       print('${(i + 1).toString().padLeft(3)} - ${taskNames[i]}');
@@ -107,6 +110,7 @@ Future<void> main(List<String> rawArgs) async {
       gitBranch: gitBranch,
       luciBuilder: luciBuilder,
       resultsPath: resultsPath,
+      useEmulator: useEmulator,
     );
   }
 }
@@ -318,6 +322,11 @@ ArgParser createArgParser(List<String> taskNames) {
       help: 'Whether to send a SIGKILL signal to any Dart processes that are still '
             'running when a task is completed. If any Dart processes are terminated '
             'in this way, the test is considered to have failed.',
+    )
+    ..addFlag(
+      'use-emulator',
+      help: 'If this is an android test, use an emulator to run the test instead of '
+            'a physical device.'
     )
     ..addMultiOption(
       'test',

--- a/dev/devicelab/lib/command/test.dart
+++ b/dev/devicelab/lib/command/test.dart
@@ -51,6 +51,10 @@ class TestCommand extends Command<void> {
       'silent',
       help: 'Suppresses standard output and only print standard error output.',
     );
+    argParser.addFlag(
+      'use-emulator',
+      help: 'Use an emulator instead of a device to run tests.'
+    );
   }
 
   @override
@@ -74,6 +78,7 @@ class TestCommand extends Command<void> {
       luciBuilder: argResults!['luci-builder'] as String?,
       resultsPath: argResults!['results-file'] as String?,
       silent: (argResults!['silent'] as bool?) ?? false,
+      useEmulator: (argResults!['use-emulator'] as bool?) ?? false,
       taskArgs: taskArgs,
     );
   }

--- a/dev/devicelab/lib/framework/runner.dart
+++ b/dev/devicelab/lib/framework/runner.dart
@@ -39,6 +39,7 @@ Future<void> runTasks(
   String? luciBuilder,
   String? resultsPath,
   List<String>? taskArgs,
+  bool useEmulator = false,
   @visibleForTesting Map<String, String>? isolateParams,
   @visibleForTesting Function(String) print = print,
   @visibleForTesting List<String>? logs,
@@ -59,6 +60,7 @@ Future<void> runTasks(
         gitBranch: gitBranch,
         luciBuilder: luciBuilder,
         isolateParams: isolateParams,
+        useEmulator: useEmulator,
       );
 
       if (!result.succeeded) {
@@ -104,6 +106,7 @@ Future<TaskResult> rerunTask(
   String? resultsPath,
   String? gitBranch,
   String? luciBuilder,
+  bool useEmulator = false,
   @visibleForTesting Map<String, String>? isolateParams,
 }) async {
   section('Running task "$taskName"');
@@ -116,6 +119,7 @@ Future<TaskResult> rerunTask(
     silent: silent,
     taskArgs: taskArgs,
     isolateParams: isolateParams,
+    useEmulator: useEmulator,
   );
 
   print('Task result:');
@@ -152,12 +156,20 @@ Future<TaskResult> runTask(
   String? localEngineSrcPath,
   String? deviceId,
   List<String>? taskArgs,
+  bool useEmulator = false,
   @visibleForTesting Map<String, String>? isolateParams,
 }) async {
   final String taskExecutable = 'bin/tasks/$taskName.dart';
 
   if (!file(taskExecutable).existsSync()) {
     throw 'Executable Dart file not found: $taskExecutable';
+  }
+
+  if (useEmulator) {
+    taskArgs ??= <String>[];
+    taskArgs
+      ..add('--android-emulator')
+      ..add('--browser-name=android-chrome');
   }
 
   final Process runner = await startProcess(

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -283,6 +283,7 @@ Future<Process> startProcess(
   newEnvironment['BOT'] = isBot ? 'true' : 'false';
   newEnvironment['LANG'] = 'en_US.UTF-8';
   print('Executing "$command" in "$finalWorkingDirectory" with environment $newEnvironment');
+
   final Process process = await _processManager.start(
     <String>[executable, ...?arguments],
     environment: newEnvironment,


### PR DESCRIPTION
The Linux_Android android_defines_test is consistently failing on release branches. 

For the linux_android defines test the use_emulator flag made it into the release branch however none of the supporting changes did. This cherry-picks two commits that are needed to support the testing with the emulator.

Commits are:
https://github.com/flutter/flutter/commit/f989d551ce4267f00da668f35d1bae975f061992
https://github.com/flutter/flutter/commit/22bbdf03e02ee685d985279aad04fd6e16c9e7be

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/120287

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
