### PR TITLE
Remove single axis assertion from GlowingOverscrollIndicator

### DIFF
--- a/packages/flutter/lib/src/widgets/overscroll_indicator.dart
+++ b/packages/flutter/lib/src/widgets/overscroll_indicator.dart
@@ -201,6 +201,11 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
     if (!widget.notificationPredicate(notification)) {
       return false;
     }
+    if (notification.metrics.axis != widget.axis) {
+      // This widget is explicitly configured to one axis. If a notification
+      // from a different axis bubbles up, do nothing.
+      return false;
+    }
 
     // Update the paint offset with the current scroll position. This makes
     // sure that the glow effect correctly scrolls in line with the current
@@ -236,7 +241,6 @@ class _GlowingOverscrollIndicatorState extends State<GlowingOverscrollIndicator>
         }
       }
       assert(controller != null);
-      assert(notification.metrics.axis == widget.axis);
       if (_accepted[isLeading]!) {
         if (notification.velocity != 0.0) {
           assert(notification.dragDetails == null);

--- a/packages/flutter/test/widgets/overscroll_indicator_test.dart
+++ b/packages/flutter/test/widgets/overscroll_indicator_test.dart
@@ -233,6 +233,35 @@ void main() {
     expect(painter, doesNotOverscroll);
   });
 
+  testWidgets('Overscroll ignored from alternate axis', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const Directionality(
+        textDirection: TextDirection.ltr,
+        child: ScrollConfiguration(
+          behavior: TestScrollBehaviorNoGlow(),
+          child: GlowingOverscrollIndicator(
+            axisDirection: AxisDirection.right,
+            color: Color(0xFF0000FF),
+            child: CustomScrollView(
+              physics: AlwaysScrollableScrollPhysics(),
+              slivers: <Widget>[
+                SliverToBoxAdapter(child: SizedBox(height: 20.0)),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    final RenderObject painter = tester.renderObject(find.byType(CustomPaint));
+    await slowDrag(tester, const Offset(200.0, 200.0), const Offset(0.0, 5.0));
+    expect(painter, doesNotOverscroll);
+    await slowDrag(tester, const Offset(200.0, 200.0), const Offset(0.0, -5.0));
+    expect(painter, doesNotOverscroll);
+
+    await tester.pumpAndSettle(const Duration(seconds: 1));
+    expect(painter, doesNotOverscroll);
+  });
+
   testWidgets('Overscroll horizontally', (WidgetTester tester) async {
     await tester.pumpWidget(
       const Directionality(
@@ -568,5 +597,14 @@ class TestScrollBehavior2 extends ScrollBehavior {
       color: const Color(0xFF0000FF),
       child: child,
     );
+  }
+}
+
+class TestScrollBehaviorNoGlow extends ScrollBehavior {
+  const TestScrollBehaviorNoGlow();
+
+  @override
+  Widget buildOverscrollIndicator(BuildContext context, Widget child, ScrollableDetails details) {
+    return child;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/120735

2D Scrolling proposal: flutter.dev/go/2D-Foundation

In preparation for 2D scrolling, this removes an assertion from the GlowingOverscrollIndicator when it receives a notification from another axis. It is already configured to only apply in one axis, and so now it will just do nothing.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
