### PR TITLE
Fix the `flutter run -d linux` tests

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -702,6 +702,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
+      xvfb: true
       dependencies: >-
         [
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -722,6 +722,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      xvfb: 1
       dependencies: >-
         [
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -702,7 +702,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
-      xvfb: true
+      xvfb: 1
       dependencies: >-
         [
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -702,7 +702,7 @@ targets:
     bringup: true
     timeout: 60
     properties:
-      xvfb: 1
+      xvfb: "1"
       dependencies: >-
         [
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
@@ -722,7 +722,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
-      xvfb: 1
+      xvfb: "1"
       dependencies: >-
         [
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},


### PR DESCRIPTION
Use the new `xvfb` property introduced by: https://flutter-review.git.corp.google.com/c/recipes/+/39186

This is required to run with a graphical UI in Linux.

Addresses https://github.com/flutter/flutter/issues/118477

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
