### PR TITLE
Update TextField subtext gap to M3 spec

### DIFF
--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -710,8 +710,6 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
        _expands = expands,
        _material3 = material3;
 
-  static const double subtextGap = 8.0;
-
   RenderBox? get icon => childForSlot(_DecorationSlot.icon);
   RenderBox? get input => childForSlot(_DecorationSlot.input);
   RenderBox? get label => childForSlot(_DecorationSlot.label);
@@ -944,6 +942,8 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
       'can be used to constrain the width of the InputDecorator or the '
       'TextField that contains it.',
     );
+
+    final double subtextGap = material3 ? 4.0 : 8.0;
 
     // Margin on each side of subtext (counter and helperError)
     final Map<RenderBox?, double> boxToBaseline = <RenderBox?, double>{};
@@ -1247,6 +1247,7 @@ class _RenderDecoration extends RenderBox with SlottedContainerRenderObjectMixin
 
   @override
   double computeMinIntrinsicHeight(double width) {
+    final double subtextGap = material3 ? 4.0 : 8.0;
     final double iconHeight = _minHeight(icon, width);
     final double iconWidth = _minWidth(icon, iconHeight);
 

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1244,15 +1244,15 @@ void main() {
     //   12 - help/error/counter text (font size 12dps)
 
     // isEmpty: true, the label is not floating
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('helper')), const Offset(12.0, 64.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
 
     // If errorText is specified then the helperText isn't shown
     await tester.pumpWidget(
@@ -1272,15 +1272,15 @@ void main() {
     await tester.pumpAndSettle();
 
     // isEmpty: false, the label _is_ floating
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('error')), const Offset(12.0, 64.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 64.0));
+    expect(tester.getTopLeft(find.text('error')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
     expect(find.text('helper'), findsNothing);
 
     // Overall height for this dense layout InputDecorator is 68dps. When the
@@ -1321,15 +1321,15 @@ void main() {
     await tester.pumpAndSettle();
 
     // isEmpty: false, the label _is_ floating
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
     expect(tester.getTopLeft(find.text('text')).dy, 24.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 40.0);
     expect(tester.getTopLeft(find.text('label')).dy, 8.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 20.0);
     expect(getBorderBottom(tester), 48.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('error')), const Offset(12.0, 56.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 56.0));
+    expect(tester.getTopLeft(find.text('error')), Offset(12.0, useMaterial3 ? 52.0 : 56.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 52.0 : 56.0));
 
     await tester.pumpWidget(
       buildInputDecorator(
@@ -1349,15 +1349,15 @@ void main() {
     await tester.pumpAndSettle();
 
     // isEmpty: false, the label is not floating
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
     expect(tester.getTopLeft(find.text('text')).dy, 24.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 40.0);
     expect(tester.getTopLeft(find.text('label')).dy, 16.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 32.0);
     expect(getBorderBottom(tester), 48.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('error')), const Offset(12.0, 56.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 56.0));
+    expect(tester.getTopLeft(find.text('error')), Offset(12.0, useMaterial3 ? 52.0 : 56.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 52.0 : 56.0));
   });
 
   testWidgets('InputDecorator counter text, widget, and null', (WidgetTester tester) async {
@@ -1492,9 +1492,9 @@ void main() {
     //    8 - below the border padding
     //   36 - error text (3 lines, font size 12dps)
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 100.0));
-    expect(tester.getTopLeft(find.text(kError3)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kError3)), const Offset(12.0, 100.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 96.0 : 100.0));
+    expect(tester.getTopLeft(find.text(kError3)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kError3)), Offset(12.0, useMaterial3 ? 96.0 : 100.0));
 
     // Overall height for this InputDecorator is 12 less than the first
     // one, 88dps, because errorText only occupies two lines.
@@ -1514,9 +1514,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 88.0));
-    expect(tester.getTopLeft(find.text(kError2)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kError2)), const Offset(12.0, 88.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 84.0 : 88.0));
+    expect(tester.getTopLeft(find.text(kError2)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kError2)), Offset(12.0, useMaterial3 ? 84.0 : 88.0));
 
     // Overall height for this InputDecorator is 24 less than the first
     // one, 88dps, because errorText only occupies one line.
@@ -1536,9 +1536,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
-    expect(tester.getTopLeft(find.text(kError1)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kError1)), const Offset(12.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getTopLeft(find.text(kError1)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kError1)), Offset(12.0, useMaterial3 ? 72.0 : 76.0));
   });
 
   testWidgets('InputDecoration helperMaxLines', (WidgetTester tester) async {
@@ -1570,9 +1570,9 @@ void main() {
     //    8 - below the border padding
     //   36 - helper text (3 lines, font size 12dps)
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 100.0));
-    expect(tester.getTopLeft(find.text(kHelper3)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper3)), const Offset(12.0, 100.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 96.0 : 100.0));
+    expect(tester.getTopLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 96.0 : 100.0));
 
     // Overall height for this InputDecorator is 12 less than the first
     // one, 88dps, because helperText only occupies two lines.
@@ -1591,9 +1591,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 88.0));
-    expect(tester.getTopLeft(find.text(kHelper3)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper3)), const Offset(12.0, 88.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 84.0 : 88.0));
+    expect(tester.getTopLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 84.0 : 88.0));
 
     // Overall height for this InputDecorator is 12 less than the first
     // one, 88dps, because helperText only occupies two lines.
@@ -1612,9 +1612,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 88.0));
-    expect(tester.getTopLeft(find.text(kHelper2)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper2)), const Offset(12.0, 88.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 84.0 : 88.0));
+    expect(tester.getTopLeft(find.text(kHelper2)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kHelper2)), Offset(12.0, useMaterial3 ? 84.0 : 88.0));
 
     // Overall height for this InputDecorator is 24 less than the first
     // one, 88dps, because helperText only occupies one line.
@@ -1633,9 +1633,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
-    expect(tester.getTopLeft(find.text(kHelper1)), const Offset(12.0, 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper1)), const Offset(12.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getTopLeft(find.text(kHelper1)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getBottomLeft(find.text(kHelper1)), Offset(12.0, useMaterial3 ? 72.0 : 76.0));
   });
 
   testWidgets('InputDecorator prefix/suffix texts', (WidgetTester tester) async {
@@ -3097,7 +3097,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled
     // (dx) - 12 = (text offset)x.
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
     final double dx = tester.getRect(find.byType(InputDecorator)).right;
     expect(tester.getRect(find.text('test')).right, dx - 12.0);
   });
@@ -3118,7 +3118,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled and top left offset is (0, 0)
     // 0 + 12 = 12.
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
     expect(tester.getRect(find.text('test')).left, 12.0);
   });
 
@@ -3138,7 +3138,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled
     // (dx) - 12 = (text offset)x.
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 52.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 48.0 : 52.0));
     final double dx = tester.getRect(find.byType(InputDecorator)).right;
     expect(tester.getRect(find.text('test')).right, dx - 12.0);
   });
@@ -3160,7 +3160,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled and top left offset is (0, 0)
     // 0 + 12 = 12.
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 52.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 48.0 : 52.0));
     expect(tester.getRect(find.text('test')).left, 12.0);
   });
 
@@ -3189,15 +3189,15 @@ void main() {
     //    8 - below the border padding
     //   12 - [counter helper/error] (font size 12dps)
 
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('counter')), const Offset(12.0, 64.0));
-    expect(tester.getTopRight(find.text('helper')), const Offset(788.0, 64.0));
+    expect(tester.getTopLeft(find.text('counter')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('helper')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
 
     // If both error and helper are specified, show the error
     await tester.pumpWidget(
@@ -3216,8 +3216,8 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(tester.getTopLeft(find.text('counter')), const Offset(12.0, 64.0));
-    expect(tester.getTopRight(find.text('error')), const Offset(788.0, 64.0));
+    expect(tester.getTopLeft(find.text('counter')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('error')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
     expect(find.text('helper'), findsNothing);
   });
 
@@ -3833,15 +3833,15 @@ void main() {
     //   12 - help/error/counter text (font size 12dps)
 
     // Label is floating because isEmpty is false.
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('helper')), const Offset(12.0, 64.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(788.0, 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
   });
 
   testWidgets('InputDecoration outline shape with no border and no floating placeholder', (WidgetTester tester) async {
@@ -4022,13 +4022,13 @@ void main() {
     //   12 - bottom padding
     //    8 - below the border padding
     //   12 - help/error/counter text (font size 12dps)
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('helper')), const Offset(0.0, 64.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(800.0, 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(0.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(800.0, useMaterial3 ? 60.0 : 64.0));
 
     // Verify that the styles were passed along
     expect(tester.widget<Text>(find.text('hint')).style!.color, hintStyle.color);
@@ -4090,13 +4090,13 @@ void main() {
     //   12 - bottom padding
     //    8 - below the border padding
     //   12 - help/error/counter text (font size 12dps)
-    expect(tester.getSize(find.byType(InputDecorator)), const Size(800.0, 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 2.0);
-    expect(tester.getTopLeft(find.text('helper')), const Offset(0.0, 64.0));
-    expect(tester.getTopRight(find.text('counter')), const Offset(800.0, 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(0.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopRight(find.text('counter')), Offset(800.0, useMaterial3 ? 60.0 : 64.0));
 
     // Verify that the styles were passed along
     expect(tester.widget<Text>(find.text('hint')).style!.color, hintStyle.color);

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -1350,15 +1350,15 @@ void main() {
     await tester.pumpAndSettle();
 
     // isEmpty: false, the label is not floating
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 60.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 24.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 40.0);
     expect(tester.getTopLeft(find.text('label')).dy, 16.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 32.0);
     expect(getBorderBottom(tester), 48.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('error')), Offset(12.0, useMaterial3 ? 52.0 : 56.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 52.0 : 56.0));
+    expect(tester.getTopLeft(find.text('error')), Offset(12.0, 48.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, 48.0 + subtextGap));
   });
 
   testWidgets('InputDecorator counter text, widget, and null', (WidgetTester tester) async {
@@ -3834,7 +3834,7 @@ void main() {
     //   12 - help/error/counter text (font size 12dps)
 
     // Label is floating because isEmpty is false.
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 58.0 + subtextGap));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
@@ -4023,13 +4023,13 @@ void main() {
     //   12 - bottom padding
     //    8 - below the border padding
     //   12 - help/error/counter text (font size 12dps)
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('helper')), Offset(0.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(800.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(0.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(800.0, 56.0 + subtextGap));
 
     // Verify that the styles were passed along
     expect(tester.widget<Text>(find.text('hint')).style!.color, hintStyle.color);

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -157,7 +157,8 @@ TextStyle? getIconStyle(WidgetTester tester, IconData icon) {
 }
 
 void main() {
-  for (final bool useMaterial3 in  <bool>[true, false]){
+  for (final bool useMaterial3 in  <bool>[true, false]) {
+  const double subtextGap = useMaterial3 ? 4.0 : 8.0;
   testWidgets('InputDecorator input/label text layout', (WidgetTester tester) async {
     // The label appears above the input text
     await tester.pumpWidget(
@@ -1244,15 +1245,15 @@ void main() {
     //   12 - help/error/counter text (font size 12dps)
 
     // isEmpty: true, the label is not floating
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 20.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 36.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('helper')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, 56.0 + subtextGap));
 
     // If errorText is specified then the helperText isn't shown
     await tester.pumpWidget(
@@ -1272,15 +1273,15 @@ void main() {
     await tester.pumpAndSettle();
 
     // isEmpty: false, the label _is_ floating
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('error')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('error')), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, 56.0 + subtextGap));
     expect(find.text('helper'), findsNothing);
 
     // Overall height for this dense layout InputDecorator is 68dps. When the
@@ -1321,15 +1322,15 @@ void main() {
     await tester.pumpAndSettle();
 
     // isEmpty: false, the label _is_ floating
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 60.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 24.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 40.0);
     expect(tester.getTopLeft(find.text('label')).dy, 8.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 20.0);
     expect(getBorderBottom(tester), 48.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('error')), Offset(12.0, useMaterial3 ? 52.0 : 56.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 52.0 : 56.0));
+    expect(tester.getTopLeft(find.text('error')), Offset(12.0, 48.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, 48.0 + subtextGap));
 
     await tester.pumpWidget(
       buildInputDecorator(
@@ -1492,9 +1493,9 @@ void main() {
     //    8 - below the border padding
     //   36 - error text (3 lines, font size 12dps)
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 96.0 : 100.0));
-    expect(tester.getTopLeft(find.text(kError3)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kError3)), Offset(12.0, useMaterial3 ? 96.0 : 100.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 92.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kError3)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kError3)), Offset(12.0, 92.0 + subtextGap));
 
     // Overall height for this InputDecorator is 12 less than the first
     // one, 88dps, because errorText only occupies two lines.
@@ -1514,9 +1515,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 84.0 : 88.0));
-    expect(tester.getTopLeft(find.text(kError2)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kError2)), Offset(12.0, useMaterial3 ? 84.0 : 88.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 80.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kError2)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kError2)), Offset(12.0, 80.0 + subtextGap));
 
     // Overall height for this InputDecorator is 24 less than the first
     // one, 88dps, because errorText only occupies one line.
@@ -1536,9 +1537,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
-    expect(tester.getTopLeft(find.text(kError1)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kError1)), Offset(12.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kError1)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kError1)), Offset(12.0, 68.0 + subtextGap));
   });
 
   testWidgets('InputDecoration helperMaxLines', (WidgetTester tester) async {
@@ -1570,9 +1571,9 @@ void main() {
     //    8 - below the border padding
     //   36 - helper text (3 lines, font size 12dps)
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 96.0 : 100.0));
-    expect(tester.getTopLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 96.0 : 100.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 92.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kHelper3)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kHelper3)), Offset(12.0, 92.0 + subtextGap));
 
     // Overall height for this InputDecorator is 12 less than the first
     // one, 88dps, because helperText only occupies two lines.
@@ -1591,9 +1592,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 84.0 : 88.0));
-    expect(tester.getTopLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper3)), Offset(12.0, useMaterial3 ? 84.0 : 88.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 80.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kHelper3)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kHelper3)), Offset(12.0, 80.0 + subtextGap));
 
     // Overall height for this InputDecorator is 12 less than the first
     // one, 88dps, because helperText only occupies two lines.
@@ -1612,9 +1613,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 84.0 : 88.0));
-    expect(tester.getTopLeft(find.text(kHelper2)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper2)), Offset(12.0, useMaterial3 ? 84.0 : 88.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 80.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kHelper2)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kHelper2)), Offset(12.0, 80.0 + subtextGap));
 
     // Overall height for this InputDecorator is 24 less than the first
     // one, 88dps, because helperText only occupies one line.
@@ -1633,9 +1634,9 @@ void main() {
       ),
     );
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
-    expect(tester.getTopLeft(find.text(kHelper1)), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getBottomLeft(find.text(kHelper1)), Offset(12.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
+    expect(tester.getTopLeft(find.text(kHelper1)), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getBottomLeft(find.text(kHelper1)), Offset(12.0, 68.0 + subtextGap));
   });
 
   testWidgets('InputDecorator prefix/suffix texts', (WidgetTester tester) async {
@@ -3097,7 +3098,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled
     // (dx) - 12 = (text offset)x.
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 60.0 + subtextGap));
     final double dx = tester.getRect(find.byType(InputDecorator)).right;
     expect(tester.getRect(find.text('test')).right, dx - 12.0);
   });
@@ -3118,7 +3119,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled and top left offset is (0, 0)
     // 0 + 12 = 12.
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 64.0 : 68.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 60.0 + subtextGap));
     expect(tester.getRect(find.text('test')).left, 12.0);
   });
 
@@ -3138,7 +3139,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled
     // (dx) - 12 = (text offset)x.
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 48.0 : 52.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 44.0 + subtextGap));
     final double dx = tester.getRect(find.byType(InputDecorator)).right;
     expect(tester.getRect(find.text('test')).right, dx - 12.0);
   });
@@ -3160,7 +3161,7 @@ void main() {
 
     // Margin for text decoration is 12 when filled and top left offset is (0, 0)
     // 0 + 12 = 12.
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 48.0 : 52.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 44.0 + subtextGap));
     expect(tester.getRect(find.text('test')).left, 12.0);
   });
 
@@ -3189,15 +3190,15 @@ void main() {
     //    8 - below the border padding
     //   12 - [counter helper/error] (font size 12dps)
 
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('counter')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('helper')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('counter')), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('helper')), Offset(788.0, 56.0 + subtextGap));
 
     // If both error and helper are specified, show the error
     await tester.pumpWidget(
@@ -3216,8 +3217,8 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    expect(tester.getTopLeft(find.text('counter')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('error')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('counter')), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('error')), Offset(788.0, 56.0 + subtextGap));
     expect(find.text('helper'), findsNothing);
   });
 
@@ -3833,15 +3834,15 @@ void main() {
     //   12 - help/error/counter text (font size 12dps)
 
     // Label is floating because isEmpty is false.
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 58.0 + subtextGap));
     expect(tester.getTopLeft(find.text('text')).dy, 28.0);
     expect(tester.getBottomLeft(find.text('text')).dy, 44.0);
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 1.0);
-    expect(tester.getTopLeft(find.text('helper')), Offset(12.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(788.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(12.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(788.0, 56.0 + subtextGap));
   });
 
   testWidgets('InputDecoration outline shape with no border and no floating placeholder', (WidgetTester tester) async {
@@ -4090,13 +4091,13 @@ void main() {
     //   12 - bottom padding
     //    8 - below the border padding
     //   12 - help/error/counter text (font size 12dps)
-    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, useMaterial3 ? 72.0 : 76.0));
+    expect(tester.getSize(find.byType(InputDecorator)), Size(800.0, 68.0 + subtextGap));
     expect(tester.getTopLeft(find.text('label')).dy, 12.0);
     expect(tester.getBottomLeft(find.text('label')).dy, 24.0);
     expect(getBorderBottom(tester), 56.0);
     expect(getBorderWeight(tester), 2.0);
-    expect(tester.getTopLeft(find.text('helper')), Offset(0.0, useMaterial3 ? 60.0 : 64.0));
-    expect(tester.getTopRight(find.text('counter')), Offset(800.0, useMaterial3 ? 60.0 : 64.0));
+    expect(tester.getTopLeft(find.text('helper')), Offset(0.0, 56.0 + subtextGap));
+    expect(tester.getTopRight(find.text('counter')), Offset(800.0, 56.0 + subtextGap));
 
     // Verify that the styles were passed along
     expect(tester.widget<Text>(find.text('hint')).style!.color, hintStyle.color);


### PR DESCRIPTION
This change makes the subtext gap on m3 `4.0` instead of `8.0` to match the spec.

Related #114950

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
