### PR TITLE
[flutter_tools] Add the NoProfile parameter to the PowerShell execution statement

### DIFF
--- a/bin/internal/shared.bat
+++ b/bin/internal/shared.bat
@@ -118,7 +118,7 @@ GOTO :after_subroutine
     REM into 1. The exit code 2 is used to detect the case where the major version is incorrect and there should be
     REM no subsequent retries.
     ECHO Downloading Dart SDK from Flutter engine %dart_required_version%... 1>&2
-    %powershell_executable% -ExecutionPolicy Bypass -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'; exit $LASTEXITCODE;"
+    %powershell_executable% -ExecutionPolicy Bypass -NoProfile -Command "Unblock-File -Path '%update_dart_bin%'; & '%update_dart_bin%'; exit $LASTEXITCODE;"
     IF "%ERRORLEVEL%" EQU "2" (
       EXIT 1
     )


### PR DESCRIPTION
Use the NoProfile parameter of `pwsh.exe`/`PowerShell.exe` to start PowerShell without a profile to avoid executing the scripts in the user profile

I fixed the issue mentioned by #120785 by adding the NoProfile parameter.

This parameter is mentioned in Microsoft's Powershell documentation: [The NoProfile parameter in pwsh](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-7.2#the-noprofile-parameter) or [The NoProfile parameter in Powershell](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_profiles?view=powershell-5.1#the-noprofile-parameter).
