### PR TITLE
Using correct origin

### DIFF
--- a/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
+++ b/packages/flutter_tools/lib/src/web/file_generators/js/flutter.js
@@ -78,7 +78,7 @@ _flutter.loader = null;
       if (window.trustedTypes) {
         this.policy = trustedTypes.createPolicy(policyName, {
           createScriptURL: function(url) {
-            const parsed = new URL(url, window.location);
+            const parsed = new URL(url, window.location.origin);
             const file = parsed.pathname.split("/").pop();
             const matches = patterns.some((pattern) => pattern.test(file));
             if (matches) {


### PR DESCRIPTION
We need to use origin of location for calculate path to service worker. Service worker placed in root directory, but current code take all url as base. It is working okay for `HashUrlStrategy`, but produces bugs with `PathUrlStrategy`.

P.S inner implementation of js class `URL(path, base)` help to work old code in case when URL has only one route param `testapp.com/routeParam`, but it can't correct handle cases like `testapp.com/routeParam1/routeParam2`

https://github.com/flutter/flutter/issues/120692

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
