### PR TITLE
Use AnimatedSwitcher's _childNumber as Key in layoutBuilder's Stack

### DIFF
--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -337,7 +337,10 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
   }) {
     final _ChildEntry entry = _ChildEntry(
       widgetChild: child,
-      transition: KeyedSubtree.wrap(builder(child, animation), _childNumber),
+      transition: KeyedSubtree(
+        key: ValueKey<int>(_childNumber),
+        child: builder(child, animation),
+      ),
       animation: animation,
       controller: controller,
     );

--- a/packages/flutter/lib/src/widgets/animated_switcher.dart
+++ b/packages/flutter/lib/src/widgets/animated_switcher.dart
@@ -216,7 +216,6 @@ class AnimatedSwitcher extends StatefulWidget {
   /// This is an [AnimatedSwitcherTransitionBuilder] function.
   static Widget defaultTransitionBuilder(Widget child, Animation<double> animation) {
     return FadeTransition(
-      key: ValueKey<Key?>(child.key),
       opacity: animation,
       child: child,
     );
@@ -389,6 +388,6 @@ class _AnimatedSwitcherState extends State<AnimatedSwitcher> with TickerProvider
   @override
   Widget build(BuildContext context) {
     _rebuildOutgoingWidgetsIfNeeded();
-    return widget.layoutBuilder(_currentEntry?.transition, _outgoingWidgets!.where((Widget outgoing) => outgoing.key != _currentEntry?.transition.key).toSet().toList());
+    return widget.layoutBuilder(_currentEntry?.transition, _outgoingWidgets!);
   }
 }

--- a/packages/flutter/test/widgets/animated_switcher_test.dart
+++ b/packages/flutter/test/widgets/animated_switcher_test.dart
@@ -415,25 +415,6 @@ void main() {
       );
     }
   });
-
-  testWidgets('AnimatedSwitcher does not duplicate animations if the same child is entered twice.', (WidgetTester tester) async {
-    Future<void> pumpChild(Widget child) async {
-      return tester.pumpWidget(
-        Directionality(
-          textDirection: TextDirection.ltr,
-          child: AnimatedSwitcher(
-            duration: const Duration(milliseconds: 1000),
-            child: child,
-          ),
-        ),
-      );
-    }
-    await pumpChild(const Text('1', key: Key('1')));
-    await pumpChild(const Text('2', key: Key('2')));
-    await pumpChild(const Text('1', key: Key('1')));
-    await tester.pump(const Duration(milliseconds: 1000));
-    expect(find.text('1'), findsOneWidget);
-  });
 }
 
 class StatefulTest extends StatefulWidget {


### PR DESCRIPTION
Previously `KeyedSubtree.wrap` gave children of the `AnimatedSwitcher` their own key as a key, if available, and their `_childNumber` as a key, if not. This could lead to multiple children having the same key in the `defaultLayoutBuilder`'s `Stack` and thus a duplicate key exception being thrown, though (see #121336 for a detailed description of how this bug occurs). This is fixed by always using the uniquely identifiable `_childNumber` as a key for the children of the `AnimatedSwitcher`.

This does not impair the functionality of having children of the same type be differentiated and transitioned between by giving them different keys, as the children's original key is still used to determine if a transition should take place or not.

This fixes #121336.

**Note:** This reverts the changes introduced by #107476, as they do not completely fix the issue of duplicate keys in the AnimatedSwitcher switcher as demonstrated by #121336, and introduce behavior that deviates from the AnimatedSwitcher's documentation.
Specifically, children that are transitioning out are immediately removed from the widget tree, if another child with the same key is added, while the AnimatedSwitcher is clearly supposed to support multiple children with the same key transitioning in and out at the same time according to its documentation: 
> The same key can be used for a new child as was used for an already-outgoing child; the two will not be considered related. (For example, if a progress indicator with key A is first shown, then an image with key B, then another progress indicator with key A again, all in rapid succession, then the old progress indicator and the image will be fading out while a new progress indicator is fading in.)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
