### PR TITLE
Funnel devicelab tests through utils process methods

### DIFF
--- a/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_engine_group_performance.dart
@@ -58,10 +58,9 @@ Future<TaskResult> _doTest() async {
     final String gradlew = Platform.isWindows ? 'gradlew.bat' : 'gradlew';
     final String gradlewExecutable =
         Platform.isWindows ? '.\\$gradlew' : './$gradlew';
-    final String flutterPath = path.join(flutterDirectory, 'bin', 'flutter');
-    await utils.eval(flutterPath, <String>['precache', '--android'],
+    await utils.flutter('precache', options: <String>['--android'],
         workingDirectory: modulePath);
-    await utils.eval(flutterPath, <String>['pub', 'get'],
+    await utils.flutter('pub', options: <String>['get'],
         workingDirectory: modulePath);
     _copyGradleFromModule(modulePath, androidPath);
 

--- a/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
+++ b/dev/devicelab/bin/tasks/flutter_gallery_v2_chrome_run_test.dart
@@ -53,9 +53,9 @@ class NewGalleryChromeRunTest {
       ]);
 
       final List<String> options = <String>['-d', 'chrome', '--verbose', '--resident'];
-      final Process process = await startProcess(
-        path.join(flutterDirectory.path, 'bin', 'flutter'),
-        flutterCommandArgs('run', options),
+      final Process process = await startFlutter(
+        'run',
+        options: options,
       );
 
       final Completer<void> stdoutDone = Completer<void>();

--- a/dev/devicelab/bin/tasks/flutter_test_performance.dart
+++ b/dev/devicelab/bin/tasks/flutter_test_performance.dart
@@ -38,14 +38,13 @@ enum TestStep {
 
 Future<int> runTest({bool coverage = false, bool noPub = false}) async {
   final Stopwatch clock = Stopwatch()..start();
-  final List<String> arguments = flutterCommandArgs('test', <String>[
-    if (coverage) '--coverage',
-    if (noPub) '--no-pub',
-    path.join('flutter_test', 'trivial_widget_test.dart'),
-  ]);
-  final Process analysis = await startProcess(
-    path.join(flutterDirectory.path, 'bin', 'flutter'),
-    arguments,
+  final Process analysis = await startFlutter(
+    'test',
+    options: <String>[
+      if (coverage) '--coverage',
+      if (noPub) '--no-pub',
+      path.join('flutter_test', 'trivial_widget_test.dart'),
+    ],
     workingDirectory: path.join(flutterDirectory.path, 'dev', 'automated_tests'),
   );
   int badLines = 0;

--- a/dev/devicelab/bin/tasks/routing_test.dart
+++ b/dev/devicelab/bin/tasks/routing_test.dart
@@ -38,10 +38,10 @@ void main() {
       final Completer<void> ready = Completer<void>();
       late bool ok;
       print('run: starting...');
-      final Process run = await startProcess(
-        path.join(flutterDirectory.path, 'bin', 'flutter'),
+      final Process run = await startFlutter(
+        'run',
         // --fast-start does not support routes.
-        <String>['run', '--verbose', '--disable-service-auth-codes', '--no-fast-start', '--no-publish-port', '-d', device.deviceId, '--route', '/smuggle-it', 'lib/route.dart'],
+        options: <String>['--verbose', '--disable-service-auth-codes', '--no-fast-start', '--no-publish-port', '-d', device.deviceId, '--route', '/smuggle-it', 'lib/route.dart'],
       );
       run.stdout
         .transform<String>(utf8.decoder)
@@ -70,9 +70,9 @@ void main() {
         throw 'Failed to run test app.';
       }
       print('drive: starting...');
-      final Process drive = await startProcess(
-        path.join(flutterDirectory.path, 'bin', 'flutter'),
-        <String>['drive', '--use-existing-app', 'http://127.0.0.1:$vmServicePort/', '--no-keep-app-running', 'lib/route.dart'],
+      final Process drive = await startFlutter(
+        'drive',
+        options: <String>['--use-existing-app', 'http://127.0.0.1:$vmServicePort/', '--no-keep-app-running', 'lib/route.dart'],
       );
       drive.stdout
         .transform<String>(utf8.decoder)

--- a/dev/devicelab/bin/tasks/service_extensions_test.dart
+++ b/dev/devicelab/bin/tasks/service_extensions_test.dart
@@ -25,9 +25,9 @@ void main() {
       final Completer<void> ready = Completer<void>();
       late bool ok;
       print('run: starting...');
-      final Process run = await startProcess(
-        path.join(flutterDirectory.path, 'bin', 'flutter'),
-        <String>['run', '--verbose', '--no-fast-start', '--no-publish-port', '--disable-service-auth-codes', '-d', device.deviceId, 'lib/main.dart'],
+      final Process run = await startFlutter(
+        'run',
+        options: <String>['--verbose', '--no-fast-start', '--no-publish-port', '--disable-service-auth-codes', '-d', device.deviceId, 'lib/main.dart'],
       );
       run.stdout
           .transform<String>(utf8.decoder)

--- a/dev/devicelab/lib/framework/utils.dart
+++ b/dev/devicelab/lib/framework/utils.dart
@@ -433,7 +433,7 @@ Future<String> eval(
   return output.toString().trimRight();
 }
 
-List<String> flutterCommandArgs(String command, List<String> options) {
+List<String> _flutterCommandArgs(String command, List<String> options) {
   // Commands support the --device-timeout flag.
   final Set<String> supportedDeviceTimeoutCommands = <String>{
     'attach',
@@ -470,10 +470,11 @@ Future<int> flutter(String command, {
   List<String> options = const <String>[],
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String>? environment,
+  String? workingDirectory,
 }) {
-  final List<String> args = flutterCommandArgs(command, options);
+  final List<String> args = _flutterCommandArgs(command, options);
   return exec(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
-    canFail: canFail, environment: environment);
+    canFail: canFail, environment: environment, workingDirectory: workingDirectory);
 }
 
 /// Starts a Flutter subprocess.
@@ -502,13 +503,15 @@ Future<Process> startFlutter(String command, {
   List<String> options = const <String>[],
   Map<String, String> environment = const <String, String>{},
   bool isBot = true, // set to false to pretend not to be on a bot (e.g. to test user-facing outputs)
-}) {
-  final List<String> args = flutterCommandArgs(command, options);
+  String? workingDirectory,
+}) async {
+  final List<String> args = _flutterCommandArgs(command, options);
   return startProcess(
     path.join(flutterDirectory.path, 'bin', 'flutter'),
     args,
     environment: environment,
     isBot: isBot,
+    workingDirectory: workingDirectory,
   );
 }
 
@@ -518,16 +521,17 @@ Future<String> evalFlutter(String command, {
   bool canFail = false, // as in, whether failures are ok. False means that they are fatal.
   Map<String, String>? environment,
   StringBuffer? stderr, // if not null, the stderr will be written here.
+  String? workingDirectory,
 }) {
-  final List<String> args = flutterCommandArgs(command, options);
+  final List<String> args = _flutterCommandArgs(command, options);
   return eval(path.join(flutterDirectory.path, 'bin', 'flutter'), args,
-      canFail: canFail, environment: environment, stderr: stderr);
+      canFail: canFail, environment: environment, stderr: stderr, workingDirectory: workingDirectory);
 }
 
 Future<ProcessResult> executeFlutter(String command, {
   List<String> options = const <String>[],
 }) async {
-  final List<String> args = flutterCommandArgs(command, options);
+  final List<String> args = _flutterCommandArgs(command, options);
   return _processManager.run(
     <String>[path.join(flutterDirectory.path, 'bin', 'flutter'), ...args],
     workingDirectory: cwd,

--- a/dev/devicelab/lib/tasks/android_choreographer_do_frame_test.dart
+++ b/dev/devicelab/lib/tasks/android_choreographer_do_frame_test.dart
@@ -88,9 +88,9 @@ Future<void> main() async {
         section('Flutter run (mode: $mode)');
         late Process run;
         await inDirectory(path.join(tempDir.path, 'app'), () async {
-          run = await startProcess(
-            path.join(flutterDirectory.path, 'bin', 'flutter'),
-            flutterCommandArgs('run', <String>['--$mode', '--verbose']),
+          run = await startFlutter(
+            'run',
+            options: <String>['--$mode', '--verbose'],
           );
         });
 

--- a/dev/devicelab/lib/tasks/android_lifecycles_test.dart
+++ b/dev/devicelab/lib/tasks/android_lifecycles_test.dart
@@ -77,9 +77,9 @@ void main() {
 
         late Process run;
         await inDirectory(path.join(tempDir.path, 'app'), () async {
-          run = await startProcess(
-            path.join(flutterDirectory.path, 'bin', 'flutter'),
-            flutterCommandArgs('run', <String>['--$mode']),
+          run = await startFlutter(
+            'run',
+            options: <String>['--$mode'],
           );
         });
 

--- a/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
+++ b/dev/devicelab/lib/tasks/dart_plugin_registry_tests.dart
@@ -143,9 +143,9 @@ class ApluginPlatformInterfaceMacOS {
 
       late Process run;
       await inDirectory(path.join(tempDir.path, 'app'), () async {
-        run = await startProcess(
-          path.join(flutterDirectory.path, 'bin', 'flutter'),
-          flutterCommandArgs('run', <String>['-d', 'macos', '-v']),
+        run = await startFlutter(
+          'run',
+          options: <String>['-d', 'macos', '-v'],
         );
       });
 

--- a/dev/devicelab/lib/tasks/perf_tests.dart
+++ b/dev/devicelab/lib/tasks/perf_tests.dart
@@ -867,17 +867,19 @@ class DevtoolsStartupTest {
           break;
       }
 
-      final Process process = await startProcess(path.join(flutterDirectory.path, 'bin', 'flutter'), <String>[
+      final Process process = await startFlutter(
         'run',
-        '--no-android-gradle-daemon',
-        '--no-publish-port',
-        '--verbose',
-        '--profile',
-        '-d',
-        device.deviceId,
-        if (applicationBinaryPath != null)
-          '--use-application-binary=$applicationBinaryPath',
-       ]);
+        options: <String>[
+          '--no-android-gradle-daemon',
+          '--no-publish-port',
+          '--verbose',
+          '--profile',
+          '-d',
+          device.deviceId,
+          if (applicationBinaryPath != null)
+            '--use-application-binary=$applicationBinaryPath',
+       ],
+      );
       final Completer<void> completer = Completer<void>();
       bool sawLine = false;
       process.stdout

--- a/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
+++ b/dev/devicelab/lib/tasks/platform_channels_benchmarks.dart
@@ -21,18 +21,15 @@ TaskFunction runTask(adb.DeviceOperatingSystem operatingSystem) {
     final Directory appDir = utils.dir(path.join(utils.flutterDirectory.path,
         'dev/benchmarks/platform_channels_benchmarks'));
     final Process flutterProcess = await utils.inDirectory(appDir, () async {
-      final String flutterExe =
-          path.join(utils.flutterDirectory.path, 'bin', 'flutter');
       final List<String> createArgs = <String>[
-        'create',
         '--platforms',
         'ios,android',
         '--no-overwrite',
         '-v',
         '.',
       ];
-      print('\nExecuting: $flutterExe $createArgs $appDir');
-      await utils.eval(flutterExe, createArgs);
+      print('\nExecuting: flutter create $createArgs $appDir');
+      await utils.flutter('create', options: createArgs);
 
       final List<String> options = <String>[
         '-v',

--- a/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
+++ b/dev/devicelab/lib/tasks/web_dev_mode_tests.dart
@@ -42,13 +42,13 @@ TaskFunction createWebDevModeTest(String webDevice, bool enableIncrementalCompil
       recursiveCopy(flutterGalleryDir, _editedFlutterGalleryDir);
       await inDirectory<void>(_editedFlutterGalleryDir, () async {
         {
-           await exec(
-              path.join(flutterDirectory.path, 'bin', 'flutter'),
-              <String>['packages', 'get'],
+          await flutter(
+            'packages',
+            options: <String>['get'],
           );
-          final Process process = await startProcess(
-              path.join(flutterDirectory.path, 'bin', 'flutter'),
-              flutterCommandArgs('run', options),
+          final Process process = await startFlutter(
+            'run',
+            options: options,
           );
 
           final Completer<void> stdoutDone = Completer<void>();
@@ -127,9 +127,9 @@ TaskFunction createWebDevModeTest(String webDevice, bool enableIncrementalCompil
         {
 
           final Stopwatch sw = Stopwatch()..start();
-          final Process process = await startProcess(
-              path.join(flutterDirectory.path, 'bin', 'flutter'),
-              flutterCommandArgs('run', options),
+          final Process process = await startFlutter(
+            'run',
+            options: options,
           );
           final Completer<void> stdoutDone = Completer<void>();
           final Completer<void> stderrDone = Completer<void>();


### PR DESCRIPTION
Devicelab tests [are failing with "lost connection"](https://github.com/flutter/flutter/issues/120808#issuecomment-1448934064), and it would be helpful to add screenshots when these commands fail (instead of adding a tricky-to-pipe `flutter run --screenshot` option, do it in the test harness).

Refactor devicelab tests to use the utils `startFlutter` etc. process methods so in my next PR I can add a hook for screenshots.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
