### PR TITLE
[web] Ensure CanvasKit is served from the correct location

### DIFF
--- a/packages/flutter_tools/lib/src/artifacts.dart
+++ b/packages/flutter_tools/lib/src/artifacts.dart
@@ -66,6 +66,9 @@ enum Artifact {
 
   /// The location of file generators.
   flutterToolsFileGenerators,
+
+  /// The path to the CanvasKit files built by the flutter engine.
+  canvasKitPath,
 }
 
 /// A subset of [Artifact]s that are platform and build mode independent
@@ -207,6 +210,7 @@ String? _artifactToFileName(Artifact artifact, Platform hostPlatform, [ BuildMod
     case Artifact.constFinder:
       return 'const_finder.dart.snapshot';
     case Artifact.flutterToolsFileGenerators:
+    case Artifact.canvasKitPath:
       return '';
   }
 }
@@ -530,9 +534,9 @@ class CachedArtifacts implements Artifacts {
       case Artifact.vmSnapshotData:
       case Artifact.windowsCppClientWrapper:
       case Artifact.windowsDesktopPath:
-        return _getHostArtifactPath(artifact, platform, mode);
       case Artifact.flutterToolsFileGenerators:
-        return _getFileGeneratorsPath();
+      case Artifact.canvasKitPath:
+        return _getHostArtifactPath(artifact, platform, mode);
     }
   }
 
@@ -569,9 +573,9 @@ class CachedArtifacts implements Artifacts {
       case Artifact.vmSnapshotData:
       case Artifact.windowsCppClientWrapper:
       case Artifact.windowsDesktopPath:
-        return _getHostArtifactPath(artifact, platform, mode);
       case Artifact.flutterToolsFileGenerators:
-        return _getFileGeneratorsPath();
+      case Artifact.canvasKitPath:
+        return _getHostArtifactPath(artifact, platform, mode);
     }
   }
 
@@ -620,9 +624,9 @@ class CachedArtifacts implements Artifacts {
       case Artifact.vmSnapshotData:
       case Artifact.windowsCppClientWrapper:
       case Artifact.windowsDesktopPath:
-        return _getHostArtifactPath(artifact, platform, mode);
       case Artifact.flutterToolsFileGenerators:
-        return _getFileGeneratorsPath();
+      case Artifact.canvasKitPath:
+        return _getHostArtifactPath(artifact, platform, mode);
     }
   }
 
@@ -699,6 +703,8 @@ class CachedArtifacts implements Artifacts {
         throw StateError('Artifact $artifact not available for platform $platform.');
       case Artifact.flutterToolsFileGenerators:
         return _getFileGeneratorsPath();
+      case Artifact.canvasKitPath:
+        return _fileSystem.path.join(_cache.getWebSdkDirectory().path, 'canvaskit');
     }
   }
 
@@ -968,6 +974,8 @@ class CachedLocalEngineArtifacts implements Artifacts {
         return _fileSystem.path.join(_getDartSdkPath(), 'bin', 'snapshots', artifactFileName);
       case Artifact.flutterToolsFileGenerators:
         return _getFileGeneratorsPath();
+      case Artifact.canvasKitPath:
+        return _fileSystem.path.join(localEngineInfo.engineOutPath, 'canvaskit');
     }
   }
 
@@ -1095,6 +1103,8 @@ class CachedLocalWebSdkArtifacts implements Artifacts {
             _getDartSdkPath(), 'bin', 'snapshots',
             _artifactToFileName(artifact, _platform, mode),
           );
+        case Artifact.canvasKitPath:
+          return _fileSystem.path.join(_webSdkPath, 'canvaskit');
         case Artifact.genSnapshot:
         case Artifact.flutterTester:
         case Artifact.flutterFramework:

--- a/packages/flutter_tools/lib/src/isolated/devfs_web.dart
+++ b/packages/flutter_tools/lib/src/isolated/devfs_web.dart
@@ -416,6 +416,18 @@ class WebAssetServer implements AssetReader {
 
     File file = _resolveDartFile(requestPath);
 
+    if (!file.existsSync() && requestPath.startsWith('canvaskit/')) {
+      final String canvasKitPath = globals.artifacts!.getArtifactPath(
+        Artifact.canvasKitPath,
+        platform: TargetPlatform.web_javascript,
+      );
+      final Uri potential = globals.fs
+          .directory(canvasKitPath)
+          .uri
+          .resolve(requestPath.replaceFirst('canvaskit/', ''));
+      file = globals.fs.file(potential);
+    }
+
     // If all of the lookups above failed, the file might have been an asset.
     // Try and resolve the path relative to the built asset directory.
     if (!file.existsSync()) {
@@ -437,7 +449,8 @@ class WebAssetServer implements AssetReader {
     if (!file.existsSync()) {
       // Paths starting with these prefixes should've been resolved above.
       if (requestPath.startsWith('assets/') ||
-          requestPath.startsWith('packages/')) {
+          requestPath.startsWith('packages/') ||
+          requestPath.startsWith('canvaskit/')) {
         return shelf.Response.notFound('');
       }
       return _serveIndex();

--- a/packages/flutter_tools/test/general.shard/artifacts_test.dart
+++ b/packages/flutter_tools/test/general.shard/artifacts_test.dart
@@ -145,6 +145,10 @@ void main() {
         artifacts.getArtifactPath(Artifact.frontendServerSnapshotForEngineDartSdk),
         fileSystem.path.join('root', 'bin', 'cache', 'dart-sdk', 'bin', 'snapshots', 'frontend_server.dart.snapshot')
       );
+      expect(
+        artifacts.getArtifactPath(Artifact.canvasKitPath),
+        fileSystem.path.join('root', 'bin', 'cache', 'flutter_web_sdk', 'canvaskit'),
+      );
     });
 
     testWithoutContext('precompiled web artifact paths are correct', () {
@@ -341,6 +345,10 @@ void main() {
       expect(
         artifacts.getHostArtifact(HostArtifact.libtessellator).path,
         fileSystem.path.join('/out', 'host_debug_unopt', 'libtessellator.so'),
+      );
+      expect(
+        artifacts.getArtifactPath(Artifact.canvasKitPath, platform: TargetPlatform.web_javascript),
+        fileSystem.path.join('/out', 'wasm_release', 'canvaskit'),
       );
     });
 


### PR DESCRIPTION
When using `--local-engine` or `--local-web-sdk` we need to make sure that we are serving the locally built CanvasKit files instead of the ones in `bin/cache`.

Part of https://github.com/flutter/flutter/issues/118799