### PR TITLE
Fix TextSelectionGestureDetectorBuilder wrong cause for onDoubleTapDown

### DIFF
--- a/packages/flutter/lib/src/widgets/text_selection.dart
+++ b/packages/flutter/lib/src/widgets/text_selection.dart
@@ -2430,7 +2430,7 @@ class TextSelectionGestureDetectorBuilder {
   @protected
   void onDoubleTapDown(TapDragDownDetails details) {
     if (delegate.selectionEnabled) {
-      renderEditable.selectWord(cause: SelectionChangedCause.tap);
+      renderEditable.selectWord(cause: SelectionChangedCause.doubleTap);
       if (shouldShowSelectionToolbar) {
         editableText.showToolbar();
       }

--- a/packages/flutter/test/widgets/text_selection_test.dart
+++ b/packages/flutter/test/widgets/text_selection_test.dart
@@ -461,6 +461,7 @@ void main() {
     final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
     expect(state.showToolbarCalled, isTrue);
     expect(renderEditable.selectPositionAtCalled, isTrue);
+    expect(renderEditable.lastCause, SelectionChangedCause.longPress);
   }, variant: const TargetPlatformVariant(<TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   testWidgets('test TextSelectionGestureDetectorBuilder long press on non-Apple Platforms', (WidgetTester tester) async {
@@ -477,6 +478,7 @@ void main() {
     final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
     expect(state.showToolbarCalled, isTrue);
     expect(renderEditable.selectWordCalled, isTrue);
+    expect(renderEditable.lastCause, SelectionChangedCause.longPress);
   }, variant: TargetPlatformVariant.all(excluding: <TargetPlatform>{ TargetPlatform.iOS, TargetPlatform.macOS }));
 
   testWidgets('TextSelectionGestureDetectorBuilder right click Apple platforms', (WidgetTester tester) async {
@@ -503,6 +505,7 @@ void main() {
     await gesture.up();
     await tester.pump();
     expect(renderEditable.selectWordCalled, isTrue);
+    expect(renderEditable.lastCause, SelectionChangedCause.tap);
 
     // Right clicking on a word within a selection shouldn't change the selection
     renderEditable.selectWordCalled = false;
@@ -589,6 +592,7 @@ void main() {
     switch (defaultTargetPlatform) {
       case TargetPlatform.iOS:
         expect(renderEditable.selectWordEdgeCalled, isTrue);
+        expect(renderEditable.lastCause, SelectionChangedCause.tap);
         break;
       case TargetPlatform.macOS:
       case TargetPlatform.android:
@@ -596,6 +600,7 @@ void main() {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(renderEditable.selectPositionAtCalled, isTrue);
+        expect(renderEditable.lastCause, SelectionChangedCause.tap);
         break;
     }
   }, variant: TargetPlatformVariant.all());
@@ -628,6 +633,7 @@ void main() {
       case TargetPlatform.linux:
       case TargetPlatform.windows:
         expect(renderEditable.selectPositionAtCalled, isTrue);
+        expect(renderEditable.lastCause, SelectionChangedCause.tap);
         break;
     }
   }, variant: TargetPlatformVariant.all());
@@ -670,6 +676,7 @@ void main() {
     final FakeRenderEditable renderEditable = tester.renderObject(find.byType(FakeEditable));
     expect(state.showToolbarCalled, isTrue);
     expect(renderEditable.selectWordCalled, isTrue);
+    expect(renderEditable.lastCause, SelectionChangedCause.doubleTap);
   });
 
   testWidgets('test TextSelectionGestureDetectorBuilder forcePress enabled', (WidgetTester tester) async {
@@ -1671,11 +1678,14 @@ class FakeRenderEditable extends RenderEditable {
     ),
   );
 
+  SelectionChangedCause? lastCause;
+
   bool selectWordsInRangeCalled = false;
   @override
   void selectWordsInRange({ required Offset from, Offset? to, required SelectionChangedCause cause }) {
     selectWordsInRangeCalled = true;
     hasFocus = true;
+    lastCause = cause;
   }
 
   bool selectWordEdgeCalled = false;
@@ -1683,6 +1693,7 @@ class FakeRenderEditable extends RenderEditable {
   void selectWordEdge({ required SelectionChangedCause cause }) {
     selectWordEdgeCalled = true;
     hasFocus = true;
+    lastCause = cause;
   }
 
   bool selectPositionAtCalled = false;
@@ -1694,12 +1705,14 @@ class FakeRenderEditable extends RenderEditable {
     selectPositionAtFrom = from;
     selectPositionAtTo = to;
     hasFocus = true;
+    lastCause = cause;
   }
 
   bool selectPositionCalled = false;
   @override
   void selectPosition({ required SelectionChangedCause cause }) {
     selectPositionCalled = true;
+    lastCause = cause;
     return super.selectPosition(cause: cause);
   }
 
@@ -1708,6 +1721,7 @@ class FakeRenderEditable extends RenderEditable {
   void selectWord({ required SelectionChangedCause cause }) {
     selectWordCalled = true;
     hasFocus = true;
+    lastCause = cause;
   }
 
   @override


### PR DESCRIPTION
## Description

This PR fixes TextSelectionGestureDetector.onDoubleTapDown calling selectWord with cause parameter set to SelectionChangedCause.tap instead of SelectionChangedCause.doubleTap.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/121091

## Tests

Updates several existing tests to check the selection change cause.
