### PR TITLE
Fix license page app bar text color on mobile view

### DIFF
--- a/packages/flutter/lib/src/material/about.dart
+++ b/packages/flutter/lib/src/material/about.dart
@@ -872,7 +872,7 @@ class _PackageLicensePageState extends State<_PackageLicensePage> {
           title: _PackageLicensePageTitle(
             title,
             subtitle,
-            theme.primaryTextTheme,
+            theme.textTheme,
             theme.appBarTheme.titleTextStyle,
           ),
         ),


### PR DESCRIPTION
This PR fixes #108991 and changes the AppBar text color to the default one so that it is readable. This is only visible on mobile devices or when your window is small.

Here is how it looks like on Windows (as example, I found this issue originally on Android):
![grafik](https://user-images.githubusercontent.com/4619618/217645802-d24448d3-0bb5-4df7-abb7-3fa8ce7f7bd1.png)

When you start scrolling you can see that the text is white:
![grafik](https://user-images.githubusercontent.com/4619618/217645943-930ab42a-0296-4b3e-a614-31d39e0fbbb1.png)

With my patch the text become visible again:
![grafik](https://user-images.githubusercontent.com/4619618/217646116-55bd8545-3ddf-45d9-9b1c-23ea95db1ba2.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat

I did not write any test since I don't know how I could test this. I hope that won't break any tests.

Might be good to know to get the green app bar I'm creating the Theme like this:

```dart
final platform = Theme.of(context).platform;
const appSeedColor = Colors.green;

return MaterialApp(
  title: _title,
  theme: ThemeData.from(
    useMaterial3: true,
    colorScheme: ColorScheme.fromSeed(seedColor: appSeedColor),
  ),
  darkTheme: ThemeData.from(
    useMaterial3: true,
    colorScheme: ColorScheme.fromSeed(seedColor: appSeedColor, brightness: Brightness.dark),
  ),
  home: MyHomePage(
    title: _title,
    platform: platform,
  ),
);
```