### PR TITLE
Add `curl` dependency to plugin_test_linux

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -706,7 +706,8 @@ targets:
         [
           {"dependency": "clang", "version": "git_revision:5d5aba78dbbee75508f01bcaa69aedb2ab79065a"},
           {"dependency": "cmake", "version": "version:3.16.1"},
-          {"dependency": "ninja", "version": "version:1.9.0"}
+          {"dependency": "ninja", "version": "version:1.9.0"},
+          {"dependency": "curl", "version": "version:7.64.0"}
         ]
       tags: >
         ["devicelab", "hostonly", "linux"]


### PR DESCRIPTION
Speculative fix for the failure discussed in https://github.com/flutter/flutter/pull/120912