### PR TITLE
[M3] Add customizable overflow property to Snackbar's action

### DIFF
--- a/dev/tools/gen_defaults/lib/snackbar_template.dart
+++ b/dev/tools/gen_defaults/lib/snackbar_template.dart
@@ -67,6 +67,12 @@ class _${blockName}DefaultsM3 extends SnackBarThemeData {
 
   @override
   bool get showCloseIcon => false;
+
+  @override
+  Color? get closeIconColor => ${componentColor("$tokenGroup.icon")};
+
+  @override
+  double get actionOverflowThreshold => 0.25;
 }
 ''';
 }

--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -43,6 +43,7 @@ class _SnackBarExampleState extends State<SnackBarExample> {
   bool _withAction = true;
   bool _multiLine = false;
   bool _longActionLabel = false;
+  double _sliderValue = 0.25;
 
   Padding _configRow(List<Widget> children) => Padding(
       padding: const EdgeInsets.all(8.0), child: Row(children: children));
@@ -130,6 +131,24 @@ class _SnackBarExampleState extends State<SnackBarExample> {
             ),
           ],
         ),
+        _configRow(
+          <Widget>[
+            const Text('Action new-line overflow threshold'),
+            Slider(
+              value: _sliderValue,
+              max: 1,
+              min: 0,
+              divisions: 20,
+              label: _sliderValue.toStringAsFixed(2),
+              onChanged:  _snackBarBehavior == SnackBarBehavior.fixed
+                ? null : (double value) {
+                setState(() {
+                  _sliderValue = value;
+                });
+              },
+            ),
+          ]
+        ),
         const SizedBox(height: 16.0),
         ElevatedButton(
           child: const Text('Show Snackbar'),
@@ -156,6 +175,7 @@ class _SnackBarExampleState extends State<SnackBarExample> {
     final String label = _multiLine
         ? 'A Snack Bar with quite a lot of text which spans across multiple lines'
         : 'Single Line Snack Bar';
+    print(_sliderValue);
     return SnackBar(
       content: Text(label),
       showCloseIcon: _withIcon,
@@ -163,6 +183,7 @@ class _SnackBarExampleState extends State<SnackBarExample> {
       behavior: _snackBarBehavior,
       action: action,
       duration: const Duration(seconds: 3),
+      actionOverflowThreshold: _sliderValue,
     );
   }
 }

--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -45,18 +45,20 @@ class _SnackBarExampleState extends State<SnackBarExample> {
   bool _longActionLabel = false;
   double _sliderValue = 0.25;
 
-  Padding _configRow(List<Widget> children) => Padding(
-      padding: const EdgeInsets.all(8.0), child: Row(children: children));
+  Padding _padRow(List<Widget> children) => Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(children: children),
+    );
 
   @override
   Widget build(BuildContext context) {
     return Padding(padding: const EdgeInsets.only(left: 50.0), child: Column(
       children: <Widget>[
-        _configRow(<Widget>[
+        _padRow(<Widget>[
           Text('Snack Bar configuration',
               style: Theme.of(context).textTheme.bodyLarge),
         ]),
-        _configRow(
+        _padRow(
           <Widget>[
             const Text('Fixed'),
             Radio<SnackBarBehavior>(
@@ -80,7 +82,7 @@ class _SnackBarExampleState extends State<SnackBarExample> {
             ),
           ],
         ),
-        _configRow(
+        _padRow(
           <Widget>[
             const Text('Include Icon '),
             Switch(
@@ -93,7 +95,7 @@ class _SnackBarExampleState extends State<SnackBarExample> {
             ),
           ],
         ),
-        _configRow(
+        _padRow(
           <Widget>[
             const Text('Include Action '),
             Switch(
@@ -118,7 +120,7 @@ class _SnackBarExampleState extends State<SnackBarExample> {
             ),
           ],
         ),
-        _configRow(
+        _padRow(
           <Widget>[
             const Text('Multi Line Text'),
             Switch(
@@ -131,15 +133,14 @@ class _SnackBarExampleState extends State<SnackBarExample> {
             ),
           ],
         ),
-        _configRow(
+        _padRow(
           <Widget>[
             const Text('Action new-line overflow threshold'),
             Slider(
               value: _sliderValue,
               divisions: 20,
               label: _sliderValue.toStringAsFixed(2),
-              onChanged:  _snackBarBehavior == SnackBarBehavior.fixed
-                ? null : (double value) {
+              onChanged:  _snackBarBehavior == SnackBarBehavior.fixed ? null : (double value) {
                 setState(() {
                   _sliderValue = value;
                 });

--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -136,8 +136,6 @@ class _SnackBarExampleState extends State<SnackBarExample> {
             const Text('Action new-line overflow threshold'),
             Slider(
               value: _sliderValue,
-              max: 1,
-              min: 0,
               divisions: 20,
               label: _sliderValue.toStringAsFixed(2),
               onChanged:  _snackBarBehavior == SnackBarBehavior.fixed

--- a/examples/api/lib/material/snack_bar/snack_bar.2.dart
+++ b/examples/api/lib/material/snack_bar/snack_bar.2.dart
@@ -175,7 +175,6 @@ class _SnackBarExampleState extends State<SnackBarExample> {
     final String label = _multiLine
         ? 'A Snack Bar with quite a lot of text which spans across multiple lines'
         : 'Single Line Snack Bar';
-    print(_sliderValue);
     return SnackBar(
       content: Text(label),
       showCloseIcon: _withIcon,

--- a/packages/flutter/lib/src/material/snack_bar.dart
+++ b/packages/flutter/lib/src/material/snack_bar.dart
@@ -239,6 +239,7 @@ class SnackBar extends StatefulWidget {
     this.shape,
     this.behavior,
     this.action,
+    this.actionOverflowThreshold,
     this.showCloseIcon,
     this.closeIconColor,
     this.duration = _snackBarDisplayDuration,
@@ -246,14 +247,12 @@ class SnackBar extends StatefulWidget {
     this.onVisible,
     this.dismissDirection = DismissDirection.down,
     this.clipBehavior = Clip.hardEdge,
-    this.actionOverflowThreshold,
   }) : assert(elevation == null || elevation >= 0.0),
-       assert(
-         width == null || margin == null,
-         'Width and margin can not be used together'),
-       assert(actionOverflowThreshold == null
-         || (actionOverflowThreshold >= 0 && actionOverflowThreshold <= 1),
-         'Action overflow threshold must be between 0 and 1 inclusive');
+       assert(width == null || margin == null,
+         'Width and margin can not be used together',
+       ),
+       assert(actionOverflowThreshold == null || (actionOverflowThreshold >= 0 && actionOverflowThreshold <= 1),
+        'Action overflow threshold must be between 0 and 1 inclusive');
 
   /// The primary content of the snack bar.
   ///
@@ -361,6 +360,18 @@ class SnackBar extends StatefulWidget {
   /// The action should not be "dismiss" or "cancel".
   final SnackBarAction? action;
 
+  /// (optional) The percentage threshold for action widget's width before it overflows
+  /// to a new line.
+  ///
+  /// Must be between 0 and 1. If the width of the snackbar's [content] is greater
+  /// than this percentage of the width of the snackbar less the width of its [action],
+  /// then the [action] will appear below the [content].
+  ///
+  /// At a value of 0, the action will not overflow to a new line.
+  ///
+  /// Defaults to 0.25.
+  final double? actionOverflowThreshold;
+
   /// (optional) Whether to include a "close" icon widget.
   ///
   /// Tapping the icon will close the snack bar.
@@ -407,15 +418,6 @@ class SnackBar extends StatefulWidget {
   /// Defaults to [Clip.hardEdge], and must not be null.
   final Clip clipBehavior;
 
-  /// The overflow threshold for action widgets.
-  ///
-  /// Must be between 0 and 1. Represents the % width value of the action widgets
-  /// permissable before the actions overflow to a new line. At a value of 0, the
-  /// action will not overflow.
-  ///
-  /// Defaults to 0.25.
-  final double? actionOverflowThreshold;
-
   // API for ScaffoldMessengerState.showSnackBar():
 
   /// Creates an animation controller useful for driving a snack bar's entrance and exit animation.
@@ -443,6 +445,7 @@ class SnackBar extends StatefulWidget {
       shape: shape,
       behavior: behavior,
       action: action,
+      actionOverflowThreshold: actionOverflowThreshold,
       showCloseIcon: showCloseIcon,
       closeIconColor: closeIconColor,
       duration: duration,
@@ -450,7 +453,6 @@ class SnackBar extends StatefulWidget {
       onVisible: onVisible,
       dismissDirection: dismissDirection,
       clipBehavior: clipBehavior,
-      actionOverflowThreshold: actionOverflowThreshold,
     );
   }
 
@@ -616,10 +618,9 @@ class _SnackBarState extends State<SnackBar> {
     final double snackBarWidth = widget.width ?? MediaQuery.sizeOf(context).width - (margin.left + margin.right);
     final double actionOverflowThreshold = widget.actionOverflowThreshold
       ?? snackBarTheme.actionOverflowThreshold
-      ?? defaults.actionOverflowThreshold
-      ?? 0.25;
-    final bool willOverflowAction =
-        actionAndIconWidth / snackBarWidth > actionOverflowThreshold;
+      ?? defaults.actionOverflowThreshold!;
+
+    final bool willOverflowAction = actionAndIconWidth / snackBarWidth > actionOverflowThreshold;
 
     final List<Widget> maybeActionAndIcon = <Widget>[
       if (widget.action != null)
@@ -660,18 +661,17 @@ class _SnackBarState extends State<SnackBar> {
                     ),
                   ),
                 ),
-                if(!willOverflowAction) ...maybeActionAndIcon,
-                if(willOverflowAction) SizedBox(width: snackBarWidth*0.4),
+                if (!willOverflowAction) ...maybeActionAndIcon,
+                if (willOverflowAction) SizedBox(width: snackBarWidth * 0.4),
               ],
             ),
-            if(willOverflowAction) Padding(
-              padding: const EdgeInsets.only(bottom: _singleLineVerticalPadding),
-              child: Row(mainAxisAlignment: MainAxisAlignment.end,
-              children: maybeActionAndIcon),
-            ),
-          ],
-
-      ),
+            if (willOverflowAction)
+              Padding(
+                padding: const EdgeInsets.only(bottom: _singleLineVerticalPadding),
+                child: Row(mainAxisAlignment: MainAxisAlignment.end, children: maybeActionAndIcon),
+              ),
+            ],
+        ),
     );
 
     if (!isFloatingSnackBar) {
@@ -835,6 +835,9 @@ class _SnackbarDefaultsM2 extends SnackBarThemeData {
 
   @override
   Color get closeIconColor => _colors.onSurface;
+
+  @override
+  double get actionOverflowThreshold => 0.25;
 }
 
 // BEGIN GENERATED TOKEN PROPERTIES - Snackbar

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -66,12 +66,9 @@ class SnackBarThemeData with Diagnosticable {
     this.closeIconColor,
     this.actionOverflowThreshold,
   })  : assert(elevation == null || elevation >= 0.0),
-        assert(
-            width == null ||
-                (identical(behavior, SnackBarBehavior.floating)),
-            'Width can only be set if behaviour is SnackBarBehavior.floating'),
-        assert(actionOverflowThreshold == null
-          || (actionOverflowThreshold >= 0 && actionOverflowThreshold <= 1),
+        assert(width == null || identical(behavior, SnackBarBehavior.floating),
+          'Width can only be set if behaviour is SnackBarBehavior.floating'),
+        assert(actionOverflowThreshold == null || (actionOverflowThreshold >= 0 && actionOverflowThreshold <= 1),
           'Action overflow threshold must be between 0 and 1 inclusive');
 
   /// Overrides the default value for [SnackBar.backgroundColor].
@@ -140,7 +137,7 @@ class SnackBarThemeData with Diagnosticable {
 
   /// Overrides the default value for [SnackBar.actionOverflowThreshold].
   ///
-  /// Must be a value between 0 and 1. Defaults to 0.25.
+  /// Must be a value between 0 and 1, if present.
   final double? actionOverflowThreshold;
 
   /// Creates a copy of this object with the given fields replaced with the

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -64,11 +64,16 @@ class SnackBarThemeData with Diagnosticable {
     this.insetPadding,
     this.showCloseIcon,
     this.closeIconColor,
+    this.actionOverflowThreshold,
   })  : assert(elevation == null || elevation >= 0.0),
         assert(
             width == null ||
                 (identical(behavior, SnackBarBehavior.floating)),
-            'Width can only be set if behaviour is SnackBarBehavior.floating');
+            'Width can only be set if behaviour is SnackBarBehavior.floating'),
+        assert(actionOverflowThreshold == null
+          || (actionOverflowThreshold >= 0 && actionOverflowThreshold <= 1),
+          'Action overflow threshold must be between 0 and 1 inclusive');
+
   /// Overrides the default value for [SnackBar.backgroundColor].
   ///
   /// If null, [SnackBar] defaults to dark grey: `Color(0xFF323232)`.
@@ -133,6 +138,11 @@ class SnackBarThemeData with Diagnosticable {
   /// This value is only used if [showCloseIcon] is true.
   final Color? closeIconColor;
 
+  /// Overrides the default value for [SnackBar.actionOverflowThreshold].
+  ///
+  /// Must be a value between 0 and 1. Defaults to 0.25.
+  final double? actionOverflowThreshold;
+
   /// Creates a copy of this object with the given fields replaced with the
   /// new values.
   SnackBarThemeData copyWith({
@@ -147,6 +157,7 @@ class SnackBarThemeData with Diagnosticable {
     EdgeInsets? insetPadding,
     bool? showCloseIcon,
     Color? closeIconColor,
+    double? actionOverflowThreshold,
   }) {
     return SnackBarThemeData(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -160,6 +171,7 @@ class SnackBarThemeData with Diagnosticable {
       insetPadding: insetPadding ?? this.insetPadding,
       showCloseIcon: showCloseIcon ?? this.showCloseIcon,
       closeIconColor: closeIconColor ?? this.closeIconColor,
+      actionOverflowThreshold: actionOverflowThreshold ?? this.actionOverflowThreshold,
     );
   }
 
@@ -180,6 +192,7 @@ class SnackBarThemeData with Diagnosticable {
       width: lerpDouble(a?.width, b?.width, t),
       insetPadding: EdgeInsets.lerp(a?.insetPadding, b?.insetPadding, t),
       closeIconColor: Color.lerp(a?.closeIconColor, b?.closeIconColor, t),
+      actionOverflowThreshold: lerpDouble(a?.actionOverflowThreshold, b?.actionOverflowThreshold, t),
     );
   }
 
@@ -196,6 +209,7 @@ class SnackBarThemeData with Diagnosticable {
         insetPadding,
         showCloseIcon,
         closeIconColor,
+        actionOverflowThreshold,
       );
 
   @override
@@ -217,7 +231,8 @@ class SnackBarThemeData with Diagnosticable {
         && other.width == width
         && other.insetPadding == insetPadding
         && other.showCloseIcon == showCloseIcon
-        && other.closeIconColor == closeIconColor;
+        && other.closeIconColor == closeIconColor
+        && other.actionOverflowThreshold == actionOverflowThreshold;
   }
 
   @override
@@ -234,5 +249,6 @@ class SnackBarThemeData with Diagnosticable {
     properties.add(DiagnosticsProperty<EdgeInsets>('insetPadding', insetPadding, defaultValue: null));
     properties.add(DiagnosticsProperty<bool>('showCloseIcon', showCloseIcon, defaultValue: null));
     properties.add(ColorProperty('closeIconColor', closeIconColor, defaultValue: null));
+    properties.add(DoubleProperty('actionOverflowThreshold', actionOverflowThreshold, defaultValue: null));
   }
 }

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -105,7 +105,6 @@ class Switch extends StatelessWidget {
     this.onInactiveThumbImageError,
     this.thumbColor,
     this.trackColor,
-    this.trackOutlineColor,
     this.thumbIcon,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -152,7 +151,6 @@ class Switch extends StatelessWidget {
     this.materialTapTargetSize,
     this.thumbColor,
     this.trackColor,
-    this.trackOutlineColor,
     this.thumbIcon,
     this.dragStartBehavior = DragStartBehavior.start,
     this.mouseCursor,
@@ -334,40 +332,6 @@ class Switch extends StatelessWidget {
   /// | Selected | [activeColor] with alpha `0x80` | [activeColor] with alpha `0x80` |
   /// | Disabled | `Colors.black12`                | `Colors.white10`                |
   final MaterialStateProperty<Color?>? trackColor;
-
-  /// {@template flutter.material.switch.trackOutlineColor}
-  /// The outline color of this [Switch]'s track.
-  ///
-  /// Resolved in the following states:
-  ///  * [MaterialState.selected].
-  ///  * [MaterialState.hovered].
-  ///  * [MaterialState.focused].
-  ///  * [MaterialState.disabled].
-  ///
-  /// {@tool snippet}
-  /// This example resolves the [trackOutlineColor] based on the current
-  /// [MaterialState] of the [Switch], providing a different [Color] when it is
-  /// [MaterialState.disabled].
-  ///
-  /// ```dart
-  /// Switch(
-  ///   value: true,
-  ///   onChanged: (_) => true,
-  ///   trackOutlineColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
-  ///     if (states.contains(MaterialState.disabled)) {
-  ///       return Colors.orange.withOpacity(.48);
-  ///     }
-  ///     return null; // Use the default color.
-  ///   }),
-  /// )
-  /// ```
-  /// {@end-tool}
-  /// {@endtemplate}
-  ///
-  /// In Material 3, the outline color defaults to transparent in the selected
-  /// state and [ColorScheme.outline] in the unselected state. In Material 2,
-  /// the [Switch] track has no outline by default.
-  final MaterialStateProperty<Color?>? trackOutlineColor;
 
   /// {@template flutter.material.switch.thumbIcon}
   /// The icon to use on the thumb of this switch
@@ -555,7 +519,6 @@ class Switch extends StatelessWidget {
       onInactiveThumbImageError: onInactiveThumbImageError,
       thumbColor: thumbColor,
       trackColor: trackColor,
-      trackOutlineColor: trackOutlineColor,
       thumbIcon: thumbIcon,
       materialTapTargetSize: materialTapTargetSize,
       dragStartBehavior: dragStartBehavior,
@@ -615,7 +578,6 @@ class _MaterialSwitch extends StatefulWidget {
     this.onInactiveThumbImageError,
     this.thumbColor,
     this.trackColor,
-    this.trackOutlineColor,
     this.thumbIcon,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -642,7 +604,6 @@ class _MaterialSwitch extends StatefulWidget {
   final ImageErrorListener? onInactiveThumbImageError;
   final MaterialStateProperty<Color?>? thumbColor;
   final MaterialStateProperty<Color?>? trackColor;
-  final MaterialStateProperty<Color?>? trackOutlineColor;
   final MaterialStateProperty<Icon?>? thumbIcon;
   final MaterialTapTargetSize? materialTapTargetSize;
   final DragStartBehavior dragStartBehavior;
@@ -804,17 +765,11 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
       ?? switchTheme.trackColor?.resolve(activeStates)
       ?? _widgetThumbColor.resolve(activeStates)?.withAlpha(0x80)
       ?? defaults.trackColor!.resolve(activeStates)!;
-    final Color effectiveActiveTrackOutlineColor = widget.trackOutlineColor?.resolve(activeStates)
-      ?? switchTheme.trackOutlineColor?.resolve(activeStates)
-      ?? Colors.transparent;
-
     final Color effectiveInactiveTrackColor = widget.trackColor?.resolve(inactiveStates)
       ?? _widgetTrackColor.resolve(inactiveStates)
       ?? switchTheme.trackColor?.resolve(inactiveStates)
       ?? defaults.trackColor!.resolve(inactiveStates)!;
-    final Color? effectiveInactiveTrackOutlineColor = widget.trackOutlineColor?.resolve(inactiveStates)
-      ?? switchTheme.trackOutlineColor?.resolve(inactiveStates)
-      ?? defaults.trackOutlineColor?.resolve(inactiveStates);
+    final Color? effectiveInactiveTrackOutlineColor = switchConfig.trackOutlineColor?.resolve(inactiveStates);
 
     final Icon? effectiveActiveIcon = widget.thumbIcon?.resolve(activeStates)
       ?? switchTheme.thumbIcon?.resolve(activeStates);
@@ -903,7 +858,6 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
             ..inactiveThumbImage = widget.inactiveThumbImage
             ..onInactiveThumbImageError = widget.onInactiveThumbImageError
             ..activeTrackColor = effectiveActiveTrackColor
-            ..activeTrackOutlineColor = effectiveActiveTrackOutlineColor
             ..inactiveTrackColor = effectiveInactiveTrackColor
             ..inactiveTrackOutlineColor = effectiveInactiveTrackOutlineColor
             ..configuration = createLocalImageConfiguration(context)
@@ -1135,16 +1089,6 @@ class _SwitchPainter extends ToggleablePainter {
     notifyListeners();
   }
 
-  Color? get activeTrackOutlineColor => _activeTrackOutlineColor;
-  Color? _activeTrackOutlineColor;
-  set activeTrackOutlineColor(Color? value) {
-    if (value == _activeTrackOutlineColor) {
-      return;
-    }
-    _activeTrackOutlineColor = value;
-    notifyListeners();
-  }
-
   Color? get inactiveTrackOutlineColor => _inactiveTrackOutlineColor;
   Color? _inactiveTrackOutlineColor;
   set inactiveTrackOutlineColor(Color? value) {
@@ -1353,7 +1297,7 @@ class _SwitchPainter extends ToggleablePainter {
     final double colorValue = CurvedAnimation(parent: positionController, curve: Curves.easeOut, reverseCurve: Curves.easeIn).value;
     final Color trackColor = Color.lerp(inactiveTrackColor, activeTrackColor, colorValue)!;
     final Color? trackOutlineColor = inactiveTrackOutlineColor == null ? null
-        : Color.lerp(inactiveTrackOutlineColor, activeTrackOutlineColor, colorValue);
+        : Color.lerp(inactiveTrackOutlineColor, Colors.transparent, colorValue);
     Color lerpedThumbColor;
     if (!reaction.isDismissed) {
       lerpedThumbColor = Color.lerp(inactivePressedColor, activePressedColor, colorValue)!;
@@ -1549,6 +1493,7 @@ mixin _SwitchConfig {
   double get pressedThumbRadius;
   double get thumbRadiusWithIcon;
   List<BoxShadow>? get thumbShadow;
+  MaterialStateProperty<Color?>? get trackOutlineColor;
   MaterialStateProperty<Color> get iconColor;
   double? get thumbOffset;
   Size get transitionalThumbSize;
@@ -1588,6 +1533,9 @@ class _SwitchConfigM2 with _SwitchConfig {
 
   @override
   double get trackHeight => 14.0;
+
+  @override
+  MaterialStateProperty<Color?>? get trackOutlineColor => null;
 
   @override
   double get trackWidth => 33.0;
@@ -1643,9 +1591,6 @@ class _SwitchDefaultsM2 extends SwitchThemeData {
   }
 
   @override
-  MaterialStateProperty<Color?>? get trackOutlineColor => null;
-
-  @override
   MaterialTapTargetSize get materialTapTargetSize => _theme.materialTapTargetSize;
 
   @override
@@ -1679,7 +1624,7 @@ class _SwitchDefaultsM2 extends SwitchThemeData {
 // Design token database by the script:
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
-// Token database version: v0_158
+// Token database version: v0_152
 
 class _SwitchDefaultsM3 extends SwitchThemeData {
   _SwitchDefaultsM3(BuildContext context)

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -105,6 +105,7 @@ class Switch extends StatelessWidget {
     this.onInactiveThumbImageError,
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.thumbIcon,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -151,6 +152,7 @@ class Switch extends StatelessWidget {
     this.materialTapTargetSize,
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.thumbIcon,
     this.dragStartBehavior = DragStartBehavior.start,
     this.mouseCursor,
@@ -332,6 +334,40 @@ class Switch extends StatelessWidget {
   /// | Selected | [activeColor] with alpha `0x80` | [activeColor] with alpha `0x80` |
   /// | Disabled | `Colors.black12`                | `Colors.white10`                |
   final MaterialStateProperty<Color?>? trackColor;
+
+  /// {@template flutter.material.switch.trackOutlineColor}
+  /// The outline color of this [Switch]'s track.
+  ///
+  /// Resolved in the following states:
+  ///  * [MaterialState.selected].
+  ///  * [MaterialState.hovered].
+  ///  * [MaterialState.focused].
+  ///  * [MaterialState.disabled].
+  ///
+  /// {@tool snippet}
+  /// This example resolves the [trackOutlineColor] based on the current
+  /// [MaterialState] of the [Switch], providing a different [Color] when it is
+  /// [MaterialState.disabled].
+  ///
+  /// ```dart
+  /// Switch(
+  ///   value: true,
+  ///   onChanged: (_) => true,
+  ///   trackOutlineColor: MaterialStateProperty.resolveWith<Color?>((Set<MaterialState> states) {
+  ///     if (states.contains(MaterialState.disabled)) {
+  ///       return Colors.orange.withOpacity(.48);
+  ///     }
+  ///     return null; // Use the default color.
+  ///   }),
+  /// )
+  /// ```
+  /// {@end-tool}
+  /// {@endtemplate}
+  ///
+  /// In Material 3, the outline color defaults to transparent in the selected
+  /// state and [ColorScheme.outline] in the unselected state. In Material 2,
+  /// the [Switch] track has no outline by default.
+  final MaterialStateProperty<Color?>? trackOutlineColor;
 
   /// {@template flutter.material.switch.thumbIcon}
   /// The icon to use on the thumb of this switch
@@ -519,6 +555,7 @@ class Switch extends StatelessWidget {
       onInactiveThumbImageError: onInactiveThumbImageError,
       thumbColor: thumbColor,
       trackColor: trackColor,
+      trackOutlineColor: trackOutlineColor,
       thumbIcon: thumbIcon,
       materialTapTargetSize: materialTapTargetSize,
       dragStartBehavior: dragStartBehavior,
@@ -578,6 +615,7 @@ class _MaterialSwitch extends StatefulWidget {
     this.onInactiveThumbImageError,
     this.thumbColor,
     this.trackColor,
+    this.trackOutlineColor,
     this.thumbIcon,
     this.materialTapTargetSize,
     this.dragStartBehavior = DragStartBehavior.start,
@@ -604,6 +642,7 @@ class _MaterialSwitch extends StatefulWidget {
   final ImageErrorListener? onInactiveThumbImageError;
   final MaterialStateProperty<Color?>? thumbColor;
   final MaterialStateProperty<Color?>? trackColor;
+  final MaterialStateProperty<Color?>? trackOutlineColor;
   final MaterialStateProperty<Icon?>? thumbIcon;
   final MaterialTapTargetSize? materialTapTargetSize;
   final DragStartBehavior dragStartBehavior;
@@ -765,11 +804,17 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
       ?? switchTheme.trackColor?.resolve(activeStates)
       ?? _widgetThumbColor.resolve(activeStates)?.withAlpha(0x80)
       ?? defaults.trackColor!.resolve(activeStates)!;
+    final Color effectiveActiveTrackOutlineColor = widget.trackOutlineColor?.resolve(activeStates)
+      ?? switchTheme.trackOutlineColor?.resolve(activeStates)
+      ?? Colors.transparent;
+
     final Color effectiveInactiveTrackColor = widget.trackColor?.resolve(inactiveStates)
       ?? _widgetTrackColor.resolve(inactiveStates)
       ?? switchTheme.trackColor?.resolve(inactiveStates)
       ?? defaults.trackColor!.resolve(inactiveStates)!;
-    final Color? effectiveInactiveTrackOutlineColor = switchConfig.trackOutlineColor?.resolve(inactiveStates);
+    final Color? effectiveInactiveTrackOutlineColor = widget.trackOutlineColor?.resolve(inactiveStates)
+      ?? switchTheme.trackOutlineColor?.resolve(inactiveStates)
+      ?? defaults.trackOutlineColor?.resolve(inactiveStates);
 
     final Icon? effectiveActiveIcon = widget.thumbIcon?.resolve(activeStates)
       ?? switchTheme.thumbIcon?.resolve(activeStates);
@@ -858,6 +903,7 @@ class _MaterialSwitchState extends State<_MaterialSwitch> with TickerProviderSta
             ..inactiveThumbImage = widget.inactiveThumbImage
             ..onInactiveThumbImageError = widget.onInactiveThumbImageError
             ..activeTrackColor = effectiveActiveTrackColor
+            ..activeTrackOutlineColor = effectiveActiveTrackOutlineColor
             ..inactiveTrackColor = effectiveInactiveTrackColor
             ..inactiveTrackOutlineColor = effectiveInactiveTrackOutlineColor
             ..configuration = createLocalImageConfiguration(context)
@@ -1089,6 +1135,16 @@ class _SwitchPainter extends ToggleablePainter {
     notifyListeners();
   }
 
+  Color? get activeTrackOutlineColor => _activeTrackOutlineColor;
+  Color? _activeTrackOutlineColor;
+  set activeTrackOutlineColor(Color? value) {
+    if (value == _activeTrackOutlineColor) {
+      return;
+    }
+    _activeTrackOutlineColor = value;
+    notifyListeners();
+  }
+
   Color? get inactiveTrackOutlineColor => _inactiveTrackOutlineColor;
   Color? _inactiveTrackOutlineColor;
   set inactiveTrackOutlineColor(Color? value) {
@@ -1297,7 +1353,7 @@ class _SwitchPainter extends ToggleablePainter {
     final double colorValue = CurvedAnimation(parent: positionController, curve: Curves.easeOut, reverseCurve: Curves.easeIn).value;
     final Color trackColor = Color.lerp(inactiveTrackColor, activeTrackColor, colorValue)!;
     final Color? trackOutlineColor = inactiveTrackOutlineColor == null ? null
-        : Color.lerp(inactiveTrackOutlineColor, Colors.transparent, colorValue);
+        : Color.lerp(inactiveTrackOutlineColor, activeTrackOutlineColor, colorValue);
     Color lerpedThumbColor;
     if (!reaction.isDismissed) {
       lerpedThumbColor = Color.lerp(inactivePressedColor, activePressedColor, colorValue)!;
@@ -1493,7 +1549,6 @@ mixin _SwitchConfig {
   double get pressedThumbRadius;
   double get thumbRadiusWithIcon;
   List<BoxShadow>? get thumbShadow;
-  MaterialStateProperty<Color?>? get trackOutlineColor;
   MaterialStateProperty<Color> get iconColor;
   double? get thumbOffset;
   Size get transitionalThumbSize;
@@ -1533,9 +1588,6 @@ class _SwitchConfigM2 with _SwitchConfig {
 
   @override
   double get trackHeight => 14.0;
-
-  @override
-  MaterialStateProperty<Color?>? get trackOutlineColor => null;
 
   @override
   double get trackWidth => 33.0;
@@ -1591,6 +1643,9 @@ class _SwitchDefaultsM2 extends SwitchThemeData {
   }
 
   @override
+  MaterialStateProperty<Color?>? get trackOutlineColor => null;
+
+  @override
   MaterialTapTargetSize get materialTapTargetSize => _theme.materialTapTargetSize;
 
   @override
@@ -1624,7 +1679,7 @@ class _SwitchDefaultsM2 extends SwitchThemeData {
 // Design token database by the script:
 //   dev/tools/gen_defaults/bin/gen_defaults.dart.
 
-// Token database version: v0_152
+// Token database version: v0_158
 
 class _SwitchDefaultsM3 extends SwitchThemeData {
   _SwitchDefaultsM3(BuildContext context)
@@ -1697,6 +1752,19 @@ class _SwitchDefaultsM3 extends SwitchThemeData {
         return _colors.surfaceVariant;
       }
       return _colors.surfaceVariant;
+    });
+  }
+
+  @override
+  MaterialStateProperty<Color?> get trackOutlineColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return Colors.transparent;
+      }
+      if (states.contains(MaterialState.disabled)) {
+        return _colors.onSurface.withOpacity(0.12);
+      }
+      return _colors.outline;
     });
   }
 
@@ -1801,19 +1869,6 @@ class _SwitchConfigM3 with _SwitchConfig {
 
   @override
   double get trackHeight => 32.0;
-
-  @override
-  MaterialStateProperty<Color?> get trackOutlineColor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return null;
-      }
-      if (states.contains(MaterialState.disabled)) {
-        return _colors.onSurface.withOpacity(0.12);
-      }
-      return _colors.outline;
-    });
-  }
 
   @override
   double get trackWidth => 52.0;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -1756,19 +1756,6 @@ class _SwitchDefaultsM3 extends SwitchThemeData {
   }
 
   @override
-  MaterialStateProperty<Color?> get trackOutlineColor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return Colors.transparent;
-      }
-      if (states.contains(MaterialState.disabled)) {
-        return _colors.onSurface.withOpacity(0.12);
-      }
-      return _colors.outline;
-    });
-  }
-
-  @override
   MaterialStateProperty<Color?> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.selected)) {
@@ -1869,6 +1856,19 @@ class _SwitchConfigM3 with _SwitchConfig {
 
   @override
   double get trackHeight => 32.0;
+
+  @override
+  MaterialStateProperty<Color?> get trackOutlineColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return null;
+      }
+      if (states.contains(MaterialState.disabled)) {
+        return _colors.onSurface.withOpacity(0.12);
+      }
+      return _colors.outline;
+    });
+  }
 
   @override
   double get trackWidth => 52.0;

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2616,8 +2616,7 @@ void main() {
 
     final ScaffoldMessengerState scaffoldMessengerState = tester.state(find.byType(ScaffoldMessenger));
     scaffoldMessengerState.showSnackBar(const SnackBar(
-      content: Text(
-          'This is a really long snackbar message. So long, it spans across more than one line!'),
+      content: Text('This is a really long snackbar message. So long, it spans across more than one line!'),
       duration: Duration(seconds: 2),
       showCloseIcon: true,
       behavior: SnackBarBehavior.floating,

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2317,6 +2317,7 @@ void main() {
     required SnackBarBehavior? behavior,
     EdgeInsetsGeometry? margin,
     double? width,
+    double? actionOverflowThreshold,
   }) {
     return MaterialApp(
       home: Scaffold(
@@ -2335,6 +2336,7 @@ void main() {
                   content: const Text('I am a snack bar.'),
                   duration: const Duration(seconds: 2),
                   action: SnackBarAction(label: 'ACTION', onPressed: () {}),
+                  actionOverflowThreshold: actionOverflowThreshold,
                 ));
               },
               child: const Text('X'),
@@ -2412,6 +2414,22 @@ void main() {
       'was set by default.',
     );
   });
+
+  for (final double overflowThreshold in [-1.0, -.0001, 1.000001, 5]) {
+    testWidgets('SnackBar will assert for actionOverflowThreshold outside of 0-1 range', (WidgetTester tester) async {
+      await tester.pumpWidget(doBuildApp(
+        actionOverflowThreshold: overflowThreshold,
+        behavior: SnackBarBehavior.fixed,
+      ));
+      await tester.tap(find.text('X'));
+      await tester.pump(); // start animation
+      await tester.pump(const Duration(milliseconds: 750));
+
+      final AssertionError exception = tester.takeException() as AssertionError;
+      expect(exception.message, 'Action overflow threshold must be between 0 and 1 inclusive');
+    });
+  }
+
 
   testWidgets('Snackbar by default clips BackdropFilter', (WidgetTester tester) async {
     // Regression test for https://github.com/flutter/flutter/issues/98205
@@ -2556,7 +2574,7 @@ void main() {
         matchesGoldenFile('snack_bar.goldenTest.floatingWithIcon.png'));
   });
 
-  testWidgets('Fixed multi-line snackbar with icon is aligned correctly', (WidgetTester tester) async {
+  testWidgets('Floating multi-line snackbar with icon is aligned correctly', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
         bottomSheet: SizedBox(
@@ -2581,6 +2599,34 @@ void main() {
 
     await expectLater(find.byType(MaterialApp),
         matchesGoldenFile('snack_bar.goldenTest.multiLineWithIcon.png'));
+  });
+
+  testWidgets('Floating multi-line snackbar with icon and actionOverflowThreshold=0 is aligned correctly', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        bottomSheet: SizedBox(
+          width: 200,
+          height: 50,
+          child: ColoredBox(
+            color: Colors.pink,
+          ),
+        ),
+      ),
+    ));
+
+    final ScaffoldMessengerState scaffoldMessengerState = tester.state(find.byType(ScaffoldMessenger));
+    scaffoldMessengerState.showSnackBar(const SnackBar(
+      content: Text(
+          'This is a really long snackbar message. So long, it spans across more than one line!'),
+      duration: Duration(seconds: 2),
+      showCloseIcon: true,
+      behavior: SnackBarBehavior.floating,
+      actionOverflowThreshold: 1,
+    ));
+    await tester.pumpAndSettle(); // Have the SnackBar fully animate out.
+
+    await expectLater(find.byType(MaterialApp),
+        matchesGoldenFile('snack_bar.goldenTest.multiLineWithIconWithZeroActionOverflowThreshold.png'));
   });
 
   testWidgets(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2601,7 +2601,7 @@ void main() {
         matchesGoldenFile('snack_bar.goldenTest.multiLineWithIcon.png'));
   });
 
-  testWidgets('Floating multi-line snackbar with icon and actionOverflowThreshold=0 is aligned correctly', (WidgetTester tester) async {
+  testWidgets('Floating multi-line snackbar with icon and actionOverflowThreshold=1 is aligned correctly', (WidgetTester tester) async {
     await tester.pumpWidget(const MaterialApp(
       home: Scaffold(
         bottomSheet: SizedBox(

--- a/packages/flutter/test/material/snack_bar_test.dart
+++ b/packages/flutter/test/material/snack_bar_test.dart
@@ -2415,7 +2415,7 @@ void main() {
     );
   });
 
-  for (final double overflowThreshold in [-1.0, -.0001, 1.000001, 5]) {
+  for (final double overflowThreshold in <double>[-1.0, -.0001, 1.000001, 5]) {
     testWidgets('SnackBar will assert for actionOverflowThreshold outside of 0-1 range', (WidgetTester tester) async {
       await tester.pumpWidget(doBuildApp(
         actionOverflowThreshold: overflowThreshold,

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -25,6 +25,7 @@ void main() {
     expect(snackBarTheme.insetPadding, null);
     expect(snackBarTheme.showCloseIcon, null);
     expect(snackBarTheme.closeIconColor, null);
+    expect(snackBarTheme.actionOverflowThreshold, null);
   });
 
   test(
@@ -65,6 +66,7 @@ void main() {
       insetPadding: EdgeInsets.all(10.0),
       showCloseIcon: false,
       closeIconColor: Color(0xFF0000AA),
+      actionOverflowThreshold: 0.5,
     ).debugFillProperties(builder);
 
     final List<String> description = builder.properties
@@ -84,6 +86,7 @@ void main() {
       'insetPadding: EdgeInsets.all(10.0)',
       'showCloseIcon: false',
       'closeIconColor: Color(0xff0000aa)',
+      'actionOverflowThreshold: 0.5',
     ]);
   });
 
@@ -313,10 +316,14 @@ void main() {
     required SnackBarBehavior themedBehavior,
     EdgeInsetsGeometry? margin,
     double? width,
+    double? themedActionOverflowThreshold,
   }) {
     return MaterialApp(
       theme: ThemeData(
-        snackBarTheme: SnackBarThemeData(behavior: themedBehavior),
+        snackBarTheme: SnackBarThemeData(
+          behavior: themedBehavior,
+          actionOverflowThreshold: themedActionOverflowThreshold,
+        ),
       ),
       home: Scaffold(
         floatingActionButton: FloatingActionButton(
@@ -371,6 +378,16 @@ void main() {
           'was set by the inherited SnackBarThemeData.',
     );
   });
+
+  for (final double overflowThreshold in [-1.0, -.0001, 1.000001, 5]) {
+    testWidgets('SnackBar theme will assert for actionOverflowThreshold outside of 0-1 range', {
+      expect(
+        () => SnackBarThemeData(
+              actionOverflowThreshold: overflowThreshold,
+            ),
+        throwsAssertionError);
+   });
+  }
 
   testWidgets('SnackBar theme behavior will assert properly for width use', (WidgetTester tester) async {
     // SnackBarBehavior.floating set in theme does not assert with width

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -379,8 +379,8 @@ void main() {
     );
   });
 
-  for (final double overflowThreshold in [-1.0, -.0001, 1.000001, 5]) {
-    testWidgets('SnackBar theme will assert for actionOverflowThreshold outside of 0-1 range', {
+  for (final double overflowThreshold in <double>[-1.0, -.0001, 1.000001, 5]) {
+    test('SnackBar theme will assert for actionOverflowThreshold outside of 0-1 range', () {
       expect(
         () => SnackBarThemeData(
               actionOverflowThreshold: overflowThreshold,


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/119809. 

Updated Goldens: https://flutter-gold.skia.org/search?issue=120394&crs=github&patchsets=8&corpus=flutter

The issue highlighted a problem where widgets in the `action` section of a snackbar were hardcoded to overflow to a clean new line if they took up more than 25% of the width of the snackbar. 

The Material 3 [spec](https://m3.material.io/components/snackbar/specs) shows this, but does not specify any specific values/ratios for when the action should overflow:

| Overflow  | No overflow |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/15033982/217928474-3ae83524-0909-4e1b-a135-0536e3088316.png) |![image](https://user-images.githubusercontent.com/15033982/217928442-412220f3-a150-4cff-97b0-805f731ce120.png) |

**Proposed solution** 

I've added a `actionOverflowThreshold` property to `SnackBar` and `SnackBarThemeData`: a value that can be set between 0 and 1. This represents the ratio of the width the action can take up before it will overflow to a new line. 

This is demonstrated with an update to the snackbar demo. With a 0 value, the action will always overflow, at 1 it will never overflow, and at 0.5 it will overflow if it takes up 50% of the width.

[Screen recording 2023-02-09 7.09.06 PM.webm](https://user-images.githubusercontent.com/15033982/217929069-c189f5bf-300c-4930-a923-68691b68532e.webm)

This will allow users to customize the overflow of their snackbar's actions, or remove it altogether if needed. I've retained the M3 default to be 0.25, as I think this reflects the spec diagram.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

