### PR TITLE
Fix `SliverAppBar.medium` & `SliverAppBar.large` title overlap with leading/actions widgets, leading width, and title spacing

### DIFF
--- a/dev/tools/gen_defaults/lib/app_bar_template.dart
+++ b/dev/tools/gen_defaults/lib/app_bar_template.dart
@@ -79,10 +79,10 @@ class _MediumScrollUnderFlexibleConfig with _ScrollUnderFlexibleConfig {
     ${textStyle('md.comp.top-app-bar.medium.headline')}?.apply(color: ${color('md.comp.top-app-bar.medium.headline.color')});
 
   @override
-  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.fromSTEB(48, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
-  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
   EdgeInsetsGeometry? get expandedTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 20);
@@ -108,10 +108,10 @@ class _LargeScrollUnderFlexibleConfig with _ScrollUnderFlexibleConfig {
     ${textStyle('md.comp.top-app-bar.large.headline')}?.apply(color: ${color('md.comp.top-app-bar.large.headline.color')});
 
   @override
-  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.fromSTEB(48, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
-  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
   EdgeInsetsGeometry? get expandedTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 28);

--- a/packages/flutter/lib/src/material/app_bar.dart
+++ b/packages/flutter/lib/src/material/app_bar.dart
@@ -1543,13 +1543,16 @@ class SliverAppBar extends StatefulWidget {
       key: key,
       leading: leading,
       automaticallyImplyLeading: automaticallyImplyLeading,
-      actions: actions,
       flexibleSpace: flexibleSpace ?? _ScrollUnderFlexibleSpace(
+        hasLeading: leading != null,
         title: title,
+        actions: actions,
         foregroundColor: foregroundColor,
         variant: _ScrollUnderFlexibleVariant.medium,
         centerCollapsedTitle: centerTitle,
         primary: primary,
+        leadingWidth: leadingWidth,
+        titleSpacing: titleSpacing,
       ),
       bottom: bottom,
       elevation: elevation,
@@ -1645,13 +1648,16 @@ class SliverAppBar extends StatefulWidget {
       key: key,
       leading: leading,
       automaticallyImplyLeading: automaticallyImplyLeading,
-      actions: actions,
       flexibleSpace: flexibleSpace ?? _ScrollUnderFlexibleSpace(
+        hasLeading: leading != null,
         title: title,
+        actions: actions,
         foregroundColor: foregroundColor,
         variant: _ScrollUnderFlexibleVariant.large,
         centerCollapsedTitle: centerTitle,
         primary: primary,
+        leadingWidth: leadingWidth,
+        titleSpacing: titleSpacing,
       ),
       bottom: bottom,
       elevation: elevation,
@@ -2092,18 +2098,26 @@ enum _ScrollUnderFlexibleVariant { medium, large }
 
 class _ScrollUnderFlexibleSpace extends StatelessWidget {
   const _ScrollUnderFlexibleSpace({
+    required this.hasLeading,
     this.title,
+    this.actions,
     this.foregroundColor,
     required this.variant,
     this.centerCollapsedTitle,
     this.primary = true,
+    this.leadingWidth,
+    this.titleSpacing,
   });
 
+  final bool hasLeading;
   final Widget? title;
+  final List<Widget>? actions;
   final Color? foregroundColor;
   final _ScrollUnderFlexibleVariant variant;
   final bool? centerCollapsedTitle;
   final bool primary;
+  final double? leadingWidth;
+  final double? titleSpacing;
 
   @override
   Widget build(BuildContext context) {
@@ -2157,6 +2171,14 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
       centerTitle = centerCollapsedTitle ?? appBarTheme.centerTitle ?? platformCenter();
     }
 
+    EdgeInsetsGeometry effectiveCollapsedTitlePadding = EdgeInsets.zero;
+    if (hasLeading && leadingWidth == null) {
+      effectiveCollapsedTitlePadding = centerTitle
+        ? config.collapsedCenteredTitlePadding!
+        : config.collapsedTitlePadding!;
+    } else if (hasLeading && leadingWidth != null) {
+      effectiveCollapsedTitlePadding = EdgeInsetsDirectional.only(start: leadingWidth!);
+    }
     final bool isCollapsed = settings.isScrolledUnder ?? false;
     return Column(
       children: <Widget>[
@@ -2164,17 +2186,20 @@ class _ScrollUnderFlexibleSpace extends StatelessWidget {
           padding: EdgeInsets.only(top: topPadding),
           child: Container(
             height: collapsedHeight,
-            padding: centerTitle ? config.collapsedCenteredTitlePadding : config.collapsedTitlePadding,
-            child: AnimatedOpacity(
-              opacity: isCollapsed ? 1 : 0,
-              duration: const Duration(milliseconds: 500),
-              curve: const Cubic(0.2, 0.0, 0.0, 1.0),
-              child: Align(
-                alignment: centerTitle
-                  ? Alignment.center
-                  : AlignmentDirectional.centerStart,
+            padding: effectiveCollapsedTitlePadding,
+            child: NavigationToolbar(
+              centerMiddle: centerTitle,
+              middleSpacing: titleSpacing ?? appBarTheme.titleSpacing ?? NavigationToolbar.kMiddleSpacing,
+              middle: AnimatedOpacity(
+                opacity: isCollapsed ? 1 : 0,
+                duration: const Duration(milliseconds: 500),
+                curve: const Cubic(0.2, 0.0, 0.0, 1.0),
                 child: collapsedTitle,
               ),
+              trailing: actions != null ? Row(
+                mainAxisSize: MainAxisSize.min,
+                children: actions!,
+              ) : null,
             ),
           ),
         ),
@@ -2310,10 +2335,10 @@ class _MediumScrollUnderFlexibleConfig with _ScrollUnderFlexibleConfig {
     _textTheme.headlineSmall?.apply(color: _colors.onSurface);
 
   @override
-  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.fromSTEB(48, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
-  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
   EdgeInsetsGeometry? get expandedTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 20);
@@ -2339,10 +2364,10 @@ class _LargeScrollUnderFlexibleConfig with _ScrollUnderFlexibleConfig {
     _textTheme.headlineMedium?.apply(color: _colors.onSurface);
 
   @override
-  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.fromSTEB(48, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
-  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 0);
+  EdgeInsetsGeometry? get collapsedCenteredTitlePadding => const EdgeInsetsDirectional.only(start: 40);
 
   @override
   EdgeInsetsGeometry? get expandedTitlePadding => const EdgeInsets.fromLTRB(16, 0, 16, 28);

--- a/packages/flutter/test/material/app_bar_test.dart
+++ b/packages/flutter/test/material/app_bar_test.dart
@@ -3974,6 +3974,401 @@ void main() {
     expect(tester.getSize(find.byKey(leadingKey)).width, leadingWidth);
   });
 
+  testWidgets(
+    'SliverAppBar.medium collapsed title does not overlap with leading/actions widgets',
+    (WidgetTester tester) async {
+      const String title = 'Medium SliverAppBar Very Long Title';
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            primary: true,
+            slivers: <Widget>[
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 200),
+                sliver: SliverAppBar.medium(
+                  leading: IconButton(
+                    icon: const Icon(Icons.menu),
+                    onPressed: () {},
+                  ),
+                  title: const Text(title, maxLines: 1),
+                  actions: const <Widget>[
+                    Icon(Icons.search),
+                    Icon(Icons.sort),
+                    Icon(Icons.more_vert),
+                  ],
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: Container(
+                  height: 1200,
+                  color: Colors.orange[400],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ));
+
+      // Scroll to collapse the SliverAppBar.
+      final ScrollController controller = primaryScrollController(tester);
+      controller.jumpTo(45);
+      await tester.pumpAndSettle();
+
+      final Offset leadingOffset = tester.getTopRight(find.byIcon(Icons.menu));
+      Offset titleOffset = tester.getTopLeft(find.text(title).first);
+      // The title widget should be to the right of the leading widget.
+      expect(titleOffset.dx, greaterThan(leadingOffset.dx));
+
+      titleOffset = tester.getTopRight(find.text(title).first);
+      final Offset searchOffset = tester.getTopLeft(find.byIcon(Icons.search));
+      // The title widget should be to the left of the search icon.
+      expect(titleOffset.dx, lessThan(searchOffset.dx));
+  });
+
+  testWidgets(
+    'SliverAppBar.large collapsed title does not overlap with leading/actions widgets',
+    (WidgetTester tester) async {
+      const String title = 'Large SliverAppBar Very Long Title';
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            primary: true,
+            slivers: <Widget>[
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(horizontal: 200),
+                sliver: SliverAppBar.large(
+                  leading: IconButton(
+                    icon: const Icon(Icons.menu),
+                    onPressed: () {},
+                  ),
+                  title: const Text(title, maxLines: 1),
+                  actions: const <Widget>[
+                    Icon(Icons.search),
+                    Icon(Icons.sort),
+                    Icon(Icons.more_vert),
+                  ],
+                ),
+              ),
+              SliverToBoxAdapter(
+                child: Container(
+                  height: 1200,
+                  color: Colors.orange[400],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ));
+
+      // Scroll to collapse the SliverAppBar.
+      final ScrollController controller = primaryScrollController(tester);
+      controller.jumpTo(45);
+      await tester.pumpAndSettle();
+
+      final Offset leadingOffset = tester.getTopRight(find.byIcon(Icons.menu));
+      Offset titleOffset = tester.getTopLeft(find.text(title).first);
+      // The title widget should be to the right of the leading widget.
+      expect(titleOffset.dx, greaterThan(leadingOffset.dx));
+
+      titleOffset = tester.getTopRight(find.text(title).first);
+      final Offset searchOffset = tester.getTopLeft(find.byIcon(Icons.search));
+      // The title widget should be to the left of the search icon.
+      expect(titleOffset.dx, lessThan(searchOffset.dx));
+  });
+
+  testWidgets('SliverAppBar.medium respects title spacing', (WidgetTester tester) async {
+    const String title = 'Medium SliverAppBar Very Long Title';
+    const double titleSpacing = 16.0;
+
+    Widget buildWidget({double? titleSpacing, bool? centerTitle}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            primary: true,
+            slivers: <Widget>[
+              SliverAppBar.medium(
+                centerTitle: centerTitle,
+                leading: IconButton(
+                  icon: const Icon(Icons.menu),
+                  onPressed: () {},
+                ),
+                title: const Text(title, maxLines: 1),
+                titleSpacing: titleSpacing,
+                actions: const <Widget>[
+                  Icon(Icons.sort),
+                  Icon(Icons.more_vert),
+                ],
+              ),
+              SliverToBoxAdapter(
+                child: Container(
+                  height: 1200,
+                  color: Colors.orange[400],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildWidget());
+
+    // Scroll to collapse the SliverAppBar.
+    ScrollController controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // By default, title widget should be to the right of the
+    // leading widget and title spacing should be respected.
+    Offset titleOffset = tester.getTopLeft(find.text(title).first);
+    Offset iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    expect(titleOffset.dx, iconOffset.dx + titleSpacing);
+
+    await tester.pumpWidget(buildWidget(centerTitle: true));
+    // Scroll to collapse the SliverAppBar.
+    controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // By default, title widget should be to the left of the first
+    // leading widget and title spacing should be respected.
+    titleOffset = tester.getTopRight(find.text(title).first);
+    iconOffset = tester.getTopLeft(find.byIcon(Icons.sort));
+    expect(titleOffset.dx, iconOffset.dx - titleSpacing);
+
+    // Test custom title spacing, set to 0.0.
+    await tester.pumpWidget(buildWidget(titleSpacing: 0.0));
+    // Scroll to collapse the SliverAppBar.
+    controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // The title widget should be to the right of the leading
+    // widget with no spacing.
+    titleOffset = tester.getTopLeft(find.text(title).first);
+    iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    expect(titleOffset.dx, iconOffset.dx);
+
+    // Set centerTitle to true so the end of the title can reach
+    // the action widgets.
+    await tester.pumpWidget(buildWidget(titleSpacing: 0.0, centerTitle: true));
+    // Scroll to collapse the SliverAppBar.
+    controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // The title widget should be to the left of the first
+    // leading widget with no spacing.
+    titleOffset = tester.getTopRight(find.text(title).first);
+    iconOffset = tester.getTopLeft(find.byIcon(Icons.sort));
+    expect(titleOffset.dx, iconOffset.dx);
+  });
+
+  testWidgets('SliverAppBar.large respects title spacing', (WidgetTester tester) async {
+    const String title = 'Large SliverAppBar Very Long Title';
+    const double titleSpacing = 16.0;
+
+    Widget buildWidget({double? titleSpacing, bool? centerTitle}) {
+      return MaterialApp(
+        home: Scaffold(
+          body: CustomScrollView(
+            primary: true,
+            slivers: <Widget>[
+              SliverAppBar.large(
+                centerTitle: centerTitle,
+                leading: IconButton(
+                  icon: const Icon(Icons.menu),
+                  onPressed: () {},
+                ),
+                title: const Text(title, maxLines: 1),
+                titleSpacing: titleSpacing,
+                actions: const <Widget>[
+                  Icon(Icons.sort),
+                  Icon(Icons.more_vert),
+                ],
+              ),
+              SliverToBoxAdapter(
+                child: Container(
+                  height: 1200,
+                  color: Colors.orange[400],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    await tester.pumpWidget(buildWidget());
+
+    // Scroll to collapse the SliverAppBar.
+    ScrollController controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // By default, title widget should be to the right of the leading
+    // widget and title spacing should be respected.
+    Offset titleOffset = tester.getTopLeft(find.text(title).first);
+    Offset iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    expect(titleOffset.dx, iconOffset.dx + titleSpacing);
+
+    await tester.pumpWidget(buildWidget(centerTitle: true));
+    // Scroll to collapse the SliverAppBar.
+    controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // By default, title widget should be to the right of the
+    // leading widget and title spacing should be respected.
+    titleOffset = tester.getTopRight(find.text(title).first);
+    iconOffset = tester.getTopLeft(find.byIcon(Icons.sort));
+    expect(titleOffset.dx, iconOffset.dx - titleSpacing);
+
+    // Test custom title spacing, set to 0.0.
+    await tester.pumpWidget(buildWidget(titleSpacing: 0.0));
+    controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // The title widget should be to the right of the leading
+    // widget with no spacing.
+    titleOffset = tester.getTopLeft(find.text(title).first);
+    iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    expect(titleOffset.dx, iconOffset.dx);
+
+    // Set centerTitle to true so the end of the title can reach
+    // the action widgets.
+    await tester.pumpWidget(buildWidget(titleSpacing: 0.0, centerTitle: true));
+    // Scroll to collapse the SliverAppBar.
+    controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    // The title widget should be to the left of the first
+    // leading widget with no spacing.
+    titleOffset = tester.getTopRight(find.text(title).first);
+    iconOffset = tester.getTopLeft(find.byIcon(Icons.sort));
+    expect(titleOffset.dx, iconOffset.dx);
+  });
+
+  testWidgets(
+    'SliverAppBar.medium without the leading widget updates collapsed title padding',
+    (WidgetTester widgetTester) async {
+      const String title = 'Medium SliverAppBar Title';
+      const double leadingPadding = 40.0;
+      const double titleSpacing = 16.0;
+
+      Widget buildWidget({ bool showLeading = true }) {
+        return MaterialApp(
+          home: Scaffold(
+            body: CustomScrollView(
+              primary: true,
+              slivers: <Widget>[
+                SliverAppBar.medium(
+                  leading: showLeading
+                    ? IconButton(
+                        icon: const Icon(Icons.menu),
+                        onPressed: () {},
+                      )
+                    : null,
+                  title: const Text(title),
+                ),
+                SliverToBoxAdapter(
+                  child: Container(
+                    height: 1200,
+                    color: Colors.orange[400],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+
+      await widgetTester.pumpWidget(buildWidget());
+
+      // Scroll to collapse the SliverAppBar.
+      ScrollController controller = primaryScrollController(widgetTester);
+      controller.jumpTo(45);
+      await widgetTester.pumpAndSettle();
+
+      // If the leading widget is present, the title widget should be to the
+      // right of the leading widget and title spacing should be respected.
+      Offset titleOffset = widgetTester.getTopLeft(find.text(title).first);
+      expect(titleOffset.dx, leadingPadding + titleSpacing);
+
+      // Hide the leading widget.
+      await widgetTester.pumpWidget(buildWidget(showLeading: false));
+      // Scroll to collapse the SliverAppBar.
+      controller = primaryScrollController(widgetTester);
+      controller.jumpTo(45);
+      await widgetTester.pumpAndSettle();
+
+      // If the leading widget is not present, the title widget will
+      // only have the default title spacing.
+      titleOffset = widgetTester.getTopLeft(find.text(title).first);
+      expect(titleOffset.dx, titleSpacing);
+  });
+
+  testWidgets(
+    'SliverAppBar.large without the leading widget updates collapsed title padding',
+    (WidgetTester widgetTester) async {
+      const String title = 'Large SliverAppBar Title';
+      const double leadingPadding = 40.0;
+      const double titleSpacing = 16.0;
+
+      Widget buildWidget({ bool showLeading = true }) {
+        return MaterialApp(
+          home: Scaffold(
+            body: CustomScrollView(
+              primary: true,
+              slivers: <Widget>[
+                SliverAppBar.large(
+                  leading: showLeading
+                    ? IconButton(
+                        icon: const Icon(Icons.menu),
+                        onPressed: () {},
+                      )
+                    : null,
+                  title: const Text(title),
+                ),
+                SliverToBoxAdapter(
+                  child: Container(
+                    height: 1200,
+                    color: Colors.orange[400],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      }
+
+      await widgetTester.pumpWidget(buildWidget());
+
+      // Scroll CustomScrollView to collapse SliverAppBar.
+      ScrollController controller = primaryScrollController(widgetTester);
+      controller.jumpTo(45);
+      await widgetTester.pumpAndSettle();
+
+      // If the leading widget is present, the title widget should be to the
+      // right of the leading widget and title spacing should be respected.
+      Offset titleOffset = widgetTester.getTopLeft(find.text(title).first);
+      expect(titleOffset.dx, leadingPadding + titleSpacing);
+
+      // Hide the leading widget.
+      await widgetTester.pumpWidget(buildWidget(showLeading: false));
+      // Scroll to collapse the SliverAppBar.
+      controller = primaryScrollController(widgetTester);
+      controller.jumpTo(45);
+      await widgetTester.pumpAndSettle();
+
+      // If the leading widget is not present, the title widget will
+      // only have the default title spacing.
+      titleOffset = widgetTester.getTopLeft(find.text(title).first);
+      expect(titleOffset.dx, titleSpacing);
+  });
+
   group('AppBar.forceMaterialTransparency', () {
     Material getAppBarMaterial(WidgetTester tester) {
       return tester.widget<Material>(find
@@ -4026,25 +4421,26 @@ void main() {
     });
 
     testWidgets(
-        'forceMaterialTransparency == false does not allow gestures beneath the app bar', (WidgetTester tester) async {
-      // Set this, and tester.tap(warnIfMissed:false), to suppress
-      // errors/warning that the button is not hittable (which is expected).
-      WidgetController.hitTestWarningShouldBeFatal = false;
+      'forceMaterialTransparency == false does not allow gestures beneath the app bar',
+        (WidgetTester tester) async {
+        // Set this, and tester.tap(warnIfMissed:false), to suppress
+        // errors/warning that the button is not hittable (which is expected).
+        WidgetController.hitTestWarningShouldBeFatal = false;
 
-      bool buttonWasPressed = false;
-      final Widget widget = buildWidget(
-        forceMaterialTransparency:false,
-        onPressed:() { buttonWasPressed = true; },
-      );
-      await tester.pumpWidget(widget);
+        bool buttonWasPressed = false;
+        final Widget widget = buildWidget(
+          forceMaterialTransparency:false,
+          onPressed:() { buttonWasPressed = true; },
+        );
+        await tester.pumpWidget(widget);
 
-      final Material material = getAppBarMaterial(tester);
-      expect(material.type, MaterialType.canvas);
+        final Material material = getAppBarMaterial(tester);
+        expect(material.type, MaterialType.canvas);
 
-      final Finder buttonFinder = find.byType(TextButton);
-      await tester.tap(buttonFinder, warnIfMissed:false);
-      await tester.pump();
-      expect(buttonWasPressed, isFalse);
+        final Finder buttonFinder = find.byType(TextButton);
+        await tester.tap(buttonFinder, warnIfMissed:false);
+        await tester.pump();
+        expect(buttonWasPressed, isFalse);
     });
   });
 }

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -9,6 +9,10 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  ScrollController primaryScrollController(WidgetTester tester) {
+    return PrimaryScrollController.of(tester.element(find.byType(CustomScrollView)));
+  }
+
   test('AppBarTheme copyWith, ==, hashCode basics', () {
     expect(const AppBarTheme(), const AppBarTheme().copyWith());
     expect(const AppBarTheme().hashCode, const AppBarTheme().copyWith().hashCode);
@@ -671,14 +675,28 @@ void main() {
     expect(navToolbar.middleSpacing, 40);
   });
 
-  testWidgets("SliverAppBar.medium's title uses AppBarTheme.foregroundColor", (WidgetTester tester) async {
+  testWidgets('SliverAppBar.medium uses AppBarTheme properties', (WidgetTester tester) async {
+    const String title = 'Medium SliverAppBar Title';
     const Color foregroundColor = Color(0xff00ff00);
+    const double titleSpacing = 10.0;
+
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: foregroundColor)),
+      theme: ThemeData(
+        appBarTheme: const AppBarTheme(
+          foregroundColor: foregroundColor,
+          titleSpacing: titleSpacing,
+          centerTitle: false,
+        ),
+      ),
       home: CustomScrollView(
+        primary: true,
         slivers: <Widget>[
           SliverAppBar.medium(
-            title: const Text('Medium Title'),
+            leading: IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.menu),
+            ),
+            title: const Text(title),
           ),
         ],
       ),
@@ -686,35 +704,84 @@ void main() {
 
     final RichText text = tester.firstWidget(find.byType(RichText));
     expect(text.text.style!.color, foregroundColor);
+
+    // Scroll to collapse the SliverAppBar.
+    final ScrollController controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    final Offset titleOffset = tester.getTopLeft(find.text(title).first);
+    final Offset iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    // Title spacing should be 10.0.
+    expect(titleOffset.dx, iconOffset.dx + titleSpacing);
   });
 
-  testWidgets(
-    "SliverAppBar.medium's foregroundColor takes priority over AppBarTheme.foregroundColor", (WidgetTester tester) async {
-      const Color foregroundColor = Color(0xff00ff00);
-      await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: Color(0xffff0000))),
-        home: CustomScrollView(
-          slivers: <Widget>[
-            SliverAppBar.medium(
-              foregroundColor: foregroundColor,
-              title: const Text('Medium Title'),
-            ),
-          ],
-        ),
-      ));
-
-      final RichText text = tester.firstWidget(find.byType(RichText));
-      expect(text.text.style!.color, foregroundColor);
-  });
-
-  testWidgets("SliverAppBar.large's title uses AppBarTheme.foregroundColor", (WidgetTester tester) async {
+  testWidgets('SliverAppBar.medium properties take priority over AppBarTheme properties', (WidgetTester tester) async {
+    const String title = 'Medium SliverAppBar Title';
     const Color foregroundColor = Color(0xff00ff00);
+    const double titleSpacing = 10.0;
+
     await tester.pumpWidget(MaterialApp(
-      theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: foregroundColor)),
+      theme: ThemeData(
+        appBarTheme: const AppBarTheme(
+          foregroundColor: Color(0xffff0000),
+          titleSpacing: 14.0,
+          centerTitle: true,
+        ),
+      ),
       home: CustomScrollView(
+        primary: true,
+        slivers: <Widget>[
+          SliverAppBar.medium(
+            centerTitle: false,
+            titleSpacing: titleSpacing,
+            foregroundColor: foregroundColor,
+            leading: IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.menu),
+            ),
+            title: const Text(title),
+          ),
+        ],
+      ),
+    ));
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text.text.style!.color, foregroundColor);
+
+    // Scroll to collapse the SliverAppBar.
+    final ScrollController controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    final Offset titleOffset = tester.getTopLeft(find.text(title).first);
+    final Offset iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    // Title spacing should be 10.0.
+    expect(titleOffset.dx, iconOffset.dx + titleSpacing);
+  });
+
+  testWidgets('SliverAppBar.large uses AppBarTheme properties', (WidgetTester tester) async {
+    const String title = 'Large SliverAppBar Title';
+    const Color foregroundColor = Color(0xff00ff00);
+    const double titleSpacing = 10.0;
+
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        appBarTheme: const AppBarTheme(
+          foregroundColor: foregroundColor,
+          titleSpacing: titleSpacing,
+          centerTitle: false,
+        ),
+      ),
+      home: CustomScrollView(
+        primary: true,
         slivers: <Widget>[
           SliverAppBar.large(
-            title: const Text('Large Title'),
+            leading: IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.menu),
+            ),
+            title: const Text(title),
           ),
         ],
       ),
@@ -722,25 +789,60 @@ void main() {
 
     final RichText text = tester.firstWidget(find.byType(RichText));
     expect(text.text.style!.color, foregroundColor);
+
+    // Scroll to collapse the SliverAppBar.
+    final ScrollController controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    final Offset titleOffset = tester.getTopLeft(find.text(title).first);
+    final Offset iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    // Title spacing should be 10.0.
+    expect(titleOffset.dx, iconOffset.dx + titleSpacing);
   });
 
-  testWidgets(
-    "SliverAppBar.large's foregroundColor takes priority over AppBarTheme.foregroundColor", (WidgetTester tester) async {
-      const Color foregroundColor = Color(0xff00ff00);
-      await tester.pumpWidget(MaterialApp(
-        theme: ThemeData(appBarTheme: const AppBarTheme(foregroundColor: Color(0xffff0000))),
-        home: CustomScrollView(
-          slivers: <Widget>[
-            SliverAppBar.large(
-              foregroundColor: foregroundColor,
-              title: const Text('Large Title'),
-            ),
-          ],
-        ),
-      ));
+  testWidgets('SliverAppBar.large properties take priority over AppBarTheme properties', (WidgetTester tester) async {
+    const String title = 'Large SliverAppBar Title';
+    const Color foregroundColor = Color(0xff00ff00);
+    const double titleSpacing = 10.0;
 
-      final RichText text = tester.firstWidget(find.byType(RichText));
-      expect(text.text.style!.color, foregroundColor);
+    await tester.pumpWidget(MaterialApp(
+      theme: ThemeData(
+        appBarTheme: const AppBarTheme(
+          foregroundColor: Color(0xffff0000),
+          titleSpacing: 14.0,
+          centerTitle: true,
+        ),
+      ),
+      home: CustomScrollView(
+        primary: true,
+        slivers: <Widget>[
+          SliverAppBar.large(
+            centerTitle: false,
+            titleSpacing: titleSpacing,
+            foregroundColor: foregroundColor,
+            leading: IconButton(
+              onPressed: () {},
+              icon: const Icon(Icons.menu),
+            ),
+            title: const Text(title),
+          ),
+        ],
+      ),
+    ));
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text.text.style!.color, foregroundColor);
+
+    // Scroll to collapse the SliverAppBar.
+    final ScrollController controller = primaryScrollController(tester);
+    controller.jumpTo(45);
+    await tester.pumpAndSettle();
+
+    final Offset titleOffset = tester.getTopLeft(find.text(title).first);
+    final Offset iconOffset = tester.getTopRight(find.byIcon(Icons.menu));
+    // Title spacing should be 10.0.
+    expect(titleOffset.dx, iconOffset.dx + titleSpacing);
   });
 
   testWidgets('Default AppBarTheme debugFillProperties', (WidgetTester tester) async {


### PR DESCRIPTION
fixes https://github.com/flutter/flutter/issues/116188
fixes https://github.com/flutter/flutter/issues/120516
fixes https://github.com/flutter/flutter/issues/120603

<details> 
<summary>code sample</summary> 

```dart
import 'package:flutter/material.dart';

void main() => runApp(const MyApp());

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      debugShowCheckedModeBanner: false,
      theme: ThemeData(useMaterial3: true),
      home: const SliverAppBarExample(),
    );
  }
}

class SliverAppBarExample extends StatefulWidget {
  const SliverAppBarExample({super.key});

  @override
  State<SliverAppBarExample> createState() => _SliverAppBarExampleState();
}

class _SliverAppBarExampleState extends State<SliverAppBarExample> {
  bool showLeading = true;
  bool centerTitle = false;
  bool removeTitleSpacing = false;

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      body: CustomScrollView(
        slivers: <Widget>[
          SliverAppBar.medium(
            leading: showLeading
                ? IconButton(
                    icon: const Icon(Icons.menu),
                    onPressed: () {},
                  )
                : null,
            // leadingWidth: 0,
            title: const Text('Medium App Bar with a long title', maxLines: 1),
            titleSpacing: removeTitleSpacing ? 0 : null,

            centerTitle: centerTitle,
            actions: <Widget>[
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
            ],
          ),
          SliverAppBar.large(
            leading: showLeading
                ? IconButton(
                    icon: const Icon(Icons.menu),
                    onPressed: () {},
                  )
                : null,
            automaticallyImplyLeading: false,
            // leadingWidth: 0,
            title: const Text('Large App Bar with a long title', maxLines: 1),
            titleSpacing: removeTitleSpacing ? 0 : null,
            centerTitle: centerTitle,
            actions: <Widget>[
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
              IconButton(icon: const Icon(Icons.favorite), onPressed: () {}),
            ],
          ),
          const SliverFillRemaining(
            child: Center(
              child: Text(
                'Scroll down to collapse the app bar',
              ),
            ),
          )
        ],
      ),
      bottomSheet: Padding(
        padding: const EdgeInsets.all(8.0),
        child: OverflowBar(
          alignment: MainAxisAlignment.spaceEvenly,
          spacing: 10,
          overflowSpacing: 10,
          children: <Widget>[
            FilledButton(
              onPressed: () {
                setState(() {
                  removeTitleSpacing = !removeTitleSpacing;
                });
              },
              child: Text('titleSpacing: ${removeTitleSpacing ? 0 : 16}'),
            ),
            FilledButton(
              onPressed: () {
                setState(() {
                  centerTitle = !centerTitle;
                });
              },
              child: Text('Center title: $centerTitle'),
            ),
            FilledButton(
              onPressed: () {
                setState(() {
                  showLeading = !showLeading;
                });
              },
              child: const Text('Toggle leading'),
            ),
          ],
        ),
      ),
    );
  }
}

``` 
	
</details>


### Description

- The title widget inside `_ScrollUnderFlexibleSpace` cannot be aware of the `actions` spacing, how many `actions` widgets there are, and what size. This information is hard to get without a global key and having to measure the `actions` row size. 
However, we can use a lower-level widget like `NavigationToolbar` which does align the title so it doesn't overlap with `actions` widgets.  As a result, added `NavigationToolbar` and provided the `title` and `actions` widgets to this.
This addresses  https://github.com/flutter/flutter/issues/116188

### Before
![title_overlap_before](https://user-images.githubusercontent.com/48603081/219005125-18b52e9e-613a-4a55-8a42-daf0216f0344.gif)

### After
![title_overlap_after](https://user-images.githubusercontent.com/48603081/219005140-43be7d71-aa61-4a68-90e8-eb74fc30eb38.gif)


- https://github.com/flutter/flutter/issues/120516 pointed out that there is no spacing between the `leading` widget and the `title`. Thanks to adding `NavigationToolbar`, we can get `titleSpacing` support. However, this requires updating the default collapsed title padding so we don't get unnecessary padding. 
This also makes it possible to update `titleSpacing` from the `SliverAppBar.medium` & `SliverAppBar.large` parameters or from the `AppBarTheme`, which is not possible without this PR.
This addresses https://github.com/flutter/flutter/issues/120516.

### Before
![title_spacing_before](https://user-images.githubusercontent.com/48603081/219005254-df7099ad-8250-4909-8897-9a88027a4c44.gif)


### After
![title_spacing_after](https://user-images.githubusercontent.com/48603081/219005277-6fedbf51-19f8-483d-8493-7604b442c340.gif)

- While fixing other `SliverAppBar.medium` & `SliverAppBar.large` issues, I noticed when the `leading` widget isn't provided, we still get the default padding in the collapsed state. I added a condition that updates the leading padding when the `leading` widget is removed.
This addresses https://github.com/flutter/flutter/issues/120603.


 ### Before
![leading_width_before](https://user-images.githubusercontent.com/48603081/219005349-8f8a198d-c640-48ff-8d60-c4ff7faa6876.gif)


### After
![leading_width_after](https://user-images.githubusercontent.com/48603081/219005385-b1013141-7a07-4838-beea-2fcccee620f6.gif)


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
