### PR TITLE
Add backward compatibility in proxied_devices.

### DIFF
--- a/packages/flutter_tools/lib/src/proxied_devices/devices.dart
+++ b/packages/flutter_tools/lib/src/proxied_devices/devices.dart
@@ -248,7 +248,8 @@ class ProxiedDevice extends Device {
       'userIdentifier': userIdentifier,
     }));
     final bool started = _cast<bool>(result['started']);
-    final String? vmServiceUriStr = _cast<String?>(result['vmServiceUri']);
+    // TODO(bkonyi): remove once clients have migrated to relying on vmServiceUri.
+    final String? vmServiceUriStr = _cast<String?>(result['vmServiceUri']) ?? _cast<String?>(result['observatoryUri']);
     final Uri? vmServiceUri = vmServiceUriStr == null ? null : Uri.parse(vmServiceUriStr);
     if (started) {
       if (vmServiceUri != null) {


### PR DESCRIPTION
The daemon has changed from sending 'observabilityUri' to 'vmServiceUri' in #121606. If the daemon is an older version proxied_devices would break. Update this to accept the older field if newer field does not exist.
