### PR TITLE
Added identical(a,b) short circuit to painting Library lerp methods

### DIFF
--- a/packages/flutter/lib/src/painting/alignment.dart
+++ b/packages/flutter/lib/src/painting/alignment.dart
@@ -87,8 +87,8 @@ abstract class AlignmentGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static AlignmentGeometry? lerp(AlignmentGeometry? a, AlignmentGeometry? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;
@@ -337,8 +337,8 @@ class Alignment extends AlignmentGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static Alignment? lerp(Alignment? a, Alignment? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return Alignment(ui.lerpDouble(0.0, b!.x, t)!, ui.lerpDouble(0.0, b.y, t)!);
@@ -528,8 +528,8 @@ class AlignmentDirectional extends AlignmentGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static AlignmentDirectional? lerp(AlignmentDirectional? a, AlignmentDirectional? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return AlignmentDirectional(ui.lerpDouble(0.0, b!.start, t)!, ui.lerpDouble(0.0, b.y, t)!);

--- a/packages/flutter/lib/src/painting/border_radius.dart
+++ b/packages/flutter/lib/src/painting/border_radius.dart
@@ -129,8 +129,8 @@ abstract class BorderRadiusGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BorderRadiusGeometry? lerp(BorderRadiusGeometry? a, BorderRadiusGeometry? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     a ??= BorderRadius.zero;
     b ??= BorderRadius.zero;
@@ -506,8 +506,8 @@ class BorderRadius extends BorderRadiusGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BorderRadius? lerp(BorderRadius? a, BorderRadius? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;
@@ -727,8 +727,8 @@ class BorderRadiusDirectional extends BorderRadiusGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BorderRadiusDirectional? lerp(BorderRadiusDirectional? a, BorderRadiusDirectional? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;

--- a/packages/flutter/lib/src/painting/borders.dart
+++ b/packages/flutter/lib/src/painting/borders.dart
@@ -260,6 +260,9 @@ class BorderSide with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BorderSide lerp(BorderSide a, BorderSide b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     if (t == 0.0) {
       return a;
     }
@@ -519,6 +522,9 @@ abstract class ShapeBorder {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static ShapeBorder? lerp(ShapeBorder? a, ShapeBorder? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     ShapeBorder? result;
     if (b != null) {
       result = b.lerpFrom(a, t);
@@ -708,6 +714,9 @@ abstract class OutlinedBorder extends ShapeBorder {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static OutlinedBorder? lerp(OutlinedBorder? a, OutlinedBorder? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     ShapeBorder? result;
     if (b != null) {
       result = b.lerpFrom(a, t);

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -103,6 +103,9 @@ abstract class BoxBorder extends ShapeBorder {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BoxBorder? lerp(BoxBorder? a, BoxBorder? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     if ((a is Border?) && (b is Border?)) {
       return Border.lerp(a, b, t);
     }
@@ -469,8 +472,8 @@ class Border extends BoxBorder {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static Border? lerp(Border? a, Border? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);
@@ -811,8 +814,8 @@ class BorderDirectional extends BoxBorder {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BorderDirectional? lerp(BorderDirectional? a, BorderDirectional? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);

--- a/packages/flutter/lib/src/painting/box_decoration.dart
+++ b/packages/flutter/lib/src/painting/box_decoration.dart
@@ -288,8 +288,8 @@ class BoxDecoration extends Decoration {
   ///    and which use [BoxDecoration.lerp] when interpolating two
   ///    [BoxDecoration]s or a [BoxDecoration] to or from null.
   static BoxDecoration? lerp(BoxDecoration? a, BoxDecoration? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);

--- a/packages/flutter/lib/src/painting/box_shadow.dart
+++ b/packages/flutter/lib/src/painting/box_shadow.dart
@@ -86,8 +86,8 @@ class BoxShadow extends ui.Shadow {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BoxShadow? lerp(BoxShadow? a, BoxShadow? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);
@@ -110,8 +110,8 @@ class BoxShadow extends ui.Shadow {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static List<BoxShadow>? lerpList(List<BoxShadow>? a, List<BoxShadow>? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     a ??= <BoxShadow>[];
     b ??= <BoxShadow>[];

--- a/packages/flutter/lib/src/painting/colors.dart
+++ b/packages/flutter/lib/src/painting/colors.dart
@@ -194,8 +194,8 @@ class HSVColor {
   ///
   /// Values outside of the valid range for each channel will be clamped.
   static HSVColor? lerp(HSVColor? a, HSVColor? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!._scaleAlpha(t);
@@ -377,8 +377,8 @@ class HSLColor {
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
   static HSLColor? lerp(HSLColor? a, HSLColor? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!._scaleAlpha(t);
@@ -479,13 +479,12 @@ class ColorSwatch<T> extends Color {
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
   static ColorSwatch<T>? lerp<T>(ColorSwatch<T>? a, ColorSwatch<T>? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     final Map<T, Color> swatch;
     if (b == null) {
-      if (a == null) {
-        return null;
-      } else {
-        swatch = a._swatch.map((T key, Color color) => MapEntry<T, Color>(key, Color.lerp(color, null, t)!));
-      }
+      swatch = a!._swatch.map((T key, Color color) => MapEntry<T, Color>(key, Color.lerp(color, null, t)!));
     } else {
       if (a == null) {
         swatch = b._swatch.map((T key, Color color) => MapEntry<T, Color>(key, Color.lerp(null, color, t)!));

--- a/packages/flutter/lib/src/painting/decoration.dart
+++ b/packages/flutter/lib/src/painting/decoration.dart
@@ -129,8 +129,8 @@ abstract class Decoration with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static Decoration? lerp(Decoration? a, Decoration? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.lerpFrom(null, t) ?? b;

--- a/packages/flutter/lib/src/painting/edge_insets.dart
+++ b/packages/flutter/lib/src/painting/edge_insets.dart
@@ -215,8 +215,8 @@ abstract class EdgeInsetsGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static EdgeInsetsGeometry? lerp(EdgeInsetsGeometry? a, EdgeInsetsGeometry? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;
@@ -611,8 +611,8 @@ class EdgeInsets extends EdgeInsetsGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static EdgeInsets? lerp(EdgeInsets? a, EdgeInsets? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;
@@ -877,8 +877,8 @@ class EdgeInsetsDirectional extends EdgeInsetsGeometry {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static EdgeInsetsDirectional? lerp(EdgeInsetsDirectional? a, EdgeInsetsDirectional? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;

--- a/packages/flutter/lib/src/painting/flutter_logo.dart
+++ b/packages/flutter/lib/src/painting/flutter_logo.dart
@@ -101,8 +101,8 @@ class FlutterLogoDecoration extends Decoration {
   static FlutterLogoDecoration? lerp(FlutterLogoDecoration? a, FlutterLogoDecoration? b, double t) {
     assert(a == null || a.debugAssertIsValid());
     assert(b == null || b.debugAssertIsValid());
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return FlutterLogoDecoration._(

--- a/packages/flutter/lib/src/painting/fractional_offset.dart
+++ b/packages/flutter/lib/src/painting/fractional_offset.dart
@@ -176,8 +176,8 @@ class FractionalOffset extends Alignment {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static FractionalOffset? lerp(FractionalOffset? a, FractionalOffset? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return FractionalOffset(ui.lerpDouble(0.5, b!.dx, t)!, ui.lerpDouble(0.5, b.dy, t)!);

--- a/packages/flutter/lib/src/painting/gradient.dart
+++ b/packages/flutter/lib/src/painting/gradient.dart
@@ -307,6 +307,9 @@ abstract class Gradient {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static Gradient? lerp(Gradient? a, Gradient? b, double t) {
+    if (identical(a, b)) {
+      return a;
+    }
     Gradient? result;
     if (b != null) {
       result = b.lerpFrom(a, t); // if a is null, this must return non-null
@@ -316,9 +319,6 @@ abstract class Gradient {
     }
     if (result != null) {
       return result;
-    }
-    if (a == null && b == null) {
-      return null;
     }
     assert(a != null && b != null);
     return t < 0.5 ? a!.scale(1.0 - (t * 2.0)) : b!.scale((t - 0.5) * 2.0);
@@ -486,8 +486,8 @@ class LinearGradient extends Gradient {
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
   static LinearGradient? lerp(LinearGradient? a, LinearGradient? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);
@@ -765,8 +765,8 @@ class RadialGradient extends Gradient {
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
   static RadialGradient? lerp(RadialGradient? a, RadialGradient? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);
@@ -1032,8 +1032,8 @@ class SweepGradient extends Gradient {
   /// Values for `t` are usually obtained from an [Animation<double>], such as
   /// an [AnimationController].
   static SweepGradient? lerp(SweepGradient? a, SweepGradient? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);

--- a/packages/flutter/lib/src/painting/linear_border.dart
+++ b/packages/flutter/lib/src/painting/linear_border.dart
@@ -59,8 +59,8 @@ class LinearBorderEdge {
   /// is null then we interpolate from `a` varying size from `a.size` to zero.
   /// Otherwise both values are interpolated.
   static LinearBorderEdge? lerp(LinearBorderEdge? a, LinearBorderEdge? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
 
     a ??= LinearBorderEdge(alignment: b!.alignment, size: 0);

--- a/packages/flutter/lib/src/painting/shape_decoration.dart
+++ b/packages/flutter/lib/src/painting/shape_decoration.dart
@@ -225,8 +225,8 @@ class ShapeDecoration extends Decoration {
   ///    and which use [ShapeDecoration.lerp] when interpolating two
   ///    [ShapeDecoration]s or a [ShapeDecoration] to or from null.
   static ShapeDecoration? lerp(ShapeDecoration? a, ShapeDecoration? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a != null && b != null) {
       if (t == 0.0) {

--- a/packages/flutter/lib/src/painting/text_style.dart
+++ b/packages/flutter/lib/src/painting/text_style.dart
@@ -1094,10 +1094,9 @@ class TextStyle with Diagnosticable {
   /// as if they have a [background] paint (creating a new [Paint] if necessary
   /// based on the [backgroundColor] property).
   static TextStyle? lerp(TextStyle? a, TextStyle? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
-
     String? lerpDebugLabel;
     assert(() {
       lerpDebugLabel = 'lerp(${a?.debugLabel ?? _kDefaultDebugLabel} ⎯${t.toStringAsFixed(1)}→ ${b?.debugLabel ?? _kDefaultDebugLabel})';

--- a/packages/flutter/test/painting/alignment_test.dart
+++ b/packages/flutter/test/painting/alignment_test.dart
@@ -34,6 +34,24 @@ void main() {
     expect(Alignment.lerp(a, null, 0.25), equals(const Alignment(-0.75, -0.75)));
   });
 
+  test('Alignment.lerp identical a,b', () {
+    expect(Alignment.lerp(null, null, 0), null);
+    const Alignment alignment = Alignment.topLeft;
+    expect(identical(Alignment.lerp(alignment, alignment, 0.5), alignment), true);
+  });
+
+  test('AlignmentGeometry.lerp identical a,b', () {
+    expect(AlignmentGeometry.lerp(null, null, 0), null);
+    const AlignmentGeometry alignment = Alignment.topLeft;
+    expect(identical(AlignmentGeometry.lerp(alignment, alignment, 0.5), alignment), true);
+  });
+
+  test('AlignmentDirectional.lerp identical a,b', () {
+    expect(AlignmentDirectional.lerp(null, null, 0), null);
+    const AlignmentDirectional alignment = AlignmentDirectional.topStart;
+    expect(identical(AlignmentDirectional.lerp(alignment, alignment, 0.5), alignment), true);
+  });
+
   test('AlignmentGeometry invariants', () {
     const AlignmentDirectional topStart = AlignmentDirectional.topStart;
     const AlignmentDirectional topEnd = AlignmentDirectional.topEnd;

--- a/packages/flutter/test/painting/border_radius_test.dart
+++ b/packages/flutter/test/painting/border_radius_test.dart
@@ -139,6 +139,12 @@ void main() {
     expect(BorderRadius.lerp(a, null, 0.25), equals(a * 0.75));
   });
 
+  test('BorderRadius.lerp identical a,b', () {
+    expect(BorderRadius.lerp(null, null, 0), null);
+    const BorderRadius border = BorderRadius.zero;
+    expect(identical(BorderRadius.lerp(border, border, 0.5), border), true);
+  });
+
   test('BorderRadius.lerp() crazy', () {
     const BorderRadius a = BorderRadius.only(
       topLeft: Radius.elliptical(10.0, 20.0),
@@ -314,6 +320,12 @@ void main() {
     expect(BorderRadiusDirectional.lerp(a, null, 0.25), equals(a * 0.75));
   });
 
+  test('BorderRadiusDirectional.lerp identical a,b', () {
+    expect(BorderRadiusDirectional.lerp(null, null, 0), null);
+    const BorderRadiusDirectional border = BorderRadiusDirectional.zero;
+    expect(identical(BorderRadiusDirectional.lerp(border, border, 0.5), border), true);
+  });
+
   test('BorderRadiusDirectional.lerp() crazy', () {
     const BorderRadiusDirectional a = BorderRadiusDirectional.only(
       topStart: Radius.elliptical(10.0, 20.0),
@@ -361,6 +373,12 @@ void main() {
     expect(BorderRadiusGeometry.lerp(a, b, 0.5)!.resolve(TextDirection.rtl), rtl);
     expect(BorderRadiusGeometry.lerp(a, b, 0.0)!.resolve(TextDirection.ltr), a);
     expect(BorderRadiusGeometry.lerp(a, b, 1.0)!.resolve(TextDirection.rtl), b.resolve(TextDirection.rtl));
+  });
+
+  test('BorderRadiusGeometry.lerp identical a,b', () {
+    expect(BorderRadiusDirectional.lerp(null, null, 0), null);
+    const BorderRadiusGeometry border = BorderRadius.zero;
+    expect(identical(BorderRadiusGeometry.lerp(border, border, 0.5), border), true);
   });
 
   test('BorderRadiusGeometry subtract', () {

--- a/packages/flutter/test/painting/border_side_test.dart
+++ b/packages/flutter/test/painting/border_side_test.dart
@@ -106,6 +106,10 @@ void main() {
     expect(paint2.color, const Color(0x00000000));
     expect(paint2.blendMode, BlendMode.srcOver);
   });
+  test('BorderSide - lerp identical a,b', () {
+    const BorderSide border = BorderSide();
+    expect(identical(BorderSide.lerp(border, border, 0.5), border), true);
+  });
   test("BorderSide - won't lerp into negative widths", () {
     const BorderSide side0 = BorderSide(width: 0.0);
     const BorderSide side1 = BorderSide();

--- a/packages/flutter/test/painting/box_decoration_test.dart
+++ b/packages/flutter/test/painting/box_decoration_test.dart
@@ -8,6 +8,12 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
+  test('BoxDecoration.lerp identical a,b', () {
+    expect(BoxDecoration.lerp(null, null, 0), null);
+    const BoxDecoration decoration = BoxDecoration();
+    expect(identical(BoxDecoration.lerp(decoration, decoration, 0.5), decoration), true);
+  });
+
   test('BoxDecoration with BorderRadiusDirectional', () {
     const BoxDecoration decoration = BoxDecoration(
       color: Color(0xFF000000),

--- a/packages/flutter/test/painting/box_painter_test.dart
+++ b/packages/flutter/test/painting/box_painter_test.dart
@@ -111,6 +111,18 @@ void main() {
     expect(shadowList, equals(<BoxShadow>[shadow4, shadow1.scale(0.5)]));
   });
 
+  test('BoxShadow.lerp identical a,b', () {
+    expect(BoxShadow.lerp(null, null, 0), null);
+    const BoxShadow border = BoxShadow();
+    expect(identical(BoxShadow.lerp(border, border, 0.5), border), true);
+  });
+
+  test('BoxShadowList.lerp identical a,b', () {
+    expect(BoxShadow.lerpList(null, null, 0), null);
+    const List<BoxShadow> border = <BoxShadow>[BoxShadow()];
+    expect(identical(BoxShadow.lerpList(border, border, 0.5), border), true);
+  });
+
   test('BoxShadow BlurStyle test', () {
     const BoxShadow shadow1 = BoxShadow(blurRadius: 4.0);
     const BoxShadow shadow2 = BoxShadow(blurRadius: 4.0, blurStyle: BlurStyle.outer);

--- a/packages/flutter/test/painting/colors_test.dart
+++ b/packages/flutter/test/painting/colors_test.dart
@@ -120,6 +120,12 @@ void main() {
     expect(output, equals(expectedColors));
   });
 
+  test('HSVColor.lerp identical a,b', () {
+    expect(HSVColor.lerp(null, null, 0), null);
+    const HSVColor color = HSVColor.fromAHSV(1.0, 0.0, 1.0, 1.0);
+    expect(identical(HSVColor.lerp(color, color, 0.5), color), true);
+  });
+
   test('HSVColor lerps hue correctly.', () {
     final List<Color> output = <Color>[];
     const HSVColor startColor = HSVColor.fromAHSV(1.0, 0.0, 1.0, 1.0);
@@ -315,6 +321,12 @@ void main() {
     expect(output, equals(expectedColors));
   });
 
+  test('HSLColor.lerp identical a,b', () {
+    expect(HSLColor.lerp(null, null, 0), null);
+    const HSLColor color = HSLColor.fromAHSL(1.0, 0.0, 0.5, 0.5);
+    expect(identical(HSLColor.lerp(color, color, 0.5), color), true);
+  });
+
   test('HSLColor lerps hue correctly.', () {
     final List<Color> output = <Color>[];
     const HSLColor startColor = HSLColor.fromAHSL(1.0, 0.0, 0.5, 0.5);
@@ -449,6 +461,12 @@ void main() {
       ColorSwatch.lerp(swatchA, swatchB, 1.1),
       const ColorSwatch<int>(0xFFFFFFFF, <int, Color>{1: Color(0xFFFFFFFF)}),
     );
+  });
+
+  test('ColorSwatch.lerp identical a,b', () {
+    expect(ColorSwatch.lerp(null, null, 0), null);
+    const ColorSwatch<int> color = ColorSwatch<int>(0x00000000, <int, Color>{1: Color(0x00000000)});
+    expect(identical(ColorSwatch.lerp(color, color, 0.5), color), true);
   });
 
   test('ColorDiagnosticsProperty includes valueProperties in JSON', () {

--- a/packages/flutter/test/painting/decoration_test.dart
+++ b/packages/flutter/test/painting/decoration_test.dart
@@ -143,6 +143,12 @@ void main() {
     expect(c.color, equals(b.color));
   });
 
+  test('Decoration.lerp identical a,b', () {
+    expect(Decoration.lerp(null, null, 0), null);
+    const Decoration decoration = BoxDecoration();
+    expect(identical(Decoration.lerp(decoration, decoration, 0.5), decoration), true);
+  });
+
   test('Decoration equality', () {
     const BoxDecoration a = BoxDecoration(
       color: Color(0xFFFFFFFF),

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -117,7 +117,6 @@ void main() {
     expect(EdgeInsets.lerp(null, null, 0), null);
     const EdgeInsets insets = EdgeInsets.zero;
     expect(identical(EdgeInsets.lerp(insets, insets, 0.5), insets), true);
-
   });
 
   test('EdgeInsets.resolve()', () {

--- a/packages/flutter/test/painting/edge_insets_test.dart
+++ b/packages/flutter/test/painting/edge_insets_test.dart
@@ -113,6 +113,13 @@ void main() {
     expect(EdgeInsets.lerp(a, null, 0.25), equals(a * 0.75));
   });
 
+  test('EdgeInsets.lerp identical a,b', () {
+    expect(EdgeInsets.lerp(null, null, 0), null);
+    const EdgeInsets insets = EdgeInsets.zero;
+    expect(identical(EdgeInsets.lerp(insets, insets, 0.5), insets), true);
+
+  });
+
   test('EdgeInsets.resolve()', () {
     expect(const EdgeInsetsDirectional.fromSTEB(10.0, 20.0, 30.0, 40.0).resolve(TextDirection.ltr), const EdgeInsets.fromLTRB(10.0, 20.0, 30.0, 40.0));
     expect(const EdgeInsetsDirectional.fromSTEB(99.0, 98.0, 97.0, 96.0).resolve(TextDirection.rtl), const EdgeInsets.fromLTRB(97.0, 98.0, 99.0, 96.0));
@@ -178,6 +185,18 @@ void main() {
     expect(EdgeInsetsGeometry.lerp(const EdgeInsetsDirectional.only(start: 10.0), const EdgeInsets.only(left: 20.0), 0.5), const EdgeInsetsDirectional.only(start: 5.0).add(const EdgeInsets.only(left: 10.0)));
     expect(EdgeInsetsGeometry.lerp(const EdgeInsetsDirectional.only(bottom: 1.0), const EdgeInsetsDirectional.only(start: 1.0, bottom: 1.0).add(const EdgeInsets.only(right: 2.0)), 0.5), const EdgeInsetsDirectional.only(start: 0.5).add(const EdgeInsets.only(right: 1.0, bottom: 1.0)));
     expect(EdgeInsetsGeometry.lerp(const EdgeInsets.only(bottom: 1.0), const EdgeInsetsDirectional.only(end: 1.0, bottom: 1.0).add(const EdgeInsets.only(right: 2.0)), 0.5), const EdgeInsetsDirectional.only(end: 0.5).add(const EdgeInsets.only(right: 1.0, bottom: 1.0)));
+  });
+
+  test('EdgeInsetsGeometry.lerp identical a,b', () {
+    expect(EdgeInsetsGeometry.lerp(null, null, 0), null);
+    const EdgeInsetsGeometry insets = EdgeInsets.zero;
+    expect(identical(EdgeInsetsGeometry.lerp(insets, insets, 0.5), insets), true);
+  });
+
+  test('EdgeInsetsDirectional.lerp identical a,b', () {
+    expect(EdgeInsetsDirectional.lerp(null, null, 0), null);
+    const EdgeInsetsDirectional insets = EdgeInsetsDirectional.zero;
+    expect(identical(EdgeInsetsDirectional.lerp(insets, insets, 0.5), insets), true);
   });
 
   test('EdgeInsetsGeometry.lerp(normal, ...)', () {

--- a/packages/flutter/test/painting/flutter_logo_test.dart
+++ b/packages/flutter/test/painting/flutter_logo_test.dart
@@ -29,6 +29,12 @@ void main() {
     expect(logo, isNull);
   });
 
+  test('FlutterLogoDecoration.lerp identical a,b', () {
+    expect(FlutterLogoDecoration.lerp(null, null, 0), null);
+    const FlutterLogoDecoration logo = FlutterLogoDecoration();
+    expect(identical(FlutterLogoDecoration.lerp(logo, logo, 0.5), logo), true);
+  });
+
   test('FlutterLogoDecoration lerp from non-null to null lerps margin', () {
     final FlutterLogoDecoration logo = FlutterLogoDecoration.lerp(start, null, 0.4)!;
     expect(logo.textColor, start.textColor);

--- a/packages/flutter/test/painting/fractional_offset_test.dart
+++ b/packages/flutter/test/painting/fractional_offset_test.dart
@@ -33,6 +33,12 @@ void main() {
     expect(FractionalOffset.lerp(a, null, 0.25), equals(const FractionalOffset(0.125, 0.125)));
   });
 
+  test('FractionalOffset.lerp identical a,b', () {
+    expect(FractionalOffset.lerp(null, null, 0), null);
+    const FractionalOffset decoration = FractionalOffset(1, 2);
+    expect(identical(FractionalOffset.lerp(decoration, decoration, 0.5), decoration), true);
+  });
+
   test('FractionalOffset.fromOffsetAndSize()', () {
     final FractionalOffset a = FractionalOffset.fromOffsetAndSize(const Offset(100.0, 100.0), const Size(200.0, 400.0));
     expect(a, const FractionalOffset(0.5, 0.25));

--- a/packages/flutter/test/painting/gradient_test.dart
+++ b/packages/flutter/test/painting/gradient_test.dart
@@ -66,6 +66,17 @@ void main() {
     ));
   });
 
+  test('LinearGradient.lerp identical a,b', () {
+    expect(LinearGradient.lerp(null, null, 0), null);
+    const LinearGradient gradient = LinearGradient(
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+    );
+    expect(identical(LinearGradient.lerp(gradient, gradient, 0.5), gradient), true);
+  });
+
   test('LinearGradient lerp test with stops', () {
     const LinearGradient testGradient1 = LinearGradient(
       begin: Alignment.topLeft,
@@ -342,6 +353,17 @@ void main() {
     ));
   });
 
+  test('RadialGradient.lerp identical a,b', () {
+    expect(RadialGradient.lerp(null, null, 0), null);
+    const RadialGradient gradient = RadialGradient(
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+    );
+    expect(identical(RadialGradient.lerp(gradient, gradient, 0.5), gradient), true);
+  });
+
   test('RadialGradient lerp test with stops', () {
     const RadialGradient testGradient1 = RadialGradient(
       center: Alignment.topLeft,
@@ -555,6 +577,17 @@ void main() {
         1.0,
       ],
     ));
+  });
+
+  test('SweepGradient.lerp identical a,b', () {
+    expect(SweepGradient.lerp(null, null, 0), null);
+    const SweepGradient gradient = SweepGradient(
+      colors: <Color>[
+        Color(0x33333333),
+        Color(0x66666666),
+      ],
+    );
+    expect(identical(SweepGradient.lerp(gradient, gradient, 0.5), gradient), true);
   });
 
   test('SweepGradient lerp test with stops', () {

--- a/packages/flutter/test/painting/linear_border_test.dart
+++ b/packages/flutter/test/painting/linear_border_test.dart
@@ -72,6 +72,18 @@ void main() {
     expect(LinearBorder.none.copyWith(side: side), const LinearBorder(side: side));
   });
 
+  test('LinearBorder lerp identical a,b', () {
+    expect(OutlinedBorder.lerp(null, null, 0), null);
+    const LinearBorder border = LinearBorder.none;
+    expect(identical(OutlinedBorder.lerp(border, border, 0.5), border), true);
+  });
+
+  test('LinearBorderEdge.lerp identical a,b', () {
+    expect(LinearBorderEdge.lerp(null, null, 0), null);
+    const LinearBorderEdge edge = LinearBorderEdge();
+    expect(identical(LinearBorderEdge.lerp(edge, edge, 0.5), edge), true);
+  });
+
   test('LinearBorderEdge, LinearBorder toString()', () {
     expect(const LinearBorderEdge(size: 0.5, alignment: -0.5).toString(), 'LinearBorderEdge(size: 0.5, alignment: -0.5)');
     expect(LinearBorder.none.toString(), 'LinearBorder.none');

--- a/packages/flutter/test/painting/shape_border_test.dart
+++ b/packages/flutter/test/painting/shape_border_test.dart
@@ -8,6 +8,36 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
+  test('Border.lerp identical a,b', () {
+    expect(Border.lerp(null, null, 0), null);
+    const Border border = Border();
+    expect(identical(Border.lerp(border, border, 0.5), border), true);
+  });
+
+  test('BoxBorder.lerp identical a,b', () {
+    expect(BoxBorder.lerp(null, null, 0), null);
+    const BoxBorder border = Border();
+    expect(identical(BoxBorder.lerp(border, border, 0.5), border), true);
+  });
+
+  test('BorderDirectional.lep identical a,b', () {
+    expect(BorderDirectional.lerp(null, null, 0), null);
+    const BorderDirectional border = BorderDirectional();
+    expect(identical(ShapeBorder.lerp(border, border, 0.5), border), true);
+  });
+
+  test('OutlinedBorder.lep identical a,b', () {
+    expect(OutlinedBorder.lerp(null, null, 0), null);
+    const OutlinedBorder border = RoundedRectangleBorder();
+    expect(identical(OutlinedBorder.lerp(border, border, 0.5), border), true);
+  });
+
+  test('ShapeBorder.lep identical a,b', () {
+    expect(ShapeBorder.lerp(null, null, 0), null);
+    const ShapeBorder border = CircleBorder();
+    expect(identical(ShapeBorder.lerp(border, border, 0.5), border), true);
+  });
+
   test('Compound borders', () {
     final Border b1 = Border.all(color: const Color(0xFF00FF00));
     final Border b2 = Border.all(color: const Color(0xFF0000FF));

--- a/packages/flutter/test/painting/shape_decoration_test.dart
+++ b/packages/flutter/test/painting/shape_decoration_test.dart
@@ -42,6 +42,12 @@ void main() {
     );
   });
 
+  test('ShapeDecoration.lerp identical a,b', () {
+    expect(ShapeDecoration.lerp(null, null, 0), null);
+    const ShapeDecoration shape = ShapeDecoration(shape: CircleBorder());
+    expect(identical(ShapeDecoration.lerp(shape, shape, 0.5), shape), true);
+  });
+
   test('ShapeDecoration.lerp and hit test', () {
     const Decoration a = ShapeDecoration(shape: CircleBorder());
     const Decoration b = ShapeDecoration(shape: RoundedRectangleBorder());

--- a/packages/flutter/test/painting/text_style_test.dart
+++ b/packages/flutter/test/painting/text_style_test.dart
@@ -555,6 +555,12 @@ void main() {
     expect(const TextStyle(fontFamily: 'fontFamily', package: 'foo').apply(fontFamily: 'fontFamily', package: 'bar').fontFamily, 'packages/bar/fontFamily');
   });
 
+  test('TextStyle.lerp identical a,b', () {
+    expect(TextStyle.lerp(null, null, 0), null);
+    const TextStyle style = TextStyle();
+    expect(identical(TextStyle.lerp(style, style, 0.5), style), true);
+  });
+
   test('Throws when lerping between inherit:true and inherit:false with unspecified fields', () {
     const TextStyle fromStyle = TextStyle();
     const TextStyle toStyle = TextStyle(inherit: false);


### PR DESCRIPTION
Handle a common case in Foo.lerp(a, b, t): if a and b are identical, then just return a. This avoids needlessly constructing a new Foo and recursively lerping all of its properties. If a and b refer to the same const object, then we also preserve their singleton identity.

This PR is similar to https://github.com/flutter/flutter/pull/120829

Nearly all of the lerp methods in the painting library began with:
```dart
if (a == null && b == null) {
  return null;
}
```
This PR safely generalizes the short-circuit to:
```dart
if (identical(a, b)) {
  return a;
}
```

There were a few lerp methods that did not follow this pattern.
- Gradient.lerp included this short-circuit after handling special cases where either a or b where non-null. AFAICT, moving the short-circuit to the beginning of the method does not change its semantics.
- The ShapeBorder, OutlinedBorder, and BoxBorder lerp methods did not include a short-circuit however they did return null for `lerp(null, null, t)` and so the `identical` seems to only be an improvement.
-  BorderSide.lerp's a and b parameters are non-nullable. 