### PR TITLE
Added identical(a,b) short circuit to Material Library lerp methods

### DIFF
--- a/packages/flutter/lib/src/material/app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/app_bar_theme.dart
@@ -204,6 +204,9 @@ class AppBarTheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static AppBarTheme lerp(AppBarTheme? a, AppBarTheme? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return AppBarTheme(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       foregroundColor: Color.lerp(a?.foregroundColor, b?.foregroundColor, t),

--- a/packages/flutter/lib/src/material/badge_theme.dart
+++ b/packages/flutter/lib/src/material/badge_theme.dart
@@ -94,6 +94,9 @@ class BadgeThemeData with Diagnosticable {
 
   /// Linearly interpolate between two [Badge] themes.
   static BadgeThemeData lerp(BadgeThemeData? a, BadgeThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return BadgeThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       textColor: Color.lerp(a?.textColor, b?.textColor, t),

--- a/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_app_bar_theme.dart
@@ -94,6 +94,9 @@ class BottomAppBarTheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BottomAppBarTheme lerp(BottomAppBarTheme? a, BottomAppBarTheme? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return BottomAppBarTheme(
       color: Color.lerp(a?.color, b?.color, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),

--- a/packages/flutter/lib/src/material/bottom_navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_navigation_bar_theme.dart
@@ -174,6 +174,9 @@ class BottomNavigationBarThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BottomNavigationBarThemeData lerp(BottomNavigationBarThemeData? a, BottomNavigationBarThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return BottomNavigationBarThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),

--- a/packages/flutter/lib/src/material/bottom_sheet_theme.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet_theme.dart
@@ -118,8 +118,8 @@ class BottomSheetThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BottomSheetThemeData? lerp(BottomSheetThemeData? a, BottomSheetThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return BottomSheetThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),

--- a/packages/flutter/lib/src/material/button_bar_theme.dart
+++ b/packages/flutter/lib/src/material/button_bar_theme.dart
@@ -146,8 +146,8 @@ class ButtonBarThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ButtonBarThemeData? lerp(ButtonBarThemeData? a, ButtonBarThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ButtonBarThemeData(
       alignment: t < 0.5 ? a?.alignment : b?.alignment,

--- a/packages/flutter/lib/src/material/button_style.dart
+++ b/packages/flutter/lib/src/material/button_style.dart
@@ -492,8 +492,8 @@ class ButtonStyle with Diagnosticable {
 
   /// Linearly interpolate between two [ButtonStyle]s.
   static ButtonStyle? lerp(ButtonStyle? a, ButtonStyle? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ButtonStyle(
       textStyle: MaterialStateProperty.lerp<TextStyle?>(a?.textStyle, b?.textStyle, t, TextStyle.lerp),

--- a/packages/flutter/lib/src/material/card_theme.dart
+++ b/packages/flutter/lib/src/material/card_theme.dart
@@ -114,6 +114,9 @@ class CardTheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static CardTheme lerp(CardTheme? a, CardTheme? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return CardTheme(
       clipBehavior: t < 0.5 ? a?.clipBehavior : b?.clipBehavior,
       color: Color.lerp(a?.color, b?.color, t),

--- a/packages/flutter/lib/src/material/checkbox_theme.dart
+++ b/packages/flutter/lib/src/material/checkbox_theme.dart
@@ -130,6 +130,9 @@ class CheckboxThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static CheckboxThemeData lerp(CheckboxThemeData? a, CheckboxThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return CheckboxThemeData(
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
       fillColor: MaterialStateProperty.lerp<Color?>(a?.fillColor, b?.fillColor, t, Color.lerp),
@@ -194,6 +197,9 @@ class CheckboxThemeData with Diagnosticable {
   static BorderSide? _lerpSides(BorderSide? a, BorderSide? b, double t) {
     if (a == null || b == null) {
       return null;
+    }
+    if (identical(a, b)) {
+      return a;
     }
     return BorderSide.lerp(a, b, t);
   }

--- a/packages/flutter/lib/src/material/chip_theme.dart
+++ b/packages/flutter/lib/src/material/chip_theme.dart
@@ -483,8 +483,8 @@ class ChipThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ChipThemeData? lerp(ChipThemeData? a, ChipThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ChipThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),

--- a/packages/flutter/lib/src/material/color_scheme.dart
+++ b/packages/flutter/lib/src/material/color_scheme.dart
@@ -827,6 +827,9 @@ class ColorScheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ColorScheme lerp(ColorScheme a, ColorScheme b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return ColorScheme(
       brightness: t < 0.5 ? a.brightness : b.brightness,
       primary: Color.lerp(a.primary, b.primary, t)!,

--- a/packages/flutter/lib/src/material/data_table_theme.dart
+++ b/packages/flutter/lib/src/material/data_table_theme.dart
@@ -122,6 +122,9 @@ class DataTableThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static DataTableThemeData lerp(DataTableThemeData a, DataTableThemeData b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return DataTableThemeData(
       decoration: Decoration.lerp(a.decoration, b.decoration, t),
       dataRowColor: MaterialStateProperty.lerp<Color?>(a.dataRowColor, b.dataRowColor, t, Color.lerp),

--- a/packages/flutter/lib/src/material/date_picker_theme.dart
+++ b/packages/flutter/lib/src/material/date_picker_theme.dart
@@ -356,6 +356,9 @@ class DatePickerThemeData with Diagnosticable {
 
   /// Linearly interpolates between two [DatePickerThemeData].
   static DatePickerThemeData lerp(DatePickerThemeData? a, DatePickerThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return DatePickerThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),
@@ -393,8 +396,8 @@ class DatePickerThemeData with Diagnosticable {
   }
 
   static BorderSide? _lerpBorderSide(BorderSide? a, BorderSide? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return BorderSide.lerp(BorderSide(width: 0, color: b!.color.withAlpha(0)), b, t);

--- a/packages/flutter/lib/src/material/dialog_theme.dart
+++ b/packages/flutter/lib/src/material/dialog_theme.dart
@@ -111,6 +111,9 @@ class DialogTheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static DialogTheme lerp(DialogTheme? a, DialogTheme? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return DialogTheme(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       elevation: lerpDouble(a?.elevation, b?.elevation, t),

--- a/packages/flutter/lib/src/material/divider_theme.dart
+++ b/packages/flutter/lib/src/material/divider_theme.dart
@@ -87,6 +87,9 @@ class DividerThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static DividerThemeData lerp(DividerThemeData? a, DividerThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return DividerThemeData(
       color: Color.lerp(a?.color, b?.color, t),
       space: lerpDouble(a?.space, b?.space, t),

--- a/packages/flutter/lib/src/material/drawer_theme.dart
+++ b/packages/flutter/lib/src/material/drawer_theme.dart
@@ -99,8 +99,8 @@ class DrawerThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static DrawerThemeData? lerp(DrawerThemeData? a, DrawerThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return DrawerThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),

--- a/packages/flutter/lib/src/material/dropdown_menu_theme.dart
+++ b/packages/flutter/lib/src/material/dropdown_menu_theme.dart
@@ -64,6 +64,9 @@ class DropdownMenuThemeData with Diagnosticable {
 
   /// Linearly interpolates between two dropdown menu themes.
   static DropdownMenuThemeData lerp(DropdownMenuThemeData? a, DropdownMenuThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return DropdownMenuThemeData(
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),
       inputDecorationTheme: t < 0.5 ? a?.inputDecorationTheme : b?.inputDecorationTheme,

--- a/packages/flutter/lib/src/material/elevated_button_theme.dart
+++ b/packages/flutter/lib/src/material/elevated_button_theme.dart
@@ -49,8 +49,8 @@ class ElevatedButtonThemeData with Diagnosticable {
 
   /// Linearly interpolate between two elevated button themes.
   static ElevatedButtonThemeData? lerp(ElevatedButtonThemeData? a, ElevatedButtonThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ElevatedButtonThemeData(
       style: ButtonStyle.lerp(a?.style, b?.style, t),

--- a/packages/flutter/lib/src/material/expansion_tile_theme.dart
+++ b/packages/flutter/lib/src/material/expansion_tile_theme.dart
@@ -124,8 +124,8 @@ class ExpansionTileThemeData with Diagnosticable {
 
   /// Linearly interpolate between ExpansionTileThemeData objects.
   static ExpansionTileThemeData? lerp(ExpansionTileThemeData? a, ExpansionTileThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ExpansionTileThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),

--- a/packages/flutter/lib/src/material/filled_button_theme.dart
+++ b/packages/flutter/lib/src/material/filled_button_theme.dart
@@ -49,8 +49,8 @@ class FilledButtonThemeData with Diagnosticable {
 
   /// Linearly interpolate between two filled button themes.
   static FilledButtonThemeData? lerp(FilledButtonThemeData? a, FilledButtonThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return FilledButtonThemeData(
       style: ButtonStyle.lerp(a?.style, b?.style, t),

--- a/packages/flutter/lib/src/material/floating_action_button_theme.dart
+++ b/packages/flutter/lib/src/material/floating_action_button_theme.dart
@@ -193,8 +193,8 @@ class FloatingActionButtonThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static FloatingActionButtonThemeData? lerp(FloatingActionButtonThemeData? a, FloatingActionButtonThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return FloatingActionButtonThemeData(
       foregroundColor: Color.lerp(a?.foregroundColor, b?.foregroundColor, t),

--- a/packages/flutter/lib/src/material/icon_button_theme.dart
+++ b/packages/flutter/lib/src/material/icon_button_theme.dart
@@ -49,8 +49,8 @@ class IconButtonThemeData with Diagnosticable {
 
   /// Linearly interpolate between two icon button themes.
   static IconButtonThemeData? lerp(IconButtonThemeData? a, IconButtonThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return IconButtonThemeData(
       style: ButtonStyle.lerp(a?.style, b?.style, t),

--- a/packages/flutter/lib/src/material/list_tile_theme.dart
+++ b/packages/flutter/lib/src/material/list_tile_theme.dart
@@ -172,8 +172,8 @@ class ListTileThemeData with Diagnosticable {
 
   /// Linearly interpolate between ListTileThemeData objects.
   static ListTileThemeData? lerp(ListTileThemeData? a, ListTileThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ListTileThemeData(
       dense: t < 0.5 ? a?.dense : b?.dense,

--- a/packages/flutter/lib/src/material/menu_bar_theme.dart
+++ b/packages/flutter/lib/src/material/menu_bar_theme.dart
@@ -41,8 +41,11 @@ class MenuBarThemeData extends MenuThemeData {
   /// Creates a const set of properties used to configure [MenuTheme].
   const MenuBarThemeData({super.style});
 
-  /// Linearly interpolate between two text button themes.
+  /// Linearly interpolate between two [MenuBar] themes.
   static MenuBarThemeData? lerp(MenuBarThemeData? a, MenuBarThemeData? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return MenuBarThemeData(style: MenuStyle.lerp(a?.style, b?.style, t));
   }
 }

--- a/packages/flutter/lib/src/material/menu_button_theme.dart
+++ b/packages/flutter/lib/src/material/menu_button_theme.dart
@@ -59,6 +59,9 @@ class MenuButtonThemeData with Diagnosticable {
 
   /// Linearly interpolate between two menu button themes.
   static MenuButtonThemeData? lerp(MenuButtonThemeData? a, MenuButtonThemeData? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return MenuButtonThemeData(style: ButtonStyle.lerp(a?.style, b?.style, t));
   }
 

--- a/packages/flutter/lib/src/material/menu_style.dart
+++ b/packages/flutter/lib/src/material/menu_style.dart
@@ -304,8 +304,8 @@ class MenuStyle with Diagnosticable {
 
   /// Linearly interpolate between two [MenuStyle]s.
   static MenuStyle? lerp(MenuStyle? a, MenuStyle? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return MenuStyle(
       backgroundColor: MaterialStateProperty.lerp<Color?>(a?.backgroundColor, b?.backgroundColor, t, Color.lerp),

--- a/packages/flutter/lib/src/material/menu_theme.dart
+++ b/packages/flutter/lib/src/material/menu_theme.dart
@@ -43,6 +43,9 @@ class MenuThemeData with Diagnosticable {
 
   /// Linearly interpolate between two menu button themes.
   static MenuThemeData? lerp(MenuThemeData? a, MenuThemeData? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return MenuThemeData(style: MenuStyle.lerp(a?.style, b?.style, t));
   }
 

--- a/packages/flutter/lib/src/material/navigation_bar_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_bar_theme.dart
@@ -125,8 +125,8 @@ class NavigationBarThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static NavigationBarThemeData? lerp(NavigationBarThemeData? a, NavigationBarThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return NavigationBarThemeData(
       height: lerpDouble(a?.height, b?.height, t),

--- a/packages/flutter/lib/src/material/navigation_drawer_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_drawer_theme.dart
@@ -124,10 +124,9 @@ class NavigationDrawerThemeData with Diagnosticable {
   /// If both arguments are null then null is returned.
   ///
   /// {@macro dart.ui.shadow.lerp}
-  static NavigationDrawerThemeData? lerp(
-      NavigationDrawerThemeData? a, NavigationDrawerThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+  static NavigationDrawerThemeData? lerp(NavigationDrawerThemeData? a, NavigationDrawerThemeData? b, double t) {
+    if (identical(a, b)) {
+      return a;
     }
     return NavigationDrawerThemeData(
       tileHeight: lerpDouble(a?.tileHeight, b?.tileHeight, t),

--- a/packages/flutter/lib/src/material/navigation_rail_theme.dart
+++ b/packages/flutter/lib/src/material/navigation_rail_theme.dart
@@ -143,8 +143,8 @@ class NavigationRailThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static NavigationRailThemeData? lerp(NavigationRailThemeData? a, NavigationRailThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return NavigationRailThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),

--- a/packages/flutter/lib/src/material/outlined_button_theme.dart
+++ b/packages/flutter/lib/src/material/outlined_button_theme.dart
@@ -49,8 +49,8 @@ class OutlinedButtonThemeData with Diagnosticable {
 
   /// Linearly interpolate between two outlined button themes.
   static OutlinedButtonThemeData? lerp(OutlinedButtonThemeData? a, OutlinedButtonThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return OutlinedButtonThemeData(
       style: ButtonStyle.lerp(a?.style, b?.style, t),

--- a/packages/flutter/lib/src/material/popup_menu_theme.dart
+++ b/packages/flutter/lib/src/material/popup_menu_theme.dart
@@ -129,8 +129,8 @@ class PopupMenuThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static PopupMenuThemeData? lerp(PopupMenuThemeData? a, PopupMenuThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return PopupMenuThemeData(
       color: Color.lerp(a?.color, b?.color, t),

--- a/packages/flutter/lib/src/material/progress_indicator_theme.dart
+++ b/packages/flutter/lib/src/material/progress_indicator_theme.dart
@@ -84,8 +84,8 @@ class ProgressIndicatorThemeData with Diagnosticable {
   ///
   /// If both arguments are null, then null is returned.
   static ProgressIndicatorThemeData? lerp(ProgressIndicatorThemeData? a, ProgressIndicatorThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ProgressIndicatorThemeData(
       color: Color.lerp(a?.color, b?.color, t),

--- a/packages/flutter/lib/src/material/radio_theme.dart
+++ b/packages/flutter/lib/src/material/radio_theme.dart
@@ -112,6 +112,9 @@ class RadioThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static RadioThemeData lerp(RadioThemeData? a, RadioThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return RadioThemeData(
       mouseCursor: t < 0.5 ? a?.mouseCursor : b?.mouseCursor,
       fillColor: MaterialStateProperty.lerp<Color?>(a?.fillColor, b?.fillColor, t, Color.lerp),

--- a/packages/flutter/lib/src/material/scrollbar_theme.dart
+++ b/packages/flutter/lib/src/material/scrollbar_theme.dart
@@ -204,6 +204,9 @@ class ScrollbarThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ScrollbarThemeData lerp(ScrollbarThemeData? a, ScrollbarThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return ScrollbarThemeData(
       thumbVisibility: MaterialStateProperty.lerp<bool?>(a?.thumbVisibility, b?.thumbVisibility, t, _lerpBool),
       thickness: MaterialStateProperty.lerp<double?>(a?.thickness, b?.thickness, t, lerpDouble),

--- a/packages/flutter/lib/src/material/segmented_button_theme.dart
+++ b/packages/flutter/lib/src/material/segmented_button_theme.dart
@@ -62,6 +62,9 @@ class SegmentedButtonThemeData with Diagnosticable {
 
   /// Linearly interpolates between two segmented button themes.
   static SegmentedButtonThemeData lerp(SegmentedButtonThemeData? a, SegmentedButtonThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return SegmentedButtonThemeData(
       style: ButtonStyle.lerp(a?.style, b?.style, t),
       selectedIcon: t < 0.5 ? a?.selectedIcon : b?.selectedIcon,

--- a/packages/flutter/lib/src/material/slider_theme.dart
+++ b/packages/flutter/lib/src/material/slider_theme.dart
@@ -650,6 +650,9 @@ class SliderThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static SliderThemeData lerp(SliderThemeData a, SliderThemeData b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return SliderThemeData(
       trackHeight: lerpDouble(a.trackHeight, b.trackHeight, t),
       activeTrackColor: Color.lerp(a.activeTrackColor, b.activeTrackColor, t),

--- a/packages/flutter/lib/src/material/snack_bar_theme.dart
+++ b/packages/flutter/lib/src/material/snack_bar_theme.dart
@@ -178,6 +178,9 @@ class SnackBarThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static SnackBarThemeData lerp(SnackBarThemeData? a, SnackBarThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return SnackBarThemeData(
       backgroundColor: Color.lerp(a?.backgroundColor, b?.backgroundColor, t),
       actionTextColor: Color.lerp(a?.actionTextColor, b?.actionTextColor, t),

--- a/packages/flutter/lib/src/material/switch_theme.dart
+++ b/packages/flutter/lib/src/material/switch_theme.dart
@@ -116,6 +116,9 @@ class SwitchThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static SwitchThemeData lerp(SwitchThemeData? a, SwitchThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return SwitchThemeData(
       thumbColor: MaterialStateProperty.lerp<Color?>(a?.thumbColor, b?.thumbColor, t, Color.lerp),
       trackColor: MaterialStateProperty.lerp<Color?>(a?.trackColor, b?.trackColor, t, Color.lerp),

--- a/packages/flutter/lib/src/material/tab_bar_theme.dart
+++ b/packages/flutter/lib/src/material/tab_bar_theme.dart
@@ -133,6 +133,9 @@ class TabBarTheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static TabBarTheme lerp(TabBarTheme a, TabBarTheme b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return TabBarTheme(
       indicator: Decoration.lerp(a.indicator, b.indicator, t),
       indicatorColor: Color.lerp(a.indicatorColor, b.indicatorColor, t),

--- a/packages/flutter/lib/src/material/text_button_theme.dart
+++ b/packages/flutter/lib/src/material/text_button_theme.dart
@@ -49,8 +49,8 @@ class TextButtonThemeData with Diagnosticable {
 
   /// Linearly interpolate between two text button themes.
   static TextButtonThemeData? lerp(TextButtonThemeData? a, TextButtonThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return TextButtonThemeData(
       style: ButtonStyle.lerp(a?.style, b?.style, t),

--- a/packages/flutter/lib/src/material/text_selection_theme.dart
+++ b/packages/flutter/lib/src/material/text_selection_theme.dart
@@ -73,8 +73,8 @@ class TextSelectionThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static TextSelectionThemeData? lerp(TextSelectionThemeData? a, TextSelectionThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return TextSelectionThemeData(
       cursorColor: Color.lerp(a?.cursorColor, b?.cursorColor, t),

--- a/packages/flutter/lib/src/material/text_theme.dart
+++ b/packages/flutter/lib/src/material/text_theme.dart
@@ -799,6 +799,9 @@ class TextTheme with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static TextTheme lerp(TextTheme? a, TextTheme? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return TextTheme(
       displayLarge: TextStyle.lerp(a?.displayLarge, b?.displayLarge, t),
       displayMedium: TextStyle.lerp(a?.displayMedium, b?.displayMedium, t),

--- a/packages/flutter/lib/src/material/theme_data.dart
+++ b/packages/flutter/lib/src/material/theme_data.dart
@@ -1978,6 +1978,9 @@ class ThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ThemeData lerp(ThemeData a, ThemeData b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return ThemeData.raw(
       // For the sanity of the reader, make sure these properties are in the same
       // order in every place that they are separated by section comments (e.g.
@@ -2732,6 +2735,9 @@ class VisualDensity with Diagnosticable {
 
   /// Linearly interpolate between two densities.
   static VisualDensity lerp(VisualDensity a, VisualDensity b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return VisualDensity(
       horizontal: lerpDouble(a.horizontal, b.horizontal, t)!,
       vertical: lerpDouble(a.vertical, b.vertical, t)!,

--- a/packages/flutter/lib/src/material/time_picker_theme.dart
+++ b/packages/flutter/lib/src/material/time_picker_theme.dart
@@ -299,7 +299,9 @@ class TimePickerThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static TimePickerThemeData lerp(TimePickerThemeData? a, TimePickerThemeData? b, double t) {
-
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     // Workaround since BorderSide's lerp does not allow for null arguments.
     BorderSide? lerpedBorderSide;
     if (a?.dayPeriodBorderSide == null && b?.dayPeriodBorderSide == null) {

--- a/packages/flutter/lib/src/material/toggle_buttons_theme.dart
+++ b/packages/flutter/lib/src/material/toggle_buttons_theme.dart
@@ -150,8 +150,8 @@ class ToggleButtonsThemeData with Diagnosticable {
 
   /// Linearly interpolate between two toggle buttons themes.
   static ToggleButtonsThemeData? lerp(ToggleButtonsThemeData? a, ToggleButtonsThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return ToggleButtonsThemeData(
       textStyle: TextStyle.lerp(a?.textStyle, b?.textStyle, t),

--- a/packages/flutter/lib/src/material/tooltip_theme.dart
+++ b/packages/flutter/lib/src/material/tooltip_theme.dart
@@ -149,8 +149,8 @@ class TooltipThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static TooltipThemeData? lerp(TooltipThemeData? a, TooltipThemeData? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     return TooltipThemeData(
       height: lerpDouble(a?.height, b?.height, t),

--- a/packages/flutter/lib/src/material/typography.dart
+++ b/packages/flutter/lib/src/material/typography.dart
@@ -329,6 +329,9 @@ class Typography with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static Typography lerp(Typography a, Typography b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     return Typography._(
       TextTheme.lerp(a.black, b.black, t),
       TextTheme.lerp(a.white, b.white, t),

--- a/packages/flutter/test/material/app_bar_theme_test.dart
+++ b/packages/flutter/test/material/app_bar_theme_test.dart
@@ -14,6 +14,11 @@ void main() {
     expect(const AppBarTheme().hashCode, const AppBarTheme().copyWith().hashCode);
   });
 
+  test('AppBarTheme lerp special cases', () {
+    const AppBarTheme data = AppBarTheme();
+    expect(identical(AppBarTheme.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no AppBarTheme returns defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/badge_theme_test.dart
+++ b/packages/flutter/test/material/badge_theme_test.dart
@@ -14,6 +14,12 @@ void main() {
     expect(const BadgeThemeData().hashCode, const BadgeThemeData().copyWith().hashCode);
   });
 
+  test('BadgeThemeData lerp special cases', () {
+    expect(BadgeThemeData.lerp(null, null, 0), const BadgeThemeData());
+    const BadgeThemeData data = BadgeThemeData();
+    expect(identical(BadgeThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('BadgeThemeData defaults', () {
     const BadgeThemeData themeData = BadgeThemeData();
     expect(themeData.backgroundColor, null);

--- a/packages/flutter/test/material/bottom_app_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_app_bar_theme_test.dart
@@ -11,6 +11,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('BottomAppBarTheme lerp special cases', () {
+    expect(BottomAppBarTheme.lerp(null, null, 0), const BottomAppBarTheme());
+    const BottomAppBarTheme data = BottomAppBarTheme();
+    expect(identical(BottomAppBarTheme.lerp(data, data, 0.5), data), true);
+  });
+
   group('Material 2 tests', () {
     testWidgets('BAB theme overrides color', (WidgetTester tester) async {
       const Color themedColor = Colors.black87;

--- a/packages/flutter/test/material/bottom_navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/bottom_navigation_bar_theme_test.dart
@@ -15,6 +15,11 @@ void main() {
     expect(const BottomNavigationBarThemeData().hashCode, const BottomNavigationBarThemeData().copyWith().hashCode);
   });
 
+  test('BottomNavigationBarThemeData lerp special cases', () {
+    const BottomNavigationBarThemeData data = BottomNavigationBarThemeData();
+    expect(identical(BottomNavigationBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('BottomNavigationBarThemeData defaults', () {
     const BottomNavigationBarThemeData themeData = BottomNavigationBarThemeData();
     expect(themeData.backgroundColor, null);

--- a/packages/flutter/test/material/bottom_sheet_theme_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_theme_test.dart
@@ -12,6 +12,18 @@ void main() {
     expect(const BottomSheetThemeData().hashCode, const BottomSheetThemeData().copyWith().hashCode);
   });
 
+  test('BottomSheetThemeData lerp special cases', () {
+    expect(BottomSheetThemeData.lerp(null, null, 0), null);
+    const BottomSheetThemeData data = BottomSheetThemeData();
+    expect(identical(BottomSheetThemeData.lerp(data, data, 0.5), data), true);
+  });
+
+  test('BottomSheetThemeData lerp special cases', () {
+    expect(BottomSheetThemeData.lerp(null, null, 0), null);
+    const BottomSheetThemeData data = BottomSheetThemeData();
+    expect(identical(BottomSheetThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('BottomSheetThemeData null fields by default', () {
     const BottomSheetThemeData bottomSheetTheme = BottomSheetThemeData();
     expect(bottomSheetTheme.backgroundColor, null);

--- a/packages/flutter/test/material/button_bar_theme_test.dart
+++ b/packages/flutter/test/material/button_bar_theme_test.dart
@@ -8,6 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
 
+  test('ButtonBarThemeData lerp special cases', () {
+    expect(ButtonBarThemeData.lerp(null, null, 0), null);
+    const ButtonBarThemeData data = ButtonBarThemeData();
+    expect(identical(ButtonBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('ButtonBarThemeData null fields by default', () {
     const ButtonBarThemeData buttonBarTheme = ButtonBarThemeData();
     expect(buttonBarTheme.alignment, null);

--- a/packages/flutter/test/material/button_style_test.dart
+++ b/packages/flutter/test/material/button_style_test.dart
@@ -14,6 +14,12 @@ void main() {
     expect(const ButtonStyle().hashCode, const ButtonStyle().copyWith().hashCode);
   });
 
+  test('ButtonStyle lerp special cases', () {
+    expect(ButtonStyle.lerp(null, null, 0), null);
+    const ButtonStyle data = ButtonStyle();
+    expect(identical(ButtonStyle.lerp(data, data, 0.5), data), true);
+  });
+
   test('ButtonStyle defaults', () {
     const ButtonStyle style = ButtonStyle();
     expect(style.textStyle, null);

--- a/packages/flutter/test/material/card_theme_test.dart
+++ b/packages/flutter/test/material/card_theme_test.dart
@@ -16,6 +16,12 @@ void main() {
     expect(const CardTheme().hashCode, const CardTheme().copyWith().hashCode);
   });
 
+  test('CardTheme lerp special cases', () {
+    expect(CardTheme.lerp(null, null, 0), const CardTheme());
+    const CardTheme theme = CardTheme();
+    expect(identical(CardTheme.lerp(theme, theme, 0.5), theme), true);
+  });
+
   testWidgets('Passing no CardTheme returns defaults', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
     await tester.pumpWidget(MaterialApp(

--- a/packages/flutter/test/material/checkbox_theme_test.dart
+++ b/packages/flutter/test/material/checkbox_theme_test.dart
@@ -15,6 +15,12 @@ void main() {
     expect(const CheckboxThemeData().hashCode, const CheckboxThemeData().copyWith().hashCode);
   });
 
+  test('CheckboxThemeData lerp special cases', () {
+    expect(CheckboxThemeData.lerp(null, null, 0), const CheckboxThemeData());
+    const CheckboxThemeData data = CheckboxThemeData();
+    expect(identical(CheckboxThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('CheckboxThemeData defaults', () {
     const CheckboxThemeData themeData = CheckboxThemeData();
     expect(themeData.mouseCursor, null);

--- a/packages/flutter/test/material/chip_theme_test.dart
+++ b/packages/flutter/test/material/chip_theme_test.dart
@@ -42,6 +42,12 @@ void main() {
     expect(const ChipThemeData().hashCode, const ChipThemeData().copyWith().hashCode);
   });
 
+  test('ChipThemeData lerp special cases', () {
+    expect(ChipThemeData.lerp(null, null, 0), null);
+    const ChipThemeData data = ChipThemeData();
+    expect(identical(ChipThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('ChipThemeData defaults', () {
     const ChipThemeData themeData = ChipThemeData();
     expect(themeData.backgroundColor, null);

--- a/packages/flutter/test/material/color_scheme_test.dart
+++ b/packages/flutter/test/material/color_scheme_test.dart
@@ -6,6 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('ColorScheme lerp special cases', () {
+    const ColorScheme scheme = ColorScheme.light();
+    expect(identical(ColorScheme.lerp(scheme, scheme, 0.5), scheme), true);
+  });
+
   test('light scheme matches the spec', () {
     // Colors should match the Material Design baseline default theme:
     // https://material.io/design/color/dark-theme.html#ui-application

--- a/packages/flutter/test/material/data_table_theme_test.dart
+++ b/packages/flutter/test/material/data_table_theme_test.dart
@@ -12,6 +12,11 @@ void main() {
     expect(const DataTableThemeData().hashCode, const DataTableThemeData().copyWith().hashCode);
   });
 
+  test('DataTableThemeData lerp special cases', () {
+    const DataTableThemeData data = DataTableThemeData();
+    expect(identical(DataTableThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('DataTableThemeData defaults', () {
     const DataTableThemeData themeData = DataTableThemeData();
     expect(themeData.decoration, null);

--- a/packages/flutter/test/material/date_picker_theme_test.dart
+++ b/packages/flutter/test/material/date_picker_theme_test.dart
@@ -75,6 +75,11 @@ void main() {
     expect(const DatePickerThemeData().hashCode, const DatePickerThemeData().copyWith().hashCode);
   });
 
+  test('DatePickerThemeData lerp special cases', () {
+    const DatePickerThemeData data = DatePickerThemeData();
+    expect(identical(DatePickerThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('DatePickerThemeData defaults', () {
     const DatePickerThemeData theme = DatePickerThemeData();
     expect(theme.backgroundColor, null);

--- a/packages/flutter/test/material/dialog_theme_test.dart
+++ b/packages/flutter/test/material/dialog_theme_test.dart
@@ -47,6 +47,12 @@ RenderParagraph _getTextRenderObject(WidgetTester tester, String text) {
 }
 
 void main() {
+  test('DialogTheme lerp special cases', () {
+    expect(DialogTheme.lerp(null, null, 0), const DialogTheme());
+    const DialogTheme theme = DialogTheme();
+    expect(identical(DialogTheme.lerp(theme, theme, 0.5), theme), true);
+  });
+
   testWidgets('Dialog Theme implements debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const DialogTheme(

--- a/packages/flutter/test/material/drawer_theme_test.dart
+++ b/packages/flutter/test/material/drawer_theme_test.dart
@@ -12,6 +12,12 @@ void main() {
     expect(const DrawerThemeData().hashCode, const DrawerThemeData().copyWith().hashCode);
   });
 
+  test('DrawerThemeData lerp special cases', () {
+    expect(DrawerThemeData.lerp(null, null, 0), null);
+    const DrawerThemeData data = DrawerThemeData();
+    expect(identical(DrawerThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Default debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const DrawerThemeData().debugFillProperties(builder);

--- a/packages/flutter/test/material/dropdown_menu_theme_test.dart
+++ b/packages/flutter/test/material/dropdown_menu_theme_test.dart
@@ -24,6 +24,12 @@ void main() {
     expect(copy, custom);
   });
 
+  test('DropdownMenuThemeData lerp special cases', () {
+    expect(DropdownMenuThemeData.lerp(null, null, 0), const DropdownMenuThemeData());
+    const DropdownMenuThemeData data = DropdownMenuThemeData();
+    expect(identical(DropdownMenuThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Default DropdownMenuThemeData debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const DropdownMenuThemeData().debugFillProperties(builder);

--- a/packages/flutter/test/material/elevated_button_theme_test.dart
+++ b/packages/flutter/test/material/elevated_button_theme_test.dart
@@ -6,6 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('ElevatedButtonThemeData lerp special cases', () {
+    expect(ElevatedButtonThemeData.lerp(null, null, 0), null);
+    const ElevatedButtonThemeData data = ElevatedButtonThemeData();
+    expect(identical(ElevatedButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no ElevatedButtonTheme returns defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/expansion_tile_theme_test.dart
+++ b/packages/flutter/test/material/expansion_tile_theme_test.dart
@@ -47,6 +47,12 @@ void main() {
     expect(const ExpansionTileThemeData().hashCode, const ExpansionTileThemeData().copyWith().hashCode);
   });
 
+  test('ExpansionTileThemeData lerp special cases', () {
+    expect(ExpansionTileThemeData.lerp(null, null, 0), null);
+    const ExpansionTileThemeData data = ExpansionTileThemeData();
+    expect(identical(ExpansionTileThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('ExpansionTileThemeData defaults', () {
     const ExpansionTileThemeData theme = ExpansionTileThemeData();
     expect(theme.backgroundColor, null);

--- a/packages/flutter/test/material/filled_button_theme_test.dart
+++ b/packages/flutter/test/material/filled_button_theme_test.dart
@@ -6,6 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('FilledButtonThemeData lerp special cases', () {
+    expect(FilledButtonThemeData.lerp(null, null, 0), null);
+    const FilledButtonThemeData data = FilledButtonThemeData();
+    expect(identical(FilledButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no FilledButtonTheme returns defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/floating_action_button_theme_test.dart
+++ b/packages/flutter/test/material/floating_action_button_theme_test.dart
@@ -13,6 +13,12 @@ void main() {
     expect(const FloatingActionButtonThemeData().hashCode, const FloatingActionButtonThemeData().copyWith().hashCode);
   });
 
+  test('FloatingActionButtonThemeData lerp special cases', () {
+    expect(FloatingActionButtonThemeData.lerp(null, null, 0), null);
+    const FloatingActionButtonThemeData data = FloatingActionButtonThemeData();
+    expect(identical(FloatingActionButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Default values are used when no FloatingActionButton or FloatingActionButtonThemeData properties are specified', (WidgetTester tester) async {
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(

--- a/packages/flutter/test/material/icon_button_theme_test.dart
+++ b/packages/flutter/test/material/icon_button_theme_test.dart
@@ -6,6 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('IconButtonThemeData lerp special cases', () {
+    expect(IconButtonThemeData.lerp(null, null, 0), null);
+    const IconButtonThemeData data = IconButtonThemeData();
+    expect(identical(IconButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no IconButtonTheme returns defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/list_tile_theme_test.dart
+++ b/packages/flutter/test/material/list_tile_theme_test.dart
@@ -46,9 +46,15 @@ class TestTextState extends State<TestText> {
 }
 
 void main() {
-  test('ListTileThemeData copyWith, ==, hashCode basics', () {
+  test('ListTileThemeData copyWith, ==, hashCode, basics', () {
     expect(const ListTileThemeData(), const ListTileThemeData().copyWith());
     expect(const ListTileThemeData().hashCode, const ListTileThemeData().copyWith().hashCode);
+  });
+
+  test('ListTileThemeData lerp special cases', () {
+    expect(ListTileThemeData.lerp(null, null, 0), null);
+    const ListTileThemeData data = ListTileThemeData();
+    expect(identical(ListTileThemeData.lerp(data, data, 0.5), data), true);
   });
 
   test('ListTileThemeData defaults', () {

--- a/packages/flutter/test/material/menu_bar_theme_test.dart
+++ b/packages/flutter/test/material/menu_bar_theme_test.dart
@@ -46,6 +46,12 @@ void main() {
     );
   }
 
+  test('MenuBarThemeData lerp special cases', () {
+    expect(MenuBarThemeData.lerp(null, null, 0), null);
+    const MenuBarThemeData data = MenuBarThemeData();
+    expect(identical(MenuBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('theme is honored', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/menu_button_theme_test.dart
+++ b/packages/flutter/test/material/menu_button_theme_test.dart
@@ -1,0 +1,14 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('MenuButtonThemeData lerp special cases', () {
+    expect(MenuButtonThemeData.lerp(null, null, 0), null);
+    const MenuButtonThemeData data = MenuButtonThemeData();
+    expect(identical(MenuButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+}

--- a/packages/flutter/test/material/menu_style_test.dart
+++ b/packages/flutter/test/material/menu_style_test.dart
@@ -35,6 +35,12 @@ void main() {
   }
 
   group('MenuStyle', () {
+    test('MenuStyle lerp special cases', () {
+      expect(MenuStyle.lerp(null, null, 0), null);
+      const MenuStyle data = MenuStyle();
+      expect(identical(MenuStyle.lerp(data, data, 0.5), data), true);
+    });
+
     testWidgets('fixedSize affects geometry', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(

--- a/packages/flutter/test/material/menu_theme_test.dart
+++ b/packages/flutter/test/material/menu_theme_test.dart
@@ -46,6 +46,12 @@ void main() {
     );
   }
 
+  test('MenuThemeData lerp special cases', () {
+    expect(MenuThemeData.lerp(null, null, 0), null);
+    const MenuThemeData data = MenuThemeData();
+    expect(identical(MenuThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('theme is honored', (WidgetTester tester) async {
     await tester.pumpWidget(
       MaterialApp(

--- a/packages/flutter/test/material/navigation_bar_theme_test.dart
+++ b/packages/flutter/test/material/navigation_bar_theme_test.dart
@@ -18,6 +18,12 @@ void main() {
     expect(const NavigationBarThemeData().hashCode, const NavigationBarThemeData().copyWith().hashCode);
   });
 
+  test('NavigationBarThemeData lerp special cases', () {
+    expect(NavigationBarThemeData.lerp(null, null, 0), null);
+    const NavigationBarThemeData data = NavigationBarThemeData();
+    expect(identical(NavigationBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Default debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const NavigationBarThemeData().debugFillProperties(builder);

--- a/packages/flutter/test/material/navigation_drawer_theme_test.dart
+++ b/packages/flutter/test/material/navigation_drawer_theme_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('NavigationDrawerThemeData copyWith, ==, hashCode, basics', () {
+    expect(const NavigationDrawerThemeData(), const NavigationDrawerThemeData().copyWith());
+    expect(const NavigationDrawerThemeData().hashCode, const NavigationDrawerThemeData().copyWith().hashCode);
+  });
+
+  test('NavigationDrawerThemeData lerp special cases', () {
+    expect(NavigationDrawerThemeData.lerp(null, null, 0), null);
+    const NavigationDrawerThemeData data = NavigationDrawerThemeData();
+    expect(identical(NavigationDrawerThemeData.lerp(data, data, 0.5), data), true);
+  });
+}

--- a/packages/flutter/test/material/outlined_button_theme_test.dart
+++ b/packages/flutter/test/material/outlined_button_theme_test.dart
@@ -6,6 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('OutlinedButtonThemeData lerp special cases', () {
+    expect(OutlinedButtonThemeData.lerp(null, null, 0), null);
+    const OutlinedButtonThemeData data = OutlinedButtonThemeData();
+    expect(identical(OutlinedButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no OutlinedButtonTheme returns defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/popup_menu_theme_test.dart
+++ b/packages/flutter/test/material/popup_menu_theme_test.dart
@@ -50,6 +50,12 @@ void main() {
     expect(const PopupMenuThemeData().hashCode, const PopupMenuThemeData().copyWith().hashCode);
   });
 
+  test('PopupMenuThemeData lerp special cases', () {
+    expect(PopupMenuThemeData.lerp(null, null, 0), null);
+    const PopupMenuThemeData data = PopupMenuThemeData();
+    expect(identical(PopupMenuThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('PopupMenuThemeData null fields by default', () {
     const PopupMenuThemeData popupMenuTheme = PopupMenuThemeData();
     expect(popupMenuTheme.color, null);

--- a/packages/flutter/test/material/progress_indicator_theme_test.dart
+++ b/packages/flutter/test/material/progress_indicator_theme_test.dart
@@ -1,0 +1,19 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('ProgressIndicatorThemeData copyWith, ==, hashCode, basics', () {
+    expect(const ProgressIndicatorThemeData(), const ProgressIndicatorThemeData().copyWith());
+    expect(const ProgressIndicatorThemeData().hashCode, const ProgressIndicatorThemeData().copyWith().hashCode);
+  });
+
+  test('ProgressIndicatorThemeData lerp special cases', () {
+    expect(ProgressIndicatorThemeData.lerp(null, null, 0), null);
+    const ProgressIndicatorThemeData data = ProgressIndicatorThemeData();
+    expect(identical(ProgressIndicatorThemeData.lerp(data, data, 0.5), data), true);
+  });
+}

--- a/packages/flutter/test/material/radio_theme_test.dart
+++ b/packages/flutter/test/material/radio_theme_test.dart
@@ -15,6 +15,12 @@ void main() {
     expect(const RadioThemeData().hashCode, const RadioThemeData().copyWith().hashCode);
   });
 
+  test('RadioThemeData lerp special cases', () {
+    expect(RadioThemeData.lerp(null, null, 0), const RadioThemeData());
+    const RadioThemeData data = RadioThemeData();
+    expect(identical(RadioThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('RadioThemeData defaults', () {
     const RadioThemeData themeData = RadioThemeData();
     expect(themeData.mouseCursor, null);

--- a/packages/flutter/test/material/scrollbar_theme_test.dart
+++ b/packages/flutter/test/material/scrollbar_theme_test.dart
@@ -25,6 +25,12 @@ void main() {
     expect(const ScrollbarThemeData().hashCode, const ScrollbarThemeData().copyWith().hashCode);
   });
 
+  test('ScrollbarThemeData lerp special cases', () {
+    expect(ScrollbarThemeData.lerp(null, null, 0), const ScrollbarThemeData());
+    const ScrollbarThemeData data = ScrollbarThemeData();
+    expect(identical(ScrollbarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no ScrollbarTheme returns defaults', (WidgetTester tester) async {
     final ScrollController scrollController = ScrollController();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/segmented_button_theme_test.dart
+++ b/packages/flutter/test/material/segmented_button_theme_test.dart
@@ -23,6 +23,12 @@ void main() {
     expect(copy, custom);
   });
 
+  test('SegmentedButtonThemeData lerp special cases', () {
+    expect(SegmentedButtonThemeData.lerp(null, null, 0), const SegmentedButtonThemeData());
+    const SegmentedButtonThemeData theme = SegmentedButtonThemeData();
+    expect(identical(SegmentedButtonThemeData.lerp(theme, theme, 0.5), theme), true);
+  });
+
   testWidgets('Default SegmentedButtonThemeData debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const SegmentedButtonThemeData().debugFillProperties(builder);

--- a/packages/flutter/test/material/slider_theme_test.dart
+++ b/packages/flutter/test/material/slider_theme_test.dart
@@ -15,6 +15,11 @@ void main() {
     expect(const SliderThemeData().hashCode, const SliderThemeData().copyWith().hashCode);
   });
 
+  test('SliderThemeData lerp special cases', () {
+    const SliderThemeData data = SliderThemeData();
+    expect(identical(SliderThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Default SliderThemeData debugFillProperties', (WidgetTester tester) async {
     final DiagnosticPropertiesBuilder builder = DiagnosticPropertiesBuilder();
     const SliderThemeData().debugFillProperties(builder);

--- a/packages/flutter/test/material/snack_bar_theme_test.dart
+++ b/packages/flutter/test/material/snack_bar_theme_test.dart
@@ -12,6 +12,12 @@ void main() {
     expect(const SnackBarThemeData().hashCode, const SnackBarThemeData().copyWith().hashCode);
   });
 
+  test('SnackBarThemeData lerp special cases', () {
+    expect(SnackBarThemeData.lerp(null, null, 0), const SnackBarThemeData());
+    const SnackBarThemeData data = SnackBarThemeData();
+    expect(identical(SnackBarThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('SnackBarThemeData null fields by default', () {
     const SnackBarThemeData snackBarTheme = SnackBarThemeData();
     expect(snackBarTheme.backgroundColor, null);

--- a/packages/flutter/test/material/switch_theme_test.dart
+++ b/packages/flutter/test/material/switch_theme_test.dart
@@ -15,6 +15,11 @@ void main() {
     expect(const SwitchThemeData().hashCode, const SwitchThemeData().copyWith().hashCode);
   });
 
+  test('SwitchThemeData lerp special cases', () {
+    const SwitchThemeData data = SwitchThemeData();
+    expect(identical(SwitchThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('SwitchThemeData defaults', () {
     const SwitchThemeData themeData = SwitchThemeData();
     expect(themeData.thumbColor, null);

--- a/packages/flutter/test/material/tab_bar_theme_test.dart
+++ b/packages/flutter/test/material/tab_bar_theme_test.dart
@@ -77,6 +77,11 @@ void main() {
     expect(const TabBarTheme().mouseCursor, null);
   });
 
+  test('TabBarTheme lerp special cases', () {
+    const TabBarTheme theme = TabBarTheme();
+    expect(identical(TabBarTheme.lerp(theme, theme, 0.5), theme), true);
+  });
+
   testWidgets('Tab bar defaults', (WidgetTester tester) async {
     // tests for the default label color and label styles when tabBarTheme and tabBar do not provide any
     await tester.pumpWidget(_withTheme(null, useMaterial3: true));

--- a/packages/flutter/test/material/text_button_theme_test.dart
+++ b/packages/flutter/test/material/text_button_theme_test.dart
@@ -6,6 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  test('TextButtonTheme lerp special cases', () {
+    expect(TextButtonThemeData.lerp(null, null, 0), null);
+    const TextButtonThemeData data = TextButtonThemeData();
+    expect(identical(TextButtonThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   testWidgets('Passing no TextButtonTheme returns defaults', (WidgetTester tester) async {
     const ColorScheme colorScheme = ColorScheme.light();
     await tester.pumpWidget(

--- a/packages/flutter/test/material/text_selection_theme_test.dart
+++ b/packages/flutter/test/material/text_selection_theme_test.dart
@@ -14,6 +14,12 @@ void main() {
     expect(const TextSelectionThemeData().hashCode, const TextSelectionThemeData().copyWith().hashCode);
   });
 
+  test('TextSelectionThemeData lerp special cases', () {
+    expect(TextSelectionThemeData.lerp(null, null, 0), null);
+    const TextSelectionThemeData data = TextSelectionThemeData();
+    expect(identical(TextSelectionThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('TextSelectionThemeData null fields by default', () {
     const TextSelectionThemeData theme = TextSelectionThemeData();
     expect(theme.cursorColor, null);

--- a/packages/flutter/test/material/text_theme_test.dart
+++ b/packages/flutter/test/material/text_theme_test.dart
@@ -14,6 +14,12 @@ void main() {
     expect(const TextTheme(), equals(const TextTheme().copyWith()));
   });
 
+  test('TextTheme lerp special cases', () {
+    expect(TextTheme.lerp(null, null, 0), const TextTheme());
+    const TextTheme theme = TextTheme();
+    expect(identical(TextTheme.lerp(theme, theme, 0.5), theme), true);
+  });
+
   test('TextTheme copyWith apply, merge basics with Typography.black', () {
     final Typography typography = Typography.material2018();
     expect(typography.black, equals(typography.black.copyWith()));

--- a/packages/flutter/test/material/time_picker_theme_test.dart
+++ b/packages/flutter/test/material/time_picker_theme_test.dart
@@ -14,6 +14,11 @@ void main() {
     expect(const TimePickerThemeData().hashCode, const TimePickerThemeData().copyWith().hashCode);
   });
 
+  test('TimePickerThemeData lerp special cases', () {
+    const TimePickerThemeData data = TimePickerThemeData();
+    expect(identical(TimePickerThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('TimePickerThemeData null fields by default', () {
     const TimePickerThemeData timePickerTheme = TimePickerThemeData();
     expect(timePickerTheme.backgroundColor, null);

--- a/packages/flutter/test/material/toggle_buttons_theme_test.dart
+++ b/packages/flutter/test/material/toggle_buttons_theme_test.dart
@@ -22,6 +22,12 @@ void main() {
     expect(const ToggleButtonsThemeData().hashCode, const ToggleButtonsThemeData().copyWith().hashCode);
   });
 
+  test('ToggleButtonsThemeData lerp special cases', () {
+    expect(ToggleButtonsThemeData.lerp(null, null, 0), null);
+    const ToggleButtonsThemeData data = ToggleButtonsThemeData();
+    expect(identical(ToggleButtonsThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('ToggleButtonsThemeData defaults', () {
     const ToggleButtonsThemeData themeData = ToggleButtonsThemeData();
     expect(themeData.textStyle, null);

--- a/packages/flutter/test/material/tooltip_theme_test.dart
+++ b/packages/flutter/test/material/tooltip_theme_test.dart
@@ -37,6 +37,12 @@ void main() {
     expect(const TooltipThemeData().hashCode, const TooltipThemeData().copyWith().hashCode);
   });
 
+  test('TooltipThemeData lerp special cases', () {
+    expect(TooltipThemeData.lerp(null, null, 0), null);
+    const TooltipThemeData data = TooltipThemeData();
+    expect(identical(TooltipThemeData.lerp(data, data, 0.5), data), true);
+  });
+
   test('TooltipThemeData defaults', () {
     const TooltipThemeData theme = TooltipThemeData();
     expect(theme.height, null);

--- a/packages/flutter/test/material/typography_test.dart
+++ b/packages/flutter/test/material/typography_test.dart
@@ -16,6 +16,11 @@ void main() {
     }
   });
 
+  test('Typography lerp special cases', () {
+    final Typography typography = Typography();
+    expect(identical(Typography.lerp(typography, typography, 0.5), typography), true);
+  });
+
   test('Typography on non-Apple platforms defaults to the correct font', () {
     expect(Typography.material2018().black.titleLarge!.fontFamily, 'Roboto');
     expect(Typography.material2018(platform: TargetPlatform.fuchsia).black.titleLarge!.fontFamily, 'Roboto');


### PR DESCRIPTION
Handle a common case in `Foo.lerp(a, b, t)`: if a and b are identical, then just return a. This avoids needlessly constructing a new `Foo`  and recursively lerping all of its properties. If a and b refer to the same const object, then we also preserve their singleton identity. 

In the Material library, ThemeData's properties are legion and by default  they are const values. The most common application of ThemeData.lerp, animating between light and dark themes, only really affects the colorScheme property. The rest of the properties are needlessly recreated by recursively applying lerping each of their own properties. And in doing so, the singleton values they're bound to and the low cost of comparing them for equality, is lost. That's a significant amount of needless churn.

The trivial changes applied in this PR aim to short-circuit the work at the ThemeData property level.

Some random observations about ~50 `Foo.lerp(Foo? a, Foo? b, double t)` methods that were updated here:
- Roughly 30% of them return `Foo` rather than `Foo?`, even though their parameters are nullable. The rest include a special case that returns null for `Foo.lerp(null, null, t)`.
- Of that 30%, all except one return a value that's equal to `Foo()` when both a and b are null. An additional special case could return `const Foo()`, but that didn't seem to be worth the trouble.
- `AppBarTheme.lerp(null, null)` is the one exception. It does not return `AppBarTheme()` it has two IconThemeData properties and `IconThemeData.lerp(null, null)` returns a new IconThemeData.
- A handful of lerp methods must deal with a nullable BorderSide property. This is problematic because BorderSide.lerp() is defined as `static BorderSide lerp(BorderSide a, BorderSide b, double t)`. Most of the work-arounds are similar but not equivalent, see for example TimePickerThemeData.lerp, _lerpSides in checkbox_theme.dart, _lerpBorderSide in date_picker_theme.dart, _lerpSides in chip_theme.dart.
- This vestigial comment persists in many of the API doc comments:
```dart
  /// The argument `t` must not be null.
```
