### PR TITLE
Delete `FlutterCommand.intArg()`, which is not used anywhere

### DIFF
--- a/packages/flutter_tools/lib/src/runner/flutter_command.dart
+++ b/packages/flutter_tools/lib/src/runner/flutter_command.dart
@@ -1734,9 +1734,6 @@ abstract class FlutterCommand extends Command<void> {
     return argResults![name] as String?;
   }
 
-  /// Gets the parsed command-line option named [name] as an `int`.
-  int? intArg(String name) => argResults?[name] as int?;
-
   /// Gets the parsed command-line option named [name] as `List<String>`.
   List<String> stringsArg(String name) {
     return argResults![name]! as List<String>? ?? <String>[];


### PR DESCRIPTION
This PR removes dead code.

What's interesting is that it has a bug in it, so it probably was never used :) The correct implementation would be:

```dart
  /// Gets the parsed command-line option named [name] as an `int`.
  int? intArg(String name) {
    if (!argParser.options.containsKey(name)) {
      return null;
    }

    final value = argResults![name] as String?;
    if (value == null) {
      return null;
    }

    return int.tryParse(value);
  }
```

*List which issues are fixed by this PR. You must list at least one issue.*

Sorry, I think this is such a small change that it doesn't require one. But if I really must, I'll do, of course :)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
