### PR TITLE
Removed "typically non-null" API doc qualifiers from ScrollMetrics min,max extent getters

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -62,7 +62,7 @@ mixin ScrollMetrics {
   ///
   /// The actual [pixels] value might be [outOfRange].
   ///
-  /// This value should typically be less than or equal to
+  /// This value is typically less than or equal to
   /// [maxScrollExtent]. It can be negative infinity, if the scroll is unbounded.
   double get minScrollExtent;
 
@@ -70,7 +70,7 @@ mixin ScrollMetrics {
   ///
   /// The actual [pixels] value might be [outOfRange].
   ///
-  /// This value should greater than or equal to
+  /// This value is typically greater than or equal to
   /// [minScrollExtent]. It can be infinity, if the scroll is unbounded.
   double get maxScrollExtent;
 

--- a/packages/flutter/lib/src/widgets/scroll_metrics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_metrics.dart
@@ -62,7 +62,7 @@ mixin ScrollMetrics {
   ///
   /// The actual [pixels] value might be [outOfRange].
   ///
-  /// This value should typically be non-null and less than or equal to
+  /// This value should typically be less than or equal to
   /// [maxScrollExtent]. It can be negative infinity, if the scroll is unbounded.
   double get minScrollExtent;
 
@@ -70,7 +70,7 @@ mixin ScrollMetrics {
   ///
   /// The actual [pixels] value might be [outOfRange].
   ///
-  /// This value should typically be non-null and greater than or equal to
+  /// This value should greater than or equal to
   /// [minScrollExtent]. It can be infinity, if the scroll is unbounded.
   double get maxScrollExtent;
 


### PR DESCRIPTION
The ScrollMetrics minScrollExtent and maxScrollExtent properties are no long nullable.

