### PR TITLE
Document on ScrollPhysics the requirement to override applyTo

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -67,6 +67,11 @@ enum ScrollDecelerationRate {
 /// // ...
 /// final ScrollPhysics mergedPhysics = physics.applyTo(const AlwaysScrollableScrollPhysics());
 /// ```
+///
+/// When implementing a subclass, you must override [applyTo] so that it returns
+/// an appropriate instance of your subclass.  Otherwise, classes like
+/// [Scrollable] that consume a [ScrollPosition] may lose your customizations
+/// when they attempt to combine them with a default [ScrollPhysics] object.
 @immutable
 class ScrollPhysics {
   /// Creates an object with the default scroll physics.

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -70,7 +70,8 @@ enum ScrollDecelerationRate {
 ///
 /// When implementing a subclass, you must override [applyTo] so that it returns
 /// an appropriate instance of your subclass.  Otherwise, classes like
-/// [Scrollable] that inform a [ScrollPosition] will combine them with the default [ScrollPhysics] object instead of your custom subclass.
+/// [Scrollable] that inform a [ScrollPosition] will combine them with
+/// the default [ScrollPhysics] object instead of your custom subclass.
 @immutable
 class ScrollPhysics {
   /// Creates an object with the default scroll physics.

--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -70,8 +70,7 @@ enum ScrollDecelerationRate {
 ///
 /// When implementing a subclass, you must override [applyTo] so that it returns
 /// an appropriate instance of your subclass.  Otherwise, classes like
-/// [Scrollable] that consume a [ScrollPosition] may lose your customizations
-/// when they attempt to combine them with a default [ScrollPhysics] object.
+/// [Scrollable] that inform a [ScrollPosition] will combine them with the default [ScrollPhysics] object instead of your custom subclass.
 @immutable
 class ScrollPhysics {
   /// Creates an object with the default scroll physics.


### PR DESCRIPTION
I missed this when first experimenting with a custom ScrollPhysics subclass a few weeks ago, which led me into about a half-hour of very confused debugging into the framework as I tried to figure out why my code wasn't running.

This requirement is already stated on `applyTo` itself, but one won't necessarily see that unless there's already a reason to pay attention to `applyTo`.  So it seems best to mention it on the documentation of the class itself.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
