### PR TITLE
Added identical(a,b) short circuit ... finale

### DIFF
--- a/packages/flutter/lib/src/cupertino/route.dart
+++ b/packages/flutter/lib/src/cupertino/route.dart
@@ -835,8 +835,8 @@ class _CupertinoEdgeShadowDecoration extends Decoration {
     _CupertinoEdgeShadowDecoration? b,
     double t,
   ) {
-    if (a == null && b == null) {
-      return null;
+    if (identical(a, b)) {
+      return a;
     }
     if (a == null) {
       return b!._colors == null ? b : _CupertinoEdgeShadowDecoration._(b._colors!.map<Color>((Color color) => Color.lerp(null, color, t)!).toList());

--- a/packages/flutter/lib/src/widgets/icon_theme_data.dart
+++ b/packages/flutter/lib/src/widgets/icon_theme_data.dart
@@ -167,6 +167,9 @@ class IconThemeData with Diagnosticable {
   ///
   /// {@macro dart.ui.shadow.lerp}
   static IconThemeData lerp(IconThemeData? a, IconThemeData? b, double t) {
+    if (identical(a, b) && a != null) {
+      return a;
+    }
     return IconThemeData(
       size: ui.lerpDouble(a?.size, b?.size, t),
       fill: ui.lerpDouble(a?.fill, b?.fill, t),

--- a/packages/flutter/test/widgets/icon_theme_data_test.dart
+++ b/packages/flutter/test/widgets/icon_theme_data_test.dart
@@ -57,6 +57,12 @@ void main() {
       expect(lerped.shadows, const <Shadow>[Shadow(color: Color(0xFFFFFFFF), blurRadius: 0.25, offset: Offset(0.25, 0.25))]);
     });
 
+    test('IconThemeData lerp special cases', () {
+      expect(IconThemeData.lerp(null, null, 0), const IconThemeData());
+      const IconThemeData data = IconThemeData();
+      expect(identical(IconThemeData.lerp(data, data, 0.5), data), true);
+    });
+
     test('with second null', () {
       final IconThemeData lerped = IconThemeData.lerp(data, null, 0.25);
 


### PR DESCRIPTION
Final identical(a,b) short circuit update for the last two lerp methods.

Handle a common case in Foo.lerp(a, b, t): if a and b are identical, then just return a. This avoids needlessly constructing a new Foo and recursively lerping all of its properties. If a and b refer to the same const object, then we also preserve their singleton identity.

_CupertinoEdgeShadowDecoration.lerp was updated for the sake of consistency. There's no new test although the existing transition tests in test/cupertino/route.dart do functionally cover it.

This PR is similar to https://github.com/flutter/flutter/pull/120829
