### PR TITLE
Don't print `cd` command if the directory is `.`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -776,11 +776,10 @@ List<String> _getPlatformWarningList(List<String> requestedPlatforms) {
 }
 
 String displayPath(String path) {
-  if (path == ".") {
+  if (path == ".")
     return "\$ flutter run";
-  } else {
-    return "\$ cd $path\n  \$ flutter run";
-  }
+
+  return "\$ cd $path\n  \$ flutter run";
 }
 
 void _printWarningDisabledPlatform(List<String> platforms) {

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -482,8 +482,7 @@ If you prefer video documentation, consider: https://www.youtube.com/c/flutterde
 
 In order to run your $application, type:
 
-  \$ cd $relativeAppPath
-  \$ flutter run
+  ${relativeAppPath != "." ? "\$ cd $relativeAppPath\n  \$ flutter run" : "\$ flutter run"}
 
 Your $application code is in $relativeAppMain.
 ''');

--- a/packages/flutter_tools/lib/src/commands/create.dart
+++ b/packages/flutter_tools/lib/src/commands/create.dart
@@ -482,7 +482,7 @@ If you prefer video documentation, consider: https://www.youtube.com/c/flutterde
 
 In order to run your $application, type:
 
-  ${relativeAppPath != "." ? "\$ cd $relativeAppPath\n  \$ flutter run" : "\$ flutter run"}
+  ${displayPath(relativeAppPath)}
 
 Your $application code is in $relativeAppMain.
 ''');
@@ -773,6 +773,14 @@ List<String> _getPlatformWarningList(List<String> requestedPlatforms) {
   ];
 
   return platformsToWarn;
+}
+
+String displayPath(String path) {
+  if (path == ".") {
+    return "\$ flutter run";
+  } else {
+    return "\$ cd $path\n  \$ flutter run";
+  }
 }
 
 void _printWarningDisabledPlatform(List<String> platforms) {


### PR DESCRIPTION
Just a simple fix when the `flutter create` command has current directory i.e. `flutter create .`. It should not print the `cd .` part in it

Just experienced this and hence fixed the problem
![image](https://user-images.githubusercontent.com/51731966/218322784-0319682e-66fd-440e-982c-801cf25c4769.png)
