### PR TITLE
Fix scrollable to clear inner semantics node if it does not use two p…

### DIFF
--- a/packages/flutter/lib/src/widgets/scrollable.dart
+++ b/packages/flutter/lib/src/widgets/scrollable.dart
@@ -1659,6 +1659,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
   @override
   void assembleSemanticsNode(SemanticsNode node, SemanticsConfiguration config, Iterable<SemanticsNode> children) {
     if (children.isEmpty || !children.first.isTagged(RenderViewport.useTwoPaneSemantics)) {
+      _innerNode = null;
       super.assembleSemanticsNode(node, config, children);
       return;
     }

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -11,6 +11,8 @@ import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'semantics_tester.dart';
+
 Future<void> pumpTest(
   WidgetTester tester,
   TargetPlatform? platform, {
@@ -1645,6 +1647,7 @@ void main() {
   });
 
   testWidgets('Swapping viewports in a scrollable does not crash', (WidgetTester tester) async {
+    final SemanticsTester semantics = SemanticsTester(tester);
     final GlobalKey key = GlobalKey();
     final GlobalKey key1 = GlobalKey();
     Widget buildScrollable(bool withViewPort) {
@@ -1669,19 +1672,23 @@ void main() {
         home: buildScrollable(true),
       ),
     );
+    expect(semantics, includesNodeWith(tags: <SemanticsTag>{RenderViewport.useTwoPaneSemantics}));
     // This does not use two panel, this should clear cached inner node.
     await tester.pumpWidget(
       MaterialApp(
         home: buildScrollable(false),
       ),
     );
+    expect(semantics, isNot(includesNodeWith(tags: <SemanticsTag>{RenderViewport.useTwoPaneSemantics})));
     // If the inner node was cleared in the previous step, this should not crash.
     await tester.pumpWidget(
       MaterialApp(
         home: buildScrollable(true),
       ),
     );
+    expect(semantics, includesNodeWith(tags: <SemanticsTag>{RenderViewport.useTwoPaneSemantics}));
     expect(tester.takeException(), isNull);
+    semantics.dispose();
   });
 }
 

--- a/packages/flutter/test/widgets/scrollable_test.dart
+++ b/packages/flutter/test/widgets/scrollable_test.dart
@@ -1644,7 +1644,7 @@ void main() {
     expect(getScrollOffset(tester), closeTo(333.2944, 0.0001));
   });
 
-  testWidgets('swapping viewport does not crash', (WidgetTester tester) async {
+  testWidgets('Swapping viewports in a scrollable does not crash', (WidgetTester tester) async {
     final GlobalKey key = GlobalKey();
     final GlobalKey key1 = GlobalKey();
     Widget buildScrollable(bool withViewPort) {

--- a/packages/flutter/test/widgets/semantics_tester.dart
+++ b/packages/flutter/test/widgets/semantics_tester.dart
@@ -487,6 +487,7 @@ class SemanticsTester {
     TextDirection? textDirection,
     List<SemanticsAction>? actions,
     List<SemanticsFlag>? flags,
+    Set<SemanticsTag>? tags,
     double? scrollPosition,
     double? scrollExtentMax,
     double? scrollExtentMin,
@@ -533,6 +534,12 @@ class SemanticsTester {
         final int expectedFlags = flags.fold<int>(0, (int value, SemanticsFlag flag) => value | flag.index);
         final int actualFlags = node.getSemanticsData().flags;
         if (expectedFlags != actualFlags) {
+          return false;
+        }
+      }
+      if (tags != null) {
+        final Set<SemanticsTag>? actualTags = node.getSemanticsData().tags;
+        if (!setEquals<SemanticsTag>(actualTags, tags)) {
           return false;
         }
       }
@@ -796,6 +803,7 @@ class _IncludesNodeWith extends Matcher {
     this.textDirection,
     this.actions,
     this.flags,
+    this.tags,
     this.scrollPosition,
     this.scrollExtentMax,
     this.scrollExtentMin,
@@ -806,6 +814,7 @@ class _IncludesNodeWith extends Matcher {
        value != null ||
        actions != null ||
        flags != null ||
+       tags != null ||
        scrollPosition != null ||
        scrollExtentMax != null ||
        scrollExtentMin != null ||
@@ -821,6 +830,7 @@ class _IncludesNodeWith extends Matcher {
   final TextDirection? textDirection;
   final List<SemanticsAction>? actions;
   final List<SemanticsFlag>? flags;
+  final Set<SemanticsTag>? tags;
   final double? scrollPosition;
   final double? scrollExtentMax;
   final double? scrollExtentMin;
@@ -839,6 +849,7 @@ class _IncludesNodeWith extends Matcher {
       textDirection: textDirection,
       actions: actions,
       flags: flags,
+      tags: tags,
       scrollPosition: scrollPosition,
       scrollExtentMax: scrollExtentMax,
       scrollExtentMin: scrollExtentMin,
@@ -865,6 +876,7 @@ class _IncludesNodeWith extends Matcher {
       if (textDirection != null) ' (${textDirection!.name})',
       if (actions != null) 'actions "${actions!.join(', ')}"',
       if (flags != null) 'flags "${flags!.join(', ')}"',
+      if (tags != null) 'tags "${tags!.join(', ')}"',
       if (scrollPosition != null) 'scrollPosition "$scrollPosition"',
       if (scrollExtentMax != null) 'scrollExtentMax "$scrollExtentMax"',
       if (scrollExtentMin != null) 'scrollExtentMin "$scrollExtentMin"',
@@ -889,6 +901,7 @@ Matcher includesNodeWith({
   TextDirection? textDirection,
   List<SemanticsAction>? actions,
   List<SemanticsFlag>? flags,
+  Set<SemanticsTag>? tags,
   double? scrollPosition,
   double? scrollExtentMax,
   double? scrollExtentMin,
@@ -905,6 +918,7 @@ Matcher includesNodeWith({
     textDirection: textDirection,
     actions: actions,
     flags: flags,
+    tags: tags,
     scrollPosition: scrollPosition,
     scrollExtentMax: scrollExtentMax,
     scrollExtentMin: scrollExtentMin,


### PR DESCRIPTION
…anel

The issue is if scrollable is first built with two panel, the innernode will be created and with the children.

Then the scrollable is built without two panel and same children, the innernode remain cached with the children while the main semantics node also set it children to be the same as inner node.

Then the scrollable is built with two panel and same children again, the main semantics node will replace its children with the inner node. This cause the children to be dropped. But then when the inner node still think it has the children and attempt to update it. This will result in a crash


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
