### PR TITLE
Force `Mac build_tests` to run on x64 bots

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -2500,6 +2500,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2519,6 +2520,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2538,6 +2540,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},
@@ -2557,6 +2560,7 @@ targets:
     timeout: 60
     properties:
       add_recipes_cq: "true"
+      cpu: x86 # https://github.com/flutter/flutter/issues/120292
       dependencies: >-
         [
           {"dependency": "android_sdk", "version": "version:33v6"},


### PR DESCRIPTION
Post-https://github.com/flutter/flutter/pull/119884 the `Mac build_tests` tests have been flaky on arm64 bots, timing out.  

Force the test to run on x64 only while the underlying issue is being investigated https://github.com/flutter/flutter/issues/119750

Fixes https://github.com/flutter/flutter/issues/120292
Fixes https://github.com/flutter/flutter/issues/120472