### PR TITLE
remove Christopher Fujino from codeowners of //dev/ci

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,6 @@
 
 /CODEOWNERS @jmagman
 /.ci.yaml @keyonghan
-/dev/ci/ @christopherfujino
 /packages/flutter_tools/pubspec.yaml @christopherfujino
 /packages/flutter_tools/templates/module/ios/ @jmagman
 /packages/flutter_tools/templates/**/Podfile* @jmagman


### PR DESCRIPTION
I don't actively maintain anything in this directory anymore