### PR TITLE
Update jdk in cirrus dockerfile image.

### DIFF
--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -82,22 +82,22 @@ RUN touch ~/.android/repositories.cfg
 ENV ANDROID_SDK_ARCHIVE="${ANDROID_TOOLS_ROOT}/archive"
 RUN wget --progress=dot:giga "${ANDROID_SDK_URL}" -O "${ANDROID_SDK_ARCHIVE}"
 RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
-RUN mkdir "${ANDROID_TOOLS_ROOT}/tools"
-RUN mv -i "${ANDROID_TOOLS_ROOT}" "${ANDROID_TOOLS_ROOT}/tools"
+RUN mkdir "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
+RUN mv -i "${ANDROID_TOOLS_ROOT}/cmdline-tools/*" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 
 # Suppressing output of sdkmanager to keep log size down
 # (it prints install progress WAY too often).
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "tools" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "build-tools;28.0.3" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platforms;android-30" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platform-tools" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "cmdline-tools;latest" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "extras;android;m2repository" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "extras;google;m2repository" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "patcher;v4" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "tools" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "build-tools;28.0.3" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "platforms;android-30" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "platform-tools" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "cmdline-tools;latest" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "extras;android;m2repository" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "extras;google;m2repository" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin/sdkmanager" "patcher;v4" > /dev/null
 RUN rm "${ANDROID_SDK_ARCHIVE}"
-ENV PATH="${ANDROID_TOOLS_ROOT}/tools:${PATH}"
-ENV PATH="${ANDROID_TOOLS_ROOT}/tools/bin:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/cmdline-tools/tools:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/cmdline-tools/tools/bin:${PATH}"
 # Silence warnings when accepting android licenses.
 RUN mkdir -p ~/.android
 RUN touch ~/.android/repositories.cfg

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -86,7 +86,10 @@ RUN ls "${ANDROID_TOOLS_ROOT}"
 
 RUN mkdir "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 RUN ls "${ANDROID_TOOLS_ROOT}/cmdline-tools"
-RUN mv -i "${ANDROID_TOOLS_ROOT}/cmdline-tools/*" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
+RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/NOTICE.txt" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
+RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
+RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/lib" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
+RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/source.properties" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 
 # Suppressing output of sdkmanager to keep log size down
 # (it prints install progress WAY too often).

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -82,6 +82,8 @@ RUN touch ~/.android/repositories.cfg
 ENV ANDROID_SDK_ARCHIVE="${ANDROID_TOOLS_ROOT}/archive"
 RUN wget --progress=dot:giga "${ANDROID_SDK_URL}" -O "${ANDROID_SDK_ARCHIVE}"
 RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
+RUN ls "${ANDROID_TOOLS_ROOT}"
+
 RUN mkdir "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 RUN mv -i "${ANDROID_TOOLS_ROOT}/cmdline-tools/*" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update && apt-get install -y google-cloud-sdk && \
     gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true
 
-# Add repo for OpenJDK 8 from JFrog.io
+# Add repo for OpenJDK from JFrog.io
 RUN wget -q -O - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -
 RUN echo 'deb [arch=amd64] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb bullseye main' | \
     tee /etc/apt/sources.list.d/adoptopenjdk.list
@@ -82,19 +82,22 @@ RUN touch ~/.android/repositories.cfg
 ENV ANDROID_SDK_ARCHIVE="${ANDROID_TOOLS_ROOT}/archive"
 RUN wget --progress=dot:giga "${ANDROID_SDK_URL}" -O "${ANDROID_SDK_ARCHIVE}"
 RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
+RUN mkdir "${ANDROID_TOOLS_ROOT}/tools"
+RUN mv -i "${ANDROID_TOOLS_ROOT}" "${ANDROID_TOOLS_ROOT}/tools"
+
 # Suppressing output of sdkmanager to keep log size down
 # (it prints install progress WAY too often).
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "tools" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "build-tools;28.0.3" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "platforms;android-30" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "platform-tools" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "cmdline-tools;latest" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "extras;android;m2repository" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "extras;google;m2repository" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "patcher;v4" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "tools" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "build-tools;28.0.3" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platforms;android-30" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platform-tools" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "cmdline-tools;latest" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "extras;android;m2repository" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "extras;google;m2repository" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "patcher;v4" > /dev/null
 RUN rm "${ANDROID_SDK_ARCHIVE}"
-ENV PATH="${ANDROID_TOOLS_ROOT}/cmdline-tools:${PATH}"
-ENV PATH="${ANDROID_TOOLS_ROOT}/cmdline-tools/bin:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/tools:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/tools/bin:${PATH}"
 # Silence warnings when accepting android licenses.
 RUN mkdir -p ~/.android
 RUN touch ~/.android/repositories.cfg

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -70,6 +70,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64"
 
+ENV CLASSPATH='/usr/share/jaxb/lib'
+
 # Install the Android SDK Dependency.
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
 ENV ANDROID_TOOLS_ROOT="/opt/android_sdk"

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64"
 
-ENV CLASSPATH='/usr/share/jaxb/lib'
+RUN export CLASSPATH='/usr/share/jaxb/lib'
 
 # Install the Android SDK Dependency.
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -73,7 +73,7 @@ ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64"
 RUN export CLASSPATH='/usr/share/jaxb/lib'
 
 # Install the Android SDK Dependency.
-ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"
+ENV ANDROID_SDK_URL="wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip"
 ENV ANDROID_TOOLS_ROOT="/opt/android_sdk"
 RUN mkdir -p "${ANDROID_TOOLS_ROOT}"
 RUN mkdir -p ~/.android

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   default-jdk-headless \
   gcc \
   google-chrome-stable \
+  jaxb \
   lib32stdc++6 \
   libglu1-mesa \
   libstdc++6 \

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -85,6 +85,7 @@ RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
 RUN ls "${ANDROID_TOOLS_ROOT}"
 
 RUN mkdir "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
+RUN ls "${ANDROID_TOOLS_ROOT}/cmdline-tools"
 RUN mv -i "${ANDROID_TOOLS_ROOT}/cmdline-tools/*" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 
 # Suppressing output of sdkmanager to keep log size down

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -52,7 +52,7 @@ RUN echo 'deb [arch=amd64] https://adoptopenjdk.jfrog.io/adoptopenjdk/deb bullse
 
 # Install the dependencies needed for the rest of the build.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  adoptopenjdk-8-hotspot \
+  adoptopenjdk-11-hotspot \
   build-essential \
   default-jdk-headless \
   gcc \
@@ -67,7 +67,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ruby-dev && \
   apt-get clean
 
-ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64"
+ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64"
 
 # Install the Android SDK Dependency.
 ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/sdk-tools-linux-4333796.zip"

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -84,17 +84,17 @@ RUN wget --progress=dot:giga "${ANDROID_SDK_URL}" -O "${ANDROID_SDK_ARCHIVE}"
 RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
 # Suppressing output of sdkmanager to keep log size down
 # (it prints install progress WAY too often).
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "tools" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "build-tools;28.0.3" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platforms;android-30" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "platform-tools" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "cmdline-tools;latest" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "extras;android;m2repository" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "extras;google;m2repository" > /dev/null
-RUN yes "y" | "${ANDROID_TOOLS_ROOT}/tools/bin/sdkmanager" "patcher;v4" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "tools" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "build-tools;28.0.3" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "platforms;android-30" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "platform-tools" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "cmdline-tools;latest" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "extras;android;m2repository" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "extras;google;m2repository" > /dev/null
+RUN yes "y" | "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin/sdkmanager" "patcher;v4" > /dev/null
 RUN rm "${ANDROID_SDK_ARCHIVE}"
-ENV PATH="${ANDROID_TOOLS_ROOT}/tools:${PATH}"
-ENV PATH="${ANDROID_TOOLS_ROOT}/tools/bin:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/cmdline-tools:${PATH}"
+ENV PATH="${ANDROID_TOOLS_ROOT}/cmdline-tools/bin:${PATH}"
 # Silence warnings when accepting android licenses.
 RUN mkdir -p ~/.android
 RUN touch ~/.android/repositories.cfg

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -73,7 +73,7 @@ ENV JAVA_HOME="/usr/lib/jvm/adoptopenjdk-11-hotspot-amd64"
 RUN export CLASSPATH='/usr/share/jaxb/lib'
 
 # Install the Android SDK Dependency.
-ENV ANDROID_SDK_URL="wget https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip"
+ENV ANDROID_SDK_URL="https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip"
 ENV ANDROID_TOOLS_ROOT="/opt/android_sdk"
 RUN mkdir -p "${ANDROID_TOOLS_ROOT}"
 RUN mkdir -p ~/.android

--- a/dev/ci/docker_linux/Dockerfile
+++ b/dev/ci/docker_linux/Dockerfile
@@ -82,10 +82,9 @@ RUN touch ~/.android/repositories.cfg
 ENV ANDROID_SDK_ARCHIVE="${ANDROID_TOOLS_ROOT}/archive"
 RUN wget --progress=dot:giga "${ANDROID_SDK_URL}" -O "${ANDROID_SDK_ARCHIVE}"
 RUN unzip -q -d "${ANDROID_TOOLS_ROOT}" "${ANDROID_SDK_ARCHIVE}"
-RUN ls "${ANDROID_TOOLS_ROOT}"
 
 RUN mkdir "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
-RUN ls "${ANDROID_TOOLS_ROOT}/cmdline-tools"
+
 RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/NOTICE.txt" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/bin" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"
 RUN mv "${ANDROID_TOOLS_ROOT}/cmdline-tools/lib" "${ANDROID_TOOLS_ROOT}/cmdline-tools/tools"


### PR DESCRIPTION
The move of the engine to jdk 11 caused some breakages within cirrus as we had not updated that docker image to jdk 11. So compilation errors were happening because the java code was compiled with jdk 11 but being run for cirrus with jdk8.

```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.UnsupportedClassVersionError: com/android/prefs/AndroidLocationsProvider has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:756)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:468)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:74)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:369)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:363)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:362)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.privateGetMethodRecursive(Class.java:3048)
	at java.lang.Class.getMethod0(Class.java:3018)
	at java.lang.Class.getMethod(Class.java:1784)
	at sun.launcher.LauncherHelper.validateMainClass(LauncherHelper.java:650)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:632)
Android sdkmanager tool was found, but failed to run (/opt/android_sdk/cmdline-tools/latest/bin/sdkmanager): "exited code 1".
Try re-installing or updating your Android SDK,
visit https://flutter.dev/docs/get-started/install/linux#android-setup for detailed instructions.
```

*List which issues are fixed by this PR. You must list at least one issue.*
Fixes https://github.com/flutter/flutter/issues/121242

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
