### PR TITLE
[Tool] [Windows] Output build duration

### DIFF
--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -229,7 +229,7 @@ class DesktopRunOutputTest extends RunOutputTask {
     return TaskResult.success(null);
   }
 
-  /// Verify that the build output of `flutter run`.
+  /// Verify the output from `flutter run`'s build step.
   void verifyBuildOutput(List<String> stdout) {}
 }
 

--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -58,7 +58,7 @@ TaskFunction createMacOSRunReleaseTest() {
 }
 
 TaskFunction createWindowsRunDebugTest() {
-  return DesktopRunOutputTest(
+  return WindowsRunOutputTest(
     '${flutterDirectory.path}/dev/integration_tests/ui',
     'lib/empty.dart',
     release: false,
@@ -66,7 +66,7 @@ TaskFunction createWindowsRunDebugTest() {
 }
 
 TaskFunction createWindowsRunReleaseTest() {
-  return DesktopRunOutputTest(
+  return WindowsRunOutputTest(
     '${flutterDirectory.path}/dev/integration_tests/ui',
     'lib/empty.dart',
     release: true,
@@ -164,6 +164,30 @@ class AndroidRunOutputTest extends RunOutputTask {
   }
 }
 
+class WindowsRunOutputTest extends DesktopRunOutputTest {
+  static final RegExp _buildOutput = RegExp(
+    r'Building Windows application\.\.\.\s*\d+(\.\d+)?(ms|s)',
+    multiLine: true,
+  );
+
+  WindowsRunOutputTest(
+    super.testDirectory,
+    super.testTarget, {
+      required super.release,
+      super.allowStderr = false,
+    }
+  );
+
+  @override
+  void verifyBuildOutput(List<String> stdout) {
+    _findNextMatcherInList(
+      stdout,
+      _buildOutput.hasMatch,
+      'Building Windows application...',
+    );
+  }
+}
+
 class DesktopRunOutputTest extends RunOutputTask {
   DesktopRunOutputTest(
     super.testDirectory,
@@ -188,6 +212,8 @@ class DesktopRunOutputTest extends RunOutputTask {
       'Launching $testTarget on',
     );
 
+    verifyBuildOutput(stdout);
+
     _findNextMatcherInList(
       stdout,
       (String line) => line.contains('Quit (terminate the application on the device).'),
@@ -202,6 +228,9 @@ class DesktopRunOutputTest extends RunOutputTask {
 
     return TaskResult.success(null);
   }
+
+  /// Verify that the build output of `flutter run`.
+  void verifyBuildOutput(List<String> stdout) {}
 }
 
 /// Test that the output of `flutter run` is expected.

--- a/dev/devicelab/lib/tasks/run_tests.dart
+++ b/dev/devicelab/lib/tasks/run_tests.dart
@@ -165,17 +165,17 @@ class AndroidRunOutputTest extends RunOutputTask {
 }
 
 class WindowsRunOutputTest extends DesktopRunOutputTest {
-  static final RegExp _buildOutput = RegExp(
-    r'Building Windows application\.\.\.\s*\d+(\.\d+)?(ms|s)',
-    multiLine: true,
-  );
-
   WindowsRunOutputTest(
     super.testDirectory,
     super.testTarget, {
       required super.release,
       super.allowStderr = false,
     }
+  );
+
+  static final RegExp _buildOutput = RegExp(
+    r'Building Windows application\.\.\.\s*\d+(\.\d+)?(ms|s)',
+    multiLine: true,
   );
 
   @override

--- a/packages/flutter_tools/lib/src/windows/build_windows.dart
+++ b/packages/flutter_tools/lib/src/windows/build_windows.dart
@@ -90,7 +90,7 @@ Future<void> buildWindows(WindowsProject windowsProject, BuildInfo buildInfo, {
     }
     await _runBuild(cmakePath, buildDirectory, buildModeName);
   } finally {
-    status.cancel();
+    status.stop();
   }
   if (buildInfo.codeSizeDirectory != null && sizeAnalyzer != null) {
     final String arch = getNameForTargetPlatform(TargetPlatform.windows_x64);


### PR DESCRIPTION
Before:

```
> flutter build windows

💪 Building with sound null safety 💪

Building Windows application...
```

After:

```
> flutter build windows

💪 Building with sound null safety 💪

Building Windows application...                             99.9s
```

Part of https://github.com/flutter/flutter/issues/120127

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
