### PR TITLE
Fix DomCSSStyleSheetExtension to work with dart2wasm.

### DIFF
--- a/packages/flutter/lib/src/services/dom.dart
+++ b/packages/flutter/lib/src/services/dom.dart
@@ -337,7 +337,7 @@ class DomCSSStyleSheet extends DomStyleSheet {}
 extension DomCSSStyleSheetExtension on DomCSSStyleSheet {
   /// Inserts a rule into this style sheet.
   int insertRule(String rule, [int? index]) =>
-    js_util.callMethod(this, 'insertRule', <Object>[
+    js_util.callMethod<double>(this, 'insertRule', <Object>[
       rule,
       if (index != null) index.toDouble()
     ]).toInt();

--- a/packages/flutter/lib/src/services/dom.dart
+++ b/packages/flutter/lib/src/services/dom.dart
@@ -336,8 +336,11 @@ class DomCSSStyleSheet extends DomStyleSheet {}
 /// [DomCSSStyleSheet]'s required extension.
 extension DomCSSStyleSheetExtension on DomCSSStyleSheet {
   /// Inserts a rule into this style sheet.
-  int insertRule(String rule, [int? index]) => js_util
-      .callMethod(this, 'insertRule', <Object>[rule, if (index != null) index]);
+  int insertRule(String rule, [int? index]) =>
+    js_util.callMethod(this, 'insertRule', <Object>[
+      rule,
+      if (index != null) index.toDouble()
+    ]).toInt();
 }
 
 /// A list of token.


### PR DESCRIPTION
This fixes https://github.com/flutter/flutter/issues/122150