### PR TITLE
Give PolynomialFit more docs, and a debug toString

### DIFF
--- a/packages/flutter/lib/src/gestures/lsq_solver.dart
+++ b/packages/flutter/lib/src/gestures/lsq_solver.dart
@@ -70,12 +70,26 @@ class PolynomialFit {
   PolynomialFit(int degree) : coefficients = Float64List(degree + 1);
 
   /// The polynomial coefficients of the fit.
+  ///
+  /// For each `i`, the element `coefficients[i]` is the coefficient of
+  /// the `i`-th power of the variable.
   final List<double> coefficients;
 
   /// An indicator of the quality of the fit.
   ///
-  /// Larger values indicate greater quality.
+  /// Larger values indicate greater quality.  The value ranges from 0.0 to 1.0.
+  ///
+  /// The confidence is defined as the fraction of the dataset's variance
+  /// that is captured by variance in the fit polynomial.  In statistics
+  /// textbooks this is often called "r-squared".
   late double confidence;
+
+  @override
+  String toString() {
+    final String coefficientString =
+        coefficients.map((double c) => c.toStringAsPrecision(3)).toList().toString();
+    return '${objectRuntimeType(this, 'PolynomialFit')}($coefficientString, confidence: ${confidence.toStringAsFixed(3)})';
+  }
 }
 
 /// Uses the least-squares algorithm to fit a polynomial to a set of data.

--- a/packages/flutter/test/gestures/lsq_solver_test.dart
+++ b/packages/flutter/test/gestures/lsq_solver_test.dart
@@ -69,4 +69,12 @@ void main() {
     expect(approx(fit.confidence, 1.0), isTrue);
   });
 
+  test('Least-squares fit: toString', () {
+    final PolynomialFit fit = PolynomialFit(2);
+    fit.coefficients[0] = 123.45;
+    fit.coefficients[1] = 54.321;
+    fit.coefficients[2] = 1.3579;
+    fit.confidence = 0.9876;
+    expect(fit.toString(), 'PolynomialFit([123, 54.3, 1.36], confidence: 0.988)');
+  });
 }


### PR DESCRIPTION
I was debugging some details of scrolling and dragging (toward #122338), and found it was helpful to print out one of these and to know what its fields mean.  To work that out I had to read the code that emits these elsewhere in this file. So here are the results of that, to save the next person from having to do the same.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
