### PR TITLE
Clear _scribbleCacheKey when connection closes

### DIFF
--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -3165,6 +3165,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       _textInputConnection!.close();
       _textInputConnection = null;
       _lastKnownRemoteTextEditingValue = null;
+      _scribbleCacheKey = null;
       removeTextPlaceholder();
     }
   }


### PR DESCRIPTION
When a TextInputConnection is recreated in the engine, it won't have its previous selectionRects remembered. But the framework still thinks it does, as `_scribbleCacheKey` isn't changed. The effect of this is that when refocusing a text field, the selectionRects will be missing until the text is changed. By clearing the cache-key, they will be properly re-sent when the TextInputConnection is re-opened.

Part of #30476

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.
