### PR TITLE
Move semantic-related bindings to SemanticsBinding

### DIFF
--- a/dev/integration_tests/flutter_gallery/test/smoke_test.dart
+++ b/dev/integration_tests/flutter_gallery/test/smoke_test.dart
@@ -184,8 +184,8 @@ void main() {
   );
 
   testWidgets('Flutter Gallery app smoke test with semantics', (WidgetTester tester) async {
-    RendererBinding.instance.setSemanticsEnabled(true);
+    final SemanticsHandle handle = SemanticsBinding.instance.ensureSemantics();
     await smokeGallery(tester);
-    RendererBinding.instance.setSemanticsEnabled(false);
+    handle.dispose();
   });
 }

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -21,7 +21,7 @@ mixin SemanticsBinding on BindingBase {
     platformDispatcher
       ..onSemanticsEnabledChanged = _handleSemanticsEnabledChanged
       ..onSemanticsAction = _handleSemanticsAction
-      ..onAccessibilityFeaturesChanged = _handleAccessibilityFeaturesChanged;
+      ..onAccessibilityFeaturesChanged = handleAccessibilityFeaturesChanged;
     _handleSemanticsEnabledChanged();
   }
 
@@ -129,11 +129,6 @@ mixin SemanticsBinding on BindingBase {
   @protected
   void performSemanticsAction(SemanticsActionEvent action);
 
-  void _handleAccessibilityFeaturesChanged() {
-    _accessibilityFeatures = platformDispatcher.accessibilityFeatures;
-    handleAccessibilityFeaturesChanged();
-  }
-
   /// The currently active set of [AccessibilityFeatures].
   ///
   /// This is set when the binding is first initialized and updated whenever a
@@ -149,8 +144,9 @@ mixin SemanticsBinding on BindingBase {
   ///
   /// See [dart:ui.PlatformDispatcher.onAccessibilityFeaturesChanged].
   @protected
+  @mustCallSuper
   void handleAccessibilityFeaturesChanged() {
-    // Nothing to do by default.
+    _accessibilityFeatures = platformDispatcher.accessibilityFeatures;
   }
 
   /// Creates an empty semantics update builder.

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -114,7 +114,7 @@ mixin SemanticsBinding on BindingBase {
     ));
   }
 
-  /// Called  whenever the platform requests an action to be performed on a
+  /// Called whenever the platform requests an action to be performed on a
   /// [SemanticsNode].
   ///
   /// This callback is invoked when a user interacts with the app via an

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -182,7 +182,7 @@ mixin SemanticsBinding on BindingBase {
 /// An event to request a [SemanticsAction] of [type] to be performed on the
 /// [SemanticsNode] identified by [nodeId].
 ///
-/// Used by [SemanticsBinding.performAction].
+/// Used by [SemanticsBinding.performSemanticsAction].
 @immutable
 class SemanticsActionEvent {
   /// Creates a [SemanticsActionEvent].

--- a/packages/flutter/lib/src/semantics/binding.dart
+++ b/packages/flutter/lib/src/semantics/binding.dart
@@ -2,22 +2,27 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui' as ui show AccessibilityFeatures, SemanticsUpdateBuilder;
+import 'dart:ui' as ui show AccessibilityFeatures, SemanticsAction, SemanticsUpdateBuilder;
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 
 import 'debug.dart';
 
 export 'dart:ui' show AccessibilityFeatures, SemanticsUpdateBuilder;
 
 /// The glue between the semantics layer and the Flutter engine.
-// TODO(zanderso): move the remaining semantic related bindings here.
 mixin SemanticsBinding on BindingBase {
   @override
   void initInstances() {
     super.initInstances();
     _instance = this;
     _accessibilityFeatures = platformDispatcher.accessibilityFeatures;
+    platformDispatcher
+      ..onSemanticsEnabledChanged = _handleSemanticsEnabledChanged
+      ..onSemanticsAction = _handleSemanticsAction
+      ..onAccessibilityFeaturesChanged = _handleAccessibilityFeaturesChanged;
+    _handleSemanticsEnabledChanged();
   }
 
   /// The current [SemanticsBinding], if one has been created.
@@ -28,12 +33,124 @@ mixin SemanticsBinding on BindingBase {
   static SemanticsBinding get instance => BindingBase.checkInstance(_instance);
   static SemanticsBinding? _instance;
 
+  /// Whether semantics information must be collected.
+  ///
+  /// Returns true if either the platform has requested semantics information
+  /// to be generated or if [ensureSemantics] has been called otherwise.
+  ///
+  /// To get notified when this value changes register a listener with
+  /// [addSemanticsEnabledListener].
+  bool get semanticsEnabled {
+    assert(_semanticsEnabled.value == (_outstandingHandles > 0));
+    return _semanticsEnabled.value;
+  }
+  late final ValueNotifier<bool> _semanticsEnabled = ValueNotifier<bool>(platformDispatcher.semanticsEnabled);
+
+  /// Adds a `listener` to be called when [semanticsEnabled] changes.
+  ///
+  /// See also:
+  ///
+  ///  * [removeSemanticsEnabledListener] to remove the listener again.
+  ///  * [ValueNotifier.addListener], which documents how and when listeners are
+  ///    called.
+  void addSemanticsEnabledListener(VoidCallback listener) {
+    _semanticsEnabled.addListener(listener);
+  }
+
+  /// Removes a `listener` added by [addSemanticsEnabledListener].
+  ///
+  /// See also:
+  ///
+  ///  * [ValueNotifier.removeListener], which documents how listeners are
+  ///    removed.
+  void removeSemanticsEnabledListener(VoidCallback listener) {
+    _semanticsEnabled.removeListener(listener);
+  }
+
+  int _outstandingHandles = 0;
+
+  /// Creates a new [SemanticsHandle] and requests the collection of semantics
+  /// information.
+  ///
+  /// Semantics information are only collected when there are clients interested
+  /// in them. These clients express their interest by holding a
+  /// [SemanticsHandle].
+  ///
+  /// Clients can close their [SemanticsHandle] by calling
+  /// [SemanticsHandle.dispose]. Once all outstanding [SemanticsHandle] objects
+  /// are closed, semantics information are no longer collected.
+  SemanticsHandle ensureSemantics() {
+    assert(_outstandingHandles >= 0);
+    _outstandingHandles++;
+    assert(_outstandingHandles > 0);
+    _semanticsEnabled.value = true;
+    return SemanticsHandle._(_didDisposeSemanticsHandle);
+  }
+
+  void _didDisposeSemanticsHandle() {
+    assert(_outstandingHandles > 0);
+    _outstandingHandles--;
+    assert(_outstandingHandles >= 0);
+    _semanticsEnabled.value = _outstandingHandles > 0;
+  }
+
+  // Handle for semantics request from the platform.
+  SemanticsHandle? _semanticsHandle;
+
+  void _handleSemanticsEnabledChanged() {
+    if (platformDispatcher.semanticsEnabled) {
+      _semanticsHandle ??= ensureSemantics();
+    } else {
+      _semanticsHandle?.dispose();
+      _semanticsHandle = null;
+    }
+  }
+
+  void _handleSemanticsAction(int id, ui.SemanticsAction action, ByteData? args) {
+    performSemanticsAction(SemanticsActionEvent(
+      nodeId: id,
+      type: action,
+      arguments: args != null ? const StandardMessageCodec().decodeMessage(args) : null,
+    ));
+  }
+
+  /// Called  whenever the platform requests an action to be performed on a
+  /// [SemanticsNode].
+  ///
+  /// This callback is invoked when a user interacts with the app via an
+  /// accessibility service (e.g. TalkBack and VoiceOver) and initiates an
+  /// action on the focused node.
+  ///
+  /// Bindings that mixin the [SemanticsBinding] must implement this method and
+  /// perform the given `action` on the [SemanticsNode] specified by
+  /// [SemanticsActionEvent.nodeId].
+  ///
+  /// See [dart:ui.PlatformDispatcher.onSemanticsAction].
+  @protected
+  void performSemanticsAction(SemanticsActionEvent action);
+
+  void _handleAccessibilityFeaturesChanged() {
+    _accessibilityFeatures = platformDispatcher.accessibilityFeatures;
+    handleAccessibilityFeaturesChanged();
+  }
+
+  /// The currently active set of [AccessibilityFeatures].
+  ///
+  /// This is set when the binding is first initialized and updated whenever a
+  /// flag is changed.
+  ///
+  /// To listen to changes to accessibility features, create a
+  /// [WidgetsBindingObserver] and listen to
+  /// [WidgetsBindingObserver.didChangeAccessibilityFeatures].
+  ui.AccessibilityFeatures get accessibilityFeatures => _accessibilityFeatures;
+  late ui.AccessibilityFeatures _accessibilityFeatures;
+
   /// Called when the platform accessibility features change.
   ///
   /// See [dart:ui.PlatformDispatcher.onAccessibilityFeaturesChanged].
   @protected
   void handleAccessibilityFeaturesChanged() {
-    _accessibilityFeatures = platformDispatcher.accessibilityFeatures;
+    // Nothing to do by default.
   }
 
   /// Creates an empty semantics update builder.
@@ -45,17 +162,6 @@ mixin SemanticsBinding on BindingBase {
   ui.SemanticsUpdateBuilder createSemanticsUpdateBuilder() {
     return ui.SemanticsUpdateBuilder();
   }
-
-  /// The currently active set of [AccessibilityFeatures].
-  ///
-  /// This is initialized the first time [runApp] is called and updated whenever
-  /// a flag is changed.
-  ///
-  /// To listen to changes to accessibility features, create a
-  /// [WidgetsBindingObserver] and listen to
-  /// [WidgetsBindingObserver.didChangeAccessibilityFeatures].
-  ui.AccessibilityFeatures get accessibilityFeatures => _accessibilityFeatures;
-  late ui.AccessibilityFeatures _accessibilityFeatures;
 
   /// The platform is requesting that animations be disabled or simplified.
   ///
@@ -70,5 +176,51 @@ mixin SemanticsBinding on BindingBase {
       return true;
     }());
     return value;
+  }
+}
+
+/// An event to request a [SemanticsAction] of [type] to be performed on the
+/// [SemanticsNode] identified by [nodeId].
+///
+/// Used by [SemanticsBinding.performAction].
+@immutable
+class SemanticsActionEvent {
+  /// Creates a [SemanticsActionEvent].
+  ///
+  /// The [type] and [nodeId] are required.
+  const SemanticsActionEvent({required this.type, required this.nodeId, this.arguments});
+
+  /// The type of action to be performed.
+  final ui.SemanticsAction type;
+
+  /// The id of the [SemanticsNode] on which the action is to be performed.
+  final int nodeId;
+
+  /// Optional arguments for the action.
+  final Object? arguments;
+}
+
+/// A reference to the semantics information generated by the framework.
+///
+/// Semantics information are only collected when there are clients interested
+/// in them. These clients express their interest by holding a
+/// [SemanticsHandle]. When the client no longer needs the
+/// semantics information, it must call [dispose] on the [SemanticsHandle] to
+/// close it. When all open [SemanticsHandle]s are disposed, the framework will
+/// stop updating the semantics information.
+///
+/// To obtain a [SemanticsHandle], call [SemanticsBinding.ensureSemantics].
+class SemanticsHandle {
+  SemanticsHandle._(this._onDispose);
+
+  final VoidCallback _onDispose;
+
+  /// Closes the semantics handle.
+  ///
+  /// When all the outstanding [SemanticsHandle] objects are closed, the
+  /// framework will stop generating semantics information.
+  @mustCallSuper
+  void dispose() {
+    _onDispose();
   }
 }

--- a/packages/flutter/lib/src/semantics/semantics.dart
+++ b/packages/flutter/lib/src/semantics/semantics.dart
@@ -3129,9 +3129,9 @@ class _TraversalSortNode implements Comparable<_TraversalSortNode> {
 /// Owns [SemanticsNode] objects and notifies listeners of changes to the
 /// render tree semantics.
 ///
-/// To listen for semantic updates, call [PipelineOwner.ensureSemantics] to
-/// obtain a [SemanticsHandle]. This will create a [SemanticsOwner] if
-/// necessary.
+/// To listen for semantic updates, call [SemanticsBinding.ensureSemantics] or
+/// [PipelineOwner.ensureSemantics] to obtain a [SemanticsHandle]. This will
+/// create a [SemanticsOwner] if necessary.
 class SemanticsOwner extends ChangeNotifier {
   /// Creates a [SemanticsOwner] that manages zero or more [SemanticsNode] objects.
   SemanticsOwner({

--- a/packages/flutter/lib/src/widgets/binding.dart
+++ b/packages/flutter/lib/src/widgets/binding.dart
@@ -260,7 +260,6 @@ mixin WidgetsBinding on BindingBase, ServicesBinding, SchedulerBinding, GestureB
     _buildOwner = BuildOwner();
     buildOwner!.onBuildScheduled = _handleBuildScheduled;
     platformDispatcher.onLocaleChanged = handleLocaleChanged;
-    platformDispatcher.onAccessibilityFeaturesChanged = handleAccessibilityFeaturesChanged;
     SystemChannels.navigation.setMethodCallHandler(_handleNavigationInvocation);
     assert(() {
       FlutterErrorDetails.propertiesTransformers.add(debugTransformDebugCreator);

--- a/packages/flutter/test/semantics/semantics_binding_test.dart
+++ b/packages/flutter/test/semantics/semantics_binding_test.dart
@@ -1,0 +1,84 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('Listeners are called when semantics are turned on with ensureSemantics', (WidgetTester tester) async {
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+
+    final List<bool> status = <bool>[];
+    void listener() {
+      status.add(SemanticsBinding.instance.semanticsEnabled);
+    }
+
+    SemanticsBinding.instance.addSemanticsEnabledListener(listener);
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+
+    final SemanticsHandle handle1 = SemanticsBinding.instance.ensureSemantics();
+    expect(status.single, isTrue);
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+    status.clear();
+
+    final SemanticsHandle handle2 = SemanticsBinding.instance.ensureSemantics();
+    expect(status, isEmpty); // Listener didn't fire again.
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+
+    expect(tester.binding.platformDispatcher.semanticsEnabled, isFalse);
+    tester.binding.platformDispatcher.semanticsEnabledTestValue = true;
+    expect(tester.binding.platformDispatcher.semanticsEnabled, isTrue);
+    tester.binding.platformDispatcher.clearSemanticsEnabledTestValue();
+    expect(tester.binding.platformDispatcher.semanticsEnabled, isFalse);
+    expect(status, isEmpty); // Listener didn't fire again.
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+
+    handle1.dispose();
+    expect(status, isEmpty); // Listener didn't fire.
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+
+    handle2.dispose();
+    expect(status.single, isFalse);
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+  }, semanticsEnabled: false);
+
+  testWidgets('Listeners are called when semantics are turned on by platform', (WidgetTester tester) async {
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+
+    final List<bool> status = <bool>[];
+    void listener() {
+      status.add(SemanticsBinding.instance.semanticsEnabled);
+    }
+
+    SemanticsBinding.instance.addSemanticsEnabledListener(listener);
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+
+    tester.binding.platformDispatcher.semanticsEnabledTestValue = true;
+    expect(status.single, isTrue);
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+    status.clear();
+
+    final SemanticsHandle handle = SemanticsBinding.instance.ensureSemantics();
+    handle.dispose();
+    expect(status, isEmpty); // Listener didn't fire.
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+
+    tester.binding.platformDispatcher.clearSemanticsEnabledTestValue();
+    expect(status.single, isFalse);
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+  }, semanticsEnabled: false);
+
+  testWidgets('SemanticsBinding.ensureSemantics triggers creation of semantics owner.', (WidgetTester tester) async {
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+    expect(tester.binding.pipelineOwner.semanticsOwner, isNull);
+
+    final SemanticsHandle handle = SemanticsBinding.instance.ensureSemantics();
+    expect(SemanticsBinding.instance.semanticsEnabled, isTrue);
+    expect(tester.binding.pipelineOwner.semanticsOwner, isNotNull);
+
+    handle.dispose();
+    expect(SemanticsBinding.instance.semanticsEnabled, isFalse);
+    expect(tester.binding.pipelineOwner.semanticsOwner, isNull);
+  }, semanticsEnabled: false);
+}

--- a/packages/flutter/test/widgets/binding_cannot_schedule_frame_test.dart
+++ b/packages/flutter/test/widgets/binding_cannot_schedule_frame_test.dart
@@ -18,7 +18,9 @@ void main() {
 
     // Enables the semantics should not schedule any frames if the root widget
     // has not been attached.
-    binding.setSemanticsEnabled(true);
+    expect(binding.semanticsEnabled, isFalse);
+    binding.ensureSemantics();
+    expect(binding.semanticsEnabled, isTrue);
     expect(SchedulerBinding.instance.framesEnabled, isFalse);
     expect(SchedulerBinding.instance.hasScheduledFrame, isFalse);
 

--- a/packages/flutter_driver/lib/src/common/handler_factory.dart
+++ b/packages/flutter_driver/lib/src/common/handler_factory.dart
@@ -443,13 +443,13 @@ mixin CommandHandlerFactory {
   }
 
   SemanticsHandle? _semantics;
-  bool get _semanticsIsEnabled => RendererBinding.instance.pipelineOwner.semanticsOwner != null;
+  bool get _semanticsIsEnabled => SemanticsBinding.instance.semanticsEnabled;
 
   Future<SetSemanticsResult> _setSemantics(Command command) async {
     final SetSemantics setSemanticsCommand = command as SetSemantics;
     final bool semanticsWasEnabled = _semanticsIsEnabled;
     if (setSemanticsCommand.enabled && _semantics == null) {
-      _semantics = RendererBinding.instance.pipelineOwner.ensureSemantics();
+      _semantics = SemanticsBinding.instance.ensureSemantics();
       if (!semanticsWasEnabled) {
         // wait for the first frame where semantics is enabled.
         final Completer<void> completer = Completer<void>();

--- a/packages/flutter_test/lib/src/controller.dart
+++ b/packages/flutter_test/lib/src/controller.dart
@@ -72,7 +72,7 @@ class SemanticsController {
   /// if no semantics are found or are not enabled.
   SemanticsNode find(Finder finder) {
     TestAsyncUtils.guardSync();
-    if (_binding.pipelineOwner.semanticsOwner == null) {
+    if (!_binding.semanticsEnabled) {
       throw StateError('Semantics are not enabled.');
     }
     final Iterable<Element> candidates = finder.evaluate();
@@ -241,7 +241,7 @@ abstract class WidgetController {
   /// use of the [Semantics] tree to determine the meaning of an application.
   /// If semantics has been disabled for the test, this will throw a [StateError].
   SemanticsController get semantics {
-    if (binding.pipelineOwner.semanticsOwner == null) {
+    if (!binding.semanticsEnabled) {
       throw StateError(
         'Semantics are not enabled. Enable them by passing '
         '`semanticsEnabled: true` to `testWidgets`, or by manually creating a '
@@ -1491,7 +1491,7 @@ abstract class WidgetController {
   ///
   /// The handle must be disposed at the end of the test.
   SemanticsHandle ensureSemantics() {
-    return binding.pipelineOwner.ensureSemantics();
+    return binding.ensureSemantics();
   }
 
   /// Given a widget `W` specified by [finder] and a [Scrollable] widget `S` in

--- a/packages/flutter_test/lib/src/finders.dart
+++ b/packages/flutter_test/lib/src/finders.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' show Tooltip;
+import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import 'all_elements.dart';
@@ -435,7 +435,7 @@ class CommonFinders {
   /// If the `skipOffstage` argument is true (the default), then this skips
   /// nodes that are [Offstage] or that are from inactive [Route]s.
   Finder bySemanticsLabel(Pattern label, { bool skipOffstage = true }) {
-    if (WidgetsBinding.instance.pipelineOwner.semanticsOwner == null) {
+    if (!SemanticsBinding.instance.semanticsEnabled) {
       throw StateError('Semantics are not enabled. '
                        'Make sure to call tester.ensureSemantics() before using '
                        'this finder, and call dispose on its return value after.');


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/121573.

Moves all the semantics related stuff out of the other bindings into `SemanticsBinding` where it belongs (see TODO fixed by this change). We added support for generating semantics information before we saw the need for a dedicated `SemanticsBinding`. That's why semantics related stuff was found in all the other bindings. This change cleans that up.

Furthermore, it also makes the `SemanticsBinding` the source of truth of whether semantics information should be generated for the entire app. For this, it introduces a new `semanticsEnabled` getter (with the option to register listeners for when that value changes) and a new `ensureSemantics` method, which clients can use to turn on semantics globally. Previously, this was all handled by the `PipelineOwner`. However, in the multi view world we will have multiple `PipelineOwner`s (one to power each view), so a single source of truth to synchronize the semantics of all these `PipelineOwner`s is needed.