### PR TITLE
Reduce macOS overscroll friction

### DIFF
--- a/packages/flutter/lib/src/widgets/scroll_physics.dart
+++ b/packages/flutter/lib/src/widgets/scroll_physics.dart
@@ -685,7 +685,7 @@ class BouncingScrollPhysics extends ScrollPhysics {
   double frictionFactor(double overscrollFraction) {
     switch (decelerationRate) {
       case ScrollDecelerationRate.fast:
-        return 0.07 * math.pow(1 - overscrollFraction, 2);
+        return 0.26 * math.pow(1 - overscrollFraction, 2);
       case ScrollDecelerationRate.normal:
         return 0.52 * math.pow(1 - overscrollFraction, 2);
     }

--- a/packages/flutter/test/cupertino/refresh_test.dart
+++ b/packages/flutter/test/cupertino/refresh_test.dart
@@ -247,7 +247,7 @@ void main() {
         ),
         if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) matchesBuilder(
           refreshState: RefreshIndicatorMode.armed,
-          pulledExtent: moreOrLessEquals(100.44528),
+          pulledExtent: moreOrLessEquals(112.51104),
           refreshTriggerPullDistance: 100,  // default value.
           refreshIndicatorExtent: 60,  // default value.
         )
@@ -464,12 +464,7 @@ void main() {
         const Rect.fromLTRB(0.0, 0.0, 800.0, 150.0),
       );
 
-      if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
-        await tester.drag(find.text('0'), const Offset(0.0, -130.0), touchSlopY: 0, warnIfMissed: false); // hits the list
-      }
-      else {
-        await tester.drag(find.text('0'), const Offset(0.0, -300.0), touchSlopY: 0, warnIfMissed: false); // hits the list
-      }
+      await tester.drag(find.text('0'), const Offset(0.0, -300.0), touchSlopY: 0, warnIfMissed: false); // hits the list
       await tester.pump();
 
       // Refresh indicator still being told to layout the same way.
@@ -484,15 +479,15 @@ void main() {
       if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
         expect(
           tester.getTopLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-          moreOrLessEquals(-40),
+          moreOrLessEquals(-210.0),
         );
         expect(
           tester.getBottomLeft(find.widgetWithText(Center, '-1', skipOffstage: false)).dy,
-          moreOrLessEquals(20),
+          moreOrLessEquals(-150.0),
         );
         expect(
           tester.getTopLeft(find.widgetWithText(Center, '0')).dy,
-          moreOrLessEquals(20),
+          moreOrLessEquals(-150.0),
         );
       }
       else {
@@ -761,7 +756,7 @@ void main() {
         if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
           expect(mockHelper.invocations, contains(matchesBuilder(
             refreshState: RefreshIndicatorMode.done,
-            pulledExtent: 97.71721346565732,
+            pulledExtent: 118.29756539042118,
             refreshTriggerPullDistance: 100,  // default value.
             refreshIndicatorExtent: 60,  // default value.
           )));
@@ -1199,17 +1194,12 @@ void main() {
           RefreshIndicatorMode.armed,
         );
 
-        if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
-          await gesture.moveBy(const Offset(0.0, -41.0)); // Overscrolling, need to move more than -40.
-        }
-        else {
-          await gesture.moveBy(const Offset(0.0, -80.0)); // Overscrolling, need to move more than -40.
-        }
+        await gesture.moveBy(const Offset(0.0, -80.0)); // Overscrolling, need to move more than -40.
         await tester.pump();
         if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
           expect(
             tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-            moreOrLessEquals(49), // Below 50 now.
+            moreOrLessEquals(10.0), // Below 50 now.
           );
         }
         else {
@@ -1317,7 +1307,7 @@ void main() {
         if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
           expect(
             tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-            moreOrLessEquals(25),
+            moreOrLessEquals(25.0),
           );
         }
         else {
@@ -1333,7 +1323,7 @@ void main() {
         );
 
         if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
-          await gesture.moveBy(const Offset(0.0, -15.0));
+          await gesture.moveBy(const Offset(0.0, -16.0));
         }
         else {
           await gesture.moveBy(const Offset(0.0, -35.0));
@@ -1342,7 +1332,7 @@ void main() {
         if (debugDefaultTargetPlatformOverride == TargetPlatform.macOS) {
           expect(
             tester.getTopLeft(find.widgetWithText(SizedBox, '0')).dy,
-            moreOrLessEquals(10),
+            moreOrLessEquals(9.0),
           );
         }
         else {

--- a/packages/flutter/test/widgets/scroll_physics_test.dart
+++ b/packages/flutter/test/widgets/scroll_physics_test.dart
@@ -271,6 +271,20 @@ void main() {
       expect(smallListOverscrollApplied, greaterThan(1.0));
       expect(smallListOverscrollApplied, lessThan(20.0));
     });
+
+    test('frictionFactor', () {
+      const BouncingScrollPhysics mobile = BouncingScrollPhysics();
+      const BouncingScrollPhysics desktop = BouncingScrollPhysics(decelerationRate: ScrollDecelerationRate.fast);
+
+      expect(desktop.frictionFactor(0), 0.26);
+      expect(mobile.frictionFactor(0), 0.52);
+
+      expect(desktop.frictionFactor(0.4), moreOrLessEquals(0.0936));
+      expect(mobile.frictionFactor(0.4), moreOrLessEquals(0.1872));
+
+      expect(desktop.frictionFactor(0.8), moreOrLessEquals(0.0104));
+      expect(mobile.frictionFactor(0.8), moreOrLessEquals(0.0208));
+    });
   });
 
   test('ClampingScrollPhysics assertion test', () {


### PR DESCRIPTION
Increases the `frictionFactor` on `BouncingScrollPhysics` when `decelerationRate = ScrollDecelerationRate.fast`. This in effect reduces the friction when overscrolling. Now it's double the friction compared to `ScrollDecelerationRate.normal`. Previously, it was over 7 times in order to match other macOS apps. But it made it impossible to use some common Flutter interactions like `RefreshIndicator`. Even though this change makes it less "native", I think the experience is better.


Fixes #119702

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
