### PR TITLE
Revert "[flutter_tools] show web-server in flutter devices"

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command_runner.dart
@@ -18,6 +18,7 @@ import '../cache.dart';
 import '../convert.dart';
 import '../globals.dart' as globals;
 import '../tester/flutter_tester.dart';
+import '../web/web_device.dart';
 
 class FlutterCommandRunner extends CommandRunner<void> {
   FlutterCommandRunner({ bool verboseHelp = false }) : super(
@@ -111,6 +112,11 @@ class FlutterCommandRunner extends CommandRunner<void> {
         hide: !verboseHelp,
         help: 'List the special "flutter-tester" device in device listings. '
               'This headless device is used to test Flutter tooling.');
+    argParser.addFlag('show-web-server-device',
+        negatable: false,
+        hide: !verboseHelp,
+        help: 'List the special "web-server" device in device listings.',
+    );
   }
 
   @override
@@ -208,6 +214,10 @@ class FlutterCommandRunner extends CommandRunner<void> {
     if (((topLevelResults['show-test-device'] as bool?) ?? false)
         || topLevelResults['device-id'] == FlutterTesterDevices.kTesterDeviceId) {
       FlutterTesterDevices.showFlutterTesterDevice = true;
+    }
+    if (((topLevelResults['show-web-server-device'] as bool?) ?? false)
+        || topLevelResults['device-id'] == WebServerDevice.kWebServerDeviceId) {
+      WebServerDevice.showWebServerDevice = true;
     }
 
     // Set up the tooling configuration.

--- a/packages/flutter_tools/lib/src/web/web_device.dart
+++ b/packages/flutter_tools/lib/src/web/web_device.dart
@@ -111,7 +111,7 @@ abstract class ChromiumDevice extends Device {
   Future<String?> get emulatorId async => null;
 
   @override
-  bool isSupported() => chromeLauncher.canFindExecutable();
+  bool isSupported() =>  chromeLauncher.canFindExecutable();
 
   @override
   DevicePortForwarder? get portForwarder => const NoOpDevicePortForwarder();
@@ -357,7 +357,8 @@ class WebDevices extends PollingDeviceDiscovery {
     }
     final MicrosoftEdgeDevice? edgeDevice = _edgeDevice;
     return <Device>[
-      _webServerDevice,
+      if (WebServerDevice.showWebServerDevice)
+        _webServerDevice,
       if (_chromeDevice.isSupported())
         _chromeDevice,
       if (edgeDevice != null && await edgeDevice._meetsVersionConstraint())
@@ -391,6 +392,7 @@ class WebServerDevice extends Device {
        );
 
   static const String kWebServerDeviceId = 'web-server';
+  static bool showWebServerDevice = false;
 
   final Logger _logger;
 

--- a/packages/flutter_tools/test/general.shard/web/devices_test.dart
+++ b/packages/flutter_tools/test/general.shard/web/devices_test.dart
@@ -189,7 +189,8 @@ void main() {
       isNot(contains(isA<GoogleChromeDevice>())));
   });
 
-  testWithoutContext('Web Server device is listed', () async {
+  testWithoutContext('Web Server device is listed if enabled via showWebServerDevice', () async {
+    WebServerDevice.showWebServerDevice = true;
     final WebDevices webDevices = WebDevices(
       featureFlags: TestFeatureFlags(isWebEnabled: true),
       fileSystem: MemoryFileSystem.test(),
@@ -202,6 +203,22 @@ void main() {
 
     expect(await webDevices.pollingGetDevices(),
       contains(isA<WebServerDevice>()));
+  });
+
+  testWithoutContext('Web Server device is not listed if disabled via showWebServerDevice', () async {
+    WebServerDevice.showWebServerDevice = false;
+    final WebDevices webDevices = WebDevices(
+      featureFlags: TestFeatureFlags(isWebEnabled: true),
+      fileSystem: MemoryFileSystem.test(),
+      logger: BufferLogger.test(),
+      platform: FakePlatform(
+        environment: <String, String>{}
+      ),
+      processManager: FakeProcessManager.any(),
+    );
+
+    expect(await webDevices.pollingGetDevices(),
+      isNot(contains(isA<WebServerDevice>())));
   });
 
   testWithoutContext('Chrome invokes version command on non-Windows platforms', () async {


### PR DESCRIPTION
Reverts flutter/flutter#121373

Per https://github.com/flutter/flutter/pull/121373#issuecomment-1446360539, removing the `--show-web-server-device` flag broke dart-code--if this is re-landed we should softly deprecate the flag. Also, we should re-evaluate the impact on customers using dart debug extension.