### PR TITLE
Cocoapods ffi error can be in stdout or stderr

### DIFF
--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -361,7 +361,7 @@ class CocoaPods {
         '  pod repo update\n',
         emphasis: true,
       );
-    } else if ((stderr.contains('ffi_c.bundle') || stderr.contains('/ffi/')) &&
+    } else if (_isFfiX86Error(stdout, stderr) &&
         _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64) {
       // https://github.com/flutter/flutter/issues/70796
       UsageEvent(
@@ -375,6 +375,13 @@ class CocoaPods {
         emphasis: true,
       );
     }
+  }
+
+  bool _isFfiX86Error(String stdout, String stderr) {
+    return stderr.contains('ffi_c.bundle') ||
+           stdout.contains('ffi_c.bundle') ||
+           stderr.contains('/ffi/') ||
+           stdout.contains('/ffi/');
   }
 
   void _warnIfPodfileOutOfDate(XcodeBasedProject xcodeProject) {

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -361,7 +361,7 @@ class CocoaPods {
         '  pod repo update\n',
         emphasis: true,
       );
-    } else if (_isFfiX86Error(stdout, stderr) &&
+    } else if ((_isFfiX86Error(stdout) || _isFfiX86Error(stderr)) &&
         _operatingSystemUtils.hostPlatform == HostPlatform.darwin_arm64) {
       // https://github.com/flutter/flutter/issues/70796
       UsageEvent(

--- a/packages/flutter_tools/lib/src/macos/cocoapods.dart
+++ b/packages/flutter_tools/lib/src/macos/cocoapods.dart
@@ -377,11 +377,8 @@ class CocoaPods {
     }
   }
 
-  bool _isFfiX86Error(String stdout, String stderr) {
-    return stderr.contains('ffi_c.bundle') ||
-           stdout.contains('ffi_c.bundle') ||
-           stderr.contains('/ffi/') ||
-           stdout.contains('/ffi/');
+  bool _isFfiX86Error(String error) {
+    return error.contains('ffi_c.bundle') || error.contains('/ffi/');
   }
 
   void _warnIfPodfileOutOfDate(XcodeBasedProject xcodeProject) {

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -19,6 +19,11 @@ import '../../src/common.dart';
 import '../../src/context.dart';
 import '../../src/fake_process_manager.dart';
 
+enum _StdioStream {
+  stdout,
+  stderr,
+}
+
 void main() {
   late FileSystem fileSystem;
   late FakeProcessManager fakeProcessManager;
@@ -492,51 +497,56 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
       'bus error': '/Library/Ruby/Gems/2.6.0/gems/ffi-1.15.5/lib/ffi/library.rb:275: [BUG] Bus Error at 0x000000010072c000',
     };
     possibleErrors.forEach((String errorName, String cocoaPodsError) {
-      testUsingContext('ffi $errorName failure on ARM macOS prompts gem install', () async {
-        final FlutterProject projectUnderTest = setupProjectUnderTest();
-        pretendPodIsInstalled();
-        pretendPodVersionIs('100.0.0');
-        fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
-          ..createSync()
-          ..writeAsStringSync('Existing Podfile');
+      void testToolExitsWithCocoapodsMessage(_StdioStream outputStream) {
+        testUsingContext('ffi $errorName failure on ARM macOS prompts gem install', () async {
+          final FlutterProject projectUnderTest = setupProjectUnderTest();
+          pretendPodIsInstalled();
+          pretendPodVersionIs('100.0.0');
+          fileSystem.file(fileSystem.path.join('project', 'ios', 'Podfile'))
+            ..createSync()
+            ..writeAsStringSync('Existing Podfile');
 
-        fakeProcessManager.addCommands(<FakeCommand>[
-          FakeCommand(
-            command: const <String>['pod', 'install', '--verbose'],
-            workingDirectory: 'project/ios',
-            environment: const <String, String>{
-              'COCOAPODS_DISABLE_STATS': 'true',
-              'LANG': 'en_US.UTF-8',
-            },
-            exitCode: 1,
-            stderr: cocoaPodsError,
-          ),
-          const FakeCommand(
-            command: <String>['which', 'sysctl'],
-          ),
-          const FakeCommand(
-            command: <String>['sysctl', 'hw.optional.arm64'],
-            stdout: 'hw.optional.arm64: 1',
-          ),
-        ]);
+          fakeProcessManager.addCommands(<FakeCommand>[
+            FakeCommand(
+              command: const <String>['pod', 'install', '--verbose'],
+              workingDirectory: 'project/ios',
+              environment: const <String, String>{
+                'COCOAPODS_DISABLE_STATS': 'true',
+                'LANG': 'en_US.UTF-8',
+              },
+              exitCode: 1,
+              stdout: outputStream == _StdioStream.stdout ? cocoaPodsError : '',
+              stderr: outputStream == _StdioStream.stderr ? cocoaPodsError : '',
+            ),
+            const FakeCommand(
+              command: <String>['which', 'sysctl'],
+            ),
+            const FakeCommand(
+              command: <String>['sysctl', 'hw.optional.arm64'],
+              stdout: 'hw.optional.arm64: 1',
+            ),
+          ]);
 
-        await expectToolExitLater(
-          cocoaPodsUnderTest.processPods(
-            xcodeProject: projectUnderTest.ios,
-            buildMode: BuildMode.debug,
-          ),
-          equals('Error running pod install'),
-        );
-        expect(
-          logger.errorText,
-          contains('set up CocoaPods for ARM macOS'),
-        );
-        expect(
-          logger.errorText,
-          contains('enable-libffi-alloc'),
-        );
-        expect(usage.events, contains(const TestUsageEvent('pod-install-failure', 'arm-ffi')));
-      });
+          await expectToolExitLater(
+            cocoaPodsUnderTest.processPods(
+              xcodeProject: projectUnderTest.ios,
+              buildMode: BuildMode.debug,
+            ),
+            equals('Error running pod install'),
+          );
+          expect(
+            logger.errorText,
+            contains('set up CocoaPods for ARM macOS'),
+          );
+          expect(
+            logger.errorText,
+            contains('enable-libffi-alloc'),
+          );
+          expect(usage.events, contains(const TestUsageEvent('pod-install-failure', 'arm-ffi')));
+        });
+      }
+      testToolExitsWithCocoapodsMessage(_StdioStream.stdout);
+      testToolExitsWithCocoapodsMessage(_StdioStream.stderr);
     });
 
     testUsingContext('ffi failure on x86 macOS does not prompt gem install', () async {

--- a/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
+++ b/packages/flutter_tools/test/general.shard/macos/cocoapods_test.dart
@@ -498,7 +498,8 @@ Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by
     };
     possibleErrors.forEach((String errorName, String cocoaPodsError) {
       void testToolExitsWithCocoapodsMessage(_StdioStream outputStream) {
-        testUsingContext('ffi $errorName failure on ARM macOS prompts gem install', () async {
+        final String streamName = outputStream == _StdioStream.stdout ? 'stdout' : 'stderr';
+        testUsingContext('ffi $errorName failure to $streamName on ARM macOS prompts gem install', () async {
           final FlutterProject projectUnderTest = setupProjectUnderTest();
           pretendPodIsInstalled();
           pretendPodVersionIs('100.0.0');


### PR DESCRIPTION
I was seeing the following error show up in _stdout_:

```
LoadError - dlopen(/Library/Ruby/Gems/2.6.0/gems/ffi-1.15.5/lib/ffi_c.bundle, 0x0009)
...
```

And it was solved by running:

```sh
sudo gem uninstall ffi && sudo gem install ffi -- --enable-libffi-alloc
```

https://github.com/flutter/flutter/issues/99195

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
