### PR TITLE
InputDecorator.hintStyle should use tokens when using material3

### DIFF
--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -24,9 +24,9 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color: Theme.of(context).disabledColor);
+      return TextStyle(color:${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
     }
-    return TextStyle(color: Theme.of(context).hintColor);
+    return TextStyle(color:${componentColor('md.comp.filled-text-field.supporting-text')});
   });
 
   @override

--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -24,7 +24,7 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color: ${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
+      return TextStyle(color: _colors.onSurface.withOpacity(0.38));
     }
     return TextStyle(color: ${componentColor('md.comp.filled-text-field.input-text.placeholder')});
   });

--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -24,7 +24,7 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color: _colors.onSurface.withOpacity(0.38));
+      return TextStyle(color: ${componentColor('md.comp.filled-text-field.disabled.input-text')});
     }
     return TextStyle(color: ${componentColor('md.comp.filled-text-field.input-text.placeholder')});
   });

--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -24,9 +24,9 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color:${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
+      return TextStyle(color: ${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
     }
-    return TextStyle(color:${componentColor('md.comp.filled-text-field.supporting-text')});
+    return TextStyle(color: ${componentColor('md.comp.filled-text-field.supporting-text')});
   });
 
   @override

--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -26,7 +26,7 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
     if (states.contains(MaterialState.disabled)) {
       return TextStyle(color: ${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
     }
-    return TextStyle(color: ${componentColor('md.comp.filled-text-field.supporting-text')});
+    return TextStyle(color: ${componentColor('md.comp.filled-text-field.input-text.placeholder')});
   });
 
   @override

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -4543,9 +4543,9 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color: Theme.of(context).disabledColor);
+      return TextStyle(color:_colors.onSurface.withOpacity(0.38));
     }
-    return TextStyle(color: Theme.of(context).hintColor);
+    return TextStyle(color:_colors.onSurfaceVariant);
   });
 
   @override

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -4543,9 +4543,9 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
   @override
   TextStyle? get hintStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     if (states.contains(MaterialState.disabled)) {
-      return TextStyle(color:_colors.onSurface.withOpacity(0.38));
+      return TextStyle(color: _colors.onSurface.withOpacity(0.38));
     }
-    return TextStyle(color:_colors.onSurfaceVariant);
+    return TextStyle(color: _colors.onSurfaceVariant);
   });
 
   @override

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -1832,19 +1832,6 @@ class _SwitchDefaultsM3 extends SwitchThemeData {
   }
 
   @override
-  MaterialStateProperty<Color?> get trackOutlineColor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return Colors.transparent;
-      }
-      if (states.contains(MaterialState.disabled)) {
-        return _colors.onSurface.withOpacity(0.12);
-      }
-      return _colors.outline;
-    });
-  }
-
-  @override
   MaterialStateProperty<Color?> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.selected)) {
@@ -1948,6 +1935,19 @@ class _SwitchConfigM3 with _SwitchConfig {
 
   @override
   double get trackHeight => 32.0;
+
+  @override
+  MaterialStateProperty<Color?> get trackOutlineColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return null;
+      }
+      if (states.contains(MaterialState.disabled)) {
+        return _colors.onSurface.withOpacity(0.12);
+      }
+      return _colors.outline;
+    });
+  }
 
   @override
   double get trackWidth => 52.0;

--- a/packages/flutter/lib/src/material/switch.dart
+++ b/packages/flutter/lib/src/material/switch.dart
@@ -1832,6 +1832,19 @@ class _SwitchDefaultsM3 extends SwitchThemeData {
   }
 
   @override
+  MaterialStateProperty<Color?> get trackOutlineColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return Colors.transparent;
+      }
+      if (states.contains(MaterialState.disabled)) {
+        return _colors.onSurface.withOpacity(0.12);
+      }
+      return _colors.outline;
+    });
+  }
+
+  @override
   MaterialStateProperty<Color?> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.selected)) {
@@ -1935,19 +1948,6 @@ class _SwitchConfigM3 with _SwitchConfig {
 
   @override
   double get trackHeight => 32.0;
-
-  @override
-  MaterialStateProperty<Color?> get trackOutlineColor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return null;
-      }
-      if (states.contains(MaterialState.disabled)) {
-        return _colors.onSurface.withOpacity(0.12);
-      }
-      return _colors.outline;
-    });
-  }
 
   @override
   double get trackWidth => 52.0;

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6302,7 +6302,6 @@ void main() {
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
-              filled: true,
               // enabled: true (default)
             ),
           ),
@@ -6325,7 +6324,6 @@ void main() {
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
-              filled: true,
               enabled: false,
             ),
           ),
@@ -6348,7 +6346,6 @@ void main() {
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
-              filled: true,
               // enabled: true, (default)
             ),
           ),
@@ -6371,7 +6368,6 @@ void main() {
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
-              filled: true,
               enabled: false,
             ),
           ),

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6291,5 +6291,97 @@ void main() {
     final Text hintTextWidget = tester.widget(hintTextFinder);
     expect(hintTextWidget.style!.overflow, decoration.hintStyle!.overflow);
   });
+
+  testWidgets('InputDecorator hint style has m3 defaults when enabled', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    final String hintText = 'This is a hint.';
+    await tester.pumpWidget(
+       MaterialApp(
+        theme: theme,
+        home: Material(
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: hintText,
+              filled: true,
+              // enabled: true (default)
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Text hintTextWidget = tester.widget(find.text(hintText));
+
+    expect(hintTextWidget.style!.color!, theme.colorScheme.onSurfaceVariant);
+  });
+
+  testWidgets('InputDecorator hint style has m3 defaults when disabled', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true);
+    final String hintText = 'This is a hint.';
+    await tester.pumpWidget(
+       MaterialApp(
+        theme: theme,
+        home: Material(
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: hintText,
+              filled: true,
+              enabled: false,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Text hintTextWidget = tester.widget(find.text(hintText));
+
+    expect(hintTextWidget.style!.color!, theme.colorScheme.onSurface.withOpacity(0.38));
+  });
+
+  testWidgets('InputDecorator hint style color is overriden by colorScheme when enabled', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true).copyWith(colorScheme: ColorScheme.light(onSurfaceVariant: Colors.green));
+    final String hintText = 'This is a hint.';
+    await tester.pumpWidget(
+       MaterialApp(
+        theme: theme,
+        home: Material(
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: hintText,
+              filled: true,
+              // enabled: true, (default)
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Text hintTextWidget = tester.widget(find.text(hintText));
+
+    expect(hintTextWidget.style!.color!, Colors.green);
+  });
+
+  testWidgets('InputDecorator hint style color is overriden by colorScheme when disabled', (WidgetTester tester) async {
+    final ThemeData theme = ThemeData(useMaterial3: true).copyWith(colorScheme: ColorScheme.light(onSurface: Colors.green));
+    final String hintText = 'This is a hint.';
+    await tester.pumpWidget(
+       MaterialApp(
+        theme: theme,
+        home: Material(
+          child: TextField(
+            decoration: InputDecoration(
+              hintText: hintText,
+              filled: true,
+              enabled: false,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final Text hintTextWidget = tester.widget(find.text(hintText));
+
+    expect(hintTextWidget.style!.color!, Colors.green.withOpacity(0.38));
+  });
 }
 }

--- a/packages/flutter/test/material/input_decorator_test.dart
+++ b/packages/flutter/test/material/input_decorator_test.dart
@@ -6294,11 +6294,11 @@ void main() {
 
   testWidgets('InputDecorator hint style has m3 defaults when enabled', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
-    final String hintText = 'This is a hint.';
+    const String hintText = 'This is a hint.';
     await tester.pumpWidget(
        MaterialApp(
         theme: theme,
-        home: Material(
+        home: const Material(
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
@@ -6312,16 +6312,16 @@ void main() {
 
     final Text hintTextWidget = tester.widget(find.text(hintText));
 
-    expect(hintTextWidget.style!.color!, theme.colorScheme.onSurfaceVariant);
+    expect(hintTextWidget.style!.color, theme.colorScheme.onSurfaceVariant);
   });
 
   testWidgets('InputDecorator hint style has m3 defaults when disabled', (WidgetTester tester) async {
     final ThemeData theme = ThemeData(useMaterial3: true);
-    final String hintText = 'This is a hint.';
+    const String hintText = 'This is a hint.';
     await tester.pumpWidget(
        MaterialApp(
         theme: theme,
-        home: Material(
+        home: const Material(
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
@@ -6335,16 +6335,16 @@ void main() {
 
     final Text hintTextWidget = tester.widget(find.text(hintText));
 
-    expect(hintTextWidget.style!.color!, theme.colorScheme.onSurface.withOpacity(0.38));
+    expect(hintTextWidget.style!.color, theme.colorScheme.onSurface.withOpacity(0.38));
   });
 
   testWidgets('InputDecorator hint style color is overriden by colorScheme when enabled', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData(useMaterial3: true).copyWith(colorScheme: ColorScheme.light(onSurfaceVariant: Colors.green));
-    final String hintText = 'This is a hint.';
+    final ThemeData theme = ThemeData(useMaterial3: true).copyWith(colorScheme: const ColorScheme.light(onSurfaceVariant: Colors.green));
+    const String hintText = 'This is a hint.';
     await tester.pumpWidget(
        MaterialApp(
         theme: theme,
-        home: Material(
+        home: const Material(
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
@@ -6358,16 +6358,16 @@ void main() {
 
     final Text hintTextWidget = tester.widget(find.text(hintText));
 
-    expect(hintTextWidget.style!.color!, Colors.green);
+    expect(hintTextWidget.style!.color, Colors.green);
   });
 
   testWidgets('InputDecorator hint style color is overriden by colorScheme when disabled', (WidgetTester tester) async {
-    final ThemeData theme = ThemeData(useMaterial3: true).copyWith(colorScheme: ColorScheme.light(onSurface: Colors.green));
-    final String hintText = 'This is a hint.';
+    final ThemeData theme = ThemeData(useMaterial3: true).copyWith(colorScheme: const ColorScheme.light(onSurface: Colors.green));
+    const String hintText = 'This is a hint.';
     await tester.pumpWidget(
        MaterialApp(
         theme: theme,
-        home: Material(
+        home: const Material(
           child: TextField(
             decoration: InputDecoration(
               hintText: hintText,
@@ -6381,7 +6381,7 @@ void main() {
 
     final Text hintTextWidget = tester.widget(find.text(hintText));
 
-    expect(hintTextWidget.style!.color!, Colors.green.withOpacity(0.38));
+    expect(hintTextWidget.style!.color, Colors.green.withOpacity(0.38));
   });
 }
 }


### PR DESCRIPTION
This adds `placeholder` tokens to the `input_decorator_template` so `hintStyle` matches m3 spec.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
