### PR TITLE
Fix PlatformMenuItems with onSelectedIntent are never enabled

### DIFF
--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -738,7 +738,8 @@ class PlatformMenuItem with Diagnosticable {
   /// An optional callback that is called when this [PlatformMenuItem] is
   /// selected.
   ///
-  /// If unset, this menu item will be disabled.
+  /// At most one of [onSelected] and [onSelectedIntent] may be set. If neither
+  /// field is set, this menu item will be disabled.
   final VoidCallback? onSelected;
 
   /// Returns a callback, if any, to be invoked if the platform menu receives a
@@ -760,7 +761,8 @@ class PlatformMenuItem with Diagnosticable {
   /// An optional intent that is invoked when this [PlatformMenuItem] is
   /// selected.
   ///
-  /// If unset, this menu item will be disabled.
+  /// At most one of [onSelected] and [onSelectedIntent] may be set. If neither
+  /// field is set, this menu item will be disabled.
   final Intent? onSelectedIntent;
 
   /// Returns all descendant [PlatformMenuItem]s of this item.

--- a/packages/flutter/lib/src/widgets/platform_menu_bar.dart
+++ b/packages/flutter/lib/src/widgets/platform_menu_bar.dart
@@ -805,7 +805,7 @@ class PlatformMenuItem with Diagnosticable {
     return <String, Object?>{
       _kIdKey: getId(item),
       _kLabelKey: item.label,
-      _kEnabledKey: item.onSelected != null,
+      _kEnabledKey: item.onSelected != null || item.onSelectedIntent != null,
       if (shortcut != null)...shortcut.serializeForMenu().toChannelRepresentation(),
     };
   }

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -15,12 +15,12 @@ void main() {
   late FakeMenuChannel fakeMenuChannel;
   late PlatformMenuDelegate originalDelegate;
   late DefaultPlatformMenuDelegate delegate;
-  final List<String> activated = <String>[];
+  final List<String> selected = <String>[];
   final List<String> opened = <String>[];
   final List<String> closed = <String>[];
 
-  void onActivate(String item) {
-    activated.add(item);
+  void onSelected(String item) {
+    selected.add(item);
   }
 
   void onOpen(String item) {
@@ -36,7 +36,7 @@ void main() {
     delegate = DefaultPlatformMenuDelegate(channel: fakeMenuChannel);
     originalDelegate = WidgetsBinding.instance.platformMenuDelegate;
     WidgetsBinding.instance.platformMenuDelegate = delegate;
-    activated.clear();
+    selected.clear();
     opened.clear();
     closed.clear();
   });
@@ -52,8 +52,8 @@ void main() {
           home: Material(
             child: PlatformMenuBar(
               menus: createTestMenus(
-                onActivate: onActivate,
-                onActivateIntent: (String item) => TestPlatformMenuBarIntent(item),
+                onSelected: onSelected,
+                onSelectedIntent: (String item) => TestPlatformMenuBarIntent(item),
                 onOpen: onOpen,
                 onClose: onClose,
                 shortcuts: <String, MenuSerializableShortcut>{
@@ -288,8 +288,8 @@ const List<String> subMenu2 = <String>[
 ];
 
 List<PlatformMenuItem> createTestMenus({
-  void Function(String)? onActivate,
-  Intent Function(String)? onActivateIntent,
+  void Function(String)? onSelected,
+  Intent Function(String)? onSelectedIntent,
   void Function(String)? onOpen,
   void Function(String)? onClose,
   Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
@@ -303,7 +303,7 @@ List<PlatformMenuItem> createTestMenus({
       menus: <PlatformMenuItem>[
         PlatformMenuItem(
           label: subMenu0[0],
-          onSelected: onActivate != null ? () => onActivate(subMenu0[0]) : null,
+          onSelected: onSelected != null ? () => onSelected(subMenu0[0]) : null,
           shortcut: shortcuts[subMenu0[0]],
         ),
       ],
@@ -317,7 +317,7 @@ List<PlatformMenuItem> createTestMenus({
           members: <PlatformMenuItem>[
             PlatformMenuItem(
               label: subMenu1[0],
-              onSelectedIntent: onActivateIntent?.call(subMenu1[0]),
+              onSelectedIntent: onSelectedIntent?.call(subMenu1[0]),
               shortcut: shortcuts[subMenu1[0]],
             ),
           ],
@@ -331,7 +331,7 @@ List<PlatformMenuItem> createTestMenus({
               members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: subSubMenu10[0],
-                  onSelected: onActivate != null ? () => onActivate(subSubMenu10[0]) : null,
+                  onSelected: onSelected != null ? () => onSelected(subSubMenu10[0]) : null,
                   shortcut: shortcuts[subSubMenu10[0]],
                 ),
               ],
@@ -340,21 +340,21 @@ List<PlatformMenuItem> createTestMenus({
               members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: subSubMenu10[1],
-                  onSelected: onActivate != null ? () => onActivate(subSubMenu10[1]) : null,
+                  onSelected: onSelected != null ? () => onSelected(subSubMenu10[1]) : null,
                   shortcut: shortcuts[subSubMenu10[1]],
                 ),
               ],
             ),
             PlatformMenuItem(
               label: subSubMenu10[2],
-              onSelected: onActivate != null ? () => onActivate(subSubMenu10[2]) : null,
+              onSelected: onSelected != null ? () => onSelected(subSubMenu10[2]) : null,
               shortcut: shortcuts[subSubMenu10[2]],
             ),
             PlatformMenuItemGroup(
               members: <PlatformMenuItem>[
                 PlatformMenuItem(
                   label: subSubMenu10[3],
-                  onSelected: onActivate != null ? () => onActivate(subSubMenu10[3]) : null,
+                  onSelected: onSelected != null ? () => onSelected(subSubMenu10[3]) : null,
                   shortcut: shortcuts[subSubMenu10[3]],
                 ),
               ],
@@ -363,7 +363,7 @@ List<PlatformMenuItem> createTestMenus({
         ),
         PlatformMenuItem(
           label: subMenu1[2],
-          onSelected: onActivate != null ? () => onActivate(subMenu1[2]) : null,
+          onSelected: onSelected != null ? () => onSelected(subMenu1[2]) : null,
           shortcut: shortcuts[subMenu1[2]],
         ),
       ],

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -349,7 +349,7 @@ List<PlatformMenuItem> createTestMenus({
   return result;
 }
 
-const expectedStructure = <String, Object?>{
+const Map<String, Object?> expectedStructure = <String, Object?>{
   '0': <Map<String, Object?>>[
     <String, Object?>{
       'id': 2,

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -46,118 +46,69 @@ void main() {
   });
 
   group('PlatformMenuBar', () {
-    testWidgets('basic menu structure is transmitted to platform', (WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          home: Material(
-            child: PlatformMenuBar(
-              menus: createTestMenus(
-                onSelected: onSelected,
-                onSelectedIntent: (String item) => TestPlatformMenuBarIntent(item),
-                onOpen: onOpen,
-                onClose: onClose,
-                shortcuts: <String, MenuSerializableShortcut>{
-                  subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
-                  subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.keyB, shift: true),
-                  subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.keyC, alt: true),
-                  subSubMenu10[3]: const SingleActivator(LogicalKeyboardKey.keyD, meta: true),
-                },
+    group('basic menu structure is transmitted to platform', () {
+      testWidgets('using onSelected', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: PlatformMenuBar(
+                menus: createTestMenus(
+                  onSelected: onSelected,
+                  onOpen: onOpen,
+                  onClose: onClose,
+                  shortcuts: <String, MenuSerializableShortcut>{
+                    subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
+                    subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.keyB, shift: true),
+                    subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.keyC, alt: true),
+                    subSubMenu10[3]: const SingleActivator(LogicalKeyboardKey.keyD, meta: true),
+                  },
+                ),
+                child: const Center(child: Text('Body')),
               ),
-              child: const Center(child: Text('Body')),
             ),
           ),
-        ),
-      );
+        );
 
-      expect(fakeMenuChannel.outgoingCalls.last.method, equals('Menu.setMenus'));
-      expect(
-        fakeMenuChannel.outgoingCalls.last.arguments,
-        equals(<String, Object?>{
-          '0': <Map<String, Object?>>[
-            <String, Object?>{
-              'id': 2,
-              'label': 'Menu 0',
-              'enabled': true,
-              'children': <Map<String, Object?>>[
-                <String, Object?>{
-                  'id': 1,
-                  'label': 'Sub Menu 00',
-                  'enabled': true,
-                },
-              ],
-            },
-            <String, Object?>{
-              'id': 18,
-              'label': 'Menu 1',
-              'enabled': true,
-              'children': <Map<String, Object?>>[
-                <String, Object?>{
-                  'id': 4,
-                  'label': 'Sub Menu 10',
-                  'enabled': true,
-                },
-                <String, Object?>{'id': 5, 'isDivider': true},
-                <String, Object?>{
-                  'id': 16,
-                  'label': 'Sub Menu 11',
-                  'enabled': true,
-                  'children': <Map<String, Object?>>[
-                    <String, Object?>{
-                      'id': 7,
-                      'label': 'Sub Sub Menu 110',
-                      'enabled': true,
-                      'shortcutTrigger': 97,
-                      'shortcutModifiers': 8,
-                    },
-                    <String, Object?>{'id': 8, 'isDivider': true},
-                    <String, Object?>{
-                      'id': 10,
-                      'label': 'Sub Sub Menu 111',
-                      'enabled': true,
-                      'shortcutTrigger': 98,
-                      'shortcutModifiers': 2,
-                    },
-                    <String, Object?>{'id': 11, 'isDivider': true},
-                    <String, Object?>{
-                      'id': 12,
-                      'label': 'Sub Sub Menu 112',
-                      'enabled': true,
-                      'shortcutTrigger': 99,
-                      'shortcutModifiers': 4,
-                    },
-                    <String, Object?>{'id': 13, 'isDivider': true},
-                    <String, Object?>{
-                      'id': 14,
-                      'label': 'Sub Sub Menu 113',
-                      'enabled': true,
-                      'shortcutTrigger': 100,
-                      'shortcutModifiers': 1,
-                    },
-                  ],
-                },
-                <String, Object?>{
-                  'id': 17,
-                  'label': 'Sub Menu 12',
-                  'enabled': true,
-                },
-              ],
-            },
-            <String, Object?>{
-              'id': 20,
-              'label': 'Menu 2',
-              'enabled': true,
-              'children': <Map<String, Object?>>[
-                <String, Object?>{
-                  'id': 19,
-                  'label': 'Sub Menu 20',
-                  'enabled': false,
-                },
-              ],
-            },
-            <String, Object?>{'id': 21, 'label': 'Menu 3', 'enabled': false, 'children': <Map<String, Object?>>[]},
-          ],
-        }),
-      );
+        expect(
+          fakeMenuChannel.outgoingCalls.last.method,
+          equals('Menu.setMenus'),
+        );
+        expect(
+          fakeMenuChannel.outgoingCalls.last.arguments,
+          equals(expectedStructure),
+        );
+      });
+      testWidgets('using onSelectedIntent', (WidgetTester tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Material(
+              child: PlatformMenuBar(
+                menus: createTestMenus(
+                  onSelectedIntent: const DoNothingIntent(),
+                  onOpen: onOpen,
+                  onClose: onClose,
+                  shortcuts: <String, MenuSerializableShortcut>{
+                    subSubMenu10[0]: const SingleActivator(LogicalKeyboardKey.keyA, control: true),
+                    subSubMenu10[1]: const SingleActivator(LogicalKeyboardKey.keyB, shift: true),
+                    subSubMenu10[2]: const SingleActivator(LogicalKeyboardKey.keyC, alt: true),
+                    subSubMenu10[3]: const SingleActivator(LogicalKeyboardKey.keyD, meta: true),
+                  },
+                ),
+                child: const Center(child: Text('Body')),
+              ),
+            ),
+          ),
+        );
+
+        expect(
+          fakeMenuChannel.outgoingCalls.last.method,
+          equals('Menu.setMenus'),
+        );
+        expect(
+          fakeMenuChannel.outgoingCalls.last.arguments,
+          equals(expectedStructure),
+        );
+      });
     });
     testWidgets('asserts when more than one has locked the delegate', (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -234,27 +185,27 @@ void main() {
     testWidgets('character constructor', (WidgetTester tester) async {
       final ShortcutSerialization serialization = ShortcutSerialization.character('?');
       expect(serialization.toChannelRepresentation(), equals(<String, Object?>{
-        'shortcutCharacter': '?',
-        'shortcutModifiers': 0,
-      }));
+            'shortcutCharacter': '?',
+            'shortcutModifiers': 0,
+          }));
       final ShortcutSerialization serializationWithModifiers = ShortcutSerialization.character('?', alt: true, control: true, meta: true);
       expect(serializationWithModifiers.toChannelRepresentation(), equals(<String, Object?>{
-        'shortcutCharacter': '?',
-        'shortcutModifiers': 13,
-      }));
+            'shortcutCharacter': '?',
+            'shortcutModifiers': 13,
+          }));
     });
 
     testWidgets('modifier constructor', (WidgetTester tester) async {
       final ShortcutSerialization serialization = ShortcutSerialization.modifier(LogicalKeyboardKey.home);
       expect(serialization.toChannelRepresentation(), equals(<String, Object?>{
-        'shortcutTrigger': LogicalKeyboardKey.home.keyId,
-        'shortcutModifiers': 0,
-      }));
+            'shortcutTrigger': LogicalKeyboardKey.home.keyId,
+            'shortcutModifiers': 0,
+          }));
       final ShortcutSerialization serializationWithModifiers = ShortcutSerialization.modifier(LogicalKeyboardKey.home, alt: true, control: true, meta: true, shift: true);
       expect(serializationWithModifiers.toChannelRepresentation(), equals(<String, Object?>{
-        'shortcutTrigger': LogicalKeyboardKey.home.keyId,
-        'shortcutModifiers': 15,
-      }));
+            'shortcutTrigger': LogicalKeyboardKey.home.keyId,
+            'shortcutModifiers': 15,
+          }));
     });
   });
 }
@@ -289,7 +240,7 @@ const List<String> subMenu2 = <String>[
 
 List<PlatformMenuItem> createTestMenus({
   void Function(String)? onSelected,
-  Intent Function(String)? onSelectedIntent,
+  Intent? onSelectedIntent,
   void Function(String)? onOpen,
   void Function(String)? onClose,
   Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
@@ -304,6 +255,7 @@ List<PlatformMenuItem> createTestMenus({
         PlatformMenuItem(
           label: subMenu0[0],
           onSelected: onSelected != null ? () => onSelected(subMenu0[0]) : null,
+          onSelectedIntent: onSelectedIntent,
           shortcut: shortcuts[subMenu0[0]],
         ),
       ],
@@ -317,7 +269,8 @@ List<PlatformMenuItem> createTestMenus({
           members: <PlatformMenuItem>[
             PlatformMenuItem(
               label: subMenu1[0],
-              onSelectedIntent: onSelectedIntent?.call(subMenu1[0]),
+              onSelected: onSelected != null ? () => onSelected(subMenu0[0]) : null,
+              onSelectedIntent: onSelectedIntent,
               shortcut: shortcuts[subMenu1[0]],
             ),
           ],
@@ -332,6 +285,7 @@ List<PlatformMenuItem> createTestMenus({
                 PlatformMenuItem(
                   label: subSubMenu10[0],
                   onSelected: onSelected != null ? () => onSelected(subSubMenu10[0]) : null,
+                  onSelectedIntent: onSelectedIntent,
                   shortcut: shortcuts[subSubMenu10[0]],
                 ),
               ],
@@ -341,6 +295,7 @@ List<PlatformMenuItem> createTestMenus({
                 PlatformMenuItem(
                   label: subSubMenu10[1],
                   onSelected: onSelected != null ? () => onSelected(subSubMenu10[1]) : null,
+                  onSelectedIntent: onSelectedIntent,
                   shortcut: shortcuts[subSubMenu10[1]],
                 ),
               ],
@@ -348,6 +303,7 @@ List<PlatformMenuItem> createTestMenus({
             PlatformMenuItem(
               label: subSubMenu10[2],
               onSelected: onSelected != null ? () => onSelected(subSubMenu10[2]) : null,
+              onSelectedIntent: onSelectedIntent,
               shortcut: shortcuts[subSubMenu10[2]],
             ),
             PlatformMenuItemGroup(
@@ -355,6 +311,7 @@ List<PlatformMenuItem> createTestMenus({
                 PlatformMenuItem(
                   label: subSubMenu10[3],
                   onSelected: onSelected != null ? () => onSelected(subSubMenu10[3]) : null,
+                  onSelectedIntent: onSelectedIntent,
                   shortcut: shortcuts[subSubMenu10[3]],
                 ),
               ],
@@ -364,6 +321,7 @@ List<PlatformMenuItem> createTestMenus({
         PlatformMenuItem(
           label: subMenu1[2],
           onSelected: onSelected != null ? () => onSelected(subMenu1[2]) : null,
+          onSelectedIntent: onSelectedIntent,
           shortcut: shortcuts[subMenu1[2]],
         ),
       ],
@@ -391,10 +349,91 @@ List<PlatformMenuItem> createTestMenus({
   return result;
 }
 
-class TestPlatformMenuBarIntent extends Intent {
-  const TestPlatformMenuBarIntent(this.item);
-  final String item;
-}
+const expectedStructure = <String, Object?>{
+  '0': <Map<String, Object?>>[
+    <String, Object?>{
+      'id': 2,
+      'label': 'Menu 0',
+      'enabled': true,
+      'children': <Map<String, Object?>>[
+        <String, Object?>{
+          'id': 1,
+          'label': 'Sub Menu 00',
+          'enabled': true,
+        },
+      ],
+    },
+    <String, Object?>{
+      'id': 18,
+      'label': 'Menu 1',
+      'enabled': true,
+      'children': <Map<String, Object?>>[
+        <String, Object?>{
+          'id': 4,
+          'label': 'Sub Menu 10',
+          'enabled': true,
+        },
+        <String, Object?>{'id': 5, 'isDivider': true},
+        <String, Object?>{
+          'id': 16,
+          'label': 'Sub Menu 11',
+          'enabled': true,
+          'children': <Map<String, Object?>>[
+            <String, Object?>{
+              'id': 7,
+              'label': 'Sub Sub Menu 110',
+              'enabled': true,
+              'shortcutTrigger': 97,
+              'shortcutModifiers': 8,
+            },
+            <String, Object?>{'id': 8, 'isDivider': true},
+            <String, Object?>{
+              'id': 10,
+              'label': 'Sub Sub Menu 111',
+              'enabled': true,
+              'shortcutTrigger': 98,
+              'shortcutModifiers': 2,
+            },
+            <String, Object?>{'id': 11, 'isDivider': true},
+            <String, Object?>{
+              'id': 12,
+              'label': 'Sub Sub Menu 112',
+              'enabled': true,
+              'shortcutTrigger': 99,
+              'shortcutModifiers': 4,
+            },
+            <String, Object?>{'id': 13, 'isDivider': true},
+            <String, Object?>{
+              'id': 14,
+              'label': 'Sub Sub Menu 113',
+              'enabled': true,
+              'shortcutTrigger': 100,
+              'shortcutModifiers': 1,
+            },
+          ],
+        },
+        <String, Object?>{
+          'id': 17,
+          'label': 'Sub Menu 12',
+          'enabled': true,
+        },
+      ],
+    },
+    <String, Object?>{
+      'id': 20,
+      'label': 'Menu 2',
+      'enabled': true,
+      'children': <Map<String, Object?>>[
+        <String, Object?>{
+          'id': 19,
+          'label': 'Sub Menu 20',
+          'enabled': false,
+        },
+      ],
+    },
+    <String, Object?>{'id': 21, 'label': 'Menu 3', 'enabled': false, 'children': <Map<String, Object?>>[]},
+  ],
+};
 
 class FakeMenuChannel implements MethodChannel {
   FakeMenuChannel(this.outgoing);

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -185,27 +185,27 @@ void main() {
     testWidgets('character constructor', (WidgetTester tester) async {
       final ShortcutSerialization serialization = ShortcutSerialization.character('?');
       expect(serialization.toChannelRepresentation(), equals(<String, Object?>{
-            'shortcutCharacter': '?',
-            'shortcutModifiers': 0,
-          }));
+        'shortcutCharacter': '?',
+        'shortcutModifiers': 0,
+      }));
       final ShortcutSerialization serializationWithModifiers = ShortcutSerialization.character('?', alt: true, control: true, meta: true);
       expect(serializationWithModifiers.toChannelRepresentation(), equals(<String, Object?>{
-            'shortcutCharacter': '?',
-            'shortcutModifiers': 13,
-          }));
+        'shortcutCharacter': '?',
+        'shortcutModifiers': 13,
+      }));
     });
 
     testWidgets('modifier constructor', (WidgetTester tester) async {
       final ShortcutSerialization serialization = ShortcutSerialization.modifier(LogicalKeyboardKey.home);
       expect(serialization.toChannelRepresentation(), equals(<String, Object?>{
-            'shortcutTrigger': LogicalKeyboardKey.home.keyId,
-            'shortcutModifiers': 0,
-          }));
+        'shortcutTrigger': LogicalKeyboardKey.home.keyId,
+        'shortcutModifiers': 0,
+      }));
       final ShortcutSerialization serializationWithModifiers = ShortcutSerialization.modifier(LogicalKeyboardKey.home, alt: true, control: true, meta: true, shift: true);
       expect(serializationWithModifiers.toChannelRepresentation(), equals(<String, Object?>{
-            'shortcutTrigger': LogicalKeyboardKey.home.keyId,
-            'shortcutModifiers': 15,
-          }));
+        'shortcutTrigger': LogicalKeyboardKey.home.keyId,
+        'shortcutModifiers': 15,
+      }));
     });
   });
 }

--- a/packages/flutter/test/widgets/platform_menu_bar_test.dart
+++ b/packages/flutter/test/widgets/platform_menu_bar_test.dart
@@ -53,6 +53,7 @@ void main() {
             child: PlatformMenuBar(
               menus: createTestMenus(
                 onActivate: onActivate,
+                onActivateIntent: (String item) => TestPlatformMenuBarIntent(item),
                 onOpen: onOpen,
                 onClose: onClose,
                 shortcuts: <String, MenuSerializableShortcut>{
@@ -288,6 +289,7 @@ const List<String> subMenu2 = <String>[
 
 List<PlatformMenuItem> createTestMenus({
   void Function(String)? onActivate,
+  Intent Function(String)? onActivateIntent,
   void Function(String)? onOpen,
   void Function(String)? onClose,
   Map<String, MenuSerializableShortcut> shortcuts = const <String, MenuSerializableShortcut>{},
@@ -315,7 +317,7 @@ List<PlatformMenuItem> createTestMenus({
           members: <PlatformMenuItem>[
             PlatformMenuItem(
               label: subMenu1[0],
-              onSelected: onActivate != null ? () => onActivate(subMenu1[0]) : null,
+              onSelectedIntent: onActivateIntent?.call(subMenu1[0]),
               shortcut: shortcuts[subMenu1[0]],
             ),
           ],
@@ -387,6 +389,11 @@ List<PlatformMenuItem> createTestMenus({
     ),
   ];
   return result;
+}
+
+class TestPlatformMenuBarIntent extends Intent {
+  const TestPlatformMenuBarIntent(this.item);
+  final String item;
 }
 
 class FakeMenuChannel implements MethodChannel {


### PR DESCRIPTION
Fixes #121805.

The fix is pretty simple: the `PlatformMenuItem` serialization logic only considered whether `onSelected` was non-null when determining whether an item should be enabled. With this change it now checks whether `onSelected` or `onSelectedIntent` are non-null.

I'm less confident about my updates to the tests for this change. The existing tests have code in place to record menu item activations, but then that data isn't actually read anywhere. Based on that observation I didn't implement recording intents sent by activated menu items, since doing so would seemingly go against the style guide's advice to `Avoid implementing features you don’t need`.

Based on `git blame`, CC @gspencergoog