### PR TITLE
Run plugin_test_macos on Intel machines

### DIFF
--- a/.ci.yaml
+++ b/.ci.yaml
@@ -3048,6 +3048,7 @@ targets:
     recipe: devicelab/devicelab_drone
     timeout: 60
     properties:
+      cpu: x86 # https://github.com/flutter/flutter/issues/119750
       dependencies: >-
         [
           {"dependency": "xcode", "version": "14a5294e"},


### PR DESCRIPTION
Another case of https://github.com/flutter/flutter/issues/119750 causing timeout flakes.

Fixes https://github.com/flutter/flutter/issues/122196
Closes https://github.com/flutter/flutter/pull/122197
