### PR TITLE
Small input decorator clean up

### DIFF
--- a/dev/tools/gen_defaults/lib/input_decorator_template.dart
+++ b/dev/tools/gen_defaults/lib/input_decorator_template.dart
@@ -137,23 +137,23 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
     final TextStyle textStyle = ${textStyle("md.comp.filled-text-field.label-text")} ?? const TextStyle();
     if(states.contains(MaterialState.error)) {
       if (states.contains(MaterialState.focused)) {
-        return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.focus.label-text')});
+        return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.focus.label-text')});
       }
       if (states.contains(MaterialState.hovered)) {
-        return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.hover.label-text')});
+        return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.hover.label-text')});
       }
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.label-text')});
     }
     if (states.contains(MaterialState.focused)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.focus.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.focus.label-text')});
     }
     if (states.contains(MaterialState.hovered)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.hover.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.hover.label-text')});
     }
     if (states.contains(MaterialState.disabled)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.disabled.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.disabled.label-text')});
     }
-    return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.label-text')});
+    return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.label-text')});
   });
 
   @override
@@ -161,50 +161,50 @@ class _${blockName}DefaultsM3 extends InputDecorationTheme {
     final TextStyle textStyle = ${textStyle("md.comp.filled-text-field.label-text")} ?? const TextStyle();
     if(states.contains(MaterialState.error)) {
       if (states.contains(MaterialState.focused)) {
-        return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.focus.label-text')});
+        return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.focus.label-text')});
       }
       if (states.contains(MaterialState.hovered)) {
-        return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.hover.label-text')});
+        return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.hover.label-text')});
       }
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.label-text')});
     }
     if (states.contains(MaterialState.focused)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.focus.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.focus.label-text')});
     }
     if (states.contains(MaterialState.hovered)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.hover.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.hover.label-text')});
     }
     if (states.contains(MaterialState.disabled)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.disabled.label-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.disabled.label-text')});
     }
-    return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.label-text')});
+    return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.label-text')});
   });
 
   @override
   TextStyle? get helperStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     final TextStyle textStyle = ${textStyle("md.comp.filled-text-field.supporting-text")} ?? const TextStyle();${componentColor('md.comp.filled-text-field.focus.supporting-text') == componentColor('md.comp.filled-text-field.supporting-text') ? '' : '''
     if (states.contains(MaterialState.focused)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.focus.supporting-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.focus.supporting-text')});
     }'''}${componentColor('md.comp.filled-text-field.hover.supporting-text') == componentColor('md.comp.filled-text-field.supporting-text') ? '' : '''
     if (states.contains(MaterialState.hovered)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.hover.supporting-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.hover.supporting-text')});
     }'''}
     if (states.contains(MaterialState.disabled)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.disabled.supporting-text')});
     }
-    return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.supporting-text')});
+    return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.supporting-text')});
   });
 
   @override
   TextStyle? get errorStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     final TextStyle textStyle = ${textStyle("md.comp.filled-text-field.supporting-text")} ?? const TextStyle();${componentColor('md.comp.filled-text-field.error.focus.supporting-text') == componentColor('md.comp.filled-text-field.error.supporting-text') ? '' : '''
     if (states.contains(MaterialState.focused)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.focus.supporting-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.focus.supporting-text')});
     }'''}${componentColor('md.comp.filled-text-field.error.hover.supporting-text') == componentColor('md.comp.filled-text-field.error.supporting-text') ? '' : '''
     if (states.contains(MaterialState.hovered)) {
-      return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.hover.supporting-text')});
+      return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.hover.supporting-text')});
     }'''}
-    return textStyle.copyWith(color:${componentColor('md.comp.filled-text-field.error.supporting-text')});
+    return textStyle.copyWith(color: ${componentColor('md.comp.filled-text-field.error.supporting-text')});
   });
 }
 ''';

--- a/packages/flutter/lib/src/material/input_decorator.dart
+++ b/packages/flutter/lib/src/material/input_decorator.dart
@@ -4645,23 +4645,23 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
     final TextStyle textStyle = _textTheme.bodyLarge ?? const TextStyle();
     if(states.contains(MaterialState.error)) {
       if (states.contains(MaterialState.focused)) {
-        return textStyle.copyWith(color:_colors.error);
+        return textStyle.copyWith(color: _colors.error);
       }
       if (states.contains(MaterialState.hovered)) {
-        return textStyle.copyWith(color:_colors.onErrorContainer);
+        return textStyle.copyWith(color: _colors.onErrorContainer);
       }
-      return textStyle.copyWith(color:_colors.error);
+      return textStyle.copyWith(color: _colors.error);
     }
     if (states.contains(MaterialState.focused)) {
-      return textStyle.copyWith(color:_colors.primary);
+      return textStyle.copyWith(color: _colors.primary);
     }
     if (states.contains(MaterialState.hovered)) {
-      return textStyle.copyWith(color:_colors.onSurfaceVariant);
+      return textStyle.copyWith(color: _colors.onSurfaceVariant);
     }
     if (states.contains(MaterialState.disabled)) {
-      return textStyle.copyWith(color:_colors.onSurface.withOpacity(0.38));
+      return textStyle.copyWith(color: _colors.onSurface.withOpacity(0.38));
     }
-    return textStyle.copyWith(color:_colors.onSurfaceVariant);
+    return textStyle.copyWith(color: _colors.onSurfaceVariant);
   });
 
   @override
@@ -4669,38 +4669,38 @@ class _InputDecoratorDefaultsM3 extends InputDecorationTheme {
     final TextStyle textStyle = _textTheme.bodyLarge ?? const TextStyle();
     if(states.contains(MaterialState.error)) {
       if (states.contains(MaterialState.focused)) {
-        return textStyle.copyWith(color:_colors.error);
+        return textStyle.copyWith(color: _colors.error);
       }
       if (states.contains(MaterialState.hovered)) {
-        return textStyle.copyWith(color:_colors.onErrorContainer);
+        return textStyle.copyWith(color: _colors.onErrorContainer);
       }
-      return textStyle.copyWith(color:_colors.error);
+      return textStyle.copyWith(color: _colors.error);
     }
     if (states.contains(MaterialState.focused)) {
-      return textStyle.copyWith(color:_colors.primary);
+      return textStyle.copyWith(color: _colors.primary);
     }
     if (states.contains(MaterialState.hovered)) {
-      return textStyle.copyWith(color:_colors.onSurfaceVariant);
+      return textStyle.copyWith(color: _colors.onSurfaceVariant);
     }
     if (states.contains(MaterialState.disabled)) {
-      return textStyle.copyWith(color:_colors.onSurface.withOpacity(0.38));
+      return textStyle.copyWith(color: _colors.onSurface.withOpacity(0.38));
     }
-    return textStyle.copyWith(color:_colors.onSurfaceVariant);
+    return textStyle.copyWith(color: _colors.onSurfaceVariant);
   });
 
   @override
   TextStyle? get helperStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     final TextStyle textStyle = _textTheme.bodySmall ?? const TextStyle();
     if (states.contains(MaterialState.disabled)) {
-      return textStyle.copyWith(color:_colors.onSurface.withOpacity(0.38));
+      return textStyle.copyWith(color: _colors.onSurface.withOpacity(0.38));
     }
-    return textStyle.copyWith(color:_colors.onSurfaceVariant);
+    return textStyle.copyWith(color: _colors.onSurfaceVariant);
   });
 
   @override
   TextStyle? get errorStyle => MaterialStateTextStyle.resolveWith((Set<MaterialState> states) {
     final TextStyle textStyle = _textTheme.bodySmall ?? const TextStyle();
-    return textStyle.copyWith(color:_colors.error);
+    return textStyle.copyWith(color: _colors.error);
   });
 }
 


### PR DESCRIPTION
This PR adds small style fixes to input decorator and its template.

Came up in review #120910, pointed out by @QuncCccccc

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
