### PR TITLE
Limit the PlatformView ID within the range of 32-bit integers.

### DIFF
--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -49,20 +49,10 @@ class PlatformViewsRegistry {
     // See https://github.com/flutter/engine/pull/39476 for more details.
 
     // We can safely assume that a Flutter application will not require more
-    // than MAX_INT32 platform views on the fly throughout its lifetime.
-    // Therefore, if the cumulative number of platform views exceeds MAX_INT32,
-    // we can reset the view IDs and start allocating them from zero again.
+    // than MAX_INT32 platform views during its lifetime.
     const int MAX_INT32 = 0x7FFFFFFF;
-    if (_nextPlatformViewId == MAX_INT32) {
-      _nextPlatformViewId = 0;
-    }
+    assert(_nextPlatformViewId <= MAX_INT32);
     return _nextPlatformViewId++;
-  }
-
-  /// For testing purposes only, modify the unique identifier of the platform view.
-  @visibleForTesting
-  void setPlatformViewIdForTesting(int viewId) {
-    _nextPlatformViewId = viewId;
   }
 }
 

--- a/packages/flutter/lib/src/services/platform_views.dart
+++ b/packages/flutter/lib/src/services/platform_views.dart
@@ -44,7 +44,26 @@ class PlatformViewsRegistry {
   ///
   /// Typically a platform view identifier is passed to a platform view widget
   /// which creates the platform view and manages its lifecycle.
-  int getNextPlatformViewId() => _nextPlatformViewId++;
+  int getNextPlatformViewId() {
+    // On the Android side, the interface exposed to users uses 32-bit integers.
+    // See https://github.com/flutter/engine/pull/39476 for more details.
+
+    // We can safely assume that a Flutter application will not require more
+    // than MAX_INT32 platform views on the fly throughout its lifetime.
+    // Therefore, if the cumulative number of platform views exceeds MAX_INT32,
+    // we can reset the view IDs and start allocating them from zero again.
+    const int MAX_INT32 = 0x7FFFFFFF;
+    if (_nextPlatformViewId == MAX_INT32) {
+      _nextPlatformViewId = 0;
+    }
+    return _nextPlatformViewId++;
+  }
+
+  /// For testing purposes only, modify the unique identifier of the platform view.
+  @visibleForTesting
+  void setPlatformViewIdForTesting(int viewId) {
+    _nextPlatformViewId = viewId;
+  }
 }
 
 /// Callback signature for when a platform view was created.

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -47,40 +47,6 @@ void main() {
       );
     });
 
-    testWidgets('Create an Android view with the ID set to the maximum 32-bit integer value', (WidgetTester tester) async {
-      const int MAX_INT32 = 0x7FFFFFFF;
-      platformViewsRegistry.setPlatformViewIdForTesting(MAX_INT32 - 1);
-
-      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
-      // The next view id is the maximum 32-bit integer value now.
-      expect(currentViewId, MAX_INT32 - 1);
-
-      final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
-      viewsController.registerViewType('webview');
-
-      await tester.pumpWidget(
-        const Center(
-          child: SizedBox(
-            width: 200.0,
-            height: 100.0,
-            child: AndroidView(viewType: 'webview', layoutDirection: TextDirection.ltr),
-          ),
-        ),
-      );
-
-      expect(
-        viewsController.views,
-        unorderedEquals(<FakeAndroidPlatformView>[
-          FakeAndroidPlatformView(
-            0, // Reallocate from zero since the current view ID has exceeded MAX_INT32.
-            'webview',
-            const Size(200.0, 100.0),
-            AndroidViewController.kAndroidLayoutDirectionLtr,
-          ),
-        ]),
-      );
-    });
-
     testWidgets('Create Android view with params', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();

--- a/packages/flutter/test/widgets/platform_view_test.dart
+++ b/packages/flutter/test/widgets/platform_view_test.dart
@@ -47,6 +47,40 @@ void main() {
       );
     });
 
+    testWidgets('Create an Android view with the ID set to the maximum 32-bit integer value', (WidgetTester tester) async {
+      const int MAX_INT32 = 0x7FFFFFFF;
+      platformViewsRegistry.setPlatformViewIdForTesting(MAX_INT32 - 1);
+
+      final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
+      // The next view id is the maximum 32-bit integer value now.
+      expect(currentViewId, MAX_INT32 - 1);
+
+      final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();
+      viewsController.registerViewType('webview');
+
+      await tester.pumpWidget(
+        const Center(
+          child: SizedBox(
+            width: 200.0,
+            height: 100.0,
+            child: AndroidView(viewType: 'webview', layoutDirection: TextDirection.ltr),
+          ),
+        ),
+      );
+
+      expect(
+        viewsController.views,
+        unorderedEquals(<FakeAndroidPlatformView>[
+          FakeAndroidPlatformView(
+            0, // Reallocate from zero since the current view ID has exceeded MAX_INT32.
+            'webview',
+            const Size(200.0, 100.0),
+            AndroidViewController.kAndroidLayoutDirectionLtr,
+          ),
+        ]),
+      );
+    });
+
     testWidgets('Create Android view with params', (WidgetTester tester) async {
       final int currentViewId = platformViewsRegistry.getNextPlatformViewId();
       final FakeAndroidPlatformViewsController viewsController = FakeAndroidPlatformViewsController();


### PR DESCRIPTION
On the Android side, the interface exposed to users uses 32-bit integers. See https://github.com/flutter/engine/pull/39476#discussion_r1112497810 for more details.

We can safely assume that a Flutter application will not require more than `0x7FFFFFFF` platform views during its lifetime.

Related issue: https://github.com/flutter/flutter/issues/120256


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
