### PR TITLE
Print sub process that failed to run in tool

### DIFF
--- a/packages/flutter_tools/lib/src/base/error_handling_io.dart
+++ b/packages/flutter_tools/lib/src/base/error_handling_io.dart
@@ -667,7 +667,10 @@ class ErrorHandlingProcessManager extends ProcessManager {
         stdoutEncoding: stdoutEncoding,
         stderrEncoding: stderrEncoding,
       );
-    }, platform: _platform);
+    },
+      platform: _platform,
+      failureMessage: 'Flutter failed to run "${command.join(' ')}"',
+    );
   }
 
   @override
@@ -688,7 +691,10 @@ class ErrorHandlingProcessManager extends ProcessManager {
         runInShell: runInShell,
         mode: mode,
       );
-    }, platform: _platform);
+    },
+      platform: _platform,
+      failureMessage: 'Flutter failed to run "${command.join(' ')}"',
+    );
   }
 
   @override
@@ -711,7 +717,10 @@ class ErrorHandlingProcessManager extends ProcessManager {
         stdoutEncoding: stdoutEncoding,
         stderrEncoding: stderrEncoding,
       );
-    }, platform: _platform);
+    },
+      platform: _platform,
+      failureMessage: 'Flutter failed to run "${command.join(' ')}"',
+    );
   }
 }
 
@@ -759,9 +768,11 @@ void _handleMacOSException(Exception e, String? message, int errorCode, String? 
   const int ebadarch = 86;
   if (errorCode == ebadarch) {
     final StringBuffer errorBuffer = StringBuffer();
-    errorBuffer.writeln(message);
-    errorBuffer.writeln('This binary was built with the incorrect architecture to run on this machine.');
-    errorBuffer.writeln('Flutter requires the Rosetta translation environment. If you are on an ARM Mac, try running:');
+    if (message != null) {
+      errorBuffer.writeln('$message.');
+    }
+    errorBuffer.writeln('The binary was built with the incorrect architecture to run on this machine.');
+    errorBuffer.writeln('If you are on an ARM Apple Silicon Mac, Flutter requires the Rosetta translation environment. Try running:');
     errorBuffer.writeln('  sudo softwareupdate --install-rosetta --agree-to-license');
     _throwFileSystemException(errorBuffer.toString());
   }

--- a/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
+++ b/packages/flutter_tools/test/general.shard/base/error_handling_io_test.dart
@@ -963,7 +963,8 @@ void main() {
         platform: windowsPlatform,
       );
 
-      const String expectedMessage = 'The flutter tool cannot access the file';
+      const String expectedMessage = 'Flutter failed to run "foo". The flutter tool cannot access the file or directory.\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.';
       expect(() async => processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
       expect(() async => processManager.run(<String>['foo']),
@@ -1021,7 +1022,8 @@ void main() {
         platform: linuxPlatform,
       );
 
-      const String expectedMessage = 'The flutter tool cannot access the file';
+      const String expectedMessage = 'Flutter failed to run "foo".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.';
 
       expect(() async => processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
@@ -1085,7 +1087,8 @@ void main() {
         platform: macOSPlatform,
       );
 
-      const String expectedMessage = 'The flutter tool cannot access the file';
+      const String expectedMessage = 'Flutter failed to run "foo".\n'
+          'Please ensure that the SDK and/or project is installed in a location that has read/write permissions for the current user.';
 
       expect(() async => processManager.start(<String>['foo']),
              throwsToolExit(message: expectedMessage));
@@ -1113,9 +1116,9 @@ void main() {
 
     testWithoutContext('when bad CPU type', () async {
       final FakeProcessManager fakeProcessManager = FakeProcessManager.list(<FakeCommand>[
-        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', ebadarch)),
-        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', ebadarch)),
-        const FakeCommand(command: <String>['foo'], exception: ProcessException('', <String>[], '', ebadarch)),
+        const FakeCommand(command: <String>['foo', '--bar'], exception: ProcessException('', <String>[], '', ebadarch)),
+        const FakeCommand(command: <String>['foo', '--bar'], exception: ProcessException('', <String>[], '', ebadarch)),
+        const FakeCommand(command: <String>['foo', '--bar'], exception: ProcessException('', <String>[], '', ebadarch)),
       ]);
 
       final ProcessManager processManager = ErrorHandlingProcessManager(
@@ -1123,13 +1126,14 @@ void main() {
         platform: macOSPlatform,
       );
 
-      const String expectedMessage = 'Flutter requires the Rosetta translation environment';
+      const String expectedMessage = 'Flutter failed to run "foo --bar".\n'
+          'The binary was built with the incorrect architecture to run on this machine.';
 
-      expect(() async => processManager.start(<String>['foo']),
+      expect(() async => processManager.start(<String>['foo', '--bar']),
           throwsToolExit(message: expectedMessage));
-      expect(() async => processManager.run(<String>['foo']),
+      expect(() async => processManager.run(<String>['foo', '--bar']),
           throwsToolExit(message: expectedMessage));
-      expect(() => processManager.runSync(<String>['foo']),
+      expect(() => processManager.runSync(<String>['foo', '--bar']),
           throwsToolExit(message: expectedMessage));
     });
   });


### PR DESCRIPTION
When the tool cannot run an executable, include the command it tried to run in the error message.

Before:
```
null
This binary was built with the incorrect architecture to run on this machine.
Flutter requires the Rosetta translation environment. If you are on an ARM Mac, try running:
  sudo softwareupdate --install-rosetta --agree-to-license
```
After:
```
Flutter failed to run "java -version".
The binary was built with the incorrect architecture to run on this machine.
If you are on an ARM Apple Silicon Mac, Flutter requires the Rosetta translation environment. Try running:
  sudo softwareupdate --install-rosetta --agree-to-license
```
Fixes https://github.com/flutter/flutter/issues/120942

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
