### PR TITLE
Fix Ink decoration image does not render

### DIFF
--- a/packages/flutter/lib/src/material/ink_decoration.dart
+++ b/packages/flutter/lib/src/material/ink_decoration.dart
@@ -288,7 +288,7 @@ class _InkState extends State<Ink> {
       _ink!.decoration = widget.decoration;
       _ink!.configuration = createLocalImageConfiguration(context);
     }
-    return widget.child ?? const SizedBox();
+    return widget.child ?? ConstrainedBox(constraints: const BoxConstraints.expand());
   }
 
   @override

--- a/packages/flutter/test/material/ink_paint_test.dart
+++ b/packages/flutter/test/material/ink_paint_test.dart
@@ -9,20 +9,17 @@ import 'package:flutter_test/flutter_test.dart';
 import '../rendering/mock_canvas.dart';
 
 void main() {
-  testWidgets('The Ink widget renders a SizedBox by default', (WidgetTester tester) async {
+  testWidgets('The Ink widget expands when no dimensions are set', (WidgetTester tester) async {
     await tester.pumpWidget(
       Material(
         child: Ink(),
       ),
     );
-    Finder sizedBox = find.descendant(
-      of: find.byType(Ink),
-      matching: find.byType(SizedBox),
-    );
-    expect(sizedBox, findsOneWidget);
-    expect(tester.getSize(sizedBox).height, 600.0);
-    expect(tester.getSize(sizedBox).width, 800.0);
+    expect(find.byType(Ink), findsOneWidget);
+    expect(tester.getSize(find.byType(Ink)), const Size(800.0, 600.0));
+  });
 
+  testWidgets('The Ink widget fits the specified size', (WidgetTester tester) async {
     const double height = 150.0;
     const double width = 200.0;
     await tester.pumpWidget(
@@ -36,13 +33,24 @@ void main() {
       ),
     );
     await tester.pumpAndSettle();
-    sizedBox = find.descendant(
-      of: find.byType(Ink),
-      matching: find.byType(SizedBox),
+    expect(find.byType(Ink), findsOneWidget);
+    expect(tester.getSize(find.byType(Ink)), const Size(width, height));
+  });
+
+  testWidgets('The Ink widget expands on a unspecified dimension', (WidgetTester tester) async {
+    const double height = 150.0;
+    await tester.pumpWidget(
+      Material(
+        child: Center( // used to constrain to child's size
+          child: Ink(
+            height: height,
+          ),
+        ),
+      ),
     );
-    expect(sizedBox, findsNWidgets(2));
-    expect(tester.getSize(sizedBox.at(0)).height, height);
-    expect(tester.getSize(sizedBox.at(0)).width, width);
+    await tester.pumpAndSettle();
+    expect(find.byType(Ink), findsOneWidget);
+    expect(tester.getSize(find.byType(Ink)), const Size(800, height));
   });
 
   testWidgets('The InkWell widget renders an ink splash', (WidgetTester tester) async {


### PR DESCRIPTION
## Description

This PR fixes an issue related to how the `Ink` widget is sized when there is only one dimension specified.
`Ink` used to rely on empty `Container()` (to expand on the unspecified directions), after https://github.com/flutter/flutter/pull/108672,  `Container()` was replaced with `SizedBox()`.

This PR uses a `ConstrainedBox`, which is more verbose but more accurate.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/119965

## Tests

Adds 1 tests.
Splits and updates 1 existing test in two tests.
