### PR TITLE
Add Non-Uniform Border to Border.

### DIFF
--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
 import 'package:flutter/foundation.dart';
 
 import 'basic_types.dart';
@@ -268,10 +267,10 @@ abstract class BoxBorder extends ShapeBorder {
       rect.top - insets.top,
       rect.right + insets.right,
       rect.bottom + insets.bottom,
-      topLeft: _clampRadius(rect.tlRadius + Radius.elliptical(insets.left, insets.top)),
-      topRight: _clampRadius(rect.trRadius + Radius.elliptical(insets.right, insets.top)),
-      bottomRight: _clampRadius(rect.brRadius + Radius.elliptical(insets.right, insets.bottom)),
-      bottomLeft: _clampRadius(rect.blRadius + Radius.elliptical(insets.left, insets.bottom)),
+      topLeft: (rect.tlRadius + Radius.elliptical(insets.left, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      topRight: (rect.trRadius + Radius.elliptical(insets.right, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomRight: (rect.brRadius + Radius.elliptical(insets.right, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomLeft: (rect.blRadius + Radius.elliptical(insets.left, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
     );
   }
 
@@ -281,18 +280,11 @@ abstract class BoxBorder extends ShapeBorder {
       rect.top + insets.top,
       rect.right - insets.right,
       rect.bottom - insets.bottom,
-      topLeft: _clampRadius(rect.tlRadius - Radius.elliptical(insets.left, insets.top)),
-      topRight: _clampRadius(rect.trRadius - Radius.elliptical(insets.right, insets.top)),
-      bottomRight: _clampRadius(rect.brRadius - Radius.elliptical(insets.right, insets.bottom)),
-      bottomLeft:_clampRadius(rect.blRadius - Radius.elliptical(insets.left, insets.bottom)),
+      topLeft: (rect.tlRadius - Radius.elliptical(insets.left, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      topRight: (rect.trRadius - Radius.elliptical(insets.right, insets.top)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomRight: (rect.brRadius - Radius.elliptical(insets.right, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
+      bottomLeft:(rect.blRadius - Radius.elliptical(insets.left, insets.bottom)).clamp(minimum: Radius.zero), // ignore_clamp_double_lint
     );
-  }
-
-  static Radius _clampRadius(Radius radius) {
-    if (radius.x.isNegative || radius.y.isNegative) {
-      return Radius.elliptical(math.max(radius.x, 0), math.max(radius.y, 0));
-    }
-    return radius;
   }
 
   static void _paintUniformBorderWithCircle(Canvas canvas, Rect rect, BorderSide side) {

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -469,24 +469,24 @@ class Border extends BoxBorder {
 
   bool get _colorIsUniform {
     final Color topColor = top.color;
-    return right.color == topColor && bottom.color == topColor && left.color == topColor;
+    return left.color == topColor && bottom.color == topColor && right.color == topColor;
   }
 
   bool get _widthIsUniform {
     final double topWidth = top.width;
-    return right.width == topWidth && bottom.width == topWidth && left.width == topWidth;
+    return left.width == topWidth && bottom.width == topWidth && right.width == topWidth;
   }
 
   bool get _styleIsUniform {
     final BorderStyle topStyle = top.style;
-    return right.style == topStyle && bottom.style == topStyle && left.style == topStyle;
+    return left.style == topStyle && bottom.style == topStyle && right.style == topStyle;
   }
 
   bool get _strokeAlignIsUniform {
     final double topStrokeAlign = top.strokeAlign;
-    return right.strokeAlign == topStrokeAlign
+    return left.strokeAlign == topStrokeAlign
         && bottom.strokeAlign == topStrokeAlign
-        && left.strokeAlign == topStrokeAlign;
+        && right.strokeAlign == topStrokeAlign;
   }
 
   @override
@@ -781,17 +781,17 @@ class BorderDirectional extends BoxBorder {
 
   bool get _colorIsUniform {
     final Color topColor = top.color;
-    return end.color == topColor && bottom.color == topColor && start.color == topColor;
+    return start.color == topColor && bottom.color == topColor && end.color == topColor;
   }
 
   bool get _widthIsUniform {
     final double topWidth = top.width;
-    return end.width == topWidth && bottom.width == topWidth && start.width == topWidth;
+    return start.width == topWidth && bottom.width == topWidth && end.width == topWidth;
   }
 
   bool get _styleIsUniform {
     final BorderStyle topStyle = top.style;
-    return end.style == topStyle && bottom.style == topStyle && start.style == topStyle;
+    return start.style == topStyle && bottom.style == topStyle && end.style == topStyle;
   }
 
   bool get _strokeAlignIsUniform {

--- a/packages/flutter/lib/src/painting/box_border.dart
+++ b/packages/flutter/lib/src/painting/box_border.dart
@@ -637,7 +637,7 @@ class Border extends BoxBorder {
     assert(() {
       if (!_strokeAlignIsUniform || top.strokeAlign != BorderSide.strokeAlignInside) {
         throw FlutterError.fromParts(<DiagnosticsNode>[
-          ErrorSummary('A Border can only draw strokeAlign different than BorderSide.strokeAlignInside on uniform borders.'),
+          ErrorSummary('A Border can only draw strokeAlign different than BorderSide.strokeAlignInside on borders with uniform colors.'),
         ]);
       }
       return true;
@@ -959,7 +959,7 @@ class BorderDirectional extends BoxBorder {
     }
 
     assert(shape == BoxShape.rectangle, 'A border can only be drawn as a circle if it is uniform.');
-    assert(_strokeAlignIsUniform && top.strokeAlign == BorderSide.strokeAlignInside, 'A Border can only draw strokeAlign different than strokeAlignInside on uniform borders.');
+    assert(_strokeAlignIsUniform && top.strokeAlign == BorderSide.strokeAlignInside, 'A Border can only draw strokeAlign different than strokeAlignInside on borders with uniform colors.');
 
     final BorderSide left, right;
     assert(textDirection != null, 'Non-uniform BorderDirectional objects require a TextDirection when painting.');

--- a/packages/flutter/test/material/data_table_test.dart
+++ b/packages/flutter/test/material/data_table_test.dart
@@ -1748,11 +1748,7 @@ void main() {
     );
     expect(
       find.ancestor(of: find.byType(Table), matching: find.byType(Container)),
-      paints
-        ..path(color: borderColor)
-        ..path(color: borderColor)
-        ..path(color: borderColor)
-        ..path(color: borderColor),
+      paints..drrect(color: borderColor),
     );
     expect(
       tester.getTopLeft(find.byType(Table)),

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -264,8 +264,8 @@ void main() {
       // Border.all supports all StrokeAlign values.
       // Border() supports [BorderSide.strokeAlignInside] only.
       const Border(
-        left: BorderSide(strokeAlign: BorderSide.strokeAlignCenter),
-        right: BorderSide(strokeAlign: BorderSide.strokeAlignOutside),
+        left: BorderSide(strokeAlign: BorderSide.strokeAlignCenter, color: Color(0xff000000)),
+        right: BorderSide(strokeAlign: BorderSide.strokeAlignOutside, color: Color(0xff000001)),
       ).paint(canvas, const Rect.fromLTWH(10.0, 20.0, 30.0, 40.0));
     } on FlutterError catch (e) {
       error = e;
@@ -274,7 +274,7 @@ void main() {
     expect(error.diagnostics.length, 1);
     expect(
       error.diagnostics[0].toStringDeep(),
-      'A Border can only draw strokeAlign different than\nBorderSide.strokeAlignInside on uniform borders.\n',
+      'A Border can only draw strokeAlign different than\nBorderSide.strokeAlignInside on borders with uniform colors.\n',
     );
   });
 

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -264,8 +264,8 @@ void main() {
       // Border.all supports all StrokeAlign values.
       // Border() supports [BorderSide.strokeAlignInside] only.
       const Border(
-        left: BorderSide(strokeAlign: BorderSide.strokeAlignCenter, color: Color(0xff000000)),
-        right: BorderSide(strokeAlign: BorderSide.strokeAlignOutside, color: Color(0xff000001)),
+        left: BorderSide(strokeAlign: BorderSide.strokeAlignCenter, color: Color(0xff000001)),
+        right: BorderSide(strokeAlign: BorderSide.strokeAlignOutside, color: Color(0xff000002)),
       ).paint(canvas, const Rect.fromLTWH(10.0, 20.0, 30.0, 40.0));
     } on FlutterError catch (e) {
       error = e;
@@ -299,5 +299,21 @@ void main() {
     const BorderSide outsideSide = BorderSide(width: 10, strokeAlign: BorderSide.strokeAlignOutside);
     const BorderDirectional outsideBorderDirectional = BorderDirectional(top: outsideSide, bottom: outsideSide, start: outsideSide, end: outsideSide);
     expect(outsideBorderDirectional.dimensions, EdgeInsetsDirectional.zero);
+
+    const Border nonUniformBorder = Border(
+      left: BorderSide(width: 5),
+      top: BorderSide(width: 10, strokeAlign: BorderSide.strokeAlignCenter),
+      right: BorderSide(width: 15, strokeAlign: BorderSide.strokeAlignOutside),
+      bottom: BorderSide(width: 20),
+    );
+    expect(nonUniformBorder.dimensions, const EdgeInsets.fromLTRB(5, 5, 0, 20));
+
+    const BorderDirectional nonUniformBorderDirectional = BorderDirectional(
+      start: BorderSide(width: 5),
+      top: BorderSide(width: 10, strokeAlign: BorderSide.strokeAlignCenter),
+      end: BorderSide(width: 15, strokeAlign: BorderSide.strokeAlignOutside),
+      bottom: BorderSide(width: 20),
+    );
+    expect(nonUniformBorderDirectional.dimensions, const EdgeInsetsDirectional.fromSTEB(5, 5, 0, 20));
   });
 }

--- a/packages/flutter/test/painting/border_test.dart
+++ b/packages/flutter/test/painting/border_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart' show FlutterError;
-import 'package:flutter/painting.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 class TestCanvas implements Canvas {
@@ -274,7 +273,7 @@ void main() {
     expect(error.diagnostics.length, 1);
     expect(
       error.diagnostics[0].toStringDeep(),
-      'A Border can only draw strokeAlign different than\nBorderSide.strokeAlignInside on borders with uniform colors.\n',
+      'A Border can only draw strokeAlign different than\nBorderSide.strokeAlignInside on borders with uniform colors and\nstyles.\n',
     );
   });
 
@@ -315,5 +314,92 @@ void main() {
       bottom: BorderSide(width: 20),
     );
     expect(nonUniformBorderDirectional.dimensions, const EdgeInsetsDirectional.fromSTEB(5, 5, 0, 20));
+  });
+
+  testWidgets('Non-Uniform Border variations', (WidgetTester tester) async {
+
+    Widget buildWidget({ required BoxBorder border, BorderRadius? borderRadius, BoxShape boxShape = BoxShape.rectangle}) {
+      return Directionality(
+        textDirection: TextDirection.ltr,
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            shape: boxShape,
+            border: border,
+            borderRadius: borderRadius,
+          ),
+        ),
+      );
+    }
+
+    // This is used to test every allowed non-uniform border combination.
+    const Border allowedBorderVariations = Border(
+      left: BorderSide(width: 5),
+      top: BorderSide(width: 10, strokeAlign: BorderSide.strokeAlignCenter),
+      right: BorderSide(width: 15, strokeAlign: BorderSide.strokeAlignOutside),
+      bottom: BorderSide(width: 20),
+    );
+
+    // This falls into non-uniform border because of strokeAlign.
+    await tester.pumpWidget(buildWidget(border: allowedBorderVariations));
+    expect(tester.takeException(), isNull,
+        reason: 'Border with non-uniform strokeAlign should not fail.');
+
+    await tester.pumpWidget(buildWidget(
+      border: allowedBorderVariations,
+      borderRadius: BorderRadius.circular(25),
+    ));
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(buildWidget(border: allowedBorderVariations, boxShape: BoxShape.circle));
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(
+      buildWidget(
+        border: const Border(
+          left: BorderSide(width: 5, style: BorderStyle.none),
+          top: BorderSide(width: 10),
+          right: BorderSide(width: 15),
+          bottom: BorderSide(width: 20),
+        ),
+        borderRadius: BorderRadius.circular(25),
+      ),
+    );
+    expect(tester.takeException(), isAssertionError,
+        reason: 'Border with non-uniform styles should fail with borderRadius.');
+
+    await tester.pumpWidget(
+      buildWidget(
+        border: const Border(
+          left: BorderSide(width: 5, color: Color(0xff123456)),
+          top: BorderSide(width: 10),
+          right: BorderSide(width: 15),
+          bottom: BorderSide(width: 20),
+        ),
+        borderRadius: BorderRadius.circular(20),
+      ),
+    );
+    expect(tester.takeException(), isAssertionError,
+        reason: 'Border with non-uniform colors should fail with borderRadius.');
+
+    // Tests for BorderDirectional.
+    const BorderDirectional allowedBorderDirectionalVariations = BorderDirectional(
+      start: BorderSide(width: 5),
+      top: BorderSide(width: 10, strokeAlign: BorderSide.strokeAlignCenter),
+      end: BorderSide(width: 15, strokeAlign: BorderSide.strokeAlignOutside),
+      bottom: BorderSide(width: 20),
+    );
+
+    await tester.pumpWidget(buildWidget(border: allowedBorderDirectionalVariations));
+    expect(tester.takeException(), isNull);
+
+    await tester.pumpWidget(buildWidget(
+      border: allowedBorderDirectionalVariations,
+      borderRadius: BorderRadius.circular(25),
+    ));
+    expect(tester.takeException(), isNull,
+        reason:'BorderDirectional should not fail with uniform styles and colors.');
+
+    await tester.pumpWidget(buildWidget(border: allowedBorderDirectionalVariations, boxShape: BoxShape.circle));
+    expect(tester.takeException(), isNull);
   });
 }


### PR DESCRIPTION
Fix https://github.com/flutter/flutter/issues/12583.
Fix https://github.com/flutter/flutter/issues/109954.

Exactly like Figma:

<img width="206" alt="image" src="https://user-images.githubusercontent.com/351125/222874009-ee49ed13-9538-413b-a6da-bba1d4401056.png">

<img width="652" alt="image" src="https://user-images.githubusercontent.com/351125/222873967-e446392a-e2ca-4a35-ad8b-37b951e1ce20.png">

What if it has multiple colors + borderRadius? It will crash as usual.
Side effects: material data tables will paint faster, because drrect > path.