### PR TITLE
Added identical(a,b) short circuit to rendering library lerp methods

### DIFF
--- a/packages/flutter/lib/src/rendering/box.dart
+++ b/packages/flutter/lib/src/rendering/box.dart
@@ -468,8 +468,8 @@ class BoxConstraints extends Constraints {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static BoxConstraints? lerp(BoxConstraints? a, BoxConstraints? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b! * t;

--- a/packages/flutter/lib/src/rendering/stack.dart
+++ b/packages/flutter/lib/src/rendering/stack.dart
@@ -165,8 +165,8 @@ class RelativeRect {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static RelativeRect? lerp(RelativeRect? a, RelativeRect? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return RelativeRect.fromLTRB(b!.left * t, b.top * t, b.right * t, b.bottom * t);

--- a/packages/flutter/lib/src/rendering/table_border.dart
+++ b/packages/flutter/lib/src/rendering/table_border.dart
@@ -153,8 +153,8 @@ class TableBorder {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static TableBorder? lerp(TableBorder? a, TableBorder? b, double t) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!.scale(t);

--- a/packages/flutter/test/rendering/box_constraints_test.dart
+++ b/packages/flutter/test/rendering/box_constraints_test.dart
@@ -90,6 +90,12 @@ void main() {
     expect(copy.maxHeight, moreOrLessEquals(97.0));
   });
 
+  test('BoxConstraints.lerp identical a,b', () {
+    expect(BoxConstraints.lerp(null, null, 0), null);
+    const BoxConstraints constraints = BoxConstraints();
+    expect(identical(BoxConstraints.lerp(constraints, constraints, 0.5), constraints), true);
+  });
+
   test('BoxConstraints lerp with unbounded width', () {
     const BoxConstraints constraints1 = BoxConstraints(
       minWidth: double.infinity,

--- a/packages/flutter/test/rendering/relative_rect_test.dart
+++ b/packages/flutter/test/rendering/relative_rect_test.dart
@@ -67,4 +67,9 @@ void main() {
     final RelativeRect r3 = RelativeRect.lerp(r1, r2, 0.5)!;
     expect(r3, const RelativeRect.fromLTRB(5.0, 10.0, 15.0, 20.0));
   });
+  test('RelativeRect.lerp identical a,b', () {
+    expect(RelativeRect.lerp(null, null, 0), null);
+    const RelativeRect rect = RelativeRect.fill;
+    expect(identical(RelativeRect.lerp(rect, rect, 0.5), rect), true);
+  });
 }

--- a/packages/flutter/test/rendering/table_border_test.dart
+++ b/packages/flutter/test/rendering/table_border_test.dart
@@ -108,6 +108,12 @@ void main() {
     );
   });
 
+  test('TableBorder.lerp identical a,b', () {
+    expect(TableBorder.lerp(null, null, 0), null);
+    const TableBorder border = TableBorder();
+    expect(identical(TableBorder.lerp(border, border, 0.5), border), true);
+  });
+
   test('TableBorder.lerp with nulls', () {
     final TableBorder table2 = TableBorder.all(width: 2.0);
     final TableBorder table1 = TableBorder.all();


### PR DESCRIPTION
Handle a common case in Foo.lerp(a, b, t): if a and b are identical, then just return a. This avoids needlessly constructing a new Foo and recursively lerping all of its properties. If a and b refer to the same const object, then we also preserve their singleton identity.

This PR is similar to https://github.com/flutter/flutter/pull/120829

All of the lerp methods in the began library began with:
```dart
if (a == null && b == null) {
  return null;
}
```
This PR safely generalizes the short-circuit to:
```dart
if (identical(a, b)) {
  return a;
}
```
