### PR TITLE
Allow scroll physics that doesn't obey physical metaphor

### DIFF
--- a/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
+++ b/dev/integration_tests/flutter_gallery/lib/demo/animation/home.dart
@@ -382,10 +382,11 @@ class _SnappingScrollPhysics extends ClampingScrollPhysics {
   }
 
   @override
-  Simulation? createBallisticSimulation(ScrollMetrics position, double dragVelocity) {
-    final Simulation? simulation = super.createBallisticSimulation(position, dragVelocity);
+  Simulation? createBallisticSimulation(ScrollMetrics position, Simulation oldSimulation, {double time = 0.0}) {
+    final Simulation? simulation = super.createBallisticSimulation(position, oldSimulation, time: time);
     final double offset = position.pixels;
 
+    final double dragVelocity = oldSimulation.dx(time);
     if (simulation != null) {
       // The drag ended with sufficient velocity to trigger creating a simulation.
       // If the simulation is headed up towards midScrollOffset but will not reach it,

--- a/packages/flutter/lib/physics.dart
+++ b/packages/flutter/lib/physics.dart
@@ -11,6 +11,7 @@ library physics;
 export 'src/physics/clamped_simulation.dart';
 export 'src/physics/friction_simulation.dart';
 export 'src/physics/gravity_simulation.dart';
+export 'src/physics/inertial_simulation.dart';
 export 'src/physics/simulation.dart';
 export 'src/physics/spring_simulation.dart';
 export 'src/physics/tolerance.dart';

--- a/packages/flutter/lib/src/physics/inertial_simulation.dart
+++ b/packages/flutter/lib/src/physics/inertial_simulation.dart
@@ -1,0 +1,44 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import 'simulation.dart';
+
+/// A simulation that never changes velocity.
+///
+/// This simulates a physical particle moving purely under inertia, with no
+/// forces acting on it.
+class InertialSimulation extends Simulation {
+  /// Creates a simulation that never changes velocity.
+  InertialSimulation({
+    this.position = 0.0,
+    this.velocity = 0.0,
+    super.tolerance,
+  });
+
+  /// A simulation that is stationary at the origin.
+  ///
+  /// In this simulation, both [position] and [velocity] are zero.
+  // Ideally this would be const, but [Simulation.tolerance] is non-final.
+  static final InertialSimulation zero = InertialSimulation();
+
+  /// The position of the particle at the beginning of the simulation.
+  final double position;
+
+  /// The velocity at which the particle travels.
+  final double velocity;
+
+  @override
+  double x(double time) => position + time * velocity;
+
+  @override
+  double dx(double time) => velocity;
+
+  @override
+  bool isDone(double time) => velocity == 0.0;
+
+  @override
+  String toString() => '${objectRuntimeType(this, 'InertialSimulation')}(x₀: ${position.toStringAsFixed(1)}, dx₀: ${velocity.toStringAsFixed(1)})';
+}

--- a/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
+++ b/packages/flutter/lib/src/widgets/list_wheel_scroll_view.dart
@@ -464,13 +464,14 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
   }
 
   @override
-  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+  Simulation? createBallisticSimulation(ScrollMetrics position, Simulation oldSimulation, {double time = 0.0}) {
     assert(
       position is _FixedExtentScrollPosition,
       'FixedExtentScrollPhysics can only be used with Scrollables that uses '
       'the FixedExtentScrollController',
     );
 
+    final double velocity = oldSimulation.dx(time);
     final _FixedExtentScrollPosition metrics = position as _FixedExtentScrollPosition;
 
     // Scenario 1:
@@ -478,13 +479,13 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
     // ballistics, which should put us back in range at the scrollable's boundary.
     if ((velocity <= 0.0 && metrics.pixels <= metrics.minScrollExtent) ||
         (velocity >= 0.0 && metrics.pixels >= metrics.maxScrollExtent)) {
-      return super.createBallisticSimulation(metrics, velocity);
+      return super.createBallisticSimulation(metrics, oldSimulation, time: time);
     }
 
     // Create a test simulation to see where it would have ballistically fallen
     // naturally without settling onto items.
     final Simulation? testFrictionSimulation =
-        super.createBallisticSimulation(metrics, velocity);
+        super.createBallisticSimulation(metrics, oldSimulation, time: time);
 
     // Scenario 2:
     // If it was going to end up past the scroll extent, defer back to the
@@ -493,7 +494,7 @@ class FixedExtentScrollPhysics extends ScrollPhysics {
     if (testFrictionSimulation != null
         && (testFrictionSimulation.x(double.infinity) == metrics.minScrollExtent
             || testFrictionSimulation.x(double.infinity) == metrics.maxScrollExtent)) {
-      return super.createBallisticSimulation(metrics, velocity);
+      return super.createBallisticSimulation(metrics, oldSimulation, time: time);
     }
 
     // From the natural final position, find the nearest item it should have

--- a/packages/flutter/lib/src/widgets/page_view.dart
+++ b/packages/flutter/lib/src/widgets/page_view.dart
@@ -563,12 +563,14 @@ class PageScrollPhysics extends ScrollPhysics {
   }
 
   @override
-  Simulation? createBallisticSimulation(ScrollMetrics position, double velocity) {
+  Simulation? createBallisticSimulation(ScrollMetrics position, Simulation oldSimulation, {double time = 0.0}) {
+    final double velocity = oldSimulation.dx(time);
+
     // If we're out of range and not headed back in range, defer to the parent
     // ballistics, which should put us back in range at a page boundary.
     if ((velocity <= 0.0 && position.pixels <= position.minScrollExtent) ||
         (velocity >= 0.0 && position.pixels >= position.maxScrollExtent)) {
-      return super.createBallisticSimulation(position, velocity);
+      return super.createBallisticSimulation(position, oldSimulation, time: time);
     }
     final Tolerance tolerance = toleranceFor(position);
     final double target = _getTargetPixels(position, tolerance, velocity);
@@ -577,6 +579,7 @@ class PageScrollPhysics extends ScrollPhysics {
     }
     return null;
   }
+
 
   @override
   bool get allowImplicitScrolling => false;

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -900,13 +900,28 @@ class ClampingScrollPhysics extends ScrollPhysics {
     if (velocity < 0.0 && position.pixels <= position.minScrollExtent) {
       return null;
     }
-    // TODO(gnprice): This is inaccurate, because ClampingScrollSimulation isn't ballistic.
-    //   https://github.com/flutter/flutter/issues/120338
-    return ClampingScrollSimulation(
-      position: position.pixels,
-      velocity: velocity,
-      tolerance: tolerance,
-    );
+
+    if (oldSimulation is ClampingScrollSimulation) {
+      // We're updating a [ClampingScrollSimulation], and we're still in the
+      // conditions where we want one.  So continue the old simulation, just with
+      // the time axis relabeled.
+      //
+      // Because [ClampingScrollSimulation] is not ballistic, this behaves very
+      // differently from a fresh simulation: a fresh simulation would decelerate
+      // much more rapidly and go less far before stopping.
+      return ClampingScrollSimulation(
+        position: oldSimulation.position,
+        velocity: oldSimulation.velocity,
+        tolerance: oldSimulation.tolerance,
+        offsetTime: time + oldSimulation.offsetTime,
+      );
+    } else {
+      return ClampingScrollSimulation(
+        position: position.pixels,
+        velocity: velocity,
+        tolerance: tolerance,
+      );
+    }
   }
 }
 

--- a/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
+++ b/packages/flutter/lib/src/widgets/scroll_position_with_single_context.dart
@@ -137,9 +137,9 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
   ///
   /// The velocity should be in logical pixels per second.
   @override
-  void goBallistic(double velocity) {
+  void goBallistic(Simulation oldSimulation, {double time = 0.0}) {
     assert(hasPixels);
-    final Simulation? simulation = physics.createBallisticSimulation(this, velocity);
+    final Simulation? simulation = physics.createBallisticSimulation(this, oldSimulation, time: time);
     if (simulation != null) {
       beginActivity(BallisticScrollActivity(
         this,
@@ -203,7 +203,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
       didUpdateScrollPositionBy(pixels - oldPixels);
       didEndScroll();
     }
-    goBallistic(0.0);
+    goBallistic(InertialSimulation.zero);
   }
 
   @override
@@ -212,7 +212,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
     // (or similar) change should be made in
     // _NestedScrollCoordinator.pointerScroll.
     if (delta == 0.0) {
-      goBallistic(0.0);
+      goBallistic(InertialSimulation.zero);
       return;
     }
 
@@ -231,7 +231,7 @@ class ScrollPositionWithSingleContext extends ScrollPosition implements ScrollAc
       didStartScroll();
       didUpdateScrollPositionBy(pixels - oldPixels);
       didEndScroll();
-      goBallistic(0.0);
+      goBallistic(InertialSimulation.zero);
     }
   }
 

--- a/packages/flutter/lib/src/widgets/scroll_simulation.dart
+++ b/packages/flutter/lib/src/widgets/scroll_simulation.dart
@@ -139,6 +139,7 @@ class ClampingScrollSimulation extends Simulation {
   ClampingScrollSimulation({
     required this.position,
     required this.velocity,
+    this.offsetTime = 0.0,
     this.friction = 0.015,
     super.tolerance,
   }) : assert(_flingVelocityPenetration(0.0) == _initialVelocityPenetration) {
@@ -146,12 +147,23 @@ class ClampingScrollSimulation extends Simulation {
     _distance = (velocity * _duration / _initialVelocityPenetration).abs();
   }
 
-  /// The position of the particle at the beginning of the simulation.
+  /// The position of the particle at the beginning of the base simulation.
+  ///
+  /// This will equal [x(-offsetTime)].
   final double position;
 
   /// The velocity at which the particle is traveling at the beginning of the
-  /// simulation.
+  /// base simulation.
+  ///
+  /// This will equal [dx(-offsetTime)].
   final double velocity;
+
+  /// The time this simulation starts at in the underlying base simulation.
+  ///
+  /// For any given time `t`, this simulation will return the same answers from
+  /// [x], [dx], and [isDone] at time `t` as a simulation with zero [offsetTime]
+  /// would give at time `t + offsetTime`.
+  final double offsetTime;
 
   /// The amount of friction the particle experiences as it travels.
   ///
@@ -207,18 +219,18 @@ class ClampingScrollSimulation extends Simulation {
 
   @override
   double x(double time) {
-    final double t = clampDouble(time / _duration, 0.0, 1.0);
+    final double t = clampDouble((time + offsetTime) / _duration, 0.0, 1.0);
     return position + _distance * _flingDistancePenetration(t) * velocity.sign;
   }
 
   @override
   double dx(double time) {
-    final double t = clampDouble(time / _duration, 0.0, 1.0);
+    final double t = clampDouble((time + offsetTime) / _duration, 0.0, 1.0);
     return _distance * _flingVelocityPenetration(t) * velocity.sign / _duration;
   }
 
   @override
   bool isDone(double time) {
-    return time >= _duration;
+    return (time + offsetTime) >= _duration;
   }
 }

--- a/packages/flutter/test/physics/inertial_simulation_test.dart
+++ b/packages/flutter/test/physics/inertial_simulation_test.dart
@@ -1,0 +1,31 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/physics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('InertialSimulation', () {
+    expect(InertialSimulation(position: 12.3, velocity: 45.6), hasOneLineDescription);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).x(0),   12.3);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).x(1),   12.3 + 45.6);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).x(1e3), 45612.3);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).dx(0), 45.6);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).dx(1), 45.6);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).isDone(0),   false);
+    expect(InertialSimulation(position: 12.3, velocity: 45.6).isDone(1e9), false);
+    expect(InertialSimulation(velocity: 0.0001).isDone(0),   false);
+    expect(InertialSimulation(velocity: 0.0001).isDone(1e9), false);
+    expect(InertialSimulation().isDone(0), true);
+  });
+
+  test('InertialSimulation.zero', () {
+    expect(InertialSimulation.zero.x(0),    0.0);
+    expect(InertialSimulation.zero.x(1e9),  0.0);
+    expect(InertialSimulation.zero.dx(0),   0.0);
+    expect(InertialSimulation.zero.dx(1e9), 0.0);
+    expect(InertialSimulation.zero.isDone(0),   true);
+    expect(InertialSimulation.zero.isDone(1e9), true);
+  });
+}

--- a/packages/flutter/test/widgets/nested_scroll_view_test.dart
+++ b/packages/flutter/test/widgets/nested_scroll_view_test.dart
@@ -21,7 +21,7 @@ class _CustomPhysics extends ClampingScrollPhysics {
   }
 
   @override
-  Simulation createBallisticSimulation(ScrollMetrics position, double dragVelocity) {
+  Simulation createBallisticSimulation(ScrollMetrics position, Simulation oldSimulation, {double time = 0.0}) {
     return ScrollSpringSimulation(spring, 1000.0, 1000.0, 1000.0);
   }
 }

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -116,9 +116,9 @@ void main() {
 
     // Calls to createBallisticSimulation may happen on every frame (i.e. when the maxScrollExtent changes)
     // Changing velocity for time 0 may cause a sudden, unwanted damping/speedup effect
-    expect(bounce.createBallisticSimulation(position, 1000)!.dx(0), moreOrLessEquals(1000));
-    expect(clamp.createBallisticSimulation(position, 1000)!.dx(0), moreOrLessEquals(1000));
-    expect(page.createBallisticSimulation(position, 1000)!.dx(0), moreOrLessEquals(1000));
+    expect(bounce.createBallisticSimulation(position, InertialSimulation(velocity: 1000))!.dx(0), moreOrLessEquals(1000));
+    expect(clamp.createBallisticSimulation(position, InertialSimulation(velocity: 1000))!.dx(0), moreOrLessEquals(1000));
+    expect(page.createBallisticSimulation(position, InertialSimulation(velocity: 1000))!.dx(0), moreOrLessEquals(1000));
   });
 
   group('BouncingScrollPhysics test', () {

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1061,7 +1061,7 @@ void main() {
     // Getting the tester to simulate a life-like fling is difficult.
     // Instead, just manually drive the activity with a ballistic simulation as
     // if the user has flung the list.
-    Scrollable.of(find.byType(SizedBox).evaluate().first).position.activity!.delegate.goBallistic(4000);
+    Scrollable.of(find.byType(SizedBox).evaluate().first).position.activity!.delegate.goBallistic(InertialSimulation(velocity: 4000));
 
     await tester.pumpAndSettle();
     expect(find.byKey(const ValueKey<String>('Box 0')), findsNothing);
@@ -1103,7 +1103,7 @@ void main() {
     // Getting the tester to simulate a life-like fling is difficult.
     // Instead, just manually drive the activity with a ballistic simulation as
     // if the user has flung the list.
-    position.activity!.delegate.goBallistic(4000);
+    position.activity!.delegate.goBallistic(InertialSimulation(velocity: 4000));
 
     await tester.pumpAndSettle();
 
@@ -1145,7 +1145,7 @@ void main() {
     // Getting the tester to simulate a life-like fling is difficult.
     // Instead, just manually drive the activity with a ballistic simulation as
     // if the user has flung the list.
-    position.activity!.delegate.goBallistic(4000);
+    position.activity!.delegate.goBallistic(InertialSimulation(velocity: 4000));
 
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
Fixes #120338.

NOTE: This is a breaking change. It needs discussion, and would need to go through the breaking-change process.

This is the alternative solution, vs. #120420, that I described at https://github.com/flutter/flutter/issues/120338#issuecomment-1423636999 .

I think the best course is probably to merge the alternative solution #120420 and close this one; see below.  So I wouldn't ask anyone to spend time reviewing this code in detail at this point.

But here it is for discussion of the overall strategy for fixing that issue.

---

#### Give scroll physics the previous simulation, not just velocity (first commit)

This provides the API to remove the requirement that a ScrollPhysics
behave ballistically, opening up one path to fixing #120338.

The crux of it is that when the ScrollPosition learns of new metrics,
the way it's been communicating that to the ScrollPhysics is by
calling its createBallisticSimulation method.  That method's
parameters were just a ScrollMetrics and a velocity, and the method
has to return a new simulation.

The requirement that the physics be ballistic was a necessary
consequence of that API: because the only information the method gets
about the old simulation is its position (as ScrollMetrics.pixels)
and its velocity, the physics has to be designed so that that's
enough information.

To lift that requirement, we let ScrollPhysics.createBallisticSimulation
see more information, by passing it the whole old Simulation.

This also requires ScrollActivityDelegate.goBallistic to take a
Simulation instead of just a velocity, so it can pass that on in its
call to createBallisticSimulation.  Then BallisticScrollActivity
passes it the actual simulation instead of just its current velocity.

In order to ergonomically handle all the goBallistic call sites
that really do have just a velocity, we add InertialSimulation as a
trivial Simulation subclass with a constant velocity, and a static
InertialSimulation.zero for the many call sites that want that.

---

#### Make ClampingScrollSimulation restartable (second commit)

Fixes #120338.

This takes advantage of the new addition to the ScrollPhysics API,
where createBallisticSimulation gets the whole previous simulation
rather than just its velocity.

In ClampingScrollPhysics, when we're in the middle of a fling-scroll,
so that we had a ClampingScrollSimulation and we still want to
continue with a ClampingScrollSimulation, we now just take the old
simulation and relabel its time axis so that we continue on its path
exactly.  This lets us correctly handle restarts even though this
physics doesn't satisfy a ballistic physical metaphor, fixing #120338.

---

This is a breaking change because ScrollPhysics implementations need to implement the new signature, as do ScrollActivityDelegate implementations.

It also makes the API more complex.  There may well be things we could do to improve on this PR's version of the API, but I think any version of this solution will make the API more complex than it is — fundamentally, if we want to remove this invariant then the ScrollPhysics needs to be told more information than it currently is.  A breaking change that makes the API simpler and cleaner is one thing, but this would be one that goes in the less appealing direction.

Given that, and because #120420 offers a way to resolve the major user-visible issues here without a breaking change, I'm inclined to think it's best to just leave this API as it is.  But I wanted to share this draft of what it would look like, to facilitate discussion of the trade-offs.

This version of the PR doesn't change the actual curve, so leaves open #113424 and #119875.  But after this change it should be possible to swap in the Android curve by relanding #77497 more or less verbatim — just with a tweak to use the new API similarly to this PR's second commit — which would resolve those.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
