### PR TITLE
[flutter_tools/dap] Inform DAP client whether restart is supported

### DIFF
--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -395,7 +395,7 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
 
     // Notify the client whether it can call 'restartRequest' when the user
     // clicks restart, instead of terminating and re-starting its own debug
-    //session (which is much slower, but required for profile/release mode).
+    // session (which is much slower, but required for profile/release mode).
     final bool supportsRestart = (params['supportsRestart'] as bool?) ?? false;
     sendEvent(CapabilitiesEventBody(capabilities: Capabilities(supportsRestartRequest: supportsRestart)));
   }

--- a/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
+++ b/packages/flutter_tools/lib/src/debug_adapters/flutter_adapter.dart
@@ -48,13 +48,6 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
   /// their handlers.
   final Map<int, Completer<Object?>> _flutterRequestCompleters = <int, Completer<Object?>>{};
 
-  /// Whether or not this adapter can handle the restartRequest.
-  ///
-  /// For Flutter apps we can handle this with a Hot Restart rather than having
-  /// the whole debug session stopped and restarted.
-  @override
-  bool get supportsRestartRequest => true;
-
   /// A list of reverse-requests from `flutter run --machine` that should be forwarded to the client.
   static const Set<String> _requestsToForwardToClient = <String>{
     // The 'app.exposeUrl' request is sent by Flutter to request the client
@@ -399,6 +392,12 @@ class FlutterDebugAdapter extends FlutterBaseDebugAdapter {
     if (_appId == null) {
       throw DebugAdapterException('Unexpected null `appId` in app.start event');
     }
+
+    // Notify the client whether it can call 'restartRequest' when the user
+    // clicks restart, instead of terminating and re-starting its own debug
+    //session (which is much slower, but required for profile/release mode).
+    final bool supportsRestart = (params['supportsRestart'] as bool?) ?? false;
+    sendEvent(CapabilitiesEventBody(capabilities: Capabilities(supportsRestartRequest: supportsRestart)));
   }
 
   /// Handles the app.started event from Flutter.

--- a/packages/flutter_tools/test/general.shard/dap/mocks.dart
+++ b/packages/flutter_tools/test/general.shard/dap/mocks.dart
@@ -18,6 +18,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     required FileSystem fileSystem,
     required Platform platform,
     bool simulateAppStarted = true,
+    bool supportsRestart = true,
     FutureOr<void> Function(MockFlutterDebugAdapter adapter)? preAppStart,
   }) {
     final StreamController<List<int>> stdinController = StreamController<List<int>>();
@@ -31,6 +32,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
       fileSystem: fileSystem,
       platform: platform,
       simulateAppStarted: simulateAppStarted,
+      supportsRestart: supportsRestart,
       preAppStart: preAppStart,
     );
   }
@@ -41,6 +43,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
     required super.fileSystem,
     required super.platform,
     this.simulateAppStarted = true,
+    this.supportsRestart = true,
     this.preAppStart,
   }) {
     clientChannel.listen((ProtocolMessage message) {
@@ -51,6 +54,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
   int _seq = 1;
   final ByteStreamServerChannel clientChannel;
   final bool simulateAppStarted;
+  final bool supportsRestart;
   final FutureOr<void> Function(MockFlutterDebugAdapter adapter)? preAppStart;
 
   late String executable;
@@ -110,6 +114,7 @@ class MockFlutterDebugAdapter extends FlutterDebugAdapter {
         'event': 'app.start',
         'params': <String, Object?>{
           'appId': 'TEST',
+          'supportsRestart': supportsRestart,
         }
       });
     }


### PR DESCRIPTION
Before this change, the Flutter adapter always sent "supportsRestartRequest: true" to the DAP client. This told the DAP client if the user clicks the "Restart" button on the debug toolbar that we (the DAP server) will handle the restart (allowing us to Hot Restart instead of a slower termination and restart of the entire debug session).

However, Profile/Release mode do not support Hot Restart, so this would result in an error "Hot Restart failed".

This change no longer sets `supportsRestartRequest: true` at startup, but instead waits for the `app.start` event, and sends the value of its `supportsRestart` field (an existing field that was already available in the `app.start` event).

This results in Hot Restart being available for debug builds, but the DAP client/IDE performing a full debug session restart for other modes.

Fixes https://github.com/Dart-Code/Dart-Code/issues/4281.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
