### PR TITLE
allow passing --file-reporter option to test running refs #69425

### DIFF
--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -208,6 +208,11 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
           'json':     'A machine-readable format. See: https://dart.dev/go/test-docs/json_reporter.md',
         },
       )
+      ..addOption('file-reporter',
+        help: 'Enable an additional reporter writing test results to a file.\n'
+          'Should be in the form <reporter>:<filepath>, '
+          'Example: "json:reports/tests.json"'
+      )
       ..addOption('timeout',
         help: 'The default test timeout, specified either '
               'in seconds (e.g. "60s"), '
@@ -463,6 +468,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       web: stringArgDeprecated('platform') == 'chrome',
       randomSeed: stringArgDeprecated('test-randomize-ordering-seed'),
       reporter: stringArgDeprecated('reporter'),
+      fileReporter: stringArg('file-reporter'),
       timeout: stringArgDeprecated('timeout'),
       runSkipped: boolArgDeprecated('run-skipped'),
       shardIndex: shardIndex,

--- a/packages/flutter_tools/lib/src/commands/test.dart
+++ b/packages/flutter_tools/lib/src/commands/test.dart
@@ -211,7 +211,7 @@ class TestCommand extends FlutterCommand with DeviceBasedDevelopmentArtifacts {
       ..addOption('file-reporter',
         help: 'Enable an additional reporter writing test results to a file.\n'
           'Should be in the form <reporter>:<filepath>, '
-          'Example: "json:reports/tests.json"'
+          'Example: "json:reports/tests.json".'
       )
       ..addOption('timeout',
         help: 'The default test timeout, specified either '

--- a/packages/flutter_tools/lib/src/test/runner.dart
+++ b/packages/flutter_tools/lib/src/test/runner.dart
@@ -45,6 +45,7 @@ abstract class FlutterTestRunner {
     bool web = false,
     String? randomSeed,
     String? reporter,
+    String? fileReporter,
     String? timeout,
     bool runSkipped = false,
     int? shardIndex,
@@ -82,6 +83,7 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
     bool web = false,
     String? randomSeed,
     String? reporter,
+    String? fileReporter,
     String? timeout,
     bool runSkipped = false,
     int? shardIndex,
@@ -103,6 +105,8 @@ class _FlutterTestRunnerImpl implements FlutterTestRunner {
         ...<String>['-r', 'json']
       else if (reporter != null)
         ...<String>['-r', reporter],
+      if (fileReporter != null)
+        '--file-reporter=$fileReporter',
       if (timeout != null)
         ...<String>['--timeout', timeout],
       '--concurrency=$concurrency',

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -804,6 +804,40 @@ dev_dependencies:
       ProcessManager: () => FakeProcessManager.any(),
     });
   });
+
+  group('File Reporter', () {
+    testUsingContext('defaults to unset null value', () async {
+      final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+      final TestCommand testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+      ]);
+      expect(testRunner.lastFileReporterValue, null);
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+    testUsingContext('when set --file-reporter value is passed on', () async {
+      final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
+
+      final TestCommand testCommand = TestCommand(testRunner: testRunner);
+      final CommandRunner<void> commandRunner = createTestCommandRunner(testCommand);
+
+      await commandRunner.run(const <String>[
+        'test',
+        '--no-pub',
+        '--file-reporter=json:out.jsonl'
+      ]);
+      expect(testRunner.lastFileReporterValue, 'json:out.jsonl');
+    }, overrides: <Type, Generator>{
+      FileSystem: () => fs,
+      ProcessManager: () => FakeProcessManager.any(),
+    });
+  });
 }
 
 class FakeFlutterTestRunner implements FlutterTestRunner {
@@ -813,6 +847,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
   Duration? leastRunTime;
   bool? lastEnableObservatoryValue;
   late DebuggingOptions lastDebuggingOptionsValue;
+  String? lastFileReporterValue;
   String? lastReporterOption;
 
   @override
@@ -839,6 +874,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
     bool web = false,
     String? randomSeed,
     String? reporter,
+    String? fileReporter,
     String? timeout,
     bool runSkipped = false,
     int? shardIndex,
@@ -849,6 +885,7 @@ class FakeFlutterTestRunner implements FlutterTestRunner {
   }) async {
     lastEnableObservatoryValue = enableObservatory;
     lastDebuggingOptionsValue = debuggingOptions;
+    lastFileReporterValue = fileReporter;
     lastReporterOption = reporter;
 
     if (leastRunTime != null) {

--- a/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/test_test.dart
@@ -821,6 +821,7 @@ dev_dependencies:
       FileSystem: () => fs,
       ProcessManager: () => FakeProcessManager.any(),
     });
+
     testUsingContext('when set --file-reporter value is passed on', () async {
       final FakeFlutterTestRunner testRunner = FakeFlutterTestRunner(0);
 


### PR DESCRIPTION
Allow passing `--file-reporter` option to test runner so that both machine and human readable output can be observed in a CI setting.

Supersedes #111969.

Fixes #69425.

**Note:** I did not made the initial commit. It was made entirely by @daniel-v, so all credits goes to him. I rebased his patch and I'm going to continue the PR process by fixing tests/checks and reacting to reviewers.

## Pre-launch Checklist
  * [x]  I read the [Contributor Guide](https://github.com/flutter/flutter/wiki/Tree-hygiene#overview) and followed the process outlined there for submitting PRs.
  * [x]  I read the [Tree Hygiene](https://github.com/flutter/flutter/wiki/Tree-hygiene) wiki page, which explains my responsibilities.
  * [x]  I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo), including [Features we expect every widget to implement](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement).
  * [x]  I signed the [CLA](https://cla.developers.google.com/).
  * [x]  I listed at least one issue that this PR fixes in the description above.
  * [x]  I updated/added relevant documentation (doc comments with `///`).
  * [x]  I added new tests to check the change I am making, or this PR is [test-exempt](https://github.com/flutter/flutter/wiki/Tree-hygiene#tests).
  * [x]  All existing and new tests are passing.
