### PR TITLE
Give error on too many arguments to `flutter config`

### DIFF
--- a/packages/flutter_tools/lib/src/commands/config.dart
+++ b/packages/flutter_tools/lib/src/commands/config.dart
@@ -101,6 +101,16 @@ class ConfigCommand extends FlutterCommand {
 
   @override
   Future<FlutterCommandResult> runCommand() async {
+    final List<String> rest = argResults?.rest ?? <String>[];
+    if (rest.isNotEmpty) {
+      throwToolExit(exitCode: 2,
+          'error: flutter config: Too many arguments.\n'
+          '\n'
+          'If a value has a space in it, enclose in quotes on the command line\n'
+          'to make a single argument.  For example:\n'
+          '    flutter config --android-studio-dir "/opt/Android Studio"');
+    }
+
     if (boolArgDeprecated('machine')) {
       await handleMachine();
       return FlutterCommandResult.success();

--- a/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
+++ b/packages/flutter_tools/test/commands.shard/hermetic/config_test.dart
@@ -44,6 +44,19 @@ void main() {
   }
 
   group('config', () {
+    testUsingContext('throws error on excess arguments', () {
+      final ConfigCommand configCommand = ConfigCommand();
+      final CommandRunner<void> commandRunner = createTestCommandRunner(configCommand);
+
+      expect(() => commandRunner.run(<String>[
+        'config',
+        '--android-studio-dir=/opt/My', 'Android', 'Studio',
+      ]), throwsToolExit());
+      verifyNoAnalytics();
+    }, overrides: <Type, Generator>{
+      Usage: () => testUsage,
+    });
+
     testUsingContext('machine flag', () async {
       final ConfigCommand command = ConfigCommand();
       await command.handleMachine();


### PR DESCRIPTION
Fixes #121467.

If `flutter config` receives any positional arguments, then something is wrong; one way or another, the command isn't what the developer intended.  Give an error and let the developer fix the command, rather than silently doing the wrong thing.

The most likely cause of this error is that the developer intended to pass a path that has spaces in it, and the shell split the path into several arguments at the spaces.  This has produced a couple of reports in the tracker.  So give a hint aimed at this possibility.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
