### PR TITLE
[tool][web] Makes flutter.js more G3 friendly.

### DIFF
--- a/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
+++ b/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
@@ -72,8 +72,7 @@ _flutter.loader = null;
      */
     constructor(validPatterns, policyName = "flutter-js") {
       const patterns = validPatterns || [
-        /\.dart\.js$/,
-        /^flutter_service_worker.js$/
+        /\.js$/,
       ];
       if (window.trustedTypes) {
         this.policy = trustedTypes.createPolicy(policyName, {

--- a/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
+++ b/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
@@ -115,11 +115,15 @@ _flutter.loader = null;
      * @returns {Promise} that resolves when the latest serviceWorker is ready.
      */
     loadServiceWorker(settings) {
-      if (!("serviceWorker" in navigator) || settings == null) {
-        // In the future, settings = null -> uninstall service worker?
+      if (!("serviceWorker" in navigator)) {
         return Promise.reject(
-          new Error("Service worker not supported (or configured).")
+          new Error("Service Worker API unavailable.")
         );
+      }
+      if (settings == null) {
+        // In the future, settings = null -> uninstall service worker?
+        console.debug("Null serviceWorker configuration. Skipping.");
+        return Promise.resolve();
       }
       const {
         serviceWorkerVersion,

--- a/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
+++ b/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
@@ -115,6 +115,11 @@ _flutter.loader = null;
      * @returns {Promise} that resolves when the latest serviceWorker is ready.
      */
     loadServiceWorker(settings) {
+      if (settings == null) {
+        // In the future, settings = null -> uninstall service worker?
+        console.debug("Null serviceWorker configuration. Skipping.");
+        return Promise.resolve();
+      }
       if (!("serviceWorker" in navigator)) {
         let errorMessage = "Service Worker API unavailable.";
         if (!window.isSecureContext) {
@@ -124,11 +129,6 @@ _flutter.loader = null;
         return Promise.reject(
           new Error(errorMessage)
         );
-      }
-      if (settings == null) {
-        // In the future, settings = null -> uninstall service worker?
-        console.debug("Null serviceWorker configuration. Skipping.");
-        return Promise.resolve();
       }
       const {
         serviceWorkerVersion,

--- a/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
+++ b/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
@@ -116,8 +116,13 @@ _flutter.loader = null;
      */
     loadServiceWorker(settings) {
       if (!("serviceWorker" in navigator)) {
+        let errorMessage = "Service Worker API unavailable.";
+        if (!window.isSecureContext) {
+          errorMessage += "\nThe current context is NOT secure."
+          errorMessage += "\nRead more: https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts";
+        }
         return Promise.reject(
-          new Error("Service Worker API unavailable.")
+          new Error(errorMessage)
         );
       }
       if (settings == null) {

--- a/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
+++ b/packages/flutter_tools/test/general.shard/build_system/targets/web_test.dart
@@ -881,6 +881,8 @@ void main() {
         flutter_js.generateFlutterJsFile(fileGeneratorsPath);
     expect(flutterJsContents, contains('"use strict";'));
     expect(flutterJsContents, contains('main.dart.js'));
+    expect(flutterJsContents, contains('if (!("serviceWorker" in navigator))'));
+    expect(flutterJsContents, contains(r'/\.js$/,'));
     expect(flutterJsContents, contains('flutter_service_worker.js?v='));
     expect(flutterJsContents, contains('document.createElement("script")'));
     expect(flutterJsContents, contains('"application/javascript"'));


### PR DESCRIPTION
## Description

This PR makes the flutter.js loading process slightly more friendly with google's internal configuration by:

* Relaxing the trusted types validation of the flutter loader, so files with different naming conventions can be used (both for the main.dart.js and flutter_service_worker.js files)
* Nagging users *less* about the serviceWorker configuration being null.
  * Only prints a warning if serviceWorker is not available, and points users to Secure Context documentation if needed.
  * (Null configuration is still output as a low level debug.info message, which is often filtered out by browsers)

_(FYI: @jacobsimionato)_

## Related issues

Fixes https://github.com/flutter/flutter/issues/120483
Fixes https://github.com/flutter/flutter/issues/116153

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
