### PR TITLE
Fix selection toolbar not showing on drag end

### DIFF
--- a/packages/flutter/lib/src/widgets/selectable_region.dart
+++ b/packages/flutter/lib/src/widgets/selectable_region.dart
@@ -537,6 +537,7 @@ class SelectableRegionState extends State<SelectableRegion> with TextSelectionDe
    } else {
      _selectionOverlay!.hideMagnifier();
      _selectionOverlay!.showToolbar(
+       context: context,
        contextMenuBuilder: (BuildContext context) {
          return widget.contextMenuBuilder!(context, this);
        },

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -129,4 +129,56 @@ void main() {
     expect(content, isNotNull);
     expect(content!.plainText, 'How');
   });
+
+  testWidgets('stopping drag of end handle will show the toolbar', (WidgetTester tester) async {
+    // Regression test for https://github.com/flutter/flutter/issues/119314
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Padding(
+            padding: const EdgeInsets.only(top: 64),
+            child: Column(
+              children: <Widget>[
+                const Text('How are you?'),
+                SelectionArea(
+                  focusNode: FocusNode(),
+                  child: const Text('Good, and you?'),
+                ),
+                const Text('Fine, thank you.'),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+    final RenderParagraph paragraph2 = tester.renderObject<RenderParagraph>(find.descendant(of: find.text('Good, and you?'), matching: find.byType(RichText)));
+    final TestGesture gesture = await tester.startGesture(textOffsetToPosition(paragraph2, 7)); // at the 'a'
+    addTearDown(gesture.removePointer);
+    await tester.pump(const Duration(milliseconds: 500));
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 500));
+    final List<TextBox> boxes = paragraph2.getBoxesForSelection(paragraph2.selections[0]);
+    expect(boxes.length, 1);
+    // There is a selection now.
+    // We check the presence of the copy button to make sure the selection toolbar
+    // is showing.
+    expect(find.text('Copy'), findsOneWidget);
+
+    // This is the position of the selection handle displayed at the end
+    final Offset handlePos = paragraph2.localToGlobal(boxes[0].toRect().bottomRight);
+    await gesture.down(handlePos);
+    await gesture.moveTo(textOffsetToPosition(paragraph2, 11) + Offset(0, paragraph2.size.height / 2));
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(milliseconds: 500));
+
+    await gesture.up();
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(milliseconds: 500));
+
+    // After lifting the finger up, the selection toolbar should be showing again.
+    expect(find.text('Copy'), findsOneWidget);
+  },
+    variant: TargetPlatformVariant.all(),
+    skip: kIsWeb, // [intended]
+  );
 }

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -163,7 +163,7 @@ void main() {
     // is showing.
     expect(find.text('Copy'), findsOneWidget);
 
-    // This is the position of the selection handle displayed at the end
+    // This is the position of the selection handle displayed at the end.
     final Offset handlePos = paragraph2.localToGlobal(boxes[0].toRect().bottomRight);
     await gesture.down(handlePos);
     await gesture.moveTo(textOffsetToPosition(paragraph2, 11) + Offset(0, paragraph2.size.height / 2));

--- a/packages/flutter/test/material/selection_area_test.dart
+++ b/packages/flutter/test/material/selection_area_test.dart
@@ -156,7 +156,6 @@ void main() {
     addTearDown(gesture.removePointer);
     await tester.pump(const Duration(milliseconds: 500));
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 500));
     final List<TextBox> boxes = paragraph2.getBoxesForSelection(paragraph2.selections[0]);
     expect(boxes.length, 1);
     // There is a selection now.
@@ -168,12 +167,10 @@ void main() {
     final Offset handlePos = paragraph2.localToGlobal(boxes[0].toRect().bottomRight);
     await gesture.down(handlePos);
     await gesture.moveTo(textOffsetToPosition(paragraph2, 11) + Offset(0, paragraph2.size.height / 2));
-    await tester.pump(const Duration(milliseconds: 500));
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
 
     await gesture.up();
-    await tester.pump(const Duration(milliseconds: 500));
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump();
 
     // After lifting the finger up, the selection toolbar should be showing again.
     expect(find.text('Copy'), findsOneWidget);


### PR DESCRIPTION
Fixes #119314

The regression was caused initially by this commit: f014c1e6dcfdfbebaf379757273c4033a5092fbc

### Before

Before, ending the drag didn't show the toolbar, making it impossible to copy the text after adjusting the selection handles.

https://user-images.githubusercontent.com/1659532/220207752-dae81cf2-5ccb-4f13-b3c4-45c0e900f494.mov

### After

Now ending the drag will show the toolbar again:

https://user-images.githubusercontent.com/1659532/220207635-92275b58-7e14-4b57-83da-b12f7e9ed9af.mov

## Pre-launch Checklist


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.