### PR TITLE
Increase Linux docs_test timeout

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -303,7 +303,7 @@ targets:
   - name: Linux docs_publish
     recipe: flutter/flutter
     presubmit: false
-    timeout: 90
+    timeout: 90 # https://github.com/flutter/flutter/issues/120901
     properties:
       cores: "32"
       dependencies: >-
@@ -321,7 +321,7 @@ targets:
 
   - name: Linux docs_test
     recipe: flutter/flutter
-    timeout: 90
+    timeout: 90 # https://github.com/flutter/flutter/issues/120901
     properties:
       cores: "32"
       dependencies: >-

--- a/.ci.yaml
+++ b/.ci.yaml
@@ -321,7 +321,7 @@ targets:
 
   - name: Linux docs_test
     recipe: flutter/flutter
-    timeout: 60
+    timeout: 90
     properties:
       cores: "32"
       dependencies: >-


### PR DESCRIPTION
The `Linux docs_test` target has timed out repeatedly:

1. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20docs_test/9036/overview
2. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20docs_test/9035/overview
3. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20docs_test/9028/overview
4. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20docs_test/9018/overview
5. https://ci.chromium.org/ui/p/flutter/builders/prod/Linux%20docs_test/9011/overview

This is a short-term mitigation to prevent unnecessary framework tree closures.

Long-term we should remove docset generation from post-submit `Linux docs_test`. This is tracked by https://github.com/flutter/flutter/issues/120901.

See this similar change: https://github.com/flutter/flutter/pull/120718

