### PR TITLE
Fix finding JDK in current Android Studio (cherry-pick)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -99,3 +99,4 @@ Nguyễn Phúc Lợi <nploi1998@gmail.com>
 Jingyi Chen <jingyichen@link.cuhk.edu.cn>
 Junhua Lin <1075209054@qq.com>
 Tomasz Gucio <tgucio@gmail.com>
+Eli Albert <crasowas@gmail.com>

--- a/packages/flutter_tools/lib/src/android/android_studio.dart
+++ b/packages/flutter_tools/lib/src/android/android_studio.dart
@@ -444,11 +444,22 @@ class AndroidStudio implements Comparable<AndroidStudio> {
       return;
     }
 
-    final String javaPath = globals.platform.isMacOS ?
-        version != null && version.major < 2020 ?
-        globals.fs.path.join(directory, 'jre', 'jdk', 'Contents', 'Home') :
-        globals.fs.path.join(directory, 'jre', 'Contents', 'Home') :
-        globals.fs.path.join(directory, 'jre');
+    final String javaPath;
+    if (globals.platform.isMacOS) {
+      if (version != null && version.major < 2020) {
+        javaPath = globals.fs.path.join(directory, 'jre', 'jdk', 'Contents', 'Home');
+      } else if (version != null && version.major == 2022) {
+        javaPath = globals.fs.path.join(directory, 'jbr', 'Contents', 'Home');
+      } else {
+        javaPath = globals.fs.path.join(directory, 'jre', 'Contents', 'Home');
+      }
+    } else {
+      if (version != null && version.major == 2022) {
+        javaPath = globals.fs.path.join(directory, 'jbr');
+      } else {
+        javaPath = globals.fs.path.join(directory, 'jre');
+      }
+    }
     final String javaExecutable = globals.fs.path.join(javaPath, 'bin', 'java');
     if (!globals.processManager.canRun(javaExecutable)) {
       _validationMessages.add('Unable to find bundled Java version.');


### PR DESCRIPTION
Cherry-pick of aed9b4adce2f8301469b242e74a9e9dea8a9da66 / #120107, to fix #106674 on the stable branch.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
