### PR TITLE
Remove more references to dart:ui.window

### DIFF
--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_child_layers.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_child_layers.dart
@@ -32,17 +32,17 @@ class BenchUpdateManyChildLayers extends SceneBuilderRecorder {
   double wobbleCounter = 0;
 
   late List<Picture> _pictures;
-  late Size windowSize;
+  late Size viewSize;
   late Size cellSize;
   late Size rectSize;
 
   @override
   Future<void> setUpAll() async {
     _pictures = <Picture>[];
-    windowSize = window.physicalSize;
+    viewSize = view.physicalSize;
     cellSize = Size(
-      windowSize.width / kColumns,
-      windowSize.height / kRows,
+      viewSize.width / kColumns,
+      viewSize.height / kRows,
     );
     rectSize = cellSize * 0.8;
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_clipped_out_pictures.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_clipped_out_pictures.dart
@@ -41,10 +41,10 @@ class BenchClippedOutPictures extends SceneBuilderRecorder {
 
   @override
   void onDrawFrame(SceneBuilder sceneBuilder) {
-    final Size screenSize = window.physicalSize / window.devicePixelRatio;
+    final Size viewSize = view.physicalSize / view.devicePixelRatio;
     final Size pictureSize = Size(
-      screenSize.width / kColumns,
-      screenSize.height / kRows,
+      viewSize.width / kColumns,
+      viewSize.height / kRows,
     );
 
     // Fills a single cell with random text.
@@ -71,8 +71,8 @@ class BenchClippedOutPictures extends SceneBuilderRecorder {
 
     // Starting with the top-left cell, fill every cell.
     sceneBuilder.pushClipRect(Rect.fromCircle(
-      center: Offset(screenSize.width / 2, screenSize.height / 2),
-      radius: math.min(screenSize.width, screenSize.height) / 6,
+      center: Offset(viewSize.width / 2, viewSize.height / 2),
+      radius: math.min(viewSize.width, viewSize.height) / 6,
     ));
     sceneBuilder.pushOffset(
       5.0 * math.cos(angle),

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_draw_rect.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_draw_rect.dart
@@ -67,11 +67,11 @@ class BenchDrawRect extends SceneBuilderRecorder {
   void onDrawFrame(SceneBuilder sceneBuilder) {
     final PictureRecorder pictureRecorder = PictureRecorder();
     final Canvas canvas = Canvas(pictureRecorder);
-    final Size windowSize = window.physicalSize;
+    final Size viewSize = view.physicalSize;
 
     final Size cellSize = Size(
-      windowSize.width / kColumns,
-      windowSize.height / kRows,
+      viewSize.width / kColumns,
+      viewSize.height / kRows,
     );
     final Size rectSize = cellSize * 0.8;
 

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_dynamic_clip_on_static_picture.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_dynamic_clip_on_static_picture.dart
@@ -51,12 +51,12 @@ class BenchDynamicClipOnStaticPicture extends SceneBuilderRecorder {
     const Color black = Color.fromARGB(255, 0, 0, 0);
     final PictureRecorder pictureRecorder = PictureRecorder();
     final Canvas canvas = Canvas(pictureRecorder);
-    screenSize = window.physicalSize / window.devicePixelRatio;
+    viewSize = view.physicalSize / view.devicePixelRatio;
     clipSize = Size(
-      screenSize.width / 2,
-      screenSize.height / 5,
+      viewSize.width / 2,
+      viewSize.height / 5,
     );
-    final double cellWidth = screenSize.width / kColumns;
+    final double cellWidth = viewSize.width / kColumns;
 
     final List<Paragraph> paragraphs = generateLaidOutParagraphs(
       paragraphCount: 500,
@@ -93,7 +93,7 @@ class BenchDynamicClipOnStaticPicture extends SceneBuilderRecorder {
 
   static const String benchmarkName = 'dynamic_clip_on_static_picture';
 
-  late Size screenSize;
+  late Size viewSize;
   late Size clipSize;
   late Picture picture;
   double pictureVerticalOffset = 0.0;

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_out_of_picture_bounds.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/bench_text_out_of_picture_bounds.dart
@@ -37,14 +37,14 @@ class BenchTextOutOfPictureBounds extends SceneBuilderRecorder {
       paragraphCount: 500,
       minWordCountPerParagraph: 2,
       maxWordCountPerParagraph: 4,
-      widthConstraint: window.physicalSize.width / 2,
+      widthConstraint: view.physicalSize.width / 2,
       color: red,
     );
     multiLineParagraphs = generateLaidOutParagraphs(
       paragraphCount: 50,
       minWordCountPerParagraph: 30,
       maxWordCountPerParagraph: 49,
-      widthConstraint: window.physicalSize.width / 2,
+      widthConstraint: view.physicalSize.width / 2,
       color: green,
     );
   }
@@ -61,19 +61,19 @@ class BenchTextOutOfPictureBounds extends SceneBuilderRecorder {
   void onDrawFrame(SceneBuilder sceneBuilder) {
     final PictureRecorder pictureRecorder = PictureRecorder();
     final Canvas canvas = Canvas(pictureRecorder);
-    final Size screenSize = window.physicalSize;
+    final Size viewSize = view.physicalSize;
     const double padding = 10.0;
 
     // Fills a single cell with random text.
     void fillCellWithText(List<Paragraph> textSource) {
       canvas.save();
       double topOffset = 0;
-      while (topOffset < screenSize.height) {
+      while (topOffset < viewSize.height) {
         final Paragraph paragraph =
             textSource[_random.nextInt(textSource.length)];
 
         // Give it enough space to make sure it ends up being a single-line paragraph.
-        paragraph.layout(ParagraphConstraints(width: screenSize.width / 2));
+        paragraph.layout(ParagraphConstraints(width: viewSize.width / 2));
 
         canvas.drawParagraph(paragraph, Offset.zero);
         canvas.translate(0, paragraph.height + padding);
@@ -83,12 +83,12 @@ class BenchTextOutOfPictureBounds extends SceneBuilderRecorder {
     }
 
     // Starting with the top-left cell, fill every cell with text.
-    canvas.translate(-screenSize.width, -screenSize.height);
+    canvas.translate(-viewSize.width, -viewSize.height);
     for (int row = 0; row < 3; row++) {
       canvas.save();
       for (int col = 0; col < 3; col++) {
         canvas.drawRect(
-          Offset.zero & screenSize,
+          Offset.zero & viewSize,
           Paint()
             ..style = PaintingStyle.stroke
             ..strokeWidth = 2.0,
@@ -98,19 +98,19 @@ class BenchTextOutOfPictureBounds extends SceneBuilderRecorder {
 
         // Fill multi-line text.
         canvas.save();
-        canvas.translate(screenSize.width / 2, 0);
+        canvas.translate(viewSize.width / 2, 0);
         fillCellWithText(multiLineParagraphs);
         canvas.restore();
 
         // Shift to next column.
-        canvas.translate(screenSize.width, 0);
+        canvas.translate(viewSize.width, 0);
       }
 
       // Undo horizontal shift.
       canvas.restore();
 
       // Shift to next row.
-      canvas.translate(0, screenSize.height);
+      canvas.translate(0, viewSize.height);
     }
 
     final Picture picture = pictureRecorder.endRecording();

--- a/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
+++ b/dev/benchmarks/macrobenchmarks/lib/src/web/recorder.dart
@@ -279,7 +279,7 @@ abstract class SceneBuilderRecorder extends Recorder {
           _profile!.record('sceneBuildDuration', () {
             final Scene scene = sceneBuilder.build();
             _profile!.record('windowRenderDuration', () {
-              window.render(scene);
+              view.render(scene);
             }, reported: false);
           }, reported: false);
         }, reported: true);
@@ -297,6 +297,11 @@ abstract class SceneBuilderRecorder extends Recorder {
     };
     PlatformDispatcher.instance.scheduleFrame();
     return profileCompleter.future;
+  }
+
+  FlutterView get view {
+    assert(PlatformDispatcher.instance.implicitView != null, 'This benchmark requires the embedder to provide an implicit view.');
+    return PlatformDispatcher.instance.implicitView!;
   }
 }
 

--- a/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show FlutterView;
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stocks/main.dart' as stocks;
@@ -60,9 +58,8 @@ void main() {
     expect(find.text('Account Balance'), findsNothing);
 
     // drag the drawer out
-    final ui.FlutterView view = tester.widget<View>(find.byType(View)).view;
-    final Offset left = Offset(0.0, (view.physicalSize / view.devicePixelRatio).height / 2.0);
-    final Offset right = Offset((view.physicalSize / view.devicePixelRatio).width, left.dy);
+    final Offset left = Offset(0.0, (WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio).height / 2.0);
+    final Offset right = Offset((WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio).width, left.dy);
     final TestGesture gesture = await tester.startGesture(left);
     await tester.pump();
     await gesture.moveTo(right);

--- a/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
+++ b/dev/benchmarks/test_apps/stocks/test/icon_color_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:ui' as ui show FlutterView;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:stocks/main.dart' as stocks;
@@ -58,8 +60,9 @@ void main() {
     expect(find.text('Account Balance'), findsNothing);
 
     // drag the drawer out
-    final Offset left = Offset(0.0, (WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio).height / 2.0);
-    final Offset right = Offset((WidgetsBinding.instance.window.physicalSize / WidgetsBinding.instance.window.devicePixelRatio).width, left.dy);
+    final ui.FlutterView view = tester.widget<View>(find.byType(View)).view;
+    final Offset left = Offset(0.0, (view.physicalSize / view.devicePixelRatio).height / 2.0);
+    final Offset right = Offset((view.physicalSize / view.devicePixelRatio).width, left.dy);
     final TestGesture gesture = await tester.startGesture(left);
     await tester.pump();
     await gesture.moveTo(right);

--- a/dev/integration_tests/windows_startup_test/lib/main.dart
+++ b/dev/integration_tests/windows_startup_test/lib/main.dart
@@ -10,7 +10,7 @@ import 'package:flutter_driver/driver_extension.dart';
 
 import 'windows.dart';
 
-void drawHelloWorld() {
+void drawHelloWorld(ui.FlutterView view) {
   final ui.ParagraphStyle style = ui.ParagraphStyle();
   final ui.ParagraphBuilder paragraphBuilder = ui.ParagraphBuilder(style)
     ..addText('Hello world');
@@ -28,10 +28,14 @@ void drawHelloWorld() {
     ..addPicture(ui.Offset.zero, picture)
     ..pop();
 
-  ui.window.render(sceneBuilder.build());
+  view.render(sceneBuilder.build());
 }
 
 void main() async {
+  // TODO(goderbauer): Create a window if embedder doesn't provide an implicit view to draw into.
+  assert(ui.PlatformDispatcher.instance.implicitView != null);
+  final ui.FlutterView view = ui.PlatformDispatcher.instance.implicitView!;
+
   // Create a completer to send the window visibility result back to the
   // integration test.
   final Completer<String> visibilityCompleter = Completer<String>();
@@ -81,7 +85,7 @@ void main() async {
 
       // Draw something to trigger the first frame callback that displays the
       // window.
-      drawHelloWorld();
+      drawHelloWorld(view);
       firstFrame = false;
     };
 

--- a/examples/layers/raw/canvas.dart
+++ b/examples/layers/raw/canvas.dart
@@ -9,6 +9,9 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+// The FlutterView into which this example will draw; set in the main method.
+late final ui.FlutterView view;
+
 ui.Picture paint(ui.Rect paintBounds) {
   // First we create a PictureRecorder to record the commands we're going to
   // feed in the canvas. The PictureRecorder will eventually produce a Picture,
@@ -29,8 +32,8 @@ ui.Picture paint(ui.Rect paintBounds) {
   final ui.Offset mid = size.center(ui.Offset.zero);
   final double radius = size.shortestSide / 2.0;
 
-  final double devicePixelRatio = ui.window.devicePixelRatio;
-  final ui.Size logicalSize = ui.window.physicalSize / devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
+  final ui.Size logicalSize = view.physicalSize / devicePixelRatio;
 
   // Saves a copy of current transform onto the save stack.
   canvas.save();
@@ -101,7 +104,7 @@ ui.Picture paint(ui.Rect paintBounds) {
 }
 
 ui.Scene composite(ui.Picture picture, ui.Rect paintBounds) {
-  final double devicePixelRatio = ui.window.devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
   final Float64List deviceTransform = Float64List(16)
     ..[0] = devicePixelRatio
     ..[5] = devicePixelRatio
@@ -115,13 +118,17 @@ ui.Scene composite(ui.Picture picture, ui.Rect paintBounds) {
 }
 
 void beginFrame(Duration timeStamp) {
-  final ui.Rect paintBounds = ui.Offset.zero & (ui.window.physicalSize / ui.window.devicePixelRatio);
+  final ui.Rect paintBounds = ui.Offset.zero & (view.physicalSize / view.devicePixelRatio);
   final ui.Picture picture = paint(paintBounds);
   final ui.Scene scene = composite(picture, paintBounds);
-  ui.window.render(scene);
+  view.render(scene);
 }
 
 void main() {
+  // TODO(goderbauer): Create a window if embedder doesn't provide an implicit view to draw into.
+  assert(ui.PlatformDispatcher.instance.implicitView != null);
+  view = ui.PlatformDispatcher.instance.implicitView!;
+
   ui.PlatformDispatcher.instance
     ..onBeginFrame = beginFrame
     ..scheduleFrame();

--- a/examples/layers/raw/hello_world.dart
+++ b/examples/layers/raw/hello_world.dart
@@ -7,9 +7,12 @@
 
 import 'dart:ui' as ui;
 
+// The FlutterView into which this example will draw; set in the main method.
+late final ui.FlutterView view;
+
 void beginFrame(Duration timeStamp) {
-  final double devicePixelRatio = ui.window.devicePixelRatio;
-  final ui.Size logicalSize = ui.window.physicalSize / devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
+  final ui.Size logicalSize = view.physicalSize / devicePixelRatio;
 
   final ui.ParagraphBuilder paragraphBuilder = ui.ParagraphBuilder(
     ui.ParagraphStyle(textDirection: ui.TextDirection.ltr),
@@ -35,12 +38,16 @@ void beginFrame(Duration timeStamp) {
     ..addPicture(ui.Offset.zero, picture)
     ..pop();
 
-  ui.window.render(sceneBuilder.build());
+  view.render(sceneBuilder.build());
 }
 
 // This function is the primary entry point to your application. The engine
 // calls main() as soon as it has loaded your code.
 void main() {
+  // TODO(goderbauer): Create a window if embedder doesn't provide an implicit view to draw into.
+  assert(ui.PlatformDispatcher.instance.implicitView != null);
+  view = ui.PlatformDispatcher.instance.implicitView!;
+
   // The engine calls onBeginFrame whenever it wants us to produce a frame.
   ui.PlatformDispatcher.instance.onBeginFrame = beginFrame;
   // Here we kick off the whole process by asking the engine to schedule a new

--- a/examples/layers/raw/spinning_square.dart
+++ b/examples/layers/raw/spinning_square.dart
@@ -9,6 +9,9 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+// The FlutterView into which this example will draw; set in the main method.
+late final ui.FlutterView view;
+
 void beginFrame(Duration timeStamp) {
   // The timeStamp argument to beginFrame indicates the timing information we
   // should use to clock our animations. It's important to use timeStamp rather
@@ -19,7 +22,7 @@ void beginFrame(Duration timeStamp) {
 
   // PAINT
 
-  final ui.Rect paintBounds = ui.Offset.zero & (ui.window.physicalSize / ui.window.devicePixelRatio);
+  final ui.Rect paintBounds = ui.Offset.zero & (view.physicalSize / view.devicePixelRatio);
   final ui.PictureRecorder recorder = ui.PictureRecorder();
   final ui.Canvas canvas = ui.Canvas(recorder, paintBounds);
   canvas.translate(paintBounds.width / 2.0, paintBounds.height / 2.0);
@@ -37,7 +40,7 @@ void beginFrame(Duration timeStamp) {
 
   // COMPOSITE
 
-  final double devicePixelRatio = ui.window.devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
   final Float64List deviceTransform = Float64List(16)
     ..[0] = devicePixelRatio
     ..[5] = devicePixelRatio
@@ -47,7 +50,7 @@ void beginFrame(Duration timeStamp) {
     ..pushTransform(deviceTransform)
     ..addPicture(ui.Offset.zero, picture)
     ..pop();
-  ui.window.render(sceneBuilder.build());
+  view.render(sceneBuilder.build());
 
   // After rendering the current frame of the animation, we ask the engine to
   // schedule another frame. The engine will call beginFrame again when its time
@@ -56,6 +59,10 @@ void beginFrame(Duration timeStamp) {
 }
 
 void main() {
+  // TODO(goderbauer): Create a window if embedder doesn't provide an implicit view to draw into.
+  assert(ui.PlatformDispatcher.instance.implicitView != null);
+  view = ui.PlatformDispatcher.instance.implicitView!;
+
   ui.PlatformDispatcher.instance
     ..onBeginFrame = beginFrame
     ..scheduleFrame();

--- a/examples/layers/raw/text.dart
+++ b/examples/layers/raw/text.dart
@@ -8,6 +8,9 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+// The FlutterView into which this example will draw; set in the main method.
+late final ui.FlutterView view;
+
 // A paragraph represents a rectangular region that contains some text.
 late ui.Paragraph paragraph;
 
@@ -15,8 +18,8 @@ ui.Picture paint(ui.Rect paintBounds) {
   final ui.PictureRecorder recorder = ui.PictureRecorder();
   final ui.Canvas canvas = ui.Canvas(recorder, paintBounds);
 
-  final double devicePixelRatio = ui.window.devicePixelRatio;
-  final ui.Size logicalSize = ui.window.physicalSize / devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
+  final ui.Size logicalSize = view.physicalSize / devicePixelRatio;
 
   canvas.translate(logicalSize.width / 2.0, logicalSize.height / 2.0);
   canvas.drawRect(
@@ -32,7 +35,7 @@ ui.Picture paint(ui.Rect paintBounds) {
 }
 
 ui.Scene composite(ui.Picture picture, ui.Rect paintBounds) {
-  final double devicePixelRatio = ui.window.devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
   final Float64List deviceTransform = Float64List(16)
     ..[0] = devicePixelRatio
     ..[5] = devicePixelRatio
@@ -46,13 +49,17 @@ ui.Scene composite(ui.Picture picture, ui.Rect paintBounds) {
 }
 
 void beginFrame(Duration timeStamp) {
-  final ui.Rect paintBounds = ui.Offset.zero & (ui.window.physicalSize / ui.window.devicePixelRatio);
+  final ui.Rect paintBounds = ui.Offset.zero & (view.physicalSize / view.devicePixelRatio);
   final ui.Picture picture = paint(paintBounds);
   final ui.Scene scene = composite(picture, paintBounds);
-  ui.window.render(scene);
+  view.render(scene);
 }
 
 void main() {
+  // TODO(goderbauer): Create a window if embedder doesn't provide an implicit view to draw into.
+  assert(ui.PlatformDispatcher.instance.implicitView != null);
+  view = ui.PlatformDispatcher.instance.implicitView!;
+
   // To create a paragraph of text, we use ParagraphBuilder.
   final ui.ParagraphBuilder builder = ui.ParagraphBuilder(
     // The text below has a primary direction of left-to-right.

--- a/examples/layers/raw/touch_input.dart
+++ b/examples/layers/raw/touch_input.dart
@@ -8,6 +8,9 @@
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+// The FlutterView into which this example will draw; set in the main method.
+late final ui.FlutterView view;
+
 late ui.Color color;
 
 ui.Picture paint(ui.Rect paintBounds) {
@@ -43,7 +46,7 @@ ui.Scene composite(ui.Picture picture, ui.Rect paintBounds) {
   // the device's screen to "normal" sized pixels. We commonly work in logical
   // pixels, which are then scaled by the device pixel ratio before being drawn
   // on the screen.
-  final double devicePixelRatio = ui.window.devicePixelRatio;
+  final double devicePixelRatio = view.devicePixelRatio;
 
   // This transform scales the x and y coordinates by the devicePixelRatio.
   final Float64List deviceTransform = Float64List(16)
@@ -67,13 +70,13 @@ ui.Scene composite(ui.Picture picture, ui.Rect paintBounds) {
 }
 
 void beginFrame(Duration timeStamp) {
-  final ui.Rect paintBounds = ui.Offset.zero & (ui.window.physicalSize / ui.window.devicePixelRatio);
+  final ui.Rect paintBounds = ui.Offset.zero & (view.physicalSize / view.devicePixelRatio);
   // First, record a picture with our painting commands.
   final ui.Picture picture = paint(paintBounds);
   // Second, include that picture in a scene graph.
   final ui.Scene scene = composite(picture, paintBounds);
   // Third, instruct the engine to render that scene graph.
-  ui.window.render(scene);
+  view.render(scene);
 }
 
 void handlePointerDataPacket(ui.PointerDataPacket packet) {
@@ -86,7 +89,7 @@ void handlePointerDataPacket(ui.PointerDataPacket packet) {
       // Rather than calling paint() synchronously, we ask the engine to
       // schedule a frame. The engine will call onBeginFrame when it is actually
       // time to produce the frame.
-      ui.window.scheduleFrame();
+      ui.PlatformDispatcher.instance.scheduleFrame();
     } else if (datum.change == ui.PointerChange.up) {
       // Similarly, if the pointer went up, we change the color of the circle to
       // green and schedule a frame. It's harmless to call scheduleFrame many
@@ -102,6 +105,10 @@ void handlePointerDataPacket(ui.PointerDataPacket packet) {
 // This function is the primary entry point to your application. The engine
 // calls main() as soon as it has loaded your code.
 void main() {
+  // TODO(goderbauer): Create a window if embedder doesn't provide an implicit view to draw into.
+  assert(ui.PlatformDispatcher.instance.implicitView != null);
+  view = ui.PlatformDispatcher.instance.implicitView!;
+
   color = const ui.Color(0xFF00FF00);
   // The engine calls onBeginFrame whenever it wants us to produce a frame.
   ui.PlatformDispatcher.instance.onBeginFrame = beginFrame;

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -401,7 +401,7 @@ class EdgeInsets extends EdgeInsetsGeometry {
   ///
   /// If you need the current system padding or view insets in the context of a
   /// widget, consider using [MediaQuery.of] to obtain these values rather than
-  /// using the value from [dart:ui.window], so that you get notified of
+  /// using the value from a [FlutterView] directly, so that you get notified of
   /// changes.
   EdgeInsets.fromWindowPadding(ui.WindowPadding padding, double devicePixelRatio)
     : left = padding.left / devicePixelRatio,

--- a/packages/flutter/lib/src/widgets/app.dart
+++ b/packages/flutter/lib/src/widgets/app.dart
@@ -252,8 +252,6 @@ typedef InitialRouteListFactory = List<Route<dynamic>> Function(String initialRo
 ///    without an explicit style.
 ///  * [MediaQuery], which establishes a subtree in which media queries resolve
 ///    to a [MediaQueryData].
-///  * [MediaQuery.fromWindow], which builds a [MediaQuery] with data derived
-///    from [WidgetsBinding.window].
 ///  * [Localizations], which defines the [Locale] for its `child`.
 ///  * [Title], a widget that describes this app in the operating system.
 ///  * [Navigator], a widget that manages a set of child widgets with a stack

--- a/packages/flutter/lib/src/widgets/media_query.dart
+++ b/packages/flutter/lib/src/widgets/media_query.dart
@@ -298,7 +298,7 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [ui.window], which provides some additional detail about this property
+  ///  * [FlutterView], which provides some additional detail about this property
   ///    and how it relates to [padding] and [viewPadding].
   final EdgeInsets viewInsets;
 
@@ -317,7 +317,7 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [ui.window], which provides some additional detail about this
+  ///  * [FlutterView], which provides some additional detail about this
   ///    property and how it relates to [viewInsets] and [viewPadding].
   ///  * [SafeArea], a widget that consumes this padding with a [Padding] widget
   ///    and automatically removes it from the [MediaQuery] for its child.
@@ -341,7 +341,7 @@ class MediaQueryData {
   ///
   /// See also:
   ///
-  ///  * [ui.window], which provides some additional detail about this
+  ///  * [FlutterView], which provides some additional detail about this
   ///    property and how it relates to [padding] and [viewInsets].
   final EdgeInsets viewPadding;
 


### PR DESCRIPTION
More work towards ultimately deprecating `dart:ui.window`.

Part of https://github.com/flutter/flutter/issues/116929.