### PR TITLE
Allow built-in EdgeDraggingAutoScroller of ReorderableList/SliverReorderableList to be configured

### DIFF
--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -610,10 +610,14 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       _autoScroller?.stopAutoScroll();
       _autoScroller = EdgeDraggingAutoScroller(
         _scrollable,
-        onScrollViewScrolled: _handleScrollableAutoScrolled
+        onScrollViewScrolled: _handleScrollableAutoScrolled,
+        velocityScalar: _kDefaultSelectToScrollVelocityScalar
       );
     }
   }
+
+  // An eye-balled value for a smooth scrolling speed.
+  static const double _kDefaultSelectToScrollVelocityScalar = 30;
 
   @override
   void didUpdateWidget(covariant SliverReorderableList oldWidget) {

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -130,6 +130,7 @@ class ReorderableList extends StatefulWidget {
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.restorationId,
     this.clipBehavior = Clip.hardEdge,
+    this.scrollVelocityScalar,
   }) : assert(itemCount >= 0),
        assert(
          itemExtent == null || prototypeItem == null,
@@ -251,6 +252,9 @@ class ReorderableList extends StatefulWidget {
 
   /// {@macro flutter.widgets.list_view.prototypeItem}
   final Widget? prototypeItem;
+
+  /// {@macro flutter.widgets.reorderable_list.scrollVelocityScalar}
+  final double scrollVelocityScalar;
 
   /// The state from the closest instance of this class that encloses the given
   /// context.
@@ -442,6 +446,7 @@ class SliverReorderableList extends StatefulWidget {
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
+    this.scrollVelocityScalar,
   }) : assert(itemCount >= 0),
        assert(
          itemExtent == null || prototypeItem == null,
@@ -474,6 +479,9 @@ class SliverReorderableList extends StatefulWidget {
 
   /// {@macro flutter.widgets.list_view.prototypeItem}
   final Widget? prototypeItem;
+
+  /// {@macro flutter.widgets.reorderable_list.scrollVelocityScalar}
+  final double scrollVelocityScalar;
 
   @override
   SliverReorderableListState createState() => SliverReorderableListState();
@@ -611,13 +619,10 @@ class SliverReorderableListState extends State<SliverReorderableList> with Ticke
       _autoScroller = EdgeDraggingAutoScroller(
         _scrollable,
         onScrollViewScrolled: _handleScrollableAutoScrolled,
-        velocityScalar: _kDefaultSelectToScrollVelocityScalar
+        velocityScalar: widget.scrollVelocityScalar
       );
     }
   }
-
-  // An eye-balled value for a smooth scrolling speed.
-  static const double _kDefaultSelectToScrollVelocityScalar = 30;
 
   @override
   void didUpdateWidget(covariant SliverReorderableList oldWidget) {

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -130,7 +130,7 @@ class ReorderableList extends StatefulWidget {
     this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
     this.restorationId,
     this.clipBehavior = Clip.hardEdge,
-    this.scrollVelocityScalar,
+    this.scrollVelocityScalar = 7,
   }) : assert(itemCount >= 0),
        assert(
          itemExtent == null || prototypeItem == null,
@@ -446,7 +446,7 @@ class SliverReorderableList extends StatefulWidget {
     this.itemExtent,
     this.prototypeItem,
     this.proxyDecorator,
-    this.scrollVelocityScalar,
+    this.scrollVelocityScalar = 7,
   }) : assert(itemCount >= 0),
        assert(
          itemExtent == null || prototypeItem == null,

--- a/packages/flutter/lib/src/widgets/reorderable_list.dart
+++ b/packages/flutter/lib/src/widgets/reorderable_list.dart
@@ -207,6 +207,13 @@ class ReorderableList extends StatefulWidget {
   /// {@endtemplate}
   final EdgeInsetsGeometry? padding;
 
+  /// {@template flutter.widgets.reorderable_list.scrollVelocityScalar}
+  /// An eyeballed value for a smooth scrolling experience.
+  ///
+  /// The default value is 7.
+  /// {@endtemplate}
+  final double scrollVelocityScalar;
+
   /// {@macro flutter.widgets.scroll_view.scrollDirection}
   final Axis scrollDirection;
 
@@ -252,9 +259,6 @@ class ReorderableList extends StatefulWidget {
 
   /// {@macro flutter.widgets.list_view.prototypeItem}
   final Widget? prototypeItem;
-
-  /// {@macro flutter.widgets.reorderable_list.scrollVelocityScalar}
-  final double scrollVelocityScalar;
 
   /// The state from the closest instance of this class that encloses the given
   /// context.

--- a/packages/flutter/test/widgets/reorderable_list_test.dart
+++ b/packages/flutter/test/widgets/reorderable_list_test.dart
@@ -779,6 +779,74 @@ void main() {
     ), throwsAssertionError);
   });
 
+  testWidgets('scrollVelocityScalar can change in ReorderableList', (WidgetTester tester) async {
+    final List<int> numbers = <int>[0,1,2];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return ReorderableList(
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(
+                    key: ValueKey<int>(numbers[index]),
+                    height: 20 + numbers[index] * 10,
+                    child: ReorderableDragStartListener(
+                      index: index,
+                      child: Text(numbers[index].toString()),
+                    )
+                  );
+                },
+                itemCount: numbers.length,
+                itemExtent: 30,
+                prototypeItem: const SizedBox(),
+                onReorder: (int fromIndex, int toIndex) { },
+                scrollVelocityScalar: 30,
+              );
+            },
+          ),
+        ),
+      )
+    );
+
+    expect(scrollVelocityScalar, 30);
+  });
+
+  testWidgets('scrollVelocityScalar can change in SliverReorderableList', (WidgetTester tester) async {
+    final List<int> numbers = <int>[0,1,2];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return SliverReorderableList(
+                itemBuilder: (BuildContext context, int index) {
+                  return SizedBox(
+                    key: ValueKey<int>(numbers[index]),
+                    height: 20 + numbers[index] * 10,
+                    child: ReorderableDragStartListener(
+                      index: index,
+                      child: Text(numbers[index].toString()),
+                    )
+                  );
+                },
+                itemCount: numbers.length,
+                itemExtent: 30,
+                prototypeItem: const SizedBox(),
+                onReorder: (int fromIndex, int toIndex) { },
+                scrollVelocityScalar: 30,
+              );
+            },
+          ),
+        ),
+      )
+    );
+
+    expect(scrollVelocityScalar, 30);
+  });
+
   testWidgets('if itemExtent is non-null, children have same extent in the scroll direction', (WidgetTester tester) async {
     final List<int> numbers = <int>[0,1,2];
 


### PR DESCRIPTION
Signed-off-by: Shogo Hida <shogo.hida@gmail.com>

Fixes #120479 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
