### PR TITLE
disable timeline trace in release mode

### DIFF
--- a/packages/flutter/lib/src/foundation/binding.dart
+++ b/packages/flutter/lib/src/foundation/binding.dart
@@ -140,7 +140,9 @@ abstract class BindingBase {
   /// [initServiceExtensions] to have bindings initialize their
   /// observatory service extensions, if any.
   BindingBase() {
-    developer.Timeline.startSync('Framework initialization');
+    if (!kReleaseMode) {
+      developer.Timeline.startSync('Framework initialization');
+    }
     assert(() {
       _debugConstructed = true;
       return true;
@@ -156,7 +158,9 @@ abstract class BindingBase {
 
     developer.postEvent('Flutter.FrameworkInitialization', <String, String>{});
 
-    developer.Timeline.finishSync();
+    if (!kReleaseMode) {
+      developer.Timeline.finishSync();
+    }
   }
 
   bool _debugConstructed = false;
@@ -550,14 +554,17 @@ abstract class BindingBase {
   /// The [Future] returned by the `callback` argument is returned by [lockEvents].
   @protected
   Future<void> lockEvents(Future<void> Function() callback) {
-    final developer.TimelineTask timelineTask = developer.TimelineTask()..start('Lock events');
+    developer.TimelineTask? timelineTask;
+    if (!kReleaseMode) {
+      timelineTask = developer.TimelineTask()..start('Lock events');
+    }
 
     _lockCount += 1;
     final Future<void> future = callback();
     future.whenComplete(() {
       _lockCount -= 1;
       if (!locked) {
-        timelineTask.finish();
+        timelineTask?.finish();
         unlocked();
       }
     });

--- a/packages/flutter/lib/src/scheduler/binding.dart
+++ b/packages/flutter/lib/src/scheduler/binding.dart
@@ -929,7 +929,10 @@ mixin SchedulerBinding on BindingBase {
     }
 
     _warmUpFrame = true;
-    final TimelineTask timelineTask = TimelineTask()..start('Warm-up frame');
+    TimelineTask? timelineTask;
+    if (!kReleaseMode) {
+      timelineTask = TimelineTask()..start('Warm-up frame');
+    }
     final bool hadScheduledFrame = _hasScheduledFrame;
     // We use timers here to ensure that microtasks flush in between.
     Timer.run(() {
@@ -958,7 +961,7 @@ mixin SchedulerBinding on BindingBase {
     // scheduled frame has finished.
     lockEvents(() async {
       await endOfFrame;
-      timelineTask.finish();
+      timelineTask?.finish();
     });
   }
 


### PR DESCRIPTION
This pull request proposes the removal of Flutter code that invokes the timeline trace method in release mode. The timeline trace method is a debugging tool that is only intended to be used in development/profile mode, as it can impact the performance of the application when used in release mode.

By removing this code, we can improve the performance of our application in release mode and reduce the potential for any unexpected issues or errors. This change does not affect the functionality of the application, as the timeline trace method is only used for debugging purposes.

Overall, this pull request aims to optimize the performance of our Flutter application by removing unnecessary code that can impact its performance in release mode.


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
