### PR TITLE
Fix `allowedButtonsFilter` not working as intended when null.

### DIFF
--- a/packages/flutter/lib/src/gestures/long_press.dart
+++ b/packages/flutter/lib/src/gestures/long_press.dart
@@ -250,9 +250,10 @@ class LongPressGestureRecognizer extends PrimaryPointerGestureRecognizer {
     super.postAcceptSlopTolerance = null,
     super.supportedDevices,
     super.debugOwner,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
+    AllowedButtonsFilter? allowedButtonsFilter,
   }) : super(
          deadline: duration ?? kLongPressTimeout,
+         allowedButtonsFilter: allowedButtonsFilter ?? _defaultButtonAcceptBehavior,
        );
 
   bool _longPressAccepted = false;

--- a/packages/flutter/lib/src/gestures/monodrag.dart
+++ b/packages/flutter/lib/src/gestures/monodrag.dart
@@ -78,8 +78,8 @@ abstract class DragGestureRecognizer extends OneSequenceGestureRecognizer {
     this.dragStartBehavior = DragStartBehavior.start,
     this.velocityTrackerBuilder = _defaultBuilder,
     super.supportedDevices,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
-  });
+    AllowedButtonsFilter? allowedButtonsFilter,
+  }) : super(allowedButtonsFilter: allowedButtonsFilter ?? _defaultButtonAcceptBehavior);
 
   static VelocityTracker _defaultBuilder(PointerEvent event) => VelocityTracker.withKind(event.kind);
 

--- a/packages/flutter/lib/src/gestures/multidrag.dart
+++ b/packages/flutter/lib/src/gestures/multidrag.dart
@@ -216,8 +216,8 @@ abstract class MultiDragGestureRecognizer extends GestureRecognizer {
   MultiDragGestureRecognizer({
     required super.debugOwner,
     super.supportedDevices,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
-  });
+    AllowedButtonsFilter? allowedButtonsFilter,
+  }) : super(allowedButtonsFilter: allowedButtonsFilter ?? _defaultButtonAcceptBehavior);
 
   // Accept the input if, and only if, [kPrimaryButton] is pressed.
   static bool _defaultButtonAcceptBehavior(int buttons) => buttons == kPrimaryButton;

--- a/packages/flutter/lib/src/gestures/multitap.dart
+++ b/packages/flutter/lib/src/gestures/multitap.dart
@@ -119,8 +119,8 @@ class DoubleTapGestureRecognizer extends GestureRecognizer {
   DoubleTapGestureRecognizer({
     super.debugOwner,
     super.supportedDevices,
-    super.allowedButtonsFilter = _defaultButtonAcceptBehavior,
-  });
+    AllowedButtonsFilter? allowedButtonsFilter,
+  }) : super(allowedButtonsFilter: allowedButtonsFilter ?? _defaultButtonAcceptBehavior);
 
   // The default value for [allowedButtonsFilter].
   // Accept the input if, and only if, [kPrimaryButton] is pressed.

--- a/packages/flutter/test/gestures/multidrag_test.dart
+++ b/packages/flutter/test/gestures/multidrag_test.dart
@@ -90,4 +90,25 @@ void main() {
     expect(didStartDrag, isFalse);
     drag.dispose();
   });
+
+  test('allowedButtonsFilter should work the same when null or not specified', () {
+    // Regression test for https://github.com/flutter/flutter/pull/122227
+
+    final ImmediateMultiDragGestureRecognizer recognizer1 = ImmediateMultiDragGestureRecognizer();
+    // ignore: avoid_redundant_argument_values
+    final ImmediateMultiDragGestureRecognizer recognizer2 = ImmediateMultiDragGestureRecognizer(allowedButtonsFilter: null);
+
+    // We want to test _allowedButtonsFilter, which is called in this method.
+    const PointerDownEvent allowedPointer = PointerDownEvent(timeStamp: Duration(days: 10));
+    // ignore: invalid_use_of_protected_member
+    expect(recognizer1.isPointerAllowed(allowedPointer), true);
+    // ignore: invalid_use_of_protected_member
+    expect(recognizer2.isPointerAllowed(allowedPointer), true);
+
+    const PointerDownEvent rejectedPointer = PointerDownEvent(timeStamp: Duration(days: 10), buttons: kMiddleMouseButton);
+    // ignore: invalid_use_of_protected_member
+    expect(recognizer1.isPointerAllowed(rejectedPointer), false);
+    // ignore: invalid_use_of_protected_member
+    expect(recognizer2.isPointerAllowed(rejectedPointer), false);
+  });
 }


### PR DESCRIPTION
I was unaware `ImmediateMultiDragGestureRecognizer()` != `ImmediateMultiDragGestureRecognizer(allowedButtonsFilter : null)`. This fixes that. Thanks @stuartmorgan for the help. Without you this wouldn't be possible.

This should have the "side effect" of making `Draggable` only work with primary click. This wasn't happening because `Draggable` applied a `null` allowedButtonsFilter and then `GestureRecognizer` just returned "true". Now it should work as intended on https://github.com/flutter/flutter/pull/111852 (but that never worked, unfortunately).

cc @Renzo-Olivares.
cc @moffatman.