### PR TITLE
added single child scroll view to Navigation rail

### DIFF
--- a/packages/flutter/lib/src/material/navigation_rail.dart
+++ b/packages/flutter/lib/src/material/navigation_rail.dart
@@ -439,38 +439,40 @@ class _NavigationRailState extends State<NavigationRail> with TickerProviderStat
                 Expanded(
                   child: Align(
                     alignment: Alignment(0, groupAlignment),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        for (int i = 0; i < widget.destinations.length; i += 1)
-                          _RailDestination(
-                            minWidth: minWidth,
-                            minExtendedWidth: minExtendedWidth,
-                            extendedTransitionAnimation: _extendedAnimation,
-                            selected: widget.selectedIndex == i,
-                            icon: widget.selectedIndex == i ? widget.destinations[i].selectedIcon : widget.destinations[i].icon,
-                            label: widget.destinations[i].label,
-                            destinationAnimation: _destinationAnimations[i],
-                            labelType: labelType,
-                            iconTheme: widget.selectedIndex == i ? selectedIconTheme : effectiveUnselectedIconTheme,
-                            labelTextStyle: widget.selectedIndex == i ? selectedLabelTextStyle : unselectedLabelTextStyle,
-                            padding: widget.destinations[i].padding,
-                            useIndicator: useIndicator,
-                            indicatorColor: useIndicator ? indicatorColor : null,
-                            indicatorShape: useIndicator ? indicatorShape : null,
-                            onTap: () {
-                              if (widget.onDestinationSelected != null) {
-                                widget.onDestinationSelected!(i);
-                              }
-                            },
-                            indexLabel: localizations.tabLabel(
-                              tabIndex: i + 1,
-                              tabCount: widget.destinations.length,
+                    child: SingleChildScrollView(
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          for (int i = 0; i < widget.destinations.length; i += 1)
+                            _RailDestination(
+                              minWidth: minWidth,
+                              minExtendedWidth: minExtendedWidth,
+                              extendedTransitionAnimation: _extendedAnimation,
+                              selected: widget.selectedIndex == i,
+                              icon: widget.selectedIndex == i ? widget.destinations[i].selectedIcon : widget.destinations[i].icon,
+                              label: widget.destinations[i].label,
+                              destinationAnimation: _destinationAnimations[i],
+                              labelType: labelType,
+                              iconTheme: widget.selectedIndex == i ? selectedIconTheme : effectiveUnselectedIconTheme,
+                              labelTextStyle: widget.selectedIndex == i ? selectedLabelTextStyle : unselectedLabelTextStyle,
+                              padding: widget.destinations[i].padding,
+                              useIndicator: useIndicator,
+                              indicatorColor: useIndicator ? indicatorColor : null,
+                              indicatorShape: useIndicator ? indicatorShape : null,
+                              onTap: () {
+                                if (widget.onDestinationSelected != null) {
+                                  widget.onDestinationSelected!(i);
+                                }
+                              },
+                              indexLabel: localizations.tabLabel(
+                                tabIndex: i + 1,
+                                tabCount: widget.destinations.length,
+                              ),
                             ),
-                          ),
-                        if (widget.trailing != null)
-                          widget.trailing!,
-                      ],
+                          if (widget.trailing != null)
+                            widget.trailing!,
+                        ],
+                      ),
                     ),
                   ),
                 ),

--- a/packages/flutter/test/material/navigation_rail_test.dart
+++ b/packages/flutter/test/material/navigation_rail_test.dart
@@ -4972,31 +4972,36 @@ TestSemantics _expectedSemantics() {
                 flags: <SemanticsFlag>[SemanticsFlag.scopesRoute],
                 children: <TestSemantics>[
                   TestSemantics(
-                    flags: <SemanticsFlag>[
-                      SemanticsFlag.isSelected,
-                      SemanticsFlag.isFocusable,
+                    flags: <SemanticsFlag>[SemanticsFlag.hasImplicitScrolling],
+                    children: <TestSemantics>[
+                      TestSemantics(
+                        flags: <SemanticsFlag>[
+                          SemanticsFlag.isSelected,
+                          SemanticsFlag.isFocusable,
+                        ],
+                        actions: <SemanticsAction>[SemanticsAction.tap],
+                        label: 'Abc\nTab 1 of 4',
+                        textDirection: TextDirection.ltr,
+                      ),
+                      TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                        actions: <SemanticsAction>[SemanticsAction.tap],
+                        label: 'Def\nTab 2 of 4',
+                        textDirection: TextDirection.ltr,
+                      ),
+                      TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                        actions: <SemanticsAction>[SemanticsAction.tap],
+                        label: 'Ghi\nTab 3 of 4',
+                        textDirection: TextDirection.ltr,
+                      ),
+                      TestSemantics(
+                        flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
+                        actions: <SemanticsAction>[SemanticsAction.tap],
+                        label: 'Jkl\nTab 4 of 4',
+                        textDirection: TextDirection.ltr,
+                      ),
                     ],
-                    actions: <SemanticsAction>[SemanticsAction.tap],
-                    label: 'Abc\nTab 1 of 4',
-                    textDirection: TextDirection.ltr,
-                  ),
-                  TestSemantics(
-                    flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
-                    actions: <SemanticsAction>[SemanticsAction.tap],
-                    label: 'Def\nTab 2 of 4',
-                    textDirection: TextDirection.ltr,
-                  ),
-                  TestSemantics(
-                    flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
-                    actions: <SemanticsAction>[SemanticsAction.tap],
-                    label: 'Ghi\nTab 3 of 4',
-                    textDirection: TextDirection.ltr,
-                  ),
-                  TestSemantics(
-                    flags: <SemanticsFlag>[SemanticsFlag.isFocusable],
-                    actions: <SemanticsAction>[SemanticsAction.tap],
-                    label: 'Jkl\nTab 4 of 4',
-                    textDirection: TextDirection.ltr,
                   ),
                   TestSemantics(
                     label: 'body',


### PR DESCRIPTION
*This PR adds the ability to scroll the Navigation rail when NavigationRailDestinations are more than the screen could contain*

Previously:
<img width="912" alt="Screenshot 2023-02-22 at 9 39 18 PM" src="https://user-images.githubusercontent.com/58727124/220691085-4559aea7-fd00-4460-96fa-8bc09cfdc415.png">

After this PR:
<img width="868" alt="Screenshot 2023-02-22 at 9 57 50 PM" src="https://user-images.githubusercontent.com/58727124/220691443-dfc4a0b6-7411-4504-8e61-9caeba80b09d.png">



*List which issues are fixed by this PR. You must list at least one issue.*
- fixes #121236 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.
