### PR TITLE
[flutter_tools] Fix service_worker not caching assets when base-href is different than "/"

### DIFF
--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -58,6 +58,7 @@ Future<void> main() async {
   await runWebServiceWorkerTestWithCachingResources(headless: false, testType: ServiceWorkerTestType.withFlutterJsTrustedTypesOn);
   await runWebServiceWorkerTestWithGeneratedEntrypoint(headless: false);
   await runWebServiceWorkerTestWithBlockedServiceWorkers(headless: false);
+  await runWebServiceWorkerTestWithCustomBaseHref(headless: false);
 
   if (hasError) {
     reportErrorsAndExit('${bold}One or more tests failed.$reset');
@@ -123,7 +124,7 @@ String _testTypeToIndexFile(ServiceWorkerTestType type) {
   return indexFile;
 }
 
-Future<void> _rebuildApp({ required int version, required ServiceWorkerTestType testType, required String target }) async {
+Future<void> _rebuildApp({ required int version, required ServiceWorkerTestType testType, required String target, String? baseHref, String? output}) async {
   await _setAppVersion(version);
   await runCommand(
     _flutter,
@@ -140,7 +141,13 @@ Future<void> _rebuildApp({ required int version, required ServiceWorkerTestType 
   );
   await runCommand(
     _flutter,
-    <String>['build', 'web', '--web-resources-cdn', '--profile', '-t', target],
+    <String>[
+      'build', 'web', '--web-resources-cdn', '--profile', '-t', target,
+       if(baseHref != null)
+       ...<String>['--base-href', baseHref],
+       if(output != null)
+       ...<String>['--output', output],
+    ],
     workingDirectory: _testAppDirectory,
     environment: <String, String>{
       'FLUTTER_WEB': 'true',
@@ -702,4 +709,110 @@ Future<void> runWebServiceWorkerTestWithBlockedServiceWorkers({
     await server?.stop();
   }
   print('END runWebServiceWorkerTestWithBlockedServiceWorkers(headless: $headless)');
+}
+
+Future<void> runWebServiceWorkerTestWithCustomBaseHref({
+  required bool headless
+}) async {
+  const String baseHref = 'basehreftest';
+
+  final Map<String, int> requestedPathCounts = <String, int>{};
+  void expectRequestCounts(Map<String, int> expectedCounts) =>
+      _expectRequestCounts(expectedCounts, requestedPathCounts);
+
+  AppServer? server;
+  Future<void> waitForAppToLoad(Map<String, int> waitForCounts) async =>
+      _waitForAppToLoad(waitForCounts, requestedPathCounts, server);
+
+  Future<void> startAppServer({
+    required String cacheControl,
+  }) async {
+    final int serverPort = await findAvailablePortAndPossiblyCauseFlakyTests();
+    final int browserDebugPort = await findAvailablePortAndPossiblyCauseFlakyTests();
+    server = await AppServer.start(
+      headless: headless,
+      cacheControl: cacheControl,
+      // TODO(yjbanov): use a better port disambiguation strategy than trying
+      //                to guess what ports other tests use.
+      appUrl: 'http://localhost:$serverPort/$baseHref/index.html',
+      serverPort: serverPort,
+      browserDebugPort: browserDebugPort,
+      appDirectory: _appBuildDirectory,
+      additionalRequestHandlers: <Handler>[
+        (Request request) {
+          final String requestedPath = request.url.path;
+          requestedPathCounts.putIfAbsent(requestedPath, () => 0);
+          requestedPathCounts[requestedPath] = requestedPathCounts[requestedPath]! + 1;
+          if (requestedPath == '$baseHref/CLOSE') {
+            return Response.ok('OK');
+          }
+          return Response.notFound('');
+        },
+      ],
+    );
+  }
+
+  // Preserve old index.html as index_og.html so we can restore it later for other tests
+  await runCommand(
+    'mv',
+    <String>[
+      'index.html',
+      'index_og.html',
+    ],
+    workingDirectory: _testAppWebDirectory,
+  );
+
+  print('BEGIN runWebServiceWorkerTestWithCustomBaseHref(headless: $headless)');
+  try {
+    await _rebuildApp(
+      version: 1,
+      testType: ServiceWorkerTestType.generatedEntrypoint,
+      target: _target,
+      baseHref: '/$baseHref/',
+      output: './build/web/$baseHref'
+    );
+    await startAppServer(cacheControl: 'max-age=3600');
+    await waitForAppToLoad(<String, int>{
+      '$baseHref/CLOSE': 1,
+    });
+    expectRequestCounts(<String, int>{
+      '$baseHref/index.html': 2,
+      '$baseHref/flutter.js': 1,
+      '$baseHref/main.dart.js': 1,
+      '$baseHref/flutter_service_worker.js': 1,
+      '$baseHref/assets/AssetManifest.json': 1,
+      '$baseHref/assets/FontManifest.json': 1,
+      '$baseHref/assets/fonts/MaterialIcons-Regular.otf': 1,
+      '$baseHref/CLOSE': 1,
+      // In headless mode Chrome does not load 'manifest.json' and 'favicon.ico'.
+      if (!headless)
+        ...<String, int>{
+          '$baseHref/manifest.json': 1,
+          '$baseHref/favicon.ico': 1,
+        },
+    });
+
+    await server!.chrome.reloadPage();
+
+    await waitForAppToLoad(<String, int>{
+      '$baseHref/CLOSE': 1,
+    });
+
+    // ensure all assets were successfully resolved by service worker
+    expectRequestCounts(<String, int>{
+      '$baseHref/CLOSE': 1,
+    });
+
+  } finally {
+    await runCommand(
+      'mv',
+      <String>[
+        'index_og.html',
+        'index.html',
+      ],
+      workingDirectory: _testAppWebDirectory,
+    );
+    await server?.stop();
+  }
+  print('END runWebServiceWorkerTestWithCustomBaseHref(headless: $headless)');
 }

--- a/dev/bots/service_worker_test.dart
+++ b/dev/bots/service_worker_test.dart
@@ -143,10 +143,14 @@ Future<void> _rebuildApp({ required int version, required ServiceWorkerTestType 
     _flutter,
     <String>[
       'build', 'web', '--web-resources-cdn', '--profile', '-t', target,
-       if(baseHref != null)
-       ...<String>['--base-href', baseHref],
-       if(output != null)
-       ...<String>['--output', output],
+       if(baseHref != null) ...<String>[
+         '--base-href',
+         baseHref,
+       ],
+       if(output != null) ...<String>[
+         '--output',
+         output,
+       ],
     ],
     workingDirectory: _testAppDirectory,
     environment: <String, String>{

--- a/dev/bots/test.dart
+++ b/dev/bots/test.dart
@@ -1218,6 +1218,7 @@ Future<void> _runWebLongRunningTests() async {
     () => runWebServiceWorkerTestWithCachingResources(headless: true, testType: ServiceWorkerTestType.withFlutterJsTrustedTypesOn),
     () => runWebServiceWorkerTestWithGeneratedEntrypoint(headless: true),
     () => runWebServiceWorkerTestWithBlockedServiceWorkers(headless: true),
+    () => runWebServiceWorkerTestWithCustomBaseHref(headless: true),
     () => _runWebStackTraceTest('profile', 'lib/stack_trace.dart'),
     () => _runWebStackTraceTest('release', 'lib/stack_trace.dart'),
     () => _runWebStackTraceTest('profile', 'lib/framework_stack_trace.dart'),

--- a/packages/flutter_tools/lib/src/web/file_generators/js/flutter_service_worker.js
+++ b/packages/flutter_tools/lib/src/web/file_generators/js/flutter_service_worker.js
@@ -2,6 +2,7 @@
 const MANIFEST = 'flutter-app-manifest';
 const TEMP = 'flutter-temp-cache';
 const CACHE_NAME = 'flutter-app-cache';
+const BASE_HREF = (self.location.pathname.split('/').slice(0, -1).join('/') + '/').substring(1);
 
 const RESOURCES = $$RESOURCES_MAP;
 // The application shell files that are downloaded before a service worker can
@@ -93,6 +94,13 @@ self.addEventListener("fetch", (event) => {
   if (event.request.url == origin || event.request.url.startsWith(origin + '/#') || key == '') {
     key = '/';
   }
+
+  // In order to get the actual asset key, it must remove the base-href from the requested URL
+  // but only if the URL is from the same origin
+  if(event.request.url.startsWith(origin)) {
+    key = key.substring(BASE_HREF.length);
+  }
+
   // If the URL is not the RESOURCE list then return to signal that the
   // browser should take over.
   if (!RESOURCES[key]) {


### PR DESCRIPTION
**What does this PR changes?**
Fixes https://github.com/flutter/flutter/issues/111866 **service_worker** not caching assets when **base-href** is different than `/` (example: `/basehreftest/`)

**Evidence of the fix working:**

https://user-images.githubusercontent.com/79719460/201554439-6ddaf720-95b6-4cd9-b07a-d3d43556f4b4.mp4

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

@ditman @mdebbar 

