### PR TITLE
Revert "Fix error when resetting configurations in tear down phase"

### DIFF
--- a/packages/flutter_test/lib/src/binding.dart
+++ b/packages/flutter_test/lib/src/binding.dart
@@ -15,7 +15,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:stack_trace/stack_trace.dart' as stack_trace;
 import 'package:test_api/expect.dart' show fail;
-import 'package:test_api/scaffolding.dart'; // ignore: deprecated_member_use
 import 'package:test_api/test_api.dart' as test_package show Timeout; // ignore: deprecated_member_use
 import 'package:vector_math/vector_math_64.dart';
 
@@ -920,13 +919,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
     // So that we can assert that it remains the same after the test finishes.
     _beforeTestCheckIntrinsicSizes = debugCheckIntrinsicSizes;
 
-    bool shouldTearDownVerifyInvariants = false;
-    addTearDown(() {
-      if (shouldTearDownVerifyInvariants) {
-        _verifyTearDownInvariants();
-      }
-    });
-
     runApp(Container(key: UniqueKey(), child: _preTestMessage)); // Reset the tree to a known state.
     await pump();
     // Pretend that the first frame produced in the test body is the first frame
@@ -957,7 +949,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
       _verifyErrorWidgetBuilderUnset(errorWidgetBuilderBeforeTest);
       _verifyShouldPropagateDevicePointerEventsUnset(shouldPropagateDevicePointerEventsBeforeTest);
       _verifyInvariants();
-      shouldTearDownVerifyInvariants = true;
     }
 
     assert(inTest);
@@ -967,11 +958,6 @@ abstract class TestWidgetsFlutterBinding extends BindingBase
   late bool _beforeTestCheckIntrinsicSizes;
 
   void _verifyInvariants() {
-    // subclasses such as AutomatedTestWidgetsFlutterBinding overrides this
-    // to perform more verifications.
-  }
-
-  void _verifyTearDownInvariants() {
     assert(debugAssertNoTransientCallbacks(
       'An animation is still running even after the widget tree was disposed.'
     ));

--- a/packages/flutter_test/test/bindings_test.dart
+++ b/packages/flutter_test/test/bindings_test.dart
@@ -12,7 +12,6 @@ library;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -102,17 +101,5 @@ void main() {
       responded = true;
     });
     expect(responded, true);
-  });
-
-  group('should be able to reset values in either tearDown or end of function', () {
-    testWidgets('addTearDown should work', (WidgetTester tester) async {
-      timeDilation = 2;
-      addTearDown(() => timeDilation = 1);
-    });
-
-    testWidgets('directly reset should work', (WidgetTester tester) async {
-      timeDilation = 2;
-      timeDilation = 1;
-    });
   });
 }


### PR DESCRIPTION
Reverts flutter/flutter#114468. /cc @fzyzcjy

Example failure: https://logs.chromium.org/logs/flutter/buildbucket/cr-buildbucket/8789140722059256001/+/u/run_test.dart_for_tool_integration_tests_shard_and_subshard_1_4/test_stdout

```
15:07 +57 ~2 -1: test/integration.shard/test_test.dart: flutter test should report a nice error when a Ticker is left running [E]                                                                      
  Expected: a value not equal to <0>
    Actual: <0>
     Which: is not a value not equal to <0>
  
  package:test_api                             expect
  test/integration.shard/test_test.dart 249:3  _testFile
  

To run this test again: /Volumes/Work/s/w/ir/x/w/flutter/bin/cache/dart-sdk/bin/dart test test/integration.shard/test_test.dart -p vm --plain-name 'flutter test should report a nice error when a Ticker is left running'
```