### PR TITLE
Fix transitioning a TabBarView manually doesn't honor duration and curve #16892

### DIFF
--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -107,14 +107,14 @@ class TabController extends ChangeNotifier {
     required this.length,
     required TickerProvider vsync,
   }) : assert(length >= 0),
-       assert(initialIndex >= 0 && (length == 0 || initialIndex < length)),
-       _index = initialIndex,
-       _previousIndex = initialIndex,
-       _animationDuration = animationDuration ?? kTabScrollDuration,
-       _animationController = AnimationController.unbounded(
-         value: initialIndex.toDouble(),
-         vsync: vsync,
-       );
+        assert(initialIndex >= 0 && (length == 0 || initialIndex < length)),
+        _index = initialIndex,
+        _previousIndex = initialIndex,
+        _animationDuration = animationDuration ?? kTabScrollDuration,
+        _animationController = AnimationController.unbounded(
+          value: initialIndex.toDouble(),
+          vsync: vsync,
+        );
 
   // Private constructor used by `_copyWith`. This allows a new TabController to
   // be created without having to create a new animationController.
@@ -125,9 +125,9 @@ class TabController extends ChangeNotifier {
     required Duration animationDuration,
     required this.length,
   }) : _index = index,
-       _previousIndex = previousIndex,
-       _animationController = animationController,
-       _animationDuration = animationDuration;
+        _previousIndex = previousIndex,
+        _animationController = animationController,
+        _animationDuration = animationDuration;
 
 
   /// Creates a new [TabController] with `index`, `previousIndex`, `length`, and
@@ -191,19 +191,23 @@ class TabController extends ChangeNotifier {
     _index = value;
     if (duration != null && duration > Duration.zero) {
       _indexIsChangingCount += 1;
+      _indexChangingDurations.add(duration);
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!
-        .animateTo(_index.toDouble(), duration: duration, curve: curve!)
-        .whenCompleteOrCancel(() {
+          .animateTo(_index.toDouble(), duration: duration, curve: curve!)
+          .whenCompleteOrCancel(() {
           if (_animationController != null) { // don't notify if we've been disposed
-            _indexIsChangingCount -= 1;
-            notifyListeners();
-          }
-        });
+          _indexIsChangingCount -= 1;
+          _indexChangingDurations.removeLast();
+          notifyListeners();
+        }
+      });
     } else {
       _indexIsChangingCount += 1;
+      _indexChangingDurations.add(Duration.zero);
       _animationController!.value = _index.toDouble();
       _indexIsChangingCount -= 1;
+      _indexChangingDurations.removeLast();
       notifyListeners();
     }
   }
@@ -237,6 +241,16 @@ class TabController extends ChangeNotifier {
   /// consequence of the user dragging (and "flinging") the [TabBarView].
   bool get indexIsChanging => _indexIsChangingCount != 0;
   int _indexIsChangingCount = 0;
+
+  /// The Duration used to animate [previousIndex] to [index] as a
+  /// consequence of calling [animateTo].
+  ///
+  /// This value is set during the [animateTo] animation that's triggered when
+  /// the user taps a [TabBar] tab. It is null when [offset] is changing as a
+  /// consequence of the user dragging (and "flinging") the [TabBarView].
+  Duration? get indexChangingDuration =>
+      _indexChangingDurations.isNotEmpty ? _indexChangingDurations.last : null;
+  final List<Duration> _indexChangingDurations = <Duration>[];
 
   /// Immediately sets [index] and [previousIndex] and then plays the
   /// [animation] from its current value to [index].
@@ -351,7 +365,7 @@ class DefaultTabController extends StatefulWidget {
     required this.child,
     this.animationDuration,
   }) : assert(length >= 0),
-       assert(length == 0 || (initialIndex >= 0 && initialIndex < length));
+        assert(length == 0 || (initialIndex >= 0 && initialIndex < length));
 
   /// The total number of tabs.
   ///

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -106,7 +106,7 @@ class TabController extends ChangeNotifier {
     Duration? animationDuration,
     required this.length,
     required TickerProvider vsync,
-  }) : assert(length >= 0),
+  })  : assert(length >= 0),
         assert(initialIndex >= 0 && (length == 0 || initialIndex < length)),
         _index = initialIndex,
         _previousIndex = initialIndex,
@@ -125,9 +125,9 @@ class TabController extends ChangeNotifier {
     required Duration animationDuration,
     required this.length,
   }) : _index = index,
-        _previousIndex = previousIndex,
-        _animationController = animationController,
-        _animationDuration = animationDuration;
+       _previousIndex = previousIndex,
+       _animationController = animationController,
+       _animationDuration = animationDuration;
 
 
   /// Creates a new [TabController] with `index`, `previousIndex`, `length`, and
@@ -195,8 +195,8 @@ class TabController extends ChangeNotifier {
       _indexChangingCurves.add(curve!);
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!
-          .animateTo(_index.toDouble(), duration: duration, curve: curve!)
-          .whenCompleteOrCancel(() {
+        .animateTo(_index.toDouble(), duration: duration, curve: curve!)
+        .whenCompleteOrCancel(() {
           if (_animationController != null) { // don't notify if we've been disposed
           _indexIsChangingCount -= 1;
           _indexChangingDurations.removeLast();
@@ -206,7 +206,7 @@ class TabController extends ChangeNotifier {
       });
     } else {
       _indexIsChangingCount += 1;
-      _indexChangingDurations.add(Duration.zero);
+      _indexChangingDurations.add(animationDuration);
       _indexChangingCurves.add(Curves.ease);
       _animationController!.value = _index.toDouble();
       _indexIsChangingCount -= 1;
@@ -379,7 +379,7 @@ class DefaultTabController extends StatefulWidget {
     required this.child,
     this.animationDuration,
   }) : assert(length >= 0),
-        assert(length == 0 || (initialIndex >= 0 && initialIndex < length));
+       assert(length == 0 || (initialIndex >= 0 && initialIndex < length));
 
   /// The total number of tabs.
   ///

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -195,7 +195,7 @@ class TabController extends ChangeNotifier {
       _indexChangingCurves.add(curve!);
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!
-        .animateTo(_index.toDouble(), duration: duration, curve: curve!)
+        .animateTo(_index.toDouble(), duration: duration, curve: curve)
         .whenCompleteOrCancel(() {
           if (_animationController != null) { // don't notify if we've been disposed
           _indexIsChangingCount -= 1;

--- a/packages/flutter/lib/src/material/tab_controller.dart
+++ b/packages/flutter/lib/src/material/tab_controller.dart
@@ -192,6 +192,7 @@ class TabController extends ChangeNotifier {
     if (duration != null && duration > Duration.zero) {
       _indexIsChangingCount += 1;
       _indexChangingDurations.add(duration);
+      _indexChangingCurves.add(curve!);
       notifyListeners(); // Because the value of indexIsChanging may have changed.
       _animationController!
           .animateTo(_index.toDouble(), duration: duration, curve: curve!)
@@ -199,15 +200,18 @@ class TabController extends ChangeNotifier {
           if (_animationController != null) { // don't notify if we've been disposed
           _indexIsChangingCount -= 1;
           _indexChangingDurations.removeLast();
+          _indexChangingCurves.removeLast();
           notifyListeners();
         }
       });
     } else {
       _indexIsChangingCount += 1;
       _indexChangingDurations.add(Duration.zero);
+      _indexChangingCurves.add(Curves.ease);
       _animationController!.value = _index.toDouble();
       _indexIsChangingCount -= 1;
       _indexChangingDurations.removeLast();
+      _indexChangingCurves.removeLast();
       notifyListeners();
     }
   }
@@ -251,6 +255,16 @@ class TabController extends ChangeNotifier {
   Duration? get indexChangingDuration =>
       _indexChangingDurations.isNotEmpty ? _indexChangingDurations.last : null;
   final List<Duration> _indexChangingDurations = <Duration>[];
+
+  /// The Curve used to animate [previousIndex] to [index] as a
+  /// consequence of calling [animateTo].
+  ///
+  /// This value is set during the [animateTo] animation that's triggered when
+  /// the user taps a [TabBar] tab. It is null when [offset] is changing as a
+  /// consequence of the user dragging (and "flinging") the [TabBarView].
+  Curve? get indexChangingCurve =>
+      _indexChangingCurves.isNotEmpty ? _indexChangingCurves.last : null;
+  final List<Curve> _indexChangingCurves = <Curve>[];
 
   /// Immediately sets [index] and [previousIndex] and then plays the
   /// [animation] from its current value to [index].

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1636,6 +1636,7 @@ class _TabBarViewState extends State<TabBarView> {
     }
 
     final Duration duration = _controller!.indexChangingDuration ?? _controller!.animationDuration;
+    final Curve curve = _controller!.indexChangingCurve ?? Curves.ease;
     final int previousIndex = _controller!.previousIndex;
 
     if ((_currentIndex! - previousIndex).abs() == 1) {
@@ -1644,7 +1645,7 @@ class _TabBarViewState extends State<TabBarView> {
         return Future<void>.value();
       }
       _warpUnderwayCount += 1;
-      await _pageController.animateToPage(_currentIndex!, duration: duration, curve: Curves.ease);
+      await _pageController.animateToPage(_currentIndex!, duration: duration, curve: curve);
       _warpUnderwayCount -= 1;
 
       if (mounted && widget.children != _children) {

--- a/packages/flutter/lib/src/material/tabs.dart
+++ b/packages/flutter/lib/src/material/tabs.dart
@@ -1635,7 +1635,7 @@ class _TabBarViewState extends State<TabBarView> {
       return Future<void>.value();
     }
 
-    final Duration duration = _controller!.animationDuration;
+    final Duration duration = _controller!.indexChangingDuration ?? _controller!.animationDuration;
     final int previousIndex = _controller!.previousIndex;
 
     if ((_currentIndex! - previousIndex).abs() == 1) {


### PR DESCRIPTION
*Calling `TabController.animateTo` with a duration and curve doesn't affect the behavior of the `TabBarView` animation. Although it's correctly affecting the behavior of the `TabPageSelector` and the `TabBar` animations.

The animation duration is always the same. The only thing that happens after the defined duration is that `whenCompleteOrFailed()` is called*

*#16892* (Transitioning a TabBarView manually doesn't honor the duration and curve)