### PR TITLE
Fix class that shouldn't be extended/instantiated/mixedin

### DIFF
--- a/packages/flutter/lib/src/material/animated_icons/animated_icons_data.dart
+++ b/packages/flutter/lib/src/material/animated_icons/animated_icons_data.dart
@@ -25,6 +25,9 @@ part of material_animated_icons; // ignore: use_string_in_part_of_directives
 ///
 ///  * [Icons], for the list of available static Material Icons.
 abstract class AnimatedIcons {
+  // This class is not meant to be instantiated or extended; this constructor
+  // prevents instantiation and extension.
+  AnimatedIcons._();
 
   /// The Material Design add to event icon animation.
   ///

--- a/packages/flutter/lib/src/material/material_state.dart
+++ b/packages/flutter/lib/src/material/material_state.dart
@@ -632,7 +632,6 @@ class _MaterialStateUnderlineInputBorder extends MaterialStateUnderlineInputBord
 ///
 /// {@macro flutter.material.MaterialStateProperty.implementations}
 abstract class MaterialStateProperty<T> {
-
   /// Returns a value of type `T` that depends on [states].
   ///
   /// Widgets like [TextButton] and [ElevatedButton] apply this method to their

--- a/packages/flutter_driver/lib/src/extension/extension.dart
+++ b/packages/flutter_driver/lib/src/extension/extension.dart
@@ -255,7 +255,6 @@ abstract class FinderExtension {
 /// See also:
 ///   * [CommandWithTarget], a base class for [Command]s with [Finder]s.
 abstract class CommandExtension {
-
   /// Identifies the type of command to be used by the driver extension.
   String get commandKind;
 


### PR DESCRIPTION
This was discovered when investigating which classes could potentially be used as a mixin and may need a mixin class modifier in Dart 3. This class came up as potential mixin candidates even though it really shouldn't be candidates.

Part of https://github.com/flutter/flutter/issues/118837.