### PR TITLE
Enable invalid_case_patterns lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -111,6 +111,7 @@ linter:
     - hash_and_equals
     - implementation_imports
     - implicit_call_tearoffs
+    - invalid_case_patterns
     - iterable_contains_unrelated_type
     # - join_return_with_assignment # not required by flutter style
     - leading_newlines_in_multiline_strings


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/118837.

This is in preparation for Dart 3. Some case expressions that are valid in Dart 2.19 and below will become an error or have changed semantics when a library is upgraded to 3.0. This lint bans those expressions in order to ease migration to Dart 3.0.

Luckily, we didn't have any offenders in the code base.