### PR TITLE
Add one DefaultTextStyle example

### DIFF
--- a/examples/api/lib/widgets/text/text.0.dart
+++ b/examples/api/lib/widgets/text/text.0.dart
@@ -1,0 +1,46 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flutter code sample for [DefaultTextStyle].
+
+import 'package:flutter/material.dart';
+
+void main() => runApp(const DefaultTextStyleApp());
+
+class DefaultTextStyleApp extends StatelessWidget {
+  const DefaultTextStyleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        brightness: Brightness.light,
+        colorSchemeSeed: Colors.purple,
+      ),
+      home: const DefaultTextStyleExample(),
+    );
+  }
+}
+
+class DefaultTextStyleExample extends StatelessWidget {
+  const DefaultTextStyleExample({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('DefaultTextStyle.merge Sample')),
+      // Inherit MaterialApp text theme and override font size and font weight.
+      body: DefaultTextStyle.merge(
+        style: const TextStyle(
+          fontSize: 24,
+          fontWeight: FontWeight.bold,
+        ),
+        child: const Center(
+          child: Text('Flutter'),
+        ),
+      ),
+    );
+  }
+}

--- a/examples/api/test/widgets/text/text.0_test.dart
+++ b/examples/api/test/widgets/text/text.0_test.dart
@@ -1,0 +1,26 @@
+// Copyright 2014 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_api_samples/widgets/text/text.0.dart' as example;
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('WidgetsApp test', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const example.DefaultTextStyleApp(),
+    );
+
+    expect(find.text('Flutter'), findsOneWidget);
+
+    final RichText text = tester.firstWidget(find.byType(RichText));
+    expect(text.text.style!.fontSize, 24);
+    expect(text.text.style!.fontWeight, FontWeight.bold);
+
+    // Because this example uses Material 3 and a light brightness, the text color
+    // should be the color scheme `onSurface` color.
+    final Color textColor = ColorScheme.fromSeed(seedColor: Colors.purple).onSurface;
+    expect(text.text.style!.color, textColor);
+  });
+}

--- a/packages/flutter/lib/src/widgets/text.dart
+++ b/packages/flutter/lib/src/widgets/text.dart
@@ -20,6 +20,14 @@ import 'selection_container.dart';
 /// The text style to apply to descendant [Text] widgets which don't have an
 /// explicit style.
 ///
+/// {@tool dartpad}
+/// This example shows how to use [DefaultTextStyle.merge] to create a default
+/// text style that inherits styling information from the current default text
+/// style and overrides some properties.
+///
+/// ** See code in examples/api/lib/widgets/text/text.0.dart **
+/// {@end-tool}
+///
 /// See also:
 ///
 ///  * [AnimatedDefaultTextStyle], which animates changes in the text style


### PR DESCRIPTION
## Description

This PR adds an example to `DefaultTextStyle` to put more emphasis on `DefaultTextStyle.merge`.

## Related Issue

Fixes https://github.com/flutter/flutter/issues/122180

## Tests

Adds 1 test for the new example.
