### PR TITLE
[flutter_tools] toolExit on sdkmanager exit during doctor --android-licenses

### DIFF
--- a/packages/flutter_tools/lib/src/android/android_workflow.dart
+++ b/packages/flutter_tools/lib/src/android/android_workflow.dart
@@ -439,8 +439,8 @@ class AndroidLicenseValidator extends DoctorValidator {
         .then(
           (Object? socket) => socket,
           onError: (dynamic err, StackTrace stack) {
-            _logger.printError('Echoing stdin to the licenses subprocess failed:');
-            _logger.printError('$err\n$stack');
+            _logger.printTrace('Echoing stdin to the licenses subprocess failed:');
+            _logger.printTrace('$err\n$stack');
           },
         ),
       );
@@ -453,12 +453,19 @@ class AndroidLicenseValidator extends DoctorValidator {
           _stdio.addStderrStream(process.stderr),
         ]);
       } on Exception catch (err, stack) {
-        _logger.printError('Echoing stdout or stderr from the license subprocess failed:');
-        _logger.printError('$err\n$stack');
+        _logger.printTrace('Echoing stdout or stderr from the license subprocess failed:');
+        _logger.printTrace('$err\n$stack');
       }
 
       final int exitCode = await process.exitCode;
-      return exitCode == 0;
+      if (exitCode != 0) {
+        throwToolExit(_userMessages.androidCannotRunSdkManager(
+          _androidSdk?.sdkManagerPath ?? '',
+          'exited code $exitCode',
+          _platform,
+        ));
+      }
+      return true;
     } on ProcessException catch (e) {
       throwToolExit(_userMessages.androidCannotRunSdkManager(
         _androidSdk?.sdkManagerPath ?? '',

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -339,7 +339,7 @@ Review licenses that have not been accepted (y/N)?
     );
 
     await licenseValidator.runLicenseManager();
-    expect(logger.errorText, contains(exceptionMessage));
+    expect(logger.traceText, contains(exceptionMessage));
     expect(processManager, hasNoRemainingExpectations);
   });
 
@@ -360,6 +360,42 @@ Review licenses that have not been accepted (y/N)?
     );
 
     expect(licenseValidator.runLicenseManager(), throwsToolExit());
+  });
+
+  testWithoutContext('runLicenseManager errors when sdkmanager exits non-zero', () async {
+    const String sdkManagerPath = '/foo/bar/sdkmanager';
+    sdk.sdkManagerPath = sdkManagerPath;
+    final BufferLogger logger = BufferLogger.test();
+    processManager.addCommand(
+      const FakeCommand(
+        command: <String>[sdkManagerPath, '--licenses'],
+        exitCode: 1,
+        stderr: 'failed to accept licenses',
+      ),
+    );
+
+    final AndroidLicenseValidator licenseValidator = AndroidLicenseValidator(
+      androidSdk: sdk,
+      fileSystem: fileSystem,
+      processManager: processManager,
+      platform: FakePlatform(environment: <String, String>{'HOME': '/home/me'}),
+      stdio: stdio,
+      logger: logger,
+      userMessages: UserMessages(),
+      androidStudio: FakeAndroidStudio(),
+      operatingSystemUtils: FakeOperatingSystemUtils(),
+    );
+
+    await expectLater(
+      licenseValidator.runLicenseManager(),
+      throwsToolExit(
+        message: 'Android sdkmanager tool was found, but failed to run ($sdkManagerPath): "exited code 1"',
+      ),
+    );
+    expect(processManager, hasNoRemainingExpectations);
+    expect(logger.traceText, isEmpty);
+    expect(stdio.writtenToStdout, isEmpty);
+    expect(stdio.writtenToStderr, isNotEmpty);
   });
 
   testWithoutContext('detects license-only SDK installation with cmdline-tools', () async {

--- a/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
+++ b/packages/flutter_tools/test/general.shard/android/android_workflow_test.dart
@@ -370,7 +370,7 @@ Review licenses that have not been accepted (y/N)?
       const FakeCommand(
         command: <String>[sdkManagerPath, '--licenses'],
         exitCode: 1,
-        stderr: 'failed to accept licenses',
+        stderr: 'sdkmanager crash',
       ),
     );
 
@@ -395,7 +395,7 @@ Review licenses that have not been accepted (y/N)?
     expect(processManager, hasNoRemainingExpectations);
     expect(logger.traceText, isEmpty);
     expect(stdio.writtenToStdout, isEmpty);
-    expect(stdio.writtenToStderr, isNotEmpty);
+    expect(stdio.writtenToStderr, contains('sdkmanager crash'));
   });
 
   testWithoutContext('detects license-only SDK installation with cmdline-tools', () async {


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/120114

This brings parity with pre-sound null safety behavior, in that in the case on macos where we get a broken pipe socket exception when the sdkmanager exits and we try to forward more tool stdin to the exited sub-process, we only show the error and stacktrace in verbose mode.

This adds a tool exit if the sub-process exited non-zero, however, which apparently before we were silently allowing (we would return false from `runLicenseManager()`, but this never bubbled up in an observable way to the user).
