### PR TITLE
Constrain date picker to max width to avoid bending outwards

### DIFF
--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -1024,6 +1024,7 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
     }
 
     final List<Widget> pickers = <Widget>[];
+    double totalColumnWidths = 4 * _kDatePickerPadSize;
 
     for (int i = 0; i < columnWidths.length; i++) {
       double offAxisFraction = 0.0;
@@ -1043,6 +1044,8 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       if (textDirectionFactor == -1) {
         padding = padding.flipped;
       }
+
+      totalColumnWidths += columnWidths[i] + (2 * _kDatePickerPadSize);
 
       pickers.add(LayoutId(
         id: i,
@@ -1068,16 +1071,23 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       ));
     }
 
+    final double maxPickerWidth = totalColumnWidths > _kPickerWidth ? totalColumnWidths : _kPickerWidth;
+
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
-        child: CustomMultiChildLayout(
-          delegate: _DatePickerLayoutDelegate(
-            columnWidths: columnWidths,
-            textDirectionFactor: textDirectionFactor,
+        child: Center(
+          child: Container(
+            constraints: BoxConstraints(maxWidth: maxPickerWidth),
+            child: CustomMultiChildLayout(
+              delegate: _DatePickerLayoutDelegate(
+                columnWidths: columnWidths,
+                textDirectionFactor: textDirectionFactor,
+              ),
+              children: pickers,
+            ),
           ),
-          children: pickers,
         ),
       ),
     );
@@ -1418,6 +1428,7 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
     }
 
     final List<Widget> pickers = <Widget>[];
+    double totalColumnWidths = 4 * _kDatePickerPadSize;
 
     for (int i = 0; i < columnWidths.length; i++) {
       final double offAxisFraction = (i - 1) * 0.3 * textDirectionFactor;
@@ -1433,6 +1444,8 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
       } else if (i == columnWidths.length - 1) {
         selectionOverlay = _endSelectionOverlay;
       }
+
+      totalColumnWidths += columnWidths[i] + (2 * _kDatePickerPadSize);
 
       pickers.add(LayoutId(
         id: i,
@@ -1456,16 +1469,23 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
       ));
     }
 
+    final double maxPickerWidth = totalColumnWidths > _kPickerWidth ? totalColumnWidths : _kPickerWidth;
+
     return MediaQuery(
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
-        child: CustomMultiChildLayout(
-          delegate: _DatePickerLayoutDelegate(
-            columnWidths: columnWidths,
-            textDirectionFactor: textDirectionFactor,
+        child: Center(
+          child: Container(
+            constraints: BoxConstraints(maxWidth: maxPickerWidth),
+            child: CustomMultiChildLayout(
+              delegate: _DatePickerLayoutDelegate(
+                columnWidths: columnWidths,
+                textDirectionFactor: textDirectionFactor,
+              ),
+              children: pickers,
+            ),
           ),
-          children: pickers,
         ),
       ),
     );

--- a/packages/flutter/lib/src/cupertino/date_picker.dart
+++ b/packages/flutter/lib/src/cupertino/date_picker.dart
@@ -81,6 +81,7 @@ class _DatePickerLayoutDelegate extends MultiChildLayoutDelegate {
   _DatePickerLayoutDelegate({
     required this.columnWidths,
     required this.textDirectionFactor,
+    required this.maxWidth,
   });
 
   // The list containing widths of all columns.
@@ -89,15 +90,18 @@ class _DatePickerLayoutDelegate extends MultiChildLayoutDelegate {
   // textDirectionFactor is 1 if text is written left to right, and -1 if right to left.
   final int textDirectionFactor;
 
+  // The max width the children should reach to avoid bending outwards.
+  final double maxWidth;
+
   @override
   void performLayout(Size size) {
-    double remainingWidth = size.width;
+    double remainingWidth = maxWidth < size.width ? maxWidth : size.width;
+
+    double currentHorizontalOffset = (size.width - remainingWidth) / 2;
 
     for (int i = 0; i < columnWidths.length; i++) {
       remainingWidth -= columnWidths[i] + _kDatePickerPadSize * 2;
     }
-
-    double currentHorizontalOffset = 0.0;
 
     for (int i = 0; i < columnWidths.length; i++) {
       final int index = textDirectionFactor == 1 ? i : columnWidths.length - i - 1;
@@ -1077,17 +1081,13 @@ class _CupertinoDatePickerDateTimeState extends State<CupertinoDatePicker> {
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
-        child: Center(
-          child: Container(
-            constraints: BoxConstraints(maxWidth: maxPickerWidth),
-            child: CustomMultiChildLayout(
-              delegate: _DatePickerLayoutDelegate(
-                columnWidths: columnWidths,
-                textDirectionFactor: textDirectionFactor,
-              ),
-              children: pickers,
-            ),
+        child: CustomMultiChildLayout(
+          delegate: _DatePickerLayoutDelegate(
+            columnWidths: columnWidths,
+            textDirectionFactor: textDirectionFactor,
+            maxWidth: maxPickerWidth,
           ),
+          children: pickers,
         ),
       ),
     );
@@ -1475,17 +1475,13 @@ class _CupertinoDatePickerDateState extends State<CupertinoDatePicker> {
       data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0),
       child: DefaultTextStyle.merge(
         style: _kDefaultPickerTextStyle,
-        child: Center(
-          child: Container(
-            constraints: BoxConstraints(maxWidth: maxPickerWidth),
-            child: CustomMultiChildLayout(
-              delegate: _DatePickerLayoutDelegate(
-                columnWidths: columnWidths,
-                textDirectionFactor: textDirectionFactor,
-              ),
-              children: pickers,
-            ),
+        child: CustomMultiChildLayout(
+          delegate: _DatePickerLayoutDelegate(
+            columnWidths: columnWidths,
+            textDirectionFactor: textDirectionFactor,
+            maxWidth: maxPickerWidth,
           ),
+          children: pickers,
         ),
       ),
     );

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -599,7 +599,7 @@ void main() {
         onDateTimeChanged: (_) { },
         initialDateTime: DateTime(2018, 1, 1, 10, 30),
       );
-      
+
       await tester.pumpWidget(
         CupertinoApp(
           home: CupertinoPageScaffold(

--- a/packages/flutter/test/cupertino/date_picker_test.dart
+++ b/packages/flutter/test/cupertino/date_picker_test.dart
@@ -592,6 +592,56 @@ void main() {
       );
     });
 
+    testWidgets('width of wheel in background does not increase at large widths', (WidgetTester tester) async {
+
+      final Widget dateWidget = CupertinoDatePicker(
+        mode: CupertinoDatePickerMode.date,
+        onDateTimeChanged: (_) { },
+        initialDateTime: DateTime(2018, 1, 1, 10, 30),
+      );
+      
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            child: Center(
+              child: SizedBox(
+                height: 200.0,
+                width: 300.0,
+                child: dateWidget,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      double decemberX = tester.getBottomLeft(find.text('December')).dx;
+      double octoberX = tester.getBottomLeft(find.text('October')).dx;
+      final double distance = octoberX - decemberX;
+
+      await tester.pumpWidget(
+        CupertinoApp(
+          home: CupertinoPageScaffold(
+            child: Center(
+              child: SizedBox(
+                height: 200.0,
+                width: 3000.0,
+                child: dateWidget,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      decemberX = tester.getBottomLeft(find.text('December')).dx;
+      octoberX = tester.getBottomLeft(find.text('October')).dx;
+
+      // The wheel does not bend outwards at large widths.
+      expect(
+        distance >= (octoberX - decemberX),
+        true,
+      );
+    });
+
     testWidgets('picker automatically scrolls away from invalid date on month change', (WidgetTester tester) async {
       late DateTime date;
       await tester.pumpWidget(


### PR DESCRIPTION
Addresses #119071. At large widths, the picker will expand outwards in order to fill the space and will lose the look of being a wheel. In order to avoid this, this PR constrains the max width to either our default based off of native, or a width estimated based off of the widths of the columns, if bigger than the default. Similarly, the native date picker wheel does not use up the whole width.

Before:
<img width="836" alt="Screenshot 2023-02-15 at 11 04 09 AM" src="https://user-images.githubusercontent.com/58190796/219128455-d1aefdcf-b4de-4cfe-b0f2-8a058b742d28.png">

After:
<img width="837" alt="Screenshot 2023-02-15 at 11 03 06 AM" src="https://user-images.githubusercontent.com/58190796/219128481-2f8c21bb-ac21-455a-bda3-f32ccfb03f6c.png">

A native iOS date picker wheel (left) and the new Flutter CupertinoDatePicker unbounded in an app. Both have a width that does not take up the whole available space.
<img width="402" alt="Screenshot 2023-02-15 at 11 01 37 AM" src="https://user-images.githubusercontent.com/58190796/219128723-f1607406-de44-496c-b6b7-8e9fac34d464.png">


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
