### PR TITLE
Update switch template

### DIFF
--- a/dev/tools/gen_defaults/lib/switch_template.dart
+++ b/dev/tools/gen_defaults/lib/switch_template.dart
@@ -86,6 +86,19 @@ class _${blockName}DefaultsM3 extends SwitchThemeData {
   }
 
   @override
+  MaterialStateProperty<Color?> get trackOutlineColor {
+    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
+      if (states.contains(MaterialState.selected)) {
+        return Colors.transparent;
+      }
+      if (states.contains(MaterialState.disabled)) {
+        return ${componentColor('md.comp.switch.disabled.unselected.track.outline')}.withOpacity(${opacity('md.comp.switch.disabled.track.opacity')});
+      }
+      return ${componentColor('md.comp.switch.unselected.track.outline')};
+    });
+  }
+
+  @override
   MaterialStateProperty<Color?> get overlayColor {
     return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
       if (states.contains(MaterialState.selected)) {
@@ -186,19 +199,6 @@ class _SwitchConfigM3 with _SwitchConfig {
 
   @override
   double get trackHeight => ${tokens['md.comp.switch.track.height']};
-
-  @override
-  MaterialStateProperty<Color?> get trackOutlineColor {
-    return MaterialStateProperty.resolveWith((Set<MaterialState> states) {
-      if (states.contains(MaterialState.selected)) {
-        return null;
-      }
-      if (states.contains(MaterialState.disabled)) {
-        return ${componentColor('md.comp.switch.disabled.unselected.track.outline')}.withOpacity(${opacity('md.comp.switch.disabled.track.opacity')});
-      }
-      return ${componentColor('md.comp.switch.unselected.track.outline')};
-    });
-  }
 
   @override
   double get trackWidth => ${tokens['md.comp.switch.track.width']};


### PR DESCRIPTION
Related to issue #120910

When the trackOutlineColor was moved to SwitchThemeData([PR](https://github.com/flutter/flutter/pull/120140)), the SwitchTemplate should also be updated. Otherwise, running the token generator will revert the change.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
