### PR TITLE
Remove accessibleNavigation reference from BottomSheet

### DIFF
--- a/packages/flutter/lib/src/material/bottom_sheet.dart
+++ b/packages/flutter/lib/src/material/bottom_sheet.dart
@@ -559,10 +559,8 @@ class _ModalBottomSheetState<T> extends State<_ModalBottomSheet<T>> {
         onDragEnd: handleDragEnd,
       ),
       builder: (BuildContext context, Widget? child) {
-        // Disable the initial animation when accessible navigation is on so
-        // that the semantics are added to the tree at the correct time.
         final double animationValue = animationCurve.transform(
-            MediaQuery.accessibleNavigationOf(context) ? 1.0 : widget.route.animation!.value,
+            widget.route.animation!.value,
         );
         return Semantics(
           scopesRoute: true,

--- a/packages/flutter/test/material/bottom_sheet_test.dart
+++ b/packages/flutter/test/material/bottom_sheet_test.dart
@@ -90,9 +90,7 @@ void main() {
     await tester.pumpWidget(Container());
   });
 
-
   testWidgets('Swiping down a BottomSheet should dismiss it by default', (WidgetTester tester) async {
-
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     bool showBottomSheetThenCalled = false;
 
@@ -128,7 +126,6 @@ void main() {
   });
 
   testWidgets('Swiping down a BottomSheet should not dismiss it when enableDrag is false', (WidgetTester tester) async {
-
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
     bool showBottomSheetThenCalled = false;
 
@@ -367,6 +364,32 @@ void main() {
     await checkNonLinearAnimation(tester);
     await tester.pumpAndSettle(); // Bottom sheet dismiss animation.
     expect(find.text('BottomSheet'), findsNothing);
+  });
+
+  // Regression test for https://github.com/flutter/flutter/issues/121098
+  testWidgets('Verify that accessibleNavigation has no impact on the BottomSheet animation', (WidgetTester tester) async {
+    await tester.pumpWidget(MaterialApp(
+      builder: (BuildContext context, Widget? child) {
+        return MediaQuery(
+          data: const MediaQueryData(accessibleNavigation: true),
+          child: child!,
+        );
+      },
+      home: const Center(child: Text('Test')),
+    ));
+
+    await tester.pump();
+    expect(find.text('BottomSheet'), findsNothing);
+
+    final BuildContext homeContext = tester.element(find.text('Test'));
+    showModalBottomSheet<void>(
+      context: homeContext,
+      builder: (BuildContext context) => const Text('BottomSheet'),
+    );
+    await tester.pump();
+
+    await checkNonLinearAnimation(tester);
+    await tester.pumpAndSettle();
   });
 
   testWidgets('Tapping outside a modal BottomSheet should not dismiss it when isDismissible=false', (WidgetTester tester) async {
@@ -841,7 +864,7 @@ void main() {
     expect(modalBarrier.color, barrierColor);
   });
 
-  testWidgets('BottomSheet uses fallback values in maretial3',
+  testWidgets('BottomSheet uses fallback values in material3',
       (WidgetTester tester) async {
     const Color surfaceColor = Colors.pink;
     const Color surfaceTintColor = Colors.blue;
@@ -890,7 +913,6 @@ void main() {
         body: const Center(child: Text('body')),
       ),
     ));
-
 
     showModalBottomSheet<void>(
       context: scaffoldKey.currentContext!,


### PR DESCRIPTION
## Description

This PR removes `MediaQueryData.accessibleNavigation` usage from `ModalBottomSheet`.
See https://github.com/flutter/flutter/issues/121098 for motivation.

~~It is a WIP PR because this removal needs more insights. No test are broken but there might be a missing one.~~

## Related Issue

Fixes https://github.com/flutter/flutter/issues/121098
Fixes https://github.com/flutter/flutter/issues/119094

## Tests

Add 1 regression test.
